### PR TITLE
Set a classname prefix for atomic styletron css classes

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -24,7 +24,7 @@ import { LightTheme, BaseProvider } from "baseui"
 import { Provider as StyletronProvider } from "styletron-react"
 import { SCSS_VARS } from "autogen/scssVariables"
 
-const engine = new Styletron()
+const engine = new Styletron({ prefix: "st-" })
 const popupZIndex = Number(SCSS_VARS["$z-index-popup-menu"])
 
 ReactDOM.render(


### PR DESCRIPTION
Issue #365 

Fixes a css conflict between the Plotly Choroplet map and the Baseweb Slider

