### PR TITLE
Fix e2e/Dockerfile

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -34,9 +34,9 @@ RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh
 ARG NVM_DIR=$HOME/.nvm
 ARG NODE_VERSION=v10.16.3
 
-# install yarn
+# install node and yarn
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install --lts=dubnium \
+    && nvm install $NODE_VERSION --lts=dubnium \
     && npm install -g yarn
 
 # node path


### PR DESCRIPTION
Dockerfile: install the specific version of node that we expect

Our e2e/Dockerfile currently fails to find `yarn`, because it's installing a different version of node than expected.