### PR TITLE
Add support for st.echo("below") to print echoed text below the Streamlit output

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -537,8 +537,14 @@ _SPACES_RE = _re.compile("\\s*")
 
 
 @_contextlib.contextmanager
-def echo():
+def echo(code_location="above"):
     """Use in a `with` block to draw some code on the app, then execute it.
+
+    Parameters
+    ----------
+    code_location : "above" or "below"
+        Whether to show the echoed code before or after the results of the
+        executed code block.
 
     Example
     -------
@@ -547,7 +553,14 @@ def echo():
     >>>     st.write('This code will be printed')
 
     """
-    code = empty()  # noqa: F821
+    if code_location == "below":
+        show_code = code
+        show_warning = warning
+    else:
+        placeholder = empty()  # noqa: F821
+        show_code = placeholder.code
+        show_warning = placeholder.warning
+
     try:
         frame = _traceback.extract_stack()[-3]
         filename, start_line = frame.filename, frame.lineno
@@ -568,10 +581,11 @@ def echo():
                     break
                 lines_to_display.append(line)
         line_to_display = _textwrap.dedent("".join(lines_to_display))
-        code.code(line_to_display, "python")
+
+        show_code(line_to_display, "python")
 
     except FileNotFoundError as err:
-        code.warning("Unable to display code. %s" % err)
+        show_warning("Unable to display code. %s" % err)
 
 
 def _transparent_write(*args):

--- a/lib/tests/streamlit/echo_test.py
+++ b/lib/tests/streamlit/echo_test.py
@@ -18,25 +18,31 @@ import streamlit as st
 
 class EchoTest(testutil.DeltaGeneratorTestCase):
     def test_echo(self):
-        # The empty lines below are part of the test. Do not remove them.
-        with st.echo():
-            st.write("Hello")
+        for echo, echo_index, output_index in [
+            (lambda: st.echo(), 0, 1),
+            (lambda: st.echo("above"), 0, 1),
+            (lambda: st.echo("below"), 1, 0),
+        ]:
 
-            "hi"
+            # The empty lines below are part of the test. Do not remove them.
+            with echo():
+                st.write("Hello")
 
-            def foo(x):
-                y = x + 10
+                "hi"
 
-                print(y)
+                def foo(x):
+                    y = x + 10
 
-            class MyClass(object):
-                def do_x(self):
-                    pass
+                    print(y)
 
-                def do_y(self):
-                    pass
+                class MyClass(object):
+                    def do_x(self):
+                        pass
 
-        expected = """```python
+                    def do_y(self):
+                        pass
+
+            echo_str = """```python
 st.write("Hello")
 
 "hi"
@@ -56,20 +62,22 @@ class MyClass(object):
 
 ```"""
 
-        element = self.get_delta_from_queue(0).new_element
-        self.assertEqual(expected, element.markdown.body)
+            element = self.get_delta_from_queue(echo_index).new_element
+            self.assertEqual(echo_str, element.markdown.body)
 
-        element = self.get_delta_from_queue(1).new_element
-        self.assertEqual("Hello", element.markdown.body)
+            element = self.get_delta_from_queue(output_index).new_element
+            self.assertEqual("Hello", element.markdown.body)
+
+            self.clear_queue()
 
     def test_root_level_echo(self):
         import tests.streamlit.echo_test_data.root_level_echo
 
-        expected = """```python
+        echo_str = """```python
 a = 123
 
 
 ```"""
 
         element = self.get_delta_from_queue(0).new_element
-        self.assertEqual(expected, element.markdown.body)
+        self.assertEqual(echo_str, element.markdown.body)

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -89,7 +89,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             )
 
     def tearDown(self):
-        self.report_queue._clear()
+        self.clear_queue()
         if self.override_root:
             add_report_ctx(threading.current_thread(), self.orig_report_ctx)
 
@@ -109,10 +109,12 @@ class DeltaGeneratorTestCase(unittest.TestCase):
         -------
         Delta
         """
-        # return self.report_queue._queue[index].delta
         deltas = self.get_all_deltas_from_queue()
         return deltas[index]
 
     def get_all_deltas_from_queue(self):
         """Return all the delta messages in our ReportQueue"""
         return [msg.delta for msg in self.report_queue._queue if msg.HasField("delta")]
+
+    def clear_queue(self):
+        self.report_queue._clear()


### PR DESCRIPTION
Now you can pass the `code_location` argument to `st.echo` to specify where the echoed text should go:
```
    code_location : "above" or "below"
        Whether to show the echoed code before or after the results of the
        executed code block.
``` 

This was a feature request from @amiechen :smiley: 