### PR TITLE
Allow disabling ForwardMsgCache from command line

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -296,7 +296,7 @@ _create_option(
         this minimum.""",
     visibility="hidden",
     default_val=10 * 1e3,
-    type_=int,
+    type_=float,
 )  # 10k
 
 _create_option(


### PR DESCRIPTION
This allows `streamlit run --global.minCachedMessageSize inf app.py`. Our config.toml accepts `inf` as a value, but streamlit run refuses to run with this value because `inf` is not a valid `int` value.

(Setting `minCachedMessageSize = inf` effectively disables the ForwardMsgCache.)