### PR TITLE
Rotate server port if current one is taken

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -88,11 +88,14 @@ class State(Enum):
     STOPPING = "STOPPING"
     STOPPED = "STOPPED"
 
+
 class ExceededRetries(Exception):
     pass
 
+
 def server_port_is_manually_set():
     return config.is_manually_set("server.port")
+
 
 def start_listening(app, call_count=0):
     """makes the server start listening at the configured port.
@@ -104,11 +107,12 @@ def start_listening(app, call_count=0):
     except OSError as e:
         if e.errno == errno.EADDRINUSE:
             if call_count >= 100:
-                raise ExceededRetries("Port %s already in use, were unable to find a free port after a hundred attempts", port)
-            if server_port_is_manually_set():
-                LOGGER.debug(
-                    "Port %s already in use, trying to use the next one", port
+                raise ExceededRetries(
+                    "Port %s already in use, were unable to find a free port after a hundred attempts",
+                    port,
                 )
+            if server_port_is_manually_set():
+                LOGGER.debug("Port %s already in use, trying to use the next one", port)
                 port += 1
                 # save port 3000 because it is used for the development server in the front end
                 if port == 3000:
@@ -121,6 +125,7 @@ def start_listening(app, call_count=0):
                 sys.exit(signal.NSIG)
         else:
             raise
+
 
 class Server(object):
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -63,6 +63,7 @@ PREHEATED_REPORT_SESSION = "PREHEATED_REPORT_SESSION"
 # up to MAX_PORT_SEARCH_RETRIES.
 MAX_PORT_SEARCH_RETRIES = 100
 
+
 class SessionInfo(object):
     """Type stored in our _report_sessions dict.
 
@@ -114,14 +115,17 @@ def start_listening(app, call_count=0):
         if e.errno == errno.EADDRINUSE:
             if call_count >= MAX_PORT_SEARCH_RETRIES:
                 raise RetriesExceeded(
-                    "Cannot start Streamlit server. Port %(port)s is already in use, and Streamlit was unable to find a free port after $(num_retries) attempts.",
-                    {"port": port, "num_retries": MAX_PORT_SEARCH_RETRIES}
+                    "Cannot start Streamlit server. Port %s is already in use, and Streamlit was unable to find a free port after %s attempts.",
+                    port,
+                    MAX_PORT_SEARCH_RETRIES,
                 )
             if server_port_is_manually_set():
                 LOGGER.error("Port %s is already in use", port)
                 sys.exit(1)
             else:
-                LOGGER.debug("Port %s already in use, trying to use the next one.", port)
+                LOGGER.debug(
+                    "Port %s already in use, trying to use the next one.", port
+                )
                 port += 1
                 # Save port 3000 because it is used for the development server in the front end.
                 if port == 3000:

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -157,11 +157,10 @@ class Server(object):
                             "Port %s already in use, trying next available one", port
                         )
                         port += 1
-                        if port == 3000: port += 1 # save the 3000
-                        config._set_option(
-                            "server.port", port, "server initialization"
-                        )
-                        start_listening(call_count+1)
+                        if port == 3000:
+                            port += 1  # save the 3000
+                        config._set_option("server.port", port, "server initialization")
+                        start_listening(call_count + 1)
                     else:
                         LOGGER.error("Port %s is already in use", port)
                         sys.exit(signal.NSIG)

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -15,6 +15,8 @@
 
 import logging
 import threading
+import sys
+import signal
 from enum import Enum
 
 import tornado.concurrent
@@ -143,21 +145,29 @@ class Server(object):
         LOGGER.debug("Starting server...")
         app = self._create_app()
 
+        class PortAlradyInUse(Exception):
+            pass
+
         def start_listening(rotate=True):
             port = config.get_option("server.port")
             try:
                 app.listen(port)
             except OSError as e:
                 ADDRESS_ALREADY_IN_USE = 48
-                if config.is_manually_set("server.port"):
-                    raise
-                if e.errno == ADDRESS_ALREADY_IN_USE :
-                    LOGGER.debug("Port %s already in use, trying next available one", port)
-                    next_port = port + 1
-                    if next_port == 3000:
-                        next_port = next_port + 1
-                    config._set_option("server.port", next_port, "server initialization")
-                    start_listening()
+                if e.errno == ADDRESS_ALREADY_IN_USE:
+                    if config.is_manually_set("server.port"):
+                        LOGGER.debug(
+                            "Port %s already in use, trying next available one", port
+                        )
+                        port += 1
+                        if port == 3000: port += 1 # save the 3000
+                        config._set_option(
+                            "server.port", port, "server initialization"
+                        )
+                        start_listening()
+                    else:
+                        LOGGER.error("Port %s is already in use", port)
+                        sys.exit(signal.NSIG)
 
         start_listening()
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -88,6 +88,12 @@ class State(Enum):
     STOPPING = "STOPPING"
     STOPPED = "STOPPED"
 
