### PR TITLE
Fix mypy in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,8 @@ commands:
           command: |
             echo 'Checking for virtualenv'
             if [ ! -d venv ] ; then
+              rm -rf ~/.cache/pipenv
+
               # The virtualenv was NOT restored from cache. Create a new one.
               python -m venv venv
               source venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,9 @@ commands:
             fi
 
       - run: &create_python_cache_key
-          # Combine hashes of the Python interpreter and Pipfile plus today's
-          # date into a file whose checksum will key the Python environ. cache.
+          # Combine hashes of the Python interpreter, Pipfile, and today's
+          # date into a file whose checksum will key the Python virtualenv.
+          # (This means that our virtualenv cache will expire each day.)
           name: Create Python environment cache key
           command: |
             md5sum $(which python) > ~/python_version.md5
@@ -117,7 +118,7 @@ commands:
             ${SUDO} apt-get install -y unixodbc-dev
 
       - run: &activate_virtualenv
-          name: Run make pipenv-lock and create virtualenv
+          name: Create virtualenv
           command: |
             echo 'Checking for virtualenv'
             if [ ! -d venv ] ; then
@@ -125,12 +126,13 @@ commands:
               source venv/bin/activate
               make setup
               pip install --upgrade pip
-              make pipenv-install
               deactivate
             else
               echo 'Virtualenv already exists, not creating'
             fi
-            echo 'source venv/bin/activate' >> $BASH_ENV
+
+            source venv/bin/activate
+            make pipenv-install
 
       - run: &generate_protobufs
           name: Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,16 +136,7 @@ commands:
               source venv/bin/activate
               pip install --upgrade pip
               make setup
-
-              # This step is non-deterministically failing on CircleCI, and
-              # leaving us with virtualenv without all our dependencies
-              # properly resolved.
-              # make pipenv-install
               make pipenv-dev-install
-              echo $(pip freeze | grep tornado)
-              pip install pipdeptree
-              echo $(pipdeptree -r -p tornado)
-
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,12 @@ commands:
       - restore_cache: &restore_virtualenv
           name: Restore virtualenv from cache
           keys:
-            - v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
+            - v12-python-venv-{{ checksum "~/python_cache_key.md5" }}
 
       - restore_cache: &restore_nvm
           name: Restore nvm and node_modules from cache
           keys:
-            - v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+            - v12-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
 
       - restore_cache: &restore_make
           name: Restore make from cache
@@ -324,13 +324,13 @@ jobs:
       #################################################################
       - save_cache:
           name: Save virtualenv to cache
-          key: v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
+          key: v12-python-venv-{{ checksum "~/python_cache_key.md5" }}
           paths:
             - venv
 
       - save_cache:
           name: Save nvm and node_modules to cache
-          key: v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+          key: v12-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
           paths:
             - ~/.nvm
             - ~/.cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,10 @@ commands:
           # (This means that our virtualenv cache will expire each day.)
           name: Create Python environment cache key
           command: |
-            md5sum $(which python) > ~/python_version.md5
-            md5sum lib/Pipfile >> ~/python_version.md5
-            md5sum lib/test-requirements.txt >> ~/python_version.md5
-            date +%F >> ~/python_version.md5
+            md5sum $(which python) > ~/python_cache_key.md5
+            md5sum lib/Pipfile >> ~/python_cache_key.md5
+            md5sum lib/test-requirements.txt >> ~/python_cache_key.md5
+            date +%F >> ~/python_cache_key.md5
 
       - run: &create_yarn_cache_key
           name: Create Yarn cache key
@@ -47,7 +47,7 @@ commands:
       - restore_cache: &restore_virtualenv
           name: Restore virtualenv from cache
           keys:
-            - v12-python-venv-{{ checksum "~/python_version.md5" }}
+            - v12-python-venv-{{ checksum "~/python_cache_key.md5" }}
 
       - restore_cache: &restore_nvm
           name: Restore nvm and node_modules from cache
@@ -331,7 +331,7 @@ jobs:
       #################################################################
       - save_cache:
           name: Save virtualenv to cache
-          key: v12-python-venv-{{ checksum "~/python_version.md5" }}
+          key: v12-python-venv-{{ checksum "~/python_cache_key.md5" }}
           paths:
             - venv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,15 @@ commands:
               python -m venv venv
               source venv/bin/activate
               pip install --upgrade pip
