### PR TITLE
Bump https-proxy-agent to ^2.2.4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -151,6 +151,7 @@
   },
   "resolutions": {
     "esm": "^3.1.0",
+    "https-proxy-agent": "^2.2.4",
     "jquery": "^3.5.0",
     "kind-of": "^6.0.3",
     "minimist": "^0.2.1",


### PR DESCRIPTION
Added the required version to yarn resolutions.