### PR TITLE
Widgets with identical IDs raise an Exception

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -128,7 +128,8 @@ def _build_duplicate_widget_message(widget_type, user_key=None):
     if user_key is not None:
         message = textwrap.dedent(
             """
-            There are multiple {widget_type} widgets that use the '{user_key}' key.
+            There are multiple identical st.{widget_type} widgets that use the
+             '{user_key}' key.
             
             To fix this, please make sure that the 'key' argument is unique for 
             each st.{widget_type} you create.
@@ -137,7 +138,8 @@ def _build_duplicate_widget_message(widget_type, user_key=None):
     else:
         message = textwrap.dedent(
             """
-            There are multiple st.{widget_type} widgets with the same generated key.
+            There are multiple identical st.{widget_type} widgets with the 
+            same generated key.
             
             (When a widget is created, it's assigned an internal key based on
             its structure. Multiple widgets with an identical structure will
@@ -165,10 +167,11 @@ def _set_widget_id(widget_type, element, user_key=None):
         If this is None, we'll generate an ID by hashing the element.
 
     """
+    element_hash = hash(element.SerializeToString())
     if user_key is not None:
-        widget_id = "%s-%s" % (widget_type, user_key)
+        widget_id = "%s-%s" % (user_key, element_hash)
     else:
-        widget_id = "%s" % hash(element.SerializeToString())
+        widget_id = "%s" % element_hash
 
     ctx = get_report_ctx()
     if ctx is not None:

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -18,7 +18,7 @@
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
 from streamlit.compatibility import setup_2_3_shims
-from streamlit.errors import DuplicateWidgetIDException
+from streamlit.errors import DuplicateWidgetID
 
 setup_2_3_shims(globals())
 
@@ -173,7 +173,7 @@ def _set_widget_id(widget_type, element, user_key=None):
     ctx = get_report_ctx()
     if ctx is not None:
         if widget_id in ctx.widget_ids_this_run:
-            raise DuplicateWidgetIDException(
+            raise DuplicateWidgetID(
                 _build_duplicate_widget_message(widget_type, user_key)
             )
         ctx.widget_ids_this_run.add(widget_id)

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1423,9 +1423,11 @@ class DeltaGenerator(object):
         ----------
         label : str
             A short label explaining to the user what this button is for.
-
         key : str
-            An optional string to use as an ID for the button.
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1448,7 +1450,7 @@ class DeltaGenerator(object):
         return current_value
 
     @_with_element
-    def checkbox(self, element, label, value=False):
+    def checkbox(self, element, label, value=False, key=None):
         """Display a checkbox widget.
 
         Parameters
@@ -1458,6 +1460,11 @@ class DeltaGenerator(object):
         value : bool
             Preselect the checkbox when it first renders. This will be
             cast to bool internally.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1475,12 +1482,14 @@ class DeltaGenerator(object):
         element.checkbox.label = label
         element.checkbox.default = bool(value)
 
-        ui_value = _get_widget_ui_value("checkbox", element)
+        ui_value = _get_widget_ui_value("checkbox", element, user_key=key)
         current_value = ui_value if ui_value is not None else value
         return bool(current_value)
 
     @_with_element
-    def multiselect(self, element, label, options, default=None, format_func=str):
+    def multiselect(
+        self, element, label, options, default=None, format_func=str, key=None
+    ):
         """Display a multiselect widget.
         The multiselect widget starts as empty.
 
@@ -1496,6 +1505,11 @@ class DeltaGenerator(object):
         format_func : function
             Function to modify the display of the labels. It receives the option
             as an argument and its output will be cast to str.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1536,12 +1550,12 @@ class DeltaGenerator(object):
             str(format_func(option)) for option in options
         ]
 
-        ui_value = _get_widget_ui_value("multiselect", element)
+        ui_value = _get_widget_ui_value("multiselect", element, user_key=key)
         current_value = ui_value.value if ui_value is not None else default_value
         return [options[i] for i in current_value]
 
     @_with_element
-    def radio(self, element, label, options, index=0, format_func=str):
+    def radio(self, element, label, options, index=0, format_func=str, key=None):
         """Display a radio button widget.
 
         Parameters
@@ -1556,6 +1570,11 @@ class DeltaGenerator(object):
         format_func : function
             Function to modify the display of the labels. It receives the option
             as an argument and its output will be cast to str.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1584,12 +1603,12 @@ class DeltaGenerator(object):
         element.radio.default = index
         element.radio.options[:] = [str(format_func(option)) for option in options]
 
-        ui_value = _get_widget_ui_value("radio", element)
+        ui_value = _get_widget_ui_value("radio", element, user_key=key)
         current_value = ui_value if ui_value is not None else index
         return options[current_value] if len(options) > 0 else NoValue
 
     @_with_element
-    def selectbox(self, element, label, options, index=0, format_func=str):
+    def selectbox(self, element, label, options, index=0, format_func=str, key=None):
         """Display a select widget.
 
         Parameters
@@ -1604,6 +1623,11 @@ class DeltaGenerator(object):
         format_func : function
             Function to modify the display of the labels. It receives the option
             as an argument and its output will be cast to str.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1631,7 +1655,7 @@ class DeltaGenerator(object):
         element.selectbox.default = index
         element.selectbox.options[:] = [str(format_func(option)) for option in options]
 
-        ui_value = _get_widget_ui_value("selectbox", element)
+        ui_value = _get_widget_ui_value("selectbox", element, user_key=key)
         current_value = ui_value if ui_value is not None else index
         return options[current_value] if len(options) > 0 else NoValue
 
@@ -1645,6 +1669,7 @@ class DeltaGenerator(object):
         value=None,
         step=None,
         format=None,
+        key=None,
     ):
         """Display a slider widget.
 
@@ -1667,6 +1692,11 @@ class DeltaGenerator(object):
             Defaults to 1 if the value is an int, 0.01 otherwise.
         format : str or None
             Printf/Python format string.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
 
         Returns
@@ -1786,7 +1816,7 @@ class DeltaGenerator(object):
         element.slider.step = step
         element.slider.format = format
 
-        ui_value = _get_widget_ui_value("slider", element)
+        ui_value = _get_widget_ui_value("slider", element, user_key=key)
         # Convert the current value to the appropriate type.
         current_value = ui_value if ui_value is not None else value
         # Cast ui_value to the same type as the input arguments
@@ -1802,7 +1832,7 @@ class DeltaGenerator(object):
         return current_value if single_value else tuple(current_value)
 
     @_with_element
-    def text_input(self, element, label, value=""):
+    def text_input(self, element, label, value="", key=None):
         """Display a single-line text input widget.
 
         Parameters
@@ -1812,6 +1842,11 @@ class DeltaGenerator(object):
         value : any
             The text value of this widget when it first renders. This will be
             cast to str internally.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1827,12 +1862,12 @@ class DeltaGenerator(object):
         element.text_input.label = label
         element.text_input.default = str(value)
 
-        ui_value = _get_widget_ui_value("text_input", element)
+        ui_value = _get_widget_ui_value("text_input", element, user_key=key)
         current_value = ui_value if ui_value is not None else value
         return str(current_value)
 
     @_with_element
-    def text_area(self, element, label, value=""):
+    def text_area(self, element, label, value="", key=None):
         """Display a multi-line text input widget.
 
         Parameters
@@ -1842,6 +1877,11 @@ class DeltaGenerator(object):
         value : any
             The text value of this widget when it first renders. This will be
             cast to str internally.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1863,12 +1903,12 @@ class DeltaGenerator(object):
         element.text_area.label = label
         element.text_area.default = str(value)
 
-        ui_value = _get_widget_ui_value("text_area", element)
+        ui_value = _get_widget_ui_value("text_area", element, user_key=key)
         current_value = ui_value if ui_value is not None else value
         return str(current_value)
 
     @_with_element
-    def time_input(self, element, label, value=None):
+    def time_input(self, element, label, value=None, key=None):
         """Display a time input widget.
 
         Parameters
@@ -1878,6 +1918,11 @@ class DeltaGenerator(object):
         value : datetime.time/datetime.datetime
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to the current time.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1905,7 +1950,7 @@ class DeltaGenerator(object):
         element.time_input.label = label
         element.time_input.default = time.strftime(value, "%H:%M")
 
-        ui_value = _get_widget_ui_value("time_input", element)
+        ui_value = _get_widget_ui_value("time_input", element, user_key=key)
         current_value = (
             datetime.strptime(ui_value, "%H:%M").time()
             if ui_value is not None
@@ -1914,7 +1959,7 @@ class DeltaGenerator(object):
         return current_value
 
     @_with_element
-    def date_input(self, element, label, value=None):
+    def date_input(self, element, label, value=None, key=None):
         """Display a date input widget.
 
         Parameters
@@ -1924,6 +1969,11 @@ class DeltaGenerator(object):
         value : datetime.date/datetime.datetime
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to today.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -1953,7 +2003,7 @@ class DeltaGenerator(object):
         element.date_input.label = label
         element.date_input.default = date.strftime(value, "%Y/%m/%d")
 
-        ui_value = _get_widget_ui_value("date_input", element)
+        ui_value = _get_widget_ui_value("date_input", element, user_key=key)
         current_value = (
             datetime.strptime(ui_value, "%Y/%m/%d").date()
             if ui_value is not None

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -172,11 +172,11 @@ def _set_widget_id(widget_type, element, user_key=None):
 
     ctx = get_report_ctx()
     if ctx is not None:
-        if widget_id in ctx.widget_ids_this_run:
+        added = ctx.widget_ids_this_run.add(widget_id)
+        if not added:
             raise DuplicateWidgetID(
                 _build_duplicate_widget_message(widget_type, user_key)
             )
-        ctx.widget_ids_this_run.add(widget_id)
     el = getattr(element, widget_type)
     el.id = widget_id
 

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -23,12 +23,15 @@ LOGGER = get_logger(__name__)
 ReportContext = namedtuple(
     "ReportContext",
     [
-        # The main DeltaGenerator for the report
+        # (DeltaGenerator) The main DeltaGenerator for the report
         "main_dg",
-        # The sidebar DeltaGenerator for the report
+        # (DeltaGenerator) The sidebar DeltaGenerator for the report
         "sidebar_dg",
-        # The Widgets state object for the report
+        # (Widgets) The Widgets state object for the report
         "widgets",
+        # (set) The set of widget IDs that have been assigned in the current
+        # report run. This set is cleared at the start of each run.
+        "widget_ids_this_run",
     ],
 )
 
@@ -40,7 +43,7 @@ class ReportThread(threading.Thread):
 
     def __init__(self, main_dg, sidebar_dg, widgets, target=None, name=None):
         super(ReportThread, self).__init__(target=target, name=name)
-        self.streamlit_report_ctx = ReportContext(main_dg, sidebar_dg, widgets)
+        self.streamlit_report_ctx = ReportContext(main_dg, sidebar_dg, widgets, set())
 
 
 def add_report_ctx(thread):

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -133,9 +133,7 @@ def _reset(main_dg, sidebar_dg):
     sidebar_dg._reset()
     global sidebar
     sidebar = sidebar_dg
-    ctx = get_report_ctx()
-    if ctx is not None:
-        ctx.widget_ids_this_run.clear()
+    get_report_ctx().widget_ids_this_run.clear()
 
 
 # Sidebar

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -133,6 +133,9 @@ def _reset(main_dg, sidebar_dg):
     sidebar_dg._reset()
     global sidebar
     sidebar = sidebar_dg
+    ctx = get_report_ctx()
+    if ctx is not None:
+        ctx.widget_ids_this_run.clear()
 
 
 # Sidebar

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -20,3 +20,7 @@ class NoStaticFiles(Exception):
 
 class S3NoCredentials(Exception):
     pass
+
+
+class DuplicateWidgetIDException(Exception):
+    pass

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -22,5 +22,5 @@ class S3NoCredentials(Exception):
     pass
 
 
-class DuplicateWidgetIDException(Exception):
+class DuplicateWidgetID(Exception):
     pass

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -213,21 +213,42 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
 
     def test_duplicate_widget_id_error(self):
         """Multiple widgets with the same key should report an error."""
-        st.button("button")
-        with self.assertRaises(DuplicateWidgetID) as ctx:
-            st.button("button")
-            self.assertIn(
-                _build_duplicate_widget_message(widget_type="button", user_key=None),
-                ctx.exception,
-            )
+        widgets = {
+            "button": lambda key=None: st.button("", key=key),
+            "checkbox": lambda key=None: st.checkbox("", key=key),
+            "multiselect": lambda key=None: st.multiselect("", options=[1, 2], key=key),
+            "radio": lambda key=None: st.radio("", options=[1, 2], key=key),
+            "selectbox": lambda key=None: st.selectbox("", options=[1, 2], key=key),
+            "slider": lambda key=None: st.slider("", key=key),
+            "text_area": lambda key=None: st.text_area("", key=key),
+            "text_input": lambda key=None: st.text_input("", key=key),
+            "time_input": lambda key=None: st.time_input("", key=key),
+            "date_input": lambda key=None: st.date_input("", key=key),
+        }
 
-        st.button("button", key="key")
-        with self.assertRaises(DuplicateWidgetID) as ctx:
-            st.button("button", key="key")
-            self.assertIn(
-                _build_duplicate_widget_message(widget_type="button", user_key="key"),
-                ctx.exception,
-            )
+        # Iterate each widget type
+        for widget_type, create_widget in widgets.items():
+            # Test duplicate auto-generated widget key
+            create_widget()
+            with self.assertRaises(DuplicateWidgetID) as ctx:
+                create_widget()
+                self.assertIn(
+                    _build_duplicate_widget_message(
+                        widget_type=widget_type, user_key=None
+                    ),
+                    ctx.exception,
+                )
+
+            # Test duplicate user-specified widget key
+            create_widget("key")
+            with self.assertRaises(DuplicateWidgetID) as ctx:
+                create_widget("key")
+                self.assertIn(
+                    _build_duplicate_widget_message(
+                        widget_type=widget_type, user_key="key"
+                    ),
+                    ctx.exception,
+                )
 
 
 class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -17,7 +17,10 @@
 
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
+
+from streamlit.DeltaGenerator import _build_duplicate_widget_message
 from streamlit.compatibility import setup_2_3_shims
+from streamlit.errors import DuplicateWidgetID
 
 setup_2_3_shims(globals())
 
@@ -207,6 +210,24 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
         st.text_input()
         c = self.get_delta_from_queue().new_element.exception
         self.assertEqual(c.type, "TypeError")
+
+    def test_duplicate_widget_id_error(self):
+        """Multiple widgets with the same key should report an error."""
+        st.button("button")
+        with self.assertRaises(DuplicateWidgetID) as ctx:
+            st.button("button")
+            self.assertIn(
+                _build_duplicate_widget_message(widget_type="button", user_key=None),
+                ctx.exception,
+            )
+
+        st.button("button", key="key")
+        with self.assertRaises(DuplicateWidgetID) as ctx:
+            st.button("button", key="key")
+            self.assertIn(
+                _build_duplicate_widget_message(widget_type="button", user_key="key"),
+                ctx.exception,
+            )
 
 
 class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -22,6 +22,7 @@ from streamlit.DeltaGenerator import DeltaGenerator
 from streamlit.ReportQueue import ReportQueue
 from streamlit.ReportThread import REPORT_CONTEXT_ATTR_NAME
 from streamlit.ReportThread import ReportContext
+from streamlit.ReportThread import _WidgetIDSet
 from streamlit.widgets import Widgets
 from streamlit.proto.BlockPath_pb2 import BlockPath
 
@@ -59,8 +60,10 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                 threading.current_thread(),
                 REPORT_CONTEXT_ATTR_NAME,
                 ReportContext(
-                    main_dg=main_dg, sidebar_dg=sidebar_dg, widgets=Widgets(),
-                    widget_ids_this_run=set(),
+                    main_dg=main_dg,
+                    sidebar_dg=sidebar_dg,
+                    widgets=Widgets(),
+                    widget_ids_this_run=_WidgetIDSet(),
                 ),
             )
 

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -59,7 +59,8 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                 threading.current_thread(),
                 REPORT_CONTEXT_ATTR_NAME,
                 ReportContext(
-                    main_dg=main_dg, sidebar_dg=sidebar_dg, widgets=Widgets()
+                    main_dg=main_dg, sidebar_dg=sidebar_dg, widgets=Widgets(),
+                    widget_ids_this_run=set(),
                 ),
             )
 


### PR DESCRIPTION
- When two widgets with the same ID are encountered in a report run, we throw a DuplicateWidgetID exception. The exception tells the user that they can use the new optional "key" parameter that each widget now takes in order to fix the issue.
- (The error is slightly different if the user has manually supplied an identical key to multiple widgets.)
- To track widget keys, `ReportContext` has a new `widget_ids_this_run` set. Each time a widget has an ID assigned, we add that ID to the set. If the ID was already in the set, the exception is thrown. (Because it's possible to access this set from multiple threads, access to it is wrapped in a `threading.Lock`).
- `ScriptRunner` clears the `widget_ids_this_run` right before running its script.
- User-supplied widget keys are "namespaced" by widget type (if you supply a custom widget key, the actual widget id becomes `"{widget_type}-{user-key}"`). So this allows two widgets with different types to share the same user key. Easy to change if this is undesirable!

Fixes #40 
