### PR TITLE
Change list() cast

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1720,7 +1720,9 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
-                default_values = list(default_values)
+                default_values = (
+                    list(default_values) if default_values else [default_values]
+                )
 
             for value in default_values:
                 if value not in options:

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1721,6 +1721,9 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
+                # This if is done before others because calling if not x (done
+                # right below) when x is of type pd.Series() or np.array() throws a
+                # ValueError exception.                
                 if is_type(default_values, "numpy.ndarray") or is_type(
                     default_values, "pandas.core.series.Series"
                 ):

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1720,8 +1720,8 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
-                if default_values is None:
-                    default_values = [None]
+                if not default_values:
+                    default_values = [default_values]
                 else:
                     default_values = list(default_values)
 

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -42,6 +42,7 @@ from streamlit.proto import ForwardMsg_pb2
 from streamlit.proto.NumberInput_pb2 import NumberInput
 from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.logger import get_logger
+from streamlit.type_util import is_type
 
 LOGGER = get_logger(__name__)
 
@@ -1720,7 +1721,10 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
-                if not default_values:
+                if not default_values and not (
+                    is_type(default_values, "numpy.ndarray")
+                    or is_type(default_values, "pandas.core.series.Series")
+                ):
                     default_values = [default_values]
                 else:
                     default_values = list(default_values)

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1720,9 +1720,10 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
-                default_values = (
-                    list(default_values) if default_values else [default_values]
-                )
+                if default_values is None:
+                    default_values = [None]
+                else:
+                    default_values = list(default_values)
 
             for value in default_values:
                 if value not in options:

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1720,7 +1720,7 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
-                default_values = [default_values]
+                default_values = list(default_values)
 
             for value in default_values:
                 if value not in options:

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1721,10 +1721,11 @@ class DeltaGenerator(object):
                 return None
 
             if not isinstance(default_values, list):
-                if not default_values and not (
-                    is_type(default_values, "numpy.ndarray")
-                    or is_type(default_values, "pandas.core.series.Series")
+                if is_type(default_values, "numpy.ndarray") or is_type(
+                    default_values, "pandas.core.series.Series"
                 ):
+                    default_values = list(default_values)
+                elif not default_values:
                     default_values = [default_values]
                 else:
                     default_values = list(default_values)

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -40,6 +40,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             (["male", "female"], ["male", "female"]),
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
+            (["m", "f"], ("m", "f")),
         ]
     )
     def test_option_types(self, options, proto_options):

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -108,12 +108,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.options, ["Coffee", "Tea", "Water"])
 
     @parameterized.expand(
-        [
-            (("Tea", "Water"), [1, 2]),
-            ((i for i in ("Tea", "Water")), [1, 2]),
-            (np.array(["Coffee", "Tea"]), [0, 1]),
-            (pd.Series(np.array(["Cofee", "Tea"])), [0, 1]),
-        ]
+        [(("Tea", "Water"), [1, 2]), ((i for i in ("Tea", "Water")), [1, 2]),]
     )
     def test_default_types(self, defaults, expected):
         """Test that iterables other than lists can be passed as defaults."""

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -112,7 +112,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             (("Tea", "Water"), [1, 2]),
             ((i for i in ("Tea", "Water")), [1, 2]),
             (np.array(["Coffee", "Tea"]), [0, 1]),
-            (pd.Series(np.array(["Cofee", "Tea"])), [0, 1]),
+            (pd.Series(np.array(["Coffee", "Tea"])), [0, 1]),
         ]
     )
     def test_default_types(self, defaults, expected):

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -108,7 +108,12 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.options, ["Coffee", "Tea", "Water"])
 
     @parameterized.expand(
-        [(("Tea", "Water"), [1, 2]), ((i for i in ("Tea", "Water")), [1, 2]),]
+        [
+            (("Tea", "Water"), [1, 2]),
+            ((i for i in ("Tea", "Water")), [1, 2]),
+            (np.array(["Coffee", "Tea"]), [0, 1]),
+            (pd.Series(np.array(["Cofee", "Tea"])), [0, 1]),
+        ]
     )
     def test_default_types(self, defaults, expected):
         """Test that iterables other than lists can be passed as defaults."""

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -41,6 +41,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
             (["m", "f"], ("m", "f")),
+            (["m", "f"], (i for i in ("m", "f"))),
         ]
     )
     def test_option_types(self, options, proto_options):

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -40,8 +40,6 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             (["male", "female"], ["male", "female"]),
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
-            (["m", "f"], ("m", "f")),
-            (["m", "f"], (i for i in ("m", "f"))),
         ]
     )
     def test_option_types(self, options, proto_options):
@@ -102,6 +100,23 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
     @parameterized.expand([(None, []), ([], []), (["Tea", "Water"], [1, 2])])
     def test_defaults(self, defaults, expected):
         """Test that valid default can be passed as expected."""
+        st.multiselect("the label", ["Coffee", "Tea", "Water"], defaults)
+
+        c = self.get_delta_from_queue().new_element.multiselect
+        self.assertEqual(c.label, "the label")
+        self.assertListEqual(c.default[:], expected)
+        self.assertEqual(c.options, ["Coffee", "Tea", "Water"])
+
+    @parameterized.expand(
+        [
+            (("Tea", "Water"), [1, 2]),
+            ((i for i in ("Tea", "Water")), [1, 2]),
+            (np.array(["Coffee", "Tea"]), [0, 1]),
+            (pd.Series(np.array(["Cofee", "Tea"])), [0, 1]),
+        ]
+    )
+    def test_default_types(self, defaults, expected):
+        """Test that iterables other than lists can be passed as defaults."""
         st.multiselect("the label", ["Coffee", "Tea", "Water"], defaults)
 
         c = self.get_delta_from_queue().new_element.multiselect


### PR DESCRIPTION
---

**Issue:** [1397 - Multiselect check for defaults goes wrong if not a list](https://github.com/streamlit/streamlit/issues/1397)

**Description:** 
- Use `list(iterable)` instead of `[iterable]` to avoid errors (see Issue) because if `iterable` is a tuple, then it converts not to a list, but to a list of tuple. Also [from SO](https://stackoverflow.com/questions/3790848/fastest-way-to-convert-an-iterator-to-a-list) it looks like a preferred practice overall

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
