### PR TITLE
[mypy] Enable check_untyped_defs throughout the codebase.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,4 +356,4 @@ connect-circleci:
 .PHONY: flake8
 # Run flake8 and show errors: E9,F63,F7,F82
 flake8:
-	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=./frontend,./lib/build
+	scripts/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=./frontend,./lib/build

--- a/examples/interactive_widgets.py
+++ b/examples/interactive_widgets.py
@@ -66,5 +66,7 @@ st.write(w9)
 st.subheader("File Uploader")
 w10 = st.file_uploader("Upload a CSV file", type="csv")
 if w10:
+    import pandas as pd
+
     data = pd.read_csv(w10)
     st.write(data)

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -30,6 +30,7 @@ opencv-python = "*"
 requests-mock = "*"
 mypy = "==0.761"
 mypy-protobuf = ">=1.17"
+flake8 = "*"
 # IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
 # And if something is only required for testing, but not anything else, please
 # add to the dev dependencies above, instead.

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -3,13 +3,13 @@ python_version = 3.5
 cache_dir = /tmp/mypy_cache
 
 # TODO(nate): Additional strictness checks to work towards.
-# check_untyped_defs = true
+# disallow_incomplete_defs = true
 # disallow_subclassing_any = true
 # disallow_untyped_decorators = true
 
 allow_redefinition = true
+check_untyped_defs = true
 disallow_any_generics = true
-disallow_incomplete_defs = true
 implicit_reexport = false
 no_implicit_optional = true
 scripts_are_modules = true
@@ -31,5 +31,5 @@ ignore_errors = True
 [mypy-streamlit.proto.*]
 ignore_errors = True
 
-[mypy-altair,base58,blinker,bokeh.embed,botocore,boto3,chart_studio.*,cPickle,funcsigs,future.*,matplotlib,matplotlib.pyplot,numpy,pandas,PIL,pipenv.*,plotly.*,prometheus_client,pydeck,setuptools,sympy,tensorflow.*,tornado.*,tzlocal,validators,watchdog,watchdog.observers]
+[mypy-altair,base58,blinker,bokeh.embed,botocore,boto3,chart_studio.*,cPickle,flake8.main,future.*,matplotlib,matplotlib.pyplot,numpy,pandas,PIL,pipenv.*,plotly.*,prometheus_client,pydeck,pyflakes,pyflakes.checker,setuptools,sympy,tensorflow.*,tornado.*,tzlocal,validators,watchdog,watchdog.observers]
 ignore_missing_imports = true

--- a/lib/streamlit/ConfigOption.py
+++ b/lib/streamlit/ConfigOption.py
@@ -24,6 +24,7 @@ setup_2_3_shims(globals())
 import datetime
 import re
 import textwrap
+from typing import Any, Callable, Optional
 
 from streamlit.logger import get_logger
 
@@ -156,7 +157,7 @@ class ConfigOption(object):
         self.default_val = default_val
         self.deprecated = deprecated
         self.replaced_by = replaced_by
-        self._get_val_func = None
+        self._get_val_func = None  # type: Optional[Callable[[], Any]]
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
         self.type = type_
 
@@ -198,8 +199,10 @@ class ConfigOption(object):
         return self
 
     @property
-    def value(self):
+    def value(self) -> Any:
         """Get the value of this config option."""
+        if self._get_val_func is None:
+            return None
         return self._get_val_func()
 
     def set_value(self, value, where_defined=None):
@@ -271,8 +274,9 @@ class ConfigOption(object):
         return now > expiration_date
 
 
-def _parse_yyyymmdd_str(date_str):
-    return datetime.datetime(*[int(token) for token in date_str.split("-")])
+def _parse_yyyymmdd_str(date_str: str) -> datetime.datetime:
+    year, month, day = [int(token) for token in date_str.split("-", 2)]
+    return datetime.datetime(year, month, day)
 
 
 class Error(Exception):

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -80,7 +80,7 @@ def _wraps_with_cleaned_sig(wrapped, num_args_to_remove):
     args_to_remove = (None,) * num_args_to_remove
     fake_wrapped = functools.partial(wrapped, *args_to_remove)
     fake_wrapped.__doc__ = wrapped.__doc__
-    fake_wrapped.__name__ = wrapped.__name__
+    fake_wrapped.__name__ = wrapped.__name__  # type: ignore[attr-defined]
     fake_wrapped.__module__ = wrapped.__module__
 
     return functools.wraps(fake_wrapped)
