### PR TITLE
Fixing date_input | min and max selectable date issues

### DIFF
--- a/e2e/scripts/st_date_input.py
+++ b/e2e/scripts/st_date_input.py
@@ -16,7 +16,7 @@ import streamlit as st
 from datetime import datetime
 from datetime import date
 
-w1 = st.date_input("Label 1", date(1970, 1, 1))
+w1 = st.date_input("Label 1", date(1970, 1, 1), min_value=date(1970, 1, 1))
 st.write("Value 1:", w1)
 
 w2 = st.date_input("Label 2", datetime(2019, 7, 6, 21, 15))

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -33,7 +33,7 @@ const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
     id: 1,
     label: "Label",
     default: "1970/01/01",
-    minDate: "1970/01/01",
+    min: "1970/01/01",
     ...elementProps,
   }),
   width: 0,
@@ -106,19 +106,19 @@ describe("DateInput widget", () => {
   })
 
   it("should have a minDate", () => {
-    expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
+    expect(wrapper.find(UIDatePicker).prop("min")).toStrictEqual(
       new Date("1970/1/1")
     )
-    expect(wrapper.find(UIDatePicker).prop("maxDate")).toBeUndefined()
+    expect(wrapper.find(UIDatePicker).prop("max")).toBeUndefined()
   })
 
   it("should have a maxDate if it is passed", () => {
     const props = getProps({
-      maxDate: "2030/02/06",
+      max: "2030/02/06",
     })
     const wrapper = shallow(<DateInput {...props} />)
 
-    expect(wrapper.find(UIDatePicker).prop("maxDate")).toStrictEqual(
+    expect(wrapper.find(UIDatePicker).prop("max")).toStrictEqual(
       new Date("2030/02/06")
     )
   })

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -33,7 +33,7 @@ const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
     id: 1,
     label: "Label",
     default: "1970/01/01",
-    min: "1970/01/01",
+    min: "1970/1/1",
     ...elementProps,
   }),
   width: 0,
@@ -106,10 +106,10 @@ describe("DateInput widget", () => {
   })
 
   it("should have a minDate", () => {
-    expect(wrapper.find(UIDatePicker).prop("min")).toStrictEqual(
+    expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
       new Date("1970/1/1")
     )
-    expect(wrapper.find(UIDatePicker).prop("max")).toBeUndefined()
+    expect(wrapper.find(UIDatePicker).prop("maxDate")).toBeUndefined()
   })
 
   it("should have a maxDate if it is passed", () => {
@@ -118,7 +118,7 @@ describe("DateInput widget", () => {
     })
     const wrapper = shallow(<DateInput {...props} />)
 
-    expect(wrapper.find(UIDatePicker).prop("max")).toStrictEqual(
+    expect(wrapper.find(UIDatePicker).prop("maxDate")).toStrictEqual(
       new Date("2030/02/06")
     )
   })

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -19,6 +19,7 @@ import React from "react"
 import { shallow } from "enzyme"
 import { fromJS } from "immutable"
 import { WidgetStateManager } from "lib/WidgetStateManager"
+import { DateInput as DateInputProto } from "autogen/proto"
 
 import DateInput, { Props } from "./DateInput"
 import { Datepicker as UIDatePicker } from "baseui/datepicker"
@@ -27,11 +28,12 @@ jest.mock("lib/WidgetStateManager")
 
 const sendBackMsg = jest.fn()
 
-const getProps = (elementProps: object = {}): Props => ({
+const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
   element: fromJS({
     id: 1,
     label: "Label",
     default: "1970/01/01",
+    minDate: "1970/01/01",
     ...elementProps,
   }),
   width: 0,
@@ -100,6 +102,24 @@ describe("DateInput widget", () => {
       props.element.get("id"),
       "2020/02/06",
       { fromUi: true }
+    )
+  })
+
+  it("should have a minDate", () => {
+    expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
+      new Date("1970/1/1")
+    )
+    expect(wrapper.find(UIDatePicker).prop("maxDate")).toBeUndefined()
+  })
+
+  it("should have a maxDate if it is passed", () => {
+    const props = getProps({
+      maxDate: "2030/02/06",
+    })
+    const wrapper = shallow(<DateInput {...props} />)
+
+    expect(wrapper.find(UIDatePicker).prop("maxDate")).toStrictEqual(
+      new Date("2030/02/06")
     )
   })
 })

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -52,7 +52,8 @@ class DateInput extends React.PureComponent<Props, State> {
   }
 
   private handleChange = ({ date }: { date: Date | Date[] }): void => {
-    const value = dateToString(date as Date)
+    const value = moment(date as Date).format("YYYY/MM/DD")
+
     this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
   }
 
