### PR TITLE
Custom hashing logic for numpy.ufunc types

### DIFF
--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -365,9 +365,7 @@ class CodeHasher:
                 self._update(h, obj.shape)
 
                 if obj.size >= NP_SIZE_LARGE:
-                    import numpy as np
-
-                    state = np.random.RandomState(0)
+                    state = numpy.random.RandomState(0)
                     obj = state.choice(obj.flat, size=NP_SAMPLE_SIZE)
 
                 self._update(h, obj.tobytes())
@@ -387,6 +385,8 @@ class CodeHasher:
                 self._update(h, obj.tell())
                 return h.digest()
             elif isinstance(obj, numpy.ufunc):
+                # For object of type numpy.ufunc returns ufunc:<object name>
+                # For example, for numpy.remainder, this is ufunc:remainder
                 return f"{obj.__class__.__name__}:{obj.__name__}".encode()
             elif inspect.isroutine(obj):
                 if hasattr(obj, "__wrapped__"):

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -31,6 +31,8 @@ import textwrap
 import tempfile
 import threading
 
+import numpy
+
 import streamlit as st
 from streamlit import compatibility
 from streamlit import config
@@ -384,6 +386,8 @@ class CodeHasher:
                 self._update(h, os.path.getmtime(obj.name))
                 self._update(h, obj.tell())
                 return h.digest()
+            elif isinstance(obj, numpy.ufunc):
+                return f"{obj.__class__.__name__}:{obj.__name__}".encode()
             elif inspect.isroutine(obj):
                 if hasattr(obj, "__wrapped__"):
                     # Ignore the wrapper of wrapped functions.

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -710,3 +710,21 @@ class CodeHashTest(unittest.TestCase):
         self.assertEqual(
             get_hash(f, hash_funcs=hash_funcs), get_hash(g, hash_funcs=hash_funcs)
         )
+
+    def test_ufunc(self):
+        """Test code that references numpy ufuncs."""
+
+        def f(a, b):
+            return np.logical_and(a, b)
+
+        def g(a, b):
+            return np.logical_and(a, b)
+
+        def h(a, b):
+            return np.remainder(a, b)
+
+        self.assertNotEqual(get_hash(np.remainder), get_hash(np.logical_and))
+        self.assertEqual(get_hash(np.logical_and), get_hash(np.logical_and))
+        self.assertEqual(get_hash(f), get_hash(f))
+        self.assertEqual(get_hash(f), get_hash(g))
+        self.assertNotEqual(get_hash(f), get_hash(h))

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -724,7 +724,5 @@ class CodeHashTest(unittest.TestCase):
             return np.remainder(a, b)
 
         self.assertNotEqual(get_hash(np.remainder), get_hash(np.logical_and))
-        self.assertEqual(get_hash(np.logical_and), get_hash(np.logical_and))
-        self.assertEqual(get_hash(f), get_hash(f))
         self.assertEqual(get_hash(f), get_hash(g))
         self.assertNotEqual(get_hash(f), get_hash(h))


### PR DESCRIPTION
**Issue:** #1057

**Description:** Adding custom hashing logic for `numpy.ufunc` types. Added unit test and tested manually on Udacity Demo that was broken (see #1057 for more details)