@@ -606,7 +606,7 @@ class DeltaGenerator(object):
         """
         import streamlit as st
 
-        if not isinstance(body, string_types):
+        if not isinstance(body, str):
             try:
                 body = json.dumps(body, default=lambda o: str(type(o)))
             except TypeError as err:
@@ -2073,7 +2073,7 @@ class DeltaGenerator(object):
         """
         from streamlit.string_util import is_binary_string
 
-        if isinstance(type, string_types):  # noqa: F821
+        if isinstance(type, str):
             type = [type]
 
         element.file_uploader.label = label

--- a/lib/streamlit/ForwardMsgCache.py
+++ b/lib/streamlit/ForwardMsgCache.py
@@ -14,11 +14,15 @@
 # limitations under the License.
 
 import hashlib
+from typing import MutableMapping, TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+if TYPE_CHECKING:
+    from streamlit.ReportSession import ReportSession
 
 LOGGER = get_logger(__name__)
 
@@ -104,8 +108,9 @@ class ForwardMsgCache(object):
 
         def __init__(self, msg):
             self.msg = msg
-            # {ReportSession -> report_run_count}
-            self._session_report_run_counts = WeakKeyDictionary()
+            self._session_report_run_counts = (
+                WeakKeyDictionary()
+            )  # type: MutableMapping[ReportSession, int]
 
         def add_session_ref(self, session, report_run_count):
             """Adds a reference to a ReportSession that has referenced

--- a/lib/streamlit/Report.py
+++ b/lib/streamlit/Report.py
@@ -17,6 +17,7 @@ import base58
 import copy
 import os
 import uuid
+from typing import Any, Dict
 
 from streamlit import config
 from streamlit.ReportQueue import ReportQueue
@@ -90,12 +91,11 @@ class Report(object):
         # this queue and delivers its contents to the browser.
         self._browser_queue = ReportQueue()
 
-        self.report_id = None
         self.generate_new_id()
 
         self.command_line = command_line
 
-    def get_debug(self):
+    def get_debug(self) -> Dict[str, Dict[str, Any]]:
         return {"master queue": self._master_queue.get_debug()}
 
     def enqueue(self, msg):
@@ -129,10 +129,9 @@ class Report(object):
         """
         return self._browser_queue.flush()
 
-    def generate_new_id(self):
+    def generate_new_id(self) -> None:
         """Randomly generate an ID representing this report's execution."""
