### PR TITLE
file_uploader: support for multiple files

### DIFF
--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -16,4 +16,15 @@
 import streamlit as st
 
 
-st.file_uploader("Drop a file:", type=["txt"])
+result = st.file_uploader("Drop a file:", type=["txt"], multiple_files=False)
+if result is not None:
+    st.text(result.getvalue())
+else:
+    st.text("No upload")
+
+result = st.file_uploader("Drop multiple files:", type=["txt"], multiple_files=True)
+if result is not None:
+    strings = sorted([s.getvalue() for s in result])
+    st.text("\n".join(strings))
+else:
+    st.text("No upload")

--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -16,13 +16,13 @@
 import streamlit as st
 
 
-result = st.file_uploader("Drop a file:", type=["txt"], multiple_files=False)
+result = st.file_uploader("Drop a file:", type=["txt"], accept_multiple_files=False)
 if result is not None:
     st.text(result.getvalue())
 else:
     st.text("No upload")
 
-result = st.file_uploader("Drop multiple files:", type=["txt"], multiple_files=True)
+result = st.file_uploader("Drop multiple files:", type=["txt"], accept_multiple_files=True)
 if result is not None:
     strings = sorted([s.getvalue() for s in result])
     st.text("\n".join(strings))

--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -22,7 +22,9 @@ if result is not None:
 else:
     st.text("No upload")
 
-result = st.file_uploader("Drop multiple files:", type=["txt"], accept_multiple_files=True)
+result = st.file_uploader(
+    "Drop multiple files:", type=["txt"], accept_multiple_files=True
+)
 if result is not None:
     strings = sorted([s.getvalue() for s in result])
     st.text("\n".join(strings))

--- a/e2e/specs/st_file_uploader.spec.ts
+++ b/e2e/specs/st_file_uploader.spec.ts
@@ -26,61 +26,104 @@ describe("st.file_uploader", () => {
   });
 
   it("shows widget correctly", () => {
-    cy.get(".stFileUploader").should("have.length", 1);
-    cy.get(".stFileUploader label").should("have.text", "Drop a file:");
+    cy.get(".stFileUploader")
+      .first()
+      .should("exist");
+    cy.get(".stFileUploader label")
+      .first()
+      .should("have.text", "Drop a file:");
 
-    cy.get(".stFileUploader").matchImageSnapshot("file_uploader");
+    cy.get(".stFileUploader")
+      .first()
+      .matchImageSnapshot("file_uploader");
   });
 
   it("shows error message for not allowed files", () => {
-    cy.get(".stFileUploader").should("have.length", 1);
-    cy.get(".stFileUploader label").should("have.text", "Drop a file:");
-
     const fileName = "example.json";
 
     cy.fixture(fileName).then(fileContent => {
-      cy.get('[data-baseweb="file-uploader"] > div').upload(
-        { fileContent, fileName, mimeType: "application/json" },
-        {
-          force: true,
-          subjectType: "drag-n-drop",
+      cy.get('[data-baseweb="file-uploader"] > div')
+        .first()
+        .upload(
+          { fileContent, fileName, mimeType: "application/json" },
+          {
+            force: true,
+            subjectType: "drag-n-drop",
 
-          // We intentionally omit the "dragleave" trigger event here;
-          // the page may start re-rendering after the "drop" event completes,
-          // which causes a cypress error due to the element being detached
-          // from the DOM when "dragleave" is emitted.
-          events: ["dragenter", "drop"]
-        }
-      );
+            // We intentionally omit the "dragleave" trigger event here;
+            // the page may start re-rendering after the "drop" event completes,
+            // which causes a cypress error due to the element being detached
+            // from the DOM when "dragleave" is emitted.
+            events: ["dragenter", "drop"]
+          }
+        );
 
-      cy.get(".uploadError").should(
-        "have.text",
-        " application/json files are not allowedOK"
-      );
+      cy.get(".uploadError")
+        .first()
+        .should("have.text", " application/json files are not allowedOK");
 
-      cy.get(".stFileUploader").matchImageSnapshot("file_uploader-error");
+      cy.get(".stFileUploader")
+        .first()
+        .matchImageSnapshot("file_uploader-error");
     });
   });
 
