### PR TITLE
Fix syntax hiliting

### DIFF
--- a/frontend/src/components/elements/Text/Text.tsx
+++ b/frontend/src/components/elements/Text/Text.tsx
@@ -122,6 +122,7 @@ class Text extends React.PureComponent<Props> {
               source={body}
               escapeHtml={!allowHTML}
               astPlugins={astPlugins}
+              renderers={renderers}
             />
           </div>
         )


### PR DESCRIPTION
It looks like syntax hiliting was broken at https://github.com/streamlit/streamlit/commit/98ac69d180313eab7d3d1dee4bb24744247d3948

@arraydude: I'm assuming that `renderers` was removed by mistake, but if not (because it doesn't play nicely with the HTML fixes you made), we should come up with a solution that allows syntax hiliting in markdown code blocks.