### PR TITLE
st.map: hard-code minimum pixel size of 3 for map dots

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -133,6 +133,7 @@ def to_deckgl_json(data, zoom):
             "getPosition": "@@=[lon, lat]",
             "getRadius": 10,
             "radiusScale": 10,
+            "radiusMinPixels": 3,
             "getFillColor": _DEFAULT_COLOR,
             "data": final_data,
         }


### PR DESCRIPTION
**Issue:** #1103

**Description:**  Adds "radiusMinPixels" : 3 to the configuration of the st.map element as a way of ensuring the visibility of the map dots.

(This doesn't really optimize the display of points on a map; it's just an easy baby-step of an improvement.)

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
