### PR TITLE
Fix Matplotlib crash on OS X

### DIFF
--- a/examples/empty_charts.py
+++ b/examples/empty_charts.py
@@ -59,7 +59,6 @@ x.add_rows(data)
 st.subheader("Here is 1 empty map")
 st.deck_gl_chart()
 
-
 # TODO: Implement add_rows on DeckGL
 # st.subheader('1 filled map')
 # x = st.deck_gl_chart()

--- a/examples/empty_charts.py
+++ b/examples/empty_charts.py
@@ -59,6 +59,7 @@ x.add_rows(data)
 st.subheader("Here is 1 empty map")
 st.deck_gl_chart()
 
+
 # TODO: Implement add_rows on DeckGL
 # st.subheader('1 filled map')
 # x = st.deck_gl_chart()

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -18,7 +18,7 @@ sphinx-rtd-theme = "*"
 recommonmark = "*"
 # Packages used in unit tests:
 altair = "*"
-matplotlib = {version = "*",markers = "python_version > '3.0'"}
+matplotlib = "*"
 scipy = "<1.3.0"
 plotly = "*"
 chart-studio = "*"

--- a/lib/Pipfile.locks/python-2.7.16
+++ b/lib/Pipfile.locks/python-2.7.16
@@ -774,7 +774,6 @@
                 "sha256:f99c43df8ed2b9d1c95a042f3cacf017f9690092feba0b4292eaa6713f92de97"
             ],
             "index": "pypi",