@@ -60,7 +61,7 @@ class DateInput extends React.PureComponent<Props, State> {
     const { element } = this.props
     const maxDate = element.get("max")
 
-    return maxDate && maxDate.length > 0 ? stringToDate(maxDate) : undefined
+    return maxDate && maxDate.length > 0 ? new Date(maxDate) : undefined
   }
 
   public render = (): React.ReactNode => {
@@ -69,7 +70,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
     const style = { width }
     const label = element.get("label")
-    const minDate = element.get("min")
+    const minDate = new Date(element.get("min"))
     const maxDate = this.getMaxDate()
 
     return (
@@ -80,21 +81,13 @@ class DateInput extends React.PureComponent<Props, State> {
           disabled={disabled}
           onChange={this.handleChange}
           overrides={datePickerOverrides}
-          value={stringToDate(value)}
-          minDate={stringToDate(minDate)}
+          value={new Date(value)}
+          minDate={minDate}
           maxDate={maxDate}
         />
       </div>
     )
   }
-}
-
-function dateToString(date: Date): string {
-  return moment(date).format("YYYY/MM/DD")
-}
-
-function stringToDate(value: string): Date {
-  return moment(value, "YYYY/MM/DD").toDate()
 }
 
 export default DateInput

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -56,19 +56,33 @@ class DateInput extends React.PureComponent<Props, State> {
     this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
   }
 
