### PR TITLE
Fix multiselect docstring example

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1708,7 +1708,7 @@ class DeltaGenerator(object):
         -------
         >>> options = st.multiselect(
         ...     'What are your favorite colors',
-                ('Green', 'Yellow', 'Red', 'Blue'),
+        ...     ('Green', 'Yellow', 'Red', 'Blue'),
         ...     ['Yellow', 'Red'])
         >>>
         >>> st.write('You selected:', options)

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1708,8 +1708,8 @@ class DeltaGenerator(object):
         -------
         >>> options = st.multiselect(
         ...     'What are your favorite colors',
-                ('Yellow', 'Red')
-        ...     ('Green', 'Yellow', 'Red', 'Blue'))
+                ('Green', 'Yellow', 'Red', 'Blue'),
+        ...     ['Yellow', 'Red'])
         >>>
         >>> st.write('You selected:', options)
 

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1708,7 +1708,7 @@ class DeltaGenerator(object):
         -------
         >>> options = st.multiselect(
         ...     'What are your favorite colors',
-        ...     ('Green', 'Yellow', 'Red', 'Blue'),
+        ...     ['Green', 'Yellow', 'Red', 'Blue'],
         ...     ['Yellow', 'Red'])
         >>>
         >>> st.write('You selected:', options)


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1441

**Description:** 

The docstring example had three small issues:
* Added a missing comma at the end of the line
* Default values (currently) need to be an actual list, so changed from a tuple
* Order of parameters was wrong, putting the default before the options

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
