### PR TITLE
Add theme for custom components

### DIFF
--- a/frontend/src/assets/css/custom_components_theme.scss
+++ b/frontend/src/assets/css/custom_components_theme.scss
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "variables";
+@import "fonts";
+@import "scrollbars";
+
+
+// Basics.
+
+body {
+  background: $white;
+  font-family: $font-family-san-serif;
+  font-size: $font-size-base;
+  line-height: $line-height-base;
+}
+
+code,
+pre {
+  font-family: $font-family-monospace;
+}
+
+a,
+a:visited {
+  color: $primary;
+}
+
+a:hover,
+a:active {
+  color: $primary;
+  text-decoration: underline;
+}
+
+
+// Some utility classes, so components can use our theme.
+
+.primary {
+  color: $primary;
+}
+
+.secondary {
+  color: $secondary;
+}
+
+.gray {
+  color: $gray;
+}
+
+.red {
+  color: $red;
+}
+
+.yellow {
+  color: $yellow;
+}
+
+.blue {
+  color: $blue;
+}
+
+.green {
+  color: $green;
+}

--- a/frontend/src/assets/css/scrollbars.scss
+++ b/frontend/src/assets/css/scrollbars.scss
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// Make scrollbars awesome on Chrome.
+
+::-webkit-scrollbar {
+  background-color: transparent;
+  border-radius: 100px;
+  height: 6px;
+  width: 6px;
+}
+
+::-webkit-scrollbar:hover {
+  background-color: rgba(0, 0, 0, 0.09);
+}
+
+::-webkit-scrollbar-thumb:vertical,
+::-webkit-scrollbar-thumb:horizontal {
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 100px;
+}
+
+::-webkit-scrollbar-thumb:vertical:active,
+::-webkit-scrollbar-thumb:horizontal:active {
+  background: rgba(0, 0, 0, 0.61);
+  border-radius: 100px;
+}

--- a/frontend/src/assets/css/theme.scss
+++ b/frontend/src/assets/css/theme.scss
@@ -18,6 +18,7 @@
 @import "fonts";
 @import "~bootstrap/scss/bootstrap";
 @import "src/assets/css/mixins";
+@import "scrollbars";
 
 // IMPORTANT! This must come after the bootstrap import.
 // Styletron creates classes called h1, h2, etc., which conflict with Bootstrap classes.
@@ -161,40 +162,4 @@ pre {
 .icon {
   width: 0.9rem;
   height: 0.9rem;
-}
-
-// Undo bootstrap changes to classes that Styletron uses and we don't.
-
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
-  all: unset;
-}
-
-// Make scrollbars awesome on Chrome.
-
-::-webkit-scrollbar {
-  background-color: transparent;
-  border-radius: 100px;
-  height: 6px;
-  width: 6px;
-}
-
-::-webkit-scrollbar:hover {
-  background-color: rgba(0, 0, 0, 0.09);
-}
-
-::-webkit-scrollbar-thumb:vertical,
-::-webkit-scrollbar-thumb:horizontal {
-  background: rgba(0, 0, 0, 0.5);
-  border-radius: 100px;
-}
-
-::-webkit-scrollbar-thumb:vertical:active,
-::-webkit-scrollbar-thumb:horizontal:active {
-  background: rgba(0, 0, 0, 0.61);
-  border-radius: 100px;
 }


### PR DESCRIPTION
This adds `frontend/src/assets/css/custom_components_theme.scss` and tweaks a couple of things in our existing theme to make them reusable in the new file.

The idea is that the Custom Components team should build a CSS file from the new SCSS file to ship with our boilerplate:

```
sass frontend/src/assets/css/custom_components_theme.scss streamlit_theme_css
```
(where `sass` [should first be installed](https://sass-lang.com/install))