### PR TITLE
Fix for the CORS check

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -486,7 +486,7 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
 
     def check_origin(self, origin):
         """Set up CORS."""
-        return is_url_from_allowed_origins(origin)
+        return super().check_origin(origin) or is_url_from_allowed_origins(origin)
 
     def open(self):
         self._session = self._server._add_browser_connection(self)


### PR DESCRIPTION
**Issue:** #964 

**Description:** 
Streamlit is using tornado for WebSocket. It has overwritten the origin check for CORS, which only allows the configured list of URLs.

However, if the HOST and ORIGIN are the same, it shouldn't invoke the check for the URL list at all. If they are the same value, it should allow the connection.

**Changes**

This will add back the torndado implementation, checking whether HOST and ORIGIN are equal, otherwise then proceed for URL list checks.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
