### PR TITLE
WebsocketConnection: handle fatal errors

### DIFF
--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -154,7 +154,7 @@ export class ConnectionManager {
     return new WebsocketConnection({
       baseUriPartsList: [baseUriParts],
       onMessage: this.props.onMessage,
-      onConnectionStateChange: s => this.setConnectionState(s),
+      onConnectionStateChange: this.setConnectionState,
       onRetry: this.showRetryError,
     })
   }

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -241,7 +241,7 @@ export class WebsocketConnection {
       return
     }
 
-    // Anything combination of state+event that is not explicitly called out
+    // Any combination of state+event that is not explicitly called out
     // below is illegal and raises an error.
 
     switch (this.state) {

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -283,7 +283,8 @@ export class WebsocketConnection {
       case ConnectionState.DISCONNECTED_FOREVER:
         // If we're in the DISCONNECTED_FOREVER state, we can't reasonably
         // process any events, and it's possible we're in this state because
-        // of a fatal error. Rather than throwing another exception
+        // of a fatal error. Just log these events rather than throwing more
+        // exceptions.
         logWarning(
           LOG,
           `Discarding ${event} while in ${ConnectionState.DISCONNECTED_FOREVER}`


### PR DESCRIPTION
Currently, if there's some sort of fatal error in WebsocketConnection, it hangs and doesn't display anything meaningful to the user. These changes fix that:

- The "CONNECTION_WTF" event is now called "FATAL_ERROR", and is properly handled. 
- If we receive this event from any FSM state, we transition to the "DISCONNECTED_FOREVER" state and send along an error message to ConnectionManager.
- These error messages are now displayed in the "Connection Error" dialog. (Previously, the dialog would just say "Unknown".)

Fixes #26