### PR TITLE
Setting textarea height and unit tests

### DIFF
--- a/frontend/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.test.tsx
@@ -143,6 +143,20 @@ describe("TextArea widget", () => {
     )
   })
 
+  it("should set widget height if it is passed from props", () => {
+    const props = getProps({
+      height: 500,
+    })
+    const wrapper = shallow(<TextArea {...props} />)
+    const overrides = wrapper.find(UITextArea).prop("overrides")
+
+    // @ts-ignore
+    const { height, resize } = overrides.Input.style
+
+    expect(height).toBe("500px")
+    expect(resize).toBe("vertical")
+  })
+
   describe("On mac it should", () => {
     Object.defineProperty(navigator, "platform", {
       value: "MacIntel",

--- a/frontend/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.tsx
@@ -99,6 +99,7 @@ class TextArea extends React.PureComponent<Props, State> {
 
     const style = { width }
     const label = element.get("label")
+    const height = element.get("height")
 
     return (
       <div className="Widget stTextArea" style={style}>
@@ -109,6 +110,15 @@ class TextArea extends React.PureComponent<Props, State> {
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           disabled={disabled}
+          overrides={{
+            Input: {
+              style: {
+                height: height ? `${height}px` : "",
+                minHeight: "95px",
+                resize: height ? "vertical" : "none",
+              },
+            },
+          }}
         />
         {dirty && !this.isFromMac && (
           <div className="instructions">Press Ctrl+Enter to apply</div>

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -311,7 +311,7 @@ class DeltaGenerator(object):
     def _get_coordinates(self):
         """Returns the element's 4-component location as string like "M.(1,2).3".
 
-        This function uniquely identifies the element's position in the front-end, 
+        This function uniquely identifies the element's position in the front-end,
         which allows (among other potential uses) the MediaFileManager to maintain
         session-specific maps of MediaFile objects placed with their "coordinates".
 
@@ -2240,7 +2240,7 @@ class DeltaGenerator(object):
         return str(current_value)
 
     @_with_element
-    def text_area(self, element, label, value="", key=None):
+    def text_area(self, element, label, value="", height=None, key=None):
         """Display a multi-line text input widget.
 
         Parameters
@@ -2250,6 +2250,9 @@ class DeltaGenerator(object):
         value : any
             The text value of this widget when it first renders. This will be
             cast to str internally.
+        height : int or None
+            Desired height of the UI element expressed in pixels. If None, a
+            default height is used.
         key : str
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
@@ -2275,6 +2278,9 @@ class DeltaGenerator(object):
         """
         element.text_area.label = label
         element.text_area.default = str(value)
+
+        if  height is not None:
+            element.text_area.height = height
 
         ui_value = _get_widget_ui_value("text_area", element, user_key=key)
         current_value = ui_value if ui_value is not None else value

--- a/lib/tests/streamlit/text_area_test.py
+++ b/lib/tests/streamlit/text_area_test.py
@@ -43,6 +43,15 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(c.label, "the label")
             self.assertTrue(re.match(proto_value, c.default))
 
+    def test_height(self):
+        """Test that it can be called with height"""
+        st.text_area("the label", "", 300)
+
+        c = self.get_delta_from_queue().new_element.text_area
+        self.assertEqual(c.label, "the label")
+        self.assertEqual(c.default, "")
+        self.assertEqual(c.height, 300)
+
 
 class SomeObj(object):
     pass

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -20,4 +20,5 @@ message TextArea {
   string id = 1;
   string label = 2;
   string default = 3;
+  uint32 height = 4;
 }


### PR DESCRIPTION
**Issue:** This PR fixes #277 

**Description:** 
- New parameter to set the height manually
- If the height is already passed the user could change the height manually
- Added unit testing

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
