### PR TITLE
Pass --skip-lock to pipenv under pipenv-install Makefile target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup:
 .PHONY: pipenv-install
 pipenv-install: lib/Pipfile
 	@# Runs pipenv install; doesn't update the Pipfile.lock.
-	cd lib; pipenv install --dev
+	cd lib; pipenv install --dev --skip-lock
 
 .PHONY: pylint
 # Run "black", our Python formatter, to verify that our source files


### PR DESCRIPTION
By not passing this, we were violating the "doesn't update the
Pipfile.lock." comment on this Makefile target. I don't see where the
lockfile was later used, and so was most likely providing little
benefit.

Finally, invocation before this change took ~1m13s on my machine when
Pipfile.lock wasn't present, and ~33s when it was. With this change,
it's reliably ~17s.

The big question is if the lockfile was providing any value that I
missed picking up, so that's the major review question.

CC @tconkling
