### PR TITLE
Add ability to set audio/video start position

### DIFF
--- a/frontend/src/components/elements/Audio/Audio.tsx
+++ b/frontend/src/components/elements/Audio/Audio.tsx
@@ -24,12 +24,27 @@ interface Props {
 }
 
 class Audio extends React.PureComponent<Props> {
+  private audioRef = React.createRef<HTMLAudioElement>()
+
+  public componentDidMount = (): void => {
+    if (this.audioRef.current) {
+      const currentTime = this.props.element.get("currentTime")
+      this.audioRef.current.currentTime = currentTime
+    }
+  }
+
   public render(): React.ReactNode {
     const { element, width } = this.props
     const dataUrl =
       "data:" + element.get("format") + ";base64," + element.get("data")
     return (
-      <audio controls src={dataUrl} className="stAudio" style={{ width }} />
+      <audio
+        ref={this.audioRef}
+        controls
+        src={dataUrl}
+        className="stAudio"
+        style={{ width }}
+      />
     )
   }
 }

--- a/frontend/src/components/elements/Audio/Audio.tsx
+++ b/frontend/src/components/elements/Audio/Audio.tsx
@@ -27,6 +27,14 @@ class Audio extends React.PureComponent<Props> {
   private audioRef = React.createRef<HTMLAudioElement>()
 
   public componentDidMount = (): void => {
+    this.updateTime()
+  }
+
+  public componentDidUpdate = (): void => {
+    this.updateTime()
+  }
+
+  private updateTime(): void {
     if (this.audioRef.current) {
       const startTime = this.props.element.get("startTime")
       this.audioRef.current.currentTime = startTime

--- a/frontend/src/components/elements/Audio/Audio.tsx
+++ b/frontend/src/components/elements/Audio/Audio.tsx
@@ -28,8 +28,8 @@ class Audio extends React.PureComponent<Props> {
 
   public componentDidMount = (): void => {
     if (this.audioRef.current) {
-      const currentTime = this.props.element.get("currentTime")
-      this.audioRef.current.currentTime = currentTime
+      const startTime = this.props.element.get("startTime")
+      this.audioRef.current.currentTime = startTime
     }
   }
 

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -27,6 +27,14 @@ class Video extends React.PureComponent<Props> {
   private videoRef = React.createRef<HTMLVideoElement>()
 
   public componentDidMount = (): void => {
+    this.updateTime()
+  }
+
+  public componentDidUpdate = (): void => {
+    this.updateTime()
+  }
+
+  private updateTime(): void {
     if (this.videoRef.current) {
       const startTime = this.props.element.get("startTime")
       this.videoRef.current.currentTime = startTime

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -24,12 +24,27 @@ interface Props {
 }
 
 class Video extends React.PureComponent<Props> {
+  private videoRef = React.createRef<HTMLVideoElement>()
+
+  public componentDidMount = (): void => {
+    if (this.videoRef.current) {
+      const currentTime = this.props.element.get("currentTime")
+      this.videoRef.current.currentTime = currentTime
+    }
+  }
+
   public render(): React.ReactNode {
     const { element, width } = this.props
     const dataUrl =
       "data:" + element.get("format") + ";base64," + element.get("data")
     return (
-      <video controls src={dataUrl} className="stVideo" style={{ width }} />
+      <video
+        ref={this.videoRef}
+        controls
+        src={dataUrl}
+        className="stVideo"
+        style={{ width }}
+      />
     )
   }
 }

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -28,8 +28,8 @@ class Video extends React.PureComponent<Props> {
 
   public componentDidMount = (): void => {
     if (this.videoRef.current) {
-      const currentTime = this.props.element.get("currentTime")
-      this.videoRef.current.currentTime = currentTime
+      const startTime = this.props.element.get("startTime")
+      this.videoRef.current.currentTime = startTime
     }
   }
 

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1299,7 +1299,7 @@ class DeltaGenerator(object):
         )
 
     @_with_element
-    def audio(self, element, data, current_time=0, format="audio/wav"):
+    def audio(self, element, data, format="audio/wav", start_time=0):
         """Display an audio player.
 
         Parameters
@@ -1308,8 +1308,8 @@ class DeltaGenerator(object):
                 io.open().
             The audio data. Must include headers and any other bytes required
             in the actual file.
-        current_time: int
-            This argument let you to set start position for this audio elements.
+        start_time: int
+            The time from which this element should start playing.
         format : str
             The mime type for the audio file. Defaults to 'audio/wav'.
             See https://tools.ietf.org/html/rfc4281 for more info.
@@ -1331,11 +1331,11 @@ class DeltaGenerator(object):
         import streamlit.elements.generic_binary_proto as generic_binary_proto
 
         generic_binary_proto.marshall(element.audio, data)
-        element.audio.current_time = current_time
         element.audio.format = format
+        element.audio.start_time = start_time
 
     @_with_element
-    def video(self, element, data, current_time=0, format="video/mp4"):
+    def video(self, element, data, format="video/mp4", start_time=0):
         """Display a video player.
 
         Parameters
@@ -1344,8 +1344,8 @@ class DeltaGenerator(object):
                 io.open().
             Must include headers and any other bytes required in the actual
             file.
-        current_time: int
-            This argument let you to set start position for this video elements.
+        start_time: int
+            The time from which this element should start playing.
         format : str
             The mime type for the video file. Defaults to 'video/mp4'.
             See https://tools.ietf.org/html/rfc4281 for more info.
@@ -1367,8 +1367,8 @@ class DeltaGenerator(object):
         import streamlit.elements.generic_binary_proto as generic_binary_proto
 
         generic_binary_proto.marshall(element.video, data)
-        element.video.current_time = current_time
         element.video.format = format
+        element.video.start_time = start_time
 
     @_with_element
     def button(self, element, label):

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1299,7 +1299,7 @@ class DeltaGenerator(object):
         )
 
     @_with_element
-    def audio(self, element, data, format="audio/wav"):
+    def audio(self, element, data, current_time=0, format="audio/wav"):
         """Display an audio player.
 
         Parameters
@@ -1308,6 +1308,8 @@ class DeltaGenerator(object):
                 io.open().
             The audio data. Must include headers and any other bytes required
             in the actual file.
+        current_time: int
+            This argument let you to set start position for this audio elements.
         format : str
             The mime type for the audio file. Defaults to 'audio/wav'.
             See https://tools.ietf.org/html/rfc4281 for more info.
@@ -1329,10 +1331,11 @@ class DeltaGenerator(object):
         import streamlit.elements.generic_binary_proto as generic_binary_proto
 
         generic_binary_proto.marshall(element.audio, data)
+        element.audio.current_time = current_time
         element.audio.format = format
 
     @_with_element
-    def video(self, element, data, format="video/mp4"):
+    def video(self, element, data, current_time=0, format="video/mp4"):
         """Display a video player.
 
         Parameters
@@ -1341,6 +1344,8 @@ class DeltaGenerator(object):
                 io.open().
             Must include headers and any other bytes required in the actual
             file.
+        current_time: int
+            This argument let you to set start position for this video elements.
         format : str
             The mime type for the video file. Defaults to 'video/mp4'.
             See https://tools.ietf.org/html/rfc4281 for more info.
@@ -1362,6 +1367,7 @@ class DeltaGenerator(object):
         import streamlit.elements.generic_binary_proto as generic_binary_proto
 
         generic_binary_proto.marshall(element.video, data)
+        element.video.current_time = current_time
         element.video.format = format
 
     @_with_element

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -80,10 +80,12 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("streamlit", ds.module)
         if is_python_2:
             self.assertEqual("<type 'function'>", ds.type)
-            self.assertEqual("(data, format=u'audio/wav')", ds.signature)
+            self.assertEqual("(data, format=u'audio/wav', start_time=0)",
+                             ds.signature)
         else:
             self.assertEqual("<class 'function'>", ds.type)
-            self.assertEqual("(data, format='audio/wav')", ds.signature)
+            self.assertEqual("(data, format='audio/wav', start_time=0)",
+                             ds.signature)
         self.assertTrue(ds.doc_string.startswith("Display an audio player"))
 
     def test_unwrapped_deltagenerator_func(self):

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -125,7 +125,18 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         # base64.b64encode(bytes('\x11\x22\x33\x44\x55\x66'.encode('utf-8')))
         self.assertEqual(el.audio.data, "ESIzRFVm")
         self.assertEqual(el.audio.format, "audio/wav")
-        self.assertEqual(el.audio.start_time, 0)
+
+    def test_st_audio_options(self):
+        """Test st.audio with options."""
+        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        st.audio(fake_audio_data, format="audio/mp3", start_time=10)
+
+        el = self.get_delta_from_queue().new_element
+        # Manually base64 encoded payload above via
+        # base64.b64encode(bytes('\x11\x22\x33\x44\x55\x66'.encode('utf-8')))
+        self.assertEqual(el.audio.data, "ESIzRFVm")
+        self.assertEqual(el.audio.format, "audio/mp3")
+        self.assertEqual(el.audio.start_time, 10)
 
     def test_st_balloons(self):
         """Test st.balloons."""
@@ -550,7 +561,18 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         # base64.b64encode(bytes('\x11\x22\x33\x44\x55\x66'.encode('utf-8')))
         self.assertEqual(el.video.data, "ESIzRFVm")
         self.assertEqual(el.video.format, "video/mp4")
-        self.assertEqual(el.video.start_time, 0)
+
+    def test_st_video_options(self):
+        """Test st.video with options."""
+        fake_video_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        st.video(fake_video_data, format="video/mp4", start_time=10)
+
+        el = self.get_delta_from_queue().new_element
+        # Manually base64 encoded payload above via
+        # base64.b64encode(bytes('\x11\x22\x33\x44\x55\x66'.encode('utf-8')))
+        self.assertEqual(el.video.data, "ESIzRFVm")
+        self.assertEqual(el.video.format, "video/mp4")
+        self.assertEqual(el.video.start_time, 10)
 
     def test_st_warning(self):
         """Test st.warning."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -125,6 +125,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         # base64.b64encode(bytes('\x11\x22\x33\x44\x55\x66'.encode('utf-8')))
         self.assertEqual(el.audio.data, "ESIzRFVm")
         self.assertEqual(el.audio.format, "audio/wav")
+        self.assertEqual(el.audio.start_time, 0)
 
     def test_st_balloons(self):
         """Test st.balloons."""
@@ -549,6 +550,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         # base64.b64encode(bytes('\x11\x22\x33\x44\x55\x66'.encode('utf-8')))
         self.assertEqual(el.video.data, "ESIzRFVm")
         self.assertEqual(el.video.format, "video/mp4")
+        self.assertEqual(el.video.start_time, 0)
 
     def test_st_warning(self):
         """Test st.warning."""

--- a/proto/streamlit/proto/Audio.proto
+++ b/proto/streamlit/proto/Audio.proto
@@ -20,10 +20,10 @@ message Audio {
   // The data in Base64 format.
   string data = 1;
 
-  // The currentTime attribute of the HTML <audio> tag's <source> subtag.
-  int32 current_time = 2;
-
   // The type attribute of the HTML <audio> tag's <source> subtag.
   // ex: "audio/mp3", "audio/wav"
-  string format = 3;
+  string format = 2;
+
+  // The currentTime attribute of the HTML <audio> tag's <source> subtag.
+  int32 start_time = 3;
 }

--- a/proto/streamlit/proto/Audio.proto
+++ b/proto/streamlit/proto/Audio.proto
@@ -20,7 +20,10 @@ message Audio {
   // The data in Base64 format.
   string data = 1;
 
+  // The currentTime attribute of the HTML <audio> tag's <source> subtag.
+  int32 current_time = 2;
+
   // The type attribute of the HTML <audio> tag's <source> subtag.
   // ex: "audio/mp3", "audio/wav"
-  string format = 2;
+  string format = 3;
 }

--- a/proto/streamlit/proto/Video.proto
+++ b/proto/streamlit/proto/Video.proto
@@ -20,10 +20,10 @@ message Video {
   // The data in Base64 format.
   string data = 1;
 
-  // The currentTime attribute of the HTML <video> tag's <source> subtag.
-  int32 current_time = 2;
-
   // The type attribute of the HTML <video> tag's <source> subtag.
   // ex: "video/mp4"
-  string format = 3;
+  string format = 2;
+
+  // The currentTime attribute of the HTML <video> tag's <source> subtag.
+  int32 start_time = 3;
 }

--- a/proto/streamlit/proto/Video.proto
+++ b/proto/streamlit/proto/Video.proto
@@ -20,7 +20,10 @@ message Video {
   // The data in Base64 format.
   string data = 1;
 
+  // The currentTime attribute of the HTML <video> tag's <source> subtag.
+  int32 current_time = 2;
+
   // The type attribute of the HTML <video> tag's <source> subtag.
   // ex: "video/mp4"
-  string format = 2;
+  string format = 3;
 }


### PR DESCRIPTION
Resolving https://github.com/streamlit/streamlit/issues/372

Set audio/video start position, just with current_time argument to st.audio()/st.video() function.