-  it("shows uploaded file name", () => {
-    cy.get(".stFileUploader").should("have.length", 1);
-    cy.get(".stFileUploader label").should("have.text", "Drop a file:");
-
-    const fileName = "example.txt";
+  it("uploads single files", () => {
+    const fileName = "file1.txt";
 
     cy.fixture(fileName).then(fileContent => {
-      cy.get('[data-baseweb="file-uploader"] > div').upload(
-        { fileContent, fileName, mimeType: "text/plain" },
-        {
-          force: true,
-          subjectType: "drag-n-drop",
-          events: ["dragenter", "drop"]
-        }
-      );
+      cy.get('[data-baseweb="file-uploader"] > div')
+        .first()
+        .upload(
+          { fileContent, fileName, mimeType: "text/plain" },
+          {
+            force: true,
+            subjectType: "drag-n-drop",
+            events: ["dragenter", "drop"]
+          }
+        );
 
-      cy.get(".uploadDone").should("have.text", fileName);
+      cy.get(".uploadDone")
+        .first()
+        .should("have.text", fileName);
+      cy.get(".fixed-width.stText")
+        .first()
+        .should("have.text", fileContent);
 
-      cy.get(".stFileUploader").matchImageSnapshot("file_uploader-uploaded");
+      cy.get(".stFileUploader")
+        .first()
+        .matchImageSnapshot("file_uploader-uploaded");
+    });
+  });
+
+  it("uploads multiple files", () => {
+    const fileName1 = "file1.txt";
+    const fileName2 = "file2.txt";
+
+    // Yes, this actually is the recommended way to load multiple fixtures
+    // in Cypress (!!) using Cypress.Promise.all is buggy. See:
+    // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__fixtures/cypress/integration/multiple-fixtures-spec.js
+
+    cy.fixture(fileName1).then(file1 => {
+      cy.fixture(fileName2).then(file2 => {
+        const files = [
+          { fileContent: file1, fileName: fileName1, mimeType: "text/plain" },
+          { fileContent: file2, fileName: fileName2, mimeType: "text/plain" }
+        ];
+
+        cy.get('[data-baseweb="file-uploader"] > div')
+          .eq(1)
+          .upload(files, {
+            force: true,
+            subjectType: "drag-n-drop",
+            events: ["dragenter", "drop"]
+          });
+
+        const content = [file1, file2].sort().join("\n");
+        cy.get(".fixed-width.stText")
+          .eq(1)
+          .should("have.text", content);
+      });
     });
   });
 });

--- a/e2e/specs/st_file_uploader.spec.ts
+++ b/e2e/specs/st_file_uploader.spec.ts
@@ -119,6 +119,15 @@ describe("st.file_uploader", () => {
             events: ["dragenter", "drop"]
           });
 
+        // The widget should show the names of the uploaded files.
+        const filenames = [fileName1, fileName2].join(", ");
+        cy.get(".uploadDone")
+          .eq(0) // eq(0), instead of eq(1), because the first widget won't have an uploadDone
+          .should("have.text", filenames);
+
+        // The script should have printed the contents of the two files
+        // into an st.text. (This tests that the upload actually went
+        // through.)
         const content = [file1, file2].sort().join("\n");
         cy.get(".fixed-width.stText")
           .eq(1)

--- a/frontend/cypress/fixtures/example.txt
+++ b/frontend/cypress/fixtures/example.txt
@@ -1,1 +1,0 @@
-Using fixtures to represent text

--- a/frontend/cypress/fixtures/file1.txt
+++ b/frontend/cypress/fixtures/file1.txt
@@ -1,0 +1,1 @@
+1. The first file!

--- a/frontend/cypress/fixtures/file2.txt
+++ b/frontend/cypress/fixtures/file2.txt
@@ -1,0 +1,1 @@
+2. The second file!

--- a/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -19,13 +19,8 @@ import React from "react"
 import { shallow } from "enzyme"
 import { FileUploader as FileUploaderBaseui } from "baseui/file-uploader"
 import { fromJS } from "immutable"
-import { WidgetStateManager } from "lib/WidgetStateManager"
-import { FileUploadClient } from "lib/FileUploadClient"
 
 import FileUploader, { Props } from "./FileUploader"
