### PR TITLE
Allow serving components from a URL

### DIFF
--- a/component_template/.env
+++ b/component_template/.env
@@ -1,0 +1,3 @@
+# Run the component's dev server on :3001
+# (The Streamlit dev server already runs on :3000)
+PORT=3001

--- a/component_template/component_example.py
+++ b/component_template/component_example.py
@@ -1,7 +1,11 @@
 import streamlit as st
 
 # Register "my_component" as a Streamlit component.
-st.register_component("my_component", "component_template/build")
+st.register_component("my_component", path="component_template/build")
+
+# Alternately, you can serve your in-development component with node,
+# and edit it live. Pass its URL instead of a path:
+# st.register_component("my_component", url="http://localhost:3001")
 
 # Create an instance of the component. Arguments we pass here
 # will be available in an "args" dictionary in the component.

--- a/component_template/src/MyComponent.tsx
+++ b/component_template/src/MyComponent.tsx
@@ -1,5 +1,5 @@
-import React from "react"
-import { connectToStreamlit, StreamlitComponent } from "./streamlit"
+import React, { ReactNode } from "react"
+import { withStreamlitConnection, StreamlitComponent } from "./streamlit"
 
 // We import bootstrap.css to get some simple default styling for our
 // text and button. You can remove or replace this.
