### PR TITLE
NumberInput format string fixes

### DIFF
--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -71,10 +71,14 @@ describe("NumberInput", () => {
 
   it("Handles malformed format strings without crashing", () => {
     // This format string is malformed (it should be %0.2f)
-    const props = getFloatProps({ format: "%0.2" })
+    const props = getFloatProps({
+      floatData: { default: 5.0 },
+      format: "%0.2",
+    })
     const wrapper = shallow(<NumberInput {...props} />)
 
     expect(wrapper).toBeDefined()
+    expect(wrapper.state("value")).toBe(5.0)
   })
 
   it("Should show a label", () => {

--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -69,6 +69,14 @@ describe("NumberInput", () => {
     expect(wrapper).toBeDefined()
   })
 
+  it("Handles malformed format strings without crashing", () => {
+    // This format string is malformed (it should be %0.2f)
+    const props = getFloatProps({ format: "%0.2" })
+    const wrapper = shallow(<NumberInput {...props} />)
+
+    expect(wrapper).toBeDefined()
+  })
+
   it("Should show a label", () => {
     const props = getIntProps()
     const wrapper = shallow(<NumberInput {...props} />)

--- a/frontend/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.tsx
@@ -20,6 +20,7 @@ import { sprintf } from "sprintf-js"
 import { Input as UIInput } from "baseui/input"
 import { Map as ImmutableMap } from "immutable"
 import { WidgetStateManager, Source } from "lib/WidgetStateManager"
+import { logWarning } from "lib/log"
 
 import Icon from "components/shared/Icon"
 
@@ -76,8 +77,17 @@ class NumberInput extends React.PureComponent<Props, State> {
 
   private formatValue = (value: number): string => {
     const format: string = this.props.element.get("format")
+    if (format == null) {
+      return String(value)
+    }
 
-    return format ? sprintf(format, value) : String(value)
+    try {
+      return sprintf(format, value)
+    } catch (e) {
+      // Don't explode if we have a malformed format string.
+      logWarning(`Error in sprintf(${format}, ${value}): ${e}`)
+      return String(value)
+    }
   }
 
   private isIntData = (): boolean => {

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2132,7 +2132,7 @@ class DeltaGenerator(object):
             Defaults to 1 if the value is an int, 0.01 otherwise.
             If the value is not specified, the format parameter will be used.
         format : str or None
-            Printf/Python format string controlling how the interface should
+            A printf-style format string controlling how the interface should
             display numbers. This does not impact the return value.
         key : str
             An optional string to use as the unique key for the widget.
@@ -2573,7 +2573,7 @@ class DeltaGenerator(object):
             elif self._delta_type == 'area_chart':
                 self.area_chart(data)
                 return
-  
+
         data, self._last_index = _maybe_melt_data_for_add_rows(
             data, self._delta_type, self._last_index
         )


### PR DESCRIPTION
1. Fixes `NumberInput` so that it doesn't explode on malformed format strings. `sprintf` throws an exception if the format string is bad, and we're currently not handling this, so a bad format string will just crash the Streamlit page.

2. Clarify the `DeltaGenerator.number_input` format doc a bit.

The frontend uses `sprintf`, which does not really support Python-style format strings, so I removed that bit of text.

(sprintf _does_ support named parameters, but the user has no control over the params that get passed to the sprintf function (there's only one param, and it's the value of the number input),
so this distinction is not meaningful here.)

