### PR TITLE
Fix sidebar crosstalk between sessions

### DIFF
--- a/e2e/specs/st_audio.spec.ts
+++ b/e2e/specs/st_audio.spec.ts
@@ -25,7 +25,7 @@ describe("st.audio", () => {
   });
 
   it("displays an audio player", () => {
-    cy.get(".element-container").find("audio.stAudio");
+    cy.get(".element-container .stAudio");
   });
 
   it("has controls", () => {

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -257,7 +257,7 @@ class DeltaGenerator(object):
 
     Parameters
     ----------
-    container: "main" or "sidebar" or None
+    container: BlockPath_pb2.BlockPath or None
       The root container for this DeltaGenerator. If None, this is a null
       DeltaGenerator which doesn't print to the app at all (useful for
       testing).
@@ -268,7 +268,7 @@ class DeltaGenerator(object):
     # The pydoc below is for user consumption, so it doesn't talk about
     # DeltaGenerator constructor parameters (which users should never use). For
     # those, see above.
-    def __init__(self, container="main", cursor=None):
+    def __init__(self, container=BlockPath_pb2.BlockPath.MAIN, cursor=None):
         """Inserts or updates elements in Streamlit apps.
 
         As a user, you should never initialize this object by hand. Instead,
@@ -308,7 +308,7 @@ class DeltaGenerator(object):
 
         def wrapper(*args, **kwargs):
             if name in streamlit_methods:
-                if self._container == "sidebar":
+                if self._container == BlockPath_pb2.BlockPath.SIDEBAR:
                     message = (
                         "Method `%(name)s()` does not exist for "
                         "`st.sidebar`. Did you mean `st.%(name)s()`?" % {"name": name}
@@ -373,13 +373,7 @@ class DeltaGenerator(object):
         # Only enqueue message if there's a container.
 
         if self._container and self._cursor:
-            assert self._container in ("sidebar", "main")
-
-            if self._container == "sidebar":
-                msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.SIDEBAR
-            else:
-                msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.MAIN
-
+            msg.metadata.parent_block.container = self._container
             msg.metadata.parent_block.path[:] = self._cursor.path
             msg.metadata.delta_id = self._cursor.index
 
@@ -2914,12 +2908,7 @@ class DeltaGenerator(object):
         )
 
         msg = ForwardMsg_pb2.ForwardMsg()
-
-        if self._container == "sidebar":
-            msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.SIDEBAR
-        else:
-            msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.MAIN
-
+        msg.metadata.parent_block.container = self._container
         msg.metadata.parent_block.path[:] = self._cursor.path
         msg.metadata.delta_id = self._cursor.index
 

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -18,7 +18,6 @@
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
 from streamlit.compatibility import setup_2_3_shims
-from streamlit.proto.TextInput_pb2 import TextInput
 
 setup_2_3_shims(globals())
 
@@ -33,11 +32,13 @@ from datetime import time
 
 from streamlit import caching
 from streamlit import config
+from streamlit import cursor
 from streamlit import metrics
 from streamlit import type_util
 from streamlit.ReportThread import get_report_ctx
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException
+from streamlit.errors import NoSessionContext
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto import Alert_pb2
@@ -45,6 +46,7 @@ from streamlit.proto import Balloons_pb2
 from streamlit.proto import BlockPath_pb2
 from streamlit.proto import ForwardMsg_pb2
 from streamlit.proto.NumberInput_pb2 import NumberInput
+from streamlit.proto.TextInput_pb2 import TextInput
 
 
 # setup logging
@@ -255,45 +257,18 @@ class DeltaGenerator(object):
 
     Parameters
     ----------
-    enqueue: callable or None
-      Function that (maybe) enqueues ForwardMsg's and returns True if
-        enqueued or False if not.
-    id: int or None
-      ID for deltas, or None to create the root DeltaGenerator (which
-        produces DeltaGenerators with incrementing IDs)
-    delta_type: str or None
-      The name of the element passed in Element.proto's oneof.
-      This is needed so we can transform dataframes for some elements when
-      performing an `add_rows`.
-    last_index: int or None
-      The last index of the DataFrame for the element this DeltaGenerator
-      created. Only applies to elements that transform dataframes,
-      like line charts.
-    is_root: bool
-      If True, this will behave like a root DeltaGenerator which an
-      auto-incrementing ID (in which case, `id` should be None).
-      If False, this will have a fixed ID as determined
-      by the `id` argument.
-    container: BlockPath
-      The root container for this DeltaGenerator. Can be MAIN or SIDEBAR.
-    path: tuple of ints
-      The full path of this DeltaGenerator, consisting of the IDs of
-      all ancestors. The 0th item is the topmost ancestor.
+    container: "main" or "sidebar" or None
+      The root container for this DeltaGenerator. If None, this is a null
+      DeltaGenerator which doesn't print to the app at all (useful for
+      testing).
+
+    cursor: cursor.AbstractCursor or None
     """
 
     # The pydoc below is for user consumption, so it doesn't talk about
     # DeltaGenerator constructor parameters (which users should never use). For
     # those, see above.
-    def __init__(
-        self,
-        enqueue,
-        id=0,
-        delta_type=None,
-        last_index=None,
-        is_root=True,
-        container=BlockPath_pb2.BlockPath.MAIN,
-        path=(),
-    ):
+    def __init__(self, container="main", cursor=None):
         """Inserts or updates elements in Streamlit apps.
 
         As a user, you should never initialize this object by hand. Instead,
@@ -308,13 +283,21 @@ class DeltaGenerator(object):
         an element `foo` inside the sidebar.
 
         """
-        self._enqueue = enqueue
-        self._id = id
-        self._delta_type = delta_type
-        self._last_index = last_index
-        self._is_root = is_root
         self._container = container
-        self._path = path
+
+        # This is either:
+        # - None: if this is the running DeltaGenerator for a top-level
+        #   container.
+        # - RunningCursor: if this is the running DeltaGenerator for a
+        #   non-top-level container (created with dg._block())
+        # - LockedCursor: if this is a locked DeltaGenerator returned by some
+        #   other DeltaGenerator method. E.g. the dg returned in dg =
+        #   st.text("foo").
+        #
+        # You should never use this! Instead use self._cursor, which is a
+        # computed property that fetches the right cursor.
+        #
+        self._provided_cursor = cursor
 
     def __getattr__(self, name):
         import streamlit as st
@@ -325,7 +308,7 @@ class DeltaGenerator(object):
 
         def wrapper(*args, **kwargs):
             if name in streamlit_methods:
-                if self._container == BlockPath_pb2.BlockPath.SIDEBAR:
+                if self._container == "sidebar":
                     message = (
                         "Method `%(name)s()` does not exist for "
                         "`st.sidebar`. Did you mean `st.%(name)s()`?" % {"name": name}
@@ -345,11 +328,12 @@ class DeltaGenerator(object):
 
         return wrapper
 
-    # Protected (should be used only by Streamlit, not by users).
-    def _reset(self):
-        """Reset delta generator so it starts from index 0."""
-        assert self._is_root
-        self._id = 0
+    @property
+    def _cursor(self):
+        if self._provided_cursor is None:
+            return cursor.get_container_cursor(self._container)
+        else:
+            return self._provided_cursor
 
     def _enqueue_new_element_delta(
         self,
@@ -377,85 +361,76 @@ class DeltaGenerator(object):
             element.
 
         """
-
-        def value_or_dg(value, dg):
-            """Widgets have return values unlike other elements and may want to
-            return `None`. We create a special `NoValue` class for this scenario
-            since `None` return values get replaced with a DeltaGenerator.
-            """
-            if value is NoValue:
-                return None
-            if value is None:
-                return dg
-            return value
-
         rv = None
-        if marshall_element:
-            msg = ForwardMsg_pb2.ForwardMsg()
-            rv = marshall_element(msg.delta.new_element)
-            msg.metadata.parent_block.container = self._container
-            msg.metadata.parent_block.path[:] = self._path
-            msg.metadata.delta_id = self._id
+
+        # Always call marshall_element() so users can run their script without
+        # Streamlit.
+        msg = ForwardMsg_pb2.ForwardMsg()
+        rv = marshall_element(msg.delta.new_element)
+
+        msg_was_enqueued = False
+
+        # Only enqueue message if there's a container.
+
+        if self._container is not None:
+            assert self._container in ("sidebar", "main")
+
+            if self._container == "sidebar":
+                msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.SIDEBAR
+            else:
+                msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.MAIN
+
+            msg.metadata.parent_block.path[:] = self._cursor.path
+            msg.metadata.delta_id = self._cursor.index
+
             if element_width is not None:
                 msg.metadata.element_dimension_spec.width = element_width
             if element_height is not None:
                 msg.metadata.element_dimension_spec.height = element_height
 
-        # "Null" delta generators (those without queues), don't send anything.
-        if self._enqueue is None:
-            return value_or_dg(rv, self)
+            _enqueue_message(msg)
+            msg_was_enqueued = True
 
-        # Figure out if we need to create a new ID for this element.
-        if self._is_root:
+        if msg_was_enqueued:
+            # Get a DeltaGenerator that is locked to the current element
+            # position.
             output_dg = DeltaGenerator(
-                enqueue=self._enqueue,
-                id=msg.metadata.delta_id,
-                delta_type=delta_type,
-                last_index=last_index,
                 container=self._container,
-                is_root=False,
+                cursor=self._cursor.get_locked_cursor(
+                    delta_type=delta_type, last_index=last_index
+                ),
             )
         else:
-            self._delta_type = delta_type
-            self._last_index = last_index
+            # If the message was not enqueued, just return self since it's a
+            # no-op from the point of view of the app.
             output_dg = self
 
-        kind = msg.delta.new_element.WhichOneof("type")
-
-        m = metrics.Client.get("streamlit_enqueue_deltas_total")
-        m.labels(kind).inc()
-        msg_was_enqueued = self._enqueue(msg)
-
-        if not msg_was_enqueued:
-            return value_or_dg(rv, self)
-
-        if self._is_root:
-            self._id += 1
-
-        return value_or_dg(rv, output_dg)
+        return _value_or_dg(rv, output_dg)
 
     def _block(self):
-        if self._enqueue is None:
+        if self._container is None or self._cursor is None:
             return self
 
         msg = ForwardMsg_pb2.ForwardMsg()
         msg.delta.new_block = True
         msg.metadata.parent_block.container = self._container
-        msg.metadata.parent_block.path[:] = self._path
-        msg.metadata.delta_id = self._id
+        msg.metadata.parent_block.path[:] = self._cursor.path
+        msg.metadata.delta_id = self._cursor.index
 
-        new_block_dg = DeltaGenerator(
-            enqueue=self._enqueue,
-            id=0,
-            is_root=True,
-            container=self._container,
-            path=self._path + (self._id,),
+        # Normally we'd return a new DeltaGenerator that uses the locked cursor
+        # below. But in this case we want to return a DeltaGenerator that uses
+        # a brand new cursor for this new block we're creating.
+        block_cursor = cursor.RunningCursor(
+            path=self._cursor.path + (self._cursor.index,)
         )
+        block_dg = DeltaGenerator(container=self._container, cursor=block_cursor)
 
-        self._enqueue(msg)
-        self._id += 1
+        # Must be called to increment this cursor's index.
+        self._cursor.get_locked_cursor(None)
 
-        return new_block_dg
+        _enqueue_message(msg)
+
+        return block_dg
 
     @_with_element
     def balloons(self, element):
@@ -1810,7 +1785,11 @@ class DeltaGenerator(object):
         ui_value = _get_widget_ui_value("radio", element, user_key=key)
         current_value = ui_value if ui_value is not None else index
 
-        return options[current_value] if len(options) > 0 and options[current_value] is not None else NoValue
+        return (
+            options[current_value]
+            if len(options) > 0 and options[current_value] is not None
+            else NoValue
+        )
 
     @_with_element
     def selectbox(self, element, label, options, index=0, format_func=str, key=None):
@@ -1865,7 +1844,11 @@ class DeltaGenerator(object):
         ui_value = _get_widget_ui_value("selectbox", element, user_key=key)
         current_value = ui_value if ui_value is not None else index
 
-        return options[current_value] if len(options) > 0 and options[current_value] is not None else NoValue
+        return (
+            options[current_value]
+            if len(options) > 0 and options[current_value] is not None
+            else NoValue
+        )
 
     @_with_element
     def slider(
@@ -2893,10 +2876,10 @@ class DeltaGenerator(object):
         >>> my_chart.add_rows(some_fancy_name=df2)  # <-- name used as keyword
 
         """
-        if self._enqueue is None:
+        if self._container is None or self._cursor is None:
             return self
 
-        if self._is_root:
+        if not self._cursor.is_locked:
             raise StreamlitAPIException("Only existing elements can `add_rows`.")
 
         # Accept syntax st.add_rows(df).
@@ -2916,24 +2899,29 @@ class DeltaGenerator(object):
         # (for example, st.line_chart() without any args), call the original
         # st.foo() element with new data instead of doing an add_rows().
         if (
-            self._delta_type in DELTAS_TYPES_THAT_MELT_DATAFRAMES
-            and self._last_index is None
+            self._cursor.props["delta_type"] in DELTAS_TYPES_THAT_MELT_DATAFRAMES
+            and self._cursor.props["last_index"] is None
         ):
             # IMPORTANT: This assumes delta types and st method names always
             # match!
-            st_method_name = self._delta_type
+            st_method_name = self._cursor.props["delta_type"]
             st_method = getattr(self, st_method_name)
             st_method(data, **kwargs)
             return
 
-        data, self._last_index = _maybe_melt_data_for_add_rows(
-            data, self._delta_type, self._last_index
+        data, self._cursor.props["last_index"] = _maybe_melt_data_for_add_rows(
+            data, self._cursor.props["delta_type"], self._cursor.props["last_index"]
         )
 
         msg = ForwardMsg_pb2.ForwardMsg()
-        msg.metadata.parent_block.container = self._container
-        msg.metadata.parent_block.path[:] = self._path
-        msg.metadata.delta_id = self._id
+
+        if self._container == "sidebar":
+            msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.SIDEBAR
+        else:
+            msg.metadata.parent_block.container = BlockPath_pb2.BlockPath.MAIN
+
+        msg.metadata.parent_block.path[:] = self._cursor.path
+        msg.metadata.delta_id = self._cursor.index
 
         import streamlit.elements.data_frame_proto as data_frame_proto
 
@@ -2943,7 +2931,7 @@ class DeltaGenerator(object):
             msg.delta.add_rows.name = name
             msg.delta.add_rows.has_name = True
 
-        self._enqueue(msg)
+        _enqueue_message(msg)
 
         return self
 
@@ -2989,3 +2977,32 @@ def _maybe_melt_data_for_add_rows(data, delta_type, last_index):
 
 def _clean_text(text):
     return textwrap.dedent(str(text)).strip()
+
+
+def _value_or_dg(value, dg):
+    """Return either value, or None, or dg.
+
+    This is needed because Widgets have meaningful return values. This is
+    unlike other elements, which always return None. Then we internally replace
+    that None with a DeltaGenerator instance.
+
+    However, sometimes a widget may want to return None, and in this case it
+    should not be replaced by a DeltaGenerator. So we have a special NoValue
+    object that gets replaced by None.
+
+    """
+    if value is NoValue:
+        return None
+    if value is None:
+        return dg
+    return value
+
+
+def _enqueue_message(msg):
+    """Enqueues a ForwardMsg proto to send to the app."""
+    ctx = get_report_ctx()
+
+    if ctx is None:
+        raise NoSessionContext()
+
+    ctx.enqueue(msg)

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -372,7 +372,7 @@ class DeltaGenerator(object):
 
         # Only enqueue message if there's a container.
 
-        if self._container is not None:
+        if self._container and self._cursor:
             assert self._container in ("sidebar", "main")
 
             if self._container == "sidebar":

--- a/lib/streamlit/ReportSession.py
+++ b/lib/streamlit/ReportSession.py
@@ -91,11 +91,6 @@ class ReportSession(object):
 
         self._uploaded_file_mgr = UploadedFileManager()
 
-        self._main_dg = DeltaGenerator(enqueue=self.enqueue, container=BlockPath.MAIN)
-        self._sidebar_dg = DeltaGenerator(
-            enqueue=self.enqueue, container=BlockPath.SIDEBAR
-        )
-
         self._widget_states = WidgetStates()
         self._local_sources_watcher = LocalSourcesWatcher(
             self._report, self._on_source_file_changed
@@ -543,8 +538,6 @@ class ReportSession(object):
         # Create the ScriptRunner, attach event handlers, and start it
         self._scriptrunner = ScriptRunner(
             report=self._report,
-            main_dg=self._main_dg,
-            sidebar_dg=self._sidebar_dg,
             widget_states=self._widget_states,
             request_queue=self._script_request_queue,
             uploaded_file_mgr=self._uploaded_file_mgr,

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -23,8 +23,8 @@ LOGGER = get_logger(__name__)
 ReportContext = namedtuple(
     "ReportContext",
     [
-        # (dict of str->RunningCursor) Mapping of container name to top-level
-        # cursor.
+        # (dict) Mapping of container (type str or BlockPath) to top-level
+        # cursor (type AbstractCursor).
         "cursors",
         # (callable) Function that enqueues ForwardMsg protos in the websocket.
         "enqueue",

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -23,10 +23,11 @@ LOGGER = get_logger(__name__)
 ReportContext = namedtuple(
     "ReportContext",
     [
-        # (DeltaGenerator) The main DeltaGenerator for the report
-        "main_dg",
-        # (DeltaGenerator) The sidebar DeltaGenerator for the report
-        "sidebar_dg",
+        # (dict of str->RunningCursor) Mapping of container name to top-level
+        # cursor.
+        "cursors",
+        # (callable) Function that enqueues ForwardMsg protos in the websocket.
+        "enqueue",
         # (Widgets) The Widgets state object for the report
         "widgets",
         # (_WidgetIDSet) The set of widget IDs that have been assigned in the
@@ -79,17 +80,11 @@ class ReportThread(threading.Thread):
     """Extends threading.Thread with a ReportContext member"""
 
     def __init__(
-        self,
-        main_dg,
-        sidebar_dg,
-        widgets,
-        target=None,
-        name=None,
-        uploaded_file_mgr=None,
+        self, enqueue, widgets, target=None, name=None, uploaded_file_mgr=None,
     ):
         super(ReportThread, self).__init__(target=target, name=name)
         self.streamlit_report_ctx = ReportContext(
-            main_dg, sidebar_dg, widgets, _WidgetIDSet(), uploaded_file_mgr
+            {}, enqueue, widgets, _WidgetIDSet(), uploaded_file_mgr
         )
 
 

--- a/lib/streamlit/ReportThread.py
+++ b/lib/streamlit/ReportThread.py
@@ -88,7 +88,7 @@ class ReportThread(threading.Thread):
         )
 
 
-def add_report_ctx(thread):
+def add_report_ctx(thread=None, ctx=None):
     """Adds the current ReportContext to a newly-created thread.
 
     This should be called from this thread's parent thread,
@@ -98,6 +98,9 @@ def add_report_ctx(thread):
     ----------
     thread : threading.Thread
         The thread to attach the current ReportContext to.
+    ctx : ReportContext or None
+        The ReportContext to add, or None to use the current thread's
+        ReportContext.
 
     Returns
     -------
@@ -105,7 +108,10 @@ def add_report_ctx(thread):
         The same thread that was passed in, for chaining.
 
     """
-    ctx = get_report_ctx()
+    if thread is None:
+        thread = threading.current_thread()
+    if ctx is None:
+        ctx = get_report_ctx()
     if ctx is not None:
         setattr(thread, REPORT_CONTEXT_ATTR_NAME, ctx)
     return thread

--- a/lib/streamlit/ScriptRunner.py
+++ b/lib/streamlit/ScriptRunner.py
@@ -49,13 +49,7 @@ class ScriptRunnerEvent(Enum):
 
 class ScriptRunner(object):
     def __init__(
-        self,
-        report,
-        main_dg,
-        sidebar_dg,
-        widget_states,
-        request_queue,
-        uploaded_file_mgr=None,
+        self, report, widget_states, request_queue, uploaded_file_mgr=None,
     ):
         """Initialize the ScriptRunner.
 
@@ -65,12 +59,6 @@ class ScriptRunner(object):
         ----------
         report : Report
             The ReportSession's report.
-
-        main_dg : DeltaGenerator
-            The ReportSession's main DeltaGenerator.
-
-        sidebar_dg : DeltaGenerator
-            The ReportSession's sidebar DeltaGenerator.
 
         widget_states : streamlit.proto.Widget_pb2.WidgetStates
             The ReportSession's current widget states
@@ -85,8 +73,6 @@ class ScriptRunner(object):
 
         """
         self._report = report
-        self._main_dg = main_dg
-        self._sidebar_dg = sidebar_dg
         self._request_queue = request_queue
         self._uploaded_file_mgr = uploaded_file_mgr
 
@@ -133,8 +119,7 @@ class ScriptRunner(object):
             raise Exception("ScriptRunner was already started")
 
         self._script_thread = ReportThread(
-            main_dg=self._main_dg,
-            sidebar_dg=self._sidebar_dg,
+            enqueue=self._report.enqueue,
             widgets=self._widgets,
             target=self._process_request_queue,
             name="ScriptRunner.scriptThread",
@@ -244,10 +229,10 @@ class ScriptRunner(object):
 
         LOGGER.debug("Running script %s", rerun_data)
 
-        # Reset delta generator so it starts from index 0.
+        # Reset widget values.
         import streamlit as st
 
-        st._reset(self._main_dg, self._sidebar_dg)
+        st._reset()
 
         self.on_event.send(ScriptRunnerEvent.SCRIPT_STARTED)
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -124,9 +124,6 @@ from streamlit.errors import StreamlitAPIException
 # Modules that the user should have access to.
 from streamlit.caching import cache  # noqa: F401
 
-# Delta generator with no queue so it can't send anything out.
-_NULL_DELTA_GENERATOR = _DeltaGenerator(None)
-
 # This is set to True inside cli._main_run(), and is False otherwise.
 # If False, we should assume that DeltaGenerator functions are effectively
 # no-ops, and adapt gracefully.
@@ -144,75 +141,67 @@ def _set_log_level():
 _config.on_config_parsed(_set_log_level)
 
 
-def _with_dg(method):
-    @_functools_wraps(method)
-    def wrapped_method(*args, **kwargs):
-        ctx = _get_report_ctx()
-        dg = ctx.main_dg if ctx is not None else _NULL_DELTA_GENERATOR
-        return method.__get__(dg)(*args, **kwargs)
-
-    return wrapped_method
-
-
-def _reset(main_dg, sidebar_dg):
-    main_dg._reset()
-    sidebar_dg._reset()
-    global sidebar
-    sidebar = sidebar_dg
+def _reset():
+    # TODO: Move this out of here. This isn't a particularly nice place to
+    # reset this...
     _get_report_ctx().widget_ids_this_run.clear()
 
 
-# Sidebar
-sidebar = _NULL_DELTA_GENERATOR
+# Delta generator with no queue so it can't send anything out. Useful for
+# testing.
+_NULL_DELTA_GENERATOR = _DeltaGenerator(container=None)
+
+_main = _DeltaGenerator(container="main")
+sidebar = _DeltaGenerator(container="sidebar")
 
 # DeltaGenerator methods:
 
-altair_chart = _with_dg(_DeltaGenerator.altair_chart)  # noqa: E221
-area_chart = _with_dg(_DeltaGenerator.area_chart)  # noqa: E221
-audio = _with_dg(_DeltaGenerator.audio)  # noqa: E221
-balloons = _with_dg(_DeltaGenerator.balloons)  # noqa: E221
-bar_chart = _with_dg(_DeltaGenerator.bar_chart)  # noqa: E221
-bokeh_chart = _with_dg(_DeltaGenerator.bokeh_chart)  # noqa: E221
-button = _with_dg(_DeltaGenerator.button)  # noqa: E221
-checkbox = _with_dg(_DeltaGenerator.checkbox)  # noqa: E221
-code = _with_dg(_DeltaGenerator.code)  # noqa: E221
-dataframe = _with_dg(_DeltaGenerator.dataframe)  # noqa: E221
-date_input = _with_dg(_DeltaGenerator.date_input)  # noqa: E221
-deck_gl_chart = _with_dg(_DeltaGenerator.deck_gl_chart)  # noqa: E221
-pydeck_chart = _with_dg(_DeltaGenerator.pydeck_chart)  # noqa: E221
-empty = _with_dg(_DeltaGenerator.empty)  # noqa: E221
-error = _with_dg(_DeltaGenerator.error)  # noqa: E221
-exception = _with_dg(_DeltaGenerator.exception)  # noqa: E221
-file_uploader = _with_dg(_DeltaGenerator.file_uploader)  # noqa: E221
-graphviz_chart = _with_dg(_DeltaGenerator.graphviz_chart)  # noqa: E221
-header = _with_dg(_DeltaGenerator.header)  # noqa: E221
-help = _with_dg(_DeltaGenerator.help)  # noqa: E221
-image = _with_dg(_DeltaGenerator.image)  # noqa: E221
-info = _with_dg(_DeltaGenerator.info)  # noqa: E221
-json = _with_dg(_DeltaGenerator.json)  # noqa: E221
-latex = _with_dg(_DeltaGenerator.latex)  # noqa: E221
-line_chart = _with_dg(_DeltaGenerator.line_chart)  # noqa: E221
-map = _with_dg(_DeltaGenerator.map)  # noqa: E221
-markdown = _with_dg(_DeltaGenerator.markdown)  # noqa: E221
-multiselect = _with_dg(_DeltaGenerator.multiselect)  # noqa: E221
-number_input = _with_dg(_DeltaGenerator.number_input)  # noqa: E221
-plotly_chart = _with_dg(_DeltaGenerator.plotly_chart)  # noqa: E221
-progress = _with_dg(_DeltaGenerator.progress)  # noqa: E221
-pyplot = _with_dg(_DeltaGenerator.pyplot)  # noqa: E221
-radio = _with_dg(_DeltaGenerator.radio)  # noqa: E221
-selectbox = _with_dg(_DeltaGenerator.selectbox)  # noqa: E221
-slider = _with_dg(_DeltaGenerator.slider)  # noqa: E221
-subheader = _with_dg(_DeltaGenerator.subheader)  # noqa: E221
-success = _with_dg(_DeltaGenerator.success)  # noqa: E221
-table = _with_dg(_DeltaGenerator.table)  # noqa: E221
-text = _with_dg(_DeltaGenerator.text)  # noqa: E221
-text_area = _with_dg(_DeltaGenerator.text_area)  # noqa: E221
-text_input = _with_dg(_DeltaGenerator.text_input)  # noqa: E221
-time_input = _with_dg(_DeltaGenerator.time_input)  # noqa: E221
-title = _with_dg(_DeltaGenerator.title)  # noqa: E221
-vega_lite_chart = _with_dg(_DeltaGenerator.vega_lite_chart)  # noqa: E221
-video = _with_dg(_DeltaGenerator.video)  # noqa: E221
-warning = _with_dg(_DeltaGenerator.warning)  # noqa: E221
+altair_chart = _main.altair_chart  # noqa: E221
+area_chart = _main.area_chart  # noqa: E221
+audio = _main.audio  # noqa: E221
+balloons = _main.balloons  # noqa: E221
+bar_chart = _main.bar_chart  # noqa: E221
+bokeh_chart = _main.bokeh_chart  # noqa: E221
+button = _main.button  # noqa: E221
+checkbox = _main.checkbox  # noqa: E221
+code = _main.code  # noqa: E221
+dataframe = _main.dataframe  # noqa: E221
+date_input = _main.date_input  # noqa: E221
+deck_gl_chart = _main.deck_gl_chart  # noqa: E221
+pydeck_chart = _main.pydeck_chart  # noqa: E221
+empty = _main.empty  # noqa: E221
+error = _main.error  # noqa: E221
+exception = _main.exception  # noqa: E221
+file_uploader = _main.file_uploader  # noqa: E221
+graphviz_chart = _main.graphviz_chart  # noqa: E221
+header = _main.header  # noqa: E221
+help = _main.help  # noqa: E221
+image = _main.image  # noqa: E221
+info = _main.info  # noqa: E221
+json = _main.json  # noqa: E221
+latex = _main.latex  # noqa: E221
+line_chart = _main.line_chart  # noqa: E221
+map = _main.map  # noqa: E221
+markdown = _main.markdown  # noqa: E221
+multiselect = _main.multiselect  # noqa: E221
+number_input = _main.number_input  # noqa: E221
+plotly_chart = _main.plotly_chart  # noqa: E221
+progress = _main.progress  # noqa: E221
+pyplot = _main.pyplot  # noqa: E221
+radio = _main.radio  # noqa: E221
+selectbox = _main.selectbox  # noqa: E221
+slider = _main.slider  # noqa: E221
+subheader = _main.subheader  # noqa: E221
+success = _main.success  # noqa: E221
+table = _main.table  # noqa: E221
+text = _main.text  # noqa: E221
+text_area = _main.text_area  # noqa: E221
+text_input = _main.text_input  # noqa: E221
+time_input = _main.time_input  # noqa: E221
+title = _main.title  # noqa: E221
+vega_lite_chart = _main.vega_lite_chart  # noqa: E221
+video = _main.video  # noqa: E221
+warning = _main.warning  # noqa: E221
 
 # Config
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -110,16 +110,17 @@ import types as _types
 import json as _json
 import numpy as _np
 
-from streamlit.util import functools_wraps as _functools_wraps
 from streamlit import code_util as _code_util
 from streamlit import env_util as _env_util
+from streamlit import source_util as _source_util
 from streamlit import string_util as _string_util
 from streamlit import type_util as _type_util
-from streamlit import source_util as _source_util
-from streamlit.ReportThread import get_report_ctx as _get_report_ctx
-from streamlit.ReportThread import add_report_ctx as _add_report_ctx
 from streamlit.DeltaGenerator import DeltaGenerator as _DeltaGenerator
+from streamlit.ReportThread import add_report_ctx as _add_report_ctx
+from streamlit.ReportThread import get_report_ctx as _get_report_ctx
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto import BlockPath_pb2 as _BlockPath_pb2
+from streamlit.util import functools_wraps as _functools_wraps
 
 # Modules that the user should have access to.
 from streamlit.caching import cache  # noqa: F401
@@ -147,8 +148,8 @@ def _reset():
     _get_report_ctx().widget_ids_this_run.clear()
 
 
-_main = _DeltaGenerator(container="main")
-sidebar = _DeltaGenerator(container="sidebar")
+_main = _DeltaGenerator(container=_BlockPath_pb2.BlockPath.MAIN)
+sidebar = _DeltaGenerator(container=_BlockPath_pb2.BlockPath.SIDEBAR)
 
 # DeltaGenerator methods:
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -147,10 +147,6 @@ def _reset():
     _get_report_ctx().widget_ids_this_run.clear()
 
 
-# Delta generator with no queue so it can't send anything out. Useful for
-# testing.
-_NULL_DELTA_GENERATOR = _DeltaGenerator(container=None)
-
 _main = _DeltaGenerator(container="main")
 sidebar = _DeltaGenerator(container="sidebar")
 

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -19,6 +19,9 @@ from streamlit.ReportThread import get_report_ctx
 def get_container_cursor(container):
     ctx = get_report_ctx()
 
+    if ctx is None:
+        return None
+
     if container in ctx.cursors:
         return ctx.cursors[container]
 

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit.ReportThread import get_report_ctx
+
+
+def get_container_cursor(container):
+    ctx = get_report_ctx()
+
+    if container in ctx.cursors:
+        return ctx.cursors[container]
+
+    cursor = RunningCursor()
+    ctx.cursors[container] = cursor
+    return cursor
+
+
+class AbstractCursor(object):
+    """A pointer to a location in the app.
+
+    When adding an element to the app, you should always call
+    get_locked_cursor() on that element's respective AbstractCursor.
+    """
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def is_locked(self):
+        return self._is_locked
+
+    def get_locked_cursor(self, **props):
+        raise NotImplementedError()
+
+
+class RunningCursor(AbstractCursor):
+    def __init__(self, path=()):
+        """A moving pointer to a location in the app.
+
+        RunningCursors auto-increment to the next available location when you
+        call get_locked_cursor() on them.
+
+        Parameters
+        ----------
+        path: tuple of ints
+          The full path of this cursor, consisting of the IDs of all ancestors. The
+          0th item is the topmost ancestor.
+
+        """
+        self._is_locked = False
+        self._index = 0
+        self._path = path
+
+    def get_locked_cursor(self, **props):
+        locked_cursor = LockedCursor(path=self._path, index=self._index, **props)
+
+        self._index += 1
+
+        return locked_cursor
+
+
+class LockedCursor(AbstractCursor):
+    def __init__(self, path=(), index=None, **props):
+        """A locked pointer to a location in the app.
+
+        LockedCursors always point to the same location, even when you call
+        get_locked_cursor() on them.
+
+        Parameters
+        ----------
+        path: tuple of ints
+          The full path of this cursor, consisting of the IDs of all ancestors. The
+          0th item is the topmost ancestor.
+        index: int or None
+        **props: any
+          Anything else you want to store in this cursor. This is a temporary
+          measure that will go away when we implement improved return values
+          for elements.
+
+        """
+        self._is_locked = True
+        self._index = index
+        self._path = path
+        self.props = props
+
+    def get_locked_cursor(self, **props):
+        self.props = props
+        return self

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -22,6 +22,10 @@ class S3NoCredentials(Exception):
     pass
 
 
+class NoSessionContext(Exception):
+    pass
+
+
 class StreamlitAPIException(Exception):
     """Base class for Streamlit API exceptions.
 

--- a/lib/tests/streamlit/ReportSession_test.py
+++ b/lib/tests/streamlit/ReportSession_test.py
@@ -19,11 +19,16 @@ import tornado.gen
 import tornado.testing
 from mock import MagicMock, patch
 
+from streamlit.ReportQueue import ReportQueue
 from streamlit.ReportSession import ReportSession
+from streamlit.ReportThread import ReportContext
+from streamlit.ReportThread import add_report_ctx
+from streamlit.ReportThread import get_report_ctx
 from streamlit.ScriptRunner import ScriptRunner
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.StaticManifest_pb2 import StaticManifest
 from tests.MockStorage import MockStorage
+import streamlit as st
 
 
 class ReportSessionTest(unittest.TestCase):
@@ -117,14 +122,19 @@ class ReportSessionSerializationTest(tornado.testing.AsyncTestCase):
         # Create a ReportSession with some mocked bits
         rs = ReportSession(self.io_loop, "mock_report.py", "")
         rs._report.report_id = "TestReportID"
+
+        orig_ctx = get_report_ctx()
+        ctx = ReportContext({}, rs._report.enqueue, None, None, None)
+        add_report_ctx(ctx=ctx)
+
         rs._scriptrunner = MagicMock()
 
         storage = MockStorage()
         rs._storage = storage
 
         # Send two deltas: empty and markdown
-        rs._main_dg.empty()
-        rs._main_dg.markdown("Text!")
+        st.empty()
+        st.markdown("Text!")
 
         yield rs.handle_save_request(_create_mock_websocket())
 
@@ -148,3 +158,5 @@ class ReportSessionSerializationTest(tornado.testing.AsyncTestCase):
         ]
 
         self.assertEqual(sent_messages, received_messages)
+
+        add_report_ctx(ctx=orig_ctx)

--- a/lib/tests/streamlit/add_rows_test.py
+++ b/lib/tests/streamlit/add_rows_test.py
@@ -23,6 +23,7 @@ setup_2_3_shims(globals())
 
 import pandas as pd
 
+import streamlit as st
 import streamlit.elements.data_frame_proto as data_frame_proto
 from tests import testutil
 
@@ -37,16 +38,12 @@ NEW_ROWS_WRONG_SHAPE = pd.DataFrame({"a": [3, 4], "b": [30, 40], "c": [50, 60]})
 class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
     """Test dg.add_rows."""
 
-    def setUp(self):
-        super(DeltaGeneratorAddRowsTest, self).setUp(override_root=False)
-        self._dg = self.new_delta_generator()
-
     def _get_unnamed_data_methods(self):
         """DeltaGenerator methods that do not produce named datasets."""
         return [
-            lambda df: self._dg.dataframe(df),
-            lambda df: self._dg.table(df),
-            lambda df: self._dg.vega_lite_chart(
+            lambda df: st.dataframe(df),
+            lambda df: st.table(df),
+            lambda df: st.vega_lite_chart(
                 df, {"mark": "line", "encoding": {"x": "a", "y": "b"}}
             ),
             # TODO: line_chart, bar_chart, etc.
@@ -54,16 +51,16 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
 
     def _get_deltas_that_melt_dataframes(self):
         return [
-            lambda df: self._dg.line_chart(df),
-            lambda df: self._dg.bar_chart(df),
-            lambda df: self._dg.area_chart(df),
+            lambda df: st.line_chart(df),
+            lambda df: st.bar_chart(df),
+            lambda df: st.area_chart(df),
         ]
 
     def _get_named_data_methods(self):
         """DeltaGenerator methods that produce named datasets."""
         # These should always name the desired data "mydata1"
         return [
-            lambda df: self._dg.vega_lite_chart(
+            lambda df: st.vega_lite_chart(
                 {
                     "mark": "line",
                     "datasets": {"mydata1": df},
@@ -108,7 +105,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 5)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_with_index_add_rows(self):
@@ -133,7 +130,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 5)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_with_index_no_data_add_rows(self):
@@ -154,7 +151,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 2)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_no_index_no_data_add_rows(self):
@@ -175,7 +172,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 2)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_simple_add_rows_with_clear_queue(self):
@@ -201,7 +198,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 3)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_named_add_rows(self):
@@ -224,7 +221,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 5)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_named_add_rows_with_clear_queue(self):
@@ -248,7 +245,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 3)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_add_rows_works_when_new_name(self):
@@ -268,7 +265,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(num_rows, 3)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()
 
     def test_add_rows_fails_when_wrong_shape(self):
@@ -284,5 +281,5 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
                 el.add_rows(NEW_ROWS_WRONG_SHAPE)
 
             # Clear the queue so the next loop is like a brand new test.
-            self._dg._reset()
+            st._reset()
             self.report_queue.clear()

--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -22,9 +22,10 @@ from mock import patch
 
 import streamlit as st
 from streamlit import caching
+from tests import testutil
 
 
-class CacheTest(unittest.TestCase):
+class CacheTest(testutil.DeltaGeneratorTestCase):
     def tearDown(self):
         # Some of these tests reach directly into _cache_info and twiddle it.
         # Reset default values on teardown.

--- a/lib/tests/streamlit/dataframe_styling_test.py
+++ b/lib/tests/streamlit/dataframe_styling_test.py
@@ -27,25 +27,18 @@ import numpy as np
 import pandas as pd
 from parameterized import parameterized
 
+import streamlit as st
 from streamlit.DeltaGenerator import DeltaGenerator
 from streamlit.ReportQueue import ReportQueue
 from streamlit.proto.DataFrame_pb2 import CellStyle
 from streamlit.proto.DataFrame_pb2 import CSSStyle
+from tests import testutil
 
 
-class DataFrameStylingTest(unittest.TestCase):
+class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
     """Tests marshalling of pandas.Styler dataframe styling data
     with both st.dataframe and st.table.
     """
-
-    def setUp(self):
-        self._report_queue = ReportQueue()
-
-        def enqueue(msg):
-            self._report_queue.enqueue(msg)
-            return True
-
-        self._dg = DeltaGenerator(enqueue)
 
     @parameterized.expand([("dataframe", "data_frame"), ("table", "table")])
     def test_unstyled_has_no_style(self, element, proto):
@@ -55,7 +48,7 @@ class DataFrameStylingTest(unittest.TestCase):
 
         df = pd.DataFrame({"A": [1, 2, 3, 4, 5]})
 
-        getattr(self._dg, element)(df.style)
+        getattr(st, element)(df.style)
         proto_df = getattr(self._get_element(), proto)
 
         rows, cols = df.shape
@@ -74,7 +67,7 @@ class DataFrameStylingTest(unittest.TestCase):
 
         df = pd.DataFrame({"A": values})
 
-        get_delta = getattr(self._dg, element)
+        get_delta = getattr(st, element)
         get_delta(df.style.format("{:.2%}"))
 
         proto_df = getattr(self._get_element(), proto)
@@ -92,7 +85,7 @@ class DataFrameStylingTest(unittest.TestCase):
 
         df = pd.DataFrame({"A": values})
 
-        get_delta = getattr(self._dg, element)
+        get_delta = getattr(st, element)
         get_delta(
             df.style.highlight_max(color="yellow").applymap(
                 lambda val: "color: red" if val < 0 else "color: black"
@@ -115,7 +108,7 @@ class DataFrameStylingTest(unittest.TestCase):
             {css_s("color", "black")},
         ]
 
-        get_delta = getattr(self._dg, element)
+        get_delta = getattr(st, element)
         x = get_delta(df1.style.applymap(lambda val: "color: red"))
 
         x.add_rows(df2.style.applymap(lambda val: "color: black"))
@@ -136,7 +129,7 @@ class DataFrameStylingTest(unittest.TestCase):
             {css_s("color", "black")},
         ]
 
-        x = getattr(self._dg, element)(df1)
+        x = getattr(st, element)(df1)
         x.add_rows(df2.style.applymap(lambda val: "color: black"))
 
         proto_df = getattr(self._get_element(), proto)
@@ -155,7 +148,7 @@ class DataFrameStylingTest(unittest.TestCase):
             set(),
         ]
 
-        get_delta = getattr(self._dg, element)
+        get_delta = getattr(st, element)
         x = get_delta(df1.style.applymap(lambda val: "color: black"))
 
         x.add_rows(df2)
@@ -165,7 +158,7 @@ class DataFrameStylingTest(unittest.TestCase):
 
     def _get_element(self):
         """Returns the most recent element in the DeltaGenerator queue"""
-        return self._report_queue._queue[-1].delta.new_element
+        return self.get_delta_from_queue().new_element
 
     def _assert_column_display_values(self, proto_df, col, display_values):
         """Asserts that cells in a column have the given display_values"""

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -44,10 +44,11 @@ from streamlit.DeltaGenerator import _build_duplicate_widget_message
 from streamlit.cursor import LockedCursor
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException
-from streamlit.proto.Element_pb2 import Element
-from streamlit.proto.TextInput_pb2 import TextInput
-from streamlit.proto.TextArea_pb2 import TextArea
+from streamlit.proto.BlockPath_pb2 import BlockPath
 from streamlit.proto.Delta_pb2 import Delta
+from streamlit.proto.Element_pb2 import Element
+from streamlit.proto.TextArea_pb2 import TextArea
+from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.DeltaGenerator import (
     _wraps_with_cleaned_sig,
     _remove_self_from_sig,
@@ -284,7 +285,7 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
         new_dg = dg._enqueue_new_element_delta(enqueue_fn, None)
         self.assertEqual(dg, new_dg)
 
-    @parameterized.expand([("main"), ("sidebar")])
+    @parameterized.expand([(BlockPath.MAIN,), (BlockPath.SIDEBAR,)])
     def test_enqueue_new_element_delta(self, container):
         dg = DeltaGenerator(container=container)
         self.assertEqual(0, dg._cursor.index)
@@ -299,7 +300,7 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
         def marshall_element(element):
             fake_dg.fake_text(element, test_data)
 
-        new_dg = dg._enqueue_new_element_delta(marshall_element, "fake")
+        new_dg = dg._enqueue_new_element_delta(marshall_element, None)
         self.assertNotEqual(dg, new_dg)
         self.assertEqual(1, dg._cursor.index)
         self.assertEqual(container, new_dg._container)
@@ -321,7 +322,7 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
         def marshall_element(element):
             fake_dg.fake_text(element, test_data)
 
-        new_dg = dg._enqueue_new_element_delta(marshall_element, "fake")
+        new_dg = dg._enqueue_new_element_delta(marshall_element, None)
         self.assertEqual(dg._cursor, new_dg._cursor)
 
         msg = self.get_message_from_queue()

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -39,14 +39,15 @@ from parameterized import parameterized
 
 import pandas as pd
 
+from streamlit.DeltaGenerator import DeltaGenerator
 from streamlit.DeltaGenerator import _build_duplicate_widget_message
+from streamlit.cursor import LockedCursor
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.proto.TextArea_pb2 import TextArea
 from streamlit.proto.Delta_pb2 import Delta
-from streamlit.proto.BlockPath_pb2 import BlockPath
 from streamlit.DeltaGenerator import (
     _wraps_with_cleaned_sig,
     _remove_self_from_sig,
@@ -77,7 +78,7 @@ class FakeDeltaGenerator(object):
 
         def wrapper(*args, **kwargs):
             if name in streamlit_methods:
-                if self._container == BlockPath.SIDEBAR:
+                if self._container == "sidebar":
                     message = (
                         "Method `%(name)s()` does not exist for "
                         "`st.sidebar`. Did you mean `st.%(name)s()`?" % {"name": name}
@@ -155,8 +156,8 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(
             str(ctx.exception),
-            "Method `write()` does not exist for `DeltaGenerator`"
-            " objects. Did you mean `st.write()`?",
+            "Method `write()` does not exist for `st.sidebar`. "
+            "Did you mean `st.write()`?",
         )
 
     def test_wraps_with_cleaned_sig(self):
@@ -263,31 +264,30 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
 class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
     """Test DeltaGenerator Class."""
 
-    def setUp(self):
-        super(DeltaGeneratorClassTest, self).setUp(override_root=False)
-
     def test_constructor(self):
         """Test default DeltaGenerator()."""
-        dg = self.new_delta_generator()
-        self.assertTrue(dg._is_root)
-        self.assertEqual(dg._id, 0)
+        dg = DeltaGenerator()
+        self.assertFalse(dg._cursor.is_locked)
+        self.assertEqual(dg._cursor.index, 0)
 
     def test_constructor_with_id(self):
         """Test DeltaGenerator() with an id."""
-        dg = self.new_delta_generator(id=1234, is_root=False)
-        self.assertFalse(dg._is_root)
-        self.assertEqual(dg._id, 1234)
+        cursor = LockedCursor(index=1234)
+        dg = DeltaGenerator(cursor=cursor)
+        self.assertTrue(dg._cursor.is_locked)
+        self.assertEqual(dg._cursor.index, 1234)
 
     def test_enqueue_new_element_delta_null(self):
         # Test "Null" Delta generators
-        dg = self.new_delta_generator(None)
-        new_dg = dg._enqueue_new_element_delta(None, None)
+        dg = DeltaGenerator(container=None)
+        enqueue_fn = lambda x: None
+        new_dg = dg._enqueue_new_element_delta(enqueue_fn, None)
         self.assertEqual(dg, new_dg)
 
-    @parameterized.expand([(BlockPath.MAIN,), (BlockPath.SIDEBAR,)])
+    @parameterized.expand([("main"), ("sidebar")])
     def test_enqueue_new_element_delta(self, container):
-        dg = self.new_delta_generator(container=container)
-        self.assertEqual(0, dg._id)
+        dg = DeltaGenerator(container=container)
+        self.assertEqual(0, dg._cursor.index)
         self.assertEqual(container, dg._container)
 
         test_data = "some test data"
@@ -301,15 +301,16 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
 
         new_dg = dg._enqueue_new_element_delta(marshall_element, "fake")
         self.assertNotEqual(dg, new_dg)
-        self.assertEqual(1, dg._id)
+        self.assertEqual(1, dg._cursor.index)
         self.assertEqual(container, new_dg._container)
 
         element = self.get_delta_from_queue().new_element
         self.assertEqual(element.text.body, test_data)
 
     def test_enqueue_new_element_delta_same_id(self):
-        dg = self.new_delta_generator(id=123, is_root=False)
-        self.assertEqual(123, dg._id)
+        cursor = LockedCursor(index=123)
+        dg = DeltaGenerator(cursor=cursor)
+        self.assertEqual(123, dg._cursor.index)
 
         test_data = "some test data"
         # Use FakeDeltaGenerator.fake_text cause if we use
@@ -321,7 +322,7 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
             fake_dg.fake_text(element, test_data)
 
         new_dg = dg._enqueue_new_element_delta(marshall_element, "fake")
-        self.assertEqual(dg, new_dg)
+        self.assertEqual(dg._cursor, new_dg._cursor)
 
         msg = self.get_message_from_queue()
         self.assertEqual(123, msg.metadata.delta_id)
@@ -496,7 +497,7 @@ class DeltaGeneratorChartTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(element.datasets[0].data.data.cols[2].int64s.data[0], 20)
 
 
-class WidgetIdText(unittest.TestCase):
+class WidgetIdText(testutil.DeltaGeneratorTestCase):
     def test_ids_are_equal_when_proto_is_equal(self):
         text_input1 = TextInput()
         text_input1.label = "Label #1"
@@ -513,9 +514,9 @@ class WidgetIdText(unittest.TestCase):
         element2.text_input.CopyFrom(text_input2)
 
         _set_widget_id("text_input", element1)
-        _set_widget_id("text_input", element2)
 
-        self.assertEqual(element1.text_input.id, element2.text_input.id)
+        with self.assertRaises(DuplicateWidgetID):
+            _set_widget_id("text_input", element2)
 
     def test_ids_are_diff_when_labels_are_diff(self):
         text_input1 = TextInput()
@@ -573,9 +574,9 @@ class WidgetIdText(unittest.TestCase):
         element2.text_input.CopyFrom(text_input2)
 
         _set_widget_id("text_input", element1, user_key="some_key")
-        _set_widget_id("text_input", element2, user_key="some_key")
 
-        self.assertEqual(element1.text_input.id, element2.text_input.id)
+        with self.assertRaises(DuplicateWidgetID):
+            _set_widget_id("text_input", element2, user_key="some_key")
 
     def test_ids_are_diff_when_keys_are_diff(self):
         text_input1 = TextInput()

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -79,10 +79,10 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("audio", ds.name)
         self.assertEqual("streamlit", ds.module)
         if is_python_2:
-            self.assertEqual("<type 'function'>", ds.type)
+            self.assertEqual("<type 'instancemethod'>", ds.type)
             self.assertEqual("(data, format=u'audio/wav', start_time=0)", ds.signature)
         else:
-            self.assertEqual("<class 'function'>", ds.type)
+            self.assertEqual("<class 'method'>", ds.type)
             self.assertEqual("(data, format='audio/wav', start_time=0)", ds.signature)
         self.assertTrue(ds.doc_string.startswith("Display an audio player"))
 
@@ -94,9 +94,9 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("dataframe", ds.name)
         self.assertEqual("streamlit", ds.module)
         if is_python_2:
-            self.assertEqual("<type 'function'>", ds.type)
+            self.assertEqual("<type 'instancemethod'>", ds.type)
         else:
-            self.assertEqual("<class 'function'>", ds.type)
+            self.assertEqual("<class 'method'>", ds.type)
         self.assertEqual("(data=None, width=None, height=None)", ds.signature)
         self.assertTrue(ds.doc_string.startswith("Display a dataframe"))
 

--- a/lib/tests/streamlit/scriptrunner/ScriptRunner_test.py
+++ b/lib/tests/streamlit/scriptrunner/ScriptRunner_test.py
@@ -389,20 +389,15 @@ class TestScriptRunner(ScriptRunner):
         def enqueue_fn(msg):
             self.report_queue.enqueue(msg)
             self.maybe_handle_execution_control_request()
-            return True
 
-        self.main_dg = DeltaGenerator(enqueue=enqueue_fn, container=BlockPath.MAIN)
-        self.sidebar_dg = DeltaGenerator(
-            enqueue=enqueue_fn, container=BlockPath.SIDEBAR
-        )
         self.script_request_queue = ScriptRequestQueue()
-
         script_path = os.path.join(os.path.dirname(__file__), "test_data", script_name)
 
+        report = Report(script_path, "test command line")
+        report.enqueue = enqueue_fn
+
         super(TestScriptRunner, self).__init__(
-            report=Report(script_path, "test command line"),
-            main_dg=self.main_dg,
-            sidebar_dg=self.sidebar_dg,
+            report=report,
             widget_states=WidgetStates(),
             request_queue=self.script_request_queue,
         )
@@ -445,6 +440,10 @@ class TestScriptRunner(ScriptRunner):
             super(TestScriptRunner, self)._process_request_queue()
         except BaseException as e:
             self.script_thread_exceptions.append(e)
+
+    def _run_script(self, rerun_data):
+        self.report_queue.clear()
+        super(TestScriptRunner, self)._run_script(rerun_data)
 
     def join(self):
         """Joins the run thread, if it was started"""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -278,9 +278,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         if sys.version_info >= (3, 0):
-            self.assertEqual(el.doc_string.type, "<class 'function'>")
+            self.assertEqual(el.doc_string.type, "<class 'method'>")
         else:
-            self.assertEqual(el.doc_string.type, u"<type 'function'>")
+            self.assertEqual(el.doc_string.type, u"<type 'instancemethod'>")
         self.assertEqual(el.doc_string.signature, "(body)")
 
     def test_st_image_PIL_image(self):

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -22,6 +22,8 @@ from streamlit.DeltaGenerator import DeltaGenerator
 from streamlit.ReportQueue import ReportQueue
 from streamlit.ReportThread import REPORT_CONTEXT_ATTR_NAME
 from streamlit.ReportThread import ReportContext
+from streamlit.ReportThread import add_report_ctx
+from streamlit.ReportThread import get_report_ctx
 from streamlit.ReportThread import _WidgetIDSet
 from streamlit.widgets import Widgets
 from streamlit.proto.BlockPath_pb2 import BlockPath
@@ -53,16 +55,16 @@ def build_mock_config_is_manually_set(overrides_dict):
 class DeltaGeneratorTestCase(unittest.TestCase):
     def setUp(self, override_root=True):
         self.report_queue = ReportQueue()
+        self.override_root = override_root
+        self.orig_report_ctx = None
 
-        if override_root:
-            main_dg = self.new_delta_generator()
-            sidebar_dg = self.new_delta_generator(container=BlockPath.SIDEBAR)
-            setattr(
+        if self.override_root:
+            self.orig_report_ctx = get_report_ctx()
+            add_report_ctx(
                 threading.current_thread(),
-                REPORT_CONTEXT_ATTR_NAME,
                 ReportContext(
-                    main_dg=main_dg,
-                    sidebar_dg=sidebar_dg,
+                    cursors={},
+                    enqueue=self.report_queue.enqueue,
                     widgets=Widgets(),
                     widget_ids_this_run=_WidgetIDSet(),
                     uploaded_file_mgr=UploadedFileManager(),
@@ -71,23 +73,8 @@ class DeltaGeneratorTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.report_queue._clear()
-        if hasattr(threading.current_thread(), REPORT_CONTEXT_ATTR_NAME):
-            delattr(threading.current_thread(), REPORT_CONTEXT_ATTR_NAME)
-
-    def new_delta_generator(self, *args, **kwargs):
-        def enqueue_fn(msg):
-            self.report_queue.enqueue(msg)
-            return True
-
-        if len(args) > 0:
-            enqueue = args[0]
-            args = args[1:]
-        elif "enqueue" in kwargs:
-            enqueue = kwargs.pop("enqueue")
-        else:
-            enqueue = enqueue_fn
-
-        return DeltaGenerator(enqueue, *args, **kwargs)
+        if self.override_root:
+            add_report_ctx(threading.current_thread(), self.orig_report_ctx)
 
     def get_message_from_queue(self, index=-1):
         """Get a ForwardMsg proto from the queue, by index.
@@ -105,4 +92,10 @@ class DeltaGeneratorTestCase(unittest.TestCase):
         -------
         Delta
         """
-        return self.report_queue._queue[index].delta
+        # return self.report_queue._queue[index].delta
+        deltas = self.get_all_deltas_from_queue()
+        return deltas[index]
+
+    def get_all_deltas_from_queue(self):
+        """Return all the delta messages in our ReportQueue"""
+        return [msg.delta for msg in self.report_queue._queue if msg.HasField("delta")]

--- a/proto/streamlit/proto/BlockPath.proto
+++ b/proto/streamlit/proto/BlockPath.proto
@@ -18,8 +18,9 @@ syntax = "proto3";
 
 message BlockPath {
   enum Container {
-    MAIN = 0;
-    SIDEBAR = 1;
+    UNUSED = 0;
+    MAIN = 1;
+    SIDEBAR = 2;
   }
 
   // Top level container of the block.


### PR DESCRIPTION
(See https://discuss.streamlit.io/t/crosstalk-between-streamlit-sessions-with-multiple-users/319)

The important changes are all in this one commit: https://github.com/streamlit/streamlit/pull/1015/commits/74eb96af0b2ecbe61b6631bd97960caa18a17b78

The other files are just me fixing tests.

The problem was due to `st.sidebar` actually being a shared object between all sessions. And that shared object contained state that shouldn't be shared (i.e. the `enqueue` function, the current index, etc). 

The bug didn't happen with non-sidebar `st.foo` methods because those didn't have a shared DeltaGenerator. Instead, they used the `_with_dg` wrapper which fetched the correct DeltaGenerator from the ThreadContext.

So the way I fixed this was to make that behavior a 1st-class citizen. That is:
1. DeltaGenerators no longer contain a reference to the `enqueue()` function for the current thread. Instead, they always fetch the `enqueue()` function from the ThreadContext. (See bottom of DeltaGenerator.py)
2. Root DeltaGenerators also don't hold any session-specific information anymore! Instead, that information now lives in a separate class called Cursor, which is _also_ stored in the ThreadContext. (However, the DeltaGenerators returned by `st.foo` methods _do_ still hold session-specific data by having references to their own Cursors. But that's OK because those DGs are never shared between sessions)
3. Because of (1) and (2), both the "main" and "sidebar" DeltaGenerators in `__init__.py` can now be shared among all threads! So we just create them a single time and never need to touch them again. And we also don't need the annoying `_with_dg` wrapper.