### PR TITLE
Stop react-markdown from converting "[foo]" to a link

### DIFF
--- a/frontend/src/components/elements/Text/Text.tsx
+++ b/frontend/src/components/elements/Text/Text.tsx
@@ -42,6 +42,11 @@ interface LinkProps {
   children: ReactElement
 }
 
+interface LinkReferenceProps {
+  href: string
+  children: [ReactElement]
+}
+
 // Using target="_blank" without rel="noopener noreferrer" is a security risk:
 // see https://mathiasbynens.github.io/rel-noopener
 const linkWithTargetBlank = (props: LinkProps): ReactElement => (
@@ -49,6 +54,22 @@ const linkWithTargetBlank = (props: LinkProps): ReactElement => (
     {props.children}
   </a>
 )
+
+// Handle rendering a link through a reference, ex [text](href)
+// Don't convert to a link if only `[text]` and missing `(href)`
+const linkReferenceHasParens = (props: LinkReferenceProps): any => {
+  const { href, children } = props
+
+  if (!href) {
+    return children.length ? `[${children[0].props.children}]` : ""
+  }
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  )
+}
 
 interface Props {
   width: number
@@ -66,6 +87,7 @@ class Text extends React.PureComponent<Props> {
     const renderers = {
       code: CodeBlock,
       link: linkWithTargetBlank,
+      linkReference: linkReferenceHasParens,
     }
 
     switch (format) {
@@ -121,11 +143,7 @@ class Text extends React.PureComponent<Props> {
             style={{ width }}
           >
             <div className="markdown-text-container">
-              <ReactMarkdown
-                source={body}
-                escapeHtml={true}
-                renderers={renderers}
-              />
+              <ReactMarkdown source={body} renderers={renderers} />
             </div>
           </div>
         )


### PR DESCRIPTION
**Issue:** #151
 
**Decription:** Reverting lost changes

- [x] By checking this box, I agree that all contributions to this project are made under the Apache 2.0 license.
