### PR TITLE
Adding width and height parameter to st.dataframe

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -175,12 +175,19 @@ class Block extends PureComponent<Props> {
       disabled: this.props.widgetsDisabled,
     }
 
+    const widthFromProps = element.get('width')
+    const heightFromProps = element.get('height')
+
+    if (widthFromProps != null) {
+      width = Math.min(widthFromProps, width)
+    }
+
     return dispatchOneOf(element, 'type', {
       audio: (el: SimpleElement) => <Audio element={el} width={width} />,
       balloons: (el: SimpleElement) => <Balloons element={el} width={width} />,
       bokehChart: (el: SimpleElement) => <BokehChart element={el} index={index} width={width} />,
       chart: (el: SimpleElement) => <Chart element={el} width={width} />,
-      dataFrame: (el: SimpleElement) => <DataFrame element={el} width={width} />,
+      dataFrame: (el: SimpleElement) => <DataFrame element={el} width={width} height={heightFromProps}/>,
       deckGlChart: (el: SimpleElement) => <DeckGlChart element={el} width={width} />,
       docString: (el: SimpleElement) => <DocString element={el} width={width} />,
       empty: () => undefined,

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -23,6 +23,7 @@ import { dispatchOneOf } from 'lib/immutableProto'
 import { ReportRunState } from 'lib/ReportRunState'
 import { WidgetStateManager } from 'lib/WidgetStateManager'
 import { makeElementWithInfoText } from 'lib/utils'
+import { ForwardMsgMetadata } from 'autogen/proto'
 
 // Load (non-lazy) elements.
 import Chart from 'components/elements/Chart/'
@@ -175,11 +176,11 @@ class Block extends PureComponent<Props> {
       disabled: this.props.widgetsDisabled,
     }
 
-    const widthFromProps = element.get('width')
-    const heightFromProps = element.get('height')
+    const metadata = element.get('metadata') as ForwardMsgMetadata
 
-    if (widthFromProps != null) {
-      width = Math.min(widthFromProps, width)
+    // Modify width using the value from the spec as passed with the message when applicable
+    if (metadata && metadata.elementDimensionSpec && metadata.elementDimensionSpec.width > 0) {
+      width = Math.min(metadata.elementDimensionSpec.width, width)
     }
 
     return dispatchOneOf(element, 'type', {
@@ -187,7 +188,8 @@ class Block extends PureComponent<Props> {
       balloons: (el: SimpleElement) => <Balloons element={el} width={width} />,
       bokehChart: (el: SimpleElement) => <BokehChart element={el} index={index} width={width} />,
       chart: (el: SimpleElement) => <Chart element={el} width={width} />,
-      dataFrame: (el: SimpleElement) => <DataFrame element={el} width={width} height={heightFromProps}/>,
+      dataFrame: (el: SimpleElement) =>
+        <DataFrame element={el} width={width} elementDimensionSpec={metadata.elementDimensionSpec}/>,
       deckGlChart: (el: SimpleElement) => <DeckGlChart element={el} width={width} />,
       docString: (el: SimpleElement) => <DocString element={el} width={width} />,
       empty: () => undefined,

--- a/frontend/src/components/elements/DataFrame/DataFrame.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrame.tsx
@@ -22,6 +22,7 @@ import DataFrameCell from './DataFrameCell'
 import {SortDirection} from './SortDirection'
 import {dataFrameGet, dataFrameGetDimensions, getSortedDataRowIndices} from 'lib/dataFrameProto'
 import {toFormattedString} from 'lib/format'
+import {ElementDimensionSpec} from 'autogen/proto'
 import './DataFrame.scss'
 
 /**
@@ -46,7 +47,7 @@ const MAX_LONELY_CELL_WIDTH_PX = 400
 
 interface Props {
   width: number;
-  elementDimensionSpec: any;
+  elementDimensionSpec: ElementDimensionSpec;
   element: ImmutableMap<string, any>;
 }
 
@@ -226,8 +227,8 @@ class DataFrame extends React.PureComponent<Props, State> {
     const rowHeight = 25
     const headerHeight = rowHeight * headerRows
     const border = 3
-    const height = Math.min(rows * rowHeight,
-      (elementDimensionSpec && elementDimensionSpec.height > 0) ? elementDimensionSpec.height : 300) + border
+    const height = border + Math.min(rows * rowHeight,
+      (elementDimensionSpec && elementDimensionSpec.height > 0) ? elementDimensionSpec.height : 300)
 
     let {elementWidth, columnWidth, headerWidth} = getWidths(
       cols, rows, headerCols, headerRows, width - border, cellContentsGetter)

--- a/frontend/src/components/elements/DataFrame/DataFrame.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrame.tsx
@@ -46,7 +46,7 @@ const MAX_LONELY_CELL_WIDTH_PX = 400
 
 interface Props {
   width: number;
-  height: number;
+  elementDimensionSpec: any;
   element: ImmutableMap<string, any>;
 }
 
@@ -217,7 +217,7 @@ class DataFrame extends React.PureComponent<Props, State> {
    * Returns rendering dimensions for this DataFrame
    */
   private getDimensions(cellContentsGetter: CellContentsGetter): Dimensions {
-    const {element, width, height} = this.props
+    const {element, width, elementDimensionSpec} = this.props
 
     const { headerRows, headerCols, dataRows, cols, rows } =
       dataFrameGetDimensions(element)
@@ -226,7 +226,8 @@ class DataFrame extends React.PureComponent<Props, State> {
     const rowHeight = 25
     const headerHeight = rowHeight * headerRows
     const border = 3
-    const computedHeight = Math.min(rows * rowHeight, height != null ? height : 300) + border
+    const height = Math.min(rows * rowHeight,
+      (elementDimensionSpec && elementDimensionSpec.height > 0) ? elementDimensionSpec.height : 300) + border
 
     let {elementWidth, columnWidth, headerWidth} = getWidths(
       cols, rows, headerCols, headerRows, width - border, cellContentsGetter)
@@ -249,7 +250,7 @@ class DataFrame extends React.PureComponent<Props, State> {
       rowHeight,
       headerHeight,
       border,
-      height: computedHeight,
+      height,
       elementWidth,
       columnWidth,
       headerWidth,

--- a/frontend/src/components/elements/DataFrame/DataFrame.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrame.tsx
@@ -46,6 +46,7 @@ const MAX_LONELY_CELL_WIDTH_PX = 400
 
 interface Props {
   width: number;
+  height: number;
   element: ImmutableMap<string, any>;
 }
 
@@ -216,7 +217,7 @@ class DataFrame extends React.PureComponent<Props, State> {
    * Returns rendering dimensions for this DataFrame
    */
   private getDimensions(cellContentsGetter: CellContentsGetter): Dimensions {
-    const {element, width} = this.props
+    const {element, width, height} = this.props
 
     const { headerRows, headerCols, dataRows, cols, rows } =
       dataFrameGetDimensions(element)
@@ -225,7 +226,7 @@ class DataFrame extends React.PureComponent<Props, State> {
     const rowHeight = 25
     const headerHeight = rowHeight * headerRows
     const border = 3
-    const height = Math.min(rows * rowHeight, 300) + border
+    const computedHeight = Math.min(rows * rowHeight, height != null ? height : 300) + border
 
     let {elementWidth, columnWidth, headerWidth} = getWidths(
       cols, rows, headerCols, headerRows, width - border, cellContentsGetter)
@@ -248,7 +249,7 @@ class DataFrame extends React.PureComponent<Props, State> {
       rowHeight,
       headerHeight,
       border,
-      height,
+      height: computedHeight,
       elementWidth,
       columnWidth,
       headerWidth,

--- a/frontend/src/lib/DeltaParser.ts
+++ b/frontend/src/lib/DeltaParser.ts
@@ -45,6 +45,8 @@ export function applyDelta(
   const parentBlock = requireNonNull(metadata.parentBlock)
   const parentBlockPath = requireNonNull(parentBlock.path)
   const parentBlockContainer = requireNonNull(parentBlock.container)
+  const width = metadata.width
+  const height = metadata.height
 
   const container = parentBlockContainer === BlockPath.Container.MAIN ? 'main' : 'sidebar'
   const deltaPath = [...parentBlockPath, metadata.deltaId]
@@ -52,7 +54,7 @@ export function applyDelta(
   dispatchOneOf(delta, 'type', {
     newElement: (element: SimpleElement) => {
       elements[container] = elements[container]
-        .setIn(deltaPath, handleNewElementMessage(container, element, reportId))
+        .setIn(deltaPath, handleNewElementMessage(container, element, reportId, width, height))
     },
     newBlock: () => {
       elements[container] = elements[container]
@@ -67,12 +69,13 @@ export function applyDelta(
   return elements
 }
 
-function handleNewElementMessage(container: Container, element: SimpleElement, reportId: string): SimpleElement {
+function handleNewElementMessage(container: Container, element: SimpleElement, reportId: string,
+    width: number, height: number): SimpleElement {
   MetricsManager.current.incrementDeltaCounter(container)
   MetricsManager.current.incrementDeltaCounter(element.get('type'))
   // Set reportId on elements so we can clear old elements
   // when the report script is re-executed.
-  return element.set('reportId', reportId)
+  return element.set('reportId', reportId).set('width', width).set('height', height)
 }
 
 function handleNewBlockMessage(container: Container, element: BlockElement): BlockElement {

--- a/frontend/src/lib/DeltaParser.ts
+++ b/frontend/src/lib/DeltaParser.ts
@@ -45,8 +45,6 @@ export function applyDelta(
   const parentBlock = requireNonNull(metadata.parentBlock)
   const parentBlockPath = requireNonNull(parentBlock.path)
   const parentBlockContainer = requireNonNull(parentBlock.container)
-  const width = metadata.width
-  const height = metadata.height
 
   const container = parentBlockContainer === BlockPath.Container.MAIN ? 'main' : 'sidebar'
   const deltaPath = [...parentBlockPath, metadata.deltaId]
@@ -54,7 +52,7 @@ export function applyDelta(
   dispatchOneOf(delta, 'type', {
     newElement: (element: SimpleElement) => {
       elements[container] = elements[container]
-        .setIn(deltaPath, handleNewElementMessage(container, element, reportId, width, height))
+        .setIn(deltaPath, handleNewElementMessage(container, element, reportId, metadata))
     },
     newBlock: () => {
       elements[container] = elements[container]
@@ -70,12 +68,13 @@ export function applyDelta(
 }
 
 function handleNewElementMessage(container: Container, element: SimpleElement, reportId: string,
-    width: number, height: number): SimpleElement {
+  metadata: ForwardMsgMetadata): SimpleElement {
   MetricsManager.current.incrementDeltaCounter(container)
   MetricsManager.current.incrementDeltaCounter(element.get('type'))
   // Set reportId on elements so we can clear old elements
   // when the report script is re-executed.
-  return element.set('reportId', reportId).set('width', width).set('height', height)
+  // Set metadata on elements so that we can use them downstream.
+  return element.set('reportId', reportId).set('metadata', metadata)
 }
 
 function handleNewBlockMessage(container: Container, element: BlockElement): BlockElement {

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -208,9 +208,9 @@ class DeltaGenerator(object):
         ----------
         marshall_element : callable
             Function which sets the fields for a NewElement protobuf.
-        elementWidth : int
+        elementWidth : int or None
             Desired width for the element
-        elementHeight : int
+        elementHeight : int or None
             Desired height for the element
 
         Returns
@@ -628,10 +628,12 @@ class DeltaGenerator(object):
             values and colors. (It does not support some of the more exotic
             pandas styling features, like bar charts, hovering, and captions.)
             Styler support is experimental!
-        width : int
-            Desired width of the UI element expressed in CSS points
-        height : int
-            Desired height of the UI element expressed in CSS points
+        width : int or None
+            Desired width of the UI element expressed in pixels. If None, a
+            default width based on the page width is used.
+        height : int or None
+            Desired height of the UI element expressed in pixels. If None, a
+            default height is used.
 
         Examples
         --------

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -200,7 +200,7 @@ class DeltaGenerator(object):
         assert self._is_root
         self._id = 0
 
-    def _enqueue_new_element_delta(self, marshall_element):
+    def _enqueue_new_element_delta(self, marshall_element, width, height):
         """Create NewElement delta, fill it, and enqueue it.
 
         Parameters
@@ -234,6 +234,10 @@ class DeltaGenerator(object):
             msg.metadata.parent_block.container = self._container
             msg.metadata.parent_block.path[:] = self._path
             msg.metadata.delta_id = self._id
+            if width is not None:
+                msg.metadata.width = width
+            if height is not None:
+                msg.metadata.height = height
 
         # "Null" delta generators (those without queues), don't send anything.
         if self._enqueue is None:
@@ -605,7 +609,7 @@ class DeltaGenerator(object):
         element.exception.stack_trace.extend(stack_trace)
 
     @_clean_up_sig
-    def dataframe(self, _, data=None):
+    def dataframe(self, _, data=None, width=None, height=None):
         """Display a dataframe as an interactive table.
 
         Parameters
@@ -651,7 +655,7 @@ class DeltaGenerator(object):
         def set_data_frame(delta):
             data_frame_proto.marshall_data_frame(data, delta.data_frame)
 
-        return self._enqueue_new_element_delta(set_data_frame)
+        return self._enqueue_new_element_delta(set_data_frame, width, height)
 
     # TODO: Either remove this or make it public. This is only used in the
     # mnist demo right now.

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -200,13 +200,18 @@ class DeltaGenerator(object):
         assert self._is_root
         self._id = 0
 
-    def _enqueue_new_element_delta(self, marshall_element, width, height):
+    def _enqueue_new_element_delta(self, marshall_element, elementWidth=None,
+                                   elementHeight=None):
         """Create NewElement delta, fill it, and enqueue it.
 
         Parameters
         ----------
         marshall_element : callable
             Function which sets the fields for a NewElement protobuf.
+        elementWidth : int
+            Desired width for the element
+        elementHeight : int
+            Desired height for the element
 
         Returns
         -------
@@ -234,10 +239,10 @@ class DeltaGenerator(object):
             msg.metadata.parent_block.container = self._container
             msg.metadata.parent_block.path[:] = self._path
             msg.metadata.delta_id = self._id
-            if width is not None:
-                msg.metadata.width = width
-            if height is not None:
-                msg.metadata.height = height
+            if elementWidth is not None:
+                msg.metadata.element_dimension_spec.width = elementWidth
+            if elementHeight is not None:
+                msg.metadata.element_dimension_spec.height = elementHeight
 
         # "Null" delta generators (those without queues), don't send anything.
         if self._enqueue is None:
@@ -623,6 +628,10 @@ class DeltaGenerator(object):
             values and colors. (It does not support some of the more exotic
             pandas styling features, like bar charts, hovering, and captions.)
             Styler support is experimental!
+        width : int
+            Desired width of the UI element expressed in CSS points
+        height : int
+            Desired height of the UI element expressed in CSS points
 
         Examples
         --------
@@ -635,6 +644,11 @@ class DeltaGenerator(object):
         .. output::
            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ
            height: 330px
+
+        >>> st.dataframe(df, 200, 100)
+
+        .. output::
+           Same as before but width and height are constrained as specified
 
         You can also pass a Pandas Styler object to change the style of
         the rendered DataFrame:

--- a/lib/tests/streamlit/dataframe_dimensions_test.py
+++ b/lib/tests/streamlit/dataframe_dimensions_test.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataframe dimension parameters test."""
+
+# Python 2/3 compatibility
+from __future__ import print_function, division, unicode_literals, absolute_import
+from streamlit.compatibility import setup_2_3_shims
+setup_2_3_shims(globals())
+
+import pandas as pd
+
+from tests import testutil
+import streamlit as st
+
+
+class DeltaGeneratorDataframeTest(testutil.DeltaGeneratorTestCase):
+    """Test the metadata in the serialized delta message for the different
+    dimension specifier options.
+    """
+    def test_no_dimensions(self):
+        """When no dimension parameters are passed
+        """
+        self._do_test(lambda fn, df: fn(df), 0, 0)
+
+    def test_with_dimensions(self):
+        """When dimension parameter are passed
+        """
+        self._do_test(lambda fn, df: fn(df, 10, 20), 10, 20)
+
+    def test_with_height_only(self):
+        """When only height parameter is passed
+        """
+        self._do_test(lambda fn, df: fn(df, height=20), 0, 20)
+
+    def test_with_width_only(self):
+        """When only width parameter is passed
+        """
+        self._do_test(lambda fn, df: fn(df, width=20), 20, 0)
+
+    def _do_test(self, fn, expectedWidth, expectedHeight):
+        df = pd.DataFrame({'A': [1, 2, 3, 4, 5]})
+
+        fn(st.dataframe, df)
+        metadata = self._get_metadata()
+        self.assertEqual(metadata.element_dimension_spec.width, expectedWidth)
+        self.assertEqual(metadata.element_dimension_spec.height,
+                         expectedHeight)
+
+    def _get_metadata(self):
+        """Returns the metadata for the most recent element in the
+        DeltaGenerator queue
+        """
+        return self.report_queue._queue[-1].metadata

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -94,7 +94,7 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(ds.type, '<type \'function\'>')
         else:
             self.assertEqual(ds.type, '<class \'function\'>')
-        self.assertEqual(ds.signature, '(data=None)')
+        self.assertEqual(ds.signature, '(data=None, width=None, height=None)')
         self.assertTrue(ds.doc_string.startswith('Display a dataframe'))
 
     def test_st_cache(self):

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -62,9 +62,14 @@ message ForwardMsgMetadata {
   // Path to parent block. Only set for Delta messages.
   BlockPath parent_block = 2;
 
-  //
-  uint32 width = 3;
+  ElementDimensionSpec element_dimension_spec = 3;
+}
 
-  //
-  uint32 height = 4;
+// Specifies the dimensions for the element
+message ElementDimensionSpec {
+  // width in CSS points
+  uint32 width = 1;
+
+  // height in CSS points
+  uint32 height = 2;
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -61,4 +61,10 @@ message ForwardMsgMetadata {
 
   // Path to parent block. Only set for Delta messages.
   BlockPath parent_block = 2;
+
+  //
+  uint32 width = 3;
+
+  //
+  uint32 height = 4;
 }


### PR DESCRIPTION
This PR proposes to add a width and height parameter to st.dataframe. Protobuf is changed to include an ElementDimensionSpec field to carry this information. This is included as part of the forward message metadata. The message is parsed and height/width information is extracted and passed down to the Dataframe React component in Block.tsx. Width is set in Block.tsx since existing logic applies to a generic element, while height is set in the Dataframe element in some ad hoc logic.