### PR TITLE
Magic fixes

### DIFF
--- a/examples/magic.py
+++ b/examples/magic.py
@@ -1,18 +1,16 @@
 import asyncio
-from contextlib import contextmanager
+import contextlib
 
 import streamlit as st
 
-@contextmanager
-def noop_context_mgr():
-    yield
+async_loop = asyncio.new_event_loop()
 
 
 magic = None
 def prep_magic(name):
     global magic
-    magic = name
-    st.code('Should print "%s":' % magic)
+    magic = "_%s_" % name
+    st.markdown('**%s** expected:' % name)
 
 
 prep_magic("no block")
@@ -46,7 +44,13 @@ while ii < 1:
     ii += 1
 
 prep_magic("WITH block")
-with noop_context_mgr():
+@contextlib.contextmanager
+def context_mgr():
+    try:
+        yield
+    finally:
+        pass
+with context_mgr():
     magic
 
 prep_magic("TRY block")
@@ -55,17 +59,47 @@ try:
 except:
     raise
 
-prep_magic("SYNC func")
-def noop_func():
+prep_magic("EXCEPT block")
+try:
+    raise RuntimeError("shenanigans!")
+except RuntimeError:
     magic
 
-noop_func()
-
-prep_magic("ASYNC func")
-async def noop_async_func():
+prep_magic("FINALLY block")
+try:
+    pass
+finally:
     magic
 
-loop = asyncio.new_event_loop()
-loop.run_until_complete(noop_async_func())
+prep_magic("FUNCTION block")
+def func():
+    magic
+func()
+
+prep_magic("ASYNC FUNCTION block")
+async def async_func():
+    magic
+async_loop.run_until_complete(async_func())
+
+prep_magic("ASYNC FOR block")
+async def async_for():
+    async def async_iter():
+        yield
+
+    async for _ in async_iter():
+        magic
+async_loop.run_until_complete(async_for())
+
+prep_magic("ASYNC WITH block")
+async def async_with():
+    @contextlib.asynccontextmanager
+    async def async_context_mgr():
+        try:
+            yield
+        finally:
+            pass
+    async with async_context_mgr():
+        magic
+async_loop.run_until_complete(async_with())
 
 st.info('done')

--- a/examples/magic.py
+++ b/examples/magic.py
@@ -1,0 +1,71 @@
+import asyncio
+from contextlib import contextmanager
+
+import streamlit as st
+
+@contextmanager
+def noop_context_mgr():
+    yield
+
+
+magic = None
+def prep_magic(name):
+    global magic
+    magic = name
+    st.code('Should print "%s":' % magic)
+
+
+prep_magic("no block")
+magic
+
+prep_magic("IF block")
+if True:
+    magic
+
+prep_magic("ELIF block")
+if False:
+    pass
+elif True:
+    magic
+
+prep_magic("ELSE block")
+if False:
+    pass
+else:
+    magic
+
+
+prep_magic("FOR block")
+for ii in range(1):
+    magic
+
+prep_magic("WHILE block")
+ii = 0
+while ii < 1:
+    magic
+    ii += 1
+
+prep_magic("WITH block")
+with noop_context_mgr():
+    magic
+
+prep_magic("TRY block")
+try:
+    magic
+except:
+    raise
+
+prep_magic("SYNC func")
+def noop_func():
+    magic
+
+noop_func()
+
+prep_magic("ASYNC func")
+async def noop_async_func():
+    magic
+
+loop = asyncio.new_event_loop()
+loop.run_until_complete(noop_async_func())
+
+st.info('done')

--- a/examples/magic.py
+++ b/examples/magic.py
@@ -7,10 +7,12 @@ async_loop = asyncio.new_event_loop()
 
 
 magic = None
+
+
 def prep_magic(name):
     global magic
     magic = "_%s_" % name
-    st.markdown('**%s** expected:' % name)
+    st.markdown("**%s** expected:" % name)
 
 
 prep_magic("no block")
@@ -44,12 +46,16 @@ while ii < 1:
     ii += 1
 
 prep_magic("WITH block")
+
+
 @contextlib.contextmanager
 def context_mgr():
     try:
         yield
     finally:
         pass
+
+
 with context_mgr():
     magic
 
@@ -72,25 +78,39 @@ finally:
     magic
 
 prep_magic("FUNCTION block")
+
+
 def func():
     magic
+
+
 func()
 
 prep_magic("ASYNC FUNCTION block")
+
+
 async def async_func():
     magic
+
+
 async_loop.run_until_complete(async_func())
 
 prep_magic("ASYNC FOR block")
+
+
 async def async_for():
     async def async_iter():
         yield
 
     async for _ in async_iter():
         magic
+
+
 async_loop.run_until_complete(async_for())
 
 prep_magic("ASYNC WITH block")
+
+
 async def async_with():
     @contextlib.asynccontextmanager
     async def async_context_mgr():
@@ -98,8 +118,11 @@ async def async_with():
             yield
         finally:
             pass
+
     async with async_context_mgr():
         magic
+
+
 async_loop.run_until_complete(async_with())
 
-st.info('done')
+st.info("done")

--- a/lib/streamlit/magic.py
+++ b/lib/streamlit/magic.py
@@ -73,7 +73,7 @@ def _modify_ast_subtree(tree, body_attr="body", is_root=False):
             _modify_ast_subtree(node)
             _modify_ast_subtree(node, "orelse")
 
