### PR TITLE
Workaround for deep import reloads not working

### DIFF
--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -98,9 +98,9 @@ class LocalSourcesWatcher(object):
         # Delete all watched modules so we can guarantee changes to the
         # updated module are reflected on reload.
         #
-        # In principle, for reloading a given module, we only need to unload 
+        # In principle, for reloading a given module, we only need to unload
         # the module itself and all of the modules which import it (directly
-        # or indirectly) such that when we exec the application code, the 
+        # or indirectly) such that when we exec the application code, the
         # changes are reloaded and reflected in the running application.
         #
         # However, determining all import paths for a given loaded module is
@@ -126,7 +126,8 @@ class LocalSourcesWatcher(object):
 
         try:
             wm = WatchedModule(
-                watcher=FileWatcher(filepath, self.on_file_changed), module_name=module_name
+                watcher=FileWatcher(filepath, self.on_file_changed),
+                module_name=module_name,
             )
         except ErrorType:
             # If you don't have permission to read this file, don't even add it

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -95,7 +95,7 @@ class LocalSourcesWatcher(object):
             return
 
         # Workaround:
-        # Delete all imported modules so we can guarantee changes to the
+        # Delete all watched modules so we can guarantee changes to the
         # updated module are reflected on reload.
         #
         # In principle, for reloading a given module, we only need to unload 

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -94,10 +94,21 @@ class LocalSourcesWatcher(object):
             LOGGER.error("Received event for non-watched file", filepath)
             return
 
-        wm = self._watched_modules[filepath]
-
-        if wm.module_name is not None and wm.module_name in sys.modules:
-            del sys.modules[wm.module_name]
+        # Workaround:
+        # Delete all imported modules so we can guarantee changes to the
+        # updated module are reflected on reload.
+        #
+        # In principle, for reloading a given module, we only need to unload 
+        # the module itself and all of the modules which import it (directly
+        # or indirectly) such that when we exec the application code, the 
+        # changes are reloaded and reflected in the running application.
+        #
+        # However, determining all import paths for a given loaded module is
+        # non-trivial, and so as a workaround we simply unload all watched
+        # modules.
+        for wm in self._watched_modules.values():
+            if wm.module_name is not None and wm.module_name in sys.modules:
+                del sys.modules[wm.module_name]
 
         self._on_file_changed()
 

--- a/lib/tests/streamlit/watcher/test_data/nested_module_child.py
+++ b/lib/tests/streamlit/watcher/test_data/nested_module_child.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/tests/streamlit/watcher/test_data/nested_module_parent.py
+++ b/lib/tests/streamlit/watcher/test_data/nested_module_parent.py
@@ -16,6 +16,6 @@
 import sys
 
 if sys.version_info[0] == 2:
-    import test_data.nested_module_child as NESTED_MODULE_CHILD
+    import nested_module_child as NESTED_MODULE_CHILD
 else:
     import tests.streamlit.watcher.test_data.nested_module_child as NESTED_MODULE_CHILD

--- a/lib/tests/streamlit/watcher/test_data/nested_module_parent.py
+++ b/lib/tests/streamlit/watcher/test_data/nested_module_parent.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2019 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+if sys.version_info[0] == 2:
+    import test_data.nested_module_child as NESTED_MODULE_CHILD
+else:
+    import tests.streamlit.watcher.test_data.nested_module_child as NESTED_MODULE_CHILD


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/366

**Description:** 
This is a sketch for now, we may want to look at a more sophisticated fix. Although it does fix the linked issue, it does so in a somewhat scorched-earth manner.

Essentially what is happening is that if you have a module which is not directly imported by the base module (e.g.` app.py` imports `a.py`, `a.py` imports `b.py`), then changes to that module will not be reloaded when a file change is detected.

As far as I can understand, this is what is happening:
- User changes `b.py`
- Reload logic:
  - Deletes `b` from `sys.modules`
  - Calls eval on the code from `app.py`
  - The code in `app.py` imports `a`, which is already present in `sys.modules`, and so we are done
  - The result is that we keep using the old copy of `b` in memory until `a` is reloaded

The ideal solution would be to unload both the modified module, as well as any modules that are importing it, but determining this tree of all possible paths for importing a given module may not be worth the effort.

Instead, what this PR does is simply unloads all watched modules. So in the scenario above, `a` gets unloaded as well when `b` changes, and so at the eval point both modules get reloaded, therefore reflecting the changes to `b` in the running app.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
