### PR TITLE
Add option to use PollingFileWatcher, even if watchdog is available

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -203,6 +203,19 @@ _create_option(
 
 
 _create_option(
+    "global.disableWatchdog",
+    description="""
+        By default, Streamlit detects file changes with the Python watchdog
+        module. Optionally, you can force Streamlit to use Polling even if 
+        watchdog is available. This is not recommended.
+
+        If you'd like to use polling, set this to True.
+    """,
+    default_val=False,
+    type_=bool,
+)
+
+_create_option(
     "global.sharingMode",
     description="""
         Configure the ability to share apps to the cloud.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -266,6 +266,7 @@ class ConfigTest(unittest.TestCase):
                 u"client.displayEnabled",
                 u"global.developmentMode",
                 u"global.disableWatchdogWarning",
+                u"global.disableWatchdog",
                 u"global.logLevel",
                 u"global.maxCachedMessageAge",
                 u"global.minCachedMessageSize",


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/538

**Description:**

Adds a command line option to streamlit `--global.disableWatchdog` to force streamlit to use polling, even if watchdog is available.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
