### PR TITLE
Enable WebSocket compression

### DIFF
--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -585,6 +585,16 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
         self._server._close_report_session(self._session.id)
         self._session = None
 
+    def get_compression_options(self):
+        """Enable WebSocket compression.
+
+        By default, this method returns None, which means compression
+        is disabled. Returning an empty dict enables it.
+
+        (See the docstring in the parent class.)
+        """
+        return {}
+
     @tornado.gen.coroutine
     def on_message(self, payload):
         if not self._session:

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -148,6 +148,21 @@ class ServerTest(ServerTestCase):
             self.assertFalse(self.server.browser_is_connected)
 
     @tornado.testing.gen_test
+    def test_websocket_compression(self):
+        with self._patch_report_session():
+            yield self.start_server_loop()
+
+            # Connect to the server, and explicitly request compression.
+            ws_client = yield tornado.websocket.websocket_connect(
+                self.get_ws_url("/stream"), compression_options={}
+            )
+
+            # Ensure that the "permessage-deflate" extension is returned
+            # from the server.
+            extensions = ws_client.headers.get("Sec-Websocket-Extensions")
+            self.assertIn("permessage-deflate", extensions)
+
+    @tornado.testing.gen_test
     def test_forwardmsg_hashing(self):
         """Test that outgoing ForwardMsgs contain hashes."""
         with self._patch_report_session():


### PR DESCRIPTION
Fixes #463

From a lines-of-code perspective, this is a trivial change; Tornado supports WebSocket compression out of the box, and this PR just flips the switch to enable it.

This obviously adds a bit of memory and CPU overhead to each WebSocket connection. I don't expect it to be onerous, but we could consider allowing this to be opt-in (or opt-out) via a config setting.