### PR TITLE
Update date_input to accept a range for a ranged datepicker

### DIFF
--- a/e2e/scripts/st_date_input.py
+++ b/e2e/scripts/st_date_input.py
@@ -16,11 +16,14 @@ import streamlit as st
 from datetime import datetime
 from datetime import date
 
-w1 = st.date_input("Label 1", date(1970, 1, 1), min_value=date(1970, 1, 1))
-st.write("Value 1:", w1)
+d1 = st.date_input("Single date", date(1970, 1, 1), min_value=date(1970, 1, 1))
+st.write("Value 1:", d1)
 
-w2 = st.date_input("Label 2", datetime(2019, 7, 6, 21, 15))
-st.write("Value 2:", w2)
+d2 = st.date_input("Single datetime", datetime(2019, 7, 6, 21, 15))
+st.write("Value 2:", d2)
 
-w3 = st.date_input("Label 3", (datetime(2019, 7, 6, 21), datetime(2019, 8, 6, 21)))
-st.write("Value 3:", w3)
+d3 = st.date_input("Range, one date", [date(2019, 7, 6)])
+st.write("Value 3:", d3)
+
+d4 = st.date_input("Range, two dates", [date(2019, 7, 6), date(2019, 7, 8)])
+st.write("Value 4:", d4)

--- a/e2e/scripts/st_date_input.py
+++ b/e2e/scripts/st_date_input.py
@@ -22,8 +22,11 @@ st.write("Value 1:", d1)
 d2 = st.date_input("Single datetime", datetime(2019, 7, 6, 21, 15))
 st.write("Value 2:", d2)
 
-d3 = st.date_input("Range, one date", [date(2019, 7, 6)])
+d3 = st.date_input("Range, no date", [])
 st.write("Value 3:", d3)
 
-d4 = st.date_input("Range, two dates", [date(2019, 7, 6), date(2019, 7, 8)])
+d4 = st.date_input("Range, one date", [date(2019, 7, 6)])
 st.write("Value 4:", d4)
+
+d4 = st.date_input("Range, two dates", [date(2019, 7, 6), date(2019, 7, 8)])
+st.write("Value 5:", d4)

--- a/e2e/scripts/st_date_input.py
+++ b/e2e/scripts/st_date_input.py
@@ -21,3 +21,6 @@ st.write("Value 1:", w1)
 
 w2 = st.date_input("Label 2", datetime(2019, 7, 6, 21, 15))
 st.write("Value 2:", w2)
+
+w3 = st.date_input("Label 3", (datetime(2019, 7, 6, 21), datetime(2019, 8, 6, 21)))
+st.write("Value 3:", w3)

--- a/e2e/specs/st_date_input.spec.ts
+++ b/e2e/specs/st_date_input.spec.ts
@@ -27,6 +27,7 @@ describe("st.date_input", () => {
       "have.text",
       "Single date" +
         "Single datetime" +
+        "Range, no date" +
         "Range, one date" +
         "Range, two dates"
     );
@@ -37,8 +38,9 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: (datetime.date(2019, 7, 6),)" +
-        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
     );
   });
 
@@ -57,15 +59,16 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-02" +
         "Value 2: 2019-07-06" +
-        "Value 3: (datetime.date(2019, 7, 6),)" +
-        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
     );
   });
 
   it("handles range end date changes", () => {
     // open date picker
     cy.get(".stDateInput")
-      .eq(2)
+      .eq(3)
       .click();
 
     // select end date '2019/07/08'
@@ -77,15 +80,16 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 10))" +
-        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 10))" +
+        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
     );
   });
 
   it("handles range start/end date changes", () => {
     // open date picker
     cy.get(".stDateInput")
-      .eq(3)
+      .eq(4)
       .click();
 
     // select start date '2019/07/10'
@@ -97,8 +101,9 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: (datetime.date(2019, 7, 6),)" +
-        "Value 4: (datetime.date(2019, 7, 10),)"
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 10),)"
     );
 
     // select end date '2019/07/10'
@@ -110,8 +115,9 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: (datetime.date(2019, 7, 6),)" +
-        "Value 4: (datetime.date(2019, 7, 10), datetime.date(2019, 7, 12))"
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 10), datetime.date(2019, 7, 12))"
     );
   });
 });

