### PR TITLE
Added intro text to hello.py

### DIFF
--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -288,10 +288,10 @@ def data_frame_demo():
 DEMOS = OrderedDict(
     {
         "---": intro,
+        "Animation Demo": fractal_demo,
+        "Plotting Demo": plotting_demo,
         "Mapping Demo": mapping_demo,
         "DataFrame Demo": data_frame_demo,
-        "Plotting Demo": plotting_demo,
-        "Animation Demo": fractal_demo,
     }
 )
 
@@ -300,11 +300,7 @@ def run():
     demo_name = st.sidebar.selectbox("Choose a demo", list(DEMOS.keys()), 0)
     demo = DEMOS[demo_name]
 
-    if demo_name != "---":
-        show_code = st.sidebar.checkbox("Show code", True)
-        st.markdown("# %s" % demo_name)
-        st.write(inspect.getdoc(demo))
-    else:
+    if demo_name == "---":
         show_code = False
         st.write(
             """
@@ -312,6 +308,13 @@ def run():
             ## The fastest way to build custom ML tools
             """
         )
+    else:
+        show_code = st.sidebar.checkbox("Show code", True)
+        st.markdown("# %s" % demo_name)
+        st.write(inspect.getdoc(demo))
+        # Clear everything from the intro page.
+        for i in range(10):
+            st.empty()
     demo()
     if show_code:
         st.markdown("## Code")

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -269,16 +269,19 @@ def data_frame_demo():
     "### Gross Agricultural Production ($)", df.loc[countries].sort_index()
 
     data = df.loc[countries].T.reset_index()
