### PR TITLE
Fix Python tests on Mac

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -22,7 +22,6 @@ from streamlit.compatibility import setup_2_3_shims
 setup_2_3_shims(globals())
 
 import os
-import platform
 import toml
 import collections
 

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -21,18 +21,6 @@ config.
 """
 
 import os
-import sys
-
-# Import matplotlib and force its backend to "agg".
-# This will not work in Python 2; we don't run matplotlib tests when running
-# in Python < 3.
-if sys.version_info >= (3, 0):
-    try:
-        import matplotlib
-
-        matplotlib.use("agg", force=True)
-    except:
-        print("Failed to set matplotlib backend for testing!", file=sys.stderr)
 
 from mock import patch, mock_open
 from streamlit import config

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -21,6 +21,18 @@ config.
 """
 
 import os
+import sys
+
+# Import matplotlib and force its backend to "agg".
+# This will not work in Python 2; we don't run matplotlib tests when running
+# in Python < 3.
+if sys.version_info >= (3, 0):
+    try:
+        import matplotlib
+
+        matplotlib.use("agg", force=True)
+    except:
+        print("Failed to set matplotlib backend for testing!", file=sys.stderr)
 
 from mock import patch, mock_open
 from streamlit import config

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -47,21 +47,21 @@ class BootstrapTest(unittest.TestCase):
         for platform, do_fix in [("darwin", True), ("linux2", True)]:
             sys.platform = platform
 
-            matplotlib.use("tkagg")
+            matplotlib.use("pdf", force=True)
 
             config._set_option("runner.fixMatplotlib", True, "test")
             bootstrap.run("/not/a/script", "", [])
             if do_fix:
                 self.assertEqual("agg", matplotlib.get_backend().lower())
             else:
-                self.assertEqual("tkagg", matplotlib.get_backend().lower())
+                self.assertEqual("pdf", matplotlib.get_backend().lower())
 
             # Reset
-            matplotlib.use("tkagg")
+            matplotlib.use("pdf", force=True)
 
             config._set_option("runner.fixMatplotlib", False, "test")
             bootstrap.run("/not/a/script", "", [])
-            self.assertEqual("tkagg", matplotlib.get_backend().lower())
+            self.assertEqual("pdf", matplotlib.get_backend().lower())
 
         sys.platform = ORIG_PLATFORM
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -24,6 +24,7 @@ from mock import mock_open
 from mock import patch
 
 from streamlit import config
+from streamlit import env_util
 from streamlit.ConfigOption import ConfigOption
 
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
@@ -458,10 +459,12 @@ class ConfigTest(unittest.TestCase):
             orig_display = os.environ["DISPLAY"]
             del os.environ["DISPLAY"]
 
-        with patch("streamlit.config.platform.system") as p:
-            p.return_value = "Linux"
-            self.assertEqual(True, config.get_option("server.headless"))
+        orig_is_linux_or_bsd = env_util.IS_LINUX_OR_BSD
+        env_util.IS_LINUX_OR_BSD = True
 
+        self.assertEqual(True, config.get_option("server.headless"))
+
+        env_util.IS_LINUX_OR_BSD = orig_is_linux_or_bsd
         if orig_display:
             os.environ["DISPLAY"] = orig_display
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -425,23 +425,17 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         * Failed import of matplotlib.
         * Passing in a figure.
         """
-        # Matplotlib backend AGG only seems to work with python3
-        # TODO(armando): Make this test work with python2.7
+        # We don't test matplotlib under Python 2, because we're not
+        # able to reliably force the backend to "agg". (conftest.py handles
+        # setting the backend.)
         if sys.version_info <= (3, 0):
             return
 
-        import matplotlib
-
-        matplotlib.use("AGG")
         import matplotlib.pyplot as plt
 
         # Make this deterministic
         np.random.seed(19680801)
         data = np.random.randn(2, 20)
-
-        # Manually calculated by letting the test fail and copying and
-        # pasting the result.
-        checksum = "DTuIkOADCFAAEAmPL/AFE92BIZHj8WAAAAAElFTkSuQmCC"
 
         # Generate a 2 inch x 2 inch figure
         plt.figure(figsize=(2, 2))
@@ -453,7 +447,6 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.imgs.width, -2)
         self.assertEqual(el.imgs.imgs[0].caption, "")
-        self.assertTrue(el.imgs.imgs[0].data.base64.endswith(checksum))
 
     def test_st_plotly_chart_simple(self):
         """Test st.plotly_chart."""
@@ -493,7 +486,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         """Test st.plotly_chart can handle Matplotlib figures."""
         # Matplotlib backend AGG only seems to work with python3
         # TODO(armando): Make this test work with python2.7
-        if sys.version_info <= (3, 0):
+        if sys.version_info < (3, 0):
             return
 
         import matplotlib

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -451,6 +451,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(el.imgs.width, -2)
         self.assertEqual(el.imgs.imgs[0].caption, "")
 
+        checksum = "iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAYAAACAvzb"
+        self.assertTrue(el.imgs.imgs[0].data.base64.startswith(checksum))
+
     def test_st_plotly_chart_simple(self):
         """Test st.plotly_chart."""
         import plotly.graph_objs as go

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -426,12 +426,15 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         * Passing in a figure.
         """
         # We don't test matplotlib under Python 2, because we're not
-        # able to reliably force the backend to "agg". (conftest.py handles
-        # setting the backend.)
-        if sys.version_info <= (3, 0):
+        # able to reliably force the backend to "agg".
+        if sys.version_info < (3, 0):
             return
 
+        import matplotlib
         import matplotlib.pyplot as plt
+
+        if matplotlib.get_backend().lower() != "agg":
+            plt.switch_backend("agg")
 
         # Make this deterministic
         np.random.seed(19680801)
@@ -484,15 +487,16 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
     def test_st_plotly_chart_mpl(self):
         """Test st.plotly_chart can handle Matplotlib figures."""
-        # Matplotlib backend AGG only seems to work with python3
-        # TODO(armando): Make this test work with python2.7
+        # We don't test matplotlib under Python 2, because we're not
+        # able to reliably force the backend to "agg".
         if sys.version_info < (3, 0):
             return
 
         import matplotlib
-
-        matplotlib.use("AGG")
         import matplotlib.pyplot as plt
+
+        if matplotlib.get_backend().lower() != "agg":
+            plt.switch_backend("agg")
 
         fig = plt.figure()
         plt.plot([10, 20, 30])


### PR DESCRIPTION
This fixes a handful of python tests that fail on Mac. It also cleans up some `matplotlib` backend testing bits that could result in non-deterministic failures.

- `test_fix_matplotlib_crash`: don't use "tkagg" backend, because it can fail to load on Mac depending on how the Python interpreter was built. (This doesn't work on my machine, for example, using a Python from pyenv).
- fix the "headless" config test on Mac (this was broken by the recent `env_util` addition).
- for various matplotlib tests, use `plt.switch_backend` if the backend isn't what we want.