### PR TITLE
Fixing progressbar animation when switching tabs

### DIFF
--- a/frontend/src/components/elements/Progress/Progress.tsx
+++ b/frontend/src/components/elements/Progress/Progress.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React from "react"
+import React, { PureComponent, ReactNode } from "react"
 import { Map as ImmutableMap } from "immutable"
 import { Progress as UIProgress } from "reactstrap"
 
@@ -28,11 +28,11 @@ interface Props {
 
 const FAST_UPDATE_MS = 50
 
-class Progress extends React.PureComponent<Props> {
+class Progress extends PureComponent<Props> {
   lastValue = -1
   lastAnimatedTime = -1
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     const { element, width } = this.props
     const value = element.get("value")
     const time = new Date().getTime()
@@ -41,7 +41,9 @@ class Progress extends React.PureComponent<Props> {
     const isMovingBackwards = value < this.lastValue
     const isMovingSuperFast = time - this.lastAnimatedTime < FAST_UPDATE_MS
     const className =
-      isMovingBackwards || isMovingSuperFast
+      isMovingBackwards ||
+      isMovingSuperFast ||
+      document.visibilityState === "hidden"
         ? "without-transition"
         : "with-transition"
 

--- a/frontend/src/components/elements/Progress/Progress.tsx
+++ b/frontend/src/components/elements/Progress/Progress.tsx
@@ -32,20 +32,37 @@ class Progress extends PureComponent<Props> {
   lastValue = -1
   lastAnimatedTime = -1
 
+  isMovingBackwards = (): boolean => {
+    const { element } = this.props
+    const value = element.get("value")
+
+    return value < this.lastValue
+  }
+
+  isMovingSuperFast = (startTime: number, endTime: number): boolean => {
+    return startTime - endTime < FAST_UPDATE_MS
+  }
+
+  // Checks if the browser tab is visible and active
+  isBrowserTabVisible = (): boolean => document.visibilityState === "hidden"
+
+  // Make progress bar stop acting weird when moving backwards or quickly.
+  shouldUseTransition = (startTime: number, endTime: number): boolean => {
+    return (
+      this.isMovingBackwards() ||
+      this.isMovingSuperFast(startTime, endTime) ||
+      this.isBrowserTabVisible()
+    )
+  }
+
   public render(): ReactNode {
     const { element, width } = this.props
     const value = element.get("value")
     const time = new Date().getTime()
 
-    // Make progress bar stop acting weird when moving backwards or quickly.
-    const isMovingBackwards = value < this.lastValue
-    const isMovingSuperFast = time - this.lastAnimatedTime < FAST_UPDATE_MS
-    const className =
-      isMovingBackwards ||
-      isMovingSuperFast ||
-      document.visibilityState === "hidden"
-        ? "without-transition"
-        : "with-transition"
+    const className = this.shouldUseTransition(time, this.lastAnimatedTime)
+      ? "without-transition"
+      : "with-transition"
 
     if (className === "with-transition") {
       this.lastAnimatedTime = time


### PR DESCRIPTION
**Issue:** Fixes streamlit/streamlit-old-private/issues/588 .

**Description:** Fixing progressbar animation when switching tabs.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
