### PR TITLE
MediaFile Grace Period using KEEP_DELAY = 5 seconds

### DIFF
--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -127,10 +127,9 @@ class MediaFileManager(object):
         # Get a flat set of every file ID in the session ID map.
         active_file_ids = set()
 
-        if len(self._files_by_session_and_coord.keys()) > 0:
-            for sessID in self._files_by_session_and_coord.keys():
-                for coord, file_id in self._files_by_session_and_coord[sessID]:
-                    active_file_ids.add(file_id)
+        for sessID in self._files_by_session_and_coord.keys():
+            for coord, file_id in self._files_by_session_and_coord[sessID].items():
+                active_file_ids.add(file_id)
 
         # Remove any file that is currently not in the file_ids set AND has
         # an expired TTD.

--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -139,10 +139,9 @@ class MediaFileManager(object):
                 del self._files_by_id[file_id]
 
     def clear_session_files(self, session_id=None):
-        """Removes ReportSession-coordinate mapping, deleting expired MediaFile objects.
+        """Removes ReportSession-coordinate mapping immediately, and id-file mapping later.
 
-        Should be called whenever ScriptRunner completes and when
-        a session ends.
+        Should be called whenever ScriptRunner completes and when a session ends.
         """
         if session_id is None:
             session_id = _get_session_id()

--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -14,7 +14,7 @@
 
 """Provides global MediaFileManager object as `media_file_manager`."""
 
-from typing import Dict, DefaultDict
+from typing import Dict, DefaultDict, Set
 from weakref import WeakValueDictionary
 import collections
 import datetime as dt
@@ -127,7 +127,7 @@ class MediaFileManager(object):
         LOGGER.debug("Deleting expired files...")
 
         # Get a flat set of every file ID in the session ID map.
-        active_file_ids = set()
+        active_file_ids = set()   # type: Set[MediaFile]
 
         for files_by_coord in self._files_by_session_and_coord.values():
             active_file_ids = active_file_ids.union(files_by_coord.values())

--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -114,10 +114,6 @@ class MediaFileManager(object):
 
     def __init__(self):
         # Dict of file ID to MediaFile.
-        #self._files_by_id = (
-        #    WeakValueDictionary()
-        #)  # type: WeakValueDictionary[str, MediaFile]
-
         self._files_by_id = dict()
 
         # Dict[session ID][coordinates] -> MediaFile.
@@ -125,19 +121,16 @@ class MediaFileManager(object):
             dict
         )  # type: DefaultDict[str, Dict[str, MediaFile]]
 
-        # Since _files_by_id is a weak dict, when a MediaFile is removed from
-        # _files_by_session_and_coord it automatically gets removed from
-        # _files_by_id.
-
-
     def _del_expired_files(self):
         LOGGER.debug("Deleting expired files...")
 
         # Get a flat set of every file ID in the session ID map.
         active_file_ids = set()
-        for sessID in self._files_by_session_and_coord.keys():
-            for coord, file_id in self._files_by_session_and_coord[sessID]:
-                active_file_ids.add(file_id)
+
+        if len(self._files_by_session_and_coord.keys()) > 0:
+            for sessID in self._files_by_session_and_coord.keys():
+                for coord, file_id in self._files_by_session_and_coord[sessID]:
+                    active_file_ids.add(file_id)
 
         # Remove any file that is currently not in the file_ids set AND has
         # an expired TTD.
@@ -147,7 +140,7 @@ class MediaFileManager(object):
                     del self._files_by_id[file_id]
 
     def clear_session_files(self, session_id=None):
-        """Clears all stored files for a given ReportSession id.
+        """Removes ReportSession-coordinate mapping, deleting expired MediaFile objects.
 
         Should be called whenever ScriptRunner completes and when
         a session ends.

--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -31,7 +31,7 @@ STATIC_MEDIA_ENDPOINT = "/media"
 # Length of time (seconds) to keep media files so that we don't pull the rug out from
 # under rapid-media-generating elements, e.g. using a slider to produce pyplots.
 # See Issues #1440, #1445, #1294
-KEEP_DELAY_SEC = 2
+KEEP_DELAY_SEC = 5
 
 
 def _get_session_id():
@@ -121,6 +121,8 @@ class MediaFileManager(object):
             dict
         )  # type: DefaultDict[str, Dict[str, MediaFile]]
 
+        self._ioloop = None
+
     def _del_expired_files(self):
         LOGGER.debug("Deleting expired files...")
 
@@ -153,7 +155,7 @@ class MediaFileManager(object):
         LOGGER.debug(
             "Sessions still active: %r", self._files_by_session_and_coord.keys()
         )
-        self._del_expired_files()
+        self._ioloop.call_later(KEEP_DELAY_SEC, self._del_expired_files)
 
         LOGGER.debug(
             "Files: %s; Sessions with files: %s",
@@ -211,6 +213,9 @@ class MediaFileManager(object):
         Raises KeyError if not found.
         """
         return self._files_by_id[mediafile_or_id]
