### PR TITLE
Add tooltip in Altair/Vega-lite docstring code

### DIFF
--- a/docs/api-examples-source/charts.vega_lite_chart.py
+++ b/docs/api-examples-source/charts.vega_lite_chart.py
@@ -7,7 +7,7 @@ df = pd.DataFrame(np.random.randn(200, 3), columns=["a", "b", "c"])
 st.vega_lite_chart(
     df,
     {
-        "mark": "circle",
+        "mark": {"type": "circle", "tooltip": True},
         "encoding": {
             "x": {"field": "a", "type": "quantitative"},
             "y": {"field": "b", "type": "quantitative"},

--- a/docs/api-examples-source/charts.vega_lite_chart.py
+++ b/docs/api-examples-source/charts.vega_lite_chart.py
@@ -15,4 +15,5 @@ st.vega_lite_chart(
             "color": {"field": "c", "type": "quantitative"},
         },
     },
+    use_container_width=True,
 )

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1042,7 +1042,7 @@ class DeltaGenerator(object):
         ...     columns=['a', 'b', 'c'])
         >>>
         >>> st.vega_lite_chart(df, {
-        ...     'mark': 'circle',
+        ...     'mark': {'type': 'circle', 'tooltip': True},
         ...     'encoding': {
         ...         'x': {'field': 'a', 'type': 'quantitative'},
         ...         'y': {'field': 'b', 'type': 'quantitative'},
@@ -1107,7 +1107,7 @@ class DeltaGenerator(object):
         ...     columns=['a', 'b', 'c'])
         ...
         >>> c = alt.Chart(df).mark_circle().encode(
-        ...     x='a', y='b', size='c', color='c')
+        ...     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])
         >>>
         >>> st.altair_chart(c, width=-1)
 
@@ -2509,7 +2509,7 @@ class DeltaGenerator(object):
         >>> my_bar = st.progress(0)
         >>>
         >>> for percent_complete in range(100):
-        ...     time.sleep(0.1)        
+        ...     time.sleep(0.1)
         ...     my_bar.progress(percent_complete + 1)
 
         """

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1109,7 +1109,7 @@ class DeltaGenerator(object):
         >>> c = alt.Chart(df).mark_circle().encode(
         ...     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])
         >>>
-        >>> st.altair_chart(c, width=-1)
+        >>> st.altair_chart(c, use_container_width=True)
 
         .. output::
            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -342,7 +342,7 @@ def write(*args, **kwargs):
     ...     columns=['a', 'b', 'c'])
     ...
     >>> c = alt.Chart(df).mark_circle().encode(
-    ...     x='a', y='b', size='c', color='c')
+    ...     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])
     >>>
     >>> st.write(c)
 


### PR DESCRIPTION


**Issue:** fixes https://github.com/streamlit/streamlit/issues/1091

**Description:**

* every time there is a link to [this embedded Streamlit app](https://share.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5), modify the code to include the tooltip interactivity. 
    * Modifies docstring for st.write
    * Modifies docstring for st.altair_chart
    * Modifies docstring for st.vega_lite_chart
* modifies the charts.vega_lite_chart.py, which I suppose generates the embedded Streamlit app _but I'm not really sure..._
---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
