### PR TITLE
Fix BytesIO, numpy exceptions st.audio/st.video

### DIFF
--- a/lib/streamlit/elements/media_proto.py
+++ b/lib/streamlit/elements/media_proto.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from streamlit import type_util
 from streamlit.compatibility import setup_2_3_shims
 
 setup_2_3_shims(globals())
@@ -67,7 +68,7 @@ def _marshall_av_media(proto, data, mimetype):
     Given a string, check if it's a url; if so, send it out without modification.
     Otherwise assume strings are filenames and let any OS errors raise.
 
-    Load data either from file or through bytes-processing methods into a 
+    Load data either from file or through bytes-processing methods into a
     MediaFile object.  Pack proto with generated Tornado-based URL.
     """
     # Audio and Video methods have already checked if this is a URL by this point.
@@ -88,11 +89,11 @@ def _marshall_av_media(proto, data, mimetype):
         pass
     elif isinstance(data, io.BytesIO):
         data.seek(0)
-        data = date.getvalue()
+        data = data.getvalue()
     elif isinstance(data, io.IOBase):
         data.seek(0)
         data = data.read()
-    elif is_type(data, "numpy.ndarray"):
+    elif type_util.is_type(data, "numpy.ndarray"):
         data = data.tobytes()
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 """Streamlit Unit test."""
+from io import BytesIO
+
 from mock import patch
 import json
 import os
@@ -161,6 +163,12 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         st.audio(None)
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.audio.url, "")
+
+        # Test that our other data types don't result in an error.
+        st.audio(b"bytes_data")
+        st.audio("str_data".encode("utf-8"))
+        st.audio(BytesIO(b"bytesio_data"))
+        st.audio(np.array([0, 1, 2, 3]))
 
     def test_st_audio_options(self):
         """Test st.audio with options."""
@@ -663,6 +671,12 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         st.video(None)
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.video.url, "")
+
+        # Test that our other data types don't result in an error.
+        st.video(b"bytes_data")
+        st.video("str_data".encode("utf-8"))
+        st.video(BytesIO(b"bytesio_data"))
+        st.video(np.array([0, 1, 2, 3]))
 
     def test_st_video_options(self):
         """Test st.video with options."""


### PR DESCRIPTION
Fixes `st.video` and `st.audio` crashing on BytesIO and numpy data