### PR TITLE
Another attempt at test_multiple_scriptrunners timeouts

### DIFF
--- a/lib/tests/streamlit/scriptrunner/ScriptRunner_test.py
+++ b/lib/tests/streamlit/scriptrunner/ScriptRunner_test.py
@@ -260,9 +260,8 @@ class ScriptRunnerTest(unittest.TestCase):
 
     def test_multiple_scriptrunners(self):
         """Tests that multiple scriptrunners can run simultaneously."""
-        # This scriptrunner will run in parallel to the other 3. It's used to
-        # retrieve the widget id before initializing deltas on other runners.
-        # Wait a beat to access deltas.
+        # This scriptrunner will run before the other 3. It's used to retrieve
+        # the widget id before initializing deltas on other runners.
         scriptrunner = TestScriptRunner("widgets_script.py")
         scriptrunner.enqueue_rerun()
         scriptrunner.start()
@@ -487,8 +486,8 @@ def require_widgets_deltas(
         if len(runner.deltas()) < NUM_DELTAS:
             err_string += "\n- incomplete deltas: {}".format(runner.text_deltas())
 
-    # Shutdown all runners before throwing an error, so that the
-    # script doesn't hang forever.
+    # Shutdown all runners before throwing an error, so that the script
+    # doesn't hang forever.
     for runner in runners:
         runner.enqueue_shutdown()
     for runner in runners:

--- a/lib/tests/streamlit/scriptrunner/test_data/widgets_script.py
+++ b/lib/tests/streamlit/scriptrunner/test_data/widgets_script.py
@@ -36,7 +36,7 @@ st.text("%s" % button)
 
 # Loop forever so that our test can check widget states
 # without the scriptrunner shutting down.
-placeholder = st.empty()
+placeholder = st.text("loop_forever")
 while True:
-    time.sleep(0.01)
+    time.sleep(0.1)
     placeholder.text("loop_forever")


### PR DESCRIPTION
- Shutdown the first scriptrunner before starting the next 3
- Longer infinite-loop sleep time in widgts_script.py, so we don't wake up too frequently
- Increase our wait_for_widgets_script_deltas timeout to 15 seconds (from 5)
- Throw a detailed error from wait_for_widgets_script_deltas
- On wait_for_widgets timeout, shutdown the scriptrunners so that the Circle job doesn't hang forever.