### PR TITLE
Remove redundant home link in menu

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,6 @@
    :maxdepth: 2
    :hidden:
 
-   Home <https://docs.streamlit.io/>
    getting_started
    main_concepts
 


### PR DESCRIPTION
`Home` link is redundant in the menu, as the link to return home is also in the house icon one inch above it

![image](https://user-images.githubusercontent.com/2762787/81601676-47141800-9399-11ea-8ab9-cc95b73b2a3c.png)
