### PR TITLE
Fix Matplotlib backend on all platforms

### DIFF
--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -70,7 +70,7 @@ def _fix_matplotlib_crash():
     This fix is OS-independent. We didn't see a good reason to make this
     Mac-only. Consistency within Streamlit seemed more important.
     """
-    if sys.platform == "darwin" and config.get_option("runner.fixMatplotlib"):
+    if config.get_option("runner.fixMatplotlib"):
         try:
             # TODO: a better option may be to set
             #  os.environ["MPLBACKEND"] = "Agg". We'd need to do this towards

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -44,7 +44,7 @@ class BootstrapTest(unittest.TestCase):
         # TODO: Find a proper way to mock sys.platform
         ORIG_PLATFORM = sys.platform
 
-        for platform, do_fix in [("darwin", True), ("linux2", False)]:
+        for platform, do_fix in [("darwin", True), ("linux2", True)]:
             sys.platform = platform
 
             matplotlib.use("tkagg")


### PR DESCRIPTION
Issue #469 

The docstring for `def _fix_matplotlib_crash():` says it's OS-independent but in the code we were restricting the fix to Mac only
```
    This fix is OS-independent. We didn't see a good reason to make this
    Mac-only. Consistency within Streamlit seemed more important.
```