### PR TITLE
A possible fix for the st.image() and st.pyplot() about those blurry things

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1260,7 +1260,7 @@ class DeltaGenerator(object):
         )
 
     @_with_element
-    def pyplot(self, element, fig=None, clear_figure=True, **kwargs):
+    def pyplot(self, element, fig=None, width=None, use_column_width=False, scale=False, clear_figure=True, **kwargs):
         """Display a matplotlib.pyplot figure.
 
         Parameters
@@ -1268,6 +1268,16 @@ class DeltaGenerator(object):
         fig : Matplotlib Figure
             The figure to plot. When this argument isn't specified, which is
             the usual case, this function will render the global plot.
+
+        width : int or None
+            Image width. None means use the image width.
+
+        use_column_width : bool
+            If True, set the image width to the column width. This overrides
+            the `width` parameter.
+
+        scale : bool
+            If true, the image will be scaled in the webpage.
 
         clear_figure : bool
             If True or unspecified, the figure will be cleared after being
@@ -1304,7 +1314,14 @@ class DeltaGenerator(object):
         """
         import streamlit.elements.pyplot as pyplot
 
-        pyplot.marshall(element, fig, clear_figure, **kwargs)
+        if use_column_width:
+            width = -2
+        elif width is None:
+            width = -1
+        elif width <= 0:
+            raise StreamlitAPIException("Image width must be positive.")
+
+        pyplot.marshall(element, fig, width, scale, clear_figure, **kwargs)
 
     @_with_element
     def bokeh_chart(self, element, figure):
@@ -1358,6 +1375,7 @@ class DeltaGenerator(object):
         caption=None,
         width=None,
         use_column_width=False,
+        scale=False,
         clamp=False,
         channels="RGB",
         format="JPEG",
@@ -1380,6 +1398,8 @@ class DeltaGenerator(object):
         use_column_width : bool
             If True, set the image width to the column width. This overrides
             the `width` parameter.
+        scale : bool
+            If True, the image will be scaled in the webpage.
         clamp : bool
             Clamp image pixel values to a valid range ([0-255] per channel).
             This is only meaningful for byte array images; the parameter is
@@ -1416,8 +1436,9 @@ class DeltaGenerator(object):
             width = -1
         elif width <= 0:
             raise StreamlitAPIException("Image width must be positive.")
+        
         image_proto.marshall_images(
-            image, caption, width, element.imgs, clamp, channels, format
+            image, caption, width, scale, element.imgs, clamp, channels, format
         )
 
     @_with_element

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -32,20 +32,17 @@ from streamlit.logger import get_logger
 LOGGER = get_logger(__name__)
 
 
-def marshall(new_element_proto, fig=None, clear_figure=True, **kwargs):
+def marshall(new_element_proto, fig, width, scale, clear_figure=True, **kwargs):
     """Construct a matplotlib.pyplot figure.
 
-    See DeltaGenerator.vega_lite_chart for docs.
+    See DeltaGenerator.pyplot for docs.
     """
     # You can call .savefig() on a Figure object or directly on the pyplot
     # module, in which case you're doing it to the latest Figure.
     if not fig:
         fig = plt
 
-    # Normally, dpi is set to 'figure', and the figure's dpi is set to 100.
-    # So here we pick double of that to make things look good in a high
-    # DPI display.
-    options = {"dpi": 200, "format": "png"}
+    options = {"format": "png"}
 
     # If some of the options are passed in from kwargs then replace
     # the values in options with the ones from kwargs
@@ -56,7 +53,7 @@ def marshall(new_element_proto, fig=None, clear_figure=True, **kwargs):
     image = io.BytesIO()
     fig.savefig(image, **kwargs)
     image_proto.marshall_images(
-        image, None, -2, new_element_proto.imgs, False, channels="RGB", format="PNG"
+        image, None, width, scale, new_element_proto.imgs, False, channels="RGB", format="PNG"
     )
 
     # Clear the figure after rendering it. This means that subsequent

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 import unittest
 
-import altair as alt
+import altair.vegalite.v3
 import numpy as np
 import pandas as pd
 import pytest
@@ -406,11 +406,14 @@ class CodeHashTest(unittest.TestCase):
     def test_external_module(self):
         """Test code that references an external module."""
 
+        # NB: If a future vegalite update removes the v3 API, these functions
+        # will need to be updated!
+
         def call_altair_concat():
-            return alt.vegalite.v3.api.concat()
+            return altair.vegalite.v3.api.concat()
 
         def call_altair_layer():
-            return alt.vegalite.v3.api.layer()
+            return altair.vegalite.v3.api.layer()
 
         self.assertNotEqual(get_hash(call_altair_concat), get_hash(call_altair_layer))
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -447,10 +447,10 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         st.pyplot()
 
         el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.imgs.width, -2)
+        self.assertEqual(el.imgs.width, -1)
         self.assertEqual(el.imgs.imgs[0].caption, "")
 
-        checksum = "iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAYAAACAvzb"
+        checksum = "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6"
         self.assertTrue(el.imgs.imgs[0].data.base64.startswith(checksum))
 
     def test_st_pyplot_clear_figure(self):


### PR DESCRIPTION
---

**Issue:** https://github.com/streamlit/streamlit/issues/796

**Description:** I think that double dpi and double width are tricky. We should not change the actual size of the image automatically via the code, and make this an option may be better.
*  **DeltaGenerator.py**: Add a new *scale* parameter to *image()*, and make *pyplot()* follow the logic of *image()* since they actually do similar things.
* **image_proto.py**: Make the function behave consistently. For example, if *scale==True* and *use_column_width==True*, scale image even if it is smaller than *MAXIMUM_CONTENT_WIDTH*. 
* **pyplot.py**: Call *marshall_images()* correctly. And the argument *dpi* should be given by users when necessary.
* **streamlit_test**: Since the default behavior of *pyplot()* changes a bit, the test code needs to be updated.
---
