### PR TITLE
Ability to bind to a server address with server.address config option

### DIFF
--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -174,6 +174,12 @@ def _print_url():
             ("URL", Report.get_url(config.get_option("browser.serverAddress")))
         ]
 
+    elif config.is_manually_set("server.address"):
+        named_urls = [
+            ("Network URL", Report.get_url(config.get_option("server.address")))
+            ("External URL", Report.get_url(net_util.get_external_ip())),
+        ]
+
     elif config.get_option("server.headless"):
         named_urls = [
             ("Network URL", Report.get_url(net_util.get_internal_ip())),

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -148,6 +148,8 @@ def _on_server_start(server):
 
         if config.is_manually_set("browser.serverAddress"):
             addr = config.get_option("browser.serverAddress")
+        elif config.is_manually_set("server.address"):
+            addr = config.get_option("server.address")
         else:
             addr = "localhost"
 

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -176,7 +176,7 @@ def _print_url():
 
     elif config.is_manually_set("server.address"):
         named_urls = [
-            ("Network URL", Report.get_url(config.get_option("server.address")))
+            ("Network URL", Report.get_url(config.get_option("server.address"))),
             ("External URL", Report.get_url(net_util.get_external_ip())),
         ]
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -438,6 +438,16 @@ def _server_run_on_save():
     return False
 
 
+@_create_option("server.address")
+def _server_address():
+    """The Address where the server will listen for client and browser
+    connections.
+
+    Default: (unset)
+    """
+    return None
+
+
 @_create_option("server.port", type_=int)
 def _server_port():
     """The port where the server will listen for client and browser

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -440,8 +440,10 @@ def _server_run_on_save():
 
 @_create_option("server.address")
 def _server_address():
-    """The Address where the server will listen for client and browser
-    connections.
+    """The address where the server will listen for client and browser
+    connections. Use this if you want to bind the server to a specific address.
+    If set, the server will only be accessible from this address, and not from
+    any aliases (like localhost).
 
     Default: (unset)
     """
@@ -450,7 +452,7 @@ def _server_address():
 
 @_create_option("server.port", type_=int)
 def _server_port():
-    """The port where the server will listen for client and browser
+    """The port where the server will listen for browser
     connections.
 
     Default: 8501

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -118,10 +118,11 @@ def start_listening(app):
     call_count = 0
 
     while call_count < MAX_PORT_SEARCH_RETRIES:
+        address = config.get_option("server.address")
         port = config.get_option("server.port")
 
         try:
-            app.listen(port)
+            app.listen(port, address)
             break  # It worked! So let's break out of the loop.
 
         except (OSError, socket.error) as e:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -302,6 +302,7 @@ class ConfigTest(unittest.TestCase):
                 "server.fileWatcherType",
                 "server.headless",
                 "server.liveSave",
+                "server.address",
                 "server.port",
                 "server.runOnSave",
                 "server.maxUploadSize",


### PR DESCRIPTION
**Issue:** fixes https://github.com/streamlit/streamlit/issues/584

**Description:** This PR fixes the linked issue. The option server.address is added to bind the server on a specific interface. The default behaviour that the server binds to all interfaces is keep.

The corresponding unit test is added.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
