### PR TITLE
Don't resize vega chart on update

### DIFF
--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -202,7 +202,7 @@ class VegaLiteChart extends React.PureComponent<PropsWithHeight, State> {
       }
     }
 
-    this.vegaView.resize().runAsync()
+    this.vegaView.runAsync()
   }
 
   /**
@@ -330,11 +330,7 @@ class VegaLiteChart extends React.PureComponent<PropsWithHeight, State> {
 
     this.vegaView = view
 
-    await view.runAsync()
-
-    // Fix bug where the "..." menu button overlaps with charts where width is
-    // set to -1 on first load.
-    this.vegaView.resize().runAsync()
+    await view.resize().runAsync()
   }
 }
 


### PR DESCRIPTION
Issue #142 

- `VegaLiteChart.componentDidUpdate` takes longer to run as the data size increases, hitting ~150ms - 200ms later in the loop.
- `this.vegaView.resize().runAsync()` takes up the chunk of the time."
- https://vega.github.io/vega/docs/api/view/#view_resize 

Why are we calling `resize`?
- Dominik: It’s necessary if the container size changes. This may have to do with resizing/repositioning axes when labels change.
- Dominik: Recomputes padding and other layout related properties. Most of the time it is not needed.

If we remove `resize`
- The call to `componentDidUpdate` seems to be faster, hitting ~125ms towards the end of the loop.

Todo
- Verify that removing `resize` hasn't broken anything