-        # Convert to str for Python2
-        self.report_id = str(base58.b58encode(uuid.uuid4().bytes).decode("utf-8"))
+        self.report_id = base58.b58encode(uuid.uuid4().bytes).decode()
 
     def serialize_running_report_to_files(self):
         """Return a running report as an easily-serializable list of tuples.

--- a/lib/streamlit/ScriptRequestQueue.py
+++ b/lib/streamlit/ScriptRequestQueue.py
@@ -50,7 +50,8 @@ class ScriptRequestQueue(object):
 
     def __init__(self):
         self._lock = threading.Lock()
-        self._queue = deque()
+        # TODO(nate): Switch to Deque[Tuple[ScriptRequest, Any]] when 3.6 is required.
+        self._queue = deque()  # type: ignore[var-annotated]
 
     @property
     def has_request(self):

--- a/lib/streamlit/ScriptRunner.py
+++ b/lib/streamlit/ScriptRunner.py
@@ -372,14 +372,14 @@ def _clean_problem_modules():
     if "keras" in sys.modules:
         try:
             keras = sys.modules["keras"]
-            keras.backend.clear_session()
+            keras.backend.clear_session()  # type: ignore[attr-defined]
         except:
             pass
 
     if "matplotlib.pyplot" in sys.modules:
         try:
             plt = sys.modules["matplotlib.pyplot"]
-            plt.close("all")
+            plt.close("all")  # type: ignore[attr-defined]
         except:
             pass
 

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -109,7 +109,7 @@ def _fix_tornado_crash():
         import asyncio
 
         try:
-            from asyncio import (
+            from asyncio import (  # type: ignore[attr-defined]
                 WindowsProactorEventLoopPolicy,
                 WindowsSelectorEventLoopPolicy,
             )

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -26,6 +26,8 @@ setup_2_3_shims(globals())
 from streamlit import config as _config
 
 import os
+from typing import Optional
+
 import click
 
 import streamlit
@@ -76,7 +78,7 @@ def _convert_config_option_to_click_option(config_option):
 
 def configurator_options(func):
     """Decorator that adds config param keys to click dynamically."""
-    for _, value in reversed(_config._config_options.items()):
+    for _, value in reversed(_config._config_options.items()):  # type: ignore[call-overload]
         parsed_parameter = _convert_config_option_to_click_option(value)
         config_option = click.option(
             parsed_parameter["option"],
@@ -236,10 +238,13 @@ def main_run(target, args=None, **kwargs):
 
 
 # Utility function to compute the command line as a string
-def _get_command_line_as_string():
+def _get_command_line_as_string() -> Optional[str]:
     import subprocess
 
-    cmd_line_as_list = [click.get_current_context().parent.command_path]
+    parent = click.get_current_context().parent
+    if parent is None:
+        return None
+    cmd_line_as_list = [parent.command_path]
     cmd_line_as_list.extend(click.get_os_args())
     return subprocess.list2cmdline(cmd_line_as_list)
 
@@ -258,26 +263,6 @@ def _main_run(file, args=[]):
         click.echo(NEW_VERSION_TEXT)
 
     bootstrap.run(file, command_line, args)
-
-
-# DEPRECATED
-
-# TODO: Remove after 2019-09-01
-@main.command("clear_cache", deprecated=True, hidden=True)
-@click.pass_context
-def main_clear_cache(ctx):
-    """Deprecated."""
-    click.echo(click.style('Use "cache clear" instead.', fg="red"))
-    ctx.invoke(cache_clear)
-
-
-# TODO: Remove after 2019-09-01
-@main.command("show_config", deprecated=True, hidden=True)
-@click.pass_context
-def main_show_config(ctx):
-    """Deprecated."""
-    click.echo(click.style('Use "config show" instead.', fg="red"))
-    ctx.invoke(config_show)
 
 
 # SUBCOMMAND: cache

--- a/lib/streamlit/compatibility.py
+++ b/lib/streamlit/compatibility.py
@@ -41,14 +41,12 @@ def setup_2_3_shims(caller_globals):
         caller_globals["string_types"] = (type(""),)
         caller_globals["native_dict"] = _dict
     else:
-        # These are the symbols we will export to the calling package.
-        export_symbols = []
-
         # Override basic types.
         native_dict = _dict
         from builtins import range, map, str, dict, object, zip, int
 
-        export_symbols += [
+        # These are the symbols we will export to the calling package.
+        export_symbols = [
             "range",
             "map",
             "str",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -17,6 +17,7 @@
 
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
+
 from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
@@ -51,6 +52,7 @@ _section_descriptions = collections.OrderedDict(
 
 # Stores the config options as key value pairs in an ordered dict to be able
 # to show the config params help in the same order they were included.
+# TODO(nate): Change type annotation to OrderedDict once Python 3.7 is required.
 _config_options = collections.OrderedDict()  # type: Dict[str, ConfigOption]
 
 # Makes sure we only parse the config file once.
@@ -828,7 +830,7 @@ def _maybe_read_env_variable(value):
         variable.
 
     """
-    if isinstance(value, string_types) and value.startswith("env:"):  # noqa F821
+    if isinstance(value, str) and value.startswith("env:"):
         var_name = value[len("env:") :]
         env_var = os.environ.get(var_name)
 

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional, Tuple
+
 from streamlit.ReportThread import get_report_ctx
 
 
@@ -37,6 +39,11 @@ class AbstractCursor(object):
     get_locked_cursor() on that element's respective AbstractCursor.
     """
 
+    def __init__(self):
+        self._is_locked = False
+        self._index = None  # type: Optional[int]
+        self._path = ()  # type: Tuple[int, ...]
+
     @property
     def index(self):
         return self._index
@@ -54,7 +61,7 @@ class AbstractCursor(object):
 
 
 class RunningCursor(AbstractCursor):
-    def __init__(self, path=()):
+    def __init__(self, path: Tuple[int, ...] = ()):
         """A moving pointer to a location in the app.
 
         RunningCursors auto-increment to the next available location when you
@@ -68,7 +75,7 @@ class RunningCursor(AbstractCursor):
 
         """
         self._is_locked = False
-        self._index = 0
+        self._index = 0  # type: int
         self._path = path
 
     def get_locked_cursor(self, **props):
@@ -80,7 +87,9 @@ class RunningCursor(AbstractCursor):
 
 
 class LockedCursor(AbstractCursor):
-    def __init__(self, path=(), index=None, **props):
+    def __init__(
+        self, path: Tuple[int, ...] = (), index: Optional[int] = None, **props
+    ):
         """A locked pointer to a location in the app.
 
         LockedCursors always point to the same location, even when you call

