### PR TITLE
Updates to LP and sidebar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,9 @@
   :maxdepth: 2
   :hidden:
 
+  GitHub <https://github.com/streamlit/streamlit>
+  Community forum < https://discuss.streamlit.io/>
   troubleshooting
-  Slack <https://streamlit.slack.com/messages/CG5K38YMT/>
 
 ```
 
@@ -34,49 +35,26 @@ Getting started is easy. Install Streamlit, import it, write some code, and run 
 
 Follow these steps and you'll have a sample report running in less than 5 minutes.
 
-1. Before you do anything, you'll need to make sure that you have [Python 2.7.0 or later / Python 3.6.x or later](https://www.python.org/downloads/).
-2. Install Streamlit using [PIP](https://pip.pypa.io/en/stable/installing/) or [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/):
-
-    **PIP**
+1. Before you do anything else, make sure that you have [Python 2.7.0 or later / Python 3.6.x or later](https://www.python.org/downloads/).
+2. Install Streamlit using [PIP](https://pip.pypa.io/en/stable/installing/):
    ```bash
    $ pip install streamlit
    ```
-
-   **Conda**
-
-   ```bash
-   # Add required channels.
-   $ conda config --add channels conda-forge
-   $ conda config --add channels https://repo.streamlit.io/streamlit-forge
-
-   # Update conda (always a good idea)
-   $ conda update conda
-
-   # Install Streamlit!
-   $ conda install streamlit
-   ```
-
-3. Run the hello world script from terminal:
+3. Run the hello world app:
 
    ```bash
    $ streamlit hello
    ```
-4. That's it! In the next few seconds the sample report will open in a new tab in your default browser.
+4. That's it! In the next few seconds the sample app will open in a new tab in your default browser.
 
 ## Get started
 
 The easiest way to learn how to use Streamlit is to try it out. Use our [get started guide](getting_started.md) to kick the tires, and learn the basics of building a report.
 
-## Build your first interactive report
+## Build your first app
 
-If you've got the basics covered, the next step is to [create an interactive report](tutorial/create_an_interactive_report.md) from scratch. When you're finished, you'll know how to fetch
-and cache data, draw charts, plot information on a map, and use interactive widgets, like sliders and checkboxes, to filter results.
+[Create an app](tutorial/create_an_interactive_report.md) to explore an Uber dataset for pickups in New York City. You'll learn about caching, drawing charts, plotting data on a map, and how to use interactive widgets.
 
-## Some helpful links
+## Join the community
 
-The left-hand navigation is the best way to move around our docs site, but we think these articles are important enough to list more than once:
-
-* [Tutorials](tutorial/index.md)
-* [API reference](api.md)
-* [Troubleshooting guide](troubleshooting.md)
-* [Slack support channel](https://streamlit.slack.com/messages/CG5K38YMT/)
+The quickest way to get help is to reach out on our [community forum](https://discuss.streamlit.io/). We'd love to hear your questions, ideas, and bugs - please share!


### PR DESCRIPTION
@tvst + @kellyamanda - This PR covers two things: 
* Updates to the Landing Page per Amanda's doc
* Updates to the Support section of the sidebar
  * Added link to GitHub
  * Added link to Community forum
  * Removed Slack

### Open questions:
* Do we want to rename the interactive report tutorial. If yes, we should update the filename as well. 
* I know that we want to change report to app throughout the docs. I did a global search on the repo, this also contains references in code and the API reference, but there are ~986 instances of the word report. How do we want to address this? It's not going to be as easy as a global find and replace. Should we start by targeting the docs? Maybe: 
  * P0 - Documentation (Concepts)
  * P1 - API Ref
  * P2 - Code comments