### PR TITLE
Implement config.baseUrlPath

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,9 +91,7 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 
-html_theme_options = {
-    "analytics_id": "UA-122023594-3",
-}
+html_theme_options = {"analytics_id": "UA-122023594-3"}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/e2e/scripts/sidebar.py
+++ b/e2e/scripts/sidebar.py
@@ -23,5 +23,5 @@ st.write("Value 1:", w1)
 w2 = st.sidebar.date_input("Label 2", datetime(2019, 7, 6, 21, 15))
 st.write("Value 2:", w2)
 
-x = st.sidebar.text('overwrite me')
-x.text('overwritten')
+x = st.sidebar.text("overwrite me")
+x.text("overwritten")

--- a/e2e/scripts/vega_lite_chart.py
+++ b/e2e/scripts/vega_lite_chart.py
@@ -87,8 +87,8 @@ st.vega_lite_chart(
     }
 )
 
-#st.write("Putting the `df` inside the spec, as inline `data` (different notation):")
-#This fails now, but not a big deal. It's a weird notation.
+# st.write("Putting the `df` inside the spec, as inline `data` (different notation):")
+# This fails now, but not a big deal. It's a weird notation.
 
 # st.vega_lite_chart({
 #     'data': {'values': df},

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -177,13 +177,16 @@ export class ConnectionManager {
       internalServerIP,
       externalServerIP,
       serverPort,
+      serverBasePath,
     } = manifest
 
+    const parts = { port: serverPort, basePath: serverBasePath }
+
     const baseUriPartsList = configuredServerAddress
