### PR TITLE
Fix wrong quote used in the provided sample code

### DIFF
--- a/docs/main_concepts.md
+++ b/docs/main_concepts.md
@@ -45,7 +45,7 @@ When you've got the data or model into the state that you want to explore, you c
 ```
 import streamlit as st
 x = st.slider('x')
-st.write(x, ‘squared is', x * x)
+st.write(x, 'squared is', x * x)
 
 ```
 


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/266

**Decription:**
In the [Main Concepts](https://streamlit.io/docs/main_concepts.html) part of documentation, there is a sample code, which gives error when copied and ran directly. The issue was due to presence of wrong quote. I have updated the doc to the correct quote.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
