### PR TITLE
Central message dispatcher for iframe messages

### DIFF
--- a/component_template/component_example.py
+++ b/component_template/component_example.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 # Register "my_component" as a Streamlit component.
-st.register_component("my_component", "build")
+st.register_component("my_component", "component_template/build")
 
 # Create an instance of the component. Arguments we pass here
 # will be available in an "args" dictionary in the component.

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -22,7 +22,7 @@ import React, { createRef, ReactNode } from "react"
 import { ComponentRegistry } from "./ComponentRegistry"
 
 /** Messages from Component -> Streamlit */
-enum ComponentBackMsgType {
+export enum ComponentBackMsgType {
   // A component sends this message when it's ready to receive messages
   // from Streamlit. Streamlit won't send any messages until it gets this.
   // No data.
@@ -39,7 +39,7 @@ enum ComponentBackMsgType {
 }
 
 /** Messages from Streamlit -> Component */
-enum ComponentForwardMsgType {
+export enum ComponentForwardMsgType {
   // Sent by Streamlit when the component should re-render.
   // Data: { args: any, disabled: boolean }
   RENDER = "render",
@@ -89,9 +89,9 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       return
     }
 
-    this.props.registry.registerComponentInstance(
+    this.props.registry.registerListener(
       this.iframeRef.current.contentWindow,
-      this
+      this.onBackMsg
     )
   }
 
@@ -103,12 +103,15 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       return
     }
 
-    this.props.registry.deregisterComponentInstance(
+    this.props.registry.deregisterListener(
       this.iframeRef.current.contentWindow
     )
   }
 
-  public onBackMsg = (type: string, data: any): void => {
+  /**
+   * Receive a ComponentBackMsg from our component iframe.
+   */
+  private onBackMsg = (type: string, data: any): void => {
     switch (type) {
       case ComponentBackMsgType.COMPONENT_READY:
         if (this.componentReady) {

--- a/frontend/src/components/widgets/CustomComponent/ComponentRegistry.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentRegistry.tsx
@@ -15,24 +15,80 @@
  * limitations under the License.
  */
 
+import { logWarning } from "lib/log"
 import { BaseUriParts, buildHttpUri } from "lib/UriUtil"
+import { ComponentInstance } from "./ComponentInstance"
 
 /**
- * Downloads and compiles components from the server.
+ * Dispatches iframe messages to ComponentInstances.
  */
 export class ComponentRegistry {
   private readonly getServerUri: () => BaseUriParts | undefined
+  private readonly instances = new Map<MessageEventSource, ComponentInstance>()
 
   public constructor(getServerUri: () => BaseUriParts | undefined) {
     this.getServerUri = getServerUri
+    window.addEventListener("message", this.onMessageEvent)
   }
 
-  public getComponentURL(componentId: string, path: string): string {
+  public registerComponentInstance = (
+    messageEventSource: MessageEventSource,
+    instance: ComponentInstance
+  ): void => {
+    if (this.instances.has(messageEventSource)) {
+      logWarning(`ComponentInstance registered multiple times!`, instance)
+    }
+
+    this.instances.set(messageEventSource, instance)
+  }
+
+  public deregisterComponentInstance = (
+    messageEventSource: MessageEventSource
+  ): void => {
+    const removed = this.instances.delete(messageEventSource)
+    if (!removed) {
+      logWarning(`Could not deregister unregistered ComponentInstance!`)
+    }
+  }
+
+  public getComponentURL = (componentId: string, path: string): string => {
     const serverURI = this.getServerUri()
     if (serverURI === undefined) {
       throw new Error("Can't fetch component: not connected to a server")
     }
 
     return buildHttpUri(serverURI, `component/${componentId}/${path}`)
+  }
+
+  private onMessageEvent = (event: MessageEvent): void => {
+    if (!event.data.hasOwnProperty("isStreamlitMessage")) {
+      // Disregard messages that don't come from components.
+      return
+    }
+
+    if (event.source == null) {
+      // This should not be possible.
+      logWarning(`Received component message with no eventSource!`, event.data)
+      return
+    }
+
+    // Get the ComponentInstance associated with the event
+    const instance = this.instances.get(event.source)
+    if (instance == null) {
+      logWarning(
+        `Received component message for unregistered ComponentInstance!`,
+        event.data
+      )
+      return
+    }
+
+    const type = event.data["type"]
+    if (type == null) {
+      logWarning(`Received Streamlit message with no type!`, event.data)
+      return
+    }
+
+    // Forward the message on to the appropriate ComponentInstance.
+    instance.onBackMsg(type, event.data)
   }
 }

--- a/lib/streamlit/components.py
+++ b/lib/streamlit/components.py
@@ -228,8 +228,11 @@ class ComponentRegistry:
         if not os.path.isdir(abspath):
             raise StreamlitAPIException("No such component directory: '%s'" % abspath)
 
-        if self._components.get(name) != abspath:
-            raise StreamlitAPIException("Component '{}' is already registered to '{}'".format(name, path))
+        existing = self._components.get(name)
+        if existing is not None and existing != abspath:
+            raise StreamlitAPIException(
+                "Component '{}' is already registered to '{}'".format(name, path)
+            )
 
         self._components[name] = abspath
         return name

--- a/proto/streamlit/proto/ComponentInstance.proto
+++ b/proto/streamlit/proto/ComponentInstance.proto
@@ -12,7 +12,7 @@ message ComponentInstance {
   // We'll probably want to transmit dataframe data separately (not in JSON).
   repeated ArgsDataframe args_dataframe = 3;
 
-  // ID that uniquely identifies the component this is an instance of.
+  // The component's unique ID.
   string component_id = 4;
 }
 


### PR DESCRIPTION
There are two changes in this PR:

- A component's ID is now just its name (rather than a hash).
- On the frontend, `ComponentRegistry` is now responsible for dispatching "ComponentBackMsgs" to their intended `ComponentInstance`. This means that instances don't all install their own event listeners.