+class ExceededRetries(Exception):
+    pass
+
+def server_port_is_manually_set():
+    return config.is_manually_set("server.port")
+
 def start_listening(app, call_count=0):
     """makes the server start listening at the configured port.
     In case the port is already taken it tries listening to the next available port.
@@ -98,10 +104,10 @@ def start_listening(app, call_count=0):
     except OSError as e:
         if e.errno == errno.EADDRINUSE:
             if call_count >= 100:
-                raise Exception("Port %s already in use, were unable to find a free port after a hundred attempts", port)
-            if config.is_manually_set("server.port"):
+                raise ExceededRetries("Port %s already in use, were unable to find a free port after a hundred attempts", port)
+            if server_port_is_manually_set():
                 LOGGER.debug(
-                    "Port %s already in use, trying next available one", port
+                    "Port %s already in use, trying to use the next one", port
                 )
                 port += 1
                 # save port 3000 because it is used for the development server in the front end

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -48,6 +48,7 @@ from streamlit.server.server_util import serialize_forward_msg
 from tests.ServerTestCase import ServerTestCase
 
 from streamlit.logger import get_logger
+
 LOGGER = get_logger(__name__)
 
 def _create_dataframe_msg(df, id=1):
@@ -348,9 +349,11 @@ class PortRotateOneTest(unittest.TestCase):
 
         return app
 
-    @mock.patch('streamlit.server.Server.config._set_option')
-    @mock.patch('streamlit.server.Server.server_port_is_manually_set')
-    def test_rotates_one_port(self, patched_server_port_is_manually_set, patched__set_option):
+    @mock.patch("streamlit.server.Server.config._set_option")
+    @mock.patch("streamlit.server.Server.server_port_is_manually_set")
+    def test_rotates_one_port(
+        self, patched_server_port_is_manually_set, patched__set_option
+    ):
         app = self.get_app()
 
         patched_server_port_is_manually_set.return_value = True
@@ -359,7 +362,9 @@ class PortRotateOneTest(unittest.TestCase):
 
             PortRotateOneTest.which_port.assert_called_with(8502)
 
-            patched__set_option.assert_called_with("server.port", 8501, "server initialization")
+            patched__set_option.assert_called_with(
+                "server.port", 8501, "server initialization"
+            )
 
 
 class MetricsHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -18,9 +18,11 @@
 import unittest
 
 import mock
+import pytest
 import tornado.testing
 import tornado.web
 import tornado.websocket
+import errno
 from mock import MagicMock
 from mock import patch
 from tornado import gen
@@ -32,6 +34,7 @@ from streamlit.elements import data_frame_proto
 from streamlit.proto.BlockPath_pb2 import BlockPath
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.server.Server import State
+from streamlit.server.Server import start_listening
 from streamlit.server.routes import DebugHandler
 from streamlit.server.routes import HealthHandler
 from streamlit.server.routes import MessageCacheHandler
@@ -304,6 +307,58 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._is_healthy = False
         response = self.fetch("/healthz")
         self.assertEqual(503, response.code)
+
+
+class PortRotateAHundredTest(unittest.TestCase):
+    """Tests port rotates up to a hundred times then sys exits"""
+
+    def get_app(self):
+        app = mock.MagicMock()
+
+        def listen(port):
+            raise OSError(errno.EADDRINUSE, "test", "asd")
+
+        app.listen = listen
+        return app
+
+    def test_rotates_a_hundred_ports(self):
+        app = self.get_app()
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            start_listening(app)
+            assert pytest_wrapped_e.type == SystemExit
+            assert pytest_wrapped_e.value.code == 42
+
+        assert app.listen.call_count == 100
+
+
+class PortRotateOneTest(unittest.TestCase):
+    """Tests port rotates one port"""
+
+    which_port = mock.Mock()
+
+    def get_app(self):
+        app = mock.MagicMock()
+
+        def listen(port):
+            if not port: # or port < 8502:
+                raise OSError(errno.EADDRINUSE, "test", "asd")
+            else:
+                PortRotateOneTest.which_port(port)
+
+        app.listen = listen
+        return app
+
+    @mock.patch('streamlit.config.is_manually_set')
+    @mock.patch('streamlit.config._set_option')
+    def test_rotates_one_port(self, patched__set_option, patched_is_manually_set):
+        app = self.get_app()
+
+        patched_is_manually_set.return_value = True
+
+        start_listening(app)
+
+        PortRotateOneTest.which_port.assert_called_with(8501)
+        patched__set_option.assert_called_with("server.port", 8502, "server initialization")
 
 
 class MetricsHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -52,6 +52,7 @@ from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
 
+
 def _create_dataframe_msg(df, id=1):
     msg = ForwardMsg()
     msg.metadata.delta_id = id


### PR DESCRIPTION
When running `streamlit` it starts up the server listening to `server.port`, in case the user has not set the port explicitly the server will add 1 to the port number and try to run the server in that port, in order to be able to have several `streamlit` projects running simultaneously.

Please review if the message set in `_set_option` third parameter is appropriate.
Please advise if you think there should be tests for this and what to test.

to test locally with `make all-devel` make sure to have the following settings
```
developmentMode=false
useNode=false
```

After having those config keys set up just run `streamlit hello` in more than one terminals and see the report pop up in the browser over a different port.

resolves #116 