### PR TITLE
Add modules in PYTHONPATH to watched modules

### DIFF
--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -162,9 +162,8 @@ def file_in_pythonpath(filepath):
     pythonpath = os.environ["PYTHONPATH"]
 
     relative_and_absolute_paths = [
-        (
-            path if os.path.isabs(path) else os.path.abspath(path)
-        ) for path in pythonpath.split(os.pathsep)
+        (path if os.path.isabs(path) else os.path.abspath(path))
+        for path in pythonpath.split(os.pathsep)
     ]
     return any(
         file_is_in_folder_glob(os.path.normpath(filepath), path)

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -159,9 +159,7 @@ def file_in_pythonpath(filepath):
     if len(pythonpath) == 0:
         return False
 
-    absolute_paths = [
-        os.path.abspath(path) for path in pythonpath.split(os.pathsep)
-    ]
+    absolute_paths = [os.path.abspath(path) for path in pythonpath.split(os.pathsep)]
     return any(
         file_is_in_folder_glob(os.path.normpath(filepath), path)
         for path in absolute_paths

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import errno
+import itertools
 import os
 
 import fnmatch
@@ -137,3 +138,28 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
 
     file_dir = os.path.dirname(filepath) + "/"
     return fnmatch.fnmatch(file_dir, folderpath_glob)
+
+
+def file_in_pythonpath(filepath):
+    """Test whether a filepath is in the same folder of a path specified in the PYTHONPATH env variable.
+
+    Returns True if PYTHONPATH is not defined or empty.
+
+    Parameters
+    ----------
+    filepath : str
+        An absolute file path.
+
+    """
+
+    if "PYTHONPATH" not in os.environ:
+        return True
+    pythonpath = os.environ["PYTHONPATH"]
+    if len(pythonpath) == 0:
+        return True
+    relative_and_absolute_paths = itertools.chain.from_iterable(
+        (path, os.path.abspath(path)) for path in pythonpath.split(os.pathsep)
+    )
+    return any(
+        file_is_in_folder_glob(os.path.normpath(filepath), path) for path in relative_and_absolute_paths
+    )

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -149,6 +149,7 @@ def file_in_pythonpath(filepath):
         An absolute file path.
 
     Returns
+    -------
     boolean
         True if contained in PYTHONPATH, False otherwise. False if PYTHONPATH is not defined or empty.
 
@@ -160,11 +161,10 @@ def file_in_pythonpath(filepath):
     if len(pythonpath) == 0:
         return False
 
-    relative_and_absolute_paths = [
-        (path if os.path.isabs(path) else os.path.abspath(path))
-        for path in pythonpath.split(os.pathsep)
+    absolute_paths = [
+        os.path.abspath(path) for path in pythonpath.split(os.pathsep)
     ]
     return any(
         file_is_in_folder_glob(os.path.normpath(filepath), path)
-        for path in relative_and_absolute_paths
+        for path in absolute_paths
     )

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -15,7 +15,6 @@
 
 import contextlib
 import errno
-import itertools
 import os
 
 import fnmatch

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -140,15 +140,10 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
     return fnmatch.fnmatch(file_dir, folderpath_glob)
 
 
-def _retrieve_pythonpath():
-    return os.environ["PYTHONPATH"]
-
-
 def file_in_pythonpath(filepath):
     """Test whether a filepath is in the same folder of a path specified in the PYTHONPATH env variable.
 
-    Returns False if PYTHONPATH is not defined.
-    If PYTHONPATH is empty it is interpreted as `.`
+    Returns False if PYTHONPATH is not defined or empty.
 
     Parameters
     ----------
@@ -160,6 +155,8 @@ def file_in_pythonpath(filepath):
     if "PYTHONPATH" not in os.environ:
         return False
     pythonpath = os.environ["PYTHONPATH"]
+    if len(pythonpath) == 0:
+        return False
 
     relative_and_absolute_paths = [
         (path if os.path.isabs(path) else os.path.abspath(path))

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -140,10 +140,15 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
     return fnmatch.fnmatch(file_dir, folderpath_glob)
 
 
+def _retrieve_pythonpath():
+    return os.environ["PYTHONPATH"]
+
+
 def file_in_pythonpath(filepath):
     """Test whether a filepath is in the same folder of a path specified in the PYTHONPATH env variable.
 
-    Returns True if PYTHONPATH is not defined or empty.
+    Returns False if PYTHONPATH is not defined.
+    If PYTHONPATH is empty it is interpreted as `.`
 
     Parameters
     ----------
@@ -153,13 +158,14 @@ def file_in_pythonpath(filepath):
     """
 
     if "PYTHONPATH" not in os.environ:
-        return True
+        return False
     pythonpath = os.environ["PYTHONPATH"]
-    if len(pythonpath) == 0:
-        return True
-    relative_and_absolute_paths = itertools.chain.from_iterable(
-        (path, os.path.abspath(path)) for path in pythonpath.split(os.pathsep)
-    )
+
+    relative_and_absolute_paths = [
+        (
+            path if os.path.isabs(path) else os.path.abspath(path)
+        ) for path in pythonpath.split(os.pathsep)
+    ]
     return any(
         file_is_in_folder_glob(os.path.normpath(filepath), path)
         for path in relative_and_absolute_paths

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -161,5 +161,6 @@ def file_in_pythonpath(filepath):
         (path, os.path.abspath(path)) for path in pythonpath.split(os.pathsep)
     )
     return any(
-        file_is_in_folder_glob(os.path.normpath(filepath), path) for path in relative_and_absolute_paths
+        file_is_in_folder_glob(os.path.normpath(filepath), path)
+        for path in relative_and_absolute_paths
     )

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -143,12 +143,15 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
 def file_in_pythonpath(filepath):
     """Test whether a filepath is in the same folder of a path specified in the PYTHONPATH env variable.
 
-    Returns False if PYTHONPATH is not defined or empty.
 
     Parameters
     ----------
     filepath : str
         An absolute file path.
+
+    Returns
+    boolean
+        True if contained in PYTHONPATH, False otherwise. False if PYTHONPATH is not defined or empty.
 
     """
 

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -155,9 +155,7 @@ def file_in_pythonpath(filepath):
 
     """
 
-    if "PYTHONPATH" not in os.environ:
-        return False
-    pythonpath = os.environ["PYTHONPATH"]
+    pythonpath = os.environ.get("PYTHONPATH", "")
     if len(pythonpath) == 0:
         return False
 

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -338,7 +338,9 @@ class CodeHasher:
                     filepath, self._get_main_script_directory()
                 )
                 file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
-                if ((file_is_local or file_is_in_pythonpath) and not self._folder_black_list.is_blacklisted(filepath)):
+                if (
+                    file_is_local or file_is_in_pythonpath
+                ) and not self._folder_black_list.is_blacklisted(filepath):
                     context = _get_context(obj)
                     if obj.__defaults__:
                         self._update(h, obj.__defaults__, context)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -244,12 +244,13 @@ class CodeHasher:
 
     def _file_should_be_hashed(self, filename):
         filepath = os.path.abspath(filename)
-        file_is_local = file_util.file_is_in_folder_glob(
-            filepath, self._get_main_script_directory()
-        )
-        file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
         file_is_blacklisted = self._folder_black_list.is_blacklisted(filepath)
-        return (file_is_local or file_is_in_pythonpath) and not file_is_blacklisted
+        # Short circuiting for performance.
+        if file_is_blacklisted:
+            return False
+        return file_util.file_is_in_folder_glob(
+            filepath, self._get_main_script_directory()
+        ) or file_util.file_in_pythonpath(filepath)
 
     def _to_bytes(self, obj, context):
         """Hash objects to bytes, including code with dependencies.

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -339,9 +339,7 @@ class CodeHasher:
                 )
                 file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
                 file_is_blacklisted = self._folder_black_list.is_blacklisted(filepath)
-                if (
-                    file_is_local or file_is_in_pythonpath
-                ) and not file_is_blacklisted:
+                if (file_is_local or file_is_in_pythonpath) and not file_is_blacklisted:
                     context = _get_context(obj)
                     if obj.__defaults__:
                         self._update(h, obj.__defaults__, context)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -338,9 +338,10 @@ class CodeHasher:
                     filepath, self._get_main_script_directory()
                 )
                 file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
+                file_is_blacklisted = self._folder_black_list.is_blacklisted(filepath)
                 if (
                     file_is_local or file_is_in_pythonpath
-                ) and not self._folder_black_list.is_blacklisted(filepath):
+                ) and not file_is_blacklisted:
                     context = _get_context(obj)
                     if obj.__defaults__:
                         self._update(h, obj.__defaults__, context)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -334,9 +334,11 @@ class CodeHasher:
                 h = hashlib.new(self.name)
                 filepath = os.path.abspath(obj.__code__.co_filename)
 
-                if file_util.file_is_in_folder_glob(
+                file_is_local = file_util.file_is_in_folder_glob(
                     filepath, self._get_main_script_directory()
-                ) and not self._folder_black_list.is_blacklisted(filepath):
+                )
+                file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
+                if ((file_is_local or file_is_in_pythonpath) and not self._folder_black_list.is_blacklisted(filepath)):
                     context = _get_context(obj)
                     if obj.__defaults__:
                         self._update(h, obj.__defaults__, context)

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -201,7 +201,8 @@ class LocalSourcesWatcher(object):
                     continue
 
                 file_is_new = filepath not in self._watched_modules
-                file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
+                # file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
+                file_is_in_pythonpath = False
                 file_is_local = file_util.file_is_in_folder_glob(
                     filepath, self._report.script_folder
                 )

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -165,7 +165,7 @@ class LocalSourcesWatcher(object):
         if self._is_closed:
             return
 
-        registered_filepaths = []
+        local_filepaths = []
 
         # Clone modules dict here because we may alter the original dict inside
         # the loop.
@@ -206,8 +206,9 @@ class LocalSourcesWatcher(object):
                     filepath, self._report.script_folder
                 )
 
+                local_filepaths.append(filepath)
+
                 if (file_is_local or file_is_in_pythonpath) and file_is_new:
-                    registered_filepaths.append(filepath)
                     self._register_watcher(filepath, name)
 
             except Exception:
@@ -225,5 +226,5 @@ class LocalSourcesWatcher(object):
         # Remove no-longer-depended-on files from self._watched_modules
         # Will this ever happen?
         for filepath in watched_modules:
-            if filepath not in registered_filepaths:
+            if filepath not in local_filepaths:
                 self._deregister_watcher(filepath)

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -161,6 +161,14 @@ class LocalSourcesWatcher(object):
         wm.watcher.close()
         del self._watched_modules[filepath]
 
+    def _file_should_be_watched(self, filepath):
+        file_is_new = filepath not in self._watched_modules
+        file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
+        file_is_local = file_util.file_is_in_folder_glob(
+            filepath, self._report.script_folder
+        )
+        return (file_is_local or file_is_in_pythonpath) and file_is_new
+
     def update_watched_modules(self):
         if self._is_closed:
             return
@@ -200,15 +208,9 @@ class LocalSourcesWatcher(object):
                 if self._folder_black_list.is_blacklisted(filepath):
                     continue
 
-                file_is_new = filepath not in self._watched_modules
-                file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
-                file_is_local = file_util.file_is_in_folder_glob(
-                    filepath, self._report.script_folder
-                )
-
                 local_filepaths.append(filepath)
 
-                if (file_is_local or file_is_in_pythonpath) and file_is_new:
+                if self._file_should_be_watched(filepath):
                     self._register_watcher(filepath, name)
 
             except Exception:

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -161,13 +161,18 @@ class LocalSourcesWatcher(object):
         wm.watcher.close()
         del self._watched_modules[filepath]
 
+    def _file_is_new(self, filepath):
+        return filepath not in self._watched_modules
+
     def _file_should_be_watched(self, filepath):
-        file_is_new = filepath not in self._watched_modules
-        file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
-        file_is_local = file_util.file_is_in_folder_glob(
-            filepath, self._report.script_folder
+        # Using short circuiting for performance.
+        return (
+            self._file_is_new(filepath)
+            and (
+                file_util.file_is_in_folder_glob(filepath, self._report.script_folder)
+                or file_util.file_in_pythonpath(filepath)
+            )
         )
-        return (file_is_local or file_is_in_pythonpath) and file_is_new
 
     def update_watched_modules(self):
         if self._is_closed:

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -201,13 +201,14 @@ class LocalSourcesWatcher(object):
                     continue
 
                 file_is_new = filepath not in self._watched_modules
+                file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
                 file_is_local = file_util.file_is_in_folder_glob(
                     filepath, self._report.script_folder
                 )
 
                 local_filepaths.append(filepath)
 
-                if file_is_local and file_is_new:
+                if (file_is_local or file_is_in_pythonpath) and file_is_new:
                     self._register_watcher(filepath, name)
 
             except Exception:

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -165,7 +165,7 @@ class LocalSourcesWatcher(object):
         if self._is_closed:
             return
 
-        local_filepaths = []
+        registered_filepaths = []
 
         # Clone modules dict here because we may alter the original dict inside
         # the loop.
@@ -201,15 +201,13 @@ class LocalSourcesWatcher(object):
                     continue
 
                 file_is_new = filepath not in self._watched_modules
-                # file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
-                file_is_in_pythonpath = False
+                file_is_in_pythonpath = file_util.file_in_pythonpath(filepath)
                 file_is_local = file_util.file_is_in_folder_glob(
                     filepath, self._report.script_folder
                 )
 
-                local_filepaths.append(filepath)
-
                 if (file_is_local or file_is_in_pythonpath) and file_is_new:
+                    registered_filepaths.append(filepath)
                     self._register_watcher(filepath, name)
 
             except Exception:
@@ -227,5 +225,5 @@ class LocalSourcesWatcher(object):
         # Remove no-longer-depended-on files from self._watched_modules
         # Will this ever happen?
         for filepath in watched_modules:
-            if filepath not in local_filepaths:
+            if filepath not in registered_filepaths:
                 self._deregister_watcher(filepath)

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -166,12 +166,9 @@ class LocalSourcesWatcher(object):
 
     def _file_should_be_watched(self, filepath):
         # Using short circuiting for performance.
-        return (
-            self._file_is_new(filepath)
-            and (
-                file_util.file_is_in_folder_glob(filepath, self._report.script_folder)
-                or file_util.file_in_pythonpath(filepath)
-            )
+        return self._file_is_new(filepath) and (
+            file_util.file_is_in_folder_glob(filepath, self._report.script_folder)
+            or file_util.file_in_pythonpath(filepath)
         )
 
     def update_watched_modules(self):

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -153,6 +153,10 @@ class FileIsInFolderTest(unittest.TestCase):
         ret = file_util.file_is_in_folder_glob("foo.py", "**/f")
         self.assertFalse(ret)
 
+    def test_rel_file_not_in_folder_glob(self):
+        ret = file_util.file_is_in_folder_glob("foo.py", "")
+        self.assertTrue(ret)
+
 
 class FileInPythonPathTest(unittest.TestCase):
     @staticmethod
@@ -170,14 +174,9 @@ class FileInPythonPathTest(unittest.TestCase):
 
     def test_empty_pythonpath(self):
         with patch("os.environ", {"PYTHONPATH": ""}):
-            self.assertTrue(
-                file_util.file_in_pythonpath(
-                    self._make_it_absolute("something/dir1/dir2/module")
-                )
-            )
             self.assertFalse(
                 file_util.file_in_pythonpath(
-                    self._make_it_absolute("../something/dir1/dir2/module")
+                    self._make_it_absolute("something/dir1/dir2/module")
                 )
             )
 

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -162,35 +162,92 @@ class FileInPythonPathTest(unittest.TestCase):
 
     def test_no_pythonpath(self):
         with patch.dict("os.environ", {}):
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("../something/dir1/dir2/module")))
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("../something/dir1/dir2/module")
+                )
+            )
 
     def test_empty_pythonpath(self):
         with patch.dict("os.environ", {"PYTHONPATH": ""}):
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("../something/dir1/dir2/module")))
-
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("../something/dir1/dir2/module")
+                )
+            )
 
     def test_python_path_relative(self):
         with patch.dict("os.environ", {"PYTHONPATH": "something"}):
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("something/dir1/dir2/module")))
-            self.assertFalse(file_util.file_in_pythonpath(self._make_it_absolute("something_else/module")))
-            self.assertFalse(file_util.file_in_pythonpath(self._make_it_absolute("../something/dir1/dir2/module")))
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something/dir1/dir2/module")
+                )
+            )
+            self.assertFalse(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something_else/module")
+                )
+            )
+            self.assertFalse(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("../something/dir1/dir2/module")
+                )
+            )
 
     def test_python_path_absolute(self):
-        with patch.dict("os.environ", {"PYTHONPATH": self._make_it_absolute("something")}):
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("something/dir1/dir2/module")))
-            self.assertFalse(file_util.file_in_pythonpath(self._make_it_absolute("something_else/module")))
-            self.assertFalse(file_util.file_in_pythonpath(self._make_it_absolute("../something/dir1/dir2/module")))
+        with patch.dict(
+            "os.environ", {"PYTHONPATH": self._make_it_absolute("something")}
+        ):
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something/dir1/dir2/module")
+                )
+            )
+            self.assertFalse(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something_else/module")
+                )
+            )
+            self.assertFalse(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("../something/dir1/dir2/module")
+                )
+            )
 
     def test_python_path_mixed(self):
-        with patch.dict("os.environ",
-                        {
-                            "PYTHONPATH": os.pathsep.join([self._make_it_absolute("something"), "something"])
-                        }):
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("something/dir1/dir2/module")))
-            self.assertFalse(file_util.file_in_pythonpath(self._make_it_absolute("something_else/module")))
+        with patch.dict(
+            "os.environ",
+            {
+                "PYTHONPATH": os.pathsep.join(
+                    [self._make_it_absolute("something"), "something"]
+                )
+            },
+        ):
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something/dir1/dir2/module")
+                )
+            )
+            self.assertFalse(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something_else/module")
+                )
+            )
 
     def test_current_directory(self):
         with patch.dict("os.environ", {"PYTHONPATH": "."}):
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("something/dir1/dir2/module")))
-            self.assertTrue(file_util.file_in_pythonpath(self._make_it_absolute("something_else/module")))
-            self.assertFalse(file_util.file_in_pythonpath(self._make_it_absolute("../something_else/module")))
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something/dir1/dir2/module")
+                )
+            )
+            self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something_else/module")
+                )
+            )
+            self.assertFalse(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("../something_else/module")
+                )
+            )

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -200,9 +200,7 @@ class FileInPythonPathTest(unittest.TestCase):
             )
 
     def test_python_path_absolute(self):
-        with patch(
-            "os.environ", {"PYTHONPATH": self._make_it_absolute("something")}
-        ):
+        with patch("os.environ", {"PYTHONPATH": self._make_it_absolute("something")}):
             self.assertTrue(
                 file_util.file_in_pythonpath(
                     self._make_it_absolute("something/dir1/dir2/module")

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -161,23 +161,28 @@ class FileInPythonPathTest(unittest.TestCase):
         return os.path.join(os.getcwd(), path)
 
     def test_no_pythonpath(self):
-        with patch.dict("os.environ", {}):
-            self.assertTrue(
+        with patch("os.environ", {}) as d:
+            self.assertFalse(
                 file_util.file_in_pythonpath(
                     self._make_it_absolute("../something/dir1/dir2/module")
                 )
             )
 
     def test_empty_pythonpath(self):
-        with patch.dict("os.environ", {"PYTHONPATH": ""}):
+        with patch("os.environ", {"PYTHONPATH": ""}):
             self.assertTrue(
+                file_util.file_in_pythonpath(
+                    self._make_it_absolute("something/dir1/dir2/module")
+                )
+            )
+            self.assertFalse(
                 file_util.file_in_pythonpath(
                     self._make_it_absolute("../something/dir1/dir2/module")
                 )
             )
 
     def test_python_path_relative(self):
-        with patch.dict("os.environ", {"PYTHONPATH": "something"}):
+        with patch("os.environ", {"PYTHONPATH": "something"}):
             self.assertTrue(
                 file_util.file_in_pythonpath(
                     self._make_it_absolute("something/dir1/dir2/module")
@@ -195,7 +200,7 @@ class FileInPythonPathTest(unittest.TestCase):
             )
 
     def test_python_path_absolute(self):
-        with patch.dict(
+        with patch(
             "os.environ", {"PYTHONPATH": self._make_it_absolute("something")}
         ):
             self.assertTrue(
@@ -215,7 +220,7 @@ class FileInPythonPathTest(unittest.TestCase):
             )
 
     def test_python_path_mixed(self):
-        with patch.dict(
+        with patch(
             "os.environ",
             {
                 "PYTHONPATH": os.pathsep.join(
@@ -235,7 +240,7 @@ class FileInPythonPathTest(unittest.TestCase):
             )
 
     def test_current_directory(self):
-        with patch.dict("os.environ", {"PYTHONPATH": "."}):
+        with patch("os.environ", {"PYTHONPATH": "."}):
             self.assertTrue(
                 file_util.file_in_pythonpath(
                     self._make_it_absolute("something/dir1/dir2/module")

--- a/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
+++ b/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
@@ -52,6 +52,7 @@ def NOOP_CALLBACK():
     pass
 
 
+@patch("streamlit.file_util.file_in_pythonpath", return_value=True)
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):
         modules = [
@@ -76,7 +77,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
                 pass
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_just_script(self, fob):
+    def test_just_script(self, fob, _):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -94,7 +95,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(fob.call_count, 1)  # __init__.py
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_permission_error(self, fob):
+    def test_permission_error(self, fob, _):
         from streamlit import compatibility
 
         if compatibility.is_running_py3():
@@ -106,7 +107,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_script_and_2_modules_at_once(self, fob):
+    def test_script_and_2_modules_at_once(self, fob, _):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -138,7 +139,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(fob.call_count, 0)
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_script_and_2_modules_in_series(self, fob):
+    def test_script_and_2_modules_in_series(self, fob, _):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -172,7 +173,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         fob.assert_called_once()
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_misbehaved_module(self, fob):
+    def test_misbehaved_module(self, fob, _):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -184,7 +185,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         fob.assert_called_once()  # Just __init__.py
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_nested_module_parent_unloaded(self, fob):
+    def test_nested_module_parent_unloaded(self, fob, _):
         lso = LocalSourcesWatcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -207,7 +208,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             self.assertNotIn("NESTED_MODULE_PARENT", sys.modules)
 
     @patch("streamlit.watcher.LocalSourcesWatcher.FileWatcher")
-    def test_config_blacklist(self, fob):
+    def test_config_blacklist(self, fob, _):
         """Test server.folderWatchBlacklist"""
         prev_blacklist = config.get_option("server.folderWatchBlacklist")
 
@@ -229,7 +230,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         # Reset the config object.
         config.set_option("server.folderWatchBlacklist", prev_blacklist)
 
-    def test_config_watcherType(self):
+    def test_config_watcherType(self, _):
         """Test server.fileWatcherType"""
 
         config.set_option("server.fileWatcherType", "none")

--- a/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
+++ b/lib/tests/streamlit/watcher/LocalSourcesWatcher_test.py
@@ -52,7 +52,7 @@ def NOOP_CALLBACK():
     pass
 
 
-@patch("streamlit.file_util.file_in_pythonpath", return_value=True)
+@patch("streamlit.file_util.file_in_pythonpath", return_value=False)
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):
         modules = [


### PR DESCRIPTION
We currently limit the modules we watch to modules contained in the current directory. This PR extends the watched modules to modules contained in the `PYTHONPATH` as well. For consistency, we also enable hashing for the same modules in the `PYTHONPATH`.

**Issue:** https://github.com/streamlit/streamlit/issues/805