### PR TITLE
Add new tests for add_rows method  with set_index in dataframes

### DIFF
--- a/lib/tests/streamlit/add_rows_test.py
+++ b/lib/tests/streamlit/add_rows_test.py
@@ -28,7 +28,9 @@ from tests import testutil
 
 
 DATAFRAME = pd.DataFrame({"a": [1, 2], "b": [10, 20]})
+DATAFRAME_WITH_INDEX = pd.DataFrame({"a": [1, 2], "b": [10, 20]}).set_index('a')
 NEW_ROWS = pd.DataFrame({"a": [3, 4, 5], "b": [30, 40, 50]})
+NEW_ROWS_WITH_INDEX = pd.DataFrame({"a": [3, 4, 5], "b": [30, 40, 50]}).set_index('a')
 NEW_ROWS_WRONG_SHAPE = pd.DataFrame({"a": [3, 4], "b": [30, 40], "c": [50, 60]})
 
 
@@ -104,6 +106,73 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             df_proto = data_frame_proto._get_data_frame(self.get_delta_from_queue())
             num_rows = len(df_proto.data.cols[0].int64s.data)
             self.assertEqual(num_rows, 5)
+
+            # Clear the queue so the next loop is like a brand new test.
+            self._dg._reset()
+            self.report_queue.clear()
+
+    def test_with_index_add_rows(self):
+        """Test plain old add_rows."""
+        all_methods = self._get_unnamed_data_methods()
+
+        for method in all_methods:
+            # Create a new data-carrying element (e.g. st.dataframe)
+            el = method(DATAFRAME_WITH_INDEX)
+           
+            # Make sure it has 2 rows in it.
+            df_proto = data_frame_proto._get_data_frame(self.get_delta_from_queue())
+            num_rows = len(df_proto.data.cols[0].int64s.data)
+            self.assertEqual(num_rows, 2)
+            
+            # This is what we're testing:
+            el.add_rows(NEW_ROWS_WITH_INDEX)
+
+            # Make sure there are 2 rows in it now.
+            df_proto = data_frame_proto._get_data_frame(self.get_delta_from_queue())
+            num_rows = len(df_proto.data.cols[0].int64s.data)
+            self.assertEqual(num_rows, 5)
+
+            # Clear the queue so the next loop is like a brand new test.
+            self._dg._reset()
+            self.report_queue.clear()
+
+    def test_with_index_no_data_add_rows(self):
+        """Test plain old add_rows."""
+        all_methods = self._get_unnamed_data_methods()
+
+        for method in all_methods:
+            # Create a new data-carrying element (e.g. st.dataframe)
+            el = method(None)
+            data_frame_proto._get_data_frame(self.get_delta_from_queue())
+            
+            # This is what we're testing:
+            el.add_rows(DATAFRAME_WITH_INDEX)
+
+            # Make sure there are 2 rows in it now.
+            df_proto = data_frame_proto._get_data_frame(self.get_delta_from_queue())
+            num_rows = len(df_proto.data.cols[0].int64s.data)
+            self.assertEqual(num_rows, 2)
+
+            # Clear the queue so the next loop is like a brand new test.
+            self._dg._reset()
+            self.report_queue.clear()
+
+    def test_no_index_no_data_add_rows(self):
+        """Test plain old add_rows."""
+        all_methods = self._get_unnamed_data_methods()
+
+        for method in all_methods:
+            # Create a new data-carrying element (e.g. st.dataframe)
+            el = method(None)
+            data_frame_proto._get_data_frame(self.get_delta_from_queue())
+            
+            # This is what we're testing:
+            el.add_rows(DATAFRAME)
+
+            # Make sure there are 2 rows in it now.
+            df_proto = data_frame_proto._get_data_frame(self.get_delta_from_queue())
+            num_rows = len(df_proto.data.cols[0].int64s.data)
+            self.assertEqual(num_rows, 2)
 
             # Clear the queue so the next loop is like a brand new test.
             self._dg._reset()


### PR DESCRIPTION
Add tests to cases when the dataframe have not a `index` column. 
Add tests to cases when the chart was created without data.