-            "markers": "python_version > '3.0'",
             "version": "==2.2.4"
         },
         "mock": {

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -44,10 +44,10 @@ def _set_up_signal_handler():
 
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
-    if sys.platform == 'win32':
-      signal.signal(signal.SIGBREAK, signal_handler)
+    if sys.platform == "win32":
+        signal.signal(signal.SIGBREAK, signal_handler)
     else:
-      signal.signal(signal.SIGQUIT, signal_handler)
+        signal.signal(signal.SIGQUIT, signal_handler)
 
 
 def _fix_sys_path(script_path):
@@ -62,15 +62,29 @@ def _fix_sys_path(script_path):
 def _fix_matplotlib_crash():
     """Set Matplotlib backend to avoid a crash.
 
-    The default Matplotlib backend crashes Python for most MacOS users.
-    So here we set a safer backend as a fix. Users can always disable this
-    behavior by setting the config runner.fixMatplotlib = false.
+    The default Matplotlib backend crashes Python on OSX when run on a thread
+    that's not the main thread, so here we set a safer backend as a fix.
+    Users can always disable this behavior by setting the config
+    runner.fixMatplotlib = false.
 
     This fix is OS-independent. We didn't see a good reason to make this
     Mac-only. Consistency within Streamlit seemed more important.
     """
     if config.get_option("runner.fixMatplotlib"):
-        os.environ["MPLBACKEND"] = "Agg"
+        try:
+            # TODO: a better option may be to set
+            #  os.environ["MPLBACKEND"] = "Agg". We'd need to do this towards
+            #  the top of __init__.py, before importing anything that imports
+            #  pandas (which imports matplotlib). Alternately, we could set
+            #  this environment variable in a new entrypoint defined in
+            #  setup.py. Both of these introduce additional trickiness: they
+            #  need to run without consulting streamlit.config.get_option,
+            #  because this would import streamlit, and therefore matplotlib.
+            import matplotlib
+
+            matplotlib.use("Agg")
+        except ImportError:
+            pass
 
 
 def _on_server_start(server):

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -70,7 +70,7 @@ def _fix_matplotlib_crash():
     This fix is OS-independent. We didn't see a good reason to make this
     Mac-only. Consistency within Streamlit seemed more important.
     """
-    if config.get_option("runner.fixMatplotlib"):
+    if sys.platform == "darwin" and config.get_option("runner.fixMatplotlib"):
         try:
             # TODO: a better option may be to set
             #  os.environ["MPLBACKEND"] = "Agg". We'd need to do this towards

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -44,14 +44,17 @@ class BootstrapTest(unittest.TestCase):
         # TODO: Find a proper way to mock sys.platform
         ORIG_PLATFORM = sys.platform
 
-        for platform in ["darwin", "linux2"]:
+        for platform, do_fix in [("darwin", True), ("linux2", False)]:
             sys.platform = platform
 
             matplotlib.use("tkagg")
 
             config._set_option("runner.fixMatplotlib", True, "test")
             bootstrap.run("/not/a/script")
-            self.assertEqual("agg", matplotlib.get_backend().lower())
+            if do_fix:
+                self.assertEqual("agg", matplotlib.get_backend().lower())
+            else:
+                self.assertEqual("tkagg", matplotlib.get_backend().lower())
 
             # Reset
             matplotlib.use("tkagg")

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -41,18 +41,26 @@ class BootstrapTest(unittest.TestCase):
         """Test that bootstrap.run sets the matplotlib backend to
         "Agg" if config.runner.fixMatplotlib=True.
         """
-        matplotlib.use("tkagg")
+        # TODO: Find a proper way to mock sys.platform
+        ORIG_PLATFORM = sys.platform
 
-        config._set_option("runner.fixMatplotlib", True, "test")
-        bootstrap.run("/not/a/script")
-        self.assertEqual("agg", matplotlib.get_backend().lower())
+        for platform in ["darwin", "linux2"]:
+            sys.platform = platform
 
-        # Reset
-        matplotlib.use("tkagg")
+            matplotlib.use("tkagg")
 
-        config._set_option("runner.fixMatplotlib", False, "test")
-        bootstrap.run("/not/a/script")
-        self.assertEqual("tkagg", matplotlib.get_backend().lower())
+            config._set_option("runner.fixMatplotlib", True, "test")
+            bootstrap.run("/not/a/script")
+            self.assertEqual("agg", matplotlib.get_backend().lower())
+
+            # Reset
+            matplotlib.use("tkagg")
+
+            config._set_option("runner.fixMatplotlib", False, "test")
+            bootstrap.run("/not/a/script")
+            self.assertEqual("tkagg", matplotlib.get_backend().lower())
+
+        sys.platform = ORIG_PLATFORM
 
 
 class BootstrapPrintTest(unittest.TestCase):

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -15,6 +15,8 @@
 
 import sys
 import unittest
+
+import matplotlib
 from mock import patch
 
 try:
@@ -30,6 +32,27 @@ from streamlit.Report import Report
 from tests import testutil
 
 report = Report("the/path", ["arg0", "arg1"])
+
+
+class BootstrapTest(unittest.TestCase):
+    @patch("streamlit.bootstrap.tornado.ioloop")
+    @patch("streamlit.bootstrap.Server")
+    def test_fix_matplotlib_crash(self, _1, _2):
+        """Test that bootstrap.run sets the matplotlib backend to
+        "Agg" if config.runner.fixMatplotlib=True.
+        """
+        matplotlib.use("tkagg")
+
+        config._set_option("runner.fixMatplotlib", True, "test")
+        bootstrap.run("/not/a/script")
+        self.assertEqual("agg", matplotlib.get_backend().lower())
+
+        # Reset
+        matplotlib.use("tkagg")
+
+        config._set_option("runner.fixMatplotlib", False, "test")
+        bootstrap.run("/not/a/script")
+        self.assertEqual("tkagg", matplotlib.get_backend().lower())
 
 
 class BootstrapPrintTest(unittest.TestCase):

--- a/scripts/run_bare_integration_tests.py
+++ b/scripts/run_bare_integration_tests.py
@@ -35,6 +35,11 @@ E2E_DIR = "e2e/scripts"
 
 EXCLUDED_FILENAMES = set()
 
+# Since there is not DISPLAY set (and since Streamlit is not actually running
+# and fixing Matplotlib in these tests), we set the MPL backend to something
+# that doesn't require a display.
+os.environ['MPLBACKEND'] = 'Agg'
+
 # Scripts that rely on matplotlib can't be run in Python2. matplotlib
 # dropped Py2 support, and so we don't install it in our virtualenv.
 try:


### PR DESCRIPTION
Fixes #177, but in a way that makes @tvst sad :)

I wrote longer notes in the issue (#177) about what needs to happen to avoid importing `matplotlib` here - but the tl;dr is that `bootstrap.run` is called after matplotlib is indirectly imported elsewhere. Since matplotlib only reads MPLBACKEND on import, bootstrap gets there too late to have its environment variable override have any effect.