### PR TITLE
When maximizing an altair chart the aspect ratio is not maintained

### DIFF
--- a/examples/altair_example.py
+++ b/examples/altair_example.py
@@ -25,7 +25,7 @@ c = alt.Chart(df).mark_circle().encode(x="a", y="b", size="c", color="c").intera
 st.title("These two should look exactly the same")
 
 st.write("Altair chart using `st.altair_chart`:")
-st.altair_chart(c, width=300)
+st.altair_chart(c)
 
 st.write("And the same chart using `st.write`:")
 st.write(c)

--- a/examples/altair_example.py
+++ b/examples/altair_example.py
@@ -25,7 +25,7 @@ c = alt.Chart(df).mark_circle().encode(x="a", y="b", size="c", color="c").intera
 st.title("These two should look exactly the same")
 
 st.write("Altair chart using `st.altair_chart`:")
-st.altair_chart(c)
+st.altair_chart(c, width=300)
 
 st.write("And the same chart using `st.write`:")
 st.write(c)

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -123,11 +123,19 @@ class VegaLiteChart extends React.PureComponent<PropsWithHeight, State> {
     //          0 : use full width
     //         >0 : use given width
     // See docs for DeltaGenerator.vega_lite_chart().
-    const width = !specWidth ? this.props.width - EMBED_PADDING : specWidth
 
-    const height = this.props.height ? this.props.height : DEFAULT_HEIGHT
-
-    return { width, height }
+    // if have height is full screen
+    if (this.props.height) {
+      return {
+        width: this.props.width - EMBED_PADDING,
+        height: this.props.height,
+      }
+    } else {
+      return {
+        width: !specWidth ? this.props.width - EMBED_PADDING : specWidth,
+        height: DEFAULT_HEIGHT,
+      }
+    }
   }
 
   public getChartPadding = (padding: Padding): Padding => {

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -123,8 +123,7 @@ class VegaLiteChart extends React.PureComponent<PropsWithHeight, State> {
     //          0 : use full width
     //         >0 : use given width
     // See docs for DeltaGenerator.vega_lite_chart().
-    const width =
-      specWidth === 0 ? this.props.width - EMBED_PADDING : specWidth
+    const width = !specWidth ? this.props.width - EMBED_PADDING : specWidth
 
     const height = this.props.height ? this.props.height : DEFAULT_HEIGHT
 

--- a/lib/streamlit/elements/vega_lite.py
+++ b/lib/streamlit/elements/vega_lite.py
@@ -65,8 +65,9 @@ def marshall(proto, data=None, spec=None, width=0, **kwargs):
     # like composed charts, for example.
     if width >= 0 and "width" not in spec:
         spec["width"] = width
-        if "autosize" not in spec:
-            spec["autosize"] = {"type": "fit", "contains": "padding"}
+
+    if "autosize" not in spec:
+        spec["autosize"] = {"type": "fit", "contains": "padding"}
 
     # Pull data out of spec dict when it's in a 'dataset' key:
     #   marshall(proto, {datasets: {foo: df1, bar: df2}, ...})

--- a/lib/tests/streamlit/vega_lite_test.py
+++ b/lib/tests/streamlit/vega_lite_test.py
@@ -184,22 +184,22 @@ class VegaLiteTest(testutil.DeltaGeneratorTestCase):
         st.vega_lite_chart(df1, {"mark": "rect"}, width=-1)
 
         c = self.get_delta_from_queue().new_element.vega_lite_chart
-        self.assertDictEqual(json.loads(c.spec), {"mark": "rect"})
+        self.assertDictEqual(json.loads(c.spec), {"mark": "rect", "autosize": {"type": "fit", "contains": "padding"}})
 
     def test_width_inside_spec(self):
         """Test that {width:-1} leaves the width up to Vega-Lite."""
         st.vega_lite_chart(df1, {"mark": "rect", "width": 500})
 
         c = self.get_delta_from_queue().new_element.vega_lite_chart
-        self.assertDictEqual(json.loads(c.spec), {"mark": "rect", "width": 500})
+        self.assertDictEqual(json.loads(c.spec), {"mark": "rect", "autosize": {"type": "fit", "contains": "padding"}, "width": 500})
 
     def test_autosize_set(self):
         """Test that autosize doesn't get overriden."""
-        st.vega_lite_chart(df1, {"mark": "rect", "autosize": None}, width=500)
+        st.vega_lite_chart(df1, {"mark": "rect", "autosize": {"type": "fit", "contains": "padding"}}, width=500)
 
         c = self.get_delta_from_queue().new_element.vega_lite_chart
         self.assertDictEqual(
-            json.loads(c.spec), {"mark": "rect", "autosize": None, "width": 500}
+            json.loads(c.spec), {"mark": "rect", "autosize": {"type": "fit", "contains": "padding"}, "width": 500}
         )
 
 


### PR DESCRIPTION
**Issue:** 
https://github.com/streamlit/streamlit/issues/549

**Description:** 
Added support for always autosize and if have not width in spect, use container values.