### PR TITLE
Use custom context manager for temporary file in cli.py

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -189,7 +189,7 @@ def _download_remote(script_path, url_path):
 @configurator_options
 @click.argument("target", required=True, envvar="STREAMLIT_RUN_TARGET")
 @click.argument("args", nargs=-1)
-def main_run(target, args=None, **kwargs):Å
+def main_run(target, args=None, **kwargs):
     """Run a Python script, piping stderr to Streamlit.
 
     The script can be local or it can be an url. In the latter case, Streamlit
@@ -200,13 +200,13 @@ def main_run(target, args=None, **kwargs):Å
 
     _apply_config_options_from_cli(kwargs)
 
-    if url(file_or_url):
+    if url(target):
         from streamlit.temporary_directory import TemporaryDirectory
         with TemporaryDirectory() as temp_dir:
             from urllib.parse import urlparse
-            path = urlparse(file_or_url).path
+            path = urlparse(target).path
             script_path = os.path.join(temp_dir, path.strip('/').rsplit('/', 1)[-1])
-            _download_remote(script_path, file_or_url)
+            _download_remote(script_path, target)
             _main_run(script_path, args)
     else:
         if not os.path.exists(target):

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -33,7 +33,6 @@ from streamlit.credentials import Credentials
 from streamlit import version
 import streamlit.bootstrap as bootstrap
 
-
 LOG_LEVELS = ["error", "warning", "info", "debug"]
 
 NEW_VERSION_TEXT = """
@@ -200,9 +199,10 @@ def main_run(file_or_url, args=None, **kwargs):
 
     if url(file_or_url):
         from streamlit.temporary_directory import TemporaryDirectory
-
         with TemporaryDirectory() as temp_dir:
-            script_path = os.path.join(temp_dir, os.path.basename(file_or_url))
+            from urllib.parse import urlparse
+            path = urlparse(file_or_url).path
+            script_path = os.path.join(temp_dir, path.rsplit('/', 1)[-1])
             _download_remote(script_path, file_or_url)
             _main_run(script_path, args)
 

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -173,15 +173,14 @@ def _apply_config_options_from_cli(kwargs):
 # Fetch remote file at url_path to script_path
 def _download_remote(script_path, url_path):
     import requests
+
     with open(script_path, "wb") as fp:
         try:
             resp = requests.get(url_path)
             resp.raise_for_status()
             fp.write(resp.content)
         except requests.exceptions.RequestException as e:
-            raise click.BadParameter(
-                ("Unable to fetch {}.\n{}".format(url_path, e))
-            )
+            raise click.BadParameter(("Unable to fetch {}.\n{}".format(url_path, e)))
 
 
 @main.command("run")
@@ -201,6 +200,7 @@ def main_run(file_or_url, args=None, **kwargs):
 
     if url(file_or_url):
         from streamlit.temporary_directory import TemporaryDirectory
+
         with TemporaryDirectory() as temp_dir:
             script_path = os.path.join(temp_dir, os.path.basename(file_or_url))
             _download_remote(script_path, file_or_url)

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -202,7 +202,7 @@ def main_run(file_or_url, args=None, **kwargs):
         with TemporaryDirectory() as temp_dir:
             from urllib.parse import urlparse
             path = urlparse(file_or_url).path
-            script_path = os.path.join(temp_dir, path.rsplit('/', 1)[-1])
+            script_path = os.path.join(temp_dir, path.strip('/').rsplit('/', 1)[-1])
             _download_remote(script_path, file_or_url)
             _main_run(script_path, args)
 

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -188,6 +188,7 @@ def main_run(file_or_url, args=None, **kwargs):
     if url(file_or_url):
         import requests
         from streamlit.temporary_file import TemporaryDirectory
+
         with TemporaryDirectory() as temp_dir:
             script_path = os.path.join(temp_dir, os.path.basename(file_or_url))
             with open(script_path, "wb") as fp:

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -189,20 +189,28 @@ def main_run(file_or_url, args=None, **kwargs):
         import tempfile
         import requests
 
-        with tempfile.NamedTemporaryFile() as fp:
-            try:
-                resp = requests.get(file_or_url)
-                resp.raise_for_status()
-                fp.write(resp.content)
-                # flush since we are reading the file within the with block
-                fp.flush()
-            except requests.exceptions.RequestException as e:
-                raise click.BadParameter(
-                    ("Unable to fetch {}.\n{}".format(file_or_url, e))
-                )
-            # this is called within the with block to make sure the temp file
-            # is not deleted
-            _main_run(fp.name, args)
+        # As documented in https://github.com/streamlit/streamlit/issues/301,
+        # in Windows, we can't actually open a file opened by NamedTemporaryFile
+        # with delete=True (the default) until the NamedTemporaryFile is closed
+        # For this reason we wrap NamedTemporaryFile in a try catch as suggested
+        # in https://stackoverflow.com/a/49868505
+        fp = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as fp:
+                try:
+                    resp = requests.get(file_or_url)
+                    resp.raise_for_status()
+                    fp.write(resp.content)
+                    # flush since we are reading the file within the with block
+                    fp.flush()
+                except requests.exceptions.RequestException as e:
+                    raise click.BadParameter(
+                        ("Unable to fetch {}.\n{}".format(file_or_url, e))
+                    )
+                _main_run(fp.name, args)
+        finally:
+            if fp is not None:
+                os.remove(fp.name)
 
     else:
         if not os.path.exists(file_or_url):

