### PR TITLE
Ensure that s3.url is an absolute URL

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -24,6 +24,7 @@ setup_2_3_shims(globals())
 import os
 import toml
 import collections
+import urllib
 
 import click
 from blinker import Signal
@@ -503,11 +504,11 @@ _create_section("mapbox", "Mapbox configuration that is being used by DeckGL.")
 
 _create_option(
     "mapbox.token",
-    description="""Configure Streamlit to use a custom Mapbox 
-                token for elements like st.deck_gl_chart and st.map. If you 
-                don't do this you'll be using Streamlit's own token, 
-                which has limitations and is not guaranteed to always work. 
-                To get a token for yourself, create an account at 
+    description="""Configure Streamlit to use a custom Mapbox
+                token for elements like st.deck_gl_chart and st.map. If you
+                don't do this you'll be using Streamlit's own token,
+                which has limitations and is not guaranteed to always work.
+                To get a token for yourself, create an account at
                 https://mapbox.com. It's free! (for moderate usage levels)""",
     default_val="pk.eyJ1IjoidGhpYWdvdCIsImEiOiJjamh3bm85NnkwMng4M3"
     "dydnNveWwzeWNzIn0.vCBDzNsEF2uFSFk2AM0WZQ",
@@ -902,6 +903,19 @@ def _check_conflicts():
             "In config.toml, s3.accessKeyId and s3.secretAccessKey must "
             "either both be set or both be unset."
         )
+
+        if is_manually_set("s3.url"):
+            # If s3.url is set, ensure that it's an absolute URL.
+            # An absolute URL starts with either `scheme://` or `//` --
+            # if the configured URL does not start with either prefix,
+            # prepend it with `//` to make it absolute. (If we don't do this,
+            # and the user enters something `url=myhost.com/reports`, the
+            # browser will assume this is a relative URL, and will prepend
+            # the hostname of the Streamlit instance to the configured URL.)
+            s3_url = get_option("s3.url")
+            parsed = urllib.parse.urlparse(s3_url)
+            if parsed.netloc == "":
+                _set_option("s3.url", "//" + s3_url, get_where_defined("s3.url"))
 
 
 def _set_development_mode():

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -909,7 +909,7 @@ def _check_conflicts():
             # An absolute URL starts with either `scheme://` or `//` --
             # if the configured URL does not start with either prefix,
             # prepend it with `//` to make it absolute. (If we don't do this,
-            # and the user enters something `url=myhost.com/reports`, the
+            # and the user enters something like `url=myhost.com/reports`, the
             # browser will assume this is a relative URL, and will prepend
             # the hostname of the Streamlit instance to the configured URL.)
             s3_url = get_option("s3.url")

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -336,7 +336,7 @@ class ConfigTest(unittest.TestCase):
         result = config._clean(" clean    this         text  ")
         self.assertEqual("clean this text", result)
 
-    def test_check_conflicts_2(self):
+    def test_check_conflicts_server_port(self):
         config._set_option("global.developmentMode", True, "test")
         config._set_option("server.port", 1234, "test")
         with pytest.raises(AssertionError) as e:
@@ -346,7 +346,7 @@ class ConfigTest(unittest.TestCase):
             "server.port does not work when global.developmentMode is true.",
         )
 
-    def test_check_conflicts_2a(self):
+    def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")
         config._set_option("browser.serverPort", 1234, "test")
         with pytest.raises(AssertionError) as e:
@@ -356,7 +356,7 @@ class ConfigTest(unittest.TestCase):
             "browser.serverPort does not work when global.developmentMode is " "true.",
         )
 
-    def test_check_conflicts_3(self):
+    def test_check_conflicts_s3_sharing_mode(self):
         with pytest.raises(AssertionError) as e:
             config._set_option("global.sharingMode", "s3", "test")
             config._set_option("s3.bucket", None, "<default>")
@@ -366,7 +366,7 @@ class ConfigTest(unittest.TestCase):
             'When global.sharingMode is set to "s3", s3.bucket must also be set',
         )
 
-    def test_check_conflicts_4(self):
+    def test_check_conflicts_s3_credentials(self):
         with pytest.raises(AssertionError) as e:
             config._set_option("global.sharingMode", "s3", "test")
             config._set_option("s3.bucket", "some.bucket", "test")


### PR DESCRIPTION
If `s3.url` is set in the user's config, ensure that it's an absolute URL.

An absolute URL starts with either `scheme://` or `//` -- if the configured URL does not start with either prefix, prepend it with `//` to make it absolute. (If we don't do this, and the user enters something like `url=myhost.com/reports`, the browser will assume this is a relative URL, and will prepend the hostname of the Streamlit instance to the configured URL.)

Fixes #802