-        # Convert expression nodes to st.write
+        # Convert standalone expression nodes to st.write
         elif node_type is ast.Expr:
             value = _get_st_write_from_expr(node, i, parent_type=type(tree))
             if value is not None:
@@ -144,6 +144,10 @@ def _get_st_write_from_expr(node, i, parent_type):
         and type(node.value) is ast.Str
         and parent_type in (ast.FunctionDef, ast.Module)
     ):
+        return None
+
+    # Don't change yield nodes
+    if type(node.value) is ast.Yield or type(node.value) is ast.YieldFrom:
         return None
 
     # If tuple, call st.write on the 0th element (rather than the

--- a/lib/streamlit/magic.py
+++ b/lib/streamlit/magic.py
@@ -53,6 +53,7 @@ def _modify_ast_subtree(tree, body_attr="body", is_root=False):
             node_type is ast.FunctionDef
             or node_type is ast.With
             or node_type is ast.For
+            or node_type is ast.While
         ):
             _modify_ast_subtree(node)
 

--- a/lib/streamlit/magic.py
+++ b/lib/streamlit/magic.py
@@ -54,6 +54,9 @@ def _modify_ast_subtree(tree, body_attr="body", is_root=False):
             or node_type is ast.With
             or node_type is ast.For
             or node_type is ast.While
+            or node_type is ast.AsyncFunctionDef
+            or node_type is ast.AsyncWith
+            or node_type is ast.AsyncFor
         ):
             _modify_ast_subtree(node)
 

--- a/lib/tests/streamlit/magic_test.py
+++ b/lib/tests/streamlit/magic_test.py
@@ -43,9 +43,9 @@ class MagicTest(unittest.TestCase):
             if type(node) is ast.Call and "streamlit" in ast.dump(node.func):
                 count += 1
         self.assertEqual(
-            count,
             expected_count,
-            ("There must be at least {} streamlit nodes," "but found {}").format(
+            count,
+            ("There must be exactly {} streamlit nodes, but found {}").format(
                 expected_count, count
             ),
         )
@@ -122,3 +122,54 @@ with None:
     a
 """
         self._testCode(CODE_WITH_STATEMENT, 1)
+
+    def test_while_statement(self):
+        """Test that 'yield' expressions do not get magicked"""
+        CODE_WHILE_STATEMENT = """
+a = 10
+while True:
+    a
+"""
+        self._testCode(CODE_WHILE_STATEMENT, 1)
+
+    def test_yield_statement(self):
+        """Test that 'yield' expressions do not get magicked"""
+        CODE_YIELD_STATEMENT = """
+def yield_func():
+    yield
+"""
+        self._testCode(CODE_YIELD_STATEMENT, 0)
+
+    def test_yield_from_statement(self):
+        """Test that 'yield from' expressions do not get magicked"""
+        CODE_YIELD_FROM_STATEMENT = """
+def yield_func():
+    yield from None
+"""
+        self._testCode(CODE_YIELD_FROM_STATEMENT, 0)
+
+    def test_async_function_statement(self):
+        """Test with async function definitions"""
+        CODE_ASYNC_FUNCTION = """
+async def myfunc(a):
+    a
+"""
+        self._testCode(CODE_ASYNC_FUNCTION, 1)
+
+    def test_async_with_statement(self):
+        """Test with async function definitions"""
+        CODE_ASYNC_WITH = """
+async def myfunc(a):
+    async with None:
+        a
+"""
+        self._testCode(CODE_ASYNC_WITH, 1)
+
+    def test_async_for_statement(self):
+        """Test with async function definitions"""
+        CODE_ASYNC_FOR = """
+async def myfunc(a):
+    async for _ in None:
+        a
+"""
+        self._testCode(CODE_ASYNC_FOR, 1)

--- a/lib/tests/streamlit/magic_test.py
+++ b/lib/tests/streamlit/magic_test.py
@@ -149,7 +149,7 @@ def yield_func():
         self._testCode(CODE_YIELD_FROM_STATEMENT, 0)
 
     def test_async_function_statement(self):
-        """Test with async function definitions"""
+        """Test async function definitions"""
         CODE_ASYNC_FUNCTION = """
 async def myfunc(a):
     a
@@ -157,7 +157,7 @@ async def myfunc(a):
         self._testCode(CODE_ASYNC_FUNCTION, 1)
 
     def test_async_with_statement(self):
-        """Test with async function definitions"""
+        """Test 'async with' statements"""
         CODE_ASYNC_WITH = """
 async def myfunc(a):
     async with None:
@@ -166,7 +166,7 @@ async def myfunc(a):
         self._testCode(CODE_ASYNC_WITH, 1)
 
     def test_async_for_statement(self):
-        """Test with async function definitions"""
+        """Test 'async for' statements"""
         CODE_ASYNC_FOR = """
 async def myfunc(a):
     async for _ in None:


### PR DESCRIPTION
- Magic supports `while`, `async with`, `async for` statements, and async functions
- Ignore `yield` and `yield from` statements (these were previously being magicked, which resulted in random-seeming "None" values being st.written to the report).
- I also created an `examples/magic.py` file for easy visual testing of these things, which I used while debugging. (The magic unit tests also verify these fixes.)

Fixes #135 