### PR TITLE
Version 0.57.3

### DIFF
--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -26,7 +26,7 @@ $ pip install --upgrade streamlit
 $ streamlit version
 ```
 
-...and then verify that the version number printed is `0.57.2`.
+...and then verify that the version number printed is `0.57.3`.
 
 **Try reproducing the issue now.** If not fixed, keep reading on.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-browser",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -8,7 +8,7 @@ from pipenv.project import Project
 from pipenv.utils import convert_deps_to_pip
 from setuptools.command.install import install
 
-VERSION = "0.57.2"  # PEP-440
+VERSION = "0.57.3"  # PEP-440
 
 NAME = "streamlit"
 


### PR DESCRIPTION
Just up version to 0.57.3 without any other changes. That's because 0.57.3 was just released consisting of 0.57.2, which is already merged into develop, plus a cherrypick that is also already merged into develop.