### PR TITLE
Fix a couple Python 3.5 regressions caught in other work:

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1003,7 +1003,7 @@ class DeltaGenerator(object):
         spec=None,
         width=0,
         use_container_width=False,
-        **kwargs,
+        **kwargs
     ):
         """Display a chart using the Vega-Lite library.
 
@@ -1235,7 +1235,7 @@ class DeltaGenerator(object):
         height=0,
         use_container_width=False,
         sharing="streamlit",
-        **kwargs,
+        **kwargs
     ):
         """Display an interactive Plotly chart.
 

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -387,7 +387,7 @@ class CodeHasher:
             elif isinstance(obj, numpy.ufunc):
                 # For object of type numpy.ufunc returns ufunc:<object name>
                 # For example, for numpy.remainder, this is ufunc:remainder
-                return f"{obj.__class__.__name__}:{obj.__name__}".encode()
+                return ("%s:%s" % (obj.__class__.__name__, obj.__name__)).encode()
             elif inspect.isroutine(obj):
                 if hasattr(obj, "__wrapped__"):
                     # Ignore the wrapper of wrapped functions.


### PR DESCRIPTION
o f-strings is a 3.6 feature
o 3.5 doesn't support a trailing comma after "**kwargs" at the end of a
  function definition.

CC @nthmost @monchier 