### PR TITLE
Explicitly use bash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Make uses /bin/sh by default, but we are using some bash features.  On Ubuntu
+# /bin/sh is POSIX compliant, ie it's not bash.  So let's be explicit:
+SHELL=/bin/bash
+
 # Black magic to get module directories
 PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard $(dir)/__init__.py)), $(realpath $(dir $(initpy))))
 PY_VERSION := $(shell python -c 'import platform; print(platform.python_version())')


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/555

**Description:**

The Makefile uses bash-isms like `[[ $(PY_VERSION) == "3.6.0" || $(PY_VERSION) > "3.6.0" ]]`
that don't work in POSIX sh.  So let's be explicit.

This fixes a problem with the build in Ubuntu, where you currently get `[[: not found`.
