### PR TITLE
Show warning to user and use skipkeys=True if json.dumps causes TypeError

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -604,11 +604,17 @@ class DeltaGenerator(object):
            height: 280px
 
         """
-        element.json.body = (
-            body
-            if isinstance(body, string_types)  # noqa: F821
-            else json.dumps(body, default=lambda o: str(type(o)))
-        )
+        import streamlit as st
+
+        if not isinstance (body, string_types):
+            try:
+                body = json.dumps(body, default=lambda o: str(type(o)))
+            except TypeError as err:
+                st.warning("Warning: this data structure was not fully serializable as "
+                           "JSON due to one or more unexpected keys.  (Error was: %s)" % err)
+                body = json.dumps(body, skipkeys=True, default=lambda o: str(type(o)))
+
+        element.json.body = body
 
     @_with_element
     def title(self, element, body):

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -606,12 +606,14 @@ class DeltaGenerator(object):
         """
         import streamlit as st
 
-        if not isinstance (body, string_types):
+        if not isinstance(body, string_types):
             try:
                 body = json.dumps(body, default=lambda o: str(type(o)))
             except TypeError as err:
-                st.warning("Warning: this data structure was not fully serializable as "
-                           "JSON due to one or more unexpected keys.  (Error was: %s)" % err)
+                st.warning(
+                    "Warning: this data structure was not fully serializable as "
+                    "JSON due to one or more unexpected keys.  (Error was: %s)" % err
+                )
                 body = json.dumps(body, skipkeys=True, default=lambda o: str(type(o)))
 
         element.json.body = body

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -389,12 +389,11 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.json.body, '{"some": "json"}')
 
-        # Test that an object containing non-json-friendly keys can still 
+        # Test that an object containing non-json-friendly keys can still
         # be displayed.  Resultant json body will be missing those keys.
 
         n = np.array([1, 2, 3, 4, 5])
-        data = {n[0]: "this key will not render as JSON",
-                "array": n}
+        data = {n[0]: "this key will not render as JSON", "array": n}
         st.json(data)
 
         el = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -389,6 +389,17 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.json.body, '{"some": "json"}')
 
+        # Test that an object containing non-json-friendly keys can still 
+        # be displayed.  Resultant json body will be missing those keys.
+
+        n = np.array([1, 2, 3, 4, 5])
+        data = {n[0]: "this key will not render as JSON",
+                "array": n}
+        st.json(data)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.json.body, '{"array": "<class \'numpy.ndarray\'>"}')
+
     def test_st_line_chart(self):
         """Test st.line_chart."""
         df = pd.DataFrame([[10, 20, 30]], columns=["a", "b", "c"])


### PR DESCRIPTION
**Issue:** #975 

**Description:**  Currently, st.json will trip over the use of a nonstandard key in a dictionary, resulting in a confusing and unhelpful traceback to the user.

This PR wraps the conversion to JSON in a try-except block that catches the TypeError that arises from use of weird keys that json.dumps cannot handle.  If triggered, we show a warning to the user that this happened, and then rerun json.dumps with skipkeys=True.  

The resultant data structure will not show the entire data, but the warning should be informative enough to the user to understand why.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