--- a/lib/streamlit/elements/deck_gl.py
+++ b/lib/streamlit/elements/deck_gl.py
@@ -17,11 +17,13 @@
 
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
+
 from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
 import json
+from typing import Any, List
 
 from streamlit import case_converters
 import streamlit.elements.lib.dicttools as dicttools
@@ -37,14 +39,7 @@ def marshall(proto, spec=None, **kwargs):
 
     See DeltaGenerator.deck_gl_chart for docs.
     """
-    if "data" in kwargs:
-        # TODO: Remove this check after 2019-11-28.
-        raise Exception(
-            "The `data` parameter is deprecated. Use `st.map` or"
-            "specify a spec dict in `st.deck_gl_chart`."
-        )
-
-    data = []
+    data = []  # type: List[Any]
 
     if spec is None:
         spec = dict()

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -17,16 +17,12 @@
 
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
+
 from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
 import inspect
-
-try:
-    import funcsigs
-except ImportError:
-    pass
 
 from streamlit.logger import get_logger
 
@@ -103,21 +99,8 @@ def _get_signature(f):
 
     sig = ""
 
-    get_signature = None
-
-    # Python 3.3+
-    if hasattr(inspect, "signature"):
-        get_signature = inspect.signature
-    else:
-        try:
-            get_signature = funcsigs.signature
-        except NameError:
-            # Funcsigs doesn't exist.
-            get_signature = lambda x: ""
-            pass
-
     try:
-        sig = str(get_signature(f))
+        sig = str(inspect.signature(f))
     except ValueError:
         # f is a builtin.
         pass

--- a/lib/streamlit/elements/exception_proto.py
+++ b/lib/streamlit/elements/exception_proto.py
@@ -16,6 +16,7 @@
 import os
 import sys
 import traceback
+from typing import Optional
 
 import streamlit
 from streamlit.errors import StreamlitAPIException, MarkdownFormattedException
@@ -175,6 +176,7 @@ def _get_stack_trace(
 
     """
     # Get and extract the traceback for the exception.
+    extracted_traceback = None  # type: Optional[traceback.StackSummary]
     if exception_traceback is not None:
         extracted_traceback = traceback.extract_tb(exception_traceback)
     elif hasattr(exception, "__traceback__"):
@@ -198,11 +200,13 @@ def _get_stack_trace(
         ]
     else:
         if strip_streamlit_stack_entries:
