### PR TITLE
Add sphinx-markdown-tables

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "recommonmark",
     "stoutput",
+    'sphinx_markdown_tables'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -15,6 +15,7 @@ wheel = "*"
 Sphinx = "==1.8.5"
 sphinx-rtd-theme = "*"
 recommonmark = "*"
+sphinx-markdown-tables = "*"
 # Packages used in unit tests:
 matplotlib = "*"
 plotly = "*"


### PR DESCRIPTION
* Adding `sphinx-markdown-tables` extension to our implementation.
* This is a value add, because we can now render tables using raw markdown.