### PR TITLE
PlotlyChart: Force recreation of <Plot> in render

### DIFF
--- a/frontend/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -43,6 +43,8 @@ interface Dimensions {
 const DEFAULT_HEIGHT = 450
 
 class PlotlyChart extends React.PureComponent<PropsWithHeight> {
+  private forceRecreatePlotKey = 0
+
   public getChartDimensions = (): Dimensions => {
     const el = this.props.element
 
@@ -89,8 +91,16 @@ class PlotlyChart extends React.PureComponent<PropsWithHeight> {
     spec.layout.width = width
     spec.layout.height = height
 
+    // 2019-11-05: Re-render with a new element key to force React to
+    // unmount the previous <Plot> component and create a new element from
+    // scratch. Plotly charts are not always re-rendering
+    // properly, per https://github.com/streamlit/streamlit/issues/512
+    // This seems to be a react-plotly bug; I made a standalone repro case
+    // and submitted it to them here: https://github.com/plotly/react-plotly.js/issues/167.
+    // TODO: Remove this hack when the react-plotly bug is fixed!
     return (
       <Plot
+        key={this.forceRecreatePlotKey++}
         className="stPlotlyChart"
         data={spec.data}
         layout={spec.layout}


### PR DESCRIPTION
Plotly charts are not always re-rendering properly, per #512.
This seems to be a react-plotly bug; I made a standalone repro case and
submitted it to them here https://github.com/plotly/react-plotly.js/issues/167.

Fixes #512

(To test this fix, you can run the test code from #512.)