### PR TITLE
Add support for getColorX and getTargetColorX to DeckGL Chart

### DIFF
--- a/frontend/src/components/elements/DeckGlChart/DeckGlChart.tsx
+++ b/frontend/src/components/elements/DeckGlChart/DeckGlChart.tsx
@@ -418,7 +418,6 @@ function parseGetters(type: any, spec: any): void {
     spec.getColor = (d: any) => [d[rField], d[gField], d[bField], d[aField]]
   }
 
-  // TODO test this with an example
   // Same as the above, but for getSourceColor/getTargetColor.
   if (
     SOURCE_TARGET_COLOR_LAYER_TYPES.has(type) &&

--- a/frontend/src/components/elements/DeckGlChart/DeckGlChart.tsx
+++ b/frontend/src/components/elements/DeckGlChart/DeckGlChart.tsx
@@ -278,6 +278,19 @@ const POSITION_LAYER_TYPES = new Set([
 // getLatitude/getTargetLatitude and getLongitude/getTargetLongitude instead.
 const SOURCE_TARGET_POSITION_LAYER_TYPES = new Set(["arclayer", "linelayer"])
 
+// Set of DeckGL Layers that take a getColor argument. We'll allow users to
+// specify color columns via getColorR, getColorB, ggetColorG and getColorA instead.
+const COLOR_LAYER_TYPES = new Set([
+  "pointcloudlayer",
+  "scatterplotlayer",
+  "textlayer",
+])
+
+// Set of DeckGL Layers that take a getSourceColor/getTargetColor argument.
+// We'll allow users to specify color columns via getColorR/getTargetColorR,
+// getColorG/getTargetColorG, etc. instead
+const SOURCE_TARGET_COLOR_LAYER_TYPES = new Set(["arclayer"])
+
 /**
  * Take a short "map style" string and convert to the full URL for the style.
  * (And it only does this if the input string is not already a URL.)
@@ -388,6 +401,54 @@ function parseGetters(type: any, spec: any): void {
     const lonField2 = spec.getTargetLongitude
     spec.getSourcePosition = (d: any) => [d[lonField], d[latField]]
     spec.getTargetPosition = (d: any) => [d[lonField2], d[latField2]]
+  }
+
+  // If this is a layer that accepts a getColor argument, build that
+  // argument from getColorR, getColorG and getColorB.
+  if (
+    COLOR_LAYER_TYPES.has(type) &&
+    spec.getColorR &&
+    spec.getColorG &&
+    spec.getColorB
+  ) {
+    const rField = spec.getColorR
+    const gField = spec.getColorG
+    const bField = spec.getColorB
+    const aField = spec.getColorA
+    spec.getColor = (d: any) => [d[rField], d[gField], d[bField], d[aField]]
+  }
+
+  // TODO test this with an example
+  // Same as the above, but for getSourceColor/getTargetColor.
+  if (
+    SOURCE_TARGET_COLOR_LAYER_TYPES.has(type) &&
+    spec.getColorR &&
+    spec.getColorG &&
+    spec.getColorB &&
+    spec.getTargetColorR &&
+    spec.getTargetColorG &&
+    spec.getTargetColorB
+  ) {
+    const rField = spec.getColorR
+    const gField = spec.getColorG
+    const bField = spec.getColorB
+    const aField = spec.getColorA
+    const rField2 = spec.getTargetColorR
+    const gField2 = spec.getTargetColorG
+    const bField2 = spec.getTargetColorB
+    const aField2 = spec.getTargetColorA
+    spec.getSourceColor = (d: any) => [
+      d[rField],
+      d[gField],
+      d[bField],
+      d[aField],
+    ]
+    spec.getTargetColor = (d: any) => [
+      d[rField2],
+      d[gField2],
+      d[bField2],
+      d[aField2],
+    ]
   }
 
   Object.keys(spec).forEach(key => {

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2359,17 +2359,16 @@ class DeltaGenerator(object):
                   PointCloudLayer, ScatterplotLayer, ScreenGridLayer,
                   TextLayer.
 
-                - "encoding" : dict
-                  A mapping connecting specific fields in the dataset to
-                  properties of the chart. The exact keys that are accepted
-                  depend on the "type" field, above.
+                - Plus anything accepted by that layer type. The exact keys that
+                  are accepted depend on the "type" field, above. For example, for
+                  ScatterplotLayer you can set fields like "opacity", "filled",
+                  "stroked", and so on.
 
-                  For example, Deck.GL"s documentation for ScatterplotLayer
+                  In addition, Deck.GL"s documentation for ScatterplotLayer
                   shows you can use a "getRadius" field to individually set
                   the radius of each circle in the plot. So here you would
-                  set "encoding": {"getRadius": "my_column"} where
-                  "my_column" is the name of the column containing the radius
-                  data.
+                  set "getRadius": "my_column" where "my_column" is the name
+                  of the column containing the radius data.
 
                   For things like "getPosition", which expect an array rather
                   than a scalar value, we provide alternates that make the
@@ -2386,10 +2385,6 @@ class DeltaGenerator(object):
                     green, blue and alpha.
                   - Instead of "getSourceColor" : use the same as above.
                   - Instead of "getTargetColor" : use "getTargetColorR", etc.
-
-                - Plus anything accepted by that layer type. For example, for
-                  ScatterplotLayer you can set fields like "opacity", "filled",
-                  "stroked", and so on.
 
         **kwargs : any
             Same as spec, but as keywords. Keys are "unflattened" at the


### PR DESCRIPTION
Issue https://github.com/streamlit/streamlit-old-private/issues/964

- Add support for getColor and getTargetColor with custom column getters, using getColorR/G/B/A and getTargetColorR/G/B/A for DeckGL Charts.
- Update DeckGL Chart documentation.

```
Connect specific fields in the dataset to properties of the chart. 
The exact keys that are accepted depend on the "type" field.

For example, Deck.GL"s documentation for ScatterplotLayer
shows you can use a "getRadius" field to individually set
the radius of each circle in the plot. So here you would
set "getRadius": "my_column" where "my_column" is the name
of the column containing the radius data.

For things like "getColor", which expect an array rather
than a scalar value, we provide alternates that make the
API simpler to use with dataframes:

- Instead of "getColor" : use "getColorR", "getColorG",
  "getColorB", and (optionally) "getColorA", for red,
  green, blue and alpha.
- Instead of "getSourceColor" : use the same as above.
- Instead of "getTargetColor" : use "getTargetColorR", etc.
```

To test:
- https://gist.github.com/jrhone/a45fa7ae88f385ae1fa1ddb1d7adfa63
- https://gist.github.com/jrhone/786f10677dce7f19460e663535c8621a
