### PR TITLE
Fix pylint errors

### DIFF
--- a/e2e/scripts/empty.py
+++ b/e2e/scripts/empty.py
@@ -15,7 +15,7 @@
 
 import streamlit as st
 
-st.text('The space between this...')
-st.text('..and this should be the same as between this...')
+st.text("The space between this...")
+st.text("..and this should be the same as between this...")
 st.empty()
-st.text('...and this')
+st.text("...and this")

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -77,20 +77,24 @@ __version__ = _pkg_resources.get_distribution("streamlit").version
 # The try/except is needed for python 2/3 compatibility
 try:
 
-    if platform.system() == 'Linux' and os.path.isfile('/etc/machine-id') == False and os.path.isfile('/var/lib/dbus/machine-id') == False:
+    if (
+        platform.system() == "Linux"
+        and os.path.isfile("/etc/machine-id") == False
+        and os.path.isfile("/var/lib/dbus/machine-id") == False
+    ):
         print("Generate machine-id")
-        subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])   
-    
+        subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])
+
     machine_id = _uuid.getnode()
-    if os.path.isfile('/etc/machine-id'):
+    if os.path.isfile("/etc/machine-id"):
         with open("/etc/machine-id", "r") as f:
             machine_id = f.read()
-    elif os.path.isfile('/var/lib/dbus/machine-id'):
+    elif os.path.isfile("/var/lib/dbus/machine-id"):
         with open("/var/lib/dbus/machine-id", "r") as f:
             machine_id = f.read()
 
     __installation_id__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, str(machine_id)))
-    
+
 except UnicodeDecodeError:
     __installation_id__ = str(
         _uuid.uuid5(_uuid.NAMESPACE_DNS, str(_uuid.getnode()).encode("utf-8"))

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -107,6 +107,7 @@ def _fix_tornado_crash():
     """
     if env_util.IS_WINDOWS and sys.version_info >= (3, 8):
         import asyncio
+
         try:
             from asyncio import (
                 WindowsProactorEventLoopPolicy,
@@ -116,14 +117,10 @@ def _fix_tornado_crash():
             pass
             # Not affected
         else:
-            if (
-                type(asyncio.get_event_loop_policy()) is
-                    WindowsProactorEventLoopPolicy
-            ):
+            if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
                 # WindowsProactorEventLoopPolicy is not compatible with
                 # Tornado 6 fallback to the pre-3.8 default of Selector
-                asyncio.set_event_loop_policy(
-                    WindowsSelectorEventLoopPolicy())
+                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 
 def _fix_sys_argv(script_path, args):

--- a/lib/streamlit/elements/lib/dicttools.py
+++ b/lib/streamlit/elements/lib/dicttools.py
@@ -122,11 +122,17 @@ def unflatten(flat_dict, encodings=None):
 
     for k, v in list(out_dict.items()):
         # Unflatten child dicts:
-        if type(v) in (dict, native_dict): # noqa: F821 pylint:disable=undefined-variable
+        if type(v) in (
+            dict,
+            native_dict,
+        ):  # noqa: F821 pylint:disable=undefined-variable
             v = unflatten(v, encodings)
         elif hasattr(v, "__iter__"):
             for i, child in enumerate(v):
-                if type(child) in (dict, native_dict): # noqa: F821 pylint:disable=undefined-variable
+                if type(child) in (
+                    dict,
+                    native_dict,
+                ):  # noqa: F821 pylint:disable=undefined-variable
                     v[i] = unflatten(child, encodings)
 
         # Move items into 'encoding' if needed:

--- a/lib/streamlit/elements/vega_lite.py
+++ b/lib/streamlit/elements/vega_lite.py
@@ -38,7 +38,9 @@ def marshall(proto, data=None, spec=None, width=0, **kwargs):
     """
     # Support passing data inside spec['datasets'] and spec['data'].
     # (The data gets pulled out of the spec dict later on.)
-    if type(data) in dict_types and spec is None: # noqa: F821 pylint:disable=undefined-variable
+    if (
+        type(data) in dict_types and spec is None
+    ):  # noqa: F821 pylint:disable=undefined-variable
         spec = data
         data = None
 
@@ -86,7 +88,9 @@ def marshall(proto, data=None, spec=None, width=0, **kwargs):
     if "data" in spec:
         data_spec = spec["data"]
 
-        if type(data_spec) in dict_types: # noqa: F821 pylint:disable=undefined-variable
+        if (
+            type(data_spec) in dict_types
+        ):  # noqa: F821 pylint:disable=undefined-variable
             if "values" in data_spec:
                 data = data_spec["values"]
                 del data_spec["values"]

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -48,7 +48,9 @@ def is_type(obj, fqn_type_pattern):
     module = the_type.__module__
     name = the_type.__name__
     actual_fqn = "%s.%s" % (module, name)
-    if isinstance(fqn_type_pattern, string_types): # noqa: F821 pylint:disable=undefined-variable
+    if isinstance(
+        fqn_type_pattern, string_types
+    ):  # noqa: F821 pylint:disable=undefined-variable
         return fqn_type_pattern == actual_fqn
     else:
         return fqn_type_pattern.match(actual_fqn) is not None
@@ -118,7 +120,7 @@ def _is_list_of_plotly_objs(obj):
 
 
 def _is_probably_plotly_dict(obj):
-    if type(obj) not in dict_types: # noqa: F821 pylint:disable=undefined-variable
+    if type(obj) not in dict_types:  # noqa: F821 pylint:disable=undefined-variable
         return False
 
     if len(obj.keys()) == 0:

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -98,9 +98,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertListEqual(c.default[:], [])
         self.assertEqual(c.options, [])
 
-    @parameterized.expand(
-        [(None, []), ([], []), (["Tea", "Water"], [1, 2])]
-    )
+    @parameterized.expand([(None, []), ([], []), (["Tea", "Water"], [1, 2])])
     def test_defaults(self, defaults, expected):
         """Test that valid default can be passed as expected."""
         st.multiselect("the label", ["Coffee", "Tea", "Water"], defaults)
@@ -111,7 +109,10 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.options, ["Coffee", "Tea", "Water"])
 
     @parameterized.expand(
-        [(["Tea", "Vodka", None], StreamlitAPIException), ([1, 2], StreamlitAPIException)]
+        [
+            (["Tea", "Vodka", None], StreamlitAPIException),
+            ([1, 2], StreamlitAPIException),
+        ]
     )
     def test_invalid_defaults(self, defaults, expected):
         """Test that invalid default trigger the expected exception."""


### PR DESCRIPTION
I ran `make pyformat` to fix black violations that are causing CircleCI builds to fail