### PR TITLE
Fix for st.code("") raising an exception in the browser

### DIFF
--- a/e2e/scripts/code.py
+++ b/e2e/scripts/code.py
@@ -16,3 +16,5 @@
 import streamlit as st
 
 st.code("# This code is awesome!")
+
+st.code("")

--- a/frontend/src/components/elements/CodeBlock/CodeBlock.tsx
+++ b/frontend/src/components/elements/CodeBlock/CodeBlock.tsx
@@ -61,7 +61,9 @@ class CodeBlock extends React.PureComponent<Props> {
       lang = Prism.languages.python
     }
 
-    const safeHtml = Prism.highlight(this.props.value, lang, "")
+    const safeHtml = this.props.value
+      ? Prism.highlight(this.props.value, lang, "")
+      : ""
     const languageClassName = `language-${this.props.language}`
     return (
       <pre className={"code-block"}>


### PR DESCRIPTION
**Issue:** 
#146 

**Description:** 
- Don't pass empty strings to Prism.highlight 
