### PR TITLE
Update 3.5 references to 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.0
+      - image: circleci/python:3.6.1
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.10
+      - image: circleci/python:3.6.3
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.9
+      - image: circleci/python:3.6.0
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.3
+      - image: circleci/python:3.6.4
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ commands:
 workflows:
   circleci:
     jobs:
-      - python-3-5: # Oldest supported Python minor version.
+      - python-3-6: # Oldest supported Python minor version.
           filters:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/ # 0.56.1.dev20201129
@@ -168,7 +168,7 @@ workflows:
               only: /^([0-9]+\.){3}dev[0-9]+/
       - nightly-release:
           requires:
-            - python-3-5
+            - python-3-6
             - python-3-8
             - cypress
           filters:
@@ -348,10 +348,10 @@ jobs:
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").
-  python-3-5:
+  python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.5.9
+      - image: circleci/python:3.6.9
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6.2
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.4
+      - image: circleci/python:3.6.5
 
   create-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
   python-3-6:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.2
+      - image: circleci/python:3.6.10
 
   create-tag:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL=/bin/bash
 PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard $(dir)/__init__.py)), $(realpath $(dir $(initpy))))
 PY_VERSION := $(shell python -c 'import platform; print(platform.python_version())')
 
-# Configure Black to not depend on syntax only supported by Python >= 3.6.
-BLACK=black --target-version=py35
+# Configure Black to support only syntax supported by the minimum supported Python version in setup.py.
+BLACK=black --target-version=py36
 
 
 .PHONY: help

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.5
+python_version = 3.6
 cache_dir = /tmp/mypy_cache
 
 # TODO(nate): Additional strictness checks to work towards.

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -59,7 +59,7 @@ setuptools.setup(
     url="https://streamlit.io",
     author="Streamlit Inc",
     author_email="hello@streamlit.io",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     license="Apache 2",
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     # Requirements

--- a/lib/streamlit/magic.py
+++ b/lib/streamlit/magic.py
@@ -175,6 +175,6 @@ def _get_st_write_from_expr(node, i, parent_type):
 
 def _is_docstring_node(node):
     if sys.version_info >= (3, 8, 0):
-        return type(node) is ast.Constant and type(node.value) is str  # type: ignore[attr-defined]
+        return type(node) is ast.Constant and type(node.value) is str
     else:
         return type(node) is ast.Str

--- a/scripts/add_license_headers.py
+++ b/scripts/add_license_headers.py
@@ -20,8 +20,8 @@ import glob
 from datetime import datetime
 
 
-if sys.version_info < (3, 5):
-    print("This script must be run with Python >= 3.5")
+if sys.version_info < (3, 6):
+    print("This script must be run with Python >= 3.6")
     sys.exit(-1)
 
 

--- a/scripts/run_bare_integration_tests.py
+++ b/scripts/run_bare_integration_tests.py
@@ -28,9 +28,7 @@ from typing import Set
 
 import click
 
-IS_PYTHON_2 = sys.version_info[0] == 2
-
-IS_PYTHON_3_5 = sys.version_info[:2] == (3, 5)
+IS_PYTHON_3_6 = sys.version_info[:2] == (3, 6)
 
 # Where we expect to find the example files.
 E2E_DIR = "e2e/scripts"
@@ -49,8 +47,8 @@ try:
 except ImportError:
     EXCLUDED_FILENAMES |= set(["empty_charts.py", "pyplot.py", "pyplot_kwargs.py"])
 
-# magic.py uses the async keyword, which is Python 3.6+
-if IS_PYTHON_2 or IS_PYTHON_3_5:
+# magic.py uses contextlib.asynccontextmanager, which is Python 3.7+
+if IS_PYTHON_3_6:
     EXCLUDED_FILENAMES.add("st_magic.py")
 
 


### PR DESCRIPTION
Per our Slack discussion yesterday, there are some places where Python 3.5 references remain. I changed these references here.

Note that some of the references conditionally test for 3.6 and above (such as the Black formatter CI code), so that code could be simplified to remove the conditional test since it will evaluate true from now on