### PR TITLE
Don't special case Path hashing

### DIFF
--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -32,6 +32,7 @@ import tempfile
 import threading
 
 import streamlit as st
+from streamlit import compatibility
 from streamlit import config
 from streamlit import file_util
 from streamlit import type_util
@@ -374,6 +375,7 @@ class CodeHasher:
             elif hasattr(obj, "name") and (
                 isinstance(obj, io.IOBase)
                 or isinstance(obj, tempfile._TemporaryFileWrapper)
+                or not compatibility.is_running_py3() and isinstance(obj, file)
             ):
                 # Hash files as name + last modification date + offset.
                 h = hashlib.new(self.name)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -372,8 +372,8 @@ class CodeHasher:
             elif inspect.isbuiltin(obj):
                 return self.to_bytes(obj.__name__)
             elif hasattr(obj, "name") and (
-                isinstance(obj, io.IOBase) or
-                isinstance(obj, tempfile._TemporaryFileWrapper)
+                isinstance(obj, io.IOBase)
+                or isinstance(obj, tempfile._TemporaryFileWrapper)
             ):
                 # Hash files as name + last modification date + offset.
                 h = hashlib.new(self.name)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -370,13 +370,7 @@ class CodeHasher:
                 return h.digest()
             elif inspect.isbuiltin(obj):
                 return self.to_bytes(obj.__name__)
-            elif hasattr(obj, "name") and (
-                isinstance(obj, io.IOBase)
-                or (
-                    isinstance(obj.name, string_types)  # noqa: F821
-                    and os.path.exists(obj.name)
-                )
-            ):
+            elif hasattr(obj, "name") and isinstance(obj, io.IOBase):
                 # Hash files as name + last modification date + offset.
                 h = hashlib.new(self.name)
                 self._update(h, obj.name)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -28,6 +28,7 @@ import io
 import os
 import sys
 import textwrap
+import tempfile
 import threading
 
 import streamlit as st
@@ -370,7 +371,10 @@ class CodeHasher:
                 return h.digest()
             elif inspect.isbuiltin(obj):
                 return self.to_bytes(obj.__name__)
-            elif hasattr(obj, "name") and isinstance(obj, io.IOBase):
+            elif hasattr(obj, "name") and (
+                isinstance(obj, io.IOBase) or
+                isinstance(obj, tempfile._TemporaryFileWrapper)
+            ):
                 # Hash files as name + last modification date + offset.
                 h = hashlib.new(self.name)
                 self._update(h, obj.name)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -374,6 +374,7 @@ class CodeHasher:
                 return self.to_bytes(obj.__name__)
             elif hasattr(obj, "name") and (
                 isinstance(obj, io.IOBase)
+                # Handle temporary files used during testing
                 or isinstance(obj, tempfile._TemporaryFileWrapper)
                 or (not compatibility.is_running_py3() and isinstance(obj, file))
             ):

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -375,7 +375,8 @@ class CodeHasher:
             elif hasattr(obj, "name") and (
                 isinstance(obj, io.IOBase)
                 or isinstance(obj, tempfile._TemporaryFileWrapper)
-                or not compatibility.is_running_py3() and isinstance(obj, file)
+                or (not compatibility.is_running_py3()
+                and isinstance(obj, file))
             ):
                 # Hash files as name + last modification date + offset.
                 h = hashlib.new(self.name)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -375,8 +375,7 @@ class CodeHasher:
             elif hasattr(obj, "name") and (
                 isinstance(obj, io.IOBase)
                 or isinstance(obj, tempfile._TemporaryFileWrapper)
-                or (not compatibility.is_running_py3()
-                and isinstance(obj, file))
+                or (not compatibility.is_running_py3() and isinstance(obj, file))
             ):
                 # Hash files as name + last modification date + offset.
                 h = hashlib.new(self.name)


### PR DESCRIPTION
Issue #857 

We were incorrectly treating `Path`s like `File`s. 

Remove special case hashing for `Path`s and let it be hashed by `__reduce__`