+              make setup
+
+              # This step is non-deterministically failing on CircleCI, and
+              # leaving us with virtualenv without all our dependencies
+              # properly resolved.
+              # make pipenv-install
+              make pipenv-dev-install
+              make pipenv-test-install
+
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.
@@ -140,8 +149,6 @@ commands:
             fi
 
             source venv/bin/activate
-            make setup
-            make pipenv-install
 
             # Add 'activate venv' to $BASH_ENV. This means that our venv will be active
             # for the remainder of the job ($BASH_ENV is evaluated at each step).

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,13 +133,15 @@ commands:
               python -m venv venv
               source venv/bin/activate
               pip install --upgrade pip
-              make setup
-              make pipenv-install
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.
               echo 'Virtualenv already exists, not creating'
             fi
+
+            source venv/bin/activate
+            make setup
+            make pipenv-install
 
             # Add 'activate venv' to $BASH_ENV. This means that our venv will be active
             # for the remainder of the job ($BASH_ENV is evaluated at each step).

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,14 @@ commands:
       - run: &create_python_cache_key
           # Combine hashes of the Python interpreter, Pipfile, and today's
           # date into a file whose checksum will key the Python virtualenv.
-          # (This means that our virtualenv cache will expire each day.)
+          #
+          # This means that our virtualenv cache will expire each day. We do
+          # this because we are not using a lockfile to pin dependencies -
+          # instead, each time CircleCI rebuilds the virtualenv, it uses the
+          # latest compatible version of each dependency (which mirrors what
+          # happens when a user installs Streamlit locally). So we expire our
+          # virtualenv cache daily to prevent it from getting far out of sync
+          # with what a fresh Streamlit installation would look like.
           name: Create Python environment cache key
           command: |
             md5sum $(which python) > ~/python_cache_key.md5
@@ -122,17 +129,17 @@ commands:
           command: |
             echo 'Checking for virtualenv'
             if [ ! -d venv ] ; then
+              # The virtualenv was NOT restored from cache. Create a new one.
               python -m venv venv
               source venv/bin/activate
               pip install --upgrade pip
+              make setup
+              make pipenv-install
               deactivate
             else
+              # The virtualenv WAS restored from cache. Don't create a new one.
               echo 'Virtualenv already exists, not creating'
             fi
-
-            source venv/bin/activate
-            make setup
-            make pipenv-install
 
             # Add 'activate venv' to $BASH_ENV. This means that our venv will be active
             # for the remainder of the job ($BASH_ENV is evaluated at each step).

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,12 @@ commands:
       - restore_cache: &restore_virtualenv
           name: Restore virtualenv from cache
           keys:
-            - v12-python-venv-{{ checksum "~/python_cache_key.md5" }}
+            - v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
 
       - restore_cache: &restore_nvm
           name: Restore nvm and node_modules from cache
           keys:
-            - v12-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+            - v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
 
       - restore_cache: &restore_make
           name: Restore make from cache
@@ -247,7 +247,7 @@ jobs:
       - restore_cache:
           name: Restore protobufs from cache
           keys:
-            - v12-protobuf-{{ checksum "~/protobuf.md5" }}
+            - v13-protobuf-{{ checksum "~/protobuf.md5" }}
 
       #################################################################
       # Pre Make commands
@@ -342,20 +342,20 @@ jobs:
       #################################################################
       - save_cache:
           name: Save virtualenv to cache
-          key: v12-python-venv-{{ checksum "~/python_cache_key.md5" }}
+          key: v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
           paths:
             - venv
 
       - save_cache:
           name: Save nvm and node_modules to cache
-          key: v12-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+          key: v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
           paths:
             - ~/.nvm
             - ~/.cache
 
       - save_cache:
           name: Save generated protobufs to cache
-          key: v12-protobuf-{{ checksum "~/protobuf.md5" }}
+          key: v13-protobuf-{{ checksum "~/protobuf.md5" }}
           paths:
             - frontend/src/autogen/proto.js
             - lib/streamlit/proto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,6 @@ commands:
           command: |
             echo 'Checking for virtualenv'
             if [ ! -d venv ] ; then