+
+    def set_ioloop(self, ioloop):
+        self._ioloop = ioloop
 
     def __contains__(self, mediafile_or_id):
         return mediafile_or_id in self._files_by_id

--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -14,7 +14,7 @@
 
 """Provides global MediaFileManager object as `media_file_manager`."""
 
-from typing import Dict, DefaultDict, Set
+from typing import Dict, DefaultDict, Set, Any
 from weakref import WeakValueDictionary
 import collections
 import datetime as dt
@@ -121,13 +121,13 @@ class MediaFileManager(object):
             dict
         )  # type: DefaultDict[str, Dict[str, MediaFile]]
 
-        self._ioloop = None
+        self._ioloop = None  # type: Any
 
     def _del_expired_files(self):
         LOGGER.debug("Deleting expired files...")
 
         # Get a flat set of every file ID in the session ID map.
-        active_file_ids = set()   # type: Set[MediaFile]
+        active_file_ids = set()  # type: Set[MediaFile]
 
         for files_by_coord in self._files_by_session_and_coord.values():
             active_file_ids = active_file_ids.union(files_by_coord.values())

--- a/lib/streamlit/MediaFileManager.py
+++ b/lib/streamlit/MediaFileManager.py
@@ -133,10 +133,9 @@ class MediaFileManager(object):
 
         # Remove any file that is currently not in the file_ids set AND has
         # an expired TTD.