-            extracted_traceback = [
+            extracted_frames = [
                 frame
                 for frame in extracted_traceback
                 if not _is_in_streamlit_package(_get_stackframe_filename(frame))
             ]
-        stack_trace = traceback.format_list(extracted_traceback)
+            stack_trace = traceback.format_list(extracted_frames)
+        else:
+            stack_trace = traceback.format_list(extracted_traceback)
 
     return stack_trace

--- a/lib/streamlit/elements/lib/dicttools.py
+++ b/lib/streamlit/elements/lib/dicttools.py
@@ -17,9 +17,12 @@
 
 # Python 2/3 compatibility
 from __future__ import print_function, division, unicode_literals, absolute_import
+
 from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
+
+from typing import Any, Dict, Optional
 
 
 def _unflatten_single_dict(flat_dict):
@@ -59,11 +62,11 @@ def _unflatten_single_dict(flat_dict):
         A tree made of dicts inside of dicts.
 
     """
-    out = dict()
+    out = dict()  # type: Dict[str, Any]
     for pathstr, v in flat_dict.items():
         path = pathstr.split("_")
 
-        prev_dict = None
+        prev_dict = None  # type: Optional[Dict[str, Any]]
         curr_dict = out
 
         for k in path:
@@ -72,7 +75,8 @@ def _unflatten_single_dict(flat_dict):
             prev_dict = curr_dict
             curr_dict = curr_dict[k]
 
-        prev_dict[k] = v
+        if prev_dict is not None:
+            prev_dict[k] = v
 
     return out
 
@@ -122,17 +126,11 @@ def unflatten(flat_dict, encodings=None):
 
     for k, v in list(out_dict.items()):
         # Unflatten child dicts:
-        if type(v) in (
-            dict,
-            native_dict,
-        ):  # noqa: F821 pylint:disable=undefined-variable
+        if isinstance(v, dict):
             v = unflatten(v, encodings)
         elif hasattr(v, "__iter__"):
             for i, child in enumerate(v):
-                if type(child) in (
-                    dict,
-                    native_dict,
-                ):  # noqa: F821 pylint:disable=undefined-variable
+                if isinstance(child, dict):
                     v[i] = unflatten(child, encodings)
 
         # Move items into 'encoding' if needed:

--- a/lib/streamlit/elements/media_proto.py
+++ b/lib/streamlit/elements/media_proto.py
@@ -23,6 +23,7 @@ import re
 
 from validators import url
 
+from streamlit import type_util
 from streamlit.proto import Video_pb2
 from streamlit.MediaFileManager import media_file_manager
 
@@ -73,7 +74,7 @@ def _marshall_av_media(proto, data, mimetype):
     """
     # Audio and Video methods have already checked if this is a URL by this point.
 
-    if isinstance(data, string_types):
+    if isinstance(data, str):
         # Assume it's a filename or blank.  Allow OS-based file errors.
         with open(data, "rb") as fh:
             this_file = media_file_manager.add(fh.read(), mimetype)
@@ -90,7 +91,7 @@ def _marshall_av_media(proto, data, mimetype):
     elif isinstance(data, io.BytesIO):
         data.seek(0)
         data = data.getvalue()
-    elif isinstance(data, io.IOBase):
+    elif isinstance(data, io.RawIOBase):
         data.seek(0)
         data = data.read()
     elif type_util.is_type(data, "numpy.ndarray"):
@@ -126,7 +127,7 @@ def marshall_video(proto, data, mimetype="video/mp4", start_time=0):
     # "type" distinguishes between YouTube and non-YouTube links
     proto.type = Video_pb2.Video.Type.NATIVE
 
-    if isinstance(data, string_types) and url(data):  # noqa: F821
+    if isinstance(data, str) and url(data):
         youtube_url = _reshape_youtube_url(data)
         if youtube_url:
             proto.url = youtube_url
@@ -158,7 +159,7 @@ def marshall_audio(proto, data, mimetype="audio/wav", start_time=0):
 
     proto.start_time = start_time
 
-    if isinstance(data, string_types) and url(data):  # noqa: F821
+    if isinstance(data, str) and url(data):
         proto.url = data
 
     else:

--- a/lib/streamlit/elements/vega_lite.py
+++ b/lib/streamlit/elements/vega_lite.py
@@ -38,9 +38,7 @@ def marshall(proto, data=None, spec=None, use_container_width=False, **kwargs):
     """
     # Support passing data inside spec['datasets'] and spec['data'].
     # (The data gets pulled out of the spec dict later on.)
-    if (
-        type(data) in dict_types and spec is None
-    ):  # noqa: F821 pylint:disable=undefined-variable
+    if isinstance(data, dict) and spec is None:
         spec = data
         data = None
 
@@ -84,9 +82,7 @@ def marshall(proto, data=None, spec=None, use_container_width=False, **kwargs):
     if "data" in spec:
         data_spec = spec["data"]
 
-        if (
-            type(data_spec) in dict_types
-        ):  # noqa: F821 pylint:disable=undefined-variable
+        if isinstance(data_spec, dict):
             if "values" in data_spec:
                 data = data_spec["values"]
                 del data_spec["values"]

--- a/lib/streamlit/hashing_py3.py
+++ b/lib/streamlit/hashing_py3.py
@@ -20,6 +20,8 @@ import dis
 import importlib
 import inspect
 import textwrap
+import types
+from typing import Optional, Union
 
 from streamlit.errors import UserHashError
 
@@ -67,7 +69,8 @@ def _get_failing_lines(code, lineno):
 
 
 def get_referenced_objects(code, context):
-    tos = None  # top of the stack
+    # tos = Top of the stack.
+    tos = None  # type: Optional[Union[str, types.ModuleType]]
     lineno = None
     refs = []
 

--- a/lib/streamlit/js_number.py
+++ b/lib/streamlit/js_number.py
@@ -20,6 +20,7 @@ from streamlit.compatibility import setup_2_3_shims
 setup_2_3_shims(globals())
 
 import numbers
+from typing import Optional, Union
 
 
 class JSNumberBoundsException(Exception):
@@ -49,7 +50,7 @@ class JSNumber(object):
     MIN_NEGATIVE_VALUE = -MAX_VALUE
 
     @classmethod
-    def validate_int_bounds(cls, value, value_name=None):
+    def validate_int_bounds(cls, value: int, value_name: Optional[str] = None) -> None:
         """Validate that an int value can be represented with perfect precision
         by a JavaScript Number.
 
@@ -72,7 +73,7 @@ class JSNumber(object):
 
         if not isinstance(value, numbers.Integral):
             raise JSNumberBoundsException("%s (%s) is not an int" % (value_name, value))
-        elif value < cls.MIN_SAFE_INTEGER:
+        elif value < cls.MIN_SAFE_INTEGER:  # type: ignore[misc]
             raise JSNumberBoundsException(
                 "%s (%s) must be >= -((1 << 53) - 1)" % (value_name, value)
             )
@@ -82,7 +83,9 @@ class JSNumber(object):
             )
 
     @classmethod
