### PR TITLE
Restructure 'Getting Started' page

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -291,7 +291,7 @@ To stop your screencast, go back to the menu (**☰**) and select **Stop recordi
 If you run into difficulties building your own Streamlit apps, here are a few resources you can turn to:
 
 - Stop by the [community forum](https://discuss.streamlit.io/) and post a question
-- Get quick help from command line with `$ streamlit --help`
+- Get quick help from the command line with `$ streamlit --help`
 - Read more documentation!
   - [Tutorials](tutorial/index.md) to make an app
   - [Advanced concepts](advanced_concepts.md) for things like caching and

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,14 +1,14 @@
 # Get started
 
-The easiest way to learn how to use Streamlit is to try things out yourself. As
+The easiest way to learn Streamlit is to try things out yourself. As
 you read through this guide, test each method. As long as your app is running,
 every time you add a new element to your script and save, Streamlit's UI will
 ask if you'd like to rerun the app and view the changes. This allows you to
-work in a fast interactive loop: you write some code, save it, review the
-output, write some more, and so on, until you're happy with the results. The
-goal is to use Streamlit to create an interactive app for your data or model
-and along the way to use Streamlit to review, debug, perfect, and share your
-code.
+work in a fast interactive loop: write some code, save it, review the
+output, write some more, and so on, until you're happy with the results.
+
+The goal of this tutorial is to use Streamlit to create an interactive app for your data or model
+and along the way to use Streamlit to review, debug, perfect, and share your code.
 
 Use the links below to jump to a specific section:
 
@@ -31,7 +31,7 @@ Before you get started, you're going to need a few things:
 If you haven't already, take a few minutes to read through [Main
 concepts](main_concepts.md) to understand Streamlit's data flow model.
 
