### PR TITLE
Caching redux: ignore implicit inputs (i.e. variables from scope outside of cached function)

### DIFF
--- a/cachetest.py
+++ b/cachetest.py
@@ -1,17 +1,11 @@
 import streamlit as st
 
 
-st.title("Cache test: adding `10` to `number`")
-
-    
-
-with st.echo():
-    things = [1,2,3]
-    number = 5
+st.title("Cache test: adding `10` to `number`.")
 
 def called_by_cached_function():
     return number + 2
-
+    
 @st.cache
 def add(num):
     resultd = {"dkey_added": number + num}
@@ -27,15 +21,30 @@ def hash_dicts(inp):
     return outd
 
 st.header("iteration 1: `number = 5`")
+
 with st.echo():
+    things = [1,2,3]
+    number = 5
+    add_answer = add(10)
+    hash_dicts_answer = hash_dicts(5)
+
+with st.echo():
+    st.write("These should generate cache HITs")
     st.write(hash_dicts(5))
     st.write(add(10))
 
-st.header("iteration 2: change `number` to `3`. Mutated `things`")
+st.header("iteration 2: change `number` to `3`. mutate `things`.")
 
 with st.echo():
     things = [4,5,6]
     number = 3
+    st.write("These should ALSO generate cache HITs")
     st.write(add(10))
     st.write(hash_dicts(5))
+
+st.header("RESULTS: Did we ignore implicit inputs?")
+with st.echo():
+    st.write("add(10):", bool(add_answer==add(10)))
+    st.write("hash_dicts(5):", bool(hash_dicts_answer==hash_dicts(5)))
+
 

--- a/cachetest.py
+++ b/cachetest.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+things = [1,2,3]
+
+@st.cache
+def hash_dicts(inp):
+    outd = {'things': things,
+            'a': inp}
+    return outd
+
+st.header("iteration 1")
+st.write(hash_dicts(5))
+
+st.header("iteration 2: mutated `things`")
+things = [4,5,6]
+
+st.write(hash_dicts(5))
+

--- a/cachetest.py
+++ b/cachetest.py
@@ -1,18 +1,41 @@
 import streamlit as st
 
-things = [1,2,3]
+
+st.title("Cache test: adding `10` to `number`")
+
+    
+
+with st.echo():
+    things = [1,2,3]
+    number = 5
+
+def called_by_cached_function():
+    return number + 2
+
+@st.cache
+def add(num):
+    resultd = {"dkey_added": number + num}
+    anothervar = num + 2
+    resultd["dkey_second_add"] = anothervar
+    resultd["dkey_number_from_called_function"] = called_by_cached_function()
+    return resultd
 
 @st.cache
 def hash_dicts(inp):
-    outd = {'things': things,
-            'a': inp}
+    outd = {"dkey_things": things,
+            "dkey_inp": inp}
     return outd
 
-st.header("iteration 1")
-st.write(hash_dicts(5))
+st.header("iteration 1: `number = 5`")
+with st.echo():
+    st.write(hash_dicts(5))
+    st.write(add(10))
 
-st.header("iteration 2: mutated `things`")
-things = [4,5,6]
+st.header("iteration 2: change `number` to `3`. Mutated `things`")
 
-st.write(hash_dicts(5))
+with st.echo():
+    things = [4,5,6]
+    number = 3
+    st.write(add(10))
+    st.write(hash_dicts(5))
 

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,9 @@
+import streamlit as st
+
+placeholder = st.empty()
+inp = st.text_input(label="chat", value="")
+
+if inp:
+    user_says = user_says + inp
+    placeholder.button(label=user_says)            # text_area(user_says)
+

