### PR TITLE
st.text_input: password support

### DIFF
--- a/frontend/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { shallow } from "enzyme"
+import { Input as UIInput } from "baseui/input"
+import { fromJS } from "immutable"
+import { WidgetStateManager } from "lib/WidgetStateManager"
+
+import TextInput, { Props } from "./TextInput"
+import { TextInput as TextInputProto } from "autogen/proto"
+
+jest.mock("lib/WidgetStateManager")
+
+const sendBackMsg = jest.fn()
+const getProps = (elementProps: object = {}): Props => ({
+  element: fromJS({
+    label: "Label",
+    default: "",
+    type: TextInputProto.Type.DEFAULT,
+    ...elementProps,
+  }),
+  width: 0,
+  disabled: false,
+  widgetMgr: new WidgetStateManager(sendBackMsg),
+})
+
+describe("TextInput widget", () => {
+  it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextInput {...props} />)
+
+    expect(wrapper).toBeDefined()
+  })
+
+  it("should show a label", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextInput {...props} />)
+
+    expect(wrapper.find("label").text()).toBe(props.element.get("label"))
+  })
+
+  it("should handle TextInputProto.Type properly", () => {
+    const defaultProps = getProps({ type: TextInputProto.Type.DEFAULT })
+    let textInput = shallow(<TextInput {...defaultProps} />)
+    let uiInput = textInput.find(UIInput)
+    expect(uiInput.props().type).toBeUndefined()
+
+    const passwordProps = getProps({ type: TextInputProto.Type.PASSWORD })
+    textInput = shallow(<TextInput {...passwordProps} />)
+    uiInput = textInput.find(UIInput)
+    expect(uiInput.props().type).toBe("password")
+  })
+})

--- a/frontend/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.tsx
@@ -19,8 +19,9 @@ import React from "react"
 import { Input as UIInput } from "baseui/input"
 import { Map as ImmutableMap } from "immutable"
 import { WidgetStateManager, Source } from "lib/WidgetStateManager"
+import { TextInput as TextInputProto } from "autogen/proto"
 
-interface Props {
+export interface Props {
   disabled: boolean
   element: ImmutableMap<string, any>
   widgetMgr: WidgetStateManager
@@ -75,6 +76,12 @@ class TextInput extends React.PureComponent<Props, State> {
     }
   }
 
+  private getTypeString(): string | undefined {
+    return this.props.element.get("type") === TextInputProto.Type.PASSWORD
+      ? "password"
+      : undefined
+  }
+
   public render = (): React.ReactNode => {
     const label: string = this.props.element.get("label")
     const style = { width: this.props.width }
@@ -88,6 +95,7 @@ class TextInput extends React.PureComponent<Props, State> {
           onChange={this.onChange}
           onKeyPress={this.onKeyPress}
           disabled={this.props.disabled}
+          type={this.getTypeString()}
         />
         {this.state.dirty ? (
           <div className="instructions">Press Enter to apply</div>

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -18,6 +18,7 @@
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
 from streamlit.compatibility import setup_2_3_shims
+from streamlit.proto.TextInput_pb2 import TextInput
 
 setup_2_3_shims(globals())
 
@@ -2097,7 +2098,7 @@ class DeltaGenerator(object):
         return io.BytesIO(data)
 
     @_with_element
-    def text_input(self, element, label, value="", key=None):
+    def text_input(self, element, label, value="", key=None, type="default"):
         """Display a single-line text input widget.
 
         Parameters
@@ -2112,6 +2113,10 @@ class DeltaGenerator(object):
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
+        type : str
+            The type of the text input. This can be either "default" (for
+            a regular text input), or "password" (for a text input that
+            masks the user's typed value). Defaults to "default".
 
         Returns
         -------
@@ -2126,6 +2131,15 @@ class DeltaGenerator(object):
         """
         element.text_input.label = label
         element.text_input.default = str(value)
+        if type == "default":
+            element.text_input.type = TextInput.DEFAULT
+        elif type == "password":
+            element.text_input.type = TextInput.PASSWORD
+        else:
+            raise StreamlitAPIException(
+                "'%s' is not a valid text_input type. Valid types are 'default' and 'password'."
+                % str(type)
+            )
 
         ui_value = _get_widget_ui_value("text_input", element, user_key=key)
         current_value = ui_value if ui_value is not None else value
@@ -2313,7 +2327,7 @@ class DeltaGenerator(object):
             If the value is not specified, the format parameter will be used.
         format : str or None
             A printf-style format string controlling how the interface should
-            display numbers. Output must be purely numeric. This does not impact 
+            display numbers. Output must be purely numeric. This does not impact
             the return value. Valid formatters: %d %e %f %g %i
         key : str
             An optional string to use as the unique key for the widget.
@@ -2657,11 +2671,13 @@ class DeltaGenerator(object):
         if not suppress_deprecation_warning:
             import streamlit as st
 
-            st.warning("""
+            st.warning(
+                """
                 The `deck_gl_chart` widget is deprecated and will be removed on
 
                 2020-03-04. To render a map, you should use `st.pyDeckChart` widget.
-            """)
+            """
+            )
 
         import streamlit.elements.deck_gl as deck_gl
 
@@ -2690,7 +2706,7 @@ class DeltaGenerator(object):
         >>> df = pd.DataFrame(
         ...    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],
         ...    columns=['lat', 'lon'])
-        
+
         >>> st.pydeck_chart(pdk.Deck(
         ...     map_style='mapbox://styles/mapbox/light-v9',
         ...     initial_view_state=pdk.ViewState(

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2138,7 +2138,7 @@ class DeltaGenerator(object):
         else:
             raise StreamlitAPIException(
                 "'%s' is not a valid text_input type. Valid types are 'default' and 'password'."
-                % str(type)
+                % type
             )
 
         ui_value = _get_widget_ui_value("text_input", element, user_key=key)

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -17,7 +17,16 @@
 syntax = "proto3";
 
 message TextInput {
+  enum Type {
+    // A normal text input.
+    DEFAULT = 0;
+
+    // A password text input. Typed values are obscured by default.
+    PASSWORD = 1;
+  }
+
   string id = 1;
   string label = 2;
   string default = 3;
+  Type type = 4;
 }


### PR DESCRIPTION
`st.text_input` takes a new optional parameter, "type". Valid values are "default" (which is used if no value is specified) and "password".

The password text_input works as you'd expect, masking user typing!

Fixes #420 