-              rm -rf ~/.cache/pipenv
-
               # The virtualenv was NOT restored from cache. Create a new one.
               python -m venv venv
               source venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ commands:
             if [ ! -d venv ] ; then
               python -m venv venv
               source venv/bin/activate
-              make setup
               pip install --upgrade pip
               deactivate
             else
@@ -132,7 +131,12 @@ commands:
             fi
 
             source venv/bin/activate
+            make setup
             make pipenv-install
+
+            # Add 'activate venv' to $BASH_ENV. This means that our venv will be active
+            # for the remainder of the job ($BASH_ENV is evaluated at each step).
+            echo 'source venv/bin/activate' >> $BASH_ENV
 
       - run: &generate_protobufs
           name: Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,20 +148,16 @@ commands:
       - run: &generate_protobufs
           name: Generate protobufs
           command: |
-            # There's a chance this file could be a cached version when
-            # the protobuf cache is restored, so checkout from github to
-            # make sure.
-            git checkout -- lib/streamlit/proto/__init__.py
-            if [ ! -e frontend/src/autogen/proto.js -o ! -e lib/streamlit/proto/DataFrame_pb2.py ] ; then
-              # install protobuf v3
-              ${SUDO} apt-get update -y
-              ${SUDO} apt-get install -y gnupg
-              echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
-              ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-              ${SUDO} apt-get update -y
-              ${SUDO} apt-get install -y protobuf-compiler
-              make protobuf
-            fi
+            # install protobuf v3
+            ${SUDO} apt-get update -y
+            ${SUDO} apt-get install -y gnupg
+            echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
+            ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
+            ${SUDO} apt-get update -y
+            ${SUDO} apt-get install -y protobuf-compiler
+
+            # Generate protobufs
+            make protobuf
 
 workflows:
   circleci:
@@ -228,26 +224,10 @@ jobs:
       #################################################################
       - pre-cache
 
