### PR TITLE
Update cli.md to reflect correct way of passing custom args

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,8 @@ $ streamlit run your_script.py [script args]
 
 Runs your app. At any time you can kill the server with **Ctrl+c**.
 
+Note that when passing your script args, **they must be passed bare** (`arg`, not `-arg` or `--arg`). This is because the module that interprets Streamlit's command line arguments (`click`) will greedily interpret anything that looks like a flag as an argument belonging to Streamlit itself.
+
 You can also pass in config options to `streamlit run`. These allow you to do
 things like change the port the app is served from, disable run-on-save, and
 more. To see all options, run:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,12 +18,17 @@ Below are a few of the most useful commands accepted by Streamlit CLI:
 ## Run Streamlit apps
 
 ```bash
-$ streamlit run your_script.py [script args]
+$ streamlit run your_script.py [-- script args]
 ```
 
 Runs your app. At any time you can kill the server with **Ctrl+c**.
 
-Note that when passing your script args, **they must be passed bare** (`arg`, not `-arg` or `--arg`). This is because the module that interprets Streamlit's command line arguments (`click`) will greedily interpret anything that looks like a flag as an argument belonging to Streamlit itself.
+```eval_rst
+.. note::
+  When passing your script some arguments, **they must be passed after a `--`**
+  (double dash). Otherwise the arguments get interpreted as anything arguments
+  to Streamlit itself.
+```
 
 You can also pass in config options to `streamlit run`. These allow you to do
 things like change the port the app is served from, disable run-on-save, and


### PR DESCRIPTION
As noted in https://github.com/streamlit/streamlit/issues/337, `streamlit run` only accepts bare arguments for arguments intended for the user script. This is currently not reflected in the documentation and could be confusing for users trying to make use of this feature.

**Issue:** https://github.com/streamlit/streamlit/issues/337

**Description:** Hi! This is just a super quick PR for a documentation update. A couple weeks back I was trying to get my script to accept custom args and couldn't figure it out from the docs. I created a PR to add some language around how custom args should be passed to a user script. Please feel free to change/suggest changes to the language if there is another way you'd prefer to explain this.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
