### PR TITLE
Sidebar z-index bug

### DIFF
--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -23,11 +23,13 @@ import { Client as Styletron } from "styletron-engine-atomic"
 import { Provider as StyletronProvider } from "styletron-react"
 import { LightTheme, BaseProvider } from "baseui"
 
+import { SCSS_VARS } from "autogen/scssVariables"
+
 const engine = new Styletron()
 
 ReactDOM.render(
   <StyletronProvider value={engine}>
-    <BaseProvider theme={LightTheme} zIndex={102}>
+    <BaseProvider theme={LightTheme} zIndex={SCSS_VARS["$z-index-popup-menu"]}>
       <App />
     </BaseProvider>
   </StyletronProvider>,

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -27,7 +27,7 @@ const engine = new Styletron()
 
 ReactDOM.render(
   <StyletronProvider value={engine}>
-    <BaseProvider theme={LightTheme}>
+    <BaseProvider theme={LightTheme} zIndex={102}>
       <App />
     </BaseProvider>
   </StyletronProvider>,


### PR DESCRIPTION
Set z-index of BaseUI component layers to the z-index of Vega Lite popups