### PR TITLE
Fix st.cache

### DIFF
--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -513,13 +513,13 @@ def cache(
             code_hasher.update(func)
             LOGGER.debug("Hashing function %s in %i bytes.", name, code_hasher.size)
 
-            value_hasher = value_hasher.hexdigest()
-            LOGGER.debug("Cache key: %s", value_hasher)
+            value_key = value_hasher.hexdigest()
+            LOGGER.debug("Cache key: %s", value_key)
 
             try:
                 return_value = _read_from_cache(
                     mem_cache=mem_cache,
-                    key=value_hasher,
+                    key=value_key,
                     persisted=persist,
                     allow_output_mutation=allow_output_mutation,
                     hash_funcs=hash_funcs,
@@ -537,7 +537,7 @@ def cache(
 
                 _write_to_cache(
                     mem_cache=mem_cache,
-                    key=value_hasher,
+                    key=value_key,
                     value=return_value,
                     persist=persist,
                     allow_output_mutation=allow_output_mutation,

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -255,7 +255,6 @@ def _get_mutated_output_error_message():
 
 
 def _read_from_mem_cache(mem_cache, key, allow_output_mutation, hash_funcs):
-    # TODO: this is broken
     if key in mem_cache:
         entry = mem_cache[key]
 

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -593,7 +593,7 @@ class Cache(Dict[Any, Any]):
     def __init__(self, persist=False, allow_output_mutation=False):
         self._persist = persist
         self._allow_output_mutation = allow_output_mutation
-        self._mem_cache = _create_mem_cache(None, None)
+        self._mem_cache = {}
 
         dict.__init__(self)
 

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -484,10 +484,17 @@ def cache(
     # inside the decorated function.
 
     func_hasher = CodeHasher("md5", None, hash_funcs)
+    # Include the function's module and qualified name in the hash.
+    # This means that two identical functions in different modules
+    # will not share a hash; it also means that two identical *nested*
+    # functions in the same module will not share a hash.
+    func_hasher.update(func.__module__)
     func_hasher.update(func.__qualname__)
     func_hasher.update(func)
     cache_key = func_hasher.hexdigest()
-    LOGGER.debug("mem_cache key for %s: %s", func.__qualname__, cache_key)
+    LOGGER.debug(
+        "mem_cache key for %s.%s: %s", func.__module__, func.__qualname__, cache_key
+    )
 
     @functools_wraps(func)
     def wrapped_func(*args, **kwargs):

--- a/lib/tests/streamlit/scriptrunner/test_data/st_cache_script.py
+++ b/lib/tests/streamlit/scriptrunner/test_data/st_cache_script.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A script for ScriptRunnerTest that uses st.cache"""
+
+import streamlit as st
+
+# Except for their names, these functions all intentionally have the same
+# bodies - so their ASTs should hash to the same values. However, they should
+# *not* share the same caches, because we include a function's qualified
+# name in its cache key. To test that this is true, the associated ScriptRunner
+# test should run the script twice:
+# - On the first run, "cached function called" should be produced 4 times
+# - On the second run, "cached function called" should not be produced
+
+
+@st.cache(suppress_st_warning=True)
+def cached1():
+    st.text("cached function called")
+    return "cached value"
+
+
+@st.cache(suppress_st_warning=True)
+def cached2():
+    st.text("cached function called")
+    return "cached value"
+
+
+def outer_func():
+    # These closures share the names and bodies of the functions in the outer
+    # scope, but they should have their own independent caches.
+    @st.cache(suppress_st_warning=True)
+    def cached1():
+        st.text("cached function called")
+        return "cached value"
+
+    @st.cache(suppress_st_warning=True)
+    def cached2():
+        st.text("cached function called")
+        return "cached value"
+
+    cached1()
+    cached2()
+
+
+cached1()
+cached2()
+outer_func()


### PR DESCRIPTION
This fixes breakage that I introduced in #1152 

Rather than creating the cache as a local variable in the st.cache wrapper, we instead manage all caches in a global `_MemCaches` class. Each cache is keyed off its wrapped function's fully qualified name, and its contents.

There's a new `ScriptRunner` test that makes sure that caches are reused across multiple runs of the same script.