### PR TITLE
Check build environment for RTD

### DIFF
--- a/docs/env_setup.sh
+++ b/docs/env_setup.sh
@@ -16,5 +16,10 @@ unzip protoc-3.11.4-linux-x86_64.zip
     ../proto/streamlit/proto/*.proto
 
 #re-run setup.py build process to make protobuf available
-#this is tremendously fragile, as ../lib is hardcoded in here
-/home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/latest/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir ../lib
+#this is tremendously fragile, as ../lib is hardcoded in here, and testing presence of environment directories
+if [ -d "/home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/latest" ]
+then
+  /home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/latest/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir ../lib
+else
+  /home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/stable/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir ../lib
+fi


### PR DESCRIPTION
For enabling ReadtheDocs, hard-coded environment name, when in fact it changes based on `stable` vs. `latest` branch. Check for the presence of the environment directory before use, so that `stable` documentation builds.
