### PR TITLE
Checking allowed file extensions

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -34,6 +34,8 @@ from streamlit import version
 import streamlit.bootstrap as bootstrap
 from streamlit.case_converters import to_snake_case
 
+ACCEPTED_FILE_EXTENSIONS = ('py', 'py3')
+
 LOG_LEVELS = ["error", "warning", "info", "debug"]
 
 NEW_VERSION_TEXT = """
@@ -206,6 +208,10 @@ def main_run(target, args=None, **kwargs):
     from validators import url
 
     _apply_config_options_from_cli(kwargs)
+
+    file_extension = target.split(".")[-1]
+    if file_extension not in ACCEPTED_FILE_EXTENSIONS:
+        raise click.BadArgumentUsage("Streamlit requires raw Python (.py) files, not %s.\nFor more information, please see https://streamlit.io/docs" % file_extension)
 
     if url(target):
         from streamlit.temporary_directory import TemporaryDirectory

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -36,7 +36,7 @@ from streamlit.case_converters import to_snake_case
 
 ACCEPTED_FILE_EXTENSIONS = ("py", "py3")
 
-LOG_LEVELS = ["error", "warning", "info", "debug"]
+LOG_LEVELS = ("error", "warning", "info", "debug")
 
 NEW_VERSION_TEXT = """
   %(new_version)s

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -209,9 +209,9 @@ def main_run(target, args=None, **kwargs):
 
     _apply_config_options_from_cli(kwargs)
 
-    file_extension = target.split(".")[-1]
-    if file_extension not in ACCEPTED_FILE_EXTENSIONS:
-        raise click.BadArgumentUsage("Streamlit requires raw Python (.py) files, not %s.\nFor more information, please see https://streamlit.io/docs" % file_extension)
+    _, extension = os.path.splitext(target)
+    if extension[1:] not in ACCEPTED_FILE_EXTENSIONS:
+        raise click.BadArgumentUsage("Streamlit requires raw Python (.py) files, not %s.\nFor more information, please see https://streamlit.io/docs" % extension)
 
     if url(target):
         from streamlit.temporary_directory import TemporaryDirectory

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -34,7 +34,7 @@ from streamlit import version
 import streamlit.bootstrap as bootstrap
 from streamlit.case_converters import to_snake_case
 
-ACCEPTED_FILE_EXTENSIONS = ('py', 'py3')
+ACCEPTED_FILE_EXTENSIONS = ("py", "py3")
 
 LOG_LEVELS = ["error", "warning", "info", "debug"]
 

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -67,6 +67,15 @@ class CliTest(unittest.TestCase):
         self.assertNotEqual(0, result.exit_code)
         self.assertTrue("File does not exist" in result.output)
 
+    def test_run_not_allowed_file_extension(self):
+        """streamlit run should fail if a not allowed file extension is passed"""
+
+        result = self.runner.invoke(cli, ["run", "file_name.doc"])
+        print(result.output)
+        self.assertNotEqual(0, result.exit_code)
+        self.assertTrue("Streamlit requires raw Python (.py) files, not doc."
+                        in result.output)
+
     @tempdir()
     def test_run_valid_url(self, temp_dir):
         """streamlit run succeeds if an existing url is passed"""

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -53,7 +53,7 @@ class CliTest(unittest.TestCase):
             "streamlit.cli._main_run"
         ), patch("os.path.exists", return_value=True):
 
-            result = self.runner.invoke(cli, ["run", "file_name"])
+            result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertEqual(0, result.exit_code)
 
     def test_run_non_existing_file_argument(self):
@@ -63,7 +63,7 @@ class CliTest(unittest.TestCase):
             "streamlit.cli._main_run"
         ), patch("os.path.exists", return_value=False):
 
-            result = self.runner.invoke(cli, ["run", "file_name"])
+            result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertNotEqual(0, result.exit_code)
         self.assertTrue("File does not exist" in result.output)
 

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -43,12 +43,12 @@ class CliTest(unittest.TestCase):
         streamlit._is_running_with_streamlit = False
 
     def test_run_no_arguments(self):
-        """streamlit run should fail if run with no arguments"""
+        """streamlit run should fail if run with no arguments."""
         result = self.runner.invoke(cli, ["run"])
         self.assertNotEqual(0, result.exit_code)
 
     def test_run_existing_file_argument(self):
-        """streamlit run succeeds if an existing file is passed"""
+        """streamlit run succeeds if an existing file is passed."""
         with patch("validators.url", return_value=False), patch(
             "streamlit.cli._main_run"
         ), patch("os.path.exists", return_value=True):
