### PR TITLE
Strip slashes around baseUrlPath value

### DIFF
--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -149,5 +149,5 @@ def _get_s3_url_host_if_manually_set():
 
 def make_url_path_regex(*path):
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
-    path = [x for x in path if x]  # Filter out falsy components.
+    path = [x.strip("/") for x in path if x]  # Filter out falsy components.
     return r"^/%s/?$" % "/".join(path)


### PR DESCRIPTION
**Issue:** #521 

**Description:** When constructing Tornado routes, strip any forward-slash characters on the value of server.baseUrlPath. Otherwise, routes with double slashes are generated, making them not match anything.

The Report class already strips slashes when generating URLs, so the URLs printed to the console don't look any different.

Given an invocation like `streamlit run --server.baseUrlPath /abc sa/gui.py`, here's the routes being generated.

```
[
  ('^//abc/stream/?$', …), 
  ('^//abc/healthz/?$', …), 
  ('^//abc/debugz/?$', …), 
  ('^//abc/metrics/?$', …), 
  ('^//abc/message/?$', …), 
  ('^//abc/(.*)/?$', …)
]
```

Stripping slashes gives the correct route.

```
[
  ('^/abc/stream/?$', …), 
  ('^/abc/healthz/?$', …), 
  ('^/abc/debugz/?$', …), 
  ('^/abc/metrics/?$', …), 
  ('^/abc/message/?$', …), 
  ('^/abc/(.*)/?$', …)
]
```

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
