### PR TITLE
Add encoding="utf-8" to fix codec error

### DIFF
--- a/lib/streamlit/ScriptRunner.py
+++ b/lib/streamlit/ScriptRunner.py
@@ -244,7 +244,7 @@ class ScriptRunner(object):
             # Python 3 got rid of the native execfile() command, so we read
             # the file, compile it, and exec() it. This implementation is
             # compatible with both 2 and 3.
-            with open(self._report.script_path) as f:
+            with open(self._report.script_path, encoding="utf-8") as f:
                 filebody = f.read()
 
             if config.get_option("runner.magicEnabled"):


### PR DESCRIPTION
**Issue:** #399 

**Description:** 
- Add `encoding="utf-8"` to the ` with open` statement

---

The way I test it is:
- Create a virtual environment and use `pip install streamlit` to install streamlit
- Run `streamlit hello` to make sure the problem is reproduced
- Modify the corresponding code in `venv\Lib\site-packages\streamlit\ScriptRunner.py`
- Run `streamlit hello` and the problem is fixed.

I believe this would prove that this change is effective for addressing the issue.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
