### PR TITLE
Raise our default max_upload_size to 200 MB

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2040,8 +2040,8 @@ class DeltaGenerator(object):
     def file_uploader(self, element, label, type=None, encoding="auto", key=None):
         """Display a file uploader widget.
 
-        By default, uploaded files are limited to 50MB but you can configure
-        that using the `server.maxUploadSize` config option.
+        By default, uploaded files are limited to 200MB. You can configure
+        this using the `server.maxUploadSize` config option.
 
         Parameters
         ----------

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -485,9 +485,11 @@ def _server_enable_cors():
 def _server_max_upload_size():
     """Max size, in megabytes, for files uploaded with the file_uploader.
 
-    Default: '50'
+    Default: 200
     """
-    return 50
+    # If this default is changed, please also update the docstring
+    # for `DeltaGenerator.file_uploader`.
+    return 200
 
 
 # Config Section: Browser #

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -637,4 +637,4 @@ class ConfigLoadingTest(unittest.TestCase):
             self.assertEqual("local_accessKeyId", config.get_option("s3.accessKeyId"))
 
     def test_upload_file_default_values(self):
-        self.assertEqual(50, config.get_option("server.maxUploadSize"))
+        self.assertEqual(200, config.get_option("server.maxUploadSize"))


### PR DESCRIPTION
Now that we handle file uploads via HTTP, it's reasonable to raise our default size limit from 50.