### PR TITLE
Remove "Share Data" from tutorial. Fix #334

### DIFF
--- a/docs/tutorial/create_a_data_explorer_app.md
+++ b/docs/tutorial/create_a_data_explorer_app.md
@@ -298,22 +298,9 @@ We're sure you've got your own ideas. When you're done with this tutorial,
 check out all the widgets that Streamlit exposes in our [API
 reference](../api.md).
 
-## Share the app
-
-That's it, you've made it to the end. The last thing to do is share your
-findings. Locate the hamburger menu in the upper-right corner of the app
-and select **Share app**.
-
-```eval_rst
-.. warning::
-   This will not share the interactive version, just the static output.
-   Interactive sharing is in the works, and if you are interested in being in
-   the early beta, send an email to product@streamlit.io.
-```
-
 ## Let's put it all together
 
-So you've made it to the end. Here's the complete script for our interactive
+That's it, you've made it to the end. Here's the complete script for our interactive
 app.
 
 ```eval_rst


### PR DESCRIPTION
Remove "Share Data" section from "Create a Data Explorer" tutorial.

**Issue:** #334 .

**Description:** I've removed the section related to the "Share App" feature. I've rephrased the following section to make the flow "more natural".

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