--- a/lib/streamlit/temporary_directory.py
+++ b/lib/streamlit/temporary_directory.py
@@ -46,5 +46,5 @@ class TemporaryDirectory(object):
         self._path = tempfile.mkdtemp(*self._args, **self._kwargs)
         return self._path
 
-    def __exit__(self, *exec):
+    def __exit__(self, exc_type, exc_value, exc_traceback):
         shutil.rmtree(self._path)

--- a/lib/streamlit/temporary_directory.py
+++ b/lib/streamlit/temporary_directory.py
@@ -16,7 +16,7 @@
 import tempfile
 import shutil
 
-# We provide our own context managers for temporary directory that wraps
+# We provide our own context manager for temporary directory that wraps
 # tempfile.mkdtemp
 
 

--- a/lib/streamlit/temporary_directory.py
+++ b/lib/streamlit/temporary_directory.py
@@ -15,48 +15,9 @@
 
 import tempfile
 import shutil
-import os
 
-# We provide our own context managers for temporary file and directory
-# that works in Windows as well.
-# As documented in https://github.com/streamlit/streamlit/issues/301,
-# Python `tempfile.NamedTemporaryFile` context manager does not behave
-# as expected in Windows.
-
-
-class TemporaryFile(object):
-    """Temporary file context mananger.
-
-    Create a temporary file that exists whithin the context manager scope.
-    It returns the path to the file. The created file
-    is closed and the user needs to open it to write/read.
-    Wrapper on top of tempfile.mkstemp.
-
-    Parameters
-    ----------
-    suffix : str or None
-        Suffix to the filename.
-    prefix : str or None
-        Prefix to the filename.
-    dir : str or None
-        Enclosing directory.
-
-    """
-
-    def __init__(self, *args, **kwargs):
-        self._args = args
-        self._kwargs = kwargs
-
-    """Context Manager """
-
-    def __enter__(self):
-        fd, self._path = tempfile.mkstemp(*self._args, **self._kwargs)
-        # We close the file descriptor since mkstemp opens it by default.
-        os.close(fd)
-        return self._path
-
-    def __exit__(self, *exec):
-        os.remove(self._path)
+# We provide our own context managers for temporary directory that wraps
+# tempfile.mkdtemp
 
 
 class TemporaryDirectory(object):

--- a/lib/streamlit/temporary_file.py
+++ b/lib/streamlit/temporary_file.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import shutil
+import os
+
+# We provide our own context managers for temporary file and directory
+# that works in Windows as well.
+# As documented in https://github.com/streamlit/streamlit/issues/301,
+# Python `tempfile.NamedTemporaryFile` context manager does not behave
+# as expected in Windows.
+
+
+class TemporaryFile(object):
+    """Temporary file context mananger.
+
+    Create a temporary file that exists whithin the context manager scope.
+    It returns the path to the file. The created file
+    is closed and the user needs to open it to write/read.
+    Wrapper on top of tempfile.mkstemp.
+
+    Parameters
+    ----------
+    suffix : str or None
+        Suffix to the filename.
+    prefix : str or None
+        Prefix to the filename.
+    dir : str or None
+        Enclosing directory.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+
+    """Context Manager """
+    def __enter__(self):
+        fd, self._path = tempfile.mkstemp(*self._args, **self._kwargs)
+        # We close the file descriptor since mkstemp opens it by default.
+        os.close(fd)
+        return self._path
+
+    def __exit__(self, *exec):
+        os.remove(self._path)
+
+
+class TemporaryDirectory(object):
+    """Temporary directory context mananger.
+
+    Creates a temporary directory that exists whithin the context manager scope.
+    It returns the path to the created directory.
+    Wrapper on top of tempfile.mkdtemp.
+
+    Parameters
+    ----------
+    suffix : str or None
+        Suffix to the filename.
+    prefix : str or None
+        Prefix to the filename.
+    dir : str or None
+        Enclosing directory.
+
+    """
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+
+    def __enter__(self):
+        self._path = tempfile.mkdtemp(*self._args, **self._kwargs)
+        return self._path
+
+    def __exit__(self, *exec):
+        shutil.rmtree(self._path)
+

--- a/lib/streamlit/temporary_file.py
+++ b/lib/streamlit/temporary_file.py
@@ -48,6 +48,7 @@ class TemporaryFile(object):
         self._kwargs = kwargs
 
     """Context Manager """
+
     def __enter__(self):
         fd, self._path = tempfile.mkstemp(*self._args, **self._kwargs)
         # We close the file descriptor since mkstemp opens it by default.
@@ -75,6 +76,7 @@ class TemporaryDirectory(object):
         Enclosing directory.
 
     """
