### PR TITLE
Fix #875: frontend error saying "Bad message format - Tried to use SessionInfo before it was initialized"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
           command: |
             mkdir ~/.streamlit
             echo '[general]' >  ~/.streamlit/credentials.toml
-            echo 'email = "jonathan@streamlit.io"' >> ~/.streamlit/credentials.toml
+            echo 'email = "test@streamlit.io"' >> ~/.streamlit/credentials.toml
             cd frontend
             yarn run cy:serve-and-run-all
 

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -76,6 +76,6 @@ RUN make develop
 # register streamlit user
 RUN mkdir $HOME/.streamlit \
     && echo '[general]' >  $HOME/.streamlit/credentials.toml \
-    && echo 'email = "jonathan@streamlit.io"' >> $HOME/.streamlit/credentials.toml
+    && echo 'email = "test@streamlit.io"' >> $HOME/.streamlit/credentials.toml
 
 CMD /bin/bash

--- a/e2e/specs/hello.spec.ts
+++ b/e2e/specs/hello.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2018-2019 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="cypress" />
+
+describe("hello", () => {
+  before(() => {
+    cy.visit("http://localhost:3000/");
+  });
+
+  it("displays the welcome message", () => {
+    cy.get(".element-container .stMarkdown h1").should(
+      "contain",
+      "Welcome to Streamlit!"
+    );
+
+    cy.get(".streamlit-dialog").should("not.exist");
+  });
+});

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -69,13 +69,13 @@ export class SessionInfo {
     mapboxToken,
   }: Args) {
     if (
-      !streamlitVersion ||
-      !pythonVersion ||
-      !installationId ||
-      !authorEmail ||
-      !maxCachedMessageAge ||
-      !commandLine ||
-      !mapboxToken
+      streamlitVersion == null ||
+      pythonVersion == null ||
+      installationId == null ||
+      authorEmail == null ||
+      maxCachedMessageAge == null ||
+      commandLine == null ||
+      mapboxToken == null
     ) {
       throw new Error("SessionInfo arguments must be strings")
     }

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -77,19 +77,30 @@ trap generate_report EXIT
 rm cypress/mochawesome/* || true
 rm mochawesome.json || true
 
-# Test core streamlit elements
-for file in ../e2e/scripts/*.py
-do
-  snapshots_flag_for_this_run=$snapshots_flag
+
+# Takes as input all the arguments that should be passed to the "streamlit" CLI
+# tool for the test. For example:
+# - run_test run foo.py
+# - run_test run foo.py --server.port=1234
+# - run_test hello
+function run_test {
+  # Get path of test spec to execute.
+  # If the user called "run_test run arg2", then the spec is the one for arg2.
+  # Otherwise, we'll just use the hello spec.
+  if [ $1 = "run" ]
+  then
+    file=$2
+    filename=$(basename $file)
+    specpath="../e2e/specs/${filename%.*}.spec.ts"
+  else
+    specpath="../e2e/specs/hello.spec.ts"
+  fi
 
   # Infinite loop to support retries.
   while true
   do
     # Run next test
-    streamlit run $file &
-
-    filename=$(basename $file)
-    specpath="../e2e/specs/${filename%.*}.spec.ts"
+    streamlit "$@" &
 
     yarn \
       cy:run \
@@ -118,6 +129,42 @@ do
     # If we got to this point, break out of the infite loop. No need to retry.
     break
   done
+}
+
+# Test "streamlit hello" in different combinations.
+
+credentials_file=~/.streamlit/credentials.toml
+mkdir -p $(dirname $credentials_file)
+
+if test -f $credentials_file
+then
+  mv $credentials_file $credentials_file.bak
+fi
+
+run_test hello --server.headless=true
+
+cat << EOF > $credentials_file
+[general]
+email = "test@streamlit.io"
+EOF
+
+run_test hello
+run_test hello --server.headless=true
+
+rm $credentials_file
+
+if test -f $credentials_file.bak
+then
+  mv $credentials_file.bak $credentials_file
+fi
+
+
+# Test core streamlit elements
+
+for file in ../e2e/scripts/*.py
+do
+  snapshots_flag_for_this_run=$snapshots_flag
+  run_test run $file
 done
 
 if [ "$any_failed" = "true" ]

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2018-2019 Streamlit Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,6 +141,9 @@ then
   mv $credentials_file $credentials_file.bak
 fi
 
+# Don't run this due to credentials prompt.
+# run_test hello --server.headless=false
+
 run_test hello --server.headless=true
 
 cat << EOF > $credentials_file
@@ -148,7 +151,7 @@ cat << EOF > $credentials_file
 email = "test@streamlit.io"
 EOF
 
-run_test hello
+run_test hello --server.headless=false
 run_test hello --server.headless=true
 
 rm $credentials_file


### PR DESCRIPTION
Fixes #879 

The issue only happens when when you have:

* `server.headless = true`
   _and_
* no email set

(Note that headless is also turned on automatically when we detect that there's no display — such as when you're running in Docker)

This caused a null check to fail because the null check wasn't actually checking `null`. Instead it was checking `falsy`, and an empty email (an empty string) is falsy.