### PR TITLE
Unset all bootstrap H* clases

### DIFF
--- a/frontend/src/assets/css/theme.scss
+++ b/frontend/src/assets/css/theme.scss
@@ -17,6 +17,17 @@
 @import "variables";
 @import "fonts";
 @import "~bootstrap/scss/bootstrap";
+// IMPORTANT! Add this ".h1, .h2, .h3, .h4, .h5, .h6 unset" just after import bootstrap libraries
+// Styletron creates classes called h1, h2, etc., which conflict with Bootstrap classes.
+// So we have to override the bootstrap classes here. (We should not use this classes in our project)
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  all: unset;
+}
 
 // Use this file to override specific bootstrap styles.
 

--- a/frontend/src/assets/css/theme.scss
+++ b/frontend/src/assets/css/theme.scss
@@ -17,9 +17,10 @@
 @import "variables";
 @import "fonts";
 @import "~bootstrap/scss/bootstrap";
-// IMPORTANT! Add this ".h1, .h2, .h3, .h4, .h5, .h6 unset" just after import bootstrap libraries
+
+// IMPORTANT! This must come after the bootstrap import.
 // Styletron creates classes called h1, h2, etc., which conflict with Bootstrap classes.
-// So we have to override the bootstrap classes here. (We should not use this classes in our project)
+// So we have to override the bootstrap classes here. (We should not use these classes in our project)
 .h1,
 .h2,
 .h3,


### PR DESCRIPTION
https://github.com/streamlit/streamlit/issues/161

Decription:
Interacting with widgets sometimes changes the vertical scroll position. This shouldn't be the case.

The problem was when styletron auto generated class h1 (or h2, h3, h4, h5 ,h6) was implemented, has a conflict with bootstrap .h* class.

To reproduce it, just run "streamlit run examples/interactive widgets.py" and change the slider value until to see the slider height changing

---

- [x] By checking this box, I agree that all contributions to this project are made under the Apache 2.0 license.