@@ -57,7 +57,7 @@ class CliTest(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_run_non_existing_file_argument(self):
-        """streamlit run should fail if a non existing file is passed"""
+        """streamlit run should fail if a non existing file is passed."""
 
         with patch("validators.url", return_value=False), patch(
             "streamlit.cli._main_run"
@@ -68,7 +68,8 @@ class CliTest(unittest.TestCase):
         self.assertTrue("File does not exist" in result.output)
 
     def test_run_not_allowed_file_extension(self):
-        """streamlit run should fail if a not allowed file extension is passed"""
+        """streamlit run should fail if a not allowed file extension is passed.
+        """
 
         result = self.runner.invoke(cli, ["run", "file_name.doc"])
 
@@ -78,7 +79,7 @@ class CliTest(unittest.TestCase):
 
     @tempdir()
     def test_run_valid_url(self, temp_dir):
-        """streamlit run succeeds if an existing url is passed"""
+        """streamlit run succeeds if an existing url is passed."""
 
         with patch("validators.url", return_value=True), patch(
             "streamlit.cli._main_run"
@@ -97,14 +98,15 @@ class CliTest(unittest.TestCase):
     @tempdir()
     def test_run_non_existing_url(self, temp_dir):
         """streamlit run should fail if a non existing but valid
-         url is passed
+         url is passed.
          """
 
         with patch("validators.url", return_value=True), patch(
             "streamlit.cli._main_run"
         ), requests_mock.mock() as m:
 
-            m.get("http://url/app.py", exc=requests.exceptions.RequestException)
+            m.get("http://url/app.py",
+                  exc=requests.exceptions.RequestException)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
                 mock_tmp.return_value.__enter__.return_value = temp_dir.path
                 result = self.runner.invoke(cli, ["run", "http://url/app.py"])
@@ -113,7 +115,7 @@ class CliTest(unittest.TestCase):
         self.assertTrue("Unable to fetch" in result.output)
 
     def test_run_arguments(self):
-        """The correct command line should be passed downstream"""
+        """The correct command line should be passed downstream."""
         with patch("validators.url", return_value=False), patch(
             "os.path.exists", return_value=True
         ):
@@ -128,7 +130,8 @@ class CliTest(unittest.TestCase):
                     ],
                 )
         mock_main_run.assert_called_with(
-            "some script.py", ("argument with space", "argument with another space")
+            "some script.py",
+            ("argument with space", "argument with another space")
         )
         self.assertEqual(0, result.exit_code)
 
@@ -139,7 +142,8 @@ class CliTest(unittest.TestCase):
         mock_context = MagicMock()
         mock_context.parent.command_path = "mock_command"
         with patch("click.get_current_context", return_value=mock_context):
-            with patch("click.get_os_args", return_value=["os_arg1", "os_arg2"]):
+            with patch("click.get_os_args",
+                       return_value=["os_arg1", "os_arg2"]):
                 result = cli._get_command_line_as_string()
                 self.assertEqual("mock_command os_arg1 os_arg2", result)
 
@@ -177,7 +181,7 @@ class CliTest(unittest.TestCase):
     @patch("streamlit.cli._config._set_option")
     def test_apply_config_options_from_cli(self, patched__set_option):
         """Test that _apply_config_options_from_cli parses the key properly and
-        passes down the parameters
+        passes down the parameters.
         """
 
         kwargs = {
@@ -209,7 +213,8 @@ class CliTest(unittest.TestCase):
         )
 
     def test_credentials_headless_no_config(self):
-        """If headless mode and no config is present, activation should be None."""
+        """If headless mode and no config is present,
+        activation should be None."""
         from streamlit import config
 
         config.set_option("server.headless", True)
@@ -228,7 +233,8 @@ class CliTest(unittest.TestCase):
 
     @parameterized.expand([(True,), (False,)])
     def test_credentials_headless_with_config(self, headless_mode):
-        """If headless, but a cofig file is present, activation should be defined.
+        """If headless, but a config file is present, activation should be
+        defined.
         So we call `_check_activated`.
         """
         from streamlit import config

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -71,9 +71,9 @@ class CliTest(unittest.TestCase):
         """streamlit run should fail if a not allowed file extension is passed"""
 
         result = self.runner.invoke(cli, ["run", "file_name.doc"])
-        print(result.output)
+
         self.assertNotEqual(0, result.exit_code)
-        self.assertTrue("Streamlit requires raw Python (.py) files, not doc."
+        self.assertTrue("Streamlit requires raw Python (.py) files, not .doc."
                         in result.output)
 
     @tempdir()


### PR DESCRIPTION
**Issue:** Fixes #671 
**Description:** Warn users when they try to run Streamlit on a not allowed file extension.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
