### PR TITLE
Added support to st.image for objects supporting IPython.display.display

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1442,6 +1442,7 @@ class DeltaGenerator(object):
             OR an RGBA image of shape (w,h,4)
             OR a URL to fetch the image from
             OR a list of one of the above, to display multiple images.
+            OR conforming to _repr_jpeg_ or _repr_png_ from IPython.display.display
         caption : str or list of str
             Image caption. If displaying multiple images, caption should be a
             list of captions (one for each image).
@@ -1478,6 +1479,10 @@ class DeltaGenerator(object):
            height: 630px
 
         """
+
+        if getattr(image, f"_repr_{format.lower()}_", None):
+            image = getattr(image, f"_repr_{format.lower()}_")()
+
         from .elements import image_proto
 
         if use_column_width:


### PR DESCRIPTION
- methods _repr_jpeg_ or _repr_png_ are invoked if they exist
- this includes the likes of fastai.vision.image.Image

## Before contributing (PLEASE READ!)

⚠️ **As with most projects, prior to starting to code on a bug fix or feature request, please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers.

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.
https://github.com/streamlit/streamlit/issues/1273

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.
Check if the format (e.g. JPEG or PNG) _repr_jpeg_ or _repr_png_ method exists and if so substitute the input with the result of calling that method.
---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
