### PR TITLE
Create a config option to toggle websocket compression

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -125,7 +125,7 @@ def _create_option(
                 default_val = 12345)
 
         (2) More complex, programmable config options use decorator syntax to
-        resolve thier values at runtime:
+        resolve their values at runtime:
 
             @_create_option('section.optionName')
             def _section_option_name():

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -498,6 +498,15 @@ def _server_max_upload_size():
     return 200
 
 
+@_create_option("server.enableWebsocketCompression", type_=bool)
+def _server_enable_websocket_compression():
+    """Enables support for websocket compression.
+
+    Default: true
+    """
+    return True
+
+
 # Config Section: Browser #
 
 _create_section("browser", "Configuration of browser front-end.")

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -608,12 +608,14 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
     def get_compression_options(self):
         """Enable WebSocket compression.
 
-        By default, this method returns None, which means compression
-        is disabled. Returning an empty dict enables it.
+        Returning an empty dict enables websocket compression. Returning
+        None disables it.
 
         (See the docstring in the parent class.)
         """
-        return {}
+        if config.get_option("server.enableWebsocketCompression"):
+            return {}
+        return None
 
     @tornado.gen.coroutine
     def on_message(self, payload):

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -163,6 +163,22 @@ class ServerTest(ServerTestCase):
             self.assertIn("permessage-deflate", extensions)
 
     @tornado.testing.gen_test
+    def test_websocket_compression_disabled(self):
+        with self._patch_report_session():
+            config._set_option("server.enableWebsocketCompression", False, "test")
+            yield self.start_server_loop()
+
+            # Connect to the server, and explicitly request compression.
+            ws_client = yield tornado.websocket.websocket_connect(
+                self.get_ws_url("/stream"), compression_options={}
+            )
+
+            # Ensure that the "Sec-Websocket-Extensions" header is not
+            # present in the response from the server.
+            self.assertIsNone(ws_client.headers.get("Sec-Websocket-Extensions"))
+
+
+    @tornado.testing.gen_test
     def test_forwardmsg_hashing(self):
         """Test that outgoing ForwardMsgs contain hashes."""
         with self._patch_report_session():

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -300,6 +300,7 @@ class ConfigTest(unittest.TestCase):
                 "s3.secretAccessKey",
                 "s3.url",
                 "server.enableCORS",
+                "server.enableWebsocketCompression",
                 "server.baseUrlPath",
                 "server.cookieSecret",
                 "server.folderWatchBlacklist",


### PR DESCRIPTION
Fixes #1543.

This patch introduced a new option "server.enableWebsocketCompression",
which is enabled by default, and can be used to optionally disable
websocket compression in the Streamlit server.