### PR TITLE
test:coverage script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,11 +8,18 @@
     "start": "export NODE_OPTIONS=--max_old_space_size=4096 && craco start",
     "build": "export NODE_OPTIONS=--max_old_space_size=4096 && craco build",
     "test": "export NODE_OPTIONS=--max_old_space_size=4096 && craco test --env=jsdom",
+    "test:coverage": "export NODE_OPTIONS=--max_old_space_size=4096 && craco test --env=jsdom --coverage --watchAll false --watch false ./",
     "cy:open": "unset NODE_OPTIONS && cypress open --env devicePixelRatio=1",
     "cy:run": "unset NODE_OPTIONS && cypress run",
     "cy:run-all": "../scripts/run_e2e_tests.sh -a true -c .. -r",
     "cy:serve-and-run-all": "NODE_OPTIONS=--max_old_space_size=4096 start-server-and-test start http://localhost:3000 cy:run-all",
     "typecheck": "tsc --noEmit"
+  },
+  "jest": {
+    "coverageReporters": [
+      "text",
+      "html"
+    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
**Description:** 
As we are needing to have a well tested code i'm adding a new script to our package.json which creates a code coverage report in order to have better insights of how we are doing our tests.

Scripts:
- `yarn test:coverage`: if you want to generate a report for the complete frontend project
- `yarn test src/components/elements/Alert/Alert.test.tsx --coverage`: If you need to check the coverage for an specific file

The report will be created in `/frontend/coverage/index.html`


<img width="949" alt="Screen Shot 2019-12-13 at 1 45 59 PM" src="https://user-images.githubusercontent.com/631997/70816750-ee6f2d80-1dae-11ea-9182-e464ca13f5e9.png">
<img width="642" alt="Screen Shot 2019-12-13 at 1 50 57 PM" src="https://user-images.githubusercontent.com/631997/70817110-a00e5e80-1daf-11ea-83df-ad65faad4a03.png">


---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
