### PR TITLE
Improve __instalation_id__ generation

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -65,6 +65,7 @@ _LOGGER = _logger.get_logger("root")
 # Give the package a version.
 import pkg_resources as _pkg_resources
 import uuid as _uuid
+import os
 
 # This used to be pkg_resources.require('streamlit') but it would cause
 # pex files to fail. See #394 for more details.
@@ -73,7 +74,17 @@ __version__ = _pkg_resources.get_distribution("streamlit").version
 # Deterministic Unique Streamlit User ID
 # The try/except is needed for python 2/3 compatibility
 try:
-    __installation_id__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, str(_uuid.getnode())))
+
+    machine_id = _uuid.getnode()
+    if os.path.isfile('/etc/machine-id'):
+        with open("/etc/machine-id", "r") as f:
+            machine_id = f.read()
+    elif os.path.isfile('/var/lib/dbus/machine-id'):
+        with open("/var/lib/dbus/machine-id", "r") as f:
+            machine_id = f.read()
+
+    __installation_id__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, str(machine_id)))
+    
 except UnicodeDecodeError:
     __installation_id__ = str(
         _uuid.uuid5(_uuid.NAMESPACE_DNS, str(_uuid.getnode()).encode("utf-8"))

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -65,6 +65,8 @@ _LOGGER = _logger.get_logger("root")
 # Give the package a version.
 import pkg_resources as _pkg_resources
 import uuid as _uuid
+import subprocess
+import platform
 import os
 
 # This used to be pkg_resources.require('streamlit') but it would cause
@@ -75,6 +77,10 @@ __version__ = _pkg_resources.get_distribution("streamlit").version
 # The try/except is needed for python 2/3 compatibility
 try:
 
+    if platform.system() == 'Linux' and os.path.isfile('/etc/machine-id') == False and os.path.isfile('/var/lib/dbus/machine-id') == False:
+        print("Generate machine-id")
+        subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])   
+    
     machine_id = _uuid.getnode()
     if os.path.isfile('/etc/machine-id'):
         with open("/etc/machine-id", "r") as f:


### PR DESCRIPTION
**Issue:**
https://github.com/streamlit/streamlit/issues/715

**Description:** 
Try to use the `machine-id` (if exist) to generate the `__instalation_id__`. If not, keep using `uuid.getnode()`