### PR TITLE
Fix login flow crashes for an invalid Credentials.toml file

### DIFF
--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -52,7 +52,7 @@ EMAIL_PROMPT = """
 
   %(email)s""" % {
     "welcome": click.style("Welcome to Streamlit!", bold=True),
-    "email": click.style("Email: ", fg="blue")
+    "email": click.style("Email: ", fg="blue"),
 }
 
 TELEMETRY_TEXT = """
@@ -74,7 +74,7 @@ INSTRUCTIONS_TEXT = """
 """ % {
     "start": click.style("Get started by typing:", fg="blue", bold=True),
     "prompt": click.style("$", fg="blue"),
-    "hello": click.style("streamlit hello", bold=True)
+    "hello": click.style("streamlit hello", bold=True),
 }
 
 
@@ -191,8 +191,8 @@ class Credentials(object):
             while not activated:
 
                 email = click.prompt(
-                    text=EMAIL_PROMPT, prompt_suffix="", default="",
-                    show_default=False)
+                    text=EMAIL_PROMPT, prompt_suffix="", default="", show_default=False
+                )
 
                 self.activation = _verify_email(email)
                 if self.activation.is_valid:

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -153,8 +153,9 @@ class Credentials(object):
         This is used by `streamlit activate reset` in case a user wants
         to start over.
         """
-        Credentials._singleton = None
-        c = Credentials()
+        c = Credentials.get_current()
+        c.activation = None
+
         try:
             os.remove(c._conf_file)
         except OSError as e:

--- a/lib/tests/streamlit/credentials_test.py
+++ b/lib/tests/streamlit/credentials_test.py
@@ -245,9 +245,13 @@ class CredentialsClassTest(unittest.TestCase):
     @patch("streamlit.credentials.util.get_streamlit_file_path", mock_get_path)
     def test_Credentials_reset(self):
         """Test Credentials.reset()."""
+        c = Credentials.get_current()
+
         with patch("streamlit.credentials.os.remove") as p:
             Credentials.reset()
             p.assert_called_once_with("/mock/home/folder/.streamlit/credentials.toml")
+
+        self.assertEqual(c, Credentials.get_current())
 
     @patch("streamlit.credentials.util.get_streamlit_file_path", mock_get_path)
     def test_Credentials_reset_error(self):


### PR DESCRIPTION
**Issue:**

#175 

**Description:**

- Fix credentials reset by only initializing credentials singleton once

---

- [x] By checking this box, I agree that all contributions to this project are made under the Apache 2.0 license.
