### PR TITLE
Enable CSRF via cookie to header approach

### DIFF
--- a/e2e/specs/st_file_uploader.spec.ts
+++ b/e2e/specs/st_file_uploader.spec.ts
@@ -20,6 +20,7 @@
 describe("st.file_uploader", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
+    cy.getCookie("_xsrf").should("exist");
 
     // Make the ribbon decoration line disappear
     cy.get(".decoration").invoke("css", "display", "none");

--- a/e2e/specs/st_file_uploader.spec.ts
+++ b/e2e/specs/st_file_uploader.spec.ts
@@ -19,7 +19,12 @@
 
 describe("st.file_uploader", () => {
   beforeEach(() => {
+    Cypress.Cookies.defaults({
+      whitelist: ["_xsrf"]
+    });
+
     cy.visit("http://localhost:3000/");
+
     cy.getCookie("_xsrf").should("exist");
 
     // Make the ribbon decoration line disappear

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -62,6 +62,12 @@ describe("FileUploadClient", () => {
           } else if (data.get("sessionId") == null) {
             return [400]
           }
+
+          if (!("X-Xsrftoken" in config.headers)) {
+            return [403]
+          } else if (!("withCredentials" in config)) {
+            return [403]
+          }
         }
 
         return [status]

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -18,6 +18,7 @@
 import axios, { CancelToken } from "axios"
 import { SessionInfo } from "lib/SessionInfo"
 import { BaseUriParts, buildHttpUri } from "lib/UriUtil"
+import { getCookie } from "lib/utils"
 
 /**
  * Handles uploading files to the server.
@@ -61,6 +62,10 @@ export class FileUploadClient {
       method: "POST",
       data: form,
       onUploadProgress,
+      withCredentials: true,
+      headers: {
+        "X-Xsrftoken": getCookie("_xsrf"),
+      },
     })
   }
 }

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { flattenElements } from "./utils"
+import { getCookie, flattenElements } from "./utils"
 import { BlockElement } from "lib/DeltaParser"
 import { List, Set as ImmutableSet, Map as ImmutableMap } from "immutable"
 
@@ -50,5 +50,19 @@ describe("flattenElements", () => {
     expect(elements).toEqual(
       ImmutableSet([simpleElement1, simpleElement2, simpleElement3])
     )
+  })
+})
+
+describe("getCookie", () => {
+  document.cookie = "flavor=chocolatechip"
+
+  it("get existing cookie", () => {
+    const cookie = getCookie("flavor")
+    expect(cookie).toEqual("chocolatechip")
+  })
+
+  it("get missing cookie", () => {
+    const cookie = getCookie("recipe")
+    expect(cookie).toEqual(undefined)
   })
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -54,15 +54,50 @@ describe("flattenElements", () => {
 })
 
 describe("getCookie", () => {
-  document.cookie = "flavor=chocolatechip"
+  afterEach(() => {
+    document.cookie.split(";").forEach(cookie => {
+      const eqPos = cookie.indexOf("=")
+      const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie
+      document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    })
+  })
 
   it("get existing cookie", () => {
+    document.cookie = "flavor=chocolatechip"
     const cookie = getCookie("flavor")
     expect(cookie).toEqual("chocolatechip")
   })
 
   it("get missing cookie", () => {
+    document.cookie = "sweetness=medium;"
+    document.cookie = "flavor=chocolatechip;"
+    document.cookie = "type=darkchocolate;"
     const cookie = getCookie("recipe")
     expect(cookie).toEqual(undefined)
+  })
+
+  it("find cookie in the front", () => {
+    document.cookie = "flavor=chocolatechip;"
+    document.cookie = "sweetness=medium;"
+    document.cookie = "type=darkchocolate;"
+    console.log(document.cookie)
+    const cookie = getCookie("flavor")
+    expect(cookie).toEqual("chocolatechip")
+  })
+
+  it("find cookie in the middle", () => {
+    document.cookie = "sweetness=medium;"
+    document.cookie = "flavor=chocolatechip;"
+    document.cookie = "type=darkchocolate;"
+    const cookie = getCookie("flavor")
+    expect(cookie).toEqual("chocolatechip")
+  })
+
+  it("find cookie in the end", () => {
+    document.cookie = "sweetness=medium;"
+    document.cookie = "type=darkchocolate;"
+    document.cookie = "flavor=chocolatechip;"
+    const cookie = getCookie("flavor")
+    expect(cookie).toEqual("chocolatechip")
   })
 })

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -125,3 +125,11 @@ export function timeout(ms: number): Promise<void> {
 export function isFromMac(): boolean {
   return /Mac/i.test(navigator.platform)
 }
+
+/**
+ * Returns cookie value
+ */
+export function getCookie(name: string): string | undefined {
+  const r = document.cookie.match("\\b" + name + "=([^;]*)\\b")
+  return r ? r[1] : undefined
+}

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -17,6 +17,7 @@
 import os
 import toml
 import collections
+import secrets
 import urllib
 from typing import Dict
 
@@ -392,6 +393,19 @@ _create_option(
     default_val="auto",
     type_=str,
 )
+
+
+@_create_option("server.cookieSecret")
+@util.memoize
+def _server_cookie_secret():
+    """Symmetric key used to produce signed cookies. If deploying on multiple
+    replicas, this should be set to ensure all replicas share the same secret.
+
+    Default: Randomly generated secret key.
+    """
+    cookie_secret = os.getenv("STREAMLIT_COOKIE_SECRET")
+    cookie_secret = cookie_secret if cookie_secret else secrets.token_hex()
+    return cookie_secret
 
 
 @_create_option("server.headless", type_=bool)

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -576,8 +576,11 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
     def initialize(self, server):
         self._server = server
         self._session = None
-        # Reading xsrf_token will set the xsrf cookie
-        # https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
+        # The XSRF cookie is normally set when xsrf_form_html is used, but in a pure-Javascript application
+        # that does not use any regular forms we just  need to read the self.xsrf_token manually to set the
+        # cookie as a side effect).
+        # See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
+        # for more details.
         self.xsrf_token
 
     def check_origin(self, origin):

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -64,6 +64,7 @@ TORNADO_SETTINGS = {
     "websocket_ping_interval": 20,  # Ping every 20s to keep WS alive.
     "websocket_ping_timeout": 30,  # Pings should be responded to within 30s.
     "websocket_max_message_size": MESSAGE_SIZE_LIMIT,  # Up the WS size limit.
+    "xsrf_cookies": True,
 }
 
 
@@ -329,7 +330,11 @@ class Server(object):
                 ]
             )
 
-        return tornado.web.Application(routes, **TORNADO_SETTINGS)
+        return tornado.web.Application(
+            routes,
+            cookie_secret=config.get_option("server.cookieSecret"),
+            **TORNADO_SETTINGS
+        )
 
     def _set_state(self, new_state):
         LOGGER.debug("Server state: %s -> %s" % (self._state, new_state))
@@ -571,6 +576,9 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
     def initialize(self, server):
         self._server = server
         self._session = None
+        # Reading xsrf_token will set the xsrf cookie
+        # https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
+        self.xsrf_token
 
     def check_origin(self, origin):
         """Set up CORS."""

--- a/lib/streamlit/server/UploadFileRequestHandler.py
+++ b/lib/streamlit/server/UploadFileRequestHandler.py
@@ -89,7 +89,6 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         # Convert bytes to string
         return arg[0].decode("utf-8")
 
-
     def post(self):
         args = {}  # type: Dict[str, str]
         files = {}  # type: Dict[str, List[Any]]

--- a/lib/streamlit/server/UploadFileRequestHandler.py
+++ b/lib/streamlit/server/UploadFileRequestHandler.py
@@ -19,7 +19,9 @@ import tornado.web
 import tornado.httputil
 
 from streamlit.UploadedFileManager import UploadedFile
+from streamlit import config
 from streamlit.logger import get_logger
+from streamlit.Report import Report
 from streamlit.server import routes
 
 LOGGER = get_logger(__name__)
@@ -42,8 +44,11 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self._file_mgr = file_mgr
 
     def set_default_headers(self):
-        if routes.allow_cross_origin_requests():
-            self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken")
+        self.set_header("Access-Control-Allow-Origin", Report.get_url(config.get_option("browser.serverAddress")))
+        self.set_header("Vary", "Origin")
+        self.set_header("Access-Control-Allow-Credentials", "true")
+
 
     def options(self):
         """/OPTIONS handler for preflight CORS checks.
@@ -83,6 +88,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
 
         # Convert bytes to string
         return arg[0].decode("utf-8")
+
 
     def post(self):
         args = {}  # type: Dict[str, str]

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -33,6 +33,7 @@ os.environ["STREAMLIT_COOKIE_SECRET"] = "chocolatechip"
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
 
+
 class ConfigTest(unittest.TestCase):
     """Test the config system."""
 
@@ -42,7 +43,6 @@ class ConfigTest(unittest.TestCase):
                 config, "_section_descriptions", new=copy.deepcopy(SECTION_DESCRIPTIONS)
             ),
             patch.object(config, "_config_options", new=copy.deepcopy(CONFIG_OPTIONS)),
-            patch.dict(os.environ, { "STREAMLIT_COOKIE_SECRET" : "chocolatechip" })
         ]
 
         for p in self.patches:
@@ -479,8 +479,6 @@ class ConfigTest(unittest.TestCase):
 
     def test_server_cookie_secret(self):
         self.assertEqual("chocolatechip", config.get_option("server.cookieSecret"))
-
-        del os.environ["STREAMLIT_COOKIE_SECRET"]
 
     def test_server_headless_via_liveSave(self):
         config.set_option("server.liveSave", True)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -54,7 +54,6 @@ class ConfigTest(unittest.TestCase):
 
         try:
             del os.environ["TEST_ENV_VAR"]
-            del os.environ["STREAMLIT_COOKIE_SECRET"]
         except Exception:
             pass
         config._delete_option("_test.tomlTest")
@@ -479,6 +478,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_server_cookie_secret(self):
         self.assertEqual("chocolatechip", config.get_option("server.cookieSecret"))
+
+        del os.environ["STREAMLIT_COOKIE_SECRET"]
 
     def test_server_headless_via_liveSave(self):
         config.set_option("server.liveSave", True)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -28,9 +28,10 @@ from streamlit import config
 from streamlit import env_util
 from streamlit.ConfigOption import ConfigOption
 
+os.environ["STREAMLIT_COOKIE_SECRET"] = "chocolatechip"
+
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
-
 
 class ConfigTest(unittest.TestCase):
     """Test the config system."""
@@ -41,6 +42,7 @@ class ConfigTest(unittest.TestCase):
                 config, "_section_descriptions", new=copy.deepcopy(SECTION_DESCRIPTIONS)
             ),
             patch.object(config, "_config_options", new=copy.deepcopy(CONFIG_OPTIONS)),
+            patch.dict(os.environ, { "STREAMLIT_COOKIE_SECRET" : "chocolatechip" })
         ]
 
         for p in self.patches:
@@ -52,6 +54,7 @@ class ConfigTest(unittest.TestCase):
 
         try:
             del os.environ["TEST_ENV_VAR"]
+            del os.environ["STREAMLIT_COOKIE_SECRET"]
         except Exception:
             pass
         config._delete_option("_test.tomlTest")
@@ -299,6 +302,7 @@ class ConfigTest(unittest.TestCase):
                 "s3.url",
                 "server.enableCORS",
                 "server.baseUrlPath",
+                "server.cookieSecret",
                 "server.folderWatchBlacklist",
                 "server.fileWatcherType",
                 "server.headless",
@@ -472,6 +476,11 @@ class ConfigTest(unittest.TestCase):
         config.set_option("global.developmentMode", False)
         config.set_option("server.port", 1234)
         self.assertEqual(1234, config.get_option("browser.serverPort"))
+
+    def test_server_cookie_secret(self):
+        self.assertEqual("chocolatechip", config.get_option("server.cookieSecret"))
+
+        del os.environ["STREAMLIT_COOKIE_SECRET"]
 
     def test_server_headless_via_liveSave(self):
         config.set_option("server.liveSave", True)


### PR DESCRIPTION
**Issue:** Fixes #1524 

**Description:** 
1. Add a config option for `server.cookieSecret`. Secret can be set in `config.toml` or as an environment variable or CLI argument. If no secret is provided, a random hex is generated (this is not recommended for deployment to multiple replicas).
2. Enable XSRF on the server.
3. Update the UploadFile request handler CORs to enable cookies and XSRF token.
4. Update the FileUploadClient to pass the XSRF token.

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
