### PR TITLE
Cleaning stale elements when the reportHash changes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,7 +78,6 @@ interface State {
   connectionState: ConnectionState
   elements: Elements
   reportId: string
-  reportName: string | null
   reportHash: string | null
   reportRunState: ReportRunState
   showLoginBox: boolean
@@ -114,7 +113,6 @@ class App extends PureComponent<Props, State> {
         sidebar: fromJS([]),
       },
       reportId: "<null>",
-      reportName: null,
       reportHash: null,
       reportRunState: ReportRunState.NOT_RUNNING,
       showLoginBox: false,
@@ -403,27 +401,12 @@ class App extends PureComponent<Props, State> {
       reportHash: newReportHash,
     })
 
-    if (reportHash !== newReportHash) {
-      this.setState(
-        {
-          reportName,
-          reportHash: newReportHash,
-          reportId: newReportProto.id,
-          elements: {
-            main: fromJS([]),
-            sidebar: fromJS([]),
-          },
-        },
-        () => {
-          this.elementListBuffer = this.state.elements
-          this.widgetMgr.clean(fromJS([]))
-        }
-      )
-    } else {
+    if (reportHash === newReportHash) {
       this.setState({
-        reportName,
         reportId: newReportProto.id,
       })
+    } else {
+      this.clearAppState(newReportHash, newReportProto.id)
     }
   }
 
@@ -487,6 +470,26 @@ class App extends PureComponent<Props, State> {
         return element.get("reportId") === reportId ? element : null
       })
       .filter((element: any) => element !== null)
+  }
+
+  /*
+   * Clear all elements from the state.
+   */
+  clearAppState(reportHash: string, reportId: string): void {
+    this.setState(
+      {
+        reportHash,
+        reportId,
+        elements: {
+          main: fromJS([]),
+          sidebar: fromJS([]),
+        },
+      },
+      () => {
+        this.elementListBuffer = this.state.elements
+        this.widgetMgr.clean(fromJS([]))
+      }
+    )
   }
 
   /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -384,8 +384,10 @@ class App extends PureComponent<Props, State> {
    * @param newReportProto a NewReport protobuf
    */
   handleNewReport(newReportProto: NewReport): void {
+    const { reportHash } = this.state
     const { name: reportName, scriptPath } = newReportProto
-    const reportHash = hashString(
+
+    const newReportHash = hashString(
       SessionInfo.current.installationId + scriptPath
     )
 
@@ -401,11 +403,12 @@ class App extends PureComponent<Props, State> {
       reportHash,
     })
 
-    if (reportHash !== this.state.reportHash) {
+    if (reportHash !== newReportHash) {
       this.setState(
         {
-          reportId: newReportProto.id,
           reportName,
+          reportHash: newReportHash,
+          reportId: newReportProto.id,
           elements: {
             main: fromJS([]),
             sidebar: fromJS([]),
@@ -418,9 +421,8 @@ class App extends PureComponent<Props, State> {
       )
     } else {
       this.setState({
-        reportId: newReportProto.id,
         reportName,
-        reportHash,
+        reportId: newReportProto.id,
       })
     }
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -400,7 +400,7 @@ class App extends PureComponent<Props, State> {
       // how many projects are being created with Streamlit while still keeping
       // possibly-sensitive info like the scriptPath outside of our metrics
       // services.
-      reportHash,
+      reportHash: newReportHash,
     })
 
     if (reportHash !== newReportHash) {


### PR DESCRIPTION
**Issue:** This PR Fixes streamlit/streamlit-old-private/issues/919

**Description:** Cleaning elements lists when the reportHash changes in order to clean old stale elements from a different report.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
