### PR TITLE
Fix hashing if the object has a name but the name is not a string.

### DIFF
--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -251,7 +251,8 @@ class CodeHasher:
         elif inspect.isbuiltin(obj):
             return self.to_bytes(obj.__name__)
         elif hasattr(obj, "name") and (
-            isinstance(obj, io.IOBase) or os.path.exists(obj.name)
+            isinstance(obj, io.IOBase) or
+            (isinstance(obj.name, string_types) and os.path.exists(obj.name))
         ):
             # Hash files as name + last modification date + offset.
             h = hashlib.new(self.name)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -230,6 +230,9 @@ class CodeHasher:
             return b"bool:1"
         elif obj is False:
             return b"bool:0"
+        elif util.is_type(obj, "pandas.core.frame.Series"):
+            import pandas as pd
+            return pd.util.hash_pandas_object(obj).sum()
         elif util.is_type(obj, "pandas.core.frame.DataFrame"):
             import pandas as pd
 

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -69,13 +69,21 @@ class HashTest(unittest.TestCase):
         self.assertEqual(get_hash(abs), get_hash(abs))
         self.assertNotEqual(get_hash(abs), get_hash(type))
 
-    def test_pandas(self):
+    def test_pandas_dataframe(self):
         df1 = pd.DataFrame({"foo": [12]})
         df2 = pd.DataFrame({"foo": [42]})
         df3 = pd.DataFrame({"foo": [12]})
 
         self.assertEqual(get_hash(df1), get_hash(df3))
         self.assertNotEqual(get_hash(df1), get_hash(df2))
+
+    def test_pandas_series(self):
+        series1 = pd.Series([1, 2])
+        series2 = pd.Series([1, 3])
+        series3 = pd.Series([1, 2])
+
+        self.assertEqual(get_hash(series1), get_hash(series3))
+        self.assertNotEqual(get_hash(series1), get_hash(series2))
 
     def test_numpy(self):
         np1 = np.zeros(10)


### PR DESCRIPTION
Fixes #115 