-## Set up your virtual environment
+## Set up a virtual environment
 
 Regardless of which package management tool you're using, we recommend running
 these commands in a virtual environment. This ensures that the dependencies

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -46,7 +46,7 @@ The 'Streamlit Hello' app should appear in a new tab in your web browser at [htt
 
 ## Part 2: Setting up a Streamlit app
 
-Now that Streamlit is installed our virtual environment and we've validated everything is working correctly,
+Now that Streamlit is installed in our virtual environment and we've validated everything is working correctly,
 let's set up a minimal Streamlit app:
 
 1. Create a new Python file named `first_app.py`, then open it with your IDE

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,78 +16,38 @@ This ensures that the dependencies pulled in for Streamlit don't impact any othe
 you're working on.
 
 These instructions assume you have already installed Python 3.6 or higher on your machine. If you need to download Python,
-please see the [official Python.org website](https://www.python.org/downloads/). The [Streamlit wiki](https://github.com/streamlit/streamlit/wiki) also provides detailed instructions about [creating Python virtual environments](https://github.com/streamlit/streamlit/wiki/Installing-in-a-virtual-environment).
+please see the [official Python.org website](https://www.python.org/downloads/). Additionally, the [Streamlit wiki](https://github.com/streamlit/streamlit/wiki) provides detailed instructions for [creating Python virtual environments](https://github.com/streamlit/streamlit/wiki/Installing-in-a-virtual-environment).
 
-#### Installing Streamlit on macOS and Linux using Pipenv
+### Installing Streamlit on macOS and Linux using Pipenv
 
-Streamlit's officially-supported environment manager for macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/):
+The officially-supported environment manager for Streamlit on macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/):
 
-1. Navigate to your project folder `myproject`:
+1. Navigate to your project folder: `cd <myproject>`
+2. Install Streamlit in your environment: `pipenv install streamlit`
+   <br />When you run the command above, two files named `Pipfile` and `Pipfile.lock` will appear in `myprojects/`. These files are where your Pipenv environment and its dependencies are declared.
+3. Activate your pipenv environment from the `<myproject>` folder: `pipenv shell`
+4. Test that the installation worked: `streamlit hello`
 
-   ```sh
-   cd myproject
-   ```
+The 'Streamlit Hello' app should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
 
-2. Install Streamlit in your environment:
+### Installing Streamlit on Windows using Anaconda
 
-   ```sh
-   pipenv install streamlit
-   ```
+The officially-supported environment manager for Streamlit on Windows is [Anaconda Navigator](https://docs.anaconda.com/anaconda/navigator/). If
+you don't have Anaconda installed yet, please follow the steps provided on the [Anaconda installation page](https://docs.anaconda.com/anaconda/install/windows/).
 
-   When you run the command above, two files named `Pipfile` and `Pipfile.lock` will appear in `myprojects/`. These files are where your Pipenv environment and its dependencies are declared.
+Once you have installed Anaconda, please follow the steps to [set up and manage your environment](https://docs.anaconda.com/anaconda/navigator/getting-started/#managing-environments) using the Anaconda Navigator.
 
-    <br />
+1. Select the "▶" icon next to your new environment. Then select "Open terminal":
+   !["Open terminal" in Anaconda Navigator](https://i.stack.imgur.com/EiiFc.png)
+2. In the terminal that appears, type: `pip install streamlit`
+3. Test that the installation worked: `streamlit hello`
 
-3. Activate your pipenv environment from the `myproject/` folder:
+The 'Streamlit Hello' should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
 
-   ```sh
-   pipenv shell
-   ```
+## Part 2: Setting up a Streamlit app
 
-4. Test that the installation worked:
-
-   ```sh
-   streamlit hello
-   ```
-
-   Streamlit's Hello app should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
-
-#### Installing Streamlit on Windows using Anaconda
-
-<!--
-
-#### Use your new environment
-
-1. Any time you want to use the new environment, you first need to go to your project folder (where the `Pipenv` file lives) and run:
-
-   ```sh
-   pipenv shell
-   ```
-
-2. Now you can use Python and Streamlit as usual:
-
-   ```sh
-   streamlit run myfile.py
-   ```
-
-3. When you're done using this environment, just type `exit` or press `ctrl-D` to return to your normall shell.
-
-### Install Streamlit
-
-```bash
-$ pip install streamlit
-```
-
-Now run the hello world app just to make sure everything it's working:
-
-```bash
-$ streamlit hello
-```
-
-### Import Streamlit
-
-Now that everything's installed, let's create a new Python script and import
-Streamlit.
+Now that Streamlit is installed our virtual environment and we've validated everything is working correctly,
+let's set up a minimal Streamlit app:
 
 1. Create a new Python file named `first_app.py`, then open it with your IDE
    or text editor.
@@ -99,15 +59,15 @@ Streamlit.
    import numpy as np
    import pandas as pd
    ```
-3. Run your app. A new tab will open in your default browser. It'll be blank
-   for now. That's OK.
+3. Run your app from a terminal window (i.e. `Terminal` for Linux/OSX, `Powershell` for Windows). A new tab will open in your default browser, which will be blank.
+   This is expected, as no Streamlit widgets have been defined yet.
 
    ```bash
    $ streamlit run first_app.py
    ```
 
-   Running a Streamlit app is no different than any other Python script.
-   Whenever you need to view the app, you can use this command.
+   Running a Streamlit app is no different than any other Python script. Whenever you want to view your app, run this command and your Streamlit app
+   will be served. You can stop your app at any time by typing **Ctrl+c** in the terminal or by closing its terminal window.
 
    ```eval_rst
    .. tip::
@@ -116,29 +76,26 @@ Streamlit.
       `$ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/app.py`
    ```
 
-4. You can kill the app at any time by typing **Ctrl+c** in the terminal.
+## Part 3: Adding widgets to a Streamlit app
 
-## Add text and data
+Streamlit has dozens of ways to add UI widgets to your app. Check out our [API reference](api.md) for a complete list.
 
-### Add a title
+### Adding a title
 
-Streamlit has a number of ways to add text to your app. Check out our
-[API reference](api.md) for a complete list.
-
-Let's add a title to test things out:
+Let's add a title to our app by placing this text in the `first_app.py` file:
 
 ```Python
 st.title('My first app')
 ```
 
-That's it! Your app has a title. You can use specific text functions to add
+That's it, your app has a title! You can use specific text functions to add
 content to your app, or you can use [`st.write()`](api.html#streamlit.write)
 and add your own markdown.
 
-### Write a data frame
+### Writing a data frame
 
 Along with [magic commands](api.html#magic-commands),
-[`st.write()`](api.html#streamlit.write) is Streamlit's "Swiss Army knife". You
+[`st.write()`](api.html#streamlit.write) is "Swiss Army knife" of Streamlit. You
 can pass almost anything to [`st.write()`](api.html#streamlit.write):
 text, data, Matplotlib figures, Altair charts, and more. Don't worry, Streamlit
 will figure it out and render things the right way.
@@ -166,9 +123,9 @@ these features and how to add colors and styling to your data frames.
    cache it.
 ```
 
-## Use magic
+### Streamlit "Magic"
 
-If you're using Python 3, you can also write to your app without calling any
+You can also write to your app without calling any
 Streamlit methods. Streamlit supports "[magic
 commands](api.html#magic-commands)," which means you don't have to use
 [`st.write()`](api.html#streamlit.write) at all! Try replacing the code above
@@ -188,18 +145,17 @@ df = pd.DataFrame({
 df
 ```
 
-How it works is simple. Any time that Streamlit sees a variable or a literal
-value on its own line, it automatically writes that to your app using
-[`st.write()`](api.html#streamlit.write). For more information, refer to the
-documentation on [magic commands](api.html#magic-commands).
+Any time that Streamlit sees a variable or a literal value on its own line, it automatically
+writes its value to your app using [`st.write()`](api.html#streamlit.write). For more information,
+refer to the documentation on [magic commands](api.html#magic-commands).
 
-## Draw charts and maps
+### Drawing charts and maps
 
 Streamlit supports several popular data charting libraries like [Matplotlib,
 Altair, deck.gl, and more](api.html#display-charts). In this section, you'll
 add a bar chart, line chart, and a map to your app.
 
-### Draw a line chart
+#### Drawing a line chart
 
 You can easily add a line chart to your app with
 [`st.line_chart()`](api.html#streamlit.line_chart). We'll generate a random
@@ -213,7 +169,7 @@ chart_data = pd.DataFrame(
 st.line_chart(chart_data)
 ```
 
-### Plot a map
+#### Plotting a map
 
 With [`st.map()`](api.html#streamlit.map) you can display data points on a map.
 Let's use Numpy to generate some sample data and plot it on a map of
@@ -227,17 +183,17 @@ map_data = pd.DataFrame(
 st.map(map_data)
 ```
 
-## Add interactivity with widgets
+### Adding interactivity with widgets
 
 With widgets, Streamlit allows you to bake interactivity directly into your
 apps with checkboxes, buttons, sliders, and more. Check out our [API
 reference](api.md) for a full list of interactive widgets.
 
-### Use checkboxes to show/hide data
+#### Using checkboxes to show/hide data
 
 One use case for checkboxes is to hide or show a specific chart or section in
 an app. [`st.checkbox()`](api.html#streamlit.checkbox) takes a single argument,
-which is the widget label. In this sample, the checkbox is used to toggle a
+the widget's label. In this sample, the checkbox is used to toggle a
 conditional statement.
 
 ```Python
@@ -249,10 +205,10 @@ if st.checkbox('Show dataframe'):
     st.line_chart(chart_data)
 ```
 
-### Use a selectbox for options
+#### Using a selectbox for options
 
 Use [`st.selectbox`](api.html#streamlit.selectbox) to choose from a series. You
-can write in the options you want, or pass through an array or data frame
+can write in the options you want as a literal array, or pass through an array or data frame
 column.
 
 Let's use the `df` data frame we created earlier.
@@ -265,11 +221,10 @@ option = st.selectbox(
 'You selected: ', option
 ```
 
-### Put widgets in a sidebar
+#### Putting widgets in a sidebar
 
 For a cleaner look, you can move your widgets into a sidebar. This keeps your
-app central, while widgets are pinned to the left. Let's take a look at how you
-can use [`st.sidebar`](api.html#add-widgets-to-sidebar) in your app.
+app central, while widgets are pinned to the left. Here's how to use [`st.sidebar`](api.html#add-widgets-to-sidebar) in your app.
 
 ```Python
 option = st.sidebar.selectbox(
@@ -280,19 +235,20 @@ option = st.sidebar.selectbox(
 ```
 
 Most of the elements you can put into your app can also be put into a sidebar using this syntax:
-`st.sidebar.[element_name]()`. Here are a few examples that show how it's used: `st.sidebar.markdown()`, `st.sidebar.slider()`, `st.sidebar.line_chart()`.
+`st.sidebar.[element_name]()`, including:
 
-The only exceptions right now are `st.write` (you
-should use `st.sidebar.markdown()` instead), `st.echo`, and `st.spinner`. Rest
-assured, though, we're currently working on adding support for those too!
+- `st.sidebar.markdown()`
+- `st.sidebar.slider()`
+- `st.sidebar.line_chart()`
 
-## Show progress
+Currently, the only exceptions to using widgets in the sidebar right now are `st.write` (you
+should use `st.sidebar.markdown()` instead), `st.echo`, and `st.spinner`.
+
+#### Showing calculation progress
 
 When adding long running computations to an app, you can use
-[`st.progress()`](api.html#streamlit.progress) to display status in real time.
-
-First, let's import time. We're going to use the `time.sleep()` method to
-simulate a long running computation:
+[`st.progress()`](api.html#streamlit.progress) to display the calculation status.
+For this example, we'll use `time.sleep()` to simulate a long running computation:
 
 ```Python
 import time
@@ -316,11 +272,13 @@ for i in range(100):
 '...and now we\'re done!'
 ```
 
-## Record a screencast
+## Part 4: Recording a screencast (optional)
 
-After you've built a Streamlit app, you may want to discuss some of it with co-workers over email or Slack, or share it with the world on Twitter. A great way to do that is with Streamlit's built-in screencast recorder. With it, you can record, narrate, stop, save, and share with a few clicks.
+After you've built a Streamlit app, you may want to discuss some of it with co-workers over email or Slack, or share it with the world on Twitter.
+A great way to share your app is by using the Streamlit built-in screencast recorder. With it, you can record, narrate, stop, save, and share with a few clicks.
 
-To start a screencast, locate the menu in the upper right corner of your app (**☰**), select **Record a screencast**, and follow the prompts. Before the recording starts, you'll see a countdown — this means it's showtime.
+To start a screencast, locate the menu in the upper right corner of your app (**☰**), select **Record a screencast**, and follow the prompts.
+Before the recording starts, you'll see a countdown — this means it's showtime.
 
 To stop your screencast, go back to the menu (**☰**) and select **Stop recording** (or hit the **ESC** key). Follow the prompts to preview your recording and save it to disk. That's it, you're ready to share your Streamlit app.
 
@@ -328,16 +286,14 @@ To stop your screencast, go back to the menu (**☰**) and select **Stop recordi
 .. image:: ./media/screenshare.gif
 ```
 
-## Get help
+## Getting help with Streamlit
 
-That's it for getting started, now you can go and build your own apps! If you
-run into difficulties here are a few things you can do.
+If you run into difficulties building your own Streamlit apps, here are a few resources you can turn to:
 
-- Check out our [community forum](https://discuss.streamlit.io/) and post a
-  question
-- Quick help from command line with `$ streamlit --help`
-- Read more documentation! Check out:
+- Stop by the [community forum](https://discuss.streamlit.io/) and post a question
+- Get quick help from command line with `$ streamlit --help`
+- Read more documentation!
   - [Tutorials](tutorial/index.md) to make an app
   - [Advanced concepts](advanced_concepts.md) for things like caching and
     inserting elements out of order
-  - [API reference](api.md) for examples of every Streamlit command -->
+  - [API reference](api.md) for examples of every Streamlit command

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -241,7 +241,7 @@ Most of the elements you can put into your app can also be put into a sidebar us
 - `st.sidebar.slider()`
 - `st.sidebar.line_chart()`
 
-Currently, the only exceptions to using widgets in the sidebar right now are `st.write` (you
+Currently, the only exceptions to using widgets in the sidebar are `st.write` (you
 should use `st.sidebar.markdown()` instead), `st.echo`, and `st.spinner`.
 
 #### Showing calculation progress

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,14 +10,6 @@ output, write some more, and so on, until you're happy with the results.
 The goal of this tutorial is to use Streamlit to create an interactive app for your data or model
 and along the way to use Streamlit to review, debug, perfect, and share your code.
 
-Use the links below to jump to a specific section:
-
-```eval_rst
-.. contents::
-    :local:
-    :depth: 1
-```
-
 ## Prerequisites
 
 Before you get started, you're going to need a few things:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,7 +7,7 @@ ask if you'd like to rerun the app and view the changes. This workflow allows fo
 working in a fast, interactive loop: write some code, save it, review the
 output, write some more, and so on until you're happy with the results.
 
-## Part 1: Install Streamlit in a virtual environment
+## Part 1: Installing Streamlit in a virtual environment
 
 Regardless of which package manager you choose ([pipenv](https://pipenv.pypa.io/en/latest/),
 [conda](https://www.anaconda.com/distribution/), [venv](https://docs.python.org/3/library/venv.html), etc.),
@@ -42,7 +42,7 @@ Once you have installed Anaconda, please follow the steps to [set up and manage 
 2. In the terminal that appears, type: `pip install streamlit`
 3. Test that the installation worked: `streamlit hello`
 
-The 'Streamlit Hello' should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
+The 'Streamlit Hello' app should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
 
 ## Part 2: Setting up a Streamlit app
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,41 +1,78 @@
-# Get started
+# 10-minute Streamlit Tutorial
 
-The easiest way to learn Streamlit is to try things out yourself. As
-you read through this guide, test each method. As long as your app is running,
-every time you add a new element to your script and save, Streamlit's UI will
-ask if you'd like to rerun the app and view the changes. This allows you to
-work in a fast interactive loop: write some code, save it, review the
-output, write some more, and so on, until you're happy with the results.
+The easiest way to learn Streamlit is to try things out yourself! As
+you work through this tutorial, be sure to run each line of code.
+Each time you make a change to your script and save, the Streamlit UI will
+ask if you'd like to rerun the app and view the changes. This workflow allows for
+working in a fast, interactive loop: write some code, save it, review the
+output, write some more, and so on until you're happy with the results.
 
-The goal of this tutorial is to use Streamlit to create an interactive app for your data or model
-and along the way to use Streamlit to review, debug, perfect, and share your code.
+## Part 1: Install Streamlit in a virtual environment
 
-## Prerequisites
-
-Before you get started, you're going to need a few things:
-
-- Your favorite IDE or text editor
-- [Python 3.6 or later](https://www.python.org/downloads/)
-- [PIP](https://pip.pypa.io/en/stable/installing/)
-- [Streamlit](index.md) — This one's kind of important, so don't forget to
-  install.
-
-If you haven't already, take a few minutes to read through [Main
-concepts](main_concepts.md) to understand Streamlit's data flow model.
-
-## Set up a virtual environment
-
-Regardless of which package management tool you're using, we recommend running
-these commands in a virtual environment. This ensures that the dependencies
-pulled in for Streamlit don't impact any other Python projects
+Regardless of which package manager you choose ([pipenv](https://pipenv.pypa.io/en/latest/),
+[conda](https://www.anaconda.com/distribution/), [venv](https://docs.python.org/3/library/venv.html), etc.),
+we recommend installing Streamlit in a separate virtual environment for each Streamlit application.
+This ensures that the dependencies pulled in for Streamlit don't impact any other Python projects
 you're working on.
 
-- [pipenv](https://pipenv.pypa.io/en/latest/)
-- [venv](https://docs.python.org/3/library/venv.html)
-- [virtualenv](https://virtualenv.pypa.io/en/latest/)
-- [conda](https://www.anaconda.com/distribution/)
+These instructions assume you have already installed Python 3.6 or higher on your machine. If you need to download Python,
+please see the [official Python.org website](https://www.python.org/downloads/). The [Streamlit wiki](https://github.com/streamlit/streamlit/wiki) also provides detailed instructions about [creating Python virtual environments](https://github.com/streamlit/streamlit/wiki/Installing-in-a-virtual-environment).
 
-## Install Streamlit
+#### Installing Streamlit on macOS and Linux using Pipenv
+
+Streamlit's officially-supported environment manager for macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/):
+
+1. Navigate to your project folder `myproject`:
+
+   ```sh
+   cd myproject
+   ```
+
+2. Install Streamlit in your environment:
+
+   ```sh
+   pipenv install streamlit
+   ```
+
+   When you run the command above, two files named `Pipfile` and `Pipfile.lock` will appear in `myprojects/`. These files are where your Pipenv environment and its dependencies are declared.
+
+    <br />
+
+3. Activate your pipenv environment from the `myproject/` folder:
+
+   ```sh
+   pipenv shell
+   ```
+
+4. Test that the installation worked:
+
+   ```sh
+   streamlit hello
+   ```
+
+   Streamlit's Hello app should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
+
+#### Installing Streamlit on Windows using Anaconda
+
+<!--
+
+#### Use your new environment
+
+1. Any time you want to use the new environment, you first need to go to your project folder (where the `Pipenv` file lives) and run:
+
+   ```sh
+   pipenv shell
+   ```
+
+2. Now you can use Python and Streamlit as usual:
+
+   ```sh
+   streamlit run myfile.py
+   ```
+
+3. When you're done using this environment, just type `exit` or press `ctrl-D` to return to your normall shell.
+
+### Install Streamlit
 
 ```bash
 $ pip install streamlit
@@ -47,7 +84,7 @@ Now run the hello world app just to make sure everything it's working:
 $ streamlit hello
 ```
 
-## Import Streamlit
+### Import Streamlit
 
 Now that everything's installed, let's create a new Python script and import
 Streamlit.
@@ -303,4 +340,4 @@ run into difficulties here are a few things you can do.
   - [Tutorials](tutorial/index.md) to make an app
   - [Advanced concepts](advanced_concepts.md) for things like caching and
     inserting elements out of order
-  - [API reference](api.md) for examples of every Streamlit command
+  - [API reference](api.md) for examples of every Streamlit command -->

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,13 +1,13 @@
-# Getting Started with Streamlit
+# Get Started with Streamlit
 
 The easiest way to learn Streamlit is to try things out yourself! As
-you work through this getting started guide, be sure to run each line of code.
+you work through this guide, be sure to run each line of code.
 Each time you make a change to your script and save, the Streamlit UI will
-ask if you'd like to rerun the app and view the changes. This workflow allows for
-working in a fast, interactive loop: write some code, save it, review the
+ask if you'd like to rerun the app and view the changes. This workflow allows the user to
+work in a fast, interactive loop: write some code, save it, review the
 output, write some more, and so on until you're happy with the results.
 
-## Part 1: Installing Streamlit in a virtual environment
+## Part 1: Install Streamlit in a virtual environment
 
 Regardless of which package manager you choose ([pipenv](https://pipenv.pypa.io/en/latest/),
 [conda](https://www.anaconda.com/distribution/), [venv](https://docs.python.org/3/library/venv.html), etc.),
@@ -16,9 +16,9 @@ This ensures that the dependencies pulled in for Streamlit don't impact any othe
 you're working on.
 
 These instructions assume you have already installed Python 3.6 or higher on your machine. If you need to download Python,
-please see the [official Python.org website](https://www.python.org/downloads/). Additionally, the [Streamlit wiki](https://github.com/streamlit/streamlit/wiki) provides detailed instructions for [creating Python virtual environments](https://github.com/streamlit/streamlit/wiki/Installing-in-a-virtual-environment).
+please see the [official Python.org website](https://www.python.org/downloads/). Additionally, the [Streamlit wiki](https://github.com/streamlit/streamlit/wiki) provides detailed instructions to [create Python virtual environments](https://github.com/streamlit/streamlit/wiki/Installing-in-a-virtual-environment).
 
-### Installing Streamlit on macOS and Linux using Pipenv
+### Install Streamlit on macOS and Linux with Pipenv
 
 The officially-supported environment manager for Streamlit on macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/):
 
@@ -30,7 +30,7 @@ The officially-supported environment manager for Streamlit on macOS and Linux is
 
 The 'Streamlit Hello' app should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
 
-### Installing Streamlit on Windows using Anaconda
+### Install Streamlit on Windows with Anaconda
 
 The officially-supported environment manager for Streamlit on Windows is [Anaconda Navigator](https://docs.anaconda.com/anaconda/navigator/). If
 you don't have Anaconda installed yet, please follow the steps provided on the [Anaconda installation page](https://docs.anaconda.com/anaconda/install/windows/).
@@ -44,7 +44,7 @@ Once you have installed Anaconda, please follow the steps to [set up and manage 
 
 The 'Streamlit Hello' app should appear in a new tab in your web browser at [http://localhost:8501](http://localhost:8501)!
 
-## Part 2: Setting up a Streamlit app
+## Part 2: Set up a Streamlit app
 
 Now that Streamlit is installed in our virtual environment and we've validated everything is working correctly,
 let's set up a minimal Streamlit app:
@@ -54,7 +54,7 @@ let's set up a minimal Streamlit app:
 2. Next, import Streamlit.
    ```Python
    import streamlit as st
-   # To make things easier later, we're also importing numpy and pandas for
+   # To make things easier later, we also import numpy and pandas for
    # working with sample data.
    import numpy as np
    import pandas as pd
@@ -76,11 +76,11 @@ let's set up a minimal Streamlit app:
       `$ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/app.py`
    ```
 
-## Part 3: Adding widgets to a Streamlit app
+## Part 3: Add widgets to a Streamlit app
 
 Streamlit has dozens of ways to add UI widgets to your app. Check out our [API reference](api.md) for a complete list.
 
-### Adding a title
+### Add a title
 
 Let's add a title to our app by placing this text in the `first_app.py` file:
 
@@ -92,7 +92,7 @@ That's it, your app has a title! You can use specific text functions to add
 content to your app, or you can use [`st.write()`](api.html#streamlit.write)
 and add your own markdown.
 
-### Writing a data frame
+### Write a data frame
 
 Along with [magic commands](api.html#magic-commands),
 [`st.write()`](api.html#streamlit.write) is the "Swiss Army knife" of Streamlit. You
@@ -110,7 +110,7 @@ st.write(pd.DataFrame({
 
 There are other data specific functions like
 [`st.dataframe()`](api.html#streamlit.dataframe) and
-[`st.table()`](api.html#streamlit.table) that you can also use for displaying
+[`st.table()`](api.html#streamlit.table) that you can also use to display
 data. Check our advanced guides on displaying data to understand when to use
 these features and how to add colors and styling to your data frames.
 
@@ -128,7 +128,7 @@ these features and how to add colors and styling to your data frames.
 You can also write to your app without calling any
 Streamlit methods. Streamlit supports "[magic
 commands](api.html#magic-commands)," which means you don't have to use
-[`st.write()`](api.html#streamlit.write) at all! Try replacing the code above
+[`st.write()`](api.html#streamlit.write) at all! Replace the code above
 with this snippet:
 
 ```Python
@@ -149,13 +149,13 @@ Any time that Streamlit sees a variable or a literal value on its own line, it a
 writes its value to your app using [`st.write()`](api.html#streamlit.write). For more information,
 refer to the documentation on [magic commands](api.html#magic-commands).
 
-### Drawing charts and maps
+### Draw charts and maps
 
 Streamlit supports several popular data charting libraries like [Matplotlib,
 Altair, deck.gl, and more](api.html#display-charts). In this section, you'll
 add a bar chart, line chart, and a map to your app.
 
-#### Drawing a line chart
+#### Draw a line chart
 
 You can easily add a line chart to your app with
 [`st.line_chart()`](api.html#streamlit.line_chart). We'll generate a random
@@ -169,7 +169,7 @@ chart_data = pd.DataFrame(
 st.line_chart(chart_data)
 ```
 
-#### Plotting a map
+#### Plot a map
 
 With [`st.map()`](api.html#streamlit.map) you can display data points on a map.
 Let's use Numpy to generate some sample data and plot it on a map of
@@ -183,13 +183,13 @@ map_data = pd.DataFrame(
 st.map(map_data)
 ```
 
-### Adding interactivity with widgets
+### Add interactivity with widgets
 
 With widgets, Streamlit allows you to bake interactivity directly into your
 apps with checkboxes, buttons, sliders, and more. Check out our [API
 reference](api.md) for a full list of interactive widgets.
 
-#### Using checkboxes to show/hide data
+#### Use checkboxes to show/hide data
 
 One use case for checkboxes is to hide or show a specific chart or section in
 an app. [`st.checkbox()`](api.html#streamlit.checkbox) takes a single argument,
@@ -205,7 +205,7 @@ if st.checkbox('Show dataframe'):
     st.line_chart(chart_data)
 ```
 
-#### Using a selectbox for options
+#### Use a selectbox for options
 
 Use [`st.selectbox`](api.html#streamlit.selectbox) to choose from a series. You
 can write in the options you want as a literal array, or pass through an array or data frame
@@ -221,7 +221,7 @@ option = st.selectbox(
 'You selected: ', option
 ```
 
-#### Putting widgets in a sidebar
+#### Put widgets in a sidebar
 
 For a cleaner look, you can move your widgets into a sidebar. This keeps your
 app central, while widgets are pinned to the left. Here's how to use [`st.sidebar`](api.html#add-widgets-to-sidebar) in your app.
@@ -234,7 +234,7 @@ option = st.sidebar.selectbox(
 'You selected:', option
 ```
 
-Most of the elements you can put into your app can also be put into a sidebar using this syntax:
+Most of the elements you can put into your app can also be put into a sidebar with this syntax:
 `st.sidebar.[element_name]()`, including:
 
 - `st.sidebar.markdown()`
@@ -244,7 +244,7 @@ Most of the elements you can put into your app can also be put into a sidebar us
 Currently, the only exceptions to using widgets in the sidebar are `st.write` (you
 should use `st.sidebar.markdown()` instead), `st.echo`, and `st.spinner`.
 
-#### Showing calculation progress
+#### Show calculation progress
 
 When adding long running computations to an app, you can use
 [`st.progress()`](api.html#streamlit.progress) to display the calculation status.
@@ -272,7 +272,7 @@ for i in range(100):
 '...and now we\'re done!'
 ```
 
-## Part 4: Recording a screencast (optional)
+## Part 4: Record a screencast (optional)
 
 After you've built a Streamlit app, you may want to discuss some of it with co-workers over email or Slack, or share it with the world on Twitter.
 A great way to share your app is by using the Streamlit built-in screencast recorder. With it, you can record, narrate, stop, save, and share with a few clicks.
@@ -286,7 +286,7 @@ To stop your screencast, go back to the menu (**☰**) and select **Stop recordi
 .. image:: ./media/screenshare.gif
 ```
 
-## Getting help with Streamlit
+## Get help with Streamlit
 
 If you run into difficulties building your own Streamlit apps, here are a few resources you can turn to:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,4 +1,4 @@
-# 10-minute Streamlit Tutorial
+# Getting Started with Streamlit
 
 The easiest way to learn Streamlit is to try things out yourself! As
 you work through this tutorial, be sure to run each line of code.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,7 +1,7 @@
 # Getting Started with Streamlit
 
 The easiest way to learn Streamlit is to try things out yourself! As
-you work through this tutorial, be sure to run each line of code.
+you work through this getting started guide, be sure to run each line of code.
 Each time you make a change to your script and save, the Streamlit UI will
 ask if you'd like to rerun the app and view the changes. This workflow allows for
 working in a fast, interactive loop: write some code, save it, review the

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -95,7 +95,7 @@ and add your own markdown.
 ### Writing a data frame
 
 Along with [magic commands](api.html#magic-commands),
-[`st.write()`](api.html#streamlit.write) is "Swiss Army knife" of Streamlit. You
+[`st.write()`](api.html#streamlit.write) is the "Swiss Army knife" of Streamlit. You
 can pass almost anything to [`st.write()`](api.html#streamlit.write):
 text, data, Matplotlib figures, Altair charts, and more. Don't worry, Streamlit
 will figure it out and render things the right way.


### PR DESCRIPTION
This PR restructures the 'Getting Started' page into a 4-step tutorial, starting with installing in a virtual environment. For the most part, the content is the same, it just re-arranges and smooths it out. This also impacts the sidebar navigation with an eye on making the steps feel more discrete:

Current:
![image](https://user-images.githubusercontent.com/2762787/83085291-8610c180-a059-11ea-9bf5-4d06bf19cb1d.png)

Proposed:
![image](https://user-images.githubusercontent.com/2762787/83153029-7a121780-a0cc-11ea-846f-0daafbd708c4.png)

This PR also removes the need for this page under troubleshooting, which IMO needs to be front in center (which is what the PR does). 

https://docs.streamlit.io/en/latest/troubleshooting/clean-install.html

This url will be redirected to `/getting_started.html#part-1-install-streamlit-in-a-virtual-environment`