### PR TITLE
Remove Python 2 check in 'hello' df demo

### DIFF
--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -217,10 +217,6 @@ def data_frame_demo():
     import pandas as pd
     import altair as alt
 
-    if sys.version_info[0] < 3:
-        reload(sys) # noqa: F821 pylint:disable=undefined-variable
-        sys.setdefaultencoding("utf-8")
-
     @st.cache
     def get_UN_data():
         AWS_BUCKET_URL = "https://streamlit-demo-data.s3-us-west-2.amazonaws.com"

--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -213,7 +213,6 @@ def plotting_demo():
 # compact code.
 # fmt: off
 def data_frame_demo():
-    import sys
     import pandas as pd
     import altair as alt
 


### PR DESCRIPTION
In hello.py, remove unnecessary check for Python 2, as by default, we're always in Python 3 now.