### PR TITLE
Fix link for pipenv in Getting Started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -38,7 +38,7 @@ these commands in a virtual environment. This ensures that the dependencies
 pulled in for Streamlit don't impact any other Python projects
 you're working on.
 
-- [pipenv](https://docs.pipenv.org/en/latest/)
+- [pipenv](https://pipenv.pypa.io/en/latest/)
 - [venv](https://docs.python.org/3/library/venv.html)
 - [virtualenv](https://virtualenv.pypa.io/en/latest/)
 - [conda](https://www.anaconda.com/distribution/)


### PR DESCRIPTION
**Description:** Fix the broken link to pipenv in Getting Started doc

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
