### PR TITLE
Fix an incomplete copy for a dict that's then modified.

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -15,6 +15,7 @@
 
 """A wrapper for simple PyDeck scatter charts."""
 
+import copy
 import json
 from typing import Any, Dict
 
@@ -122,7 +123,7 @@ def to_deckgl_json(data, zoom):
             {"lon": float(row[lon_col_index]), "lat": float(row[lat_col_index])}
         )
 
-    default = dict(_DEFAULT_MAP)
+    default = copy.deepcopy(_DEFAULT_MAP)
     default["initialViewState"]["latitude"] = center_lat
     default["initialViewState"]["longitude"] = center_lon
     default["initialViewState"]["zoom"] = zoom

--- a/lib/tests/streamlit/map_test.py
+++ b/lib/tests/streamlit/map_test.py
@@ -52,6 +52,13 @@ class StMapTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.get("initialViewState").get("pitch"), 0)
         self.assertEqual(c.get("layers")[0].get("@@type"), "ScatterplotLayer")
 
+    def test_default_map_copy(self):
+        """Test that _DEFAULT_MAP is not modified as other work occurs."""
+        self.assertEqual(_DEFAULT_MAP["initialViewState"]["latitude"], 0)
+
+        st.map(df1)
+        self.assertEqual(_DEFAULT_MAP["initialViewState"]["latitude"], 0)
+
     def test_map_leak(self):
         """Test that maps don't stay in memory when you create a new blank one.
 


### PR DESCRIPTION
New test fails before the change, and passes afterwards.