### PR TITLE
Show error message when urllib fails in hello.py

### DIFF
--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -95,8 +95,12 @@ def mapping_demo():
                 "widthMaxPixels": 30,
             }
         }
-    except urllib.error.URLError:
-        st.error("Connection Error. This demo requires internet access")
+    except urllib.error.URLError as e:
+        st.error("""
+            **This demo requires internet access.**
+
+            Connection error: %s
+        """ % e.reason)
         return
 
     st.sidebar.markdown('### Map Layers')
@@ -215,8 +219,12 @@ def data_frame_demo():
 
     try:
         df = get_UN_data()
-    except urllib.error.URLError:
-        st.error("Connection Error. This demo requires internet access")
+    except urllib.error.URLError as e:
+        st.error("""
+            **This demo requires internet access.**
+
+            Connection error: %s
+        """ % e.reason)
         return
 
     countries = st.multiselect(

--- a/lib/streamlit/hello/hello.py
+++ b/lib/streamlit/hello/hello.py
@@ -37,9 +37,9 @@ DEMOS = OrderedDict(
             (
                 demos.fractal_demo,
                 """
-This demo shows how to use
-[`st.deck_gl_chart`](https://streamlit.io/docs/api.html#streamlit.deck_gl_chart)
-to display geospatial data.
+This app shows how you can use Streamlit to build cool animations.
+It displays an animated fractal based on the the Julia Set. Use the slider
+to tune different parameters.
 """,
             ),
         ),
@@ -48,9 +48,9 @@ to display geospatial data.
             (
                 demos.plotting_demo,
                 """
-This app shows how you can use Streamlit to build cool animations.
-It displays an animated fractal based on the the Julia Set. Use the slider
-to tune different parameters.
+This demo illustrates a combination of plotting and animation with
+Streamlit. We're generating a bunch of random numbers in a loop for around
+5 seconds. Enjoy!
 """,
             ),
         ),
@@ -59,9 +59,9 @@ to tune different parameters.
             (
                 demos.mapping_demo,
                 """
-This demo illustrates a combination of plotting and animation with
-Streamlit. We're generating a bunch of random numbers in a loop for around
-5 seconds. Enjoy!
+This demo shows how to use
+[`st.deck_gl_chart`](https://streamlit.io/docs/api.html#streamlit.deck_gl_chart)
+to display geospatial data.
 """,
             ),
         ),


### PR DESCRIPTION
To help debug errors like [this one](https://discuss.streamlit.io/t/connection-error-this-demo-requires-internet-access/370), this PR shows the exception message when `urllib` fails in `hello.py`.

Also: I just noticed that in `develop` the demo descriptions for `hello.py` are all shuffled. So I fixed that here too.