### PR TITLE
Handle lack of trailing slash

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -37,6 +37,7 @@ from streamlit.ReportSession import ReportSession
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.server.routes import AddSlashHandler
 from streamlit.server.routes import DebugHandler
 from streamlit.server.routes import HealthHandler
 from streamlit.server.routes import MessageCacheHandler
@@ -263,6 +264,10 @@ class Server(object):
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
                         {"path": "%s/" % static_path, "default_filename": "index.html"},
+                    ),
+                    (
+                        make_url_path_regex(base, trailing_slash=False),
+                        AddSlashHandler
                     )
                 ]
             )

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -53,6 +53,12 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             self.set_header("Cache-Control", "public")
 
 
+class AddSlashHandler(tornado.web.RequestHandler):
+    @tornado.web.addslash
+    def get(self):
+        pass
+
+
 class _SpecialRequestHandler(tornado.web.RequestHandler):
     """Superclass for "special" endpoints, like /healthz."""
 

--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -147,7 +147,8 @@ def _get_s3_url_host_if_manually_set():
         return util.get_hostname(config.get_option("s3.url"))
 
 
-def make_url_path_regex(*path):
+def make_url_path_regex(*path, trailing_slash=True):
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
     path = [x.strip("/") for x in path if x]  # Filter out falsy components.
-    return r"^/%s/?$" % "/".join(path)
+    path_format = r"^/%s/?$" if trailing_slash else r"^/%s$"
+    return path_format % "/".join(path)

--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -147,8 +147,8 @@ def _get_s3_url_host_if_manually_set():
         return util.get_hostname(config.get_option("s3.url"))
 
 
-def make_url_path_regex(*path, trailing_slash=True):
+def make_url_path_regex(*path, **kwargs):
     """Get a regex of the form ^/foo/bar/baz/?$ for a path (foo, bar, baz)."""
     path = [x.strip("/") for x in path if x]  # Filter out falsy components.
-    path_format = r"^/%s/?$" if trailing_slash else r"^/%s$"
+    path_format = r"^/%s/?$" if kwargs.get("trailing_slash", True) else r"^/%s$"
     return path_format % "/".join(path)

--- a/lib/tests/streamlit/Report_test.py
+++ b/lib/tests/streamlit/Report_test.py
@@ -118,6 +118,7 @@ class ReportTest(unittest.TestCase):
             (None, None, "http://the_ip_address:8501"),
             (None, 9988, "http://the_ip_address:9988"),
             ("foo", None, "http://the_ip_address:8501/foo"),
+            ("foo/", None, "http://the_ip_address:8501/foo"),
             ("/foo/bar/", None, "http://the_ip_address:8501/foo/bar"),
             ("/foo/bar/", 9988, "http://the_ip_address:9988/foo/bar"),
         ]


### PR DESCRIPTION
**Issue:** #525 

**Description:** The report urls don't show a trailing slash. This works when Streamlit is running at the base URL because browsers will implicitly add a `/` for a request on the root. But, this does not work when a custom `server.baseUrlPath` is defined, resulting in a 404 Not Found.

This PR adds a redirect from no trailing slash to with trailing slash. And, it also adds a trailing slash to the report URL so that the correct path is shown to users.

**Before:**

```
root@672e90be303e:/project# streamlit run --server.baseUrlPath abc sa/gui.py

  You can now view your Streamlit app in your browser.

  Network URL: http://172.17.0.2:8501/abc
  External URL: http://209.89.162.170:8501/abc
```

```
‣ ~ http -h http://127.0.0.1:8501/abc 
HTTP/1.1 404 Not Found
‣ ~ http -h http://127.0.0.1:8501/abc/
HTTP/1.1 200 OK
```

**After:**

```
root@672e90be303e:/project# streamlit run --server.baseUrlPath abc sa/gui.py

  You can now view your Streamlit app in your browser.

  Network URL: http://172.17.0.2:8501/abc/
  External URL: http://209.89.162.170:8501/abc/
```

```
‣ ~ http -h http://127.0.0.1:8501/abc 
HTTP/1.1 301 Moved Permanently
Location: /abc/
‣ ~ http -h http://127.0.0.1:8501/abc/
HTTP/1.1 200 OK
```

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
