### PR TITLE
Roll back widget_id (commit 0577857)

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -169,10 +169,11 @@ def _set_widget_id(widget_type, element, user_key=None):
         If this is None, we'll generate an ID by hashing the element.
 
     """
-    if user_key is None:
-        widget_id = "%s" % hash(element.SerializeToString())
+    element_hash = hash(element.SerializeToString())
+    if user_key is not None:
+        widget_id = "%s-%s" % (user_key, element_hash)
     else:
-        widget_id = "%s-%s" % (user_key, widget_type)
+        widget_id = "%s" % element_hash
 
     ctx = get_report_ctx()
     if ctx is not None:

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -27,6 +27,7 @@ setup_2_3_shims(globals())
 
 import json
 import sys
+import unittest
 
 import pandas as pd
 
@@ -39,6 +40,7 @@ from parameterized import parameterized
 
 from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.TextInput_pb2 import TextInput
+from streamlit.proto.TextArea_pb2 import TextArea
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.BlockPath_pb2 import BlockPath
 from streamlit.DeltaGenerator import (
@@ -187,21 +189,6 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
         dg = FakeDeltaGenerator()
         result = wrapped(dg, "foo", data="bar")
         self.assertEqual(result, ("foo", "bar"))
-
-    def test_set_widget_id(self):
-        # Create a new TextInput proto
-        text_input = TextInput()
-        text_input.label = 'some_label'
-
-        # Create a new Element protoand set the TextInput message
-        element = Element()
-        element.text_input.CopyFrom(text_input)
-
-        # Send to set the widget_id for the new element
-        _set_widget_id('text_input', element, user_key='some_key')
-        
-        # Check widget_id with user_key format
-        self.assertEqual(element.text_input.id, 'some_key-text_input')
 
     def test_with_element(self):
         wrapped = _with_element(FakeDeltaGenerator.fake_text)
@@ -478,6 +465,128 @@ class DeltaGeneratorChartTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(chart_spec["mark"], "bar")
         self.assertEqual(element.datasets[0].data.data.cols[2].int64s.data[0], 20)
+
+
+class WidgetIdText(unittest.TestCase):
+    def test_ids_are_equal_when_proto_is_equal(self):
+        text_input1 = TextInput()
+        text_input1.label = 'Label #1'
+        text_input1.default = 'Value #1'
+
+        text_input2 = TextInput()
+        text_input2.label = 'Label #1'
+        text_input2.default = 'Value #1'
+
+        element1 = Element()
+        element1.text_input.CopyFrom(text_input1)
+
+        element2 = Element()
+        element2.text_input.CopyFrom(text_input2)
+
+        _set_widget_id('text_input', element1)
+        _set_widget_id('text_input', element2)
+
+        self.assertEqual(element1.text_input.id, element2.text_input.id)
+
+    def test_ids_are_diff_when_labels_are_diff(self):
+        text_input1 = TextInput()
+        text_input1.label = 'Label #1'
+        text_input1.default = 'Value #1'
+
+        text_input2 = TextInput()
+        text_input2.label = 'Label #2'
+        text_input2.default = 'Value #1'
+
+        element1 = Element()
+        element1.text_input.CopyFrom(text_input1)
+
+        element2 = Element()
+        element2.text_input.CopyFrom(text_input2)
+
+        _set_widget_id('text_input', element1)
+        _set_widget_id('text_input', element2)
+
+        self.assertNotEqual(element1.text_input.id, element2.text_input.id)
+
+    def test_ids_are_diff_when_types_are_diff(self):
+        text_input1 = TextInput()
+        text_input1.label = 'Label #1'
+        text_input1.default = 'Value #1'
+
+        text_area2 = TextArea()
+        text_area2.label = 'Label #1'
+        text_area2.default = 'Value #1'
+
+        element1 = Element()
+        element1.text_input.CopyFrom(text_input1)
+
+        element2 = Element()
+        element2.text_area.CopyFrom(text_area2)
+
+        _set_widget_id('text_input', element1)
+        _set_widget_id('text_input', element2)
+
+        self.assertNotEqual(element1.text_input.id, element2.text_area.id)
+
+    def test_ids_are_equal_when_keys_are_equal(self):
+        text_input1 = TextInput()
+        text_input1.label = 'Label #1'
+        text_input1.default = 'Value #1'
+
+        text_input2 = TextInput()
+        text_input2.label = 'Label #1'
+        text_input2.default = 'Value #1'
+
+        element1 = Element()
+        element1.text_input.CopyFrom(text_input1)
+
+        element2 = Element()
+        element2.text_input.CopyFrom(text_input2)
+
+        _set_widget_id('text_input', element1, user_key='some_key')
+        _set_widget_id('text_input', element2, user_key='some_key')
+
+        self.assertEqual(element1.text_input.id, element2.text_input.id)
+
+    def test_ids_are_diff_when_keys_are_diff(self):
+        text_input1 = TextInput()
+        text_input1.label = 'Label #1'
+        text_input1.default = 'Value #1'
+
+        text_input2 = TextInput()
+        text_input2.label = 'Label #1'
+        text_input2.default = 'Value #1'
+
+        element1 = Element()
+        element1.text_input.CopyFrom(text_input1)
+
+        element2 = Element()
+        element2.text_input.CopyFrom(text_input2)
+
+        _set_widget_id('text_input', element1, user_key='some_key1')
+        _set_widget_id('text_input', element2, user_key='some_key2')
+
+        self.assertNotEqual(element1.text_input.id, element2.text_input.id)
+
+    def test_ids_are_diff_when_values_are_diff(self):
+        text_input1 = TextInput()
+        text_input1.label = 'Label #1'
+        text_input1.default = 'Value #1'
+
+        text_input2 = TextInput()
+        text_input2.label = 'Label #1'
+        text_input2.default = 'Value #2'
+
+        element1 = Element()
+        element1.text_input.CopyFrom(text_input1)
+
+        element2 = Element()
+        element2.text_input.CopyFrom(text_input2)
+
+        _set_widget_id('text_input', element1, user_key='some_key1')
+        _set_widget_id('text_input', element2, user_key='some_key1')
+
+        self.assertNotEqual(element1.text_input.id, element2.text_input.id)
 
 
 class DeltaGeneratorImageTest(testutil.DeltaGeneratorTestCase):


### PR DESCRIPTION
Turns out the original commit broke the case where one widget depends on the output from another:

```py
country = st.selectbox("Country", countries)
states = country_state_map[country]
state = st.selectbox("State", states)
```