### PR TITLE
Fix #1230: OSError not caught when writing cache to disk

### DIFF
--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -250,7 +250,11 @@ def _read_from_disk_cache(key):
     except util.Error as e:
         LOGGER.error(e)
         raise CacheError('Unable to read from cache: %s' % e)
-    except FileNotFoundError:
+
+    except (
+            OSError,  # Python 2
+            FileNotFoundError  # Python 3
+        ):
         raise CacheKeyNotFoundError('Key not found in disk cache')
     return value, args_mutated
 
@@ -266,7 +270,7 @@ def _write_to_disk_cache(key, value, args_mutated):
     # In python 3, it's an open error in util.
     except (util.Error, struct.error) as e:
         LOGGER.debug(e)
-        # Cleanup file so we don't leave zero byte files.
+        # Clean up file so we don't leave zero byte files.
         try:
             os.remove(path)
         except (FileNotFoundError, IOError, OSError):

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -265,14 +265,19 @@ class CodeHasher():
         elif inspect.iscode(obj):
             return self._code_to_bytes(obj, context)
         elif inspect.ismodule(obj):
+            # TODO: Figure out how to best show this kind of warning to the
+            # user. In the meantime, show nothing. This scenario is too common,
+            # so the current warning is quite annoying...
+            # st.warning(('Streamlit does not support hashing modules. '
+            #             'We did not hash `%s`.') % obj.__name__)
             # TODO: Hash more than just the name for internal modules.
-            st.warning(('Streamlit does not support hashing modules. '
-                        'We did not hash `%s`.') % obj.__name__)
             return self.to_bytes(obj.__name__)
         elif inspect.isclass(obj):
-            # TODO: Hash more than just the name of classes.
+            # TODO: Figure out how to best show this kind of warning to the
+            # user.
             st.warning(('Streamlit does not support hashing classes. '
                         'We did not hash `%s`.') % obj.__name__)
+            # TODO: Hash more than just the name of classes.
             return self.to_bytes(obj.__name__)
         elif isinstance(obj, functools.partial):
             # The return value of functools.partial is not a plain function:
@@ -288,6 +293,8 @@ class CodeHasher():
                 # As a last resort, we pickle the object to hash it.
                 return pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
             except Exception:
+                # TODO: Figure out how to best show this kind of warning to the
+                # user.
                 st.warning('Streamlit cannot hash an object of type %s.' % type(obj))
 
     def _code_to_bytes(self, code, context):


### PR DESCRIPTION
This fixes an uncaught Python 2 exception, as reported here: #1230.

It also hides a hashing warning when a user imports a module from inside a cached function. This is a common scenario, and the warning UI is too invasive today. We should come up with a better UI.