### PR TITLE
Datetime timezone bandaid - convert all dataframe datetimes to UTC

### DIFF
--- a/frontend/src/lib/dataFrameProto.ts
+++ b/frontend/src/lib/dataFrameProto.ts
@@ -20,6 +20,7 @@
  */
 
 import camelcase from "camelcase"
+import moment from "moment"
 import { dispatchOneOf, mapOneOf, updateOneOf } from "./immutableProto"
 import { fromJS } from "immutable"
 import { format } from "./format"
@@ -391,7 +392,7 @@ function anyArrayGet(anyArray: any, i: any): any {
     strings: getData,
     doubles: getData,
     int64s: getData,
-    datetimes: (obj: any) => format.nanosToDate(getData(obj)),
+    datetimes: (obj: any) => moment.utc(format.nanosToDate(getData(obj))),
     timedeltas: (obj: any) => format.nanosToDuration(getData(obj)),
   })
 }

--- a/lib/streamlit/elements/data_frame_proto.py
+++ b/lib/streamlit/elements/data_frame_proto.py
@@ -234,8 +234,9 @@ def _marshall_index(pandas_index, proto_index):
             proto_index.multi_index.labels.add().data.extend(label)
     elif type(pandas_index) == pd.DatetimeIndex:
         if pandas_index.tz is None:
-            current_zone = tzlocal.get_localzone()
-            pandas_index = pandas_index.tz_localize(current_zone)
+            pandas_index = pandas_index.tz_localize('UTC')
+        else:
+            pandas_index = pandas_index.tz_convert('UTC')
         proto_index.datetime_index.data.data.extend(pandas_index.astype(np.int64))
     elif type(pandas_index) == pd.TimedeltaIndex:
         proto_index.timedelta_index.data.data.extend(pandas_index.astype(np.int64))
@@ -291,10 +292,10 @@ def _marshall_any_array(pandas_array, proto_array):
     # to
     #   datetime64[ns, UTC], <class 'pandas._libs.tslibs.timestamps.Timestamp'>
     elif pandas_array.dtype.name.startswith("datetime64"):
-        # TODO(armando): Convert eveything to UTC not local timezone.
         if pandas_array.dt.tz is None:
-            current_zone = tzlocal.get_localzone()
-            pandas_array = pandas_array.dt.tz_localize(current_zone)
+            pandas_array = pandas_array.dt.tz_localize('UTC')
+        else:
+            pandas_array = pandas_array.dt.tz_convert('UTC')
         proto_array.datetimes.data.extend(pandas_array.astype(np.int64))
     else:
         raise NotImplementedError("Dtype %s not understood." % pandas_array.dtype)

--- a/lib/tests/streamlit/data_frame_proto_test.py
+++ b/lib/tests/streamlit/data_frame_proto_test.py
@@ -128,16 +128,14 @@ class DataFrameProtoTest(unittest.TestCase):
         self.assertEqual([0, 1], proto.multi_index.labels[0].data)
 
         # datetimeindex
-        truth = [int(x * 1e9) for x in (1554138000, 1554141600, 1554145200)]
+        truth = [int(x * 1e9) for x in (1554127200, 1554130800, 1554134400)]
         df_dt = pd.date_range(
-            start="2019/04/01 10:00", end="2019/04/01 12:00", freq="H"
+            start="2019/04/01 14:00", end="2019/04/01 16:00", freq="H"
         )
         proto = Index()
-        obj_to_patch = "streamlit.elements.data_frame_proto.tzlocal.get_localzone"
-        with patch(obj_to_patch) as p:
-            p.return_value = "America/Los_Angeles"
-            data_frame_proto._marshall_index(df_dt, proto)
-            self.assertEqual(truth, proto.datetime_index.data.data)
+
+        data_frame_proto._marshall_index(df_dt, proto)
+        self.assertEqual(truth, proto.datetime_index.data.data)
 
         # timedeltaindex
         df_td = pd.to_timedelta(np.arange(1, 5), unit="ns")
@@ -230,20 +228,17 @@ class DataFrameProtoTest(unittest.TestCase):
         self.assertEqual(obj_proto.strings.data, truth)
 
         # No timezone
-        dt_data = pd.Series([np.datetime64("2019-04-09T12:34:56")])
+        dt_data = pd.Series([np.datetime64("2019-04-09T19:34:56")])
         dt_proto = AnyArray()
 
-        obj_to_patch = "streamlit.elements.data_frame_proto.tzlocal.get_localzone"
-        with patch(obj_to_patch) as p:
-            p.return_value = "America/Los_Angeles"
-            data_frame_proto._marshall_any_array(dt_data, dt_proto)
-            self.assertEqual(1554838496.0, dt_proto.datetimes.data[0] / 1000000000)
+        data_frame_proto._marshall_any_array(dt_data, dt_proto)
+        self.assertEqual(1554838496, dt_proto.datetimes.data[0] / 1000000000)
 
         # With timezone
         dt_data = pd.Series([np.datetime64("2019-04-09T12:34:56")])
-        dt_data = dt_data.dt.tz_localize("UTC")
+        dt_data = dt_data.dt.tz_localize("America/Los_Angeles")
         data_frame_proto._marshall_any_array(dt_data, dt_proto)
-        self.assertEqual(1554838496.0, dt_proto.datetimes.data[0] / 1000000000)
+        self.assertEqual(1554838496, dt_proto.datetimes.data[0] / 1000000000)
 
         # string
         str_data = np.array(["random", "string"])


### PR DESCRIPTION
**Issue:** #1288, #1061

**Description:** This is not the final solution and is intended only as a bandaid for handling errors when converting timezones around daylight savings. Changes:
1. We're converting all datetimes to UTC.
2. On the frontend, displaying all timezones in UTC. 

The ultimate solution (in progress) will allow for displaying datetime in the provided timezones.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
