### PR TITLE
#558 fix bart_vs_bikes example

### DIFF
--- a/examples/bart_vs_bikes.py
+++ b/examples/bart_vs_bikes.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import copy
-import os
+from urllib.parse import urljoin
 import pandas as pd
 import streamlit as st
 
@@ -33,8 +33,8 @@ st.write(
 
 @st.cache
 def from_data_file(filename):
-    dirname = "https://raw.githubusercontent.com/streamlit/streamlit/develop/examples/"
-    url = os.path.join(dirname, "data", filename)
+    dirname = "https://raw.githubusercontent.com/streamlit/streamlit/develop/examples/data/"    
+    url = urljoin(dirname, filename)
     return pd.read_json(url)
 
 


### PR DESCRIPTION
Issue [558](https://github.com/streamlit/streamlit/issues/558)

fixing bart_vs_bikes.py example, url is now properly defined regardless of the OS.
