### PR TITLE
Add _templates directory, move searchbar to topnav

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,10 @@
+/*float search box to right of navbar*/
+div[role="search"] {
+  float: right;
+}
+
+/*styles search bar*/
+#rtd-search-form > input[type="text"] {
+  width: 250px;
+  border-radius: 50px;
+}

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,0 +1,91 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{# Support for Sphinx 1.3+ page_source_suffix, but don't break old builds. #}
+
+{% if page_source_suffix %}
+{% set suffix = page_source_suffix %}
+{% else %}
+{% set suffix = source_suffix %}
+{% endif %}
+
+{% if meta is defined and meta is not none %}
+{% set check_meta = True %}
+{% else %}
+{% set check_meta = False %}
+{% endif %}
+
+{% if check_meta and 'github_url' in meta %}
+{% set display_github = True %}
+{% endif %}
+
+{% if check_meta and 'bitbucket_url' in meta %}
+{% set display_bitbucket = True %}
+{% endif %}
+
+{% if check_meta and 'gitlab_url' in meta %}
+{% set display_gitlab = True %}
+{% endif %}
+
+<div role="navigation" aria-label="breadcrumbs navigation">
+
+  <ul class="wy-breadcrumbs">
+    {% block breadcrumbs %}
+    <li><a href="{{ pathto(master_doc) }}" class="icon icon-home"></a> &raquo;</li>
+    {% for doc in parents %}
+    <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
+    {% endfor %}
+    <li>{{ title }}</li>
+    {% endblock %}
+    {% block breadcrumbs_aside %}
+    <li class="wy-breadcrumbs-aside">
+      {% if hasdoc(pagename) %}
+      {% if display_github %}
+      {% if check_meta and 'github_url' in meta %}
+      <!-- User defined GitHub URL -->
+      <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+      {% else %}
+      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}"
+        class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+      {% endif %}
+      {% elif display_bitbucket %}
+      {% if check_meta and 'bitbucket_url' in meta %}
+      <!-- User defined Bitbucket URL -->
+      <a href="{{ meta['bitbucket_url'] }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
+      {% else %}
+      <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}?mode={{ theme_vcs_pageview_mode|default("view") }}"
+        class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
+      {% endif %}
+      {% elif display_gitlab %}
+      {% if check_meta and 'gitlab_url' in meta %}
+      <!-- User defined GitLab URL -->
+      <a href="{{ meta['gitlab_url'] }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
+      {% else %}
+      <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}"
+        class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
+      {% endif %}
+      {% elif show_source and source_url_prefix %}
+      <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>
+      {% elif show_source and has_source and sourcename %}
+      <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>
+      {% endif %}
+      {% endif %}
+    </li>
+    {% endblock %}
+  </ul>
+
+  {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+  <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="breadcrumb navigation">
+    {% if next %}
+    <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}"
+      accesskey="n">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
+    {% endif %}
+    {% if prev %}
+    <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}"
+      accesskey="p"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {% include "searchbox.html" %}
+  <hr />
+</div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,251 @@
+{%- extends "sphinx_rtd_theme/layout.html" %}
+
+{# TEMPLATE VAR SETTINGS #}
+{%- set url_root = pathto('', 1) %}
+{%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
+{%- if not embedded and docstitle %}
+{%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
+{%- else %}
+{%- set titlesuffix = "" %}
+{%- endif %}
+{%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
+{%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' %}
+
+<!DOCTYPE html>
+<html class="{{ sphinx_writer }}" lang="{{ lang_attr }}">
+
+<head>
+  <meta charset="utf-8">
+  {{ metatags }}
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% block htmltitle %}
+  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+  {% endblock %}
+
+  {# CSS #}
+  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
+  {%- for css in css_files %}
+  {%- if css|attr("rel") %}
+  <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css" {% if css.title is not none %}
+    title="{{ css.title }}" {% endif %} />
+  {%- else %}
+  <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+  {%- endif %}
+  {%- endfor %}
+
+  {%- for cssfile in extra_css_files %}
+  <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+  {%- endfor %}
+
+  {# FAVICON #}
+  {% if favicon %}
+  <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}" />
+  {% endif %}
+  {# CANONICAL URL #}
+  {% if theme_canonical_url %}
+  <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
+  {% endif %}
+
+  {# JAVASCRIPTS #}
+  {%- block scripts %}
+  <!--[if lt IE 9]>
+    <script src="{{ pathto('_static/js/html5shiv.min.js', 1) }}"></script>
+  <![endif]-->
+  {%- if not embedded %}
+  {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
+  {% if sphinx_version >= "1.8.0" %}
+  <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}"
+    src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+  {%- for scriptfile in script_files %}
+  {{ js_tag(scriptfile) }}
+  {%- endfor %}
+  {% else %}
+  <script type="text/javascript">
+    var DOCUMENTATION_OPTIONS = {
+      URL_ROOT: '{{ url_root }}',
+      VERSION: '{{ release|e }}',
+      LANGUAGE: '{{ language }}',
+      COLLAPSE_INDEX: false,
+      FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
+      HAS_SOURCE: {{ has_source| lower }},
+    SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
+          };
+  </script>
+  {%- for scriptfile in script_files %}
+  <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+  {%- endfor %}
+  {% endif %}
+  <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+
+  {# OPENSEARCH #}
+  {%- if use_opensearch %}
+  <link rel="search" type="application/opensearchdescription+xml"
+    title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"
+    href="{{ pathto('_static/opensearch.xml', 1) }}" />
+  {%- endif %}
+  {%- endif %}
+  {%- endblock %}
+
+  {%- block linktags %}
+  {%- if hasdoc('about') %}
+  <link rel="author" title="{{ _('About these documents') }}" href="{{ pathto('about') }}" />
+  {%- endif %}
+  {%- if hasdoc('genindex') %}
+  <link rel="index" title="{{ _('Index') }}" href="{{ pathto('genindex') }}" />
+  {%- endif %}
+  {%- if hasdoc('search') %}
+  <link rel="search" title="{{ _('Search') }}" href="{{ pathto('search') }}" />
+  {%- endif %}
+  {%- if hasdoc('copyright') %}
+  <link rel="copyright" title="{{ _('Copyright') }}" href="{{ pathto('copyright') }}" />
+  {%- endif %}
+  {%- if next %}
+  <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e }}" />
+  {%- endif %}
+  {%- if prev %}
+  <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
+  {%- endif %}
+  {%- endblock %}
+  {%- block extrahead %} {% endblock %}
+</head>
+
+<body class="wy-body-for-nav">
+
+  {% block extrabody %} {% endblock %}
+  <div class="wy-grid-for-nav">
+    {# SIDE NAV, TOGGLES ON MOBILE #}
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side">
+      <div class="wy-side-scroll">
+        <div class="wy-side-nav-search" {% if theme_style_nav_header_background %}
+          style="background: {{theme_style_nav_header_background}}" {% endif %}>
+          {% block sidebartitle %}
+
+          {% if logo and theme_logo_only %}
+          <a href="{{ pathto(master_doc) }}">
+            {% else %}
+            <a href="{{ pathto(master_doc) }}" class="icon icon-home" alt="{{ _("Documentation Home") }}"> {{ project }}
+              {% endif %}
+
+              {% if logo %}
+              {# Not strictly valid HTML, but it's the only way to display/scale
+               it properly, without weird scripting or heaps of work
+            #}
+              <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}" />
+              {% endif %}
+            </a>
+
+            {% if theme_display_version %}
+            {%- set nav_version = version %}
+            {% if READTHEDOCS and current_version %}
+            {%- set nav_version = current_version %}
+            {% endif %}
+            {% if nav_version %}
+            <div class="version">
+              {{ nav_version }}
+            </div>
+            {% endif %}
+            {% endif %}
+
+            <!-- {% include "searchbox.html" %} -->
+
+            {% endblock %}
+        </div>
+
+        {% block navigation %}
+        <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+          {% block menu %}
+
+          {#
+              The singlehtml builder doesn't handle this toctree call when the
+              toctree is empty. Skip building this for now.
+            #}
+          {% if 'singlehtml' not in builder %}
+          {% set global_toc = toctree(maxdepth=theme_navigation_depth|int,
+                                          collapse=theme_collapse_navigation|tobool,
+                                          includehidden=theme_includehidden|tobool,
+                                          titles_only=theme_titles_only|tobool) %}
+          {% endif %}
+          {% if global_toc %}
+          {{ global_toc }}
+          {% else %}
+          <!-- Local TOC -->
+          <div class="local-toc">{{ toc }}</div>
+          {% endif %}
+          {% endblock %}
+        </div>
+        {% endblock %}
+      </div>
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+
+      {# MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
+      <nav class="wy-nav-top" aria-label="top navigation">
+        {% block mobile_nav %}
+        <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+        <a href="{{ pathto(master_doc) }}">{{ project }}</a>
+        {% endblock %}
+      </nav>
+
+
+      <div class="wy-nav-content">
+        {%- block content %}
+        {% if theme_style_external_links|tobool %}
+        <div class="rst-content style-external-links">
+          {% else %}
+          <div class="rst-content">
+            {% endif %}
+            {% include "breadcrumbs.html" %}
+            <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+              {%- block document %}
+              <div itemprop="articleBody">
+                {% block body %}{% endblock %}
+              </div>
+              {% if self.comments()|trim %}
+              <div class="articleComments">
+                {% block comments %}{% endblock %}
+              </div>
+              {% endif%}
+            </div>
+            {%- endblock %}
+            {% include "footer.html" %}
+          </div>
+          {%- endblock %}
+        </div>
+
+    </section>
+
+  </div>
+  {% include "versions.html" %}
+
+  <script type="text/javascript">
+    jQuery(function () {
+      SphinxRtdTheme.Navigation.enable({{ 'true' if theme_sticky_navigation | tobool else 'false' }});
+      });
+  </script>
+
+  {# Do not conflict with RTD insertion of analytics script #}
+  {% if not READTHEDOCS %}
+  {% if theme_analytics_id %}
+  <!-- Theme Analytics -->
+  <script>
+    (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+    ga('create', '{{ theme_analytics_id }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+
+  {% endif %}
+  {% endif %}
+
+  {%- block footer %} {% endblock %}
+
+</body>
+
+</html>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,12 +18,13 @@ sys.path.append(os.path.abspath("./_ext"))
 
 # -- RTD setup --------------------------------------------------------------
 
-#RZ, 20200508: If protobufs don't exist, build them
-#Catching ImportError on Alert_pb2 assumes Alert continues to be part of st lib
+# RZ, 20200508: If protobufs don't exist, build them
+# Catching ImportError on Alert_pb2 assumes Alert continues to be part of st lib
 try:
     from streamlit.proto import Alert_pb2
 except ImportError:
     import subprocess
+
     subprocess.run(["bash", "env_setup.sh"])
 
 # -- Project information -----------------------------------------------------
@@ -108,7 +109,11 @@ html_favicon = "favicon.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
+html_static_path = ["_static"]
+
+html_css_files = [
+    "css/custom.css",
+]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
PR sets up infrastructure to allow for modifying the documentation template, as well as adding a custom CSS stylesheet to override styles from the base theme.

As a visual test, I've moved the search bar from the left menu navigation to the topnav, modifying the size and border-radius of the search using the `custom.css` stylesheet.

Currently:
![image](https://user-images.githubusercontent.com/2762787/83447860-11ee6900-a41f-11ea-8787-f785caa1cb51.png)


Proposed:
![image](https://user-images.githubusercontent.com/2762787/83447797-faaf7b80-a41e-11ea-8b3c-6b4e64f5a084.png)