--- a/e2e/specs/st_date_input.spec.ts
+++ b/e2e/specs/st_date_input.spec.ts
@@ -25,16 +25,20 @@ describe("st.date_input", () => {
   it("shows labels", () => {
     cy.get(".stDateInput label").should(
       "have.text",
-      "Label 1" + "Label 2" + "Label 3"
+      "Single date" +
+        "Single datetime" +
+        "Range, one date" +
+        "Range, two dates"
     );
   });
 
   it("has correct values", () => {
     cy.get(".stMarkdown").should(
       "have.text",
-      "Value 1: (datetime.date(1970, 1, 1), datetime.date(1970, 1, 1))" +
-        "Value 2: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 6))" +
-        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 8, 6))"
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: (datetime.date(2019, 7, 6),)" +
+        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
     );
   });
 
@@ -51,21 +55,63 @@ describe("st.date_input", () => {
 
     cy.get(".stMarkdown").should(
       "have.text",
-      "Value 1: (datetime.date(1970, 1, 2),)" +
-        "Value 2: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 6))" +
-        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 8, 6))"
+      "Value 1: 1970-01-02" +
+        "Value 2: 2019-07-06" +
+        "Value 3: (datetime.date(2019, 7, 6),)" +
+        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
     );
+  });
 
-    // select '1970/01/03'
+  it("handles range end date changes", () => {
+    // open date picker
+    cy.get(".stDateInput")
+      .eq(2)
+      .click();
+
+    // select end date '2019/07/08'
     cy.get(
-      '[data-baseweb="calendar"] [aria-label^="Choose Saturday, January 3rd 1970."]'
+      '[data-baseweb="calendar"] [aria-label^="Choose Wednesday, July 10th 2019."]'
     ).click();
 
     cy.get(".stMarkdown").should(
       "have.text",
-      "Value 1: (datetime.date(1970, 1, 2), datetime.date(1970, 1, 3))" +
-        "Value 2: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 6))" +
-        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 8, 6))"
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 10))" +
+        "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))"
+    );
+  });
+
+  it("handles range start/end date changes", () => {
+    // open date picker
+    cy.get(".stDateInput")
+      .eq(3)
+      .click();
+
+    // select start date '2019/07/10'
+    cy.get(
+      '[data-baseweb="calendar"] [aria-label^="Choose Wednesday, July 10th 2019."]'
+    ).click();
+
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: (datetime.date(2019, 7, 6),)" +
+        "Value 4: (datetime.date(2019, 7, 10),)"
+    );
+
+    // select end date '2019/07/10'
+    cy.get(
+      '[data-baseweb="calendar"] [aria-label^="Choose Friday, July 12th 2019."]'
+    ).click();
+
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: (datetime.date(2019, 7, 6),)" +
+        "Value 4: (datetime.date(2019, 7, 10), datetime.date(2019, 7, 12))"
     );
   });
 });

--- a/e2e/specs/st_date_input.spec.ts
+++ b/e2e/specs/st_date_input.spec.ts
@@ -23,13 +23,18 @@ describe("st.date_input", () => {
   });
 
   it("shows labels", () => {
-    cy.get(".stDateInput label").should("have.text", "Label 1" + "Label 2");
+    cy.get(".stDateInput label").should(
+      "have.text",
+      "Label 1" + "Label 2" + "Label 3"
+    );
   });
 
   it("has correct values", () => {
     cy.get(".stMarkdown").should(
       "have.text",
-      "Value 1: 1970-01-01" + "Value 2: 2019-07-06"
+      "Value 1: (datetime.date(1970, 1, 1), datetime.date(1970, 1, 1))" +
+        "Value 2: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 6))" +
+        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 8, 6))"
     );
   });
 
@@ -46,7 +51,21 @@ describe("st.date_input", () => {
 
     cy.get(".stMarkdown").should(
       "have.text",
-      "Value 1: 1970-01-02" + "Value 2: 2019-07-06"
+      "Value 1: (datetime.date(1970, 1, 2),)" +
+        "Value 2: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 6))" +
+        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 8, 6))"
+    );
+
+    // select '1970/01/03'
+    cy.get(
+      '[data-baseweb="calendar"] [aria-label^="Choose Saturday, January 3rd 1970."]'
+    ).click();
+
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: (datetime.date(1970, 1, 2), datetime.date(1970, 1, 3))" +
+        "Value 2: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 6))" +
+        "Value 3: (datetime.date(2019, 7, 6), datetime.date(2019, 8, 6))"
     );
   });
 });

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -32,7 +32,7 @@ const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
   element: fromJS({
     id: 1,
     label: "Label",
-    default: "1970/01/01",
+    default: ["1970/01/01"],
     min: "1970/1/1",
     ...elementProps,
   }),
