### PR TITLE
Fix useless stack trace from bugs like #554.

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -397,8 +397,10 @@ class Server(object):
             self._set_state(State.STOPPED)
 
         except Exception as e:
-            print("EXCEPTION!", e)
-            traceback.print_stack(file=sys.stdout)
+            # Can't just re-raise here because co-routines use Tornado
+            # exceptions for control flow, which appears to swallow the reraised
+            # exception.
+            traceback.print_exc()
             LOGGER.info(
                 """
 Please report this bug at https://github.com/streamlit/streamlit/issues.


### PR DESCRIPTION
The old code tried to work around a Tornado issue where exceptions were being swallowed, but it only partially succeeded. It showed the correct exception but the wrong stack trace. This fixes that.