### PR TITLE
st.bar_chart should work with indices with names besides "index"

### DIFF
--- a/lib/streamlit/elements/altair.py
+++ b/lib/streamlit/elements/altair.py
@@ -35,9 +35,10 @@ def generate_chart(chart_type, data):
         data = convert_anything_to_df(data)
 
     n_cols = len(data.columns)
-    index_name = "index"
-    if data.index.name is not None:
-        index_name = data.index.name
+    
+    index_name = data.index.name
+    if index_name is None:
+       index_name = "index" 
         
     data = pd.melt(data.reset_index(), id_vars=[index_name])
 

--- a/lib/streamlit/elements/altair.py
+++ b/lib/streamlit/elements/altair.py
@@ -35,7 +35,11 @@ def generate_chart(chart_type, data):
         data = convert_anything_to_df(data)
 
     n_cols = len(data.columns)
-    data = pd.melt(data.reset_index(), id_vars=["index"])
+    index_name = "index"
+    if data.index.name is not None:
+        index_name = data.index.name
+        
+    data = pd.melt(data.reset_index(), id_vars=[index_name])
 
     if chart_type == "area":
         opacity = {"value": 0.7}
@@ -45,10 +49,10 @@ def generate_chart(chart_type, data):
     chart = (
         getattr(alt.Chart(data), "mark_" + chart_type)()
         .encode(
-            alt.X("index", title=""),
+            alt.X(index_name, title=""),
             alt.Y("value", title=""),
             alt.Color("variable", title="", type="nominal"),
-            alt.Tooltip(["index", "value", "variable"]),
+            alt.Tooltip([index_name, "value", "variable"]),
             opacity=opacity,
         )
         .interactive()


### PR DESCRIPTION
**Issue:**
https://github.com/streamlit/streamlit/issues/691

**Description:** 
This fix the issue for line_chart, bar_chart and area_chart.

```
import streamlit as st
import pandas as pd

data = pd.DataFrame({
    'index': ['Cincinnati', 'San Francisco', 'Pittsburgh'],
    'sports_teams': [6, 8, 9],
}).set_index('index')

st.write(data.index.name)
st.write(data)
st.bar_chart(data)



data = pd.DataFrame({
    'city': ['Cincinnati', 'San Francisco', 'Pittsburgh'],
    'sports_teams': [6, 8, 9],
}).set_index('city')

st.write(data.index.name)
st.write(data)
st.bar_chart(data)
```

<img width="723" alt="Screen Shot 2019-11-18 at 4 04 23 PM" src="https://user-images.githubusercontent.com/22157341/69081708-54b99800-0a1d-11ea-9626-0b7ea2cf249a.png">