@@ -54,9 +54,9 @@ describe("DateInput widget", () => {
   })
 
   it("should set widget value on did mount", () => {
-    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       props.element.get("id"),
-      props.element.get("default"),
+      props.element.get("default").toJS(),
       { fromUi: false }
     )
   })
@@ -76,9 +76,9 @@ describe("DateInput widget", () => {
   })
 
   it("should render a default value", () => {
-    expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual(
-      new Date(props.element.get("default"))
-    )
+    expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([
+      new Date(props.element.get("default").toJS()),
+    ])
   })
 
   it("could be disabled", () => {
@@ -97,10 +97,10 @@ describe("DateInput widget", () => {
       date: newDate,
     })
 
-    expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual(newDate)
-    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+    expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([newDate])
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       props.element.get("id"),
-      "2020/02/06",
+      ["2020/02/06"],
       { fromUi: true }
     )
   })

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -34,12 +34,15 @@ interface State {
    * The value specified by the user via the UI. If the user didn't touch this
    * widget's UI, the default value is used.
    */
-  value: string
+  values: Date[]
 }
 
 class DateInput extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default"),
+    values: this.props.element
+      .get("default")
+      .toJS()
+      .map((val: string) => new Date(val)),
   }
 
   public componentDidMount(): void {
@@ -48,13 +51,20 @@ class DateInput extends React.PureComponent<Props, State> {
 
   private setWidgetValue = (source: Source): void => {
     const widgetId: string = this.props.element.get("id")
-    this.props.widgetMgr.setStringValue(widgetId, this.state.value, source)
+
+    this.props.widgetMgr.setStringArrayValue(
+      widgetId,
+      this.state.values.map((value: Date) =>
+        moment(value as Date).format("YYYY/MM/DD")
+      ),
+      source
+    )
   }
 
   private handleChange = ({ date }: { date: Date | Date[] }): void => {
-    const value = moment(date as Date).format("YYYY/MM/DD")
-
-    this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
+    this.setState({ values: Array.isArray(date) ? date : [date] }, () =>
+      this.setWidgetValue({ fromUi: true })
+    )
   }
 
   private getMaxDate = (): Date | undefined => {
@@ -66,7 +76,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
   public render = (): React.ReactNode => {
     const { width, element, disabled } = this.props
-    const { value } = this.state
+    const { values } = this.state
 
     const style = { width }
     const label = element.get("label")
@@ -81,9 +91,11 @@ class DateInput extends React.PureComponent<Props, State> {
           disabled={disabled}
           onChange={this.handleChange}
           overrides={datePickerOverrides}
-          value={new Date(value)}
+          value={values}
           minDate={minDate}
           maxDate={maxDate}
+          range
+          mask="9999/99/99 – 9999/99/99"
         />
       </div>
     )

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -35,6 +35,7 @@ interface State {
    * widget's UI, the default value is used.
    */
   values: Date[]
+  range: boolean
 }
 
 class DateInput extends React.PureComponent<Props, State> {
@@ -43,6 +44,7 @@ class DateInput extends React.PureComponent<Props, State> {
       .get("default")
       .toJS()
       .map((val: string) => new Date(val)),
+    range: this.props.element.get("range"),
   }
 
   public componentDidMount(): void {
@@ -76,12 +78,13 @@ class DateInput extends React.PureComponent<Props, State> {
 
   public render = (): React.ReactNode => {
     const { width, element, disabled } = this.props
-    const { values } = this.state
+    const { values, range } = this.state
 
     const style = { width }
     const label = element.get("label")
     const minDate = new Date(element.get("min"))
     const maxDate = this.getMaxDate()
+    const dateMask = "9999/99/99"
 
     return (
       <div className="Widget stDateInput" style={style}>
@@ -94,8 +97,8 @@ class DateInput extends React.PureComponent<Props, State> {
           value={values}
           minDate={minDate}
           maxDate={maxDate}
-          range
-          mask="9999/99/99 – 9999/99/99"
+          range={range}
+          mask={range ? `${dateMask} – ${dateMask}` : dateMask}
         />
       </div>
     )

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -31,11 +31,14 @@ export interface Props {
 
 interface State {
   /**
-   * The value specified by the user via the UI. If the user didn't touch this
-   * widget's UI, the default value is used.
+   * An array with start and end date specified by the user via the UI. If the user
+   * didn't touch this widget's UI, the default value is used. End date is optional.
    */
   values: Date[]
-  range: boolean
+  /**
+   * Boolean to toggle between single-date picker and range date picker.
+   */
+  isRange: boolean
 }
 
 class DateInput extends React.PureComponent<Props, State> {
@@ -44,7 +47,7 @@ class DateInput extends React.PureComponent<Props, State> {
       .get("default")
       .toJS()
       .map((val: string) => new Date(val)),
-    range: this.props.element.get("range"),
+    isRange: this.props.element.get("isRange") || false,
   }
 
   public componentDidMount(): void {
@@ -78,13 +81,12 @@ class DateInput extends React.PureComponent<Props, State> {
 
   public render = (): React.ReactNode => {
     const { width, element, disabled } = this.props
-    const { values, range } = this.state
+    const { values, isRange } = this.state
 
     const style = { width }
     const label = element.get("label")
     const minDate = new Date(element.get("min"))
     const maxDate = this.getMaxDate()
-    const dateMask = "9999/99/99"
 
     return (
       <div className="Widget stDateInput" style={style}>
@@ -97,8 +99,7 @@ class DateInput extends React.PureComponent<Props, State> {
           value={values}
           minDate={minDate}
           maxDate={maxDate}
-          range={range}
-          mask={range ? `${dateMask} – ${dateMask}` : dateMask}
+          range={isRange}
         />
       </div>
     )

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -19,6 +19,7 @@ import {
   IBackMsg,
   IntArray,
   FloatArray,
+  StringArray,
   WidgetState,
   WidgetStates,
 } from "autogen/proto"
@@ -120,6 +121,17 @@ export class WidgetStateManager {
     source: Source
   ): void {
     this.getOrCreateWidgetStateProto(widgetId).stringValue = value
+    this.maybeSendUpdateWidgetsMessage(source)
+  }
+
+  public setStringArrayValue(
+    widgetId: string,
+    value: string[],
+    source: Source
+  ): void {
+    this.getOrCreateWidgetStateProto(
+      widgetId
+    ).stringArrayValue = StringArray.fromObject({ data: value })
     this.maybeSendUpdateWidgetsMessage(source)
   }
 

--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -284,6 +284,8 @@ export const datePickerOverrides = {
   },
   Input: {
     props: {
+      // The default maskChar ` ` causes empty dates to display as ` / / `
+      // Clearing the maskChar so empty dates will not display
       maskChar: null,
     },
   },

--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -282,6 +282,11 @@ export const datePickerOverrides = {
       },
     },
   },
+  Input: {
+    props: {
+      maskChar: null,
+    },
+  },
 }
 
 export const buttonOverrides = {

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1946,11 +1946,11 @@ class DeltaGenerator(object):
 
         # Ensure that the value is either a single value or a range of values.
         single_value = isinstance(value, (int, float))
-        range_value = isinstance(value, (list, tuple))
+        range_value = isinstance(value, (list, tuple)) and len(value) in (0, 1, 2)
         if not single_value and not range_value:
             raise StreamlitAPIException(
                 "Slider value should either be an int/float or a list/tuple of "
-                "int/float"
+                "0 to 2 ints/floats"
             )
 
         # Ensure that the value is either an int/float or a list/tuple of ints/floats.
@@ -2396,7 +2396,7 @@ class DeltaGenerator(object):
         value : datetime.date or datetime.datetime or list/tuple of datetime.date or datetime.datetime or None
             The value of this widget when it first renders. If a list/tuple with
             0 to 2 date/datetime values is provided, the datepicker will allow
-            users to provide a range. Defaults to today as a single datepicker.
+            users to provide a range. Defaults to today as a single-date picker.
         min_value : datetime.date or datetime.datetime
             The minimum selectable date. Defaults to datetime.min.
         max_value : datetime.date or datetime.datetime
@@ -2425,17 +2425,17 @@ class DeltaGenerator(object):
             value = datetime.now().date()
 
         single_value = isinstance(value, (date, datetime))
-        range_value = isinstance(value, (list, tuple))
+        range_value = isinstance(value, (list, tuple)) and len(value) in (0, 1, 2)
         if not single_value and not range_value:
             raise StreamlitAPIException(
                 "DateInput value should either be an date/datetime or a list/tuple of "
-                "date/datetime"
+                "0 - 2 date/datetime values"
             )
 
         if single_value:
             value = [value]
-        else:
-            element.date_input.range = True
+
+        element.date_input.is_range = range_value
 
         value = [v.date() if isinstance(v, datetime) else v for v in value]
 
@@ -2456,15 +2456,16 @@ class DeltaGenerator(object):
 
         element.date_input.max = date.strftime(max_value, "%Y/%m/%d")
 
-        result = value
         ui_value = _get_widget_ui_value("date_input", element, user_key=key)
+
         if ui_value is not None:
-            result = getattr(ui_value, "data")
+            value = getattr(ui_value, "data")
+            value = [datetime.strptime(v, "%Y/%m/%d").date() for v in value]
 
         if single_value:
-            return datetime.strptime(result[0], "%Y/%m/%d").date() if isinstance(result[0], str) else result[0]
+            return value[0]
         else:
-            return tuple(map(lambda dt: datetime.strptime(dt, "%Y/%m/%d").date() if isinstance(dt, str) else dt,result))
+            return tuple(value)
 
     @_with_element
     def number_input(

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2394,8 +2394,9 @@ class DeltaGenerator(object):
         label : str
             A short label explaining to the user what this date input is for.
         value : datetime.date or datetime.datetime or list/tuple of datetime.date or datetime.datetime or None
-            The value of this widget when it first renders. This will be
-            cast to str internally. Defaults to today.
+            The value of this widget when it first renders. If a list/tuple with
+            0 to 2 date/datetime values is provided, the datepicker will allow
+            users to provide a range. Defaults to today as a single datepicker.
         min_value : datetime.date or datetime.datetime
             The minimum selectable date. Defaults to datetime.min.
         max_value : datetime.date or datetime.datetime

--- a/lib/tests/streamlit/date_input_test.py
+++ b/lib/tests/streamlit/date_input_test.py
@@ -31,11 +31,16 @@ class DateInputTest(testutil.DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.date_input
         self.assertEqual(c.label, "the label")
         self.assertLessEqual(
-            datetime.strptime(c.default, "%Y/%m/%d").date(), datetime.now().date()
+            datetime.strptime(c.default[0], "%Y/%m/%d").date(), datetime.now().date()
         )
 
     @parameterized.expand(
-        [(date(1970, 1, 1), "1970/01/01"), (datetime(2019, 7, 6, 21, 15), "2019/07/06")]
+        [
+            (date(1970, 1, 1), ["1970/01/01"]),
+            (datetime(2019, 7, 6, 21, 15), ["2019/07/06"]),
+            ([datetime(2019, 7, 6, 21, 15)], ["2019/07/06"]),
+            ([datetime(2019, 7, 6, 21, 15), datetime(2019, 7, 6, 21, 15)], ["2019/07/06", "2019/07/06"])
+        ]
     )
     def test_value_types(self, arg_value, proto_value):
         """Test that it supports different types of values."""

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -22,4 +22,5 @@ message DateInput {
   repeated string default = 3;
   string min = 4;
   string max = 5;
+  bool range = 6;
 }

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -22,5 +22,5 @@ message DateInput {
   repeated string default = 3;
   string min = 4;
   string max = 5;
-  bool range = 6;
+  bool is_range = 6;
 }

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 message DateInput {
   string id = 1;
   string label = 2;
-  string default = 3;
+  repeated string default = 3;
   string min = 4;
   string max = 5;
 }

--- a/proto/streamlit/proto/Widget.proto
+++ b/proto/streamlit/proto/Widget.proto
@@ -16,6 +16,8 @@
 
 syntax = "proto3";
 
+import "streamlit/proto/DataFrame.proto";
+
 // Contains updated state for each widget in a report
 message WidgetStates {
   repeated WidgetState widgets = 1;
@@ -38,8 +40,9 @@ message WidgetState {
     double float_value = 4;
     sint64 int_value = 5;
     string string_value = 6;
-    IntArray int_array_value = 8;
     FloatArray float_array_value = 7;
+    IntArray int_array_value = 8;
+    StringArray string_array_value = 9;
   }
 }
 


### PR DESCRIPTION
**Issue:** #1020 

**Description:**
1. Updated `date_input` so that `value` can be a single date/datetime or a list of 0-2 date/datetime.
  - DateInput updated to accept an array of dates.
  - If a single value is passed, it is converted into a list.
  - If a list is provided, the range attribute will be set to `True`.
2. Update `slider` so that `value` can be an empty list. If an empty list is provided, set the default to max/min values.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
