### PR TITLE
Remove excess parenthesis from selectbox example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -159,8 +159,8 @@ Here's an example of how you'd add a selectbox to your sidebar.
 import streamlit as st
 
 add_selectbox = st.sidebar.selectbox(
-    'How would you like to be contacted?',
-    ('Email', 'Home phone', 'Mobile phone'))
+    "How would you like to be contacted?",
+    ("Email", "Home phone", "Mobile phone")
 )
 ```
 


### PR DESCRIPTION
Fixes #808 by removing trailing parenthesis