### PR TITLE
Adding missing key parameter to text_input

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2073,8 +2073,6 @@ class DeltaGenerator(object):
         >>> st.write('The current number is ', number)
         """
 
-        from streamlit.util import is_int_value
-
         if isinstance(value, NoValue):
             if min_value:
                 value = min_value

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2031,6 +2031,7 @@ class DeltaGenerator(object):
         value=NoValue(),
         step=None,
         format=None,
+        key=None,
     ):
         """Display a numeric input widget.
 
@@ -2054,6 +2055,11 @@ class DeltaGenerator(object):
         format : str or None
             Printf/Python format string controlling how the interface should
             display numbers. This does not impact the return value.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------
@@ -2154,7 +2160,7 @@ class DeltaGenerator(object):
         if format is not None:
             element.number_input.format = format
 
-        ui_value = _get_widget_ui_value("number_input", element)
+        ui_value = _get_widget_ui_value("number_input", element, user_key=key)
 
         return ui_value if ui_value is not None else value
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -487,24 +487,3 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
 
     file_dir = os.path.dirname(filepath) + "/"
     return fnmatch.fnmatch(file_dir, folderpath_glob)
-
-
-def is_int_value(value):
-    """Test if a given value is int
-    Parameters
-    ----------
-    value: any
-
-    Returns
-    -------
-    bool
-        True if is an int, False if not
-    """
-
-    try:
-        a = float(value)
-        b = int(a)
-    except ValueError:
-        return False
-    else:
-        return a == b

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -16,8 +16,7 @@
 """A bunch of useful utilities."""
 
 # Python 2/3 compatibility
-from __future__ import print_function, division, unicode_literals, \
-    absolute_import
+from __future__ import print_function, division, unicode_literals, absolute_import
 from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
@@ -349,8 +348,7 @@ def is_plotly_chart(obj):
 
 def is_graphviz_chart(obj):
     """True if input looks like a GraphViz chart."""
-    return is_type(obj, "graphviz.dot.Graph") or is_type(obj,
-                                                         "graphviz.dot.Digraph")
+    return is_type(obj, "graphviz.dot.Graph") or is_type(obj, "graphviz.dot.Digraph")
 
 
 def _is_plotly_obj(obj):
@@ -374,8 +372,7 @@ def _is_probably_plotly_dict(obj):
     if len(obj.keys()) == 0:
         return False
 
-    if any(
-        k not in ["config", "data", "frames", "layout"] for k in obj.keys()):
+    if any(k not in ["config", "data", "frames", "layout"] for k in obj.keys()):
         return False
 
     if any(_is_plotly_obj(v) for v in obj.values()):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -224,6 +224,7 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
             "text_input": lambda key=None: st.text_input("", key=key),
             "time_input": lambda key=None: st.time_input("", key=key),
             "date_input": lambda key=None: st.date_input("", key=key),
+            "number_input": lambda key=None: st.number_input("", key=key),
         }
 
         # Iterate each widget type


### PR DESCRIPTION
We forgot to add the key parameter to the `text_input` widget. This PR adds the parameter and update the related test.