### PR TITLE
wrapping emoji within span

### DIFF
--- a/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.tsx
+++ b/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.tsx
@@ -56,7 +56,7 @@ class VideoRecordedDialog extends PureComponent<Props> {
               <p>Preview your video below:</p>
               <video src={videoSource} controls />
             </div>
-            <div className="third-column first-step"></div>
+            <div className="third-column first-step" />
 
             <div className="first-column second-step">Step 2 →</div>
             <div className="second-column second-step">
@@ -80,7 +80,10 @@ class VideoRecordedDialog extends PureComponent<Props> {
             <div className="first-column third-step">Step 3 →</div>
             <div className="second-column third-step">
               Share it with the world on Twitter, LinkedIn, YouTube, or just
-              plain email! 😀
+              plain email!{" "}
+              <span role="img" aria-label="Happy">
+                😀
+              </span>
             </div>
           </div>
         </ModalBody>


### PR DESCRIPTION
**Issue:** Emojis should be wrapped in `<span>`, have role=“img”, and have an accessible description with `aria-label` or `aria-labelledby` jsx-a11y/accessible-emoji

**Description:** Wrapping emoji

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
