### PR TITLE
Don't watch files the user has no permission to read

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -20,8 +20,6 @@ import ReactDOM from "react-dom"
 import { SessionInfo } from "./lib/SessionInfo"
 import { MetricsManager } from "./lib/MetricsManager"
 import { getMetricsManagerForTest } from "./lib/MetricsManagerTestUtils"
-import { BlockElement } from "lib/DeltaParser"
-import { List, Set as ImmutableSet, Map as ImmutableMap } from "immutable"
 import App from "./App"
 
 beforeEach(() => {

--- a/frontend/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -81,7 +81,7 @@ class GraphVizChart extends React.PureComponent<PropsWithHeight> {
           }
         })
 
-      const { width, height } = this.getChartDimensions()
+      const { height } = this.getChartDimensions()
       if (height > 0) {
         // Override or reset the graph height
         graph.height(height)

--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -52,12 +52,13 @@ def intro():
 # fmt: off
 def mapping_demo():
     import pandas as pd
-    import os
 
     @st.cache
     def from_data_file(filename):
-        GITHUB_DATA = "https://raw.githubusercontent.com/streamlit/streamlit/develop/examples/"
-        return pd.read_json(os.path.join(GITHUB_DATA, "data", filename))
+        url = (
+            "https://raw.githubusercontent.com/streamlit/"
+            "streamlit/develop/examples/data/%s" % filename)
+        return pd.read_json(url)
 
     try:
         ALL_LAYERS = {

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -25,6 +25,7 @@ except ImportError:
     # Python 3
     import importlib
 
+from streamlit import compatibility
 from streamlit import config
 from streamlit import util
 from streamlit.folder_black_list import FolderBlackList
@@ -107,11 +108,16 @@ class LocalSourcesWatcher(object):
         self._is_closed = True
 
     def _register_watcher(self, filepath, module_name):
+        if compatibility.is_running_py3():
+            ErrorType = PermissionError
+        else:
+            ErrorType = OSError
+
         try:
             wm = WatchedModule(
                 watcher=FileWatcher(filepath, self.on_file_changed), module_name=module_name
             )
-        except PermissionError:
+        except ErrorType:
             # If you don't have permission to read this file, don't even add it
             # to watchers.
             return

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -107,9 +107,15 @@ class LocalSourcesWatcher(object):
         self._is_closed = True
 
     def _register_watcher(self, filepath, module_name):
-        wm = WatchedModule(
-            watcher=FileWatcher(filepath, self.on_file_changed), module_name=module_name
-        )
+        try:
+            wm = WatchedModule(
+                watcher=FileWatcher(filepath, self.on_file_changed), module_name=module_name
+            )
+        except PermissionError:
+            # If you don't have permission to read this file, don't even add it
+            # to watchers.
+            return
+
         self._watched_modules[filepath] = wm
 
     def _deregister_watcher(self, filepath):

--- a/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
+++ b/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
@@ -79,7 +79,14 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
     def test_permission_error(self, fob):
-        fob.side_effect = RuntimeError('This error should be caught!')
+        from streamlit import compatibility
+
+        if compatibility.is_running_py3():
+            ErrorType = PermissionError
+        else:
+            ErrorType = OSError
+
+        fob.side_effect = ErrorType('This error should be caught!')
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")

--- a/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
+++ b/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
@@ -79,7 +79,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
     def test_permission_error(self, fob):
-        fob.side_effect = PermissionError('This error should be caught!')
+        fob.side_effect = RuntimeError('This error should be caught!')
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")

--- a/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
+++ b/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
@@ -78,6 +78,11 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(fob.call_count, 1)  # __init__.py
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
+    def test_permission_error(self, fob):
+        fob.side_effect = PermissionError('This error should be caught!')
+        lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
+
+    @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
     def test_script_and_2_modules_at_once(self, fob):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 


### PR DESCRIPTION
See: https://discuss.streamlit.io/t/issue-in-running-streamlit-app-in-anaconda-environment/380

This fixes the error in the post, but I think there's a deeper issue at hand: why does the user have no permission to read a file that Streamlit wants to read?

My guess is the temporary file we save the URL to is stored in a common `tmp` folder that contains things the user has no access to. Should we create a subfolder in `tmp` and put the file in there, to avoid this problem? @monchier 
- If so, then let's do that in another PR