-    def validate_float_bounds(cls, value, value_name):
+    def validate_float_bounds(
+        cls, value: Union[int, float], value_name: Optional[str]
+    ) -> None:
         """Validate that a float value can be represented by a JavaScript Number.
 
         Parameters

--- a/lib/streamlit/magic.py
+++ b/lib/streamlit/magic.py
@@ -179,6 +179,6 @@ def _get_st_write_from_expr(node, i, parent_type):
 
 def _is_docstring_node(node):
     if sys.version_info >= (3, 8, 0):
-        return type(node) is ast.Constant and type(node.value) is str
+        return type(node) is ast.Constant and type(node.value) is str  # type: ignore[attr-defined]
     else:
         return type(node) is ast.Str

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -21,6 +21,7 @@ import errno
 import traceback
 import click
 from enum import Enum
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 import tornado.concurrent
 import tornado.gen
@@ -30,6 +31,7 @@ import tornado.websocket
 
 from streamlit import config
 from streamlit import file_util
+from streamlit.ConfigOption import ConfigOption
 from streamlit.ForwardMsgCache import ForwardMsgCache
 from streamlit.ForwardMsgCache import create_reference_msg
 from streamlit.ForwardMsgCache import populate_hash_if_needed
@@ -49,6 +51,9 @@ from streamlit.server.server_util import is_cacheable_msg
 from streamlit.server.server_util import is_url_from_allowed_origins
 from streamlit.server.server_util import make_url_path_regex
 from streamlit.server.server_util import serialize_forward_msg
+
+if TYPE_CHECKING:
+    from streamlit.Report import Report
 
 LOGGER = get_logger(__name__)
 
@@ -143,7 +148,7 @@ def start_listening(app):
                         port += 1
 
                     config._set_option(
-                        "server.port", port, config.ConfigOption.STREAMLIT_DEFINITION
+                        "server.port", port, ConfigOption.STREAMLIT_DEFINITION
                     )
                     call_count += 1
             else:
@@ -160,7 +165,7 @@ def start_listening(app):
 
 class Server(object):
 
-    _singleton = None
+    _singleton = None  # type: Optional[Server]
 
     @classmethod
     def get_current(cls):
@@ -198,6 +203,7 @@ class Server(object):
         self._state = None
         self._set_state(State.INITIAL)
         self._message_cache = ForwardMsgCache()
+        self._report = None  # type: Optional[Report]
 
     def start(self, on_started):
         """Start the server.
@@ -223,8 +229,10 @@ class Server(object):
 
         self._ioloop.spawn_callback(self._loop_coroutine, on_started)
 
