### PR TITLE
Added a static path to Tornado settings.

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -58,12 +58,14 @@ if TYPE_CHECKING:
 
 LOGGER = get_logger(__name__)
 
-
+#IMPULSO HACK
+import os
 TORNADO_SETTINGS = {
     "compress_response": True,  # Gzip HTTP responses.
     "websocket_ping_interval": 20,  # Ping every 20s to keep WS alive.
     "websocket_ping_timeout": 30,  # Pings should be responded to within 30s.
     "websocket_max_message_size": MESSAGE_SIZE_LIMIT,  # Up the WS size limit.
+    "static_path": os.path.join(os.getcwd(), "static"),
 }
 
 


### PR DESCRIPTION
This allows for static files in our server.
The static files must be in a folder called "static" in the same dir as the running script (app.py).
If used alongside iframe and embed in HTML it allows for javascript inside Streamlit.