### PR TITLE
st._text_exception isn't used anywhere. Remove it!

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -714,21 +714,6 @@ class DeltaGenerator(object):
 
         exception_proto.marshall(element.exception, exception, exception_traceback)
 
-    @_with_element
-    def _text_exception(self, element, exception_type, message, stack_trace):
-        """Display an exception.
-
-        Parameters
-        ----------
-        exception_type : str
-        message : str
-        stack_trace : list of str
-
-        """
-        element.exception.type = exception_type
-        element.exception.message = message
-        element.exception.stack_trace.extend(stack_trace)
-
     @_remove_self_from_sig
     def dataframe(self, data=None, width=None, height=None):
         """Display a dataframe as an interactive table.

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -183,8 +183,6 @@ vega_lite_chart = _with_dg(_DeltaGenerator.vega_lite_chart)  # noqa: E221
 video = _with_dg(_DeltaGenerator.video)  # noqa: E221
 warning = _with_dg(_DeltaGenerator.warning)  # noqa: E221
 
-_text_exception = _with_dg(_DeltaGenerator._text_exception)  # noqa: E221
-
 # Config
 set_option = _config.set_option
 get_option = _config.get_option

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -581,24 +581,3 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.text.body, "some warning")
         self.assertEqual(el.text.format, Text.WARNING)
-
-    def test_st_text_exception(self):
-        """Test st._text_exception."""
-        data = {
-            "type": "ModuleNotFoundError",
-            "message": "No module named 'numpy'",
-            "stack_trace": [
-                "Traceback (most recent call last):",
-                '  File "<stdin>", line 1, in <module>',
-                "ModuleNotFoundError: No module named 'numpy'",
-            ],
-        }
-
-        st._text_exception(
-            data.get("type"), data.get("message"), data.get("stack_trace")
-        )
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.exception.type, data.get("type"))
-        self.assertEqual(el.exception.message, data.get("message"))
-        self.assertEqual(el.exception.stack_trace, data.get("stack_trace"))


### PR DESCRIPTION
`st._text_exception` is a private function that's not used anywhere, and isn't intended to be used by user code. So now it's gone!