### PR TITLE
Adding `streamlit run` by url

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -58,6 +58,7 @@ toml = "*"
 # 6.0 doesn't support Python 2
 tornado = ">=5.0,<6.0"
 tzlocal = "*"
+validators = "*"
 watchdog = "*"
 
 # Only Python 3.x packages

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -127,20 +127,21 @@ def main_run(file_or_url, args):
     if url(file_or_url):
         import tempfile
         import requests
+
         with tempfile.NamedTemporaryFile() as fp:
             try:
                 resp = requests.get(file_or_url)
                 resp.raise_for_status()
                 fp.write(resp.content)
             except requests.exceptions.RequestException as e:
-                raise click.BadParameter(("Unable to fetch {}.\n{}"
-                                          .format(file_or_url, e)))
+                raise click.BadParameter(
+                    ("Unable to fetch {}.\n{}".format(file_or_url, e))
+                )
             _main_run(fp.name, args)
 
     else:
         if not os.path.exists(file_or_url):
-            raise click.BadParameter("File does not exist: {}"
-                                     .format(file_or_url))
+            raise click.BadParameter("File does not exist: {}".format(file_or_url))
         _main_run(file_or_url, args)
 
 

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -133,11 +133,14 @@ def main_run(file_or_url, args):
                 resp = requests.get(file_or_url)
                 resp.raise_for_status()
                 fp.write(resp.content)
+                # flush since we are reading the file within the with block
                 fp.flush()
             except requests.exceptions.RequestException as e:
                 raise click.BadParameter(
                     ("Unable to fetch {}.\n{}".format(file_or_url, e))
                 )
+            # this is called within the with block to make sure the temp file
+            # is not deleted
             _main_run(fp.name, args)
 
     else:

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -133,6 +133,7 @@ def main_run(file_or_url, args):
                 resp = requests.get(file_or_url)
                 resp.raise_for_status()
                 fp.write(resp.content)
