### PR TITLE
Rename ignore_hash to allow_output_mutation

### DIFF
--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -429,8 +429,10 @@ def cache(
         Whether to persist the cache on disk.
 
     allow_output_mutation : boolean
-        Disable hashing return values. These hash values are otherwise
-        used to validate that return values are not mutated.
+        Streamlit normally shows a warning when return values are not mutated, as that
+        can have unintended consequences. This is done by hashing the return value internally.
+
+        If you know what you're doing and would like to override this warning, set this to True.
 
     show_spinner : boolean
         Enable the spinner. Default is True to show a spinner when there is
@@ -474,6 +476,7 @@ def cache(
 
     """
     # Help users migrate to the new kwarg
+    # Remove this warning after 2020-03-16.
     if "ignore_hash" in kwargs:
         raise Exception(
             "The `ignore_hash` argument has been renamed to `allow_output_mutation`."

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -596,12 +596,7 @@ class Cache(dict):
 
     """
 
-    def __init__(self, persist=False, allow_output_mutation=False, **kwargs):
-        if "ignore_hash" in kwargs:
-            raise Exception(
-                "The `ignore_hash` argument has been renamed to `allow_output_mutation`."
-            )
-
+    def __init__(self, persist=False, allow_output_mutation=False):
         self._persist = persist
         self._allow_output_mutation = allow_output_mutation
 

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -175,7 +175,7 @@ def _hashing_error_message(start):
         following:
 
         * **Preferred:** modify your code to avoid using this type of object.
-        * Or add the argument `ignore_hash=True` to the `st.cache` decorator.
+        * Or add the argument `allow_output_mutation=True` to the `st.cache` decorator.
     """
         % {"start": start}
     ).strip("\n")

--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -16,6 +16,7 @@
 """st.caching unit tests."""
 import threading
 import unittest
+import pytest
 
 from mock import patch
 
@@ -38,6 +39,18 @@ class CacheTest(unittest.TestCase):
 
         self.assertEqual(foo(), 42)
         self.assertEqual(foo(), 42)
+
+    def test_deprecated_kwarg(self):
+        with pytest.raises(Exception) as e:
+
+            @st.cache(ignore_hash=True)
+            def foo():
+                return 42
+
+        assert (
+            "The `ignore_hash` argument has been renamed to `allow_output_mutation`."
+            in str(e.value)
+        )
 
     @patch.object(st, "warning")
     def test_args(self, warning):
@@ -207,11 +220,11 @@ class CachingObjectTest(unittest.TestCase):
 
             self.assertEqual(c.value, val)
 
-    def off_test_ignore_hash(self):
+    def off_test_allow_output_mutation(self):
         val = 42
 
         for _ in range(2):
-            c = st.Cache(ignore_hash=True)
+            c = st.Cache(allow_output_mutation=True)
             if c:
                 c.value = val
 

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -80,12 +80,10 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("streamlit", ds.module)
         if is_python_2:
             self.assertEqual("<type 'function'>", ds.type)
-            self.assertEqual("(data, format=u'audio/wav', start_time=0)",
-                             ds.signature)
+            self.assertEqual("(data, format=u'audio/wav', start_time=0)", ds.signature)
         else:
             self.assertEqual("<class 'function'>", ds.type)
-            self.assertEqual("(data, format='audio/wav', start_time=0)",
-                             ds.signature)
+            self.assertEqual("(data, format='audio/wav', start_time=0)", ds.signature)
         self.assertTrue(ds.doc_string.startswith("Display an audio player"))
 
     def test_unwrapped_deltagenerator_func(self):
@@ -117,7 +115,8 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
                 ds.signature,
                 (
                     "(func=None, persist=False, "
-                    "ignore_hash=False, show_spinner=True, suppress_st_warning=False)"
+                    "allow_output_mutation=False, show_spinner=True, suppress_st_warning=False, "
+                    "**kwargs)"
                 ),
             )
             self.assertTrue(ds.doc_string.startswith("Function decorator to"))


### PR DESCRIPTION
**Issue:**

#412 

- Rename `ignore_hash` to `allow_output_mutation`
- Help users migrate to the new name by throwing an error if `ignore_hash` is used
  - Only added to `@st.cache` and not `class Cache` since only the decorator is exposed to the user right now