--- a/frontend/src/components/elements/Audio/Audio.tsx
+++ b/frontend/src/components/elements/Audio/Audio.tsx
@@ -43,9 +43,9 @@ class Audio extends React.PureComponent<Props> {
 
   public render(): React.ReactNode {
     const { element, width } = this.props
+
+    // TODO: simplify after checking no more to do here.
     const src = element.get("url")
-      ? element.get("url")
-      : "data:" + element.get("format") + ";base64," + element.get("data")
 
     return (
       <audio

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -68,9 +68,8 @@ class Video extends React.PureComponent<Props> {
       )
     }
 
+    // TODO: simplify after checking no more to do here
     const src = element.get("url")
-      ? element.get("url")
-      : "data:" + element.get("format") + ";base64," + element.get("data")
 
     return (
       <video

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1429,21 +1429,22 @@ class DeltaGenerator(object):
 
         Example
         -------
-        >>> audio_file = open('myaudio.ogg', 'rb')
-        >>> audio_bytes = audio_file.read()
-        >>>
-        >>> st.audio(audio_bytes, format='audio/ogg')
+        >>> st.audio('myaudio.ogg', format='audio/ogg')
 
         .. output::
            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb
            height: 400px
 
         """
-        # TODO: Provide API to convert raw NumPy arrays to audio file (with
-        # proper headers, etc)?
         from .elements import media_proto
 
-        media_proto.marshall_audio(element.audio, data, format, start_time)
+        # TODO: write bytes to file.
+        url = data
+        media_proto.marshall_audio(element.audio, url, format, start_time)
+
+        # TODO: Get rid of the following TODO.
+        # TODO: Provide API to convert raw NumPy arrays to audio file (with
+        # proper headers, etc)?
 
     @_with_element
     def video(self, element, data, format="video/mp4", start_time=0):
@@ -1465,10 +1466,7 @@ class DeltaGenerator(object):
 
         Example
         -------
-        >>> video_file = open('myvideo.mp4', 'rb')
-        >>> video_bytes = video_file.read()
-        >>>
-        >>> st.video(video_bytes)
+        >>> st.video('myvideo.mp4')
 
         .. output::
            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=Wba9sZELKfKwXH4nDCCbMv
@@ -1479,7 +1477,9 @@ class DeltaGenerator(object):
         # proper headers, etc)?
         from .elements import media_proto
 
-        media_proto.marshall_video(element.video, data, format, start_time)
+        # TODO: write bytes to file.
+        url = data
+        media_proto.marshall_video(element.video, url, format, start_time)
 
     @_with_element
     def button(self, element, label, key=None):

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -444,8 +444,8 @@ def cache(
         Whether to persist the cache on disk.
 
     allow_output_mutation : boolean
-        Streamlit normally shows a warning when return values are not mutated, as that
-        can have unintended consequences. This is done by hashing the return value internally.
+        Streamlit normally shows a warning when return values are mutated, as that can have
+        unintended consequences. This is done by hashing the return value internally.
 
         If you know what you're doing and would like to override this warning, set this to True.
 

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -444,8 +444,13 @@ def cache(
         Whether to persist the cache on disk.
 
     allow_output_mutation : boolean
+<<<<<<< HEAD
         Streamlit normally shows a warning when return values are mutated, as that can have
         unintended consequences. This is done by hashing the return value internally.
+=======
+        Streamlit normally shows a warning when return values are not mutated, as that
+        can have unintended consequences. This is done by hashing the return value internally.
+>>>>>>> parent of 6dc3706... not supposed to be in here
 
         If you know what you're doing and would like to override this warning, set this to True.
 
@@ -632,9 +637,12 @@ class Cache(dict):
 
 
     """
+<<<<<<< HEAD
     # Developer Note: We've changed the behavior of @st.cache to stop caching
     # internal variables, but none of the changes in @st.cache were applied to
     # to the Cache object herein.  --nm  12/3/2019
+=======
+>>>>>>> parent of 6dc3706... not supposed to be in here
 
     def __init__(self, persist=False, allow_output_mutation=False):
         self._persist = persist

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -632,6 +632,9 @@ class Cache(dict):
 
 
     """
+    # Developer Note: We've changed the behavior of @st.cache to stop caching
+    # internal variables, but none of the changes in @st.cache were applied to
+    # to the Cache object herein.  --nm  12/3/2019
 
     def __init__(self, persist=False, allow_output_mutation=False):
         self._persist = persist

--- a/lib/streamlit/elements/media_proto.py
+++ b/lib/streamlit/elements/media_proto.py
@@ -53,7 +53,7 @@ def _reshape_youtube_url(url):
 
     Example
     -------
-    >>> print(process_video_url('https://youtu.be/_T8LGqJtuGc'))
+    >>> print(_reshape_youtube_url('https://youtu.be/_T8LGqJtuGc'))
 
     .. output::
         https://www.youtube.com/embed/_T8LGqJtuGc
@@ -64,50 +64,14 @@ def _reshape_youtube_url(url):
     return None
 
 
-def _marshall_binary(proto, data):
-    """Marshals a proto with binary data (converts to base64).
+def marshall_video(proto, url, format="video/mp4", start_time=0):
+    """Marshalls a video proto, using url processors as needed.
 
     Parameters
     ----------
     proto : the proto to fill. Must have a string field called "data".
-    data : a buffer with the binary data. Supported formats: str, bytes,
-        BytesIO, NumPy array, or a file opened with io.open().
-    """
-    if type(data) in string_types:  # noqa: F821
-        # Python3 raises TypeError for unencodable text (but not Python 2.7)
-        b64encodable = bytes(data)
-    elif type(data) is newbytes:
-        b64encodable = data
-    elif type(data) is bytes:
-        # Must come after str, since byte and str are equivalent in Python 2.7.
-        b64encodable = data
-    elif isinstance(data, io.BytesIO):
-        data.seek(0)
-        b64encodable = data.getvalue()
-    elif isinstance(data, io.IOBase):
-        data.seek(0)
-        b64encodable = data.read()
-    elif type(data).__name__ == "ndarray":
-        b64encodable = data
-    else:
-        raise RuntimeError("Invalid binary data format: %s" % type(data))
-
-    data_b64 = base64.b64encode(b64encodable)
-    proto.data = data_b64.decode("utf-8")
-
-
-def marshall_video(proto, data, format="video/mp4", start_time=0):
-    """Marshalls a video proto, using data and url processors as needed.
-
-    Parameters
-    ----------
-    proto : the proto to fill. Must have a string field called "data".
-    data : str, bytes, BytesIO, numpy.ndarray, or file opened with
-           io.open().
-        Raw video data or a string with a URL pointing to the video
-        to load. Includes support for YouTube URLs.
-        If passing the raw data, this must include headers and any other
-        bytes required in the actual file.
+    url : str
+        String with a URL pointing to the file to load.
     format : str
         The mime type for the video file. Defaults to 'video/mp4'.
         See https://tools.ietf.org/html/rfc4281 for more info.
@@ -119,28 +83,22 @@ def marshall_video(proto, data, format="video/mp4", start_time=0):
     proto.start_time = start_time
     proto.type = Video_pb2.Video.Type.NATIVE
 
-    if isinstance(data, string_types) and url(data):  # noqa: F821
-        youtube_url = _reshape_youtube_url(data)
-        if youtube_url:
-            proto.url = youtube_url
-            proto.type = Video_pb2.Video.Type.YOUTUBE_IFRAME
-        else:
-            proto.url = data
+    youtube_url = _reshape_youtube_url(url)
+    if youtube_url:
+        proto.url = youtube_url
+        proto.type = Video_pb2.Video.Type.YOUTUBE_IFRAME
     else:
-        _marshall_binary(proto, data)
+        proto.url = url
 
 
-def marshall_audio(proto, data, format="audio/wav", start_time=0):
+def marshall_audio(proto, url, format="audio/wav", start_time=0):
     """Marshalls an audio proto, using data and url processors as needed.
 
     Parameters
     ----------
-    proto : The proto to fill. Must have a string field called "data".
-    data : str, bytes, BytesIO, numpy.ndarray, or file opened with
-            io.open()
-        Raw audio data or a string with a URL pointing to the file to load.
-        If passing the raw data, this must include headers and any other bytes
-        required in the actual file.
+    proto : The proto to fill. Must have a string field called "url".
+    url : str  
+        String with a URL pointing to the file to load.
     format : str
         The mime type for the audio file. Defaults to "audio/wav".
         See https://tools.ietf.org/html/rfc4281 for more info.
@@ -150,8 +108,4 @@ def marshall_audio(proto, data, format="audio/wav", start_time=0):
 
     proto.format = format
     proto.start_time = start_time
-
-    if isinstance(data, string_types) and url(data):  # noqa: F821
-        proto.url = data
-    else:
-        _marshall_binary(proto, data)
+    proto.url = url

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -415,7 +415,7 @@ class CodeHasher:
         else:
             # This won't correctly follow nested calls like `foo.bar.baz()`.
             for name in code.co_names:
-                if name in context.globals:
+                if name in context.globals and type(context.globals[name]) == "function":
                     try:
                         self._update(h, context.globals[name], context)
                     except Exception:

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -398,11 +398,13 @@ class CodeHasher:
         self._update(h, code.co_code)
 
         # Hash constants that are referenced by the bytecode but ignore names of lambdas.
+        # Do not hash variables defined outside the scope of this code, e.g. globals.
         consts = [
             n
             for n in code.co_consts
             if not isinstance(n, string_types)  # noqa: F821
-            or not n.endswith(".<lambda>")
+                or not n in code.co_names
+                or not n.endswith(".<lambda>")
         ]
         self._update(h, consts, context)
 

--- a/lib/streamlit/hashing_py3.py
+++ b/lib/streamlit/hashing_py3.py
@@ -41,10 +41,12 @@ def get_referenced_objects(code, context):
 
     for op in dis.get_instructions(code):
         if op.opname in ["LOAD_GLOBAL", "LOAD_NAME"]:
-            if op.argval in context.globals:
-                set_tos(context.globals[op.argval])
-            else:
-                set_tos(op.argval)
+            pass
+            #TODO: verify we're not ignoring things we need.
+            #if op.argval in context.globals:
+            #    set_tos(context.globals[op.argval])
+            #else:
+            #    set_tos(op.argval)
         elif op.opname in ["LOAD_DEREF", "LOAD_CLOSURE"]:
             set_tos(context.cells[op.argval])
         elif op.opname == "IMPORT_NAME":

--- a/poc.py
+++ b/poc.py
@@ -1,0 +1,67 @@
+# Proof-of-Concept for AV_URL branch
+
+import io
+import streamlit as st
+import numpy as np
+import wave
+
+st.title("Audio test")
+
+
+def generated():
+    st.title("Generated audio (440Hz sine wave)")
+
+    def note(freq, length, amp, rate):
+        t = np.linspace(0, length, length * rate)
+        data = np.sin(2 * np.pi * freq * t) * amp
+        return data.astype(np.int16)
+
+    frequency = 440  # hertz
+    nchannels = 1
+    sampwidth = 2
+    sampling_rate = 44100
+    duration = 89  # Max size, given the bitrate and sample width
+    comptype = "NONE"
+    compname = "not compressed"
+    amplitude = 10000
+    nframes = duration * sampling_rate
+
+    x = st.text("Making wave...")
+    sine_wave = note(frequency, duration, amplitude, sampling_rate)
+
+    f = wave.open("sound.wav", "w")
+    f.setparams((nchannels, sampwidth, int(sampling_rate), nframes, comptype, compname))
+
+    x.text("Converting wave...")
+    f.writeframes(sine_wave)
+
+    f.close()
+    x.text("Sending wave...")
+    # x.audio("sound.wav")
+    # x.audio("file:///Users/nthmost/projects/git/STREAMLIT/streamlit/sound.wav")
+    x.audio("http://localhost:8000/sound.wav")
+
+
+generated()
+
+
+st.title("Audio from a URL")
+
+
+def shorten_audio_option(opt):
+    return opt.split("/")[-1]
+
+
+song = st.selectbox(
+    "Pick an MP3 to play",
+    (
+        "file:///Users/nthmost/projects/git/streamlit-experiments/text2speech/welcome.wav",
+        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
+        "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-8.mp3",
+    ),
+    0,
+    shorten_audio_option,
+)
+
+st.audio(song)

--- a/proto/streamlit/proto/Audio.proto
+++ b/proto/streamlit/proto/Audio.proto
@@ -17,13 +17,7 @@
 syntax = "proto3";
 
 message Audio {
-  oneof src {
-    // The data in Base64 format.
-    string data = 1;
-
-    // A url pointing to an audio file
-    string url = 4;
-  }
+  string url = 1;
 
   // The type attribute of the HTML <audio> tag's <source> subtag.
   // ex: "audio/mp3", "audio/wav"

--- a/proto/streamlit/proto/Video.proto
+++ b/proto/streamlit/proto/Video.proto
@@ -17,13 +17,8 @@
 syntax = "proto3";
 
 message Video {
-  oneof src {
-    // The data in Base64 format.
-    string data = 1;
-
-    // A url pointing to a video file
-    string url = 4;
-  }
+  // A url pointing to a video file
+  string url = 1;
 
   enum Type {
     UNUSED = 0;  // This should always exist.
@@ -31,7 +26,7 @@ message Video {
     YOUTUBE_IFRAME = 2;
   }
 
-  Type type = 5;
+  Type type = 4;
 
   // The type attribute of the HTML <video> tag's <source> subtag.
   // ex: "video/mp4"


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/789

**Description:** 

We're changing the behavior of the @st.cache to ignore "implicit inputs", meaning (usually) changes to global variables that are used within the body of the function.  

Before this change, global variables and outer-nested function variable changes would cause a cache MISS, because implicit variables were counted in the hash key for that function.  So the following code would produce two different answers for `add(10)` and `hash_dicts(5)`:

```
import streamlit as st

st.title("Cache test: adding `10` to `number`.")

def called_by_cached_function():
    return number + 2

@st.cache
def add(num):
    resultd = {"dkey_added": number + num}
    anothervar = num + 2
    resultd["dkey_second_add"] = anothervar
    resultd["dkey_number_from_called_function"] = called_by_cached_function()
    return resultd

@st.cache
def hash_dicts(inp):
    outd = {"dkey_things": things,
            "dkey_inp": inp}
    return outd

st.header("iteration 1: `number = 5`")

with st.echo():
    things = [1,2,3]
    number = 5
    add_answer = add(10)
    hash_dicts_answer = hash_dicts(5)

with st.echo():
    st.write("These should generate cache HITs")
    st.write(hash_dicts(5))
    st.write(add(10))

st.header("iteration 2: change `number` to `3`. mutate `things`.")

with st.echo():
    things = [4,5,6]
    number = 3
    st.write("These should ALSO generate cache HITs")
    st.write(add(10))
    st.write(hash_dicts(5))

st.header("RESULTS: Did we ignore implicit inputs?")
with st.echo():
    st.write("add(10):", bool(add_answer==add(10)))
    st.write("hash_dicts(5):", bool(hash_dicts_answer==hash_dicts(5)))
```

After this change, the above code would produce just one answer for `add(10)` and `hash_dicts(5)`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
