### PR TITLE
Adding custom filterOptions function to SelectBox

### DIFF
--- a/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -121,15 +121,17 @@ describe("Selectbox widget", () => {
   })
 
   it("should not filter options based on index", () => {
-    // @ts-ignore
     const options = wrapper.find(UISelect).prop("options")
     const filterOptionsFn = wrapper.find(UISelect).prop("filterOptions")
-    const filteredOptions = filterOptionsFn!(options!, "1")
+    if (filterOptionsFn === undefined || options === undefined) {
+      fail("Unexepcted undefined value")
+      return 0
+    }
+    const filteredOptions = filterOptionsFn(options, "1")
     expect(filteredOptions).toEqual([])
   })
 
   it("should filter options based on label", () => {
-    // @ts-ignore
     const options = wrapper.find(UISelect).prop("options")
     const filterOptionsFn = wrapper.find(UISelect).prop("filterOptions")
     if (filterOptionsFn === undefined || options === undefined) {

--- a/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -119,4 +119,29 @@ describe("Selectbox widget", () => {
       value: "1",
     })
   })
+
+  it("should not filter options based on index", () => {
+    // @ts-ignore
+    const options = wrapper.find(UISelect).prop("options")
+    const filterOptionsFn = wrapper.find(UISelect).prop("filterOptions")
+    const filteredOptions = filterOptionsFn!(options!, "1")
+    expect(filteredOptions).toEqual([])
+  })
+
+  it("should filter options based on label", () => {
+    // @ts-ignore
+    const options = wrapper.find(UISelect).prop("options")
+    const filterOptionsFn = wrapper.find(UISelect).prop("filterOptions")
+    if (filterOptionsFn === undefined || options === undefined) {
+      fail("Unexepcted undefined value")
+      return 0
+    }
+    const filteredOptions = filterOptionsFn(options, "b")
+    expect(filteredOptions).toEqual([
+      {
+        label: "b",
+        value: "1",
+      },
+    ])
+  })
 })

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react"
-import { Select as UISelect, OnChangeParams } from "baseui/select"
+import { Select as UISelect, OnChangeParams, Option } from "baseui/select"
 import { Map as ImmutableMap } from "immutable"
 import { WidgetStateManager, Source } from "lib/WidgetStateManager"
 import { logWarning } from "lib/log"
@@ -68,6 +68,18 @@ class Selectbox extends React.PureComponent<Props, State> {
     )
   }
 
+  // Add a custom filterOptions method to filter labels only based on labels.
+  // The baseweb default method filters based on labels or indeces
+  // More details: https://github.com/streamlit/streamlit/issues/1010
+  private filterOptions = (
+    options: readonly Option[],
+    filterValue: string
+  ): readonly Option[] => {
+    return options.filter((value: Option) =>
+      (value as SelectOption).label.includes(filterValue.toString())
+    )
+  }
+
   public render = (): React.ReactNode => {
     const style = { width: this.props.width }
     const label = this.props.element.get("label")
@@ -106,6 +118,7 @@ class Selectbox extends React.PureComponent<Props, State> {
           labelKey="label"
           onChange={this.onChange}
           options={selectOptions}
+          filterOptions={this.filterOptions}
           value={value}
           valueKey="value"
         />

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -68,7 +68,7 @@ class Selectbox extends React.PureComponent<Props, State> {
     )
   }
 
-  // Add a custom filterOptions method to filter labels only based on labels.
+  // Add a custom filterOptions method to filter options only based on labels.
   // The baseweb default method filters based on labels or indeces
   // More details: https://github.com/streamlit/streamlit/issues/1010
   private filterOptions = (


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1010

**Description:** Adding a custom `filterOptions` to make the selectbox filter options based on the labels only. The default `filterOptions` function in baseweb filters based on labels or indeces at the same time.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