-    data = pd.melt(data, id_vars=['index']).rename(columns={
-        'index': 'year',
-        'value': 'Gross Agricultural Product ($)',
-    })
-    chart = alt.Chart(data).mark_area(opacity=0.3).encode(
-        x="year:T",
-        y=alt.Y("Gross Agricultural Product ($):Q", stack=None),
-        color="Region:N"
+    data = pd.melt(data, id_vars=["index"]).rename(
+        columns={"index": "year", "value": "Gross Agricultural Product ($)"}
     )
-    '', '', chart
+    chart = (
+        alt.Chart(data)
+        .mark_area(opacity=0.3)
+        .encode(
+            x="year:T",
+            y=alt.Y("Gross Agricultural Product ($):Q", stack=None),
+            color="Region:N",
+        )
+    )
+    "", "", chart
 
 
 # fmt: on
@@ -310,15 +313,7 @@ def run():
             ## The fastest way to build custom ML tools
             """
         )
-    try:
-        demo()
-    except ImportError as e:
-        st.write('Got an error')
-        st.write(dir(e))
-        st.show(e.name)
-        st.show(e.path)
-        st.show(e.args)
-        st.write(e)
+    demo()
     if show_code:
         st.markdown("## Code")
         sourcelines, n_lines = inspect.getsourcelines(demo)

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -17,20 +17,40 @@
 from __future__ import division
 
 import streamlit as st
+from streamlit.logger import get_logger
 import inspect
 from collections import OrderedDict
 import urllib
 
+LOGGER = get_logger(__name__)
+
 def intro():
+    @st.cache(show_spinner=False)
+    def load_image(url):
+        import requests
+        from PIL import Image
+        from io import BytesIO
+        img = Image.open(BytesIO(requests.get(url).content))
+        old_width, old_height = img.size
+        new_width = 1024
+        new_height = int(old_height * new_width / old_width)
+        return img.resize((new_width, new_height), Image.BICUBIC)
+
+    st.sidebar.error('Select a demo above.')
+
     st.markdown(
         """
             Streamlit is a completely free and open-source library to create
             web tools for Machine Learning and Data Science projects.
 
             **Select a demo from the menu on the left** to see Streamlit in action.
+        """
+    )
 
-            ![](https://streamlit-demo-data.s3-us-west-2.amazonaws.com/hello-welcome.png)
+    image_location = st.empty()
 
+    st.markdown(
+        """
             ### Want to learn more?
 
             - [Get started with help](https://streamlit.io/docs)
@@ -42,9 +62,16 @@ def intro():
               (https://github.com/streamlit/demo-self-driving)
             - [Explore a New York City rideshare dataset]
               (https://github.com/streamlit/demo-uber-nyc-pickups)
-"""
+        """
     )
 
+    try:
+        img_url = 'https://streamlit-demo-data.s3-us-west-2.amazonaws.com/hello-welcome.png'
+        img = load_image(img_url)
+        image_location.image(img, use_column_width=True)
+    except Exception as e:
+        LOGGER.warning(e)
+        LOGGER.warning(img_url)
 
 def mapping_demo():
     """

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -265,7 +265,7 @@ def data_frame_demo():
         st.error("Please select at least one country.")
         return
 
-    "### Gross Agricultural Production ($)", df.loc[countries].sort_index()
+    st.write("### Gross Agricultural Production ($)", df.loc[countries].sort_index())
 
     data = df.loc[countries].T.reset_index()
     data = pd.melt(data, id_vars=["index"]).rename(
@@ -280,7 +280,7 @@ def data_frame_demo():
             color="Region:N",
         )
     )
-    "", "", chart
+    st.write("", "", chart)
 
 
 # fmt: on

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -73,6 +73,8 @@ def intro():
         LOGGER.warning(e)
         LOGGER.warning(img_url)
 
+# Turn off black formatting for this funtion to present the user with more compact code.
+# fmt: off
 def mapping_demo():
     """
     This demo shows how to use
@@ -132,7 +134,10 @@ def mapping_demo():
         st.deck_gl_chart(viewport=viewport, layers=selected_layers)
     else:
         st.error("Please choose at least one layer above.")
+# fmt: on
 
+# Turn off black formatting for this funtion to present the user with more compact code.
+# fmt: off
 def fractal_demo():
     """
     This app shows how you can use Streamlit to build cool animations.
@@ -169,7 +174,10 @@ def fractal_demo():
     progress_bar.empty()
     frame_text.empty()
     st.button("Re-run")
+# fmt: on
 
+# Turn off black formatting for this funtion to present the user with more compact code.
+# fmt: off
 def plotting_demo():
     """
     This demo illustrates a combination of plotting and animation with Streamlit.
@@ -192,7 +200,10 @@ def plotting_demo():
         time.sleep(0.05)
     progress_bar.empty()
     st.button("Re-run")
+# fmt: on
 
+# Turn off black formatting for this funtion to present the user with more compact code.
+# fmt: off
 def data_frame_demo():
     """
     This demo shows how to use `st.write` to visualize Pandas DataFrames.
@@ -232,7 +243,7 @@ def data_frame_demo():
     ax.tick_params(labelsize=20)
     ax.legend(loc=2, prop={"size": 20})
     st.pyplot()
-
+# fmt: on
 
 DEMOS = OrderedDict({
     "---": intro,

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -24,19 +24,21 @@ import urllib
 
 LOGGER = get_logger(__name__)
 
+
 def intro():
     @st.cache(show_spinner=False)
     def load_image(url):
         import requests
         from PIL import Image
         from io import BytesIO
+
         img = Image.open(BytesIO(requests.get(url).content))
         old_width, old_height = img.size
         new_width = 1024
         new_height = int(old_height * new_width / old_width)
         return img.resize((new_width, new_height), Image.BICUBIC)
 
-    st.sidebar.error('Select a demo above.')
+    st.sidebar.success("Select a demo above.")
 
     st.markdown(
         """
@@ -58,20 +60,23 @@ def intro():
 
             ### See more complex demos
 
-            - [Use neural nets to analyze the Udacity Self-driving Car Image Dataset]
+            - Use a neural net to [analyze the Udacity Self-driving Car Image Dataset]
               (https://github.com/streamlit/demo-self-driving)
-            - [Explore a New York City rideshare dataset]
+            - Explore a [New York City rideshare dataset]
               (https://github.com/streamlit/demo-uber-nyc-pickups)
         """
     )
 
     try:
-        img_url = 'https://streamlit-demo-data.s3-us-west-2.amazonaws.com/hello-welcome.png'
+        img_url = (
+            "https://streamlit-demo-data.s3-us-west-2.amazonaws.com/hello-welcome.png"
+        )
         img = load_image(img_url)
         image_location.image(img, use_column_width=True)
     except Exception as e:
         LOGGER.warning(e)
         LOGGER.warning(img_url)
+
 
 # Turn off black formatting for this funtion to present the user with more compact code.
 # fmt: off
@@ -147,7 +152,7 @@ def fractal_demo():
     import numpy as np
 
     iterations = st.sidebar.slider("Level of detail", 1, 100, 70, 1)
-    separation = st.sidebar.slider('Separation', 0.7, 2.0, 0.7885)
+    separation = st.sidebar.slider("Separation", 0.7, 2.0, 0.7885)
 
     m, n, s = 480, 320, 200
     x = np.linspace(-m / s, m / s, num=m).reshape((1, m))
@@ -158,7 +163,7 @@ def fractal_demo():
     frame_text = st.sidebar.empty()
     for frame_num, a in enumerate(np.linspace(0.0, 4 * np.pi, 100)):
         progress_bar.progress(frame_num)
-        frame_text.text('Frame %i/100' % (frame_num + 1))
+        frame_text.text("Frame %i/100" % (frame_num + 1))
         c = separation * np.exp(1j * a)
         Z = np.tile(x, (n, 1)) + 1j * np.tile(y, (1, m))
         C = np.full((n, m), c)
@@ -174,6 +179,8 @@ def fractal_demo():
     progress_bar.empty()
     frame_text.empty()
     st.button("Re-run")
+
+
 # fmt: on
 
 # Turn off black formatting for this funtion to present the user with more compact code.
@@ -192,7 +199,7 @@ def plotting_demo():
     last_rows = np.random.randn(1, 1)
     chart = st.line_chart(last_rows)
     for i in range(1, 101):
-        new_rows = last_rows[-1,:] + np.random.randn(5, 1).cumsum(axis=0)
+        new_rows = last_rows[-1, :] + np.random.randn(5, 1).cumsum(axis=0)
         status_text.text("%i%% Complete" % i)
         chart.add_rows(new_rows)
         progress_bar.progress(i)
@@ -200,6 +207,8 @@ def plotting_demo():
         time.sleep(0.05)
     progress_bar.empty()
     st.button("Re-run")
+
+
 # fmt: on
 
 # Turn off black formatting for this funtion to present the user with more compact code.
@@ -212,6 +221,7 @@ def data_frame_demo():
     """
     import sys
     import pandas as pd
+
     if sys.version_info[0] < 3:
         reload(sys)
         sys.setdefaultencoding("utf-8")
@@ -228,8 +238,9 @@ def data_frame_demo():
         st.error("Connection Error. This demo requires internet access")
         return
 
-    countries = st.multiselect("Choose countries", list(df.index),
-                               ["China", "United States of America"])
+    countries = st.multiselect(
+        "Choose countries", list(df.index), ["China", "United States of America"]
+    )
     if not countries:
         st.error("Please select at least one country.")
         return
@@ -243,15 +254,20 @@ def data_frame_demo():
     ax.tick_params(labelsize=20)
     ax.legend(loc=2, prop={"size": 20})
     st.pyplot()
+
+
 # fmt: on
 
-DEMOS = OrderedDict({
-    "---": intro,
-    "Mapping Demo": mapping_demo,
-    "Animation Demo": fractal_demo,
-    "DataFrame Demo": data_frame_demo,
-    "Plotting Demo": plotting_demo,
-})
+DEMOS = OrderedDict(
+    {
+        "---": intro,
+        "Mapping Demo": mapping_demo,
+        "Animation Demo": fractal_demo,
+        "DataFrame Demo": data_frame_demo,
+        "Plotting Demo": plotting_demo,
+    }
+)
+
 
 def run():
     demo_name = st.sidebar.selectbox("Choose a demo", list(DEMOS.keys()), 0)
@@ -276,6 +292,7 @@ def run():
         )
         demo()
 
+
 # This function parses the lines of a function and removes the docstring
 # if found. If no docstring is found, it returns None.
 def remove_docstring(lines):
@@ -289,7 +306,7 @@ def remove_docstring(lines):
         if index > 100:
             return lines
     # lined[index] is the closing """
-    return lines[index + 1:]
+    return lines[index + 1 :]
 
 
 # This function remove the common leading indentation from a code block

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -27,12 +27,12 @@ LOGGER = get_logger(__name__)
 
 
 def intro():
+    import requests
+    from PIL import Image
+    from io import BytesIO
+
     @st.cache(show_spinner=False)
     def load_image(url):
-        import requests
-        from PIL import Image
-        from io import BytesIO
-
         img = Image.open(BytesIO(requests.get(url).content))
         old_width, old_height = img.size
         new_width = 1024

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -289,9 +289,9 @@ DEMOS = OrderedDict(
     {
         "---": intro,
         "Mapping Demo": mapping_demo,
-        "Animation Demo": fractal_demo,
         "DataFrame Demo": data_frame_demo,
         "Plotting Demo": plotting_demo,
+        "Animation Demo": fractal_demo,
     }
 )
 

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -27,13 +27,12 @@ LOGGER = get_logger(__name__)
 
 
 def intro():
-    import requests
     from PIL import Image
     from io import BytesIO
 
     @st.cache(show_spinner=False)
     def load_image(url):
-        img = Image.open(BytesIO(requests.get(url).content))
+        img = Image.open(BytesIO(urllib.request.urlopen(url).read()))
         old_width, old_height = img.size
         new_width = 1024
         new_height = int(old_height * new_width / old_width)
@@ -79,7 +78,7 @@ def intro():
         LOGGER.warning(img_url)
 
 
-# Turn off black formatting for this funtion to present the user with more compact code.
+# Turn off black formatting for this function to present the user with more compact code.
 # fmt: off
 def mapping_demo():
     """
@@ -142,7 +141,7 @@ def mapping_demo():
         st.error("Please choose at least one layer above.")
 # fmt: on
 
-# Turn off black formatting for this funtion to present the user with more compact code.
+# Turn off black formatting for this function to present the user with more compact code.
 # fmt: off
 def fractal_demo():
     """
@@ -200,7 +199,7 @@ def fractal_demo():
 
 # fmt: on
 
-# Turn off black formatting for this funtion to present the user with more compact code.
+# Turn off black formatting for this function to present the user with more compact code.
 # fmt: off
 def plotting_demo():
     """
@@ -230,7 +229,7 @@ def plotting_demo():
 
 # fmt: on
 
-# Turn off black formatting for this funtion to present the user with more compact code.
+# Turn off black formatting for this function to present the user with more compact code.
 # fmt: off
 def data_frame_demo():
     """
@@ -265,18 +264,20 @@ def data_frame_demo():
         st.error("Please select at least one country.")
         return
 
-    st.write("### Gross Agricultural Production ($)", df.loc[countries].sort_index())
+    data = df.loc[countries]
+    data /= 1000000.0
+    st.write("### Gross Agricultural Production ($B)", data.sort_index())
 
-    data = df.loc[countries].T.reset_index()
+    data = data.T.reset_index()
     data = pd.melt(data, id_vars=["index"]).rename(
-        columns={"index": "year", "value": "Gross Agricultural Product ($)"}
+        columns={"index": "year", "value": "Gross Agricultural Product ($B)"}
     )
     chart = (
         alt.Chart(data)
         .mark_area(opacity=0.3)
         .encode(
             x="year:T",
-            y=alt.Y("Gross Agricultural Product ($):Q", stack=None),
+            y=alt.Y("Gross Agricultural Product ($B):Q", stack=None),
             color="Region:N",
         )
     )
@@ -313,6 +314,7 @@ def run():
         st.markdown("# %s" % demo_name)
         st.write(inspect.getdoc(demo))
         # Clear everything from the intro page.
+        # We only have 4 elements in the page so this is intentional overkill.
         for i in range(10):
             st.empty()
     demo()

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -24,14 +24,24 @@ import urllib
 def intro():
     st.markdown(
         """
-## Intro...
+            Streamlit is a completely free and open-source library to create
+            web tools for Machine Learning and Data Science projects.
 
-text text text text text text text text text text text text text text text text
-text text text text text text text text text text text text text text text text
-text text text text text text text text text text text text text text text text
-text text text text text text text text text text text text text text text text
-text text text text text text text text text text text text text text text text
-text text text text text text text text text text text text text text text text
+            **Select a demo from the menu on the left** to see Streamlit in action.
+
+            ![](https://streamlit-demo-data.s3-us-west-2.amazonaws.com/hello-welcome.png)
+
+            ### Want to learn more?
+
+            - [Get started with help](https://streamlit.io/docs)
+            - [Ask our community a question](https://discuss.streamlit.io)
+
+            ### See more complex demos
+
+            - [Use neural nets to analyze the Udacity Self-driving Car Image Dataset]
+              (https://github.com/streamlit/demo-self-driving)
+            - [Explore a New York City rideshare dataset]
+              (https://github.com/streamlit/demo-uber-nyc-pickups)
 """
     )
 
@@ -220,14 +230,13 @@ def run():
             sourcelines = reset_indentation(remove_docstring(sourcelines))
             st.code("".join(sourcelines))
     else:
-        st.title("Welcome to Streamlit!")
         st.write(
             """
-            Streamlit is the best way to create bespoke apps.
+            # Welcome to Streamlit
+            ## The fastest way to build custom ML tools
             """
         )
         demo()
-
 
 # This function parses the lines of a function and removes the docstring
 # if found. If no docstring is found, it returns None.

--- a/lib/streamlit/hello.py
+++ b/lib/streamlit/hello.py
@@ -210,7 +210,6 @@ def plotting_demo():
     """
     import time
     import numpy as np
-    import time2
 
     progress_bar = st.sidebar.progress(0)
     status_text = st.sidebar.empty()

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -22,5 +22,5 @@ yarn --cwd "frontend" pretty-quick --staged
 # "--diff-filter=ACMR" only lists files that are [A]dded, [C]opied, [M]odified,
 # or [R]enamed; we don't want to try to format files that have been deleted.
 if command -v "black" > /dev/null; then
-  git diff --diff-filter=ACMR --name-only --cached | grep -E "\.pyi?$" | grep -v "hello.py" | xargs black
+  git diff --diff-filter=ACMR --name-only --cached | grep -E "\.pyi?$" | xargs black
 fi


### PR DESCRIPTION
# Issue:

- Mostly, this was my final pass on `hello.py`.
- This does fix #208 

# Decription:

## Intro Text for `streamlit hello`
- Added text to `intro()` which the user sees first when they type `streamlit hello`.
- Downloading an displaying [an image](https://streamlit-demo-data.s3-us-west-2.amazonaws.com/hello-welcome.png) on the landing page for `streamlit hello`

## Fractal Demo
- Added more comments

## DataFrame Demo
- Replaced `matplotlib` with `altair`

## Black Formatting `streamlit hello`
- Removed a hack I added to suppress black formatting.
- Instead, now using `# fmt: off` as [suggested by Henrikh](https://streamlit.slack.com/archives/C9FJJN8Q7/p1569541419014700)

## Overall
- Changed the demo order
- Replaced @monchier's homespun `reset_indentation` with `textwrap.dedent` 

---

- [x] By checking this box, I agree that all contributions to this project are made under the Apache 2.0 license.