@@ -15,7 +15,7 @@ interface State {
 class MyComponent extends StreamlitComponent<State> {
   public state = { numClicks: 0 }
 
-  public render = (): React.ReactNode => {
+  public render = (): ReactNode => {
     // Arguments that are passed to the plugin in Python are accessible
     // via `this.props.args`. Here, we access the "name" arg.
     let name = this.props.args["name"]
@@ -46,10 +46,10 @@ class MyComponent extends StreamlitComponent<State> {
   }
 }
 
-// "connectToStreamlit" is a wrapper function. It bootstraps the
+// "withStreamlitConnection" is a wrapper function. It bootstraps the
 // connection between your component and the Streamlit app, and handles
 // passing arguments from Python -> Component, and widget values from
 // Component -> Python.
 //
-// You don't need to edit connectToStreamlit (but you're welcome to!).
-export default connectToStreamlit(MyComponent)
+// You don't need to edit withStreamlitConnection (but you're welcome to!).
+export default withStreamlitConnection(MyComponent)

--- a/component_template/src/examples/BuggyComponent.tsx
+++ b/component_template/src/examples/BuggyComponent.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react"
-import { connectToStreamlit, StreamlitComponent } from "../streamlit"
+import { withStreamlitConnection, StreamlitComponent } from "../streamlit"
 
 class BuggyComponent extends StreamlitComponent {
   public render = (): ReactNode => {
@@ -8,4 +8,4 @@ class BuggyComponent extends StreamlitComponent {
   }
 }
 
-export default connectToStreamlit(BuggyComponent)
+export default withStreamlitConnection(BuggyComponent)

--- a/component_template/src/examples/DataframeComponent.tsx
+++ b/component_template/src/examples/DataframeComponent.tsx
@@ -8,7 +8,11 @@ import React, {
   useEffect,
 } from "react"
 import { Table as UITable } from "reactstrap"
-import { ArrowTable, ComponentProps, connectToStreamlit } from "../streamlit"
+import {
+  ArrowTable,
+  ComponentProps,
+  withStreamlitConnection,
+} from "../streamlit"
 
 interface TableProps {
   element: ArrowTable
@@ -146,4 +150,4 @@ const DataframeComponent = (props: ComponentProps) => {
   return <Table element={props.args.data} />
 }
 
-export default connectToStreamlit(DataframeComponent)
+export default withStreamlitConnection(DataframeComponent)

--- a/component_template/src/examples/RadioButton.tsx
+++ b/component_template/src/examples/RadioButton.tsx
@@ -6,7 +6,7 @@ import { Client as Styletron } from "styletron-engine-atomic"
 import { Provider as StyletronProvider } from "styletron-react"
 import {
   ComponentProps,
-  connectToStreamlit,
+  withStreamlitConnection,
   StreamlitComponent,
 } from "../streamlit"
 
@@ -110,4 +110,4 @@ class RadioButton extends StreamlitComponent<State> {
   }
 }
 
-export default connectToStreamlit(RadioButton)
+export default withStreamlitConnection(RadioButton)

--- a/component_template/src/examples/Resizer.tsx
+++ b/component_template/src/examples/Resizer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { connectToStreamlit, StreamlitComponent } from "../streamlit"
+import { withStreamlitConnection, StreamlitComponent } from "../streamlit"
 
 interface State {
   fontSize: number
@@ -39,4 +39,4 @@ class Resizer extends StreamlitComponent<State> {
   }
 }
 
-export default connectToStreamlit(Resizer)
+export default withStreamlitConnection(Resizer)

--- a/component_template/src/streamlit/index.tsx
+++ b/component_template/src/streamlit/index.tsx
@@ -21,5 +21,5 @@ import { ComponentProps as ComponentProps_ } from "./StreamlitComponent"
 
 export { StreamlitComponent } from "./StreamlitComponent"
 export { ArrowTable } from "./ArrowTable"
-export { connectToStreamlit } from "./connectToStreamlit"
+export { withStreamlitConnection } from "./withStreamlitConnection"
 export type ComponentProps = ComponentProps_

--- a/component_template/src/streamlit/withStreamlitConnection.tsx
+++ b/component_template/src/streamlit/withStreamlitConnection.tsx
@@ -14,7 +14,7 @@ interface ArgsDataframe {
  *
  * Component writers do not need to edit this function.
  */
-export function connectToStreamlit(
+export function withStreamlitConnection(
   WrappedComponent: React.ComponentType<ComponentProps>
 ): React.ComponentType {
   interface WrapperProps {}

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -215,7 +215,17 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
 
   public render = (): ReactNode => {
     const componentId = this.props.element.get("componentId")
-    const src = this.props.registry.getComponentURL(componentId, "index.html")
+    const url = this.props.element.get("url")
+
+    // Determine the component iframe's src. If a URL is specified,
+    // we just use that. Otherwise, we derive the URL from the the
+    // component's ID.
+    let src: string
+    if (url != null && url !== "") {
+      src = url
+    } else {
+      src = this.props.registry.getComponentURL(componentId, "index.html")
+    }
 
     const renderArgs = JSON.parse(this.props.element.get("argsJson"))
     const renderDfs = this.props.element.get("argsDataframe").toJS()

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -217,9 +217,8 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
     const componentId = this.props.element.get("componentId")
     const url = this.props.element.get("url")
 
-    // Determine the component iframe's src. If a URL is specified,
-    // we just use that. Otherwise, we derive the URL from the the
-    // component's ID.
+    // Determine the component iframe's src. If a URL is specified, we just
+    // use that. Otherwise, we derive the URL from the component's ID.
     let src: string
     if (url != null && url !== "") {
       src = url

--- a/lib/streamlit/components.py
+++ b/lib/streamlit/components.py
@@ -211,7 +211,7 @@ class ComponentRegistry:
         return cls._instance
 
     def __init__(self):
-        self._components = {}  # type: Dict[str, str]
+        self._components = {}  # type: Dict[str, Optional[str]]
 
     def register_component(self, name: str, path: Optional[str] = None) -> str:
         """Register a filesystem path as a custom component.
@@ -229,14 +229,13 @@ class ComponentRegistry:
         str
             The component's ID. (This is just its name.)
         """
+        abspath = None
         if path is not None:
             abspath = os.path.abspath(path)
             if not os.path.isdir(abspath):
                 raise StreamlitAPIException(
                     "No such component directory: '%s'" % abspath
                 )
-        else:
-            abspath = None
 
         self._components[name] = abspath
         return name

--- a/lib/streamlit/components.py
+++ b/lib/streamlit/components.py
@@ -134,11 +134,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             self.set_status(404)
             return
 
-        if len(parts) > 1:
-            filename = "/".join(parts[1:])
-        else:
-            filename = "index.html"
-
+        filename = "/".join(parts[1:])
         abspath = os.path.join(component_root, filename)
 
         LOGGER.debug("ComponentRequestHandler: GET: %s -> %s", path, abspath)

--- a/lib/streamlit/components.py
+++ b/lib/streamlit/components.py
@@ -220,9 +220,6 @@ class ComponentRegistry:
     def register_component(self, name: str, path: Optional[str] = None) -> str:
         """Register a filesystem path as a custom component.
 
-        Raises an Exception if the name has already been registered to a
-        component with a different path.
-
         Parameters
         ----------
         name : str
@@ -244,12 +241,6 @@ class ComponentRegistry:
                 )
         else:
             abspath = None
-
-        existing = self._components.get(name)
-        if existing is not None and existing != abspath:
-            raise StreamlitAPIException(
-                "Component '{}' is already registered to '{}'".format(name, path)
-            )
 
         self._components[name] = abspath
         return name

--- a/proto/streamlit/proto/ComponentInstance.proto
+++ b/proto/streamlit/proto/ComponentInstance.proto
@@ -14,6 +14,11 @@ message ComponentInstance {
 
   // The component's unique ID.
   string component_id = 4;
+
+  // Optional URL to load the component from. By default this is not set,
+  // but while testing, a user can e.g. point this to a local node server
+  // that they're developing their component in.
+  string url = 5;
 }
 
 message ArgsDataframe {


### PR DESCRIPTION
- `yarn start` works to serve components
- I renamed `connectToStreamlit()` -> `withStreamlitConnection()`