### PR TITLE
Fixing broken example strings for radio() and date_input()

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1647,13 +1647,13 @@ class DeltaGenerator(object):
         Example
         -------
         >>> genre = st.radio(
-        ...     'What\'s your favorite movie genre',
+        ...     "What\'s your favorite movie genre",
         ...     ('Comedy', 'Drama', 'Documentary'))
         >>>
         >>> if genre == 'Comedy':
         ...     st.write('You selected comedy.')
         ... else:
-        ...     st.write('You didn\'t select comedy.')
+        ...     st.write("You didn\'t select comedy.")
 
         """
         if not isinstance(index, int):
@@ -2058,7 +2058,7 @@ class DeltaGenerator(object):
         Example
         -------
         >>> d = st.date_input(
-        ...     'When\'s your birthday',
+        ...     "When\'s your birthday",
         ...     datetime.date(2019, 7, 6))
         >>> st.write('Your birthday is:', d)
 


### PR DESCRIPTION
**Issue:** Fixes #659 
**Description:** `radio()` and `date_input()` example strings were broken

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
