### PR TITLE
Remove incorrect background of code inside error messages

### DIFF
--- a/frontend/src/components/elements/Text/Text.scss
+++ b/frontend/src/components/elements/Text/Text.scss
@@ -70,7 +70,6 @@
     margin: 0;
 
     code {
-      background: rgba(255, 255, 255, 0.5);
       color: inherit;
     }
 


### PR DESCRIPTION
Before:

<img width="677" alt="Screen Shot 2019-08-23 at 10 23 05 PM" src="https://user-images.githubusercontent.com/589034/63632916-b15f0f80-c5f4-11e9-8363-ab94bbc3b1fd.png">

After:

<img width="641" alt="Screen Shot 2019-08-23 at 10 23 59 PM" src="https://user-images.githubusercontent.com/589034/63632920-ba4fe100-c5f4-11e9-83ef-0baec8115aeb.png">
