### PR TITLE
Fix WebsocketConnection totalTries count

### DIFF
--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -470,8 +470,32 @@ function doHealthPing(
   xhr.timeout = timeoutMs
 
   xhr.onload = () => {
-    if (xhr.readyState === /* DONE */ 4 && xhr.responseText === 'ok') {
+    if (xhr.responseText === 'ok') {
       resolver.resolve(uriNumber)
+    } else if (xhr.status === /* NO RESPONSE */ 0) {
+      const uri = uriList[uriNumber]
+      if (uri.startsWith('//localhost:')) {
+
+        const scriptname =
+          SessionInfo.isSet() && SessionInfo.current.commandLine.length ?
+            SessionInfo.current.commandLine[0] : 'yourscript.py'
+
+        retry(
+          <Fragment>
+            <p>
+              Is Streamlit still running? If you accidentally stopped
+              Streamlit, just restart it in your terminal:
+            </p>
+            <pre>
+              <code>
+                  $ streamlit run {scriptname}
+              </code>
+            </pre>
+          </Fragment>
+        )
+      } else {
+        retry('Connection failed with status 0.')
+      }
     } else if (xhr.status === 403) {
       retry(
         <Fragment>
@@ -479,51 +503,16 @@ function doHealthPing(
             Cannot connect to Streamlit (HTTP status: 403).
           </p>
           <p>
-            If you are trying to access a Streamlit app running on another server, this could be due to the app's <a
+            If you are trying to access a Streamlit app running on another
+            server, this could be due to the app's <a
               href={CORS_ERROR_MESSAGE_DOCUMENTATION_LINK}>CORS</a> settings.
           </p>
         </Fragment>
       )
     } else {
-      retry('Connected, but response is not "ok" or has bad status.')
-    }
-  }
-
-  xhr.onreadystatechange = () => {
-    if (xhr.readyState === /* DONE */ 4) {
-      if (xhr.responseText === 'ok') {
-        resolver.resolve(uriNumber)
-
-      } else if (xhr.status === /* NO RESPONSE */ 0) {
-        const uri = uriList[uriNumber]
-        if (uri.startsWith('//localhost:')) {
-
-          const scriptname =
-            SessionInfo.isSet() && SessionInfo.current.commandLine.length ?
-              SessionInfo.current.commandLine[0] : 'yourscript.py'
-
-          retry(
-            <Fragment>
-              <p>
-                Is Streamlit still running? If you accidentally stopped
-                Streamlit, just restart it in your terminal:
-              </p>
-              <pre>
-                <code>
-                  $ streamlit run {scriptname}
-                </code>
-              </pre>
-            </Fragment>
-          )
-        } else {
-          retry('Connection failed with status 0.')
-        }
-
-      } else {
-        retry(
-          `Connection failed with status ${xhr.status}, ` +
-          `and response "${xhr.responseText}".`)
-      }
+      retry(
+        `Connection failed with status ${xhr.status}, ` +
+        `and response "${xhr.responseText}".`)
     }
   }
 

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -118,9 +118,6 @@ type Event =
   | 'CONNECTION_SUCCEEDED'
   | 'CONNECTION_TIMED_OUT'
   | 'SERVER_PING_SUCCEEDED'
-  | 'WAIT_TIMER_FIRED'
-  | 'WAIT_TIMER_STARTED'
-
 
 /**
  * This class is the "brother" of StaticConnection. The class connects to the


### PR DESCRIPTION
1. Moved `onreadystatechange`  logics to `onload` event as these two events were overlapping between.
2. Removed unused events