-    def get_debug(self):
-        return {"report": self._report.get_debug()}
+    def get_debug(self) -> Dict[str, Dict[str, Any]]:
+        if self._report:
+            return {"report": self._report.get_debug()}
+        return {}
 
     def _create_app(self):
         """Create our tornado web app.
@@ -506,11 +514,16 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
         self._session = self._server._create_report_session(self)
 
     def on_close(self):
+        if not self._session:
+            return
         self._server._close_report_session(self._session.id)
         self._session = None
 
     @tornado.gen.coroutine
     def on_message(self, payload):
+        if not self._session:
+            return
+
         msg = BackMsg()
 
         try:

--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -15,6 +15,8 @@
 
 """Server related utility functions"""
 
+from typing import Callable, List, Optional, Union
+
 from streamlit import config
 from streamlit import net_util
 from streamlit import type_util
@@ -111,7 +113,7 @@ def is_url_from_allowed_origins(url):
 
     hostname = url_util.get_hostname(url)
 
-    allowed_domains = [
+    allowed_domains = [  # List[Union[str, Callable[[], Optional[str]]]]
         # Check localhost first.
         "localhost",
         "0.0.0.0",
@@ -127,7 +129,7 @@ def is_url_from_allowed_origins(url):
     ]
 
     for allowed_domain in allowed_domains:
-        if type_util.is_function(allowed_domain):
+        if callable(allowed_domain):
             allowed_domain = allowed_domain()
 
         if allowed_domain is None:
@@ -139,14 +141,16 @@ def is_url_from_allowed_origins(url):
     return False
 
 
-def _get_server_address_if_manually_set():
+def _get_server_address_if_manually_set() -> Optional[str]:
     if config.is_manually_set("browser.serverAddress"):
         return url_util.get_hostname(config.get_option("browser.serverAddress"))
+    return None
 
 
-def _get_s3_url_host_if_manually_set():
+def _get_s3_url_host_if_manually_set() -> Optional[str]:
     if config.is_manually_set("s3.url"):
         return url_util.get_hostname(config.get_option("s3.url"))
+    return None
 
 
 def make_url_path_regex(*path, **kwargs):

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -51,9 +51,7 @@ def is_type(obj, fqn_type_pattern):
     module = the_type.__module__
     name = the_type.__name__
     actual_fqn = "%s.%s" % (module, name)
-    if isinstance(
-        fqn_type_pattern, string_types
-    ):  # noqa: F821 pylint:disable=undefined-variable
+    if isinstance(fqn_type_pattern, str):
         return fqn_type_pattern == actual_fqn
     else:
         return fqn_type_pattern.match(actual_fqn) is not None
@@ -75,7 +73,6 @@ _DATAFRAME_LIKE_TYPES = (
 
 _DATAFRAME_COMPATIBLE_TYPES = (
     dict,
-    type({}),  # For Python 2. See dict_types in compatibility.py.
     list,
     type(None),
 )  # type: Tuple[type, ...]
@@ -154,7 +151,7 @@ def _is_list_of_plotly_objs(obj):
 
 
 def _is_probably_plotly_dict(obj):
-    if type(obj) not in dict_types:  # noqa: F821 pylint:disable=undefined-variable
+    if not isinstance(obj, dict):
         return False
 
     if len(obj.keys()) == 0:

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -19,9 +19,9 @@ from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
 
-# flake8: noqa
 import re
 import urllib
+from typing import Optional
 
 # Regular expression for process_gitblob_url
 _GITBLOB_RE = re.compile(
@@ -32,7 +32,7 @@ _GITBLOB_RE = re.compile(
 )
 
 
-def process_gitblob_url(url):
+def process_gitblob_url(url: str) -> str:
     """Check url to see if it describes a GitHub Gist "blob" URL.
 
     If so, returns a new URL to get the "raw" script.
@@ -57,7 +57,7 @@ def process_gitblob_url(url):
     return url
 
 
-def get_hostname(url):
+def get_hostname(url: str) -> Optional[str]:
     """Return the hostname of a URL (with or without protocol)."""
     # Just so urllib can parse the URL, make sure there's a protocol.
     # (The actual protocol doesn't matter to us)

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -25,6 +25,7 @@ import functools
 import os
 import sys
 import subprocess
+from typing import Any, List
 
 from streamlit import env_util
 
@@ -53,7 +54,7 @@ else:
 
 def memoize(func):
     """Decorator to memoize the result of a no-args func."""
-    result = []
+    result = []  # type: List[Any]
 
     @functools_wraps(func)
     def wrapped_func():

--- a/lib/streamlit/watcher/LocalSourcesWatcher.py
+++ b/lib/streamlit/watcher/LocalSourcesWatcher.py
@@ -19,7 +19,6 @@ import os
 import sys
 import collections
 
-from streamlit import compatibility
 from streamlit import config
 from streamlit import env_util
 from streamlit import file_util
@@ -127,17 +126,12 @@ class LocalSourcesWatcher(object):
         if FileWatcher is None:
             return
 
-        if compatibility.is_running_py3():
-            ErrorType = PermissionError
-        else:
-            ErrorType = OSError
-
         try:
             wm = WatchedModule(
                 watcher=FileWatcher(filepath, self.on_file_changed),
                 module_name=module_name,
             )