-      - run:
-          # There is no lock file for the protobufs so we run a checksum
-          # across all the protos along with Python and the protobuf compilers
-          # and save that to a file to use as cache key.
-          name: Checksum all protobufs
-          command: |
-            md5sum proto/streamlit/proto/*.proto > ~/protobuf.md5
-            md5sum $(which python) >> ~/protobuf.md5
-            md5sum $(which protoc) >> ~/protobuf.md5
-            md5sum $(which protoc-gen-mypy) >> ~/protobuf.md5
-
       #################################################################
       # Restore from cache
       #################################################################
       - restore-from-cache
-
-      - restore_cache:
-          name: Restore protobufs from cache
-          keys:
-            - v13-protobuf-{{ checksum "~/protobuf.md5" }}
 
       #################################################################
       # Pre Make commands
@@ -338,7 +318,7 @@ jobs:
             fi
 
       #################################################################
-      # Save cache for python virtualenv, node_modules, protobuf
+      # Save cache for python virtualenv and node_modules.
       #################################################################
       - save_cache:
           name: Save virtualenv to cache
@@ -352,13 +332,6 @@ jobs:
           paths:
             - ~/.nvm
             - ~/.cache
-
-      - save_cache:
-          name: Save generated protobufs to cache
-          key: v13-protobuf-{{ checksum "~/protobuf.md5" }}
-          paths:
-            - frontend/src/autogen/proto.js
-            - lib/streamlit/proto
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").
@@ -479,8 +452,6 @@ jobs:
       - checkout:
           name: Checkout Streamlit code
 
-      # NOTE restore protobuf from cache wasn't
-      # working so generating protobufs instead.
       - pre-cache
       - restore-from-cache
       - pre-make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ commands:
               source venv/bin/activate
               pip install --upgrade pip
               make setup
-              make pipenv-dev-install
+              make pipenv-install
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,8 @@ commands:
               # make pipenv-install
               make pipenv-dev-install
               echo $(pip freeze | grep tornado)
+              pip install pipdeptree
+              echo $(pipdeptree -r -p tornado)
 
               deactivate
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,15 +140,13 @@ commands:
               # properly resolved.
               # make pipenv-install
               make pipenv-dev-install
-              make pipenv-test-install
+              echo $(pip freeze | grep tornado)
 
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.
               echo 'Virtualenv already exists, not creating'
             fi
-
-            source venv/bin/activate
 
             # Add 'activate venv' to $BASH_ENV. This means that our venv will be active
             # for the remainder of the job ($BASH_ENV is evaluated at each step).

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ eggs/
 .coverage
 .coverage\.*
 .pytest_cache/
+.mypy_cache/
 test-reports
 
 # Test fixtures

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ clean: clean-docs
 	find . -name '*.pyc' -type f -delete || true
 	find . -name __pycache__ -type d -delete || true
 	find . -name .pytest_cache -exec rm -rfv {} \; || true
+	rm -rf .mypy_cache
 	rm -f lib/streamlit/proto/*_pb2.py*
 	rm -rf lib/streamlit/static
 	rm -f lib/Pipfile.lock

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,13 @@ pipenv-install: pipenv-dev-install pipenv-test-install
 
 .PHONY: pipenv-dev-install
 pipenv-dev-install: lib/Pipfile
-	@# Runs pipenv install; doesn't update the Pipfile.lock.
+	# Run pipenv install; don't update the Pipfile.lock.
+	# We use `--sequential` here to ensure our results are...
+	# "more deterministic", per pipenv's documentation.
+	# (Omitting this flag is causing incorrect dependency version
+	# resolution on CircleCI.)
 	cd lib; \
-		pipenv install --dev --skip-lock
+		pipenv install --dev --skip-lock --sequential
 
 .PHONY: pipenv-test-install
 pipenv-test-install: lib/test-requirements.txt

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -46,7 +46,7 @@ python-dateutil = "*"
 requests = "*"
 toml = "*"
 # TODO: upgrade tornado to 6.x now that we don't have to support Python 2
-tornado = "~=5.1"
+tornado = "~=5.1,<6.0"
 tzlocal = "*"
 validators = "*"
 watchdog = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -45,9 +45,8 @@ pydeck = ">=0.1.dev5"
 python-dateutil = "*"
 requests = "*"
 toml = "*"
-# 5.0 has a fix for etag header: https://github.com/tornadoweb/tornado/issues/2262
 # TODO: upgrade tornado to 6.x now that we don't have to support Python 2
-tornado = ">=5.0,<6.0"
+tornado = "~=5.1"
 tzlocal = "*"
 validators = "*"
 watchdog = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -46,7 +46,7 @@ python-dateutil = "*"
 requests = "*"
 toml = "*"
 # TODO: upgrade tornado to 6.x now that we don't have to support Python 2
-tornado = "~=5.1,<6.0"
+tornado = ">=5.0,<6.0"
 tzlocal = "*"
 validators = "*"
 watchdog = "*"

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
-python_version = 3.6
-cache_dir = /tmp/mypy_cache
+python_version = 3.8
+cache_dir = .mypy_cache
 
 # TODO(nate): Additional strictness checks to work towards.
 # disallow_incomplete_defs = true

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -69,7 +69,7 @@ def _convert_config_option_to_click_option(config_option):
 
 def configurator_options(func):
     """Decorator that adds config param keys to click dynamically."""
-    for _, value in reversed(_config._config_options.items()):  # type: ignore[call-overload]
+    for _, value in reversed(_config._config_options.items()):
         parsed_parameter = _convert_config_option_to_click_option(value)
         config_option = click.option(
             parsed_parameter["option"],


### PR DESCRIPTION
Our `mypy` task has been failing in CircleCI.

The issue is that `pipenv` is failing to deterministically resolve dependency versions, and is frequently resolving our `tornado=>=5.0, <6.0` dependency to Tornado 6 (because of other transitive dependencies on Tornado).

The solution is to use the `--sequential` flag in our `pipenv install` build step. From the pipenv docs:

> Installation is intended to be as deterministic as possible — use the --sequential flag to increase this, if experiencing issues.

So: pipenv installation is intended to be as deterministic as possible, but it's also possible to "increase its determinism" with a flag! (I think this is...madness.)

This PR *also* cleans up and documents a few things that I found confusing while tracking this down (with @jrhone's help!):

- The `mypy` cache is now stored in the project directory (and gitignored), rather than in `/tmp`
- We expire our CircleCI virtualenv cache key every day; I documented why we do this.
- Added docs to the "Create virtualenv" CircleCI build step.
- Removed the protobuf-caching step from the CircleCI jobs, because it's not actually doing anything.
- Updated the mypy ini to target Python 3.8, and fixed a new mypy warning.