-      ? [{ host: configuredServerAddress, port: serverPort }]
+      ? [{ ...parts, host: configuredServerAddress }]
       : [
-          { host: externalServerIP, port: serverPort },
-          { host: internalServerIP, port: serverPort },
+          { ...parts, host: externalServerIP },
+          { ...parts, host: internalServerIP },
         ]
 
     return new WebsocketConnection({

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -20,7 +20,11 @@ import fetchMock from "fetch-mock"
 import { ForwardMsgCache } from "lib/ForwardMessageCache"
 import { buildHttpUri } from "lib/UriUtil"
 
-const MOCK_SERVER_URI = { host: "streamlit.mock", port: 80 }
+const MOCK_SERVER_URI = {
+  host: "streamlit.mock",
+  port: 80,
+  basePath: "",
+}
 
 interface MockCache {
   cache: ForwardMsgCache

--- a/frontend/src/lib/UriUtil.test.ts
+++ b/frontend/src/lib/UriUtil.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2018-2019 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildHttpUri, buildWsUri, getWindowBaseUriParts } from "./UriUtil"
+
+const location = {}
+
+global.window = Object.create(window)
+Object.defineProperty(window, "location", { value: location })
+
+test("gets all window URI parts", () => {
+  location.hostname = "the_host"
+  location.port = "9988"
+  location.pathname = "foo"
+
+  const parts = getWindowBaseUriParts()
+  expect(parts).toStrictEqual({
+    host: "the_host",
+    port: 9988,
+    basePath: "foo",
+  })
+})
+
+test("gets window URI parts without basePath", () => {
+  location.hostname = "the_host"
+  location.port = "9988"
+  location.pathname = ""
+
+  const parts = getWindowBaseUriParts()
+  expect(parts).toStrictEqual({
+    host: "the_host",
+    port: 9988,
+    basePath: "",
+  })
+})
+
+test("gets window URI parts with long basePath", () => {
+  location.hostname = "the_host"
+  location.port = "9988"
+  location.pathname = "/foo/bar"
+
+  const parts = getWindowBaseUriParts()
+  expect(parts).toStrictEqual({
+    host: "the_host",
+    port: 9988,
+    basePath: "foo/bar",
+  })
+})
+
+test("gets window URI parts with weird basePath", () => {
+  location.hostname = "the_host"
+  location.port = "9988"
+  location.pathname = "///foo/bar//"
+
+  const parts = getWindowBaseUriParts()
+  expect(parts).toStrictEqual({
+    host: "the_host",
+    port: 9988,
+    basePath: "foo/bar",
+  })
+})
+
+test("builds HTTP URI correctly", () => {
+  location.href = "http://something"
+  const uri = buildHttpUri(
+    {
+      host: "the_host",
+      port: 9988,
+      basePath: "foo/bar",
+    },
+    "baz"
+  )
+  expect(uri).toBe("http://the_host:9988/foo/bar/baz")
+})
+
+test("builds HTTPS URI correctly", () => {
+  location.href = "https://something"
+  const uri = buildHttpUri(
+    {
+      host: "the_host",
+      port: 9988,
+      basePath: "foo/bar",
+    },
+    "baz"
+  )
+  expect(uri).toBe("https://the_host:9988/foo/bar/baz")
+})
+
+test("builds HTTP URI with no base path", () => {
+  location.href = "http://something"
+  const uri = buildHttpUri(
+    {
+      host: "the_host",
+      port: 9988,
+      basePath: "",
+    },
+    "baz"
+  )
+  expect(uri).toBe("http://the_host:9988/baz")
+})
+
+test("builds WS URI correctly", () => {
+  location.href = "http://something"
+  const uri = buildWsUri(
+    {
+      host: "the_host",
+      port: 9988,
+      basePath: "foo/bar",
+    },
+    "baz"
+  )
+  expect(uri).toBe("ws://the_host:9988/foo/bar/baz")
+})
+
+test("builds WSS URI correctly", () => {
+  location.href = "https://something"
+  const uri = buildWsUri(
+    {
+      host: "the_host",
+      port: 9988,
+      basePath: "foo/bar",
+    },
+    "baz"
+  )
+  expect(uri).toBe("wss://the_host:9988/foo/bar/baz")
+})
+
+test("builds WS URI with no base path", () => {
+  location.href = "http://something"
+  const uri = buildWsUri(
+    {
+      host: "the_host",
+      port: 9988,
+      basePath: "",
+    },
+    "baz"
+  )
+  expect(uri).toBe("ws://the_host:9988/baz")
+})

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -26,6 +26,9 @@ export interface BaseUriParts {
   basePath: string
 }
 
+const FINAL_SLASH_RE = /\/+$/
+const INITIAL_SLASH_RE = /^\/+/
+
 /**
  * Return the BaseUriParts for the global window
  */
@@ -45,6 +48,8 @@ export function getWindowBaseUriParts(): BaseUriParts {
         : 80
 
   const basePath = window.location.pathname
+    .replace(FINAL_SLASH_RE, "")
+    .replace(INITIAL_SLASH_RE, "")
 
   return { host, port, basePath }
 }
@@ -74,8 +79,8 @@ export function buildHttpUri(
 }
 
 function makePath(basePath: string, subPath: string): string {
-  basePath = basePath.replace("/", "")
-  subPath = subPath.replace("/", "")
+  basePath = basePath.replace(FINAL_SLASH_RE, "").replace(INITIAL_SLASH_RE, "")
+  subPath = subPath.replace(FINAL_SLASH_RE, "").replace(INITIAL_SLASH_RE, "")
 
   if (basePath.length === 0) {
     return subPath

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1271,7 +1271,8 @@ class DeltaGenerator(object):
             `image[:, :, 2]` is blue. For images coming from libraries like
             OpenCV you should set this to 'BGR', instead.
         format : 'JPEG' or 'PNG'
-            This parameter specifies the image format. Defaults to 'JPEG'.
+            This parameter specifies the image format to use when transferring
+            the image data. Defaults to 'JPEG'.
 
         Example
         -------

--- a/lib/streamlit/Report.py
+++ b/lib/streamlit/Report.py
@@ -51,13 +51,13 @@ class Report(object):
             The URL.
         """
         port = _get_browser_address_bar_port()
-        base_path = config.get_option('server.baseUrlPath').strip('/')
+        base_path = config.get_option("server.baseUrlPath").strip("/")
 
         if base_path:
-            base_path = '/' + base_path
+            base_path = "/" + base_path
 
         return "http://%(host_ip)s:%(port)s%(base_path)s" % {
-            "host_ip": host_ip.strip('/'),
+            "host_ip": host_ip.strip("/"),
             "port": port,
             "base_path": base_path,
         }
@@ -252,9 +252,7 @@ class Report(object):
             # websocket port, not the web server port. (These are the same in
             # prod, but different in dev)
             manifest.server_port = config.get_option("browser.serverPort")
-            manifest.server_base_path = config.get_option(
-                "server.baseUrlPath"
-            )
+            manifest.server_base_path = config.get_option("server.baseUrlPath")
         else:
             manifest.num_messages = num_messages
 

--- a/lib/streamlit/Report.py
+++ b/lib/streamlit/Report.py
@@ -51,13 +51,13 @@ class Report(object):
             The URL.
         """
         port = _get_browser_address_bar_port()
-        base_path = config.get_option('server.baseUrlPath')
+        base_path = config.get_option('server.baseUrlPath').strip('/')
 
-        if len(base_path) > 1:
-            base_path.rstrip('/')
+        if base_path:
+            base_path = '/' + base_path
 
-        return "http://%(host_ip)s:%(port)s/%(base_path)s" % {
-            "host_ip": host_ip.rstrip('/'),
+        return "http://%(host_ip)s:%(port)s%(base_path)s" % {
+            "host_ip": host_ip.strip('/'),
             "port": port,
             "base_path": base_path,
         }

--- a/lib/streamlit/Report.py
+++ b/lib/streamlit/Report.py
@@ -51,7 +51,16 @@ class Report(object):
             The URL.
         """
         port = _get_browser_address_bar_port()
-        return "http://%(host_ip)s:%(port)s" % {"host_ip": host_ip, "port": port}
+        base_path = config.get_option('server.baseUrlPath')
+
+        if len(base_path) > 1:
+            base_path.rstrip('/')
+
+        return "http://%(host_ip)s:%(port)s/%(base_path)s" % {
+            "host_ip": host_ip.rstrip('/'),
+            "port": port,
+            "base_path": base_path,
+        }
 
     def __init__(self, script_path, command_line):
         """Constructor.
@@ -243,6 +252,9 @@ class Report(object):
             # websocket port, not the web server port. (These are the same in
             # prod, but different in dev)
             manifest.server_port = config.get_option("browser.serverPort")
+            manifest.server_base_path = config.get_option(
+                "server.baseUrlPath"
+            )
         else:
             manifest.num_messages = num_messages
 

--- a/lib/streamlit/ReportSession.py
+++ b/lib/streamlit/ReportSession.py
@@ -87,10 +87,10 @@ class ReportSession(object):
 
         self._state = ReportSessionState.REPORT_NOT_RUNNING
 
-        self._main_dg = DeltaGenerator(
-            enqueue=self.enqueue, container=BlockPath.MAIN)
+        self._main_dg = DeltaGenerator(enqueue=self.enqueue, container=BlockPath.MAIN)
         self._sidebar_dg = DeltaGenerator(
-            enqueue=self.enqueue, container=BlockPath.SIDEBAR)
+            enqueue=self.enqueue, container=BlockPath.SIDEBAR
+        )
 
         self._widget_states = WidgetStates()
         self._local_sources_watcher = LocalSourcesWatcher(
@@ -526,6 +526,7 @@ class ReportSession(object):
             The report's websocket handler.
 
         """
+
         @tornado.gen.coroutine
         def progress(percent):
             progress_msg = ForwardMsg()

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -423,6 +423,16 @@ def _server_port():
     return 8501
 
 
+_create_option(
+    "server.baseUrlPath",
+    description="""
+        The base path for the URL where Streamlit should be served from.
+        """,
+    default_val="/",
+    type_=str,
+)
+
+
 @_create_option("server.enableCORS", type_=bool)
 def _server_enable_cors():
     """Enables support for Cross-Origin Request Sharing, for added security.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -428,7 +428,7 @@ _create_option(
     description="""
         The base path for the URL where Streamlit should be served from.
         """,
-    default_val="/",
+    default_val="",
     type_=str,
 )
 

--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -221,11 +221,14 @@ def data_frame_demo():
     try:
         df = get_UN_data()
     except urllib.error.URLError as e:
-        st.error("""
+        st.error(
+            """
             **This demo requires internet access.**
 
             Connection error: %s
-        """ % e.reason)
+        """
+            % e.reason
+        )
         return
 
     countries = st.multiselect(

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -228,28 +228,22 @@ class Server(object):
         tornado.web.Application
 
         """
-        base = config.get_option('server.baseUrlPath')
+        base = config.get_option("server.baseUrlPath")
         routes = [
             (
-                make_url_path_regex(base, 'stream'),
+                make_url_path_regex(base, "stream"),
                 _BrowserWebSocketHandler,
-                dict(server=self)),
-            (
-                make_url_path_regex(base, 'healthz'),
-                HealthHandler,
-                dict(callback=lambda: self.is_ready_for_browser_connection),
-            ),
-            (
-                make_url_path_regex(base, 'debugz'),
-                DebugHandler,
                 dict(server=self),
             ),
             (
-                make_url_path_regex(base, 'metrics'),
-                MetricsHandler,
+                make_url_path_regex(base, "healthz"),
+                HealthHandler,
+                dict(callback=lambda: self.is_ready_for_browser_connection),
             ),
+            (make_url_path_regex(base, "debugz"), DebugHandler, dict(server=self)),
+            (make_url_path_regex(base, "metrics"), MetricsHandler),
             (
-                make_url_path_regex(base, 'message'),
+                make_url_path_regex(base, "message"),
                 MessageCacheHandler,
                 dict(cache=self._message_cache),
             ),
@@ -266,7 +260,7 @@ class Server(object):
             routes.extend(
                 [
                     (
-                        make_url_path_regex(base, '(.*)'),
+                        make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
                         {"path": "%s/" % static_path, "default_filename": "index.html"},
                     )

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -83,19 +83,19 @@ class _SpecialRequestHandler(tornado.web.RequestHandler):
 
 
 class HealthHandler(_SpecialRequestHandler):
-    def initialize(self, health_check):
+    def initialize(self, callback):
         """Initialize the handler
 
         Parameters
         ----------
-        health_check : callable
+        callback : callable
             A function that returns True if the server is healthy
 
         """
-        self._health_check = health_check
+        self._callback = callback
 
     def get(self):
-        if self._health_check():
+        if self._callback():
             self.write("ok")
             self.set_status(200)
         else:

--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -145,3 +145,9 @@ def _get_server_address_if_manually_set():
 def _get_s3_url_host_if_manually_set():
     if config.is_manually_set("s3.url"):
         return util.get_hostname(config.get_option("s3.url"))
+
+
+def make_url_path_regex(*path):
+    """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
+    path = [x for x in path if x]  # Filter out falsy components.
+    return r'^/%s/?$' % '/'.join(path)

--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -150,4 +150,4 @@ def _get_s3_url_host_if_manually_set():
 def make_url_path_regex(*path):
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
     path = [x for x in path if x]  # Filter out falsy components.
-    return r'^/%s/?$' % '/'.join(path)
+    return r"^/%s/?$" % "/".join(path)

--- a/lib/streamlit/version.py
+++ b/lib/streamlit/version.py
@@ -32,7 +32,7 @@ CHECK_PYPI_PROBABILITY = 0.10
 
 
 def _version_str_to_tuple(version_str):
-    return tuple(int(x) for x in version_str.split('.'))
+    return tuple(int(x) for x in version_str.split("."))
 
 
 def _get_installed_streamlit_version():

--- a/lib/tests/streamlit/Report_test.py
+++ b/lib/tests/streamlit/Report_test.py
@@ -113,28 +113,27 @@ class ReportTest(unittest.TestCase):
         self.assertEqual("external_ip", manifest.external_server_ip)
         self.assertEqual("internal_ip", manifest.internal_server_ip)
 
-    @parameterized.expand([
-        (None, None, 'http://the_ip_address:8501'),
-        (None, 9988, 'http://the_ip_address:9988'),
-        ('foo', None, 'http://the_ip_address:8501/foo'),
-        ('/foo/bar/', None, 'http://the_ip_address:8501/foo/bar'),
-        ('/foo/bar/', 9988, 'http://the_ip_address:9988/foo/bar'),
-    ])
+    @parameterized.expand(
+        [
+            (None, None, "http://the_ip_address:8501"),
+            (None, 9988, "http://the_ip_address:9988"),
+            ("foo", None, "http://the_ip_address:8501/foo"),
+            ("/foo/bar/", None, "http://the_ip_address:8501/foo/bar"),
+            ("/foo/bar/", 9988, "http://the_ip_address:9988/foo/bar"),
+        ]
+    )
     def test_get_url(self, baseUrl, port, expected_url):
-        options = {
-            'global.useNode': False,
-            'server.headless': False,
-        }
+        options = {"global.useNode": False, "server.headless": False}
 
         if baseUrl:
-            options['server.baseUrlPath'] = baseUrl
+            options["server.baseUrlPath"] = baseUrl
 
         if port:
-            options['server.port'] = port
+            options["server.port"] = port
 
         mock_get_option = testutil.build_mock_config_get_option(options)
 
-        with patch.object(config, 'get_option', new=mock_get_option):
-            actual_url = Report.get_url('the_ip_address')
+        with patch.object(config, "get_option", new=mock_get_option):
+            actual_url = Report.get_url("the_ip_address")
 
         self.assertEqual(expected_url, actual_url)

--- a/lib/tests/streamlit/Report_test.py
+++ b/lib/tests/streamlit/Report_test.py
@@ -19,11 +19,13 @@ import copy
 import unittest
 
 from mock import patch
+from parameterized import parameterized
 
 from streamlit import config
 from streamlit.Report import Report
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.StaticManifest_pb2 import StaticManifest
+from tests import testutil
 
 INIT_MSG = ForwardMsg()
 INIT_MSG.initialize.config.sharing_enabled = True
@@ -110,3 +112,29 @@ class ReportTest(unittest.TestCase):
         self.assertEqual(config.get_option("browser.serverPort"), manifest.server_port)
         self.assertEqual("external_ip", manifest.external_server_ip)
         self.assertEqual("internal_ip", manifest.internal_server_ip)
+
+    @parameterized.expand([
+        (None, None, 'http://the_ip_address:8501'),
+        (None, 9988, 'http://the_ip_address:9988'),
+        ('foo', None, 'http://the_ip_address:8501/foo'),
+        ('/foo/bar/', None, 'http://the_ip_address:8501/foo/bar'),
+        ('/foo/bar/', 9988, 'http://the_ip_address:9988/foo/bar'),
+    ])
+    def test_get_url(self, baseUrl, port, expected_url):
+        options = {
+            'global.useNode': False,
+            'server.headless': False,
+        }
+
+        if baseUrl:
+            options['server.baseUrlPath'] = baseUrl
+
+        if port:
+            options['server.port'] = port
+
+        mock_get_option = testutil.build_mock_config_get_option(options)
+
+        with patch.object(config, 'get_option', new=mock_get_option):
+            actual_url = Report.get_url('the_ip_address')
+
+        self.assertEqual(expected_url, actual_url)

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -304,7 +304,7 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     def get_app(self):
         return tornado.web.Application(
-            [(r"/healthz", HealthHandler, dict(health_check=self.is_healthy))]
+            [(r"/healthz", HealthHandler, dict(callback=self.is_healthy))]
         )
 
     def test_healthz(self):

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -135,3 +135,48 @@ class BootstrapPrintTest(unittest.TestCase):
         out = sys.stdout.getvalue()
         self.assertTrue("Local URL: http://localhost" in out)
         self.assertTrue("Network URL: http://internal-ip" in out)
+
+    @patch('streamlit.bootstrap.util.get_internal_ip')
+    def test_print_urls_port(self, mock_get_internal_ip):
+        mock_is_manually_set = testutil.build_mock_config_is_manually_set(
+            {"browser.serverAddress": False}
+        )
+        mock_get_option = testutil.build_mock_config_get_option({
+            'server.headless': False,
+            'server.port': 9988,
+            'global.useNode': False,
+        })
+
+        mock_get_internal_ip.return_value = 'internal-ip'
+
+        with patch.object(config, 'get_option', new=mock_get_option), \
+                patch.object(
+                    config, 'is_manually_set', new=mock_is_manually_set):
+            bootstrap._print_url()
+
+        out = sys.stdout.getvalue()
+        self.assertTrue('Local URL: http://localhost:9988' in out)
+        self.assertTrue('Network URL: http://internal-ip:9988' in out)
+
+    @patch('streamlit.bootstrap.util.get_internal_ip')
+    def test_print_urls_base(self, mock_get_internal_ip):
+        mock_is_manually_set = testutil.build_mock_config_is_manually_set(
+            {"browser.serverAddress": False}
+        )
+        mock_get_option = testutil.build_mock_config_get_option({
+            'server.headless': False,
+            'server.baseUrlPath': 'foo',
+            'server.port': 8501,
+            'global.useNode': False,
+        })
+
+        mock_get_internal_ip.return_value = 'internal-ip'
+
+        with patch.object(config, 'get_option', new=mock_get_option), \
+                patch.object(
+                    config, 'is_manually_set', new=mock_is_manually_set):
+            bootstrap._print_url()
+
+        out = sys.stdout.getvalue()
+        self.assertTrue('Local URL: http://localhost:8501/foo' in out)
+        self.assertTrue('Network URL: http://internal-ip:8501/foo' in out)

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -136,47 +136,47 @@ class BootstrapPrintTest(unittest.TestCase):
         self.assertTrue("Local URL: http://localhost" in out)
         self.assertTrue("Network URL: http://internal-ip" in out)
 
-    @patch('streamlit.bootstrap.util.get_internal_ip')
+    @patch("streamlit.bootstrap.util.get_internal_ip")
     def test_print_urls_port(self, mock_get_internal_ip):
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(
             {"browser.serverAddress": False}
         )
-        mock_get_option = testutil.build_mock_config_get_option({
-            'server.headless': False,
-            'server.port': 9988,
-            'global.useNode': False,
-        })
+        mock_get_option = testutil.build_mock_config_get_option(
+            {"server.headless": False, "server.port": 9988, "global.useNode": False}
+        )
 
-        mock_get_internal_ip.return_value = 'internal-ip'
+        mock_get_internal_ip.return_value = "internal-ip"
 
-        with patch.object(config, 'get_option', new=mock_get_option), \
-                patch.object(
-                    config, 'is_manually_set', new=mock_is_manually_set):
+        with patch.object(config, "get_option", new=mock_get_option), patch.object(
+            config, "is_manually_set", new=mock_is_manually_set
+        ):
             bootstrap._print_url()
 
         out = sys.stdout.getvalue()
-        self.assertTrue('Local URL: http://localhost:9988' in out)
-        self.assertTrue('Network URL: http://internal-ip:9988' in out)
+        self.assertTrue("Local URL: http://localhost:9988" in out)
+        self.assertTrue("Network URL: http://internal-ip:9988" in out)
 
-    @patch('streamlit.bootstrap.util.get_internal_ip')
+    @patch("streamlit.bootstrap.util.get_internal_ip")
     def test_print_urls_base(self, mock_get_internal_ip):
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(
             {"browser.serverAddress": False}
         )
-        mock_get_option = testutil.build_mock_config_get_option({
-            'server.headless': False,
-            'server.baseUrlPath': 'foo',
-            'server.port': 8501,
-            'global.useNode': False,
-        })
+        mock_get_option = testutil.build_mock_config_get_option(
+            {
+                "server.headless": False,
+                "server.baseUrlPath": "foo",
+                "server.port": 8501,
+                "global.useNode": False,
+            }
+        )
 
-        mock_get_internal_ip.return_value = 'internal-ip'
+        mock_get_internal_ip.return_value = "internal-ip"
 
-        with patch.object(config, 'get_option', new=mock_get_option), \
-                patch.object(
-                    config, 'is_manually_set', new=mock_is_manually_set):
+        with patch.object(config, "get_option", new=mock_get_option), patch.object(
+            config, "is_manually_set", new=mock_is_manually_set
+        ):
             bootstrap._print_url()
 
         out = sys.stdout.getvalue()
-        self.assertTrue('Local URL: http://localhost:8501/foo' in out)
-        self.assertTrue('Network URL: http://internal-ip:8501/foo' in out)
+        self.assertTrue("Local URL: http://localhost:8501/foo" in out)
+        self.assertTrue("Network URL: http://internal-ip:8501/foo" in out)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -286,6 +286,7 @@ class ConfigTest(unittest.TestCase):
                 u"s3.secretAccessKey",
                 u"s3.url",
                 u"server.enableCORS",
+                u"server.baseUrlPath",
                 u"server.folderWatchBlacklist",
                 u"server.headless",
                 u"server.liveSave",

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -80,12 +80,10 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("streamlit", ds.module)
         if is_python_2:
             self.assertEqual("<type 'function'>", ds.type)
-            self.assertEqual("(data, format=u'audio/wav', start_time=0)",
-                             ds.signature)
+            self.assertEqual("(data, format=u'audio/wav', start_time=0)", ds.signature)
         else:
             self.assertEqual("<class 'function'>", ds.type)
-            self.assertEqual("(data, format='audio/wav', start_time=0)",
-                             ds.signature)
+            self.assertEqual("(data, format='audio/wav', start_time=0)", ds.signature)
         self.assertTrue(ds.doc_string.startswith("Display an audio player"))
 
     def test_unwrapped_deltagenerator_func(self):

--- a/lib/tests/streamlit/version_test.py
+++ b/lib/tests/streamlit/version_test.py
@@ -37,7 +37,9 @@ class VersionTest(unittest.TestCase):
             self.assertEqual((1, 2, 3), _get_latest_streamlit_version())
 
     def test_should_show_new_version_notice_skip(self):
-        with mock.patch("streamlit.version._get_latest_streamlit_version") as get_latest:
+        with mock.patch(
+            "streamlit.version._get_latest_streamlit_version"
+        ) as get_latest:
             version.CHECK_PYPI_PROBABILITY = 0
             self.assertFalse(should_show_new_version_notice())
             get_latest.assert_not_called()

--- a/proto/streamlit/proto/StaticManifest.proto
+++ b/proto/streamlit/proto/StaticManifest.proto
@@ -48,4 +48,7 @@ message StaticManifest {
 
   // Set only when status is RUNNING. The server's websocket's port.
   uint32 server_port = 7;
+
+  // Set only when status is RUNNING. The "server.baseUrlPath" config value.
+  string server_base_path = 8;
 }


### PR DESCRIPTION
Fixes #225 

Adds the config option config.baseUrlPath. When set to a value like 'foo', Streamlit will be served from 'hostname:port/foo'.