+                fp.flush()
             except requests.exceptions.RequestException as e:
                 raise click.BadParameter(
                     ("Unable to fetch {}.\n{}".format(file_or_url, e))

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -23,6 +23,7 @@ from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
+import os
 import click
 
 from streamlit.credentials import Credentials
@@ -113,11 +114,35 @@ def main_hello():
 
 
 @main.command("run")
-@click.argument("file", type=click.Path(exists=True))
+@click.argument("file_or_url", required=True)
 @click.argument("args", nargs=-1)
-def main_run(file, args):
-    """Run a Python script, piping stderr to Streamlit."""
-    _main_run(file, args)
+def main_run(file_or_url, args):
+    """Run a Python script, piping stderr to Streamlit.
+    The script can be local or it can be an url. In the
+    latter case, streamlit will download the script to a
+    temporary file and runs this file.
+    """
+    from validators import url
+    import tempfile
+    import requests
+
+    if url(file_or_url):
+        with tempfile.NamedTemporaryFile() as fp:
+            try:
+                resp = requests.get(file_or_url)
+                resp.raise_for_status()
+                fp.write(resp.content)
+            except requests.exceptions.RequestException as e:
+                raise click.BadParameter(("Streamlit failed to fetch the url "
+                                          "{} and an exception was raised: {}"
+                                          .format(file_or_url, e)))
+            file = fp.name
+            _main_run(file, args)
+    else:
+        if not os.path.exists(file_or_url):
+            raise click.BadParameter("File does not exist: {}"
+                                     .format(file_or_url))
+        _main_run(file_or_url, args)
 
 
 def _main_run(file, args=None):

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -123,21 +123,20 @@ def main_run(file_or_url, args):
     temporary file and runs this file.
     """
     from validators import url
-    import tempfile
-    import requests
 
     if url(file_or_url):
+        import tempfile
+        import requests
         with tempfile.NamedTemporaryFile() as fp:
             try:
                 resp = requests.get(file_or_url)
                 resp.raise_for_status()
                 fp.write(resp.content)
             except requests.exceptions.RequestException as e:
-                raise click.BadParameter(("Streamlit failed to fetch the url "
-                                          "{} and an exception was raised: {}"
+                raise click.BadParameter(("Unable to fetch {}.\n{}"
                                           .format(file_or_url, e)))
-            file = fp.name
-            _main_run(file, args)
+            _main_run(fp.name, args)
+
     else:
         if not os.path.exists(file_or_url):
             raise click.BadParameter("File does not exist: {}"

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the cli."""
+
+import unittest
+from click.testing import CliRunner
+
+import tempfile
+
+from streamlit import cli
+
+
+class CliTest(unittest.TestCase):
+    """Unit tests for the cli."""
+
+    def test_help(self):
+        """streamlit help should show the expected help text"""
+        expected_help = """Usage: _jb_pytest_runner.py [OPTIONS] COMMAND [ARGS]...
+
+  Try out a demo with:
+
+      $ streamlit hello
+
+  Or use the line below to run your own script:
+
+      $ streamlit run your_script.py
+
+Options:
+  --log_level [error|warning|info|debug]
+  --version                       Show the version and exit.
+  --help                          Show this message and exit.
+
+Commands:
+  activate  Activate Streamlit by entering your email.
+  cache     Manage the Streamlit cache.
+  config    Manage Streamlit's config settings.
+  docs      Show help in browser.
+  hello     Runs the Hello World script.
+  help      Print this help message.
+  run       Run a Python script, piping stderr to Streamlit.
+  version   Print Streamlit's version number.
+"""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['help'])
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(expected_help, result.output)
+
+    def test_run_no_arguments(self):
+        """streamlit run should fail if run with no arguments"""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['run'])
+        self.assertNotEqual(0, result.exit_code)
+
+    def test_run_existing_file_argument(self):
+        """streamlit run succeeds if an existing file is passed"""
+        runner = CliRunner()
+
+        # Mocking _main_run
+        cli._main_run = lambda arg1, args2: None
+
+        with tempfile.NamedTemporaryFile() as file:
+            result = runner.invoke(cli, ['run', file.name])
+        self.assertEqual(0, result.exit_code)
+
+    def test_run_non_existing_file_argument(self):
+        """streamlit run should fail if a non existing file is passed"""
+        runner = CliRunner()
+
+        # Mocking _main_run
+        cli._main_run = lambda arg1, args2: None
+
+        result = runner.invoke(cli, ['run', '/non-existing-streamlit-script'])
+        self.assertNotEqual(0, result.exit_code)
+
+    def test_run_valid_url(self):
+        """streamlit run succeeds if an existing url is passed"""
+        runner = CliRunner()
+
+        # Mocking _main_run
+        cli._main_run = lambda arg1, args2: None
+
+        result = runner.invoke(cli, ['run', 'http://www.cnn.com'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_run_non_valid_url(self):
+        """streamlit run should fail if a non valid url is passed"""
+        runner = CliRunner()
+
+        # Mocking _main_run
+        cli._main_run = lambda arg1, args2: None
+
+        result = runner.invoke(cli, ['run', 'odd_protocol://www.cnn.com'])
+        self.assertNotEqual(0, result.exit_code)
+
+    def test_run_non_existing_url(self):
+        """streamlit run should fail if a non existing but valid
+         url is passed
+         """
+        runner = CliRunner()
+
+        # Mocking _main_run
+        cli._main_run = lambda arg1, args2: None
+
+        result = runner.invoke(cli, [
+            'run',
+            'http://www.cnn.com/some-cnn-streamlit-script'
+        ])
+        self.assertNotEqual(0, result.exit_code)

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -16,7 +16,7 @@
 """Unit tests for the cli."""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from mock import MagicMock, patch
 from click.testing import CliRunner
 
 import requests

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -16,7 +16,7 @@
 """Unit tests for the cli."""
 
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 import requests

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -27,6 +27,10 @@ from streamlit import cli
 class CliTest(unittest.TestCase):
     """Unit tests for the cli."""
 
+    def setUp(self):
+        cli.name = 'test'
+        self.runner = CliRunner()
+
     def test_help(self):
         """streamlit help should show the expected help text"""
         expected_help = """Usage: _jb_pytest_runner.py [OPTIONS] COMMAND [ARGS]...
@@ -54,68 +58,56 @@ Commands:
   run       Run a Python script, piping stderr to Streamlit.
   version   Print Streamlit's version number.
 """
-        runner = CliRunner()
-        result = runner.invoke(cli, ['help'])
+        result = self.runner.invoke(cli, ['help'])
         self.assertEqual(0, result.exit_code)
         self.assertEqual(expected_help, result.output)
 
     def test_run_no_arguments(self):
         """streamlit run should fail if run with no arguments"""
-        runner = CliRunner()
-        result = runner.invoke(cli, ['run'])
+        result = self.runner.invoke(cli, ['run'])
         self.assertNotEqual(0, result.exit_code)
 
     def test_run_existing_file_argument(self):
         """streamlit run succeeds if an existing file is passed"""
-        runner = CliRunner()
-
         # Mocking _main_run
         cli._main_run = MagicMock()
 
         with tempfile.NamedTemporaryFile() as file:
-            result = runner.invoke(cli, ['run', file.name])
+            result = self.runner.invoke(cli, ['run', file.name])
         self.assertEqual(0, result.exit_code)
 
     def test_run_non_existing_file_argument(self):
         """streamlit run should fail if a non existing file is passed"""
-        runner = CliRunner()
-
         # Mocking _main_run
         cli._main_run = MagicMock()
 
-        result = runner.invoke(cli, ['run', '/non-existing-streamlit-script'])
+        result = self.runner.invoke(cli, ['run', '/non-existing-streamlit-script'])
         self.assertNotEqual(0, result.exit_code)
 
     def test_run_valid_url(self):
         """streamlit run succeeds if an existing url is passed"""
-        runner = CliRunner()
-
         # Mocking _main_run
         cli._main_run = MagicMock()
 
-        result = runner.invoke(cli, ['run', 'http://www.cnn.com'])
+        result = self.runner.invoke(cli, ['run', 'http://www.cnn.com'])
         self.assertEqual(0, result.exit_code)
 
     def test_run_non_valid_url(self):
         """streamlit run should fail if a non valid url is passed"""
-        runner = CliRunner()
-
         # Mocking _main_run
         cli._main_run = MagicMock()
 
-        result = runner.invoke(cli, ['run', 'odd_protocol://www.cnn.com'])
+        result = self.runner.invoke(cli, ['run', 'odd_protocol://www.cnn.com'])
         self.assertNotEqual(0, result.exit_code)
 
     def test_run_non_existing_url(self):
         """streamlit run should fail if a non existing but valid
          url is passed
          """
-        runner = CliRunner()
-
         # Mocking _main_run
         cli._main_run = MagicMock()
 
-        result = runner.invoke(cli, [
+        result = self.runner.invoke(cli, [
             'run',
             'http://www.cnn.com/some-cnn-streamlit-script'
         ])

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -16,6 +16,7 @@
 """Unit tests for the cli."""
 
 import unittest
+from unittest.mock import MagicMock
 from click.testing import CliRunner
 
 import tempfile
@@ -69,7 +70,7 @@ Commands:
         runner = CliRunner()
 
         # Mocking _main_run
-        cli._main_run = lambda arg1, args2: None
+        cli._main_run = MagicMock()
 
         with tempfile.NamedTemporaryFile() as file:
             result = runner.invoke(cli, ['run', file.name])
@@ -80,7 +81,7 @@ Commands:
         runner = CliRunner()
 
         # Mocking _main_run
-        cli._main_run = lambda arg1, args2: None
+        cli._main_run = MagicMock()
 
         result = runner.invoke(cli, ['run', '/non-existing-streamlit-script'])
         self.assertNotEqual(0, result.exit_code)
@@ -90,7 +91,7 @@ Commands:
         runner = CliRunner()
 
         # Mocking _main_run
-        cli._main_run = lambda arg1, args2: None
+        cli._main_run = MagicMock()
 
         result = runner.invoke(cli, ['run', 'http://www.cnn.com'])
         self.assertEqual(0, result.exit_code)
@@ -100,7 +101,7 @@ Commands:
         runner = CliRunner()
 
         # Mocking _main_run
-        cli._main_run = lambda arg1, args2: None
+        cli._main_run = MagicMock()
 
         result = runner.invoke(cli, ['run', 'odd_protocol://www.cnn.com'])
         self.assertNotEqual(0, result.exit_code)
@@ -112,7 +113,7 @@ Commands:
         runner = CliRunner()
 
         # Mocking _main_run
-        cli._main_run = lambda arg1, args2: None
+        cli._main_run = MagicMock()
 
         result = runner.invoke(cli, [
             'run',


### PR DESCRIPTION
We want to support `streamlit run <url>`

This PR adds support for this usage of the `run` command. 
- Added logic to recognize a url - we use `validators.url` for this. `http://somethign` is a url. `something` is not
- Moved file validation from click to custom logic, since the first argument of `run` is now overloaded and can be file or url
- Added cli unit tests