+  private getMaxDate = (): Date | undefined => {
+    const { element } = this.props
+    const maxDate = element.get("maxDate")
+
+    return maxDate && maxDate.length > 0 ? stringToDate(maxDate) : undefined
+  }
+
   public render = (): React.ReactNode => {
-    const style = { width: this.props.width }
-    const label = this.props.element.get("label")
+    const { width, element, disabled } = this.props
+    const { value } = this.state
+
+    const style = { width }
+    const label = element.get("label")
+    const minDate = element.get("minDate")
+    const maxDate = this.getMaxDate()
 
     return (
       <div className="Widget stDateInput" style={style}>
         <label>{label}</label>
         <UIDatePicker
           formatString="yyyy/MM/dd"
-          disabled={this.props.disabled}
+          disabled={disabled}
           onChange={this.handleChange}
           overrides={datePickerOverrides}
-          value={stringToDate(this.state.value)}
+          value={stringToDate(value)}
+          minDate={stringToDate(minDate)}
+          maxDate={maxDate}
         />
       </div>
     )

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -58,7 +58,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
   private getMaxDate = (): Date | undefined => {
     const { element } = this.props
-    const maxDate = element.get("maxDate")
+    const maxDate = element.get("max")
 
     return maxDate && maxDate.length > 0 ? stringToDate(maxDate) : undefined
   }
@@ -69,7 +69,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
     const style = { width }
     const label = element.get("label")
-    const minDate = element.get("minDate")
+    const minDate = element.get("min")
     const maxDate = this.getMaxDate()
 
     return (

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2351,7 +2351,7 @@ class DeltaGenerator(object):
         return current_value
 
     @_with_element
-    def date_input(self, element, label, value=None, min_value=date(1970, 1, 1), max_value=None, key=None):
+    def date_input(self, element, label, value=None, min_value=datetime.min, max_value=None, key=None):
         """Display a date input widget.
 
         Parameters
@@ -2362,7 +2362,7 @@ class DeltaGenerator(object):
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to today.
         min_value : datetime.date or datetime.datetime
-            The minimum selectable date. Defaults to 1970/1/1.
+            The minimum selectable date. Defaults to datetime.min.
         max_value : datetime.date or datetime.datetime
             The maximum selectable date. Defaults to 2030/12.
         key : str

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2364,7 +2364,7 @@ class DeltaGenerator(object):
         min_value : datetime.date or datetime.datetime
             The minimum selectable date. Defaults to datetime.min.
         max_value : datetime.date or datetime.datetime
-            The maximum selectable date. Defaults to 2030/12.
+            The maximum selectable date. Defaults to today+10y.
         key : str
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
@@ -2406,11 +2406,14 @@ class DeltaGenerator(object):
 
         element.date_input.min = date.strftime(min_value, "%Y/%m/%d")
 
-        if max_value is not None:
-            if isinstance(max_value, datetime):
-                max_value = max_value.date()
+        if max_value is None:
+            today = date.today()
+            max_value = date(today.year+10, today.month, today.day)
 
-            element.date_input.max = date.strftime(max_value, "%Y/%m/%d")
+        if isinstance(max_value, datetime):
+            max_value = max_value.date()
+
+        element.date_input.max = date.strftime(max_value, "%Y/%m/%d")
 
         ui_value = _get_widget_ui_value("date_input", element, user_key=key)
         current_value = (

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2351,7 +2351,7 @@ class DeltaGenerator(object):
         return current_value
 
     @_with_element
-    def date_input(self, element, label, value=None, key=None):
+    def date_input(self, element, label, value=None, min_date=date(1970, 1, 1), max_date=None, key=None):
         """Display a date input widget.
 
         Parameters
@@ -2361,6 +2361,10 @@ class DeltaGenerator(object):
         value : datetime.date/datetime.datetime
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to today.
+        min_date : datetime.date/datetime.datetime
+            A min date that is selectable. Defaults to 1970/1/1
+        max_date : datetime.date/datetime.datetime
+            A max date that is selectable.
         key : str
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
@@ -2396,6 +2400,18 @@ class DeltaGenerator(object):
 
         element.date_input.label = label
         element.date_input.default = date.strftime(value, "%Y/%m/%d")
+
+        if isinstance(min_date, datetime):
+            min_date = min_date.date()
+
+        element.date_input.min_date = date.strftime(min_date, "%Y/%m/%d")
+
+        if max_date is not None:
+            if isinstance(max_date, datetime):
+                max_date = max_date.date()
+
+            element.date_input.max_date = date.strftime(max_date, "%Y/%m/%d")
+
 
         ui_value = _get_widget_ui_value("date_input", element, user_key=key)
         current_value = (

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2351,20 +2351,20 @@ class DeltaGenerator(object):
         return current_value
 
     @_with_element
-    def date_input(self, element, label, value=None, min_date=date(1970, 1, 1), max_date=None, key=None):
+    def date_input(self, element, label, value=None, min_value=date(1970, 1, 1), max_value=None, key=None):
         """Display a date input widget.
 
         Parameters
         ----------
         label : str
             A short label explaining to the user what this date input is for.
-        value : datetime.date/datetime.datetime
+        value : datetime.date or datetime.datetime
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to today.
-        min_date : datetime.date/datetime.datetime
-            A min date that is selectable. Defaults to 1970/1/1
-        max_date : datetime.date/datetime.datetime
-            A max date that is selectable.
+        min_value : datetime.date or datetime.datetime
+            The minimum selectable date. Defaults to 1970/1/1.
+        max_value : datetime.date or datetime.datetime
+            The maximum selectable date. Defaults to 2030/12.
         key : str
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
@@ -2401,17 +2401,16 @@ class DeltaGenerator(object):
         element.date_input.label = label
         element.date_input.default = date.strftime(value, "%Y/%m/%d")
 
-        if isinstance(min_date, datetime):
-            min_date = min_date.date()
+        if isinstance(min_value, datetime):
+            min_value = min_value.date()
 
-        element.date_input.min_date = date.strftime(min_date, "%Y/%m/%d")
+        element.date_input.min = date.strftime(min_value, "%Y/%m/%d")
 
-        if max_date is not None:
-            if isinstance(max_date, datetime):
-                max_date = max_date.date()
+        if max_value is not None:
+            if isinstance(max_value, datetime):
+                max_value = max_value.date()
 
-            element.date_input.max_date = date.strftime(max_date, "%Y/%m/%d")
-
+            element.date_input.max = date.strftime(max_value, "%Y/%m/%d")
 
         ui_value = _get_widget_ui_value("date_input", element, user_key=key)
         current_value = (

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -20,6 +20,6 @@ message DateInput {
   string id = 1;
   string label = 2;
   string default = 3;
-  string min_date = 4;
-  string max_date = 5;
+  string min = 4;
+  string max = 5;
 }

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -20,4 +20,6 @@ message DateInput {
   string id = 1;
   string label = 2;
   string default = 3;
+  string min_date = 4;
+  string max_date = 5;
 }


### PR DESCRIPTION
**Issue:** This PR fixes #741
**Description:** 
New args:
- min_date: default to 1970/1/1
- max_date: using BaseWeb's defaults

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
