### PR TITLE
Fix the install script to install new packages not in lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup:
 .PHONY: pipenv-install
 pipenv-install: lib/Pipfile
 	@# Runs pipenv install; doesn't update the Pipfile.lock.
-	cd lib; pipenv install --dev --skip-lock
+	cd lib; pipenv install --dev
 
 .PHONY: pylint
 # Run "black", our Python formatter, to verify that our source files


### PR DESCRIPTION
**Issue:** 

#1147 protoc-gen-mypy: program not found or is not executable

Actually this will applies to almost all new packages added to Pipfile, especially for any workspace which has the local environment set up before. 

**Description:** 

We need to revert back the changes introduced in #1093 , as this will break out the future development environment set up.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