-
-jest.mock("lib/WidgetStateManager")
-jest.mock("lib/FileUploadClient")
 
 const blobFile = new File(["Text in a file!"], "filename.txt", {
   type: "text/plain",
@@ -41,8 +36,10 @@ const getProps = (elementProps: object = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetStateManager: new WidgetStateManager(jest.fn()),
-  uploadClient: new FileUploadClient(jest.fn()),
+  // @ts-ignore
+  widgetStateManager: jest.fn(),
+  // @ts-ignore
+  uploadClient: { uploadFiles: jest.fn().mockResolvedValue(undefined) },
 })
 
 describe("FileUploader widget", () => {
@@ -67,7 +64,7 @@ describe("FileUploader widget", () => {
     const internalFileUploader = wrapper.find(FileUploaderBaseui)
     internalFileUploader.props().onDrop([blobFile], [], null)
 
-    expect(props.uploadClient.uploadFile.mock.calls.length).toBe(1)
+    expect(props.uploadClient.uploadFiles.mock.calls.length).toBe(1)
   })
 
   it("should change status when dropping a File", () => {

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -86,22 +86,17 @@ class FileUploader extends React.PureComponent<Props, State> {
       }
     }
 
+    this.setState({ acceptedFiles, status: "UPLOADING" })
+
     // Upload all the files
     this.currentUploadCanceller = axios.CancelToken.source()
-    const promises: Promise<void>[] = []
-    for (const file of acceptedFiles) {
-      const p = this.props.uploadClient.uploadFile(
+    this.props.uploadClient
+      .uploadFiles(
         this.props.element.get("id"),
-        file,
+        acceptedFiles,
         undefined,
         this.currentUploadCanceller.token
       )
-      promises.push(p)
-    }
-
-    this.setState({ acceptedFiles, status: "UPLOADING" })
-
-    Promise.all(promises)
       .then(() => {
         this.currentUploadCanceller = undefined
         this.setState({ status: "UPLOADED" })
@@ -171,6 +166,8 @@ class FileUploader extends React.PureComponent<Props, State> {
       .toArray()
       .map((value: string) => "." + value)
 
+    const multipleFiles: boolean = element.get("multipleFiles")
+
     // Hack to hide drag-and-drop message and leave space for filename.
     let overrides: any = fileUploaderOverrides
 
@@ -196,6 +193,7 @@ class FileUploader extends React.PureComponent<Props, State> {
           accept={accept.length === 0 ? undefined : accept}
           disabled={this.props.disabled}
           overrides={overrides}
+          multiple={multipleFiles}
         />
       </>
     )

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -170,6 +170,7 @@ class FileUploader extends React.PureComponent<Props, State> {
 
     // Hack to hide drag-and-drop message and leave space for filename.
     let overrides: any = fileUploaderOverrides
+    let filenameText = ""
 
     if (status === "UPLOADED") {
       overrides = { ...overrides }
@@ -178,13 +179,21 @@ class FileUploader extends React.PureComponent<Props, State> {
       overrides.ContentMessage.style.visibility = "hidden"
       overrides.ContentMessage.style.overflow = "hidden"
       overrides.ContentMessage.style.height = "0.625rem" // half of lineHeightTight
+
+      if (multipleFiles) {
+        filenameText = this.state.acceptedFiles
+          .map(file => file.name)
+          .join(", ")
+      } else {
+        filenameText = this.state.acceptedFiles[0].name
+      }
     }
 
     return (
       <>
         {status === "UPLOADED" ? (
           <div className="uploadOverlay uploadDone">
-            <span className="body">{this.state.acceptedFiles[0].name}</span>
+            <span className="body">{filenameText}</span>
           </div>
         ) : null}
         <FileUploaderBaseui

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -73,10 +73,13 @@ describe("FileUploadClient", () => {
 
     mockUploadResponseStatus(200)
 
-    const file = new File(["File contents"], "file.txt")
+    const files = [
+      new File(["file1"], "file1.txt"),
+      new File(["file2"], "file2.txt"),
+    ]
 
     await expect(
-      uploader.uploadFile("widgetId", file)
+      uploader.uploadFiles("widgetId", files)
     ).resolves.toBeUndefined()
   })
 
@@ -85,9 +88,12 @@ describe("FileUploadClient", () => {
 
     mockUploadResponseStatus(400)
 
-    const file = new File(["File contents"], "file.txt")
+    const files = [
+      new File(["file1"], "file1.txt"),
+      new File(["file2"], "file2.txt"),
+    ]
 
-    await expect(uploader.uploadFile("widgetId", file)).rejects.toEqual(
+    await expect(uploader.uploadFiles("widgetId", files)).rejects.toEqual(
       new Error("Request failed with status code 400")
     )
   })

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -25,7 +25,7 @@ import { BaseUriParts, buildHttpUri } from "lib/UriUtil"
 export class FileUploadClient {
   private readonly getServerUri: () => BaseUriParts | undefined
 
-  constructor(getServerUri: () => BaseUriParts | undefined) {
+  public constructor(getServerUri: () => BaseUriParts | undefined) {
     this.getServerUri = getServerUri
   }
 
@@ -33,13 +33,13 @@ export class FileUploadClient {
    * Upload a file to the server. It will be associated with this browser's sessionID.
    *
    * @param widgetId: the ID of the FileUploader widget that's doing the upload.
-   * @param file: the file to upload.
+   * @param files: the files to upload.
    * @param onUploadProgress: an optional function that will be called repeatedly with progress events during the upload.
    * @param cancelToken: an optional axios CancelToken that can be used to cancel the in-progress upload.
    */
-  public async uploadFile(
+  public async uploadFiles(
     widgetId: string,
-    file: File,
+    files: File[],
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<void> {
@@ -51,8 +51,9 @@ export class FileUploadClient {
     const form = new FormData()
     form.append("sessionId", SessionInfo.current.sessionId)
     form.append("widgetId", widgetId)
-    form.append("lastModified", file.lastModified.toString())
-    form.append(file.name, file)
+    for (const file of files) {
+      form.append(file.name, file)
+    }
 
     await axios.request({
       cancelToken: cancelToken,

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2040,6 +2040,11 @@ class DeltaGenerator(object):
             The encoding to use when opening textual files (i.e. non-binary).
             For example: 'utf-8'. If set to 'auto', will try to guess the
             encoding. If None, will assume the file is binary.
+        key : str
+            An optional string to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may
+            not share the same key.
 
         Returns
         -------

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2019,7 +2019,7 @@ class DeltaGenerator(object):
 
     @_with_element
     def file_uploader(
-        self, element, label, type=None, encoding="auto", key=None, multiple_files=False
+        self, element, label, type=None, encoding="auto", key=None, accept_multiple_files=False
     ):
         """Display a file uploader widget.
 
@@ -2042,7 +2042,7 @@ class DeltaGenerator(object):
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
-        multiple_files : bool
+        accept_multiple_files : bool
             If True, the uploader widget will accept multiple files, and the
             returned value will be a list of all files. Defaults to False.
 
@@ -2076,7 +2076,7 @@ class DeltaGenerator(object):
         element.file_uploader.max_upload_size_mb = config.get_option(
             "server.maxUploadSize"
         )
-        element.file_uploader.multiple_files = multiple_files
+        element.file_uploader.multiple_files = accept_multiple_files
         _set_widget_id("file_uploader", element, user_key=key)
 
         files = None
@@ -2090,7 +2090,7 @@ class DeltaGenerator(object):
             return NoValue
 
         file_datas = [get_encoded_file_data(file.data, encoding) for file in files]
-        return file_datas if multiple_files else file_datas[0]
+        return file_datas if accept_multiple_files else file_datas[0]
 
     @_with_element
     def text_input(self, element, label, value="", key=None, type="default"):

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -15,7 +15,6 @@
 
 """Allows us to create and absorb changes (aka Deltas) to elements."""
 
-import io
 import functools
 import json
 import random
@@ -28,13 +27,12 @@ from datetime import time
 from streamlit import caching
 from streamlit import config
 from streamlit import cursor
-from streamlit import metrics
 from streamlit import type_util
 from streamlit.ReportThread import get_report_ctx
-from streamlit.server.Server import Server
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException
 from streamlit.errors import NoSessionContext
+from streamlit.file_util import get_encoded_file_data
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto import Alert_pb2
@@ -43,9 +41,6 @@ from streamlit.proto import BlockPath_pb2
 from streamlit.proto import ForwardMsg_pb2
 from streamlit.proto.NumberInput_pb2 import NumberInput
 from streamlit.proto.TextInput_pb2 import TextInput
-
-
-# setup logging
 from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -2023,7 +2018,9 @@ class DeltaGenerator(object):
         return current_value if single_value else tuple(current_value)
 
     @_with_element
-    def file_uploader(self, element, label, type=None, encoding="auto", key=None):
+    def file_uploader(
+        self, element, label, type=None, encoding="auto", key=None, multiple_files=False
+    ):
         """Display a file uploader widget.
 
         By default, uploaded files are limited to 200MB. You can configure
@@ -2045,13 +2042,19 @@ class DeltaGenerator(object):
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
+        multiple_files : bool
+            If True, the uploader widget will accept multiple files, and the
+            returned value will be a list of all files. Defaults to False.
 
         Returns
         -------
-        BytesIO or StringIO or None
-            The data for the uploaded file. If the file is in a well-known
-            textual format (or if the encoding parameter is set), returns a
-            StringIO. Otherwise BytesIO. If no file is loaded, returns None.
+        BytesIO or StringIO or or list of BytesIO/StringIO or None
+            If no file has been uploaded, returns None. Otherwise, returns
+            the data for the uploaded file(s):
+            - If the file is in a well-known textual format (or if the encoding
+            parameter is set), the file data is a StringIO.
+            - Otherwise the file data is BytesIO.
+            - If multiple_files is True, a list of file datas will be returned.
 
             Note that BytesIO/StringIO are "file-like", which means you can
             pass them anywhere where a file is expected!
@@ -2064,7 +2067,6 @@ class DeltaGenerator(object):
         ...     st.write(data)
 
         """
-        from streamlit.string_util import is_binary_string
 
         if isinstance(type, str):
             type = [type]
@@ -2074,31 +2076,21 @@ class DeltaGenerator(object):
         element.file_uploader.max_upload_size_mb = config.get_option(
             "server.maxUploadSize"
         )
+        element.file_uploader.multiple_files = multiple_files
         _set_widget_id("file_uploader", element, user_key=key)
 
-        data = None
+        files = None
         ctx = get_report_ctx()
         if ctx is not None:
-            data = ctx.uploaded_file_mgr.get_file_data(
+            files = ctx.uploaded_file_mgr.get_files(
                 session_id=ctx.session_id, widget_id=element.file_uploader.id
             )
 
-        if data is None:
+        if files is None:
             return NoValue
 
-        if encoding == "auto":
-            if is_binary_string(data):
-                encoding = None
-            else:
-                # If the file does not look like a pure binary file, assume
-                # it's utf-8. It would be great if we could guess it a little
-                # more smartly here, but it is what it is!
-                encoding = "utf-8"
-
-        if encoding:
-            return io.StringIO(data.decode(encoding))
-
-        return io.BytesIO(data)
+        file_datas = [get_encoded_file_data(file.data, encoding) for file in files]
+        return file_datas if multiple_files else file_datas[0]
 
     @_with_element
     def text_input(self, element, label, value="", key=None, type="default"):

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2019,7 +2019,13 @@ class DeltaGenerator(object):
 
     @_with_element
     def file_uploader(
-        self, element, label, type=None, encoding="auto", key=None, accept_multiple_files=False
+        self,
+        element,
+        label,
+        type=None,
+        encoding="auto",
+        key=None,
+        accept_multiple_files=False,
     ):
         """Display a file uploader widget.
 

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2068,7 +2068,7 @@ class DeltaGenerator(object):
             - If the file is in a well-known textual format (or if the encoding
             parameter is set), the file data is a StringIO.
             - Otherwise the file data is BytesIO.
-            - If multiple_files is True, a list of file datas will be returned.
+            - If multiple_files is True, a list of file data will be returned.
 
             Note that BytesIO/StringIO are "file-like", which means you can
             pass them anywhere where a file is expected!

--- a/lib/streamlit/UploadedFileManager.py
+++ b/lib/streamlit/UploadedFileManager.py
@@ -17,6 +17,7 @@ import threading
 from typing import Dict
 from typing import List
 from typing import NamedTuple
+from typing import Tuple
 
 from blinker import Signal
 
@@ -43,7 +44,7 @@ class UploadedFileManager(object):
     """
 
     def __init__(self):
-        self._files_by_id = {}  # type: Dict[(str, str), UploadedFileList]
+        self._files_by_id = {}  # type: Dict[Tuple[str, str], UploadedFileList]
         self._files_lock = threading.Lock()
         self.on_files_added = Signal(
             doc="""Emitted when a file list is added to the manager.

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -15,15 +15,47 @@
 
 import contextlib
 import errno
+import io
 import os
 
 import fnmatch
 
 from streamlit import env_util
 from streamlit import util
+from streamlit.string_util import is_binary_string
 
 # Configuration and credentials are stored inside the ~/.streamlit folder
 CONFIG_FOLDER_NAME = ".streamlit"
+
+
+def get_encoded_file_data(data, encoding="auto"):
+    """Coerce bytes to a BytesIO or a StringIO.
+
+    Parameters
+    ----------
+    data : bytes
+    encoding : str
+
+    Returns
+    -------
+    BytesIO or StringIO
+        If the file's data is in a well-known textual format (or if the encoding
+        parameter is set), return a StringIO. Otherwise, return BytesIO.
+
+    """
+    if encoding == "auto":
+        if is_binary_string(data):
+            encoding = None
+        else:
+            # If the file does not look like a pure binary file, assume
+            # it's utf-8. It would be great if we could guess it a little
+            # more smartly here, but it is what it is!
+            encoding = "utf-8"
+
+    if encoding:
+        return io.StringIO(data.decode(encoding))
+
+    return io.BytesIO(data)
 
 
 @contextlib.contextmanager

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -212,7 +212,7 @@ class Server(object):
         self._set_state(State.INITIAL)
         self._message_cache = ForwardMsgCache()
         self._uploaded_file_mgr = UploadedFileManager()
-        self._uploaded_file_mgr.on_file_added.connect(self._on_file_uploaded)
+        self._uploaded_file_mgr.on_files_added.connect(self._on_file_uploaded)
         self._report = None  # type: Optional[Report]
 
     def _on_file_uploaded(self, file):
@@ -233,7 +233,7 @@ class Server(object):
         else:
             # If an uploaded file doesn't belong to an existing session,
             # remove it so it doesn't stick around forever.
-            self._uploaded_file_mgr.remove_file(file.session_id, file.widget_id)
+            self._uploaded_file_mgr.remove_files(file.session_id, file.widget_id)
 
     def _get_session_info(self, session_id):
         """Return the SessionInfo with the given id, or None if no such

--- a/lib/streamlit/server/UploadFileRequestHandler.py
+++ b/lib/streamlit/server/UploadFileRequestHandler.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from typing import Dict, Any
+from typing import List
 
 import tornado.web
 import tornado.httputil
@@ -86,7 +87,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
 
     def post(self):
         args = {}  # type: Dict[str, str]
-        files = {}  # type: Dict[str, Any]
+        files = {}  # type: Dict[str, List[Any]]
 
         tornado.httputil.parse_body_arguments(
             content_type=self.request.headers["Content-Type"],
@@ -95,20 +96,6 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             files=files,
         )
 
-        if len(files) != 1:
-            self.send_error(400, reason="Expected 1 file, but got %s" % len(files))
-            return
-
-        # Grab the first file entry. Because multiple files with the same
-        # name can be uploaded, this entry is itself a list. Ensure
-        # there's only one in there as well.
-        file_list = list(files.values())[0]
-        if len(file_list) != 1:
-            self.send_error(400, reason="Expected 1 file, but got %s" % len(file_list))
-            return
-
-        file = file_list[0]
-
         try:
             session_id = self._require_arg(args, "sessionId")
             widget_id = self._require_arg(args, "widgetId")
@@ -116,13 +103,22 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             self.send_error(400, reason=str(e))
             return
 
-        self._file_mgr.add_file(
-            UploadedFile(
-                session_id=session_id,
-                widget_id=widget_id,
-                name=file["filename"],
-                data=file["body"],
-            )
+        # Create an UploadedFile object for each file.
+        uploaded_files = []
+        for flist in files.values():
+            # Because multiple files with the same name can be uploaded, each
+            # entry in the files dict is itself a list.
+            for file in flist:
+                uploaded_files.append(
+                    UploadedFile(name=file["filename"], data=file["body"])
+                )
+
+        if len(uploaded_files) == 0:
+            self.send_error(400, reason="Expected at least 1 file, but got 0")
+            return
+
+        self._file_mgr.add_files(
+            session_id=session_id, widget_id=widget_id, files=uploaded_files,
         )
 
         self.set_status(200)

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -298,21 +298,20 @@ class ServerTest(ServerTestCase):
             session_info1 = list(self.server._session_info_by_id.values())[0]
             session_info2 = list(self.server._session_info_by_id.values())[1]
 
+            file = UploadedFile("file.txt", b"123")
+
             # "Upload a file" for Session1
-            self.server._uploaded_file_mgr.add_file(
-                UploadedFile(
-                    session_id=session_info1.session.id,
-                    widget_id="widget_id",
-                    name="file.txt",
-                    data=b"file contents",
-                )
+            self.server._uploaded_file_mgr.add_files(
+                session_id=session_info1.session.id,
+                widget_id="widget_id",
+                files=[file],
             )
 
             self.assertEquals(
-                self.server._uploaded_file_mgr.get_file_data(
+                self.server._uploaded_file_mgr.get_files(
                     session_info1.session.id, "widget_id"
                 ),
-                b"file contents",
+                [file],
             )
 
             # Session1 should have a rerun request; Session2 should not
@@ -328,19 +327,14 @@ class ServerTest(ServerTestCase):
             yield self.ws_connect()
 
             # "Upload a file" for a session that doesn't exist
-            self.server._uploaded_file_mgr.add_file(
-                UploadedFile(
-                    session_id="no_such_session",
-                    widget_id="widget_id",
-                    name="file.txt",
-                    data=b"file contents",
-                )
+            self.server._uploaded_file_mgr.add_files(
+                session_id="no_such_session",
+                widget_id="widget_id",
+                files=[UploadedFile("file.txt", b"123")],
             )
 
             self.assertIsNone(
-                self.server._uploaded_file_mgr.get_file_data(
-                    "no_such_session", "widget_id"
-                )
+                self.server._uploaded_file_mgr.get_files("no_such_session", "widget_id")
             )
 
     @staticmethod

--- a/lib/tests/streamlit/UploadFileRequestHandler_test.py
+++ b/lib/tests/streamlit/UploadFileRequestHandler_test.py
@@ -29,6 +29,11 @@ from streamlit.server.UploadFileRequestHandler import UploadFileRequestHandler
 LOGGER = get_logger(__name__)
 
 
+def _get_filename(file):
+    """Sort key for lists of UploadedFiles"""
+    return file.name
+
+
 class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
     """Tests the /upload_file endpoint."""
 
@@ -78,7 +83,10 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         response = self._upload_files(params)
         self.assertEqual(200, response.code)
         self.assertEqual(
-            [file1, file2, file3], self.file_mgr.get_files("fooReport", "barWidget"),
+            sorted([file1, file2, file3], key=_get_filename),
+            sorted(
+                self.file_mgr.get_files("fooReport", "barWidget"), key=_get_filename
+            ),
         )
 
     def test_missing_params(self):

--- a/lib/tests/streamlit/UploadFileRequestHandler_test.py
+++ b/lib/tests/streamlit/UploadFileRequestHandler_test.py
@@ -38,7 +38,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             [("/upload_file", UploadFileRequestHandler, dict(file_mgr=self.file_mgr))]
         )
 
-    def _upload_file(self, params):
+    def _upload_files(self, params):
         # We use requests.Request to construct our multipart/form-data request
         # here, because they are absurdly fiddly to compose, and Tornado
         # doesn't include a utility for building them. We then use self.fetch()
@@ -59,7 +59,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "sessionId": (None, "fooReport"),
             "widgetId": (None, "barWidget"),
         }
-        response = self._upload_file(params)
+        response = self._upload_files(params)
         self.assertEqual(200, response.code)
         self.assertEqual([file], self.file_mgr.get_files("fooReport", "barWidget"))
 
@@ -75,7 +75,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "sessionId": (None, "fooReport"),
             "widgetId": (None, "barWidget"),
         }
-        response = self._upload_file(params)
+        response = self._upload_files(params)
         self.assertEqual(200, response.code)
         self.assertEqual(
             [file1, file2, file3], self.file_mgr.get_files("fooReport", "barWidget"),
@@ -89,7 +89,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             # "widgetId": (None, 'barWidget'),
         }
 
-        response = self._upload_file(params)
+        response = self._upload_files(params)
         self.assertEqual(400, response.code)
         self.assertIn("Missing 'widgetId'", response.reason)
 
@@ -100,6 +100,6 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "sessionId": (None, "fooReport"),
             "widgetId": (None, "barWidget"),
         }
-        response = self._upload_file(params)
+        response = self._upload_files(params)
         self.assertEqual(400, response.code)
         self.assertIn("Expected at least 1 file, but got 0", response.reason)

--- a/lib/tests/streamlit/UploadedFileManager_test.py
+++ b/lib/tests/streamlit/UploadedFileManager_test.py
@@ -18,69 +18,59 @@
 import unittest
 
 from streamlit.UploadedFileManager import UploadedFile
+from streamlit.UploadedFileManager import UploadedFileList
 from streamlit.UploadedFileManager import UploadedFileManager
 
-FILE_1A = UploadedFile(
-    session_id="session",
-    widget_id="widget",
-    name="FILE_1A",
-    data=b"FILE_1A",
-)
-
-FILE_1B = UploadedFile(
-    session_id="session",
-    widget_id="widget",
-    name="FILE_1B",
-    data=b"FILE_1B",
-)
-
-FILE_2 = UploadedFile(
-    session_id="session2",
-    widget_id="widget",
-    name="FILE_2",
-    data=b"FILE_2",
-)
+file1 = UploadedFile(name="file1", data=b"file1")
+file2 = UploadedFile(name="file2", data=b"file2")
 
 
 class UploadedFileManagerTest(unittest.TestCase):
     def setUp(self):
         self.mgr = UploadedFileManager()
-        self.file_added_events = []
-        self.mgr.on_file_added.connect(self._on_file_added)
+        self.filemgr_events = []
+        self.mgr.on_files_added.connect(self._on_files_added)
 
-    def _on_file_added(self, file, **kwargs):
-        self.file_added_events.append(file)
+    def _on_files_added(self, file_list, **kwargs):
+        self.filemgr_events.append(file_list)
 
     def test_add_file(self):
-        self.assertIsNone(self.mgr.get_file_data("non-report", "non-widget"))
+        self.assertIsNone(self.mgr.get_files("non-report", "non-widget"))
 
-        self.mgr.add_file(FILE_1A)
-        self.assertEqual(b"FILE_1A", self.mgr.get_file_data("session", "widget"))
-        self.assertEqual([FILE_1A], self.file_added_events)
+        event1 = UploadedFileList("session", "widget", [file1])
+        event2 = UploadedFileList("session", "widget", [file2])
+
+        self.mgr.add_files("session", "widget", [file1])
+        self.assertEqual([file1], self.mgr.get_files("session", "widget"))
+        self.assertEqual([event1], self.filemgr_events)
 
         # Add another file with the same ID
-        self.mgr.add_file(FILE_1B)
-        self.assertEqual([FILE_1A, FILE_1B], self.file_added_events)
-        self.assertEqual(b"FILE_1B", self.mgr.get_file_data("session", "widget"))
+        self.mgr.add_files("session", "widget", [file2])
+        self.assertEqual([file2], self.mgr.get_files("session", "widget"))
+        self.assertEqual([event1, event2], self.filemgr_events)
 
     def test_remove_file(self):
         # This should not error.
-        self.mgr.remove_file("non-report", "non-widget")
+        self.mgr.remove_files("non-report", "non-widget")
 
-        self.mgr.add_file(FILE_1A)
-        self.assertEqual(b"FILE_1A", self.mgr.get_file_data("session", "widget"))
+        self.mgr.add_files("session", "widget", [file1])
+        self.assertEqual([file1], self.mgr.get_files("session", "widget"))
 
-        self.mgr.remove_file("session", "widget")
-        self.assertIsNone(self.mgr.get_file_data("session", "widget"))
-        self.assertEqual([FILE_1A], self.file_added_events)
+        self.mgr.remove_files("session", "widget")
+        self.assertIsNone(self.mgr.get_files("session", "widget"))
 
     def test_remove_all_files(self):
+        # This should not error.
         self.mgr.remove_session_files("non-report")
 
-        self.mgr.add_file(FILE_1A)
-        self.mgr.add_file(FILE_2)
+        # Add two files with different session IDs, but the same widget ID.
+        self.mgr.add_files("session1", "widget", [file1])
+        self.mgr.add_files("session2", "widget", [file1])
 
-        self.mgr.remove_session_files("session")
-        self.assertIsNone(self.mgr.get_file_data("session", "widget"))
-        self.assertEqual(b"FILE_2", self.mgr.get_file_data("session2", "widget"))
-        self.assertEqual([FILE_1A, FILE_2], self.file_added_events)
+        event1 = UploadedFileList("session1", "widget", [file1])
+        event2 = UploadedFileList("session2", "widget", [file1])
+
+        self.mgr.remove_session_files("session1")
+        self.assertIsNone(self.mgr.get_files("session1", "widget"))
+        self.assertEqual([file1], self.mgr.get_files("session2", "widget"))
+        self.assertEqual([event1, event2], self.filemgr_events)

--- a/lib/tests/streamlit/file_uploader_test.py
+++ b/lib/tests/streamlit/file_uploader_test.py
@@ -28,19 +28,26 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.label, "the label")
 
-    def test_string_typel(self):
+    def test_single_type(self):
         """Test that it can be called using a string for type parameter."""
         st.file_uploader("the label", type="png")
 
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, ["png"])
 
-    def test_several_types(self):
+    def test_multiple_types(self):
         """Test that it can be called using an array for type parameter."""
         st.file_uploader("the label", type=["png", "svg", "jpeg"])
 
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, ["png", "svg", "jpeg"])
+
+    def test_multiple_files(self):
+        """Test the multiple_files flag"""
+        for multiple_files in [True, False]:
+            st.file_uploader("label", type="png", multiple_files=multiple_files)
+            c = self.get_delta_from_queue().new_element.file_uploader
+            self.assertEqual(multiple_files, c.multiple_files)
 
     def test_max_upload_size_mb(self):
         """Test that the max upload size is the configuration value."""

--- a/lib/tests/streamlit/file_uploader_test.py
+++ b/lib/tests/streamlit/file_uploader_test.py
@@ -48,22 +48,22 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
 
     @patch("streamlit.UploadedFileManager.UploadedFileManager.get_files")
     def test_multiple_files(self, get_files_patch):
-        """Test the multiple_files flag"""
+        """Test the accept_multiple_files flag"""
         files = [UploadedFile("file1", b"123"), UploadedFile("file2", b"456")]
         file_vals = [get_encoded_file_data(file.data).getvalue() for file in files]
 
         get_files_patch.return_value = files
 
-        for multiple_files in [True, False]:
+        for accept_multiple in [True, False]:
             return_val = st.file_uploader(
-                "label", type="png", multiple_files=multiple_files
+                "label", type="png", accept_multiple_files=accept_multiple
             )
             c = self.get_delta_from_queue().new_element.file_uploader
-            self.assertEqual(multiple_files, c.multiple_files)
+            self.assertEqual(accept_multiple, c.multiple_files)
 
-            # If "multiple_files" is True, then we should get a list of values
+            # If "accept_multiple_files" is True, then we should get a list of values
             # back. Otherwise, we should just get a single value.
-            if multiple_files:
+            if accept_multiple:
                 self.assertEqual(file_vals, [val.getvalue() for val in return_val])
             else:
                 self.assertEqual(file_vals[0], return_val.getvalue())

--- a/proto/streamlit/proto/FileUploader.proto
+++ b/proto/streamlit/proto/FileUploader.proto
@@ -30,5 +30,8 @@ message FileUploader {
   // Max file size allowed by server config
   int32 max_upload_size_mb = 4;
 
+  // If true, the widget accepts multiple files for upload.
+  bool multiple_files = 6;
+
   reserved 5;
 }


### PR DESCRIPTION
This adds basic support for uploading multiple files to a single st.file_uploader

- `st.file_uploader` now has a new flag, `accept_multiple_files`. It defaults to false.
- When `accept_multiple_files` is true, the frontend widget will accept multiple files, and the Python API will return a list of BytesIO/StringIO objects if 1 or more files are uploaded to the widget. (That is, even if the user uploads a single file, the multi-file uploader will always return a list. The single-file variant will never return a list.)
- `UploadedFileManager` now stores lists of files by `session_id/widget_id` key, instead of just single files.
- The e2e test validates the entire round trip of both single and multiple file uploads.

Closes #912 (there are additional API changes to make to file_uploader, but we're going to be addressing them in future PRs.)