### PR TITLE
Only install watchdog on Mac if gcc is working

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -19,15 +19,15 @@ requirements = convert_deps_to_pip(packages, r=False)
 
 # Check whether xcode tools are available before making watchdog a
 # dependency (only if the current system is a Mac).
-is_mac = platform.system() == "Darwin"
-has_xcode = subprocess.call(["xcode-select", "--version"], shell=False) == 0
-has_gcc = subprocess.call(["gcc", "--version"], shell=False) == 0
+if platform.system() == "Darwin":
+    has_xcode = subprocess.call(["xcode-select", "--version"], shell=False) == 0
+    has_gcc = subprocess.call(["gcc", "--version"], shell=False) == 0
 
-if is_mac and not (has_xcode and has_gcc):
-    try:
-        requirements.remove("watchdog")
-    except ValueError:
-        pass
+    if not (has_xcode and has_gcc):
+        try:
+            requirements.remove("watchdog")
+        except ValueError:
+            pass
 
 
 def readme():

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -19,12 +19,9 @@ requirements = convert_deps_to_pip(packages, r=False)
 
 # Check whether xcode tools are available before making watchdog a
 # dependency (only if the current system is a Mac).
-if (
-    platform.system() == "Darwin"
-    and (
-        subprocess.call(["xcode-select", "--version"], shell=False) != 0
-        or subprocess.call(["gcc",  "--version"], shell=False) != 0
-    )
+if platform.system() == "Darwin" and (
+    subprocess.call(["xcode-select", "--version"], shell=False) != 0
+    or subprocess.call(["gcc", "--version"], shell=False) != 0
 ):
     try:
         requirements.remove("watchdog")

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -21,7 +21,10 @@ requirements = convert_deps_to_pip(packages, r=False)
 # dependency (only if the current system is a Mac).
 if (
     platform.system() == "Darwin"
-    and subprocess.call(["xcode-select", "--version"], shell=False) != 0
+    and (
+        subprocess.call(["xcode-select", "--version"], shell=False) != 0
+        or subprocess.call(["gcc",  "--version"], shell=False) != 0
+    )
 ):
     try:
         requirements.remove("watchdog")

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -19,10 +19,11 @@ requirements = convert_deps_to_pip(packages, r=False)
 
 # Check whether xcode tools are available before making watchdog a
 # dependency (only if the current system is a Mac).
-if platform.system() == "Darwin" and (
-    subprocess.call(["xcode-select", "--version"], shell=False) != 0
-    or subprocess.call(["gcc", "--version"], shell=False) != 0
-):
+is_mac = platform.system() == "Darwin"
+has_xcode = subprocess.call(["xcode-select", "--version"], shell=False) == 0
+has_gcc = subprocess.call(["gcc", "--version"], shell=False) == 0
+
+if is_mac and not (has_xcode and has_gcc):
     try:
         requirements.remove("watchdog")
     except ValueError:


### PR DESCRIPTION
Issue #283 

Check if we can run `gcc` before making watchdog a requirement.

Todo:
Verify that `gcc --version` returns a failure exit code if `xcrun` can't be found