### PR TITLE
Email, metrics prompt

### DIFF
--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -34,8 +34,6 @@ interface DeltaCounter {
 
 type Event = [string, object]
 
-type SendFunction = (evName: string, evData: object) => void
-
 export class MetricsManager {
   private initialized = false
 
@@ -72,9 +70,12 @@ export class MetricsManager {
     this.actuallySendMetrics = gatherUsageStats
 
     if (this.actuallySendMetrics || IS_SHARED_REPORT) {
-      this.identify(SessionInfo.current.installationId, {
-        authoremail: SessionInfo.current.authorEmail,
-      })
+      // Only record the user's email if they entered a non-empty one.
+      const userTraits: any = {}
+      if (SessionInfo.current.authorEmail !== "") {
+        userTraits["authoremail"] = SessionInfo.current.authorEmail
+      }
+      this.identify(SessionInfo.current.installationId, userTraits)
       this.sendPendingEvents()
     }
 

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -50,8 +50,8 @@ EMAIL_PROMPT = '''
   Email''' % {'welcome': click.style('Welcome to Streamlit!', fg='green')}
 
 TELEMETRY_TEXT = '''
-  Telemetry: as an open source project, we use collect summary
-  statistics and metadata to understand how people are using Streamlit.
+  Telemetry: as an open source project, we collect summary statistics 
+  and metadata to understand how people are using Streamlit.
   
   If you'd like to opt out, add the following to ~/.streamlit/config.toml,
   creating that file if necessary:

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -41,28 +41,28 @@ except NameError:  # pragma: nocover
 
 
 EMAIL_PROMPT = '''
-👋 %(welcome)s
-
-If you are one of our development partners or are interested in
-getting personal technical support, please enter your email address
-below. Otherwise, you may leave the field blank.
-
-Email''' % {'welcome': click.style('Welcome to Streamlit!', fg='green')}
+  👋 %(welcome)s
+  
+  If you are one of our development partners or are interested in
+  getting personal technical support, please enter your email address
+  below. Otherwise, you may leave the field blank.
+  
+  Email''' % {'welcome': click.style('Welcome to Streamlit!', fg='green')}
 
 TELEMETRY_TEXT = '''
-Telemetry: as an open source project, we use collect summary
-statistics and metadata to understand how people are using Streamlit.
-
-If you'd like to opt out, add the following to ~/.streamlit/config.toml,
-creating that file if necessary:
-
-[browser]
-gatherUsageStats = false
+  Telemetry: as an open source project, we use collect summary
+  statistics and metadata to understand how people are using Streamlit.
+  
+  If you'd like to opt out, add the following to ~/.streamlit/config.toml,
+  creating that file if necessary:
+  
+  [browser]
+  gatherUsageStats = false
 '''
 
 INSTRUCTIONS_TEXT = '''
-Get started by typing:
-$ %(hello)s
+  Get started by typing:
+  $ %(hello)s
 ''' % {'hello': click.style('streamlit hello', bold=True)}
 
 
@@ -172,16 +172,15 @@ class Credentials(object):
             while not activated:
 
                 email = click.prompt(
-                    text=textwrap.indent(EMAIL_PROMPT, prefix='  '),
+                    text=EMAIL_PROMPT,
                     default='', show_default=False)
 
                 self.activation = _verify_email(email)
                 if self.activation.is_valid:
                     self.save()
-                    click.secho(textwrap.indent(TELEMETRY_TEXT, prefix='  '))
+                    click.secho(TELEMETRY_TEXT)
                     if show_instructions:
-                        click.secho(
-                            textwrap.indent(INSTRUCTIONS_TEXT, prefix='  '))
+                        click.secho(INSTRUCTIONS_TEXT)
                     activated = True
                 else:  # pragma: nocover
                     LOGGER.error('Please try again.')

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -40,6 +40,32 @@ except NameError:  # pragma: nocover
     FileNotFoundError = IOError
 
 
+EMAIL_PROMPT = '''
+👋 %(welcome)s
+
+If you are one of our development partners or are interested in
+getting personal technical support, please enter your email address
+below. Otherwise, you may leave the field blank.
+
+Email''' % {'welcome': click.style('Welcome to Streamlit!', fg='green')}
+
+TELEMETRY_TEXT = '''
+Telemetry: as an open source project, we use collect summary
+statistics and metadata to understand how people are using Streamlit.
+
+If you'd like to opt out, add the following to ~/.streamlit/config.toml,
+creating that file if necessary:
+
+[browser]
+gatherUsageStats = false
+'''
+
+INSTRUCTIONS_TEXT = '''
+Get started by typing:
+$ %(hello)s
+''' % {'hello': click.style('streamlit hello', bold=True)}
+
+
 class Credentials(object):
     """Credentials class."""
     _singleton = None
@@ -144,31 +170,18 @@ class Credentials(object):
             activated = False
 
             while not activated:
-                email_prompt = textwrap.dedent('''
-                👋 %(welcome)s
-
-                If you are one of our development partners or are interested in
-                getting personal technical support, please enter your email address
-                below. Otherwise, you may leave the field blank.
-
-                Email''' % {
-                    'welcome': click.style('Welcome to Streamlit!', fg='green')
-                })
 
                 email = click.prompt(
-                    text=email_prompt, default='', show_default=False)
+                    text=textwrap.indent(EMAIL_PROMPT, prefix='  '),
+                    default='', show_default=False)
 
                 self.activation = _verify_email(email)
                 if self.activation.is_valid:
                     self.save()
-                    click.secho('')
-                    click.secho('  Welcome to Streamlit!', fg='green')
-                    click.secho('')
+                    click.secho(textwrap.indent(TELEMETRY_TEXT, prefix='  '))
                     if show_instructions:
-                        click.secho('  Get started by typing:')
-                        click.secho('  $ ', nl=False)
-                        click.secho('streamlit hello', bold=True)
-                        click.secho('')
+                        click.secho(
+                            textwrap.indent(INSTRUCTIONS_TEXT, prefix='  '))
                     activated = True
                 else:  # pragma: nocover
                     LOGGER.error('Please try again.')

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -190,25 +190,23 @@ class Credentials(object):
 def _verify_email(email):
     """Verify the user's email address.
 
-    The email can either be an empty string (which gets converted to None),
-    or a string with a single '@' somewhere in it.
+    The email can either be an empty string (if the user chooses not to enter
+    it), or a string with a single '@' somewhere in it.
 
     Parameters
     ----------
-    email : str | None
+    email : str
 
     Returns
     -------
     Activation
         An Activation object. Its 'is_valid' property will be True only if
         the email was validated.
-    """
-    if email is not None:
-        email = email.strip()
-        if len(email) == 0:
-            email = None
 
-    if email is not None and email.count('@') != 1:
+    """
+    email = email.strip()
+
+    if len(email) > 0 and email.count('@') != 1:
         LOGGER.error('That doesn\'t look like an email :(')
         return Activation(None, False)
 

--- a/lib/tests/streamlit/credentials_test.py
+++ b/lib/tests/streamlit/credentials_test.py
@@ -92,12 +92,13 @@ class CredentialsClassTest(unittest.TestCase):
         """Test Credentials.load() with empty email"""
         data = textwrap.dedent('''
             [general]
+            email = ""
         ''').strip()
         m = mock_open(read_data=data)
         with patch('streamlit.credentials.open', m, create=True):
             c = Credentials.get_current()
             c.load()
-            self.assertEqual(None, c.activation.email)
+            self.assertEqual('', c.activation.email)
 
     @patch('streamlit.credentials.util.get_streamlit_file_path', mock_get_path)
     def test_Credentials_load_twice(self):
@@ -259,6 +260,4 @@ class CredentialsModulesTest(unittest.TestCase):
         """Test _verify_email."""
         self.assertTrue(_verify_email('user@domain.com').is_valid)
         self.assertTrue(_verify_email('').is_valid)
-        self.assertTrue(_verify_email(None).is_valid)
-
         self.assertFalse(_verify_email('missing_at_sign').is_valid)


### PR DESCRIPTION
- Nicer `streamlit activate` prompt and text from @tvst
- Remove the unused "activation code" stuff from Credentials.
- Credentials: email is now optional. If the user doesn't enter one, it will be stored as the empty string. The client will omit the "authoremail" trait from the Segment.io identifier if the user didn't enter an email.

Fixes #63 