-        except ErrorType:
+        except PermissionError:
             # If you don't have permission to read this file, don't even add it
             # to watchers.
             return

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -53,7 +53,7 @@ def calc_md5_with_blocking_retries(file_path):
         The MD5 checksum.
 
     """
-    file_bytes = None
+    file_bytes = b""
 
     # There's a race condition where sometimes file_path no longer exists when
     # we try to read it (since the file is in the process of being written).

--- a/lib/tests/ServerTestCase.py
+++ b/lib/tests/ServerTestCase.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 import mock
-import requests
 import tornado.testing
 import tornado.web
 import tornado.websocket
+import urllib.parse
 from tornado import gen
 from tornado.concurrent import Future
 
@@ -41,7 +41,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         # to no-op. This prevents it from shutting down the
         # ioloop when it stops.
         self.server = Server(self.io_loop, "/not/a/script.py", "test command line")
-        self.server._on_stopped = mock.MagicMock()
+        self.server._on_stopped = mock.MagicMock()  # type: ignore[assignment]
         app = self.server._create_app()
         return app
 
@@ -72,9 +72,9 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         # get_url() gives us a result with the 'http' scheme;
         # we swap it out for 'ws'.
         url = self.get_url(path)
-        parts = list(requests.utils.urlparse(url))
+        parts = list(urllib.parse.urlparse(url))
         parts[0] = "ws"
-        return requests.utils.urlunparse(tuple(parts))
+        return urllib.parse.urlunparse(tuple(parts))
 
     def ws_connect(self):
         """Open a websocket connection to the server.

--- a/lib/tests/streamlit/credentials_test.py
+++ b/lib/tests/streamlit/credentials_test.py
@@ -200,7 +200,7 @@ class CredentialsClassTest(unittest.TestCase):
 
             c.save()
 
-            make_dirs.assert_called_once_with(streamlit_root_path)
+            make_dirs.assert_called_once_with(streamlit_root_path, exist_ok=True)
             open.return_value.write.assert_called_once_with(truth)
 
     @patch("streamlit.credentials.file_util.get_streamlit_file_path", mock_get_path)

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -516,10 +516,10 @@ class CodeHashTest(unittest.TestCase):
         # will need to be updated!
 
         def call_altair_concat():
-            return alt.vegalite.v4.api.concat()
+            return altair.vegalite.v4.api.concat()
 
         def call_altair_layer():
-            return alt.vegalite.v4.api.layer()
+            return altair.vegalite.v4.api.layer()
 
         self.assertNotEqual(get_hash(call_altair_concat), get_hash(call_altair_layer))
 

--- a/scripts/flake8
+++ b/scripts/flake8
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invoke flake8 tool with patch to incorporate pyflakes fa92556c."""
+
+import re
+
+import pyflakes.checker
+from flake8.main import cli
+
+# Apply important parts of fa92556c.
+ASCII_NON_ALNUM = ''.join([chr(i) for i in range(128) if not chr(i).isalnum()])
+pyflakes.checker.TYPE_IGNORE_RE = re.compile(
+    pyflakes.checker.TYPE_COMMENT_RE.pattern + r'ignore([{}]|$)'.format(ASCII_NON_ALNUM))
+
+cli.main()

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -98,7 +98,7 @@ def update_files(data, python=True):
         filename = os.path.join(BASE_DIR, filename)
         matched = False
         pattern = re.compile(regex)
-        for line in fileinput.input(filename, inplace=1):
+        for line in fileinput.input(filename, inplace=True):
             if pattern.match(line.rstrip()):
                 matched = True
             line = re.sub(regex, r"\g<pre>%s\g<post>" % version, line.rstrip())


### PR DESCRIPTION
This includes many small changes to make mypy understand why various
constructs are safe, and in a few cases to fix real bugs. Many of mypy's
resolved complaints had to do with functions that sometimes return None
(e.g., inspect.currentframe()), and immediate dereferences of these
"union" types made of the expected return type and None.

While making these changes, Python 2-isms were in some cases removed if
they made fixing the problematic statements simpler to fix or the
resulting code easier to understand.

This also introduces scripts/flake8 to allow a minor monkeypatch of
pyflakes (part of flake8) to incorporate
PyCQA/pyflakes@fa92556,
allowing for "# type: ignore[attr-defined]" comments allowing for
specific ignore of Mypy complaints. With this, fixes *all* flake8
complaints in our codebase.

This was committed to pyflakes in August but there have been no releases
and we shouldn't be holding our breath for one per issues like
PyCQA/pyflakes#475.