### PR TITLE
Fix st.file_uploader return value

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1959,12 +1959,14 @@ class DeltaGenerator(object):
         """
         from streamlit.string_util import is_binary_string
 
-        if isinstance(type, string_types): # noqa: F821
+        if isinstance(type, string_types):  # noqa: F821
             type = [type]
 
         element.file_uploader.label = label
         element.file_uploader.type[:] = type if type is not None else []
-        element.file_uploader.max_upload_size_mb = config.get_option("server.maxUploadSize")
+        element.file_uploader.max_upload_size_mb = config.get_option(
+            "server.maxUploadSize"
+        )
         _set_widget_id("file_uploader", element, user_key=key)
 
         data = None
@@ -1976,14 +1978,14 @@ class DeltaGenerator(object):
         if data is None:
             return NoValue
 
-        if encoding == 'auto':
+        if encoding == "auto":
             if is_binary_string(data):
                 encoding = None
             else:
                 # If the file does not look like a pure binary file, assume
                 # it's utf-8. It would be great if we could guess it a little
                 # more smartly here, but it is what it is!
-                encoding = 'utf-8'
+                encoding = "utf-8"
 
         if encoding:
             return io.StringIO(data.decode(encoding))

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1952,10 +1952,11 @@ class DeltaGenerator(object):
 
         Examples
         --------
-        >>> input_data = st.file_uploader("Choose a CSV file", type="csv")
-        >>> if input_data is not None:
-        ...     data = pd.read_csv(input_data)
+        >>> uploaded_file = st.file_uploader("Choose a CSV file", type="csv")
+        >>> if uploaded_file is not None:
+        ...     data = pd.read_csv(uploaded_file)
         ...     st.write(data)
+
         """
         from streamlit.string_util import is_binary_string
 

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -21,6 +21,7 @@ from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
+import io
 import functools
 import json
 import random
@@ -31,17 +32,17 @@ from datetime import date
 from datetime import time
 
 from streamlit import caching
-from streamlit import metrics
 from streamlit import config
+from streamlit import metrics
 from streamlit.ReportThread import get_report_ctx
+from streamlit.UploadedFileManager import UploadedFileManager
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto import Alert_pb2
 from streamlit.proto import Balloons_pb2
 from streamlit.proto import BlockPath_pb2
 from streamlit.proto import ForwardMsg_pb2
 from streamlit.proto import Text_pb2
-from streamlit.fileManager import FileManager
-from streamlit.proto import Alert_pb2
 
 # setup logging
 from streamlit.logger import get_logger
@@ -1921,7 +1922,7 @@ class DeltaGenerator(object):
         return current_value if single_value else tuple(current_value)
 
     @_with_element
-    def file_uploader(self, element, label, type=None, key=None):
+    def file_uploader(self, element, label, type=None, encoding="auto", key=None):
 
         """Display a file uploader widget.
 
@@ -1934,18 +1935,29 @@ class DeltaGenerator(object):
         type : str or list of str or None
             Array of allowed extensions. ['png', 'jpg']
             By default, all extensions are allowed.
+        encoding : str or None
+            The encoding to use when opening textual files (i.e. non-binary).
+            For example: 'utf-8'. If set to 'auto', will try to guess the
+            encoding. If None, will assume the file is binary.
 
         Returns
         -------
-        byte[] or None
-            The byte array of uploaded file or None if no one file is loaded.
+        BytesIO or StringIO or None
+            The data for the uploaded file. If the file is in a well-known
+            textual format (or if the encoding parameter is set), returns a
+            StringIO. Otherwise BytesIO. If no file is loaded, returns None.
+
+            Note that BytesIO/StringIO are "file-like", which means you can
+            pass them anywhere where a file is expected!
 
         Examples
         --------
-        >>> file = st.file_uploader("Upload a image", type="png")
-        >>> if file is not None:
-        >>>     st.image(file)
+        >>> input_data = st.file_uploader("Choose a CSV file", type="csv")
+        >>> if input_data is not None:
+        ...     data = pd.read_csv(input_data)
+        ...     st.write(data)
         """
+        from streamlit.string_util import is_binary_string
 
         if isinstance(type, string_types): # noqa: F821
             type = [type]
@@ -1958,10 +1970,25 @@ class DeltaGenerator(object):
         data = None
         ctx = get_report_ctx()
         if ctx is not None:
-            progress, data = ctx.file_manager.get_data(element.file_uploader.id)
+            progress, data = ctx.uploaded_file_mgr.get_data(element.file_uploader.id)
             element.file_uploader.progress = progress
 
