### PR TITLE
Clean up old widget state after a run

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -20,6 +20,8 @@ import ReactDOM from "react-dom"
 import { SessionInfo } from "./lib/SessionInfo"
 import { MetricsManager } from "./lib/MetricsManager"
 import { getMetricsManagerForTest } from "./lib/MetricsManagerTestUtils"
+import { BlockElement } from "lib/DeltaParser"
+import { List, Set as ImmutableSet, Map as ImmutableMap } from "immutable"
 import App from "./App"
 
 beforeEach(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,7 @@ import {
   BlockElement,
   SimpleElement,
 } from "lib/DeltaParser"
-import { Map as ImmutableMap } from "immutable"
+import { Set as ImmutableSet } from "immutable"
 import {
   ForwardMsg,
   SessionEvent,
@@ -427,10 +427,10 @@ class App extends PureComponent<Props, State> {
 
       if (this.elementListBuffer) {
         const ids = this.flattenElements(this.elementListBuffer.main)
-          .concat(this.flattenElements(this.elementListBuffer.sidebar))
-          .map(e => {
+          .union(this.flattenElements(this.elementListBuffer.sidebar))
+          .map((e: SimpleElement) => {
             const type = e.get("type")
-            return e.get(type).get("id")
+            return e.get(type).get("id") as string
           })
           .filter(id => id != null)
         this.widgetMgr.clean(ids)
@@ -464,13 +464,16 @@ class App extends PureComponent<Props, State> {
       .filter((element: any) => element !== null)
   }
 
-  flattenElements = (elements: BlockElement): SimpleElement[] => {
-    return elements.reduce((acc: SimpleElement[], element: Element) => {
-      if (element instanceof List) {
-        return this.flattenElements(element as BlockElement)
-      }
-      return acc.concat([element as SimpleElement])
-    }, [])
+  flattenElements = (elements: BlockElement): ImmutableSet<SimpleElement> => {
+    return elements.reduce(
+      (acc: ImmutableSet<SimpleElement>, element: Element) => {
+        if (element instanceof List) {
+          return this.flattenElements(element as BlockElement)
+        }
+        return acc.union(ImmutableSet.of(element as SimpleElement))
+      },
+      ImmutableSet.of<SimpleElement>()
+    )
   }
 
   /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -465,21 +465,12 @@ class App extends PureComponent<Props, State> {
   }
 
   flattenElements = (elements: BlockElement): SimpleElement[] => {
-    const result: SimpleElement[] = []
-    const walker = (
-      elements: BlockElement,
-      fn: (e: SimpleElement) => void
-    ): void => {
-      elements.forEach((element: Element) => {
-        if (element instanceof List) {
-          walker(element as BlockElement, fn)
-          return
-        }
-        fn(element as SimpleElement)
-      })
-    }
-    walker(elements, (e: SimpleElement) => result.push(e))
-    return result
+    return elements.reduce((acc: SimpleElement[], element: Element) => {
+      if (element instanceof List) {
+        return this.flattenElements(element as BlockElement)
+      }
+      return acc.concat([element as SimpleElement])
+    }, [])
   }
 
   /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -420,15 +420,29 @@ class App extends PureComponent<Props, State> {
       )
 
       if (this.elementListBuffer) {
-        const ids = this.elementListBuffer.main
-          .map(e =>
-            (e as ImmutableMap<string, any>)
-              .get((e as ImmutableMap<string, any>).get("type"))
-              .get("id")
-          )
-          .filter(x => x != null)
-          .toArray()
-        this.widgetMgr.clean(ids as [string])
+        // const cleanOldState = (blockElement: BlockElement) => {
+        //   const ids = blockElement
+        //     .map(e =>
+        //       (e as ImmutableMap<string, any>)
+        //         .get((e as ImmutableMap<string, any>).get("type"))
+        //         .get("id")
+        //     )
+        //     .filter(x => x != null)
+        //     .toArray()
+        //   this.widgetMgr.clean(ids as [string])
+        // }
+        // cleanOldState(this.elementListBuffer.main)
+        // cleanOldState(this.elementListBuffer.sidebar)
+        const ids: string[] = []
+        // any??
+        const getId = (e: any) => {
+          const type = e.get("type")
+          ids.push(e.get(type).get("id"))
+        }
+        // make it a map
+        this.walkElements(this.elementListBuffer.main, getId)
+        this.walkElements(this.elementListBuffer.sidebar, getId)
+        this.widgetMgr.clean(ids.filter(x => x != null))
       }
 
       // Tell the ConnectionManager to increment the message cache run
@@ -457,6 +471,19 @@ class App extends PureComponent<Props, State> {
         return element.get("reportId") === reportId ? element : null
       })
       .filter((element: any) => element !== null)
+  }
+
+  walkElements = (
+    elements: any,
+    fn: (e: ImmutableMap<string, any>) => void
+  ): void => {
+    return elements.map((element: ImmutableMap<string, any>) => {
+      if (element instanceof List) {
+        this.walkElements(elements, fn)
+        return
+      }
+      fn(element)
+    })
   }
 
   /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import { ConnectionState } from "lib/ConnectionState"
 import { ReportRunState } from "lib/ReportRunState"
 import { SessionEventDispatcher } from "lib/SessionEventDispatcher"
 import { applyDelta, Elements, BlockElement } from "lib/DeltaParser"
+import { Map as ImmutableMap } from "immutable"
 import {
   ForwardMsg,
   SessionEvent,
@@ -417,6 +418,18 @@ class App extends PureComponent<Props, State> {
           this.elementListBuffer = this.state.elements
         }
       )
+
+      if (this.elementListBuffer) {
+        const ids = this.elementListBuffer.main
+          .map(e =>
+            (e as ImmutableMap<string, any>)
+              .get((e as ImmutableMap<string, any>).get("type"))
+              .get("id")
+          )
+          .filter(x => x != null)
+          .toArray()
+        this.widgetMgr.clean(ids as [string])
+      }
 
       // Tell the ConnectionManager to increment the message cache run
       // count. This will result in expired ForwardMsgs being removed from

--- a/frontend/src/lib/DeltaParser.ts
+++ b/frontend/src/lib/DeltaParser.ts
@@ -28,7 +28,7 @@ import { MetricsManager } from "lib/MetricsManager"
 import { requireNonNull } from "lib/utils"
 
 type Container = "main" | "sidebar"
-type SimpleElement = ImmutableMap<string, any>
+export type SimpleElement = ImmutableMap<string, any>
 export type Element = SimpleElement | BlockElement
 export interface BlockElement extends List<Element> {}
 

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -180,6 +180,14 @@ export class WidgetStateManager {
     this.sendBackMsg({ updateWidgets: this.createWigetStatesMsg() })
   }
 
+  public clean(ids: [string]): void {
+    this.widgetStates.forEach((value, key) => {
+      if (!ids.includes(key)) {
+        this.deleteWidgetStateProto(key)
+      }
+    })
+  }
+
   private createWigetStatesMsg(): WidgetStates {
     const msg = new WidgetStates()
     this.widgetStates.forEach(value => msg.widgets.push(value))

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -180,7 +180,7 @@ export class WidgetStateManager {
     this.sendBackMsg({ updateWidgets: this.createWigetStatesMsg() })
   }
 
-  public clean(ids: [string]): void {
+  public clean(ids: string[]): void {
     this.widgetStates.forEach((value, key) => {
       if (!ids.includes(key)) {
         this.deleteWidgetStateProto(key)

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -23,6 +23,8 @@ import {
   WidgetStates,
 } from "autogen/proto"
 
+import { Set as ImmutableSet } from "immutable"
+
 export interface Source {
   fromUi: boolean
 }
@@ -180,7 +182,7 @@ export class WidgetStateManager {
     this.sendBackMsg({ updateWidgets: this.createWigetStatesMsg() })
   }
 
-  public clean(ids: string[]): void {
+  public clean(ids: ImmutableSet<string>): void {
     this.widgetStates.forEach((value, key) => {
       if (!ids.includes(key)) {
         this.deleteWidgetStateProto(key)

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -182,9 +182,12 @@ export class WidgetStateManager {
     this.sendBackMsg({ updateWidgets: this.createWigetStatesMsg() })
   }
 
-  public clean(ids: ImmutableSet<string>): void {
+  /**
+   * Remove the state of widgets that are not contained in `active_ids`.
+   */
+  public clean(active_ids: ImmutableSet<string>): void {
     this.widgetStates.forEach((value, key) => {
-      if (!ids.includes(key)) {
+      if (!active_ids.includes(key)) {
         this.deleteWidgetStateProto(key)
       }
     })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2018-2019 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { flattenElements } from "./utils"
+import { BlockElement } from "lib/DeltaParser"
+import { List, Set as ImmutableSet, Map as ImmutableMap } from "immutable"
+
+describe("flattenElements", () => {
+  const simpleElement1 = ImmutableMap({ key1: "value1", key2: "value2" })
+  const simpleElement2 = ImmutableMap({ key3: "value3", key4: "value4" })
+  const simpleElement3 = ImmutableMap({ key5: "value5", key6: "value6" })
+  const simpleBlockElement: BlockElement = List([
+    simpleElement1,
+    simpleElement2,
+  ])
+  const nestedBlockElement: BlockElement = List([
+    List(simpleBlockElement),
+    simpleElement3,
+  ])
+
+  it("should walk down a simple BlockElement", () => {
+    const elements = flattenElements(simpleBlockElement)
+    expect(elements).toEqual(ImmutableSet([simpleElement1, simpleElement2]))
+  })
+
+  it("should walk down a simple BlockElement", () => {
+    const elements = flattenElements(nestedBlockElement)
+    expect(elements).toEqual(
+      ImmutableSet([simpleElement1, simpleElement2, simpleElement3])
+    )
+  })
+})


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/218

**Description:** Widget old state was not cleaned up and caused old values to be returned to the user. This PR add some logic to clean up the state of widget that are not currently shown on the page. Widget that are shown on the page are not cleaned up.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