-        for file_id, mf in list(self._files_by_id.items()):
-            if file_id not in active_file_ids:
-                if mf.ttd < time.time():
-                    del self._files_by_id[file_id]
+        for file_id in set(list(self._files_by_id.keys())).difference(active_file_ids):
+            if self._files_by_id[file_id].ttd < time.time():
+                del self._files_by_id[file_id]
 
     def clear_session_files(self, session_id=None):
         """Removes ReportSession-coordinate mapping, deleting expired MediaFile objects.

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -34,6 +34,7 @@ from streamlit.ConfigOption import ConfigOption
 from streamlit.ForwardMsgCache import ForwardMsgCache
 from streamlit.ForwardMsgCache import create_reference_msg
 from streamlit.ForwardMsgCache import populate_hash_if_needed
+from streamlit.MediaFileManager import media_file_manager
 from streamlit.ReportSession import ReportSession
 from streamlit.UploadedFileManager import UploadedFileManager
 from streamlit.logger import get_logger
@@ -198,6 +199,8 @@ class Server(object):
         self._ioloop = ioloop
         self._script_path = script_path
         self._command_line = command_line
+
+        media_file_manager.set_ioloop(ioloop = self._ioloop)
 
         # Mapping of ReportSession.id -> SessionInfo.
         self._session_info_by_id = {}

--- a/lib/tests/streamlit/media_file_manager_test.py
+++ b/lib/tests/streamlit/media_file_manager_test.py
@@ -96,7 +96,8 @@ class UploadedFileManagerTest(unittest.TestCase):
 
         # Make sure we get different file ids for files with same bytes but diff't mimetypes.
         self.assertNotEqual(
-            _calculate_file_id(fake_bytes, "audio/wav"), _calculate_file_id(fake_bytes, "video/mp4")
+            _calculate_file_id(fake_bytes, "audio/wav"),
+            _calculate_file_id(fake_bytes, "video/mp4"),
         )
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")

--- a/lib/tests/streamlit/media_file_manager_test.py
+++ b/lib/tests/streamlit/media_file_manager_test.py
@@ -19,11 +19,11 @@ import mock
 import random
 import time
 
+from tornado.testing import AsyncTestCase
+
 from streamlit.MediaFileManager import MediaFileManager
 from streamlit.MediaFileManager import _calculate_file_id
-
-
-mfm = MediaFileManager()
+from streamlit.MediaFileManager import KEEP_DELAY_SEC
 
 
 def random_coordinates():
@@ -77,13 +77,16 @@ ALL_FIXTURES.update(VIDEO_FIXTURES)
 ALL_FIXTURES.update(IMAGE_FIXTURES)
 
 
-class MediaFileManagerTest(unittest.TestCase):
+class MediaFileManagerTest(AsyncTestCase):
     def setUp(self):
+        super(MediaFileManagerTest, self).setUp()
+        self.mfm = MediaFileManager()
+        self.mfm.set_ioloop(self.io_loop)
         random.seed(1337)
 
     def tearDown(self):
-        mfm._files_by_id.clear()
-        mfm._files_by_session_and_coord.clear()
+        self.mfm._files_by_id.clear()
+        self.mfm._files_by_session_and_coord.clear()
 
     def test_calculate_file_id(self):
         """Test that file_id generation from data works as expected."""
@@ -109,38 +112,55 @@ class MediaFileManagerTest(unittest.TestCase):
 
         # Make sure we reject files containing None
         with self.assertRaises(TypeError):
-            mfm.add(None, "media/any", coord)
+            self.mfm.add(None, "media/any", coord)
 
         sample_coords = set()
         while len(sample_coords) < len(ALL_FIXTURES):
             sample_coords.add(random_coordinates())
 
         for sample in ALL_FIXTURES.values():
-            f = mfm.add(sample["content"], sample["mimetype"], sample_coords.pop())
-            self.assertTrue(f.id in mfm)
+            f = self.mfm.add(sample["content"], sample["mimetype"], sample_coords.pop())
+            self.assertTrue(f.id in self.mfm)
 
         # There should be as many files in MFM as we added.
-        self.assertEqual(len(mfm), len(ALL_FIXTURES))
+        self.assertEqual(len(self.mfm), len(ALL_FIXTURES))
 
         # There should only be 1 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")
-    def test_add_files_same_coord(self, _get_session_id):
+    @mock.patch("time.time")
+    def test_add_files_same_coord(self, _time, _get_session_id):
         """Test that MediaFileManager.add works as expected."""
         _get_session_id.return_value = "SESSION1"
+        _time.return_value = 0
 
         coord = random_coordinates()
 
         for sample in ALL_FIXTURES.values():
-            f = mfm.add(sample["content"], sample["mimetype"], coord)
-            self.assertTrue(f.id in mfm)
+            f = self.mfm.add(sample["content"], sample["mimetype"], coord)
+            self.assertTrue(f.id in self.mfm)
 
-        # There should be only 1 file in MFM.
-        self.assertEqual(len(mfm), 1)
+        # There should be 6 files in MFM.
+        self.assertEqual(len(self.mfm), len(ALL_FIXTURES))
 
         # There should only be 1 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
+
+        # There should only be 1 coord in that session.
+        self.assertEqual(len(self.mfm._files_by_session_and_coord["SESSION1"]), 1)
+
+        pretend_time_passed = self.get_mock_call_later()
+        self.mfm.clear_session_files()
+
+        _time.return_value = KEEP_DELAY_SEC + 1
+        pretend_time_passed[0]()
+
+        # There should be only 0 file in MFM.
+        self.assertEqual(len(self.mfm), 0)
+
+        # There should only be 0 session with registered files.
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")
     def test_add_file_already_exists_same_coord(self, _get_session_id):
@@ -149,19 +169,19 @@ class MediaFileManagerTest(unittest.TestCase):
         sample = IMAGE_FIXTURES["png"]
         coord = random_coordinates()
 
-        mfm.add(sample["content"], sample["mimetype"], coord)
+        self.mfm.add(sample["content"], sample["mimetype"], coord)
         file_id = _calculate_file_id(sample["content"], sample["mimetype"])
-        self.assertTrue(file_id in mfm)
+        self.assertTrue(file_id in self.mfm)
 
-        mediafile = mfm.add(sample["content"], sample["mimetype"], coord)
-        self.assertTrue(file_id in mfm)
+        mediafile = self.mfm.add(sample["content"], sample["mimetype"], coord)
+        self.assertTrue(file_id in self.mfm)
         self.assertEqual(mediafile.id, file_id)
 
         # There should only be 1 file in MFM.
-        self.assertEqual(len(mfm), 1)
+        self.assertEqual(len(self.mfm), 1)
 
         # There should only be 1 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")
     def test_add_file_already_exists_different_coord(self, _get_session_id):
@@ -170,20 +190,20 @@ class MediaFileManagerTest(unittest.TestCase):
         sample = IMAGE_FIXTURES["png"]
 
         coord = random_coordinates()
-        mfm.add(sample["content"], sample["mimetype"], coord)
+        self.mfm.add(sample["content"], sample["mimetype"], coord)
         file_id = _calculate_file_id(sample["content"], sample["mimetype"])
-        self.assertTrue(file_id in mfm)
+        self.assertTrue(file_id in self.mfm)
 
         coord = random_coordinates()
-        mediafile = mfm.add(sample["content"], sample["mimetype"], coord)
-        self.assertTrue(file_id in mfm)
+        mediafile = self.mfm.add(sample["content"], sample["mimetype"], coord)
+        self.assertTrue(file_id in self.mfm)
         self.assertEqual(mediafile.id, file_id)
 
         # There should only be 1 file in MFM.
-        self.assertEqual(len(mfm), 1)
+        self.assertEqual(len(self.mfm), 1)
 
         # There should only be 1 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")
     def test_add_file_different_mimetypes(self, _get_session_id):
@@ -192,46 +212,58 @@ class MediaFileManagerTest(unittest.TestCase):
         coord = random_coordinates()
 
         sample = AUDIO_FIXTURES["mp3"]
-        f1 = mfm.add(sample["content"], "audio/mp3", coord)
-        self.assertTrue(f1.id in mfm)
+        f1 = self.mfm.add(sample["content"], "audio/mp3", coord)
+        self.assertTrue(f1.id in self.mfm)
 
-        f2 = mfm.add(sample["content"], "video/mp4", coord)
+        f2 = self.mfm.add(sample["content"], "video/mp4", coord)
         self.assertNotEqual(f1.id, f2.id)
-        self.assertTrue(f2.id in mfm)
+        self.assertTrue(f2.id in self.mfm)
 
         # There should be only 2 files in MFM, one for each mimetye.
-        self.assertEqual(len(mfm), 2)
+        self.assertEqual(len(self.mfm), 2)
 
         # There should be only 1 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")
-    def test_clear_session_files(self, _get_session_id):
+    @mock.patch("time.time")
+    def test_clear_session_files(self, _time, _get_session_id):
         """Test that MediaFileManager removes session maps when requested (even if empty)."""
         _get_session_id.return_value = "SESSION1"
+        _time.return_value = 0
 
-        self.assertEqual(len(mfm), 0)
-        self.assertEqual(len(mfm._files_by_session_and_coord), 0)
-        mfm.clear_session_files()
+        self.assertEqual(len(self.mfm), 0)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)
 
-        self.assertEqual(len(mfm), 0)
-        self.assertEqual(len(mfm._files_by_session_and_coord), 0)
+        pretend_time_passed = self.get_mock_call_later()
+        self.mfm.clear_session_files()
+
+        self.assertEqual(len(self.mfm), 0)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)
+
+        pretend_time_passed[0]()
+
+        self.assertEqual(len(self.mfm), 0)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)
 
         for sample in VIDEO_FIXTURES.values():
             coord = random_coordinates()
-            mfm.add(sample["content"], sample["mimetype"], coord)
+            self.mfm.add(sample["content"], sample["mimetype"], coord)
 
-        self.assertEqual(len(mfm), len(VIDEO_FIXTURES))
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm), len(VIDEO_FIXTURES))
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
 
-        # force MediaFile to have a TTD of now, so we can see it get deleted w/o waiting.
-        for mf in mfm._files_by_id.values():
-            mf.ttd = time.time()
+        pretend_time_passed = self.get_mock_call_later()
+        self.mfm.clear_session_files()
 
-        mfm.clear_session_files()
+        self.assertEqual(len(self.mfm), len(VIDEO_FIXTURES))  # Clears later
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)  # Clears immediately
 
-        self.assertEqual(len(mfm), 0)
-        self.assertEqual(len(mfm._files_by_session_and_coord), 0)
+        _time.return_value = KEEP_DELAY_SEC + 1
+        pretend_time_passed[0]()
+
+        self.assertEqual(len(self.mfm), 0)  # Now this is cleared too!
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)
 
     @mock.patch("streamlit.MediaFileManager._get_session_id")
     def test_add_file_multiple_sessions_then_clear(self, _get_session_id):
@@ -240,32 +272,62 @@ class MediaFileManagerTest(unittest.TestCase):
         sample = next(iter(ALL_FIXTURES.values()))
 
         coord = random_coordinates()
-        f = mfm.add(sample["content"], sample["mimetype"], coord)
-        self.assertTrue(f.id in mfm)
+        f = self.mfm.add(sample["content"], sample["mimetype"], coord)
+        self.assertTrue(f.id in self.mfm)
 
         _get_session_id.return_value = "SESSION2"
 
         coord = random_coordinates()
-        f = mfm.add(sample["content"], sample["mimetype"], coord)
-        self.assertTrue(f.id in mfm)
+        f = self.mfm.add(sample["content"], sample["mimetype"], coord)
+        self.assertTrue(f.id in self.mfm)
 
         # There should be only 1 file in MFM.
-        self.assertEqual(len(mfm), 1)
+        self.assertEqual(len(self.mfm), 1)
 
         # There should be 2 sessions with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 2)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 2)
 
         # force every MediaFile to have a TTD of now, so we can see it get deleted w/o waiting.
-        for mf in mfm._files_by_id.values():
+        for mf in self.mfm._files_by_id.values():
             mf.ttd = time.time()
 
-        mfm.clear_session_files()
+        self.mfm.clear_session_files()
 
         # There should be 1 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 1)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 1)
 
         _get_session_id.return_value = "SESSION1"
-        mfm.clear_session_files()
+        self.mfm.clear_session_files()
 
         # There should be 0 session with registered files.
-        self.assertEqual(len(mfm._files_by_session_and_coord), 0)
+        self.assertEqual(len(self.mfm._files_by_session_and_coord), 0)
+
+    def get_mock_call_later(self):
+        """Poor-man's mock of ioloop.call_later.
+
+        Returns a list that, once ioloop.call_later is called, will contain the
+        call_later's callback.
+
+        This means you should use it this way:
+
+            pretend_time_passed = self.get_mock_call_later()
+            self.mfm.something_that_calls_call_later()
+
+            # Add tests here for the case where the callback was not called yet.
+
+            pretend_time_passed[0]()
+
+            # Add tests here for the case where the callback was called.
+        """
+
+        # Don't need to do this since io_loop gets reset with every test.
+        # orig_call_later = self.io_loop.call_later
+
+        pretend_time_passed = []  # Hack!
+
+        def new_call_later(_, cb):
+            pretend_time_passed.append(cb)
+
+        self.io_loop.call_later = new_call_later
+
+        return pretend_time_passed

--- a/lib/tests/streamlit/media_file_manager_test.py
+++ b/lib/tests/streamlit/media_file_manager_test.py
@@ -77,7 +77,7 @@ ALL_FIXTURES.update(VIDEO_FIXTURES)
 ALL_FIXTURES.update(IMAGE_FIXTURES)
 
 
-class UploadedFileManagerTest(unittest.TestCase):
+class MediaFileManagerTest(unittest.TestCase):
     def setUp(self):
         random.seed(1337)
 

--- a/lib/tests/streamlit/scriptrunner/ScriptRunner_test.py
+++ b/lib/tests/streamlit/scriptrunner/ScriptRunner_test.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 """Tests ScriptRunner functionality"""
+from typing import List
+import os
 import sys
 import time
 import unittest
-from typing import List
 
-import os
 from parameterized import parameterized
+from tornado.testing import AsyncTestCase
 
 from streamlit.Report import Report
+from streamlit.MediaFileManager import media_file_manager
 from streamlit.ReportQueue import ReportQueue
 from streamlit.ScriptRequestQueue import RerunData
 from streamlit.ScriptRequestQueue import ScriptRequest
@@ -46,7 +48,15 @@ def _create_widget(id, states):
     return states.widgets[-1]
 
 
-class ScriptRunnerTest(unittest.TestCase):
+class ScriptRunnerTest(AsyncTestCase):
+    def setUp(self):
+        super(ScriptRunnerTest, self).setUp()
+        media_file_manager.set_ioloop(self.io_loop)
+
+    def tearDown(self):
+        super(ScriptRunnerTest, self).tearDown()
+        media_file_manager.set_ioloop(None)
+
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""
         scriptrunner = TestScriptRunner("good_script.py")


### PR DESCRIPTION
Fixes #1440, Fixes #1294, Fixes #1454 

**Description:** 

The MediaFileManager currently uses a method of management that involves assuming that when a Session has completed its run, those files are no longer needed and can be safely deleted.

However, the reality is that the browser may not have had enough time between session runs to request that file, particularly in rapid-fire script reruns, resulting in broken images being shown to the user as the browser tries to request files that have already been deleted.

Examples of rapid-fire session creation-and-destruction include:

* Using the slider to generate pyplots.
* Rapidly checking and unchecking a checkbox that generates/shows an image.
* Streaming a video from YouTube and using an `st.image` element to show each frame from that video.

This PR introduces a KEEP_DELAY (which could potentially be configurable, but for now is statically defined) in `MediaFileManager.py` (MFM) and presently set to 5 seconds (a setting found by experimentation... I tried 1-2 seconds and that didn't work too well).

When a MediaFile is created, it gets a `ttd` (time to die) time set to `time.time() + KEEP_DELAY`

Each time a session finishes, it triggers the checking of each file_id currently stored in the MFM to see if its `ttd` has expired compared to `time.time()`

This results in enough of a grace period before wiping expired media files to eliminate the effects seen in #1440 and similar bugs (see issues listed above).


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.