### PR TITLE
Fix typo in st.graphviz_chart docstring

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1141,7 +1141,7 @@ class DeltaGenerator(object):
         >>> import graphviz as graphviz
         >>>
         >>> # Create a graphlib graph object
-        >>> graph = graphviz.DiGraph()
+        >>> graph = graphviz.Digraph()
         >>> graph.edge('run', 'intr')
         >>> graph.edge('intr', 'runbl')
         >>> graph.edge('runbl', 'run')


### PR DESCRIPTION
`graphviz.DiGraph` -> `graphviz.Digraph`

Fixes #1304