### PR TITLE
Clean signatures of wrapped DeltaGenerator methods

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -72,28 +72,18 @@ def _wraps_with_cleaned_sig(wrapped, num_args_to_remove):
     num_args_to_remove). This is useful since function signatures are visible
     in our user-facing docs, and many methods in DeltaGenerator have arguments
     that users have no access to.
+
+    Note that "self" is ignored by default. So to remove both "self" and the
+    next argument you'd pass num_args_to_remove=1.
     """
     # By passing (None, ...), we're removing (arg1, ...) from *args
     args_to_remove = (None,) * num_args_to_remove
     fake_wrapped = functools.partial(wrapped, *args_to_remove)
     fake_wrapped.__doc__ = wrapped.__doc__
-
-    # These fields are used by wraps(), but in Python 2 partial() does not
-    # produce them.
-    fake_wrapped.__module__ = wrapped.__module__
     fake_wrapped.__name__ = wrapped.__name__
+    fake_wrapped.__module__ = wrapped.__module__
 
     return functools.wraps(fake_wrapped)
-
-
-def _remove_self_from_sig(method):
-    """Remove the `self` argument from `method`'s signature."""
-
-    @_wraps_with_cleaned_sig(method, 1)  # Remove self from sig.
-    def wrapped_method(self, *args, **kwargs):
-        return method(self, *args, **kwargs)
-
-    return wrapped_method
 
 
 def _with_element(method):
@@ -117,7 +107,7 @@ def _with_element(method):
 
     """
 
-    @_wraps_with_cleaned_sig(method, 2)  # Remove self and element from sig.
+    @_wraps_with_cleaned_sig(method, 1)  # Remove self and element from sig.
     def wrapped_method(dg, *args, **kwargs):
         # Warn if we're called from within an @st.cache function
         caching.maybe_show_cached_st_function_warning(dg)
@@ -803,7 +793,6 @@ class DeltaGenerator(object):
 
         exception_proto.marshall(element.exception, exception, exception_traceback)
 
-    @_remove_self_from_sig
     def dataframe(self, data=None, width=None, height=None):
         """Display a dataframe as an interactive table.
 
@@ -2515,7 +2504,7 @@ class DeltaGenerator(object):
         >>> my_bar = st.progress(0)
         >>>
         >>> for percent_complete in range(100):
-        ...     time.sleep(0.1)        
+        ...     time.sleep(0.1)
         ...     my_bar.progress(percent_complete + 1)
 
         """

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -35,9 +35,7 @@ LOGGER = get_logger(__name__)
 
 CONFUSING_STREAMLIT_MODULES = ("streamlit.DeltaGenerator", "streamlit.caching")
 
-CONFUSING_STREAMLIT_SIG_PREFIXES = (
-    "(element, ",
-)
+CONFUSING_STREAMLIT_SIG_PREFIXES = ("(element, ",)
 
 
 def marshall(proto, obj):

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -36,10 +36,7 @@ LOGGER = get_logger(__name__)
 CONFUSING_STREAMLIT_MODULES = ("streamlit.DeltaGenerator", "streamlit.caching")
 
 CONFUSING_STREAMLIT_SIG_PREFIXES = (
-    "(self, element, ",
-    "(self, _, ",
-    "(self, ",
-    "(ui_value, ",
+    "(element, ",
 )
 
 

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -160,15 +160,37 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
             "Did you mean `st.write()`?",
         )
 
-    @parameterized.expand([
-        (st.empty().empty, 'streamlit.DeltaGenerator', 'empty', '()'),
-        (st.empty().text, 'streamlit.DeltaGenerator', 'text', '(body)'),
-        (st.empty().markdown, 'streamlit.DeltaGenerator', 'markdown', '(body, unsafe_allow_html=False)'),
-        (st.empty().checkbox, 'streamlit.DeltaGenerator', 'checkbox', '(label, value=False, key=None)'),
-        (st.empty().dataframe, 'streamlit.DeltaGenerator', 'dataframe', '(data=None, width=None, height=None)'),
-        (st.empty().add_rows, 'streamlit.DeltaGenerator', 'add_rows', '(data=None, **kwargs)'),
-        (st.write, 'streamlit', 'write', '(*args, **kwargs)'),
-    ])
+    @parameterized.expand(
+        [
+            (st.empty().empty, "streamlit.DeltaGenerator", "empty", "()"),
+            (st.empty().text, "streamlit.DeltaGenerator", "text", "(body)"),
+            (
+                st.empty().markdown,
+                "streamlit.DeltaGenerator",
+                "markdown",
+                "(body, unsafe_allow_html=False)",
+            ),
+            (
+                st.empty().checkbox,
+                "streamlit.DeltaGenerator",
+                "checkbox",
+                "(label, value=False, key=None)",
+            ),
+            (
+                st.empty().dataframe,
+                "streamlit.DeltaGenerator",
+                "dataframe",
+                "(data=None, width=None, height=None)",
+            ),
+            (
+                st.empty().add_rows,
+                "streamlit.DeltaGenerator",
+                "add_rows",
+                "(data=None, **kwargs)",
+            ),
+            (st.write, "streamlit", "write", "(*args, **kwargs)"),
+        ]
+    )
     def test_function_signatures(self, func, module, name, sig):
         self.assertEqual(module, func.__module__)
         self.assertEqual(name, func.__name__)


### PR DESCRIPTION
Prior to this PR, something broke the signatures of wrapped DG methods. This was reflected in docs.streamlit.io (where things like `st.text(body)` were written as `st.text()`) and in the Python console (e.g. `help(st.text)`). It was probably broken in IDEs too.

That's because we use some magic to make our signatures cleaner, and something broke that magic. I fixed that now and added tests.