### PR TITLE
Update data explorer docs w/ small communication fix

### DIFF
--- a/docs/tutorial/create_a_data_explorer_app.md
+++ b/docs/tutorial/create_a_data_explorer_app.md
@@ -102,10 +102,10 @@ luckily Streamlit allows you to cache the data.
    see anything change. Let’s tweak your file a little bit more so that you can
    see the power of caching.
 
-3. Replace the line `st.write('Done!')` with this:
+3. Replace the line `data_load_state.text('Loading data...done!')` with this:
 
    ```python
-   st.write('Done! (using st.cache)')
+   data_load_state.text("Done! (using st.cache)")
    ```
 
 4. Now save. See how the line you added appeared immediately? If you take a
@@ -330,7 +330,7 @@ def load_data(nrows):
 
 data_load_state = st.text('Loading data...')
 data = load_data(10000)
-data_load_state.text('Loading data... done!')
+data_load_state.text("Done! (using st.cache)")
 
 if st.checkbox('Show raw data'):
     st.subheader('Raw data')


### PR DESCRIPTION
"Replace the line `st.write('Done!')` with this:" -> "Replace the line `data_load_state.text('Loading data...done!')` with this:"

`st.write('Done!')` isn't used in the data explorer demo app, replaced parts where it's referenced with appropriate text.

PS Absolutely beautiful documentation. Looking more and more forward to using Streamlit for my own apps :)

---

**Issue:** Doc fix 

**Description:** Small documentation update to maintain consistency of language/code.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