-        return NoValue if data is None else data
+        if data is None:
+            return NoValue
+
+        if encoding == 'auto':
+            if is_binary_string(data):
+                encoding = None
+            else:
+                # If the file does not look like a pure binary file, assume
+                # it's utf-8. It would be great if we could guess it a little
+                # more smartly here, but it is what it is!
+                encoding = 'utf-8'
+
+        if encoding:
+            return io.StringIO(data.decode(encoding))
+
+        return io.BytesIO(data)
 
     @_with_element
     def text_input(self, element, label, value="", key=None):

--- a/lib/streamlit/ReportSession.py
+++ b/lib/streamlit/ReportSession.py
@@ -88,7 +88,7 @@ class ReportSession(object):
 
         self._state = ReportSessionState.REPORT_NOT_RUNNING
 
-        self._file_manager = UploadedFileManager()
+        self._uploaded_file_mgr = UploadedFileManager()
 
         self._main_dg = DeltaGenerator(enqueue=self.enqueue, container=BlockPath.MAIN)
         self._sidebar_dg = DeltaGenerator(
@@ -135,7 +135,7 @@ class ReportSession(object):
         """
         if self._state != ReportSessionState.SHUTDOWN_REQUESTED:
             LOGGER.debug("Shutting down (id=%s)", self.id)
-            self._file_manager.delete_all_files()
+            self._uploaded_file_mgr.delete_all_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
@@ -446,7 +446,7 @@ class ReportSession(object):
         self.request_rerun(widget_state)
 
     def handle_upload_file(self, upload_file):
-        self._file_manager.create_or_clear_file(
+        self._uploaded_file_mgr.create_or_clear_file(
             widget_id=upload_file.widget_id,
             name=upload_file.name,
             size=upload_file.size,
@@ -457,7 +457,7 @@ class ReportSession(object):
         self.handle_rerun_script_request(widget_state=self._widget_states)
 
     def handle_upload_file_chunk(self, upload_file_chunk):
-        progress = self._file_manager.process_chunk(
+        progress = self._uploaded_file_mgr.process_chunk(
             widget_id=upload_file_chunk.widget_id,
             index=upload_file_chunk.index,
             data=upload_file_chunk.data,
@@ -467,7 +467,7 @@ class ReportSession(object):
             self.handle_rerun_script_request(widget_state=self._widget_states)
 
     def handle_delete_uploaded_file(self, delete_uploaded_file):
-        self._file_manager.delete_file(widget_id=delete_uploaded_file.widget_id)
+        self._uploaded_file_mgr.delete_file(widget_id=delete_uploaded_file.widget_id)
         self.handle_rerun_script_request(widget_state=self._widget_states)
 
     def handle_stop_script_request(self):
@@ -546,7 +546,7 @@ class ReportSession(object):
             sidebar_dg=self._sidebar_dg,
             widget_states=self._widget_states,
             request_queue=self._script_request_queue,
-            file_manager=self._file_manager,
+            uploaded_file_mgr=self._uploaded_file_mgr,
         )
         self._scriptrunner.on_event.connect(self._on_scriptrunner_event)
         self._scriptrunner.start()

--- a/lib/streamlit/ReportSession.py
+++ b/lib/streamlit/ReportSession.py
@@ -25,7 +25,7 @@ from streamlit import __version__
 from streamlit import caching
 from streamlit import config
 from streamlit import url_util
-from streamlit.fileManager import FileManager
+from streamlit.UploadedFileManager import UploadedFileManager
 from streamlit.DeltaGenerator import DeltaGenerator
 from streamlit.Report import Report
 from streamlit.ScriptRequestQueue import RerunData
@@ -88,10 +88,12 @@ class ReportSession(object):
 
         self._state = ReportSessionState.REPORT_NOT_RUNNING
 
-        self._file_manager = FileManager()
+        self._file_manager = UploadedFileManager()
 
         self._main_dg = DeltaGenerator(enqueue=self.enqueue, container=BlockPath.MAIN)
-        self._sidebar_dg = DeltaGenerator(enqueue=self.enqueue, container=BlockPath.SIDEBAR)
+        self._sidebar_dg = DeltaGenerator(
+            enqueue=self.enqueue, container=BlockPath.SIDEBAR
+        )
 
         self._widget_states = WidgetStates()
         self._local_sources_watcher = LocalSourcesWatcher(
@@ -456,10 +458,12 @@ class ReportSession(object):
 
     def handle_upload_file_chunk(self, upload_file_chunk):
         progress = self._file_manager.process_chunk(
-            widget_id=upload_file_chunk.widget_id, index=upload_file_chunk.index, data=upload_file_chunk.data
+            widget_id=upload_file_chunk.widget_id,
+            index=upload_file_chunk.index,
+            data=upload_file_chunk.data,
         )
 
-        if progress==1:
+        if progress == 1:
             self.handle_rerun_script_request(widget_state=self._widget_states)
 
     def handle_delete_uploaded_file(self, delete_uploaded_file):
@@ -542,7 +546,7 @@ class ReportSession(object):
             sidebar_dg=self._sidebar_dg,
             widget_states=self._widget_states,
             request_queue=self._script_request_queue,
-            file_manager=self._file_manager
+            file_manager=self._file_manager,
         )
         self._scriptrunner.on_event.connect(self._on_scriptrunner_event)
         self._scriptrunner.start()

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -79,8 +79,13 @@ class ReportThread(threading.Thread):
     """Extends threading.Thread with a ReportContext member"""
 
     def __init__(
-        self, main_dg, sidebar_dg, widgets, target=None, name=None,
-        uploaded_file_mgr=None
+        self,
+        main_dg,
+        sidebar_dg,
+        widgets,
+        target=None,
+        name=None,
+        uploaded_file_mgr=None,
     ):
         super(ReportThread, self).__init__(target=target, name=name)
         self.streamlit_report_ctx = ReportContext(

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -33,7 +33,7 @@ ReportContext = namedtuple(
         # current report run. This set is cleared at the start of each run.
         "widget_ids_this_run",
         # (UploadedFileManager) Object that manages files uploaded by this user.
-        "file_manager",
+        "uploaded_file_mgr",
     ],
 )
 
@@ -79,11 +79,12 @@ class ReportThread(threading.Thread):
     """Extends threading.Thread with a ReportContext member"""
 
     def __init__(
-        self, main_dg, sidebar_dg, widgets, target=None, name=None, file_manager=None
+        self, main_dg, sidebar_dg, widgets, target=None, name=None,
+        uploaded_file_mgr=None
     ):
         super(ReportThread, self).__init__(target=target, name=name)
         self.streamlit_report_ctx = ReportContext(
-            main_dg, sidebar_dg, widgets, _WidgetIDSet(), file_manager
+            main_dg, sidebar_dg, widgets, _WidgetIDSet(), uploaded_file_mgr
         )
 
 

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -32,7 +32,7 @@ ReportContext = namedtuple(
         # (_WidgetIDSet) The set of widget IDs that have been assigned in the
         # current report run. This set is cleared at the start of each run.
         "widget_ids_this_run",
-        # (FileManager) The File Manager to store sesion data
+        # (UploadedFileManager) Object that manages files uploaded by this user.
         "file_manager",
     ],
 )
@@ -78,7 +78,9 @@ REPORT_CONTEXT_ATTR_NAME = "streamlit_report_ctx"
 class ReportThread(threading.Thread):
     """Extends threading.Thread with a ReportContext member"""
 
-    def __init__(self, main_dg, sidebar_dg, widgets, target=None, name=None, file_manager=None):
+    def __init__(
+        self, main_dg, sidebar_dg, widgets, target=None, name=None, file_manager=None
+    ):
         super(ReportThread, self).__init__(target=target, name=name)
         self.streamlit_report_ctx = ReportContext(
             main_dg, sidebar_dg, widgets, _WidgetIDSet(), file_manager

--- a/lib/streamlit/ScriptRunner.py
+++ b/lib/streamlit/ScriptRunner.py
@@ -55,7 +55,7 @@ class ScriptRunner(object):
         sidebar_dg,
         widget_states,
         request_queue,
-        file_manager=None,
+        uploaded_file_mgr=None,
     ):
         """Initialize the ScriptRunner.
 
@@ -80,7 +80,7 @@ class ScriptRunner(object):
             ScriptRunner will continue running until the queue is empty,
             and then shut down.
 
-        file_manager : UploadedFileManager
+        uploaded_file_mgr : UploadedFileManager
             The File manager to store the data uploaded by the file_uplpader widget.
 
         """
@@ -88,7 +88,7 @@ class ScriptRunner(object):
         self._main_dg = main_dg
         self._sidebar_dg = sidebar_dg
         self._request_queue = request_queue
-        self._file_manager = file_manager
+        self._uploaded_file_mgr = uploaded_file_mgr
 
         self._widgets = Widgets()
         self._widgets.set_state(widget_states)
@@ -138,7 +138,7 @@ class ScriptRunner(object):
             widgets=self._widgets,
             target=self._process_request_queue,
             name="ScriptRunner.scriptThread",
-            file_manager=self._file_manager,
+            uploaded_file_mgr=self._uploaded_file_mgr,
         )
         self._script_thread.start()
 

--- a/lib/streamlit/ScriptRunner.py
+++ b/lib/streamlit/ScriptRunner.py
@@ -48,7 +48,15 @@ class ScriptRunnerEvent(Enum):
 
 
 class ScriptRunner(object):
-    def __init__(self, report, main_dg, sidebar_dg, widget_states, request_queue, file_manager=None):
+    def __init__(
+        self,
+        report,
+        main_dg,
+        sidebar_dg,
+        widget_states,
+        request_queue,
+        file_manager=None,
+    ):
         """Initialize the ScriptRunner.
 
         (The ScriptRunner won't start executing until start() is called.)
@@ -72,7 +80,7 @@ class ScriptRunner(object):
             ScriptRunner will continue running until the queue is empty,
             and then shut down.
 
-        file_manager : FileManager
+        file_manager : UploadedFileManager
             The File manager to store the data uploaded by the file_uplpader widget.
 
         """

--- a/lib/streamlit/UploadedFileManager.py
+++ b/lib/streamlit/UploadedFileManager.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class File(object):
-    """Thread-safe queue that smartly accumulates the report's messages."""
+    """Queue that smartly accumulates the report's messages."""
 
     def __init__(self, widget_id, name, size, last_modified, chunks):
 
@@ -38,7 +39,7 @@ class File(object):
             return 1
 
         if len(self.buffers) > 0:
-            return float(len(self.buffers))/self.total_chunks
+            return float(len(self.buffers)) / self.total_chunks
 
     def _coalesce_chunks(self):
         self.data = bytearray()
@@ -50,7 +51,8 @@ class File(object):
 
         self.buffers = {}
 
-class FileManager(object):
+
+class UploadedFileManager(object):
     def __init__(self):
         self._file_list = {}
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -37,7 +37,7 @@ from streamlit.ReportSession import ReportSession
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.fileManager import FileManager
+from streamlit.UploadedFileManager import UploadedFileManager
 from streamlit.server.routes import AddSlashHandler
 from streamlit.server.routes import DebugHandler
 from streamlit.server.routes import HealthHandler
@@ -528,9 +528,13 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
             elif msg_type == "upload_file":
                 self._session.handle_upload_file(upload_file=msg.upload_file)
             elif msg_type == "upload_file_chunk":
-                self._session.handle_upload_file_chunk(upload_file_chunk=msg.upload_file_chunk)
+                self._session.handle_upload_file_chunk(
+                    upload_file_chunk=msg.upload_file_chunk
+                )
             elif msg_type == "delete_uploaded_file":
-                self._session.handle_delete_uploaded_file(delete_uploaded_file=msg.delete_uploaded_file)
+                self._session.handle_delete_uploaded_file(
+                    delete_uploaded_file=msg.delete_uploaded_file
+                )
             elif msg_type == "close_connection":
                 if config.get_option("global.developmentMode"):
                     Server.get_current().stop()

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -53,3 +53,12 @@ def escape_markdown(raw_string):
     for character in metacharacters:
         result = result.replace(character, "\\" + character)
     return result
+
+
+TEXTCHARS = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})
+
+
+def is_binary_string(inp):
+    """Guess if an input bytesarray can be encoded as a string."""
+    # From https://stackoverflow.com/a/7392391
+    return bool(inp.translate(None, TEXTCHARS))

