### PR TITLE
#203 Skipping credentials in headless mode

### DIFF
--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -24,6 +24,7 @@ import click
 import toml
 
 from streamlit import util
+from streamlit import config
 from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -193,8 +194,6 @@ class Credentials(object):
             activated = False
 
             while not activated:
-                from streamlit import config
-
                 if config.get_option("server.headless"):
                     email = ""
                 else:

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -199,7 +199,8 @@ class Credentials(object):
                     email = ""
                 else:
                     email = click.prompt(
-                        text=EMAIL_PROMPT, prompt_suffix="", default="", show_default=False
+                        text=EMAIL_PROMPT, prompt_suffix="", default="",
+                        show_default=False
                     )
 
                 self.activation = _verify_email(email)

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -193,10 +193,14 @@ class Credentials(object):
             activated = False
 
             while not activated:
+                from streamlit import config
 
-                email = click.prompt(
-                    text=EMAIL_PROMPT, prompt_suffix="", default="", show_default=False
-                )
+                if config.get_option("server.headless"):
+                    email = ""
+                else:
+                    email = click.prompt(
+                        text=EMAIL_PROMPT, prompt_suffix="", default="", show_default=False
+                    )
 
                 self.activation = _verify_email(email)
                 if self.activation.is_valid:

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -194,6 +194,10 @@ class Credentials(object):
             activated = False
 
             while not activated:
+
+                # Don't stop execution to show an interactive prompt
+                # when in headless mode, as this makes it harder for
+                # people to deploy Streamlit apps.
                 if config.get_option("server.headless"):
                     email = ""
                 else:


### PR DESCRIPTION
**Issue:** #203 

**Description:** Skipping the credentials dialog while headless mode is setted up, 

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
