### PR TITLE
Protobuf: use "reserved" keyword

### DIFF
--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -87,4 +87,6 @@ message Element {
     Video video = 14;
     // Next ID: 34
   }
+
+  reserved 9;
 }

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -29,7 +29,7 @@ message NumberInput {
   bool has_min = 11;
   bool has_max = 12;
 
-  // deprecated: 3, 4, 5, 6, 7
+  reserved 3, 4, 5, 6, 7;
 }
 
 message IntNumberInput {


### PR DESCRIPTION
Use the `reserved` keyword for field numbers that shouldn't be re-used. The proto compiler will enforce this.