--- a/lib/tests/streamlit/UploadedFileManager_test.py
+++ b/lib/tests/streamlit/UploadedFileManager_test.py
@@ -13,25 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for FileManager"""
+"""Unit tests for UploadedFileManager"""
 
 import unittest
 
-from streamlit.fileManager import FileManager
+from streamlit.UploadedFileManager import UploadedFileManager
 from datetime import date
 
-class FileManagerTest(unittest.TestCase):
+
+class UploadedFileManagerTest(unittest.TestCase):
     def test_msg_hash(self):
         """Test that ForwardMsg hash generation works as expected"""
 
-        widget_idA = 'A0123456789'
-        widget_idB = 'B0123456789'
-        file_name = 'example_file.png'
-        file_bytes = bytearray('0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789', 'utf-8')
-        file_manager = FileManager()
-        
-        file_manager.create_or_clear_file(widget_idA, file_name, len(file_bytes), date.today(), 1)
-        file_manager.create_or_clear_file(widget_idB, file_name, len(file_bytes), date.today(), 2)
+        widget_idA = "A0123456789"
+        widget_idB = "B0123456789"
+        file_name = "example_file.png"
+        file_bytes = bytearray(
+            "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+            "utf-8",
+        )
+        file_manager = UploadedFileManager()
+
+        file_manager.create_or_clear_file(
+            widget_idA, file_name, len(file_bytes), date.today(), 1
+        )
+        file_manager.create_or_clear_file(
+            widget_idB, file_name, len(file_bytes), date.today(), 2
+        )
 
         progress_a = file_manager.process_chunk(widget_idA, 0, file_bytes)
         self.assertEqual(progress_a, 1)
@@ -49,9 +57,9 @@ class FileManagerTest(unittest.TestCase):
         self.assertEqual(len(data_a), len(file_bytes))
         self.assertEqual(data_a, file_bytes)
         self.assertEqual(data_a, data_b)
-        
+
         file_manager.delete_file(widget_idA)
-        
+
         progress_a, data_a = file_manager.get_data(widget_idA)
         self.assertEqual(progress_a, 0)
         self.assertEqual(data_a, None)
@@ -60,4 +68,3 @@ class FileManagerTest(unittest.TestCase):
         progress_b, data_b = file_manager.get_data(widget_idB)
         self.assertEqual(progress_b, 0)
         self.assertEqual(data_b, None)
-        

--- a/lib/tests/streamlit/UploadedFileManager_test.py
+++ b/lib/tests/streamlit/UploadedFileManager_test.py
@@ -32,39 +32,39 @@ class UploadedFileManagerTest(unittest.TestCase):
             "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
             "utf-8",
         )
-        file_manager = UploadedFileManager()
+        uploaded_file_mgr = UploadedFileManager()
 
-        file_manager.create_or_clear_file(
+        uploaded_file_mgr.create_or_clear_file(
             widget_idA, file_name, len(file_bytes), date.today(), 1
         )
-        file_manager.create_or_clear_file(
+        uploaded_file_mgr.create_or_clear_file(
             widget_idB, file_name, len(file_bytes), date.today(), 2
         )
 
-        progress_a = file_manager.process_chunk(widget_idA, 0, file_bytes)
+        progress_a = uploaded_file_mgr.process_chunk(widget_idA, 0, file_bytes)
         self.assertEqual(progress_a, 1)
 
-        progress_b = file_manager.process_chunk(widget_idB, 0, file_bytes[0:50])
+        progress_b = uploaded_file_mgr.process_chunk(widget_idB, 0, file_bytes[0:50])
         self.assertEqual(progress_b, 0.5)
 
-        progress_b = file_manager.process_chunk(widget_idB, 1, file_bytes[50:100])
+        progress_b = uploaded_file_mgr.process_chunk(widget_idB, 1, file_bytes[50:100])
         self.assertEqual(progress_b, 1)
 
-        progress_a, data_a = file_manager.get_data(widget_idA)
-        progress_b, data_b = file_manager.get_data(widget_idB)
+        progress_a, data_a = uploaded_file_mgr.get_data(widget_idA)
+        progress_b, data_b = uploaded_file_mgr.get_data(widget_idB)
         self.assertEqual(progress_a, 1)
         self.assertEqual(progress_b, 1)
         self.assertEqual(len(data_a), len(file_bytes))
         self.assertEqual(data_a, file_bytes)
         self.assertEqual(data_a, data_b)
 
-        file_manager.delete_file(widget_idA)
+        uploaded_file_mgr.delete_file(widget_idA)
 
-        progress_a, data_a = file_manager.get_data(widget_idA)
+        progress_a, data_a = uploaded_file_mgr.get_data(widget_idA)
         self.assertEqual(progress_a, 0)
         self.assertEqual(data_a, None)
 
-        file_manager.delete_all_files()
-        progress_b, data_b = file_manager.get_data(widget_idB)
+        uploaded_file_mgr.delete_all_files()
+        progress_b, data_b = uploaded_file_mgr.get_data(widget_idB)
         self.assertEqual(progress_b, 0)
         self.assertEqual(data_b, None)

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -64,7 +64,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                     sidebar_dg=sidebar_dg,
                     widgets=Widgets(),
                     widget_ids_this_run=_WidgetIDSet(),
-                    file_manager=None,
+                    uploaded_file_mgr=None,
                 ),
             )
 


### PR DESCRIPTION
This does two things:
* Changes the return value of `st.file_uploader`.
   * When `encoding` is `None`, returns `BytesIO`
   * When `encoding` is set to a valid encoding or its unset (i.e. set to `"auto"`), returns `StringIO`
   * When no file has been selected, returns `None`
* Renames `FileManager` to `UploadedFileManager`


The nice thing about `BytesIO` and `StringIO` is that they act exactly like files!