+
     def __init__(self, *args, **kwargs):
         self._args = args
         self._kwargs = kwargs
@@ -85,4 +87,3 @@ class TemporaryDirectory(object):
 
     def __exit__(self, *exec):
         shutil.rmtree(self._path)
-

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -17,12 +17,14 @@
 
 import unittest
 
+import os
+
 import requests
 import requests_mock
 import mock
 from click.testing import CliRunner
 from mock import patch, MagicMock
-import click
+from testfixtures import tempdir
 
 import streamlit
 from streamlit import cli
@@ -63,20 +65,26 @@ class CliTest(unittest.TestCase):
         self.assertNotEqual(0, result.exit_code)
         self.assertTrue("File does not exist" in result.output)
 
-    def test_run_valid_url(self):
+    @tempdir()
+    def test_run_valid_url(self, temp_dir):
         """streamlit run succeeds if an existing url is passed"""
 
         with patch("validators.url", return_value=True), patch(
             "streamlit.cli._main_run"
         ), requests_mock.mock() as m:
 
-            m.get("http://url", content=b"content")
-            with patch("tempfile.NamedTemporaryFile"):
-                result = self.runner.invoke(cli, ["run", "http://url"])
+            file_content = b"content"
+            m.get("http://url/app.py", content=file_content)
+            with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
+                mock_tmp.return_value.__enter__.return_value = temp_dir.path
+                result = self.runner.invoke(cli, ["run", "http://url/app.py"])
+                with open(os.path.join(temp_dir.path, "app.py"), "rb") as f:
+                    self.assertEqual(file_content, f.read())
 
         self.assertEqual(0, result.exit_code)
 
-    def test_run_non_existing_url(self):
+    @tempdir()
+    def test_run_non_existing_url(self, temp_dir):
         """streamlit run should fail if a non existing but valid
          url is passed
          """
@@ -85,9 +93,10 @@ class CliTest(unittest.TestCase):
             "streamlit.cli._main_run"
         ), requests_mock.mock() as m:
 
-            m.get("http://url", exc=requests.exceptions.RequestException)
-            with patch("tempfile.NamedTemporaryFile"):
-                result = self.runner.invoke(cli, ["run", "http://url"])
+            m.get("http://url/app.py", exc=requests.exceptions.RequestException)
+            with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
+                mock_tmp.return_value.__enter__.return_value = temp_dir.path
+                result = self.runner.invoke(cli, ["run", "http://url/app.py"])
 
         self.assertNotEqual(0, result.exit_code)
         self.assertTrue("Unable to fetch" in result.output)

--- a/lib/tests/streamlit/temporary_directory_test.py
+++ b/lib/tests/streamlit/temporary_directory_test.py
@@ -18,18 +18,11 @@ import os
 import unittest
 from testfixtures import tempdir
 
-from streamlit.temporary_file import TemporaryFile, TemporaryDirectory
+from streamlit.temporary_directory import TemporaryDirectory
 
 
 class TemporaryFileTest(unittest.TestCase):
-    """Test temp file and directory context manager."""
-
-    @tempdir()
-    def test_temp_file(self, dir):
-        """Test that the file only exists inside the context."""
-        with TemporaryFile(dir=dir.path) as temp_fname:
-            self.assertTrue(os.path.exists(temp_fname))
-        self.assertFalse(os.path.exists(temp_fname))
+    """Test temp directory context manager."""
 
     @tempdir()
     def test_temp_directory(self, dir):

--- a/lib/tests/streamlit/temporary_file_test.py
+++ b/lib/tests/streamlit/temporary_file_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import unittest
+from testfixtures import tempdir
+
+from streamlit.temporary_file import TemporaryFile, TemporaryDirectory
+
+
+class TemporaryFileTest(unittest.TestCase):
+    """Test temp file and directory context manager."""
+
+    @tempdir()
+    def test_temp_file(self, dir):
+        """Test that the file only exists inside the context."""
+        with TemporaryFile(dir=dir.path) as temp_fname:
+            self.assertTrue(os.path.exists(temp_fname))
+        self.assertFalse(os.path.exists(temp_fname))
+
+    @tempdir()
+    def test_temp_directory(self, dir):
+        """Test that the directory only exists inside the context."""
+        with TemporaryDirectory(dir=dir.path) as temp_fname:
+            self.assertTrue(os.path.exists(temp_fname))
+        self.assertFalse(os.path.exists(temp_fname))
+

--- a/lib/tests/streamlit/temporary_file_test.py
+++ b/lib/tests/streamlit/temporary_file_test.py
@@ -37,4 +37,3 @@ class TemporaryFileTest(unittest.TestCase):
         with TemporaryDirectory(dir=dir.path) as temp_fname:
             self.assertTrue(os.path.exists(temp_fname))
         self.assertFalse(os.path.exists(temp_fname))
-


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/301

**Description:** In Windows, we cannot rely on NamedTemporaryFile removing the temporary file that we use for the temporary python script on running from url. This PR adds a custom `TemporaryDirectory` context manager to use with remote files.

The `TemporaryDirectory` context manager remove the content of the temporary directory when exits.


---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
