### PR TITLE
Fix bug where message is not initialized in the spinner code

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -433,11 +433,12 @@ def spinner(text='In progress...'):
 
     """
     display_message_lock = None
+    message = empty()
+
     try:
         # Set the message 0.1 seconds in the future to avoid annoying
         # flickering if this spinner runs too quickly.
         DELAY_SECS = 0.1
-        message = empty()  # noqa: F821
         display_message = True
         display_message_lock = _threading.Lock()
 


### PR DESCRIPTION
This is a fix for https://github.com/streamlit/streamlit/issues/53

As we said, we will leave the issue open until we have confidence the bug is not showing up anymore