### PR TITLE
Set auto_envvar_prefix to STREAMLIT

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,9 +25,9 @@ Runs your app. At any time you can kill the server with **Ctrl+c**.
 
 ```eval_rst
 .. note::
-  When passing your script some arguments, **they must be passed after a `--`**
-  (double dash). Otherwise the arguments get interpreted as anything arguments
-  to Streamlit itself.
+  When passing your script some custom arguments, **they must be passed after a
+  "--"** (double dash). Otherwise the arguments get interpreted as arguments to
+  Streamlit itself.
 ```
 
 You can also pass in config options to `streamlit run`. These allow you to do

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,14 +61,26 @@ $ streamlit config show
 ```
 
 Shows all config options available for Streamlit, including their current
-values. You can set these options in three different ways:
+values. You can set these options in four different ways:
 
-- **Globally:** `~/.streamlit/config.toml`.
+- **In a global config file at `~/.streamlit/config.toml`.** For instance:
+  ```toml
+  [server]
+  port = 80
+  ```
 
-- **Per project:** `$CWD/.streamlit/config.toml`, where `$CWD` is
-  the folder you're running Streamlit from.
+- **In a per-project config file at `$CWD/.streamlit/config.toml`,** where
+  `$CWD` is the folder you're running Streamlit from.
 
-- **Per execution:** just pass the options as flags when running `streamlit run`. See more info above.
+- **Through `STREAMLIT_CONFIG_*` environment variables,** such as:
+  ```bash
+  $ export STREAMLIT_CONFIG_SERVER_PORT=80
+  ```
+
+- **As flags in the command line** when running `streamlit run`. For example:
+  ```bash
+  $ streamlit run your_script.py --server.port 80
+  ```
 
 ## Clear the cache
 

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -52,7 +52,7 @@ NEW_VERSION_TEXT = """
 }
 
 
-@click.group()
+@click.group(context_settings={'auto_envvar_prefix':'STREAMLIT'})
 @click.option("--log_level", show_default=True, type=click.Choice(LOG_LEVELS))
 @click.version_option(prog_name="Streamlit")
 @click.pass_context

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -129,12 +129,14 @@ def _convert_config_option_to_click_option(config_option):
         description += "\n {} - {}".format(
             config_option.deprecation_text, config_option.deprecation_date
         )
+    envvar = "STREAMLIT_CONFIG_{}".format(param.upper())
 
     return {
         "param": param,
         "description": description,
         "type": config_option.type,
         "option": option,
+        "envvar": envvar,
     }
 
 
@@ -147,7 +149,7 @@ def configurator_options(func):
             parsed_parameter["param"],
             help=parsed_parameter["description"],
             type=parsed_parameter["type"],
-            envvar='STREAMLIT_CONFIG_{}'.format(parsed_parameter["param"].upper()),
+            envvar=parsed_parameter["envvar"],
         )
         func = config_option(func)
     return func

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -147,6 +147,7 @@ def configurator_options(func):
             parsed_parameter["param"],
             help=parsed_parameter["description"],
             type=parsed_parameter["type"],
+            envvar='STREAMLIT_CONFIG_{}'.format(parsed_parameter["param"].upper()),
         )
         func = config_option(func)
     return func

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -173,7 +173,7 @@ def _apply_config_options_from_cli(kwargs):
 
 @main.command("run")
 @configurator_options
-@click.argument("file_or_url", required=True)
+@click.argument("file_or_url", required=True, envvar="STREAMLIT_RUN_FILE_OR_URL")
 @click.argument("args", nargs=-1)
 def main_run(file_or_url, args=None, **kwargs):
     """Run a Python script, piping stderr to Streamlit.

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -175,9 +175,9 @@ def _apply_config_options_from_cli(kwargs):
 
 @main.command("run")
 @configurator_options
-@click.argument("file_or_url", required=True, envvar="STREAMLIT_RUN_FILE_OR_URL")
+@click.argument("target", required=True, envvar="STREAMLIT_RUN_TARGET")
 @click.argument("args", nargs=-1)
-def main_run(file_or_url, args=None, **kwargs):
+def main_run(target, args=None, **kwargs):
     """Run a Python script, piping stderr to Streamlit.
 
     The script can be local or it can be an url. In the latter case, Streamlit
@@ -188,29 +188,29 @@ def main_run(file_or_url, args=None, **kwargs):
 
     _apply_config_options_from_cli(kwargs)
 
-    if url(file_or_url):
+    if url(target):
         import tempfile
         import requests
 
         with tempfile.NamedTemporaryFile() as fp:
             try:
-                resp = requests.get(file_or_url)
+                resp = requests.get(target)
                 resp.raise_for_status()
                 fp.write(resp.content)
                 # flush since we are reading the file within the with block
                 fp.flush()
             except requests.exceptions.RequestException as e:
                 raise click.BadParameter(
-                    ("Unable to fetch {}.\n{}".format(file_or_url, e))
+                    ("Unable to fetch {}.\n{}".format(target, e))
                 )
             # this is called within the with block to make sure the temp file
             # is not deleted
             _main_run(fp.name, args)
 
     else:
-        if not os.path.exists(file_or_url):
-            raise click.BadParameter("File does not exist: {}".format(file_or_url))
-        _main_run(file_or_url, args)
+        if not os.path.exists(target):
+            raise click.BadParameter("File does not exist: {}".format(target))
+        _main_run(target, args)
 
 
 # Utility function to compute the command line as a string


### PR DESCRIPTION


**Issue:** #476 

**Description:** Set auto_envvar_prefix to STREAMLIT to accept parameters from environment variables in addition to regular CLI arguments. This is a Click option that will automatically get values from  env vars if available.

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
