### PR TITLE
Add config to disable CSRF + conflict check with CORS

### DIFF
--- a/e2e/specs/st_file_uploader.spec.ts
+++ b/e2e/specs/st_file_uploader.spec.ts
@@ -25,8 +25,6 @@ describe("st.file_uploader", () => {
 
     cy.visit("http://localhost:3000/");
 
-    cy.getCookie("_xsrf").should("exist");
-
     // Make the ribbon decoration line disappear
     cy.get(".decoration").invoke("css", "display", "none");
   });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -105,40 +105,6 @@ describe("App", () => {
     expect(window.location.reload).toHaveBeenCalled()
   })
 
-  it("should update request config for csrf", () => {
-    const wrapper = getWrapper()
-
-    const spyUpdateCsrf = jest.spyOn(
-      wrapper.instance().uploadClient,
-      "updateCsrfToken"
-    )
-
-    const fwMessage = new ForwardMsg()
-
-    fwMessage.initialize = {
-      environmentInfo: {
-        streamlitVersion: "sv",
-        pythonVersion: "",
-      },
-      sessionId: "sessionId",
-      userInfo: {
-        installationId: "",
-        email: "",
-      },
-      config: {
-        mapboxToken: "",
-        maxCachedMessageAge: "",
-      },
-      sessionState: {},
-      commandLine: "",
-    }
-
-    // @ts-ignore
-    wrapper.instance().handleMessage(fwMessage)
-
-    expect(spyUpdateCsrf).toHaveBeenCalled()
-  })
-
   it("should start screencast recording when the MainMenu is clicked", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -105,6 +105,40 @@ describe("App", () => {
     expect(window.location.reload).toHaveBeenCalled()
   })
 
+  it("should update request config for csrf", () => {
+    const wrapper = getWrapper()
+
+    const spyUpdateCsrf = jest.spyOn(
+      wrapper.instance().uploadClient,
+      "updateCsrfToken"
+    )
+
+    const fwMessage = new ForwardMsg()
+
+    fwMessage.initialize = {
+      environmentInfo: {
+        streamlitVersion: "sv",
+        pythonVersion: "",
+      },
+      sessionId: "sessionId",
+      userInfo: {
+        installationId: "",
+        email: "",
+      },
+      config: {
+        mapboxToken: "",
+        maxCachedMessageAge: "",
+      },
+      sessionState: {},
+      commandLine: "",
+    }
+
+    // @ts-ignore
+    wrapper.instance().handleMessage(fwMessage)
+
+    expect(spyUpdateCsrf).toHaveBeenCalled()
+  })
+
   it("should start screencast recording when the MainMenu is clicked", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import {
   ReportElement,
   SimpleElement,
 } from "lib/DeltaParser"
+import { setCookie } from "lib/utils"
 import {
   BackMsg,
   Delta,
@@ -225,6 +226,8 @@ export class App extends PureComponent<Props, State> {
       )
       this.widgetMgr.sendUpdateWidgetsMessage()
       this.setState({ dialog: null })
+    } else {
+      setCookie("_xsrf", "")
     }
   }
 
@@ -314,6 +317,8 @@ export class App extends PureComponent<Props, State> {
 
       return
     }
+
+    this.uploadClient.updateCsrfToken()
 
     SessionInfo.current = new SessionInfo({
       sessionId: sessionId,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,7 +143,7 @@ export class App extends PureComponent<Props, State> {
       return this.connectionManager
         ? this.connectionManager.getBaseUriParts()
         : undefined
-    })
+    }, true)
     this.elementListBufferTimerIsSet = false
     this.elementListBuffer = null
 
@@ -317,8 +317,6 @@ export class App extends PureComponent<Props, State> {
 
       return
     }
-
-    this.uploadClient.updateCsrfToken()
 
     SessionInfo.current = new SessionInfo({
       sessionId: sessionId,

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -20,6 +20,7 @@ import MockAdapter from "axios-mock-adapter"
 import { FileUploadClient } from "lib/FileUploadClient"
 import { SessionInfo } from "lib/SessionInfo"
 import { buildHttpUri } from "lib/UriUtil"
+import { getCookie } from "lib/utils"
 
 const MOCK_SERVER_URI = {
   host: "streamlit.mock",
@@ -63,10 +64,12 @@ describe("FileUploadClient", () => {
             return [400]
           }
 
-          if (!("X-Xsrftoken" in config.headers)) {
-            return [403]
-          } else if (!("withCredentials" in config)) {
-            return [403]
+          if (getCookie("_xsrf")) {
+            if (!("X-Xsrftoken" in config.headers)) {
+              return [403]
+            } else if (!("withCredentials" in config)) {
+              return [403]
+            }
           }
         }
 

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -50,7 +50,7 @@ export class FileUploadClient extends HttpClient {
       form.append(file.name, file)
     }
 
-    await this.axiosInstance.request({
+    await this.request({
       cancelToken: cancelToken,
       url: buildHttpUri(serverURI, "upload_file"),
       method: "POST",

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -15,21 +15,15 @@
  * limitations under the License.
  */
 
-import axios, { CancelToken } from "axios"
+import { CancelToken } from "axios"
+import HttpClient from "lib/HttpClient"
 import { SessionInfo } from "lib/SessionInfo"
-import { BaseUriParts, buildHttpUri } from "lib/UriUtil"
-import { getCookie } from "lib/utils"
+import { buildHttpUri } from "lib/UriUtil"
 
 /**
  * Handles uploading files to the server.
  */
-export class FileUploadClient {
-  private readonly getServerUri: () => BaseUriParts | undefined
-
-  public constructor(getServerUri: () => BaseUriParts | undefined) {
-    this.getServerUri = getServerUri
-  }
-
+export class FileUploadClient extends HttpClient {
   /**
    * Upload a file to the server. It will be associated with this browser's sessionID.
    *
@@ -56,16 +50,12 @@ export class FileUploadClient {
       form.append(file.name, file)
     }
 
-    await axios.request({
+    await this.axiosInstance.request({
       cancelToken: cancelToken,
       url: buildHttpUri(serverURI, "upload_file"),
       method: "POST",
       data: form,
       onUploadProgress,
-      withCredentials: true,
-      headers: {
-        "X-Xsrftoken": getCookie("_xsrf"),
-      },
     })
   }
 }

--- a/frontend/src/lib/HttpClient.test.ts
+++ b/frontend/src/lib/HttpClient.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import HttpClient from "lib/HttpClient"
+import { SessionInfo } from "lib/SessionInfo"
+
+const MOCK_SERVER_URI = {
+  host: "streamlit.mock",
+  port: 80,
+  basePath: "",
+}
+
+describe("HttpClient", () => {
+  beforeEach(() => {
+    SessionInfo.current = new SessionInfo({
+      sessionId: "sessionId",
+      streamlitVersion: "sv",
+      pythonVersion: "pv",
+      installationId: "iid",
+      authorEmail: "ae",
+      maxCachedMessageAge: 2,
+      commandLine: "command line",
+      userMapboxToken: "mockUserMapboxToken",
+    })
+  })
+
+  afterEach(() => {
+    document.cookie.split(";").forEach(cookie => {
+      const eqPos = cookie.indexOf("=")
+      const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie
+      document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    })
+  })
+
+  test("has xsrf enabled", () => {
+    document.cookie = "_xsrf=cookie;"
+    const client = new HttpClient(() => MOCK_SERVER_URI)
+    client.updateCsrfToken()
+
+    expect(client.axiosInstance.defaults.headers["X-Xsrftoken"]).toBe("cookie")
+    expect(client.axiosInstance.defaults.withCredentials).toBe(true)
+  })
+
+  test("has xsrf disabled", () => {
+    const client = new HttpClient(() => MOCK_SERVER_URI)
+
+    client.updateCsrfToken()
+
+    expect(client.axiosInstance.defaults.headers["X-Xsrftoken"]).toBe(
+      undefined
+    )
+    expect(client.axiosInstance.defaults.withCredentials).toBe(false)
+  })
+})

--- a/frontend/src/lib/HttpClient.ts
+++ b/frontend/src/lib/HttpClient.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axiosLib, { AxiosInstance } from "axios"
+import { BaseUriParts } from "lib/UriUtil"
+import { getCookie } from "lib/utils"
+
+/**
+ * Base class for HTTP Clients
+ */
+export default class HttpClient {
+  protected readonly getServerUri: () => BaseUriParts | undefined
+  protected axiosInstance: AxiosInstance
+  protected readonly csrfEnabled: boolean
+
+  public constructor(getServerUri: () => BaseUriParts | undefined) {
+    const xsrf_cookie = getCookie("_xsrf")
+    this.getServerUri = getServerUri
+    this.csrfEnabled = !!xsrf_cookie
+    this.axiosInstance = axiosLib.create(
+      this.csrfEnabled
+        ? {
+            withCredentials: true,
+            headers: {
+              "X-Xsrftoken": xsrf_cookie,
+            },
+          }
+        : {}
+    )
+  }
+
+  public updateCsrfToken(): void {
+    const csrfCookie = getCookie("_xsrf")
+    if (csrfCookie) {
+      this.axiosInstance.defaults.headers["X-Xsrftoken"] = csrfCookie
+      this.axiosInstance.defaults.withCredentials = true
+    } else {
+      delete this.axiosInstance.defaults.headers["X-Xsrftoken"]
+      this.axiosInstance.defaults.withCredentials = false
+    }
+  }
+}

--- a/frontend/src/lib/HttpClient.ts
+++ b/frontend/src/lib/HttpClient.ts
@@ -34,6 +34,10 @@ export default class HttpClient {
     this.csrfEnabled = csrfEnabled
   }
 
+  /**
+   * Wrapper around axios.request to update the request config with
+   * CSRF headers if client has CSRF protection enabled.
+   */
   public request(params: AxiosRequestConfig): Promise {
     if (this.csrfEnabled) {
       const xsrf_cookie = getCookie("_xsrf")

--- a/frontend/src/lib/HttpClient.ts
+++ b/frontend/src/lib/HttpClient.ts
@@ -34,7 +34,7 @@ export default class HttpClient {
     this.csrfEnabled = csrfEnabled
   }
 
-  public request(params: AxiosRequestConfig) {
+  public request(params: AxiosRequestConfig): Promise {
     if (this.csrfEnabled) {
       const xsrf_cookie = getCookie("_xsrf")
       if (xsrf_cookie != null) {

--- a/frontend/src/lib/HttpClient.ts
+++ b/frontend/src/lib/HttpClient.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import axios, { AxiosRequestConfig } from "axios"
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
 import { BaseUriParts } from "lib/UriUtil"
 import { getCookie } from "lib/utils"
 
@@ -38,7 +38,7 @@ export default class HttpClient {
    * Wrapper around axios.request to update the request config with
    * CSRF headers if client has CSRF protection enabled.
    */
-  public request(params: AxiosRequestConfig): Promise {
+  public request(params: AxiosRequestConfig): Promise<AxiosResponse> {
     if (this.csrfEnabled) {
       const xsrf_cookie = getCookie("_xsrf")
       if (xsrf_cookie != null) {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getCookie, flattenElements } from "./utils"
+import { getCookie, flattenElements, setCookie } from "./utils"
 import { BlockElement } from "lib/DeltaParser"
 import { List, Set as ImmutableSet, Map as ImmutableMap } from "immutable"
 
@@ -80,7 +80,6 @@ describe("getCookie", () => {
     document.cookie = "flavor=chocolatechip;"
     document.cookie = "sweetness=medium;"
     document.cookie = "type=darkchocolate;"
-    console.log(document.cookie)
     const cookie = getCookie("flavor")
     expect(cookie).toEqual("chocolatechip")
   })
@@ -99,5 +98,32 @@ describe("getCookie", () => {
     document.cookie = "flavor=chocolatechip;"
     const cookie = getCookie("flavor")
     expect(cookie).toEqual("chocolatechip")
+  })
+})
+
+describe("setCookie", () => {
+  afterEach(() => {
+    document.cookie.split(";").forEach(cookie => {
+      const eqPos = cookie.indexOf("=")
+      const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie
+      document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    })
+  })
+
+  it("set new cookie", () => {
+    setCookie("flavor", "chocolatechip")
+    expect(document.cookie).toEqual("flavor=chocolatechip")
+  })
+
+  it("update existing cookie", () => {
+    document.cookie = "flavor=chocolatechip"
+    setCookie("flavor", "sugar")
+    expect(document.cookie).toEqual("flavor=sugar")
+  })
+
+  it("remove cookie", () => {
+    document.cookie = "flavor=chocolatechip"
+    setCookie("flavor")
+    expect(document.cookie).toEqual("")
   })
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -103,6 +103,12 @@ describe("getCookie", () => {
 
 describe("setCookie", () => {
   afterEach(() => {
+    /*
+      Setting a cookie with document.cookie = "key=value" will append or modify "key"
+      with "value". It does not overwrite the existing list of cookies in document.cookie.
+      In order to delete the cookie, give the cookie an expiration date that has passed.
+      This cleanup ensures that we delete all cookies after each test.
+    */
     document.cookie.split(";").forEach(cookie => {
       const eqPos = cookie.indexOf("=")
       const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -133,3 +133,18 @@ export function getCookie(name: string): string | undefined {
   const r = document.cookie.match("\\b" + name + "=([^;]*)\\b")
   return r ? r[1] : undefined
 }
+
+/**
+ * Sets cookie value
+ */
+export function setCookie(
+  name: string,
+  value?: string,
+  expiration?: Date
+): void {
+  const expirationDate = value ? expiration : new Date()
+  const expirationStr: string = expirationDate
+    ? `expires=${expirationDate.toUTCString()};`
+    : ""
+  document.cookie = `${name}=${value};${expirationStr}path=/`
+}

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -408,6 +408,24 @@ def _server_cookie_secret():
     return cookie_secret
 
 
+@_create_option("server.enableCORS", type_=bool)
+def _server_enable_cors():
+    """Enables support for Cross-Origin Request Sharing, for added security.
+
+    Default: true
+    """
+    return True
+
+
+@_create_option("server.enableXSRF", type_=bool)
+def _server_enable_XSRF():
+    """Enables support for protection from Cross-site request forgery attacks. Requires CORS to be disabled.
+
+    Default: true
+    """
+    return True
+
+
 @_create_option("server.headless", type_=bool)
 @util.memoize
 def _server_headless():
@@ -476,15 +494,6 @@ _create_option(
     default_val="",
     type_=str,
 )
-
-
-@_create_option("server.enableCORS", type_=bool)
-def _server_enable_cors():
-    """Enables support for Cross-Origin Request Sharing, for added security.
-
-    Default: true
-    """
-    return True
 
 
 @_create_option("server.maxUploadSize", type_=int)
@@ -971,6 +980,14 @@ def _check_conflicts():
             "Streamlit itself, and is not supported for other use-cases. "
             "\n\nTo remove this warning, set the 'sharingMode' option to "
             "another value, or remove it from your Streamlit config."
+        )
+
+    # XSRF conflicts
+
+    if get_option("server.enableXSRF") and get_option("server.enableCORS"):
+        LOGGER.warning(
+            "Any POST, PUT, or DELETE requests are not supported across different origins. "
+            "If cross origin POST, PUT or DELETE requests are required, please disable 'enableXSRF'"
         )
 
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -417,8 +417,8 @@ def _server_enable_cors():
     return True
 
 
-@_create_option("server.enableXSRF", type_=bool)
-def _server_enable_XSRF():
+@_create_option("server.enableCSRF", type_=bool)
+def _server_enable_CSRF():
     """Enables support for protection from Cross-site request forgery attacks. Requires CORS to be disabled.
 
     Default: true
@@ -982,13 +982,14 @@ def _check_conflicts():
             "another value, or remove it from your Streamlit config."
         )
 
-    # XSRF conflicts
+    # CSRF conflicts
 
-    if get_option("server.enableXSRF") and get_option("server.enableCORS"):
-        LOGGER.warning(
-            "Any POST, PUT, or DELETE requests are not supported across different origins. "
-            "If cross origin POST, PUT or DELETE requests are required, please disable 'enableXSRF'"
-        )
+    if get_option("server.enableCSRF"):
+        if not get_option("server.enableCORS") or get_option("global.useNode"):
+            LOGGER.warning(
+                "Any POST, PUT, or DELETE requests are not supported across different origins. "
+                "If cross origin POST, PUT or DELETE requests are required, please disable 'enableCSRF'"
+            )
 
 
 def _set_development_mode():

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -999,7 +999,7 @@ def _check_conflicts():
                 "server.enableCSRF is not compatible with server.enableCORS. "
                 "We will prioritize server.enableCSRF over server.enableCORS "
                 "where CSRF has been enabled. If cross origin POST, PUT or "
-                "DELETE requests are required, please disable 'enableCSRF'"
+                "DELETE requests are required, please disable 'server.enableCSRF'"
             )
 
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -410,7 +410,7 @@ def _server_cookie_secret():
 
 @_create_option("server.enableCORS", type_=bool)
 def _server_enable_cors():
-    """Enables support for Cross-Origin Request Sharing, for added security.
+    """Enables protection against Cross-Origin Request Sharing, for added security.
 
     Default: true
     """

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -487,7 +487,7 @@ def _server_enable_cors():
     return True
 
 
-@_create_option("server.enableCSRF", type_=bool)
+@_create_option("server.enableCSRFProtection", type_=bool)
 def _server_enable_CSRF():
     """Enables support for protection from Cross-site request forgery attacks. Requires CORS to be disabled.
 
@@ -993,13 +993,13 @@ def _check_conflicts():
 
     # CSRF conflicts
 
-    if get_option("server.enableCSRF"):
+    if get_option("server.enableCSRFProtection"):
         if not get_option("server.enableCORS") or get_option("global.useNode"):
             LOGGER.warning(
-                "server.enableCSRF is not compatible with server.enableCORS. "
-                "We will prioritize server.enableCSRF over server.enableCORS "
+                "server.enableCSRFProtection is not compatible with server.enableCORS. "
+                "We will prioritize server.enableCSRFProtection over server.enableCORS "
                 "where CSRF has been enabled. If cross origin POST, PUT or "
-                "DELETE requests are required, please disable 'server.enableCSRF'"
+                "DELETE requests are required, please disable 'server.enableCSRFProtection'"
             )
 
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -408,24 +408,6 @@ def _server_cookie_secret():
     return cookie_secret
 
 
-@_create_option("server.enableCORS", type_=bool)
-def _server_enable_cors():
-    """Enables protection against Cross-Origin Request Sharing, for added security.
-
-    Default: true
-    """
-    return True
-
-
-@_create_option("server.enableCSRF", type_=bool)
-def _server_enable_CSRF():
-    """Enables support for protection from Cross-site request forgery attacks. Requires CORS to be disabled.
-
-    Default: true
-    """
-    return True
-
-
 @_create_option("server.headless", type_=bool)
 @util.memoize
 def _server_headless():
@@ -494,6 +476,24 @@ _create_option(
     default_val="",
     type_=str,
 )
+
+
+@_create_option("server.enableCORS", type_=bool)
+def _server_enable_cors():
+    """Enables protection against Cross-Origin Request Sharing, for added security.
+
+    Default: true
+    """
+    return True
+
+
+@_create_option("server.enableCSRF", type_=bool)
+def _server_enable_CSRF():
+    """Enables support for protection from Cross-site request forgery attacks. Requires CORS to be disabled.
+
+    Default: true
+    """
+    return True
 
 
 @_create_option("server.maxUploadSize", type_=int)
@@ -987,8 +987,10 @@ def _check_conflicts():
     if get_option("server.enableCSRF"):
         if not get_option("server.enableCORS") or get_option("global.useNode"):
             LOGGER.warning(
-                "Any POST, PUT, or DELETE requests are not supported across different origins. "
-                "If cross origin POST, PUT or DELETE requests are required, please disable 'enableCSRF'"
+                "server.enableCSRF is not compatible with server.enableCORS. "
+                "We will prioritize server.enableCSRF over server.enableCORS "
+                "where CSRF has been enabled. If cross origin POST, PUT or "
+                "DELETE requests are required, please disable 'enableCSRF'"
             )
 
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -336,7 +336,7 @@ class Server(object):
         return tornado.web.Application(
             routes,  # type: ignore[arg-type]
             cookie_secret=config.get_option("server.cookieSecret"),
-            csrf_cookies=config.get_option("server.enableCSRF"),
+            csrf_cookies=config.get_option("server.enableCSRFProtection"),
             **TORNADO_SETTINGS # type: ignore[arg-type]
         )
 
@@ -590,7 +590,7 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
         # cookie as a side effect.
         # See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
         # for more details.
-        if config.get_option("server.enableCSRF"):
+        if config.get_option("server.enableCSRFProtection"):
             self.xsrf_token
 
     def check_origin(self, origin):

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -64,7 +64,6 @@ TORNADO_SETTINGS = {
     "websocket_ping_interval": 20,  # Ping every 20s to keep WS alive.
     "websocket_ping_timeout": 30,  # Pings should be responded to within 30s.
     "websocket_max_message_size": MESSAGE_SIZE_LIMIT,  # Up the WS size limit.
-    "xsrf_cookies": True,
 }
 
 
@@ -337,6 +336,7 @@ class Server(object):
         return tornado.web.Application(
             routes,
             cookie_secret=config.get_option("server.cookieSecret"),
+            csrf_cookies=config.get_option("server.enableCSRF"),
             **TORNADO_SETTINGS
         )
 
@@ -581,11 +581,12 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
         self._server = server
         self._session = None
         # The XSRF cookie is normally set when xsrf_form_html is used, but in a pure-Javascript application
-        # that does not use any regular forms we just  need to read the self.xsrf_token manually to set the
-        # cookie as a side effect).
+        # that does not use any regular forms we just need to read the self.xsrf_token manually to set the
+        # cookie as a side effect.
         # See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
         # for more details.
-        self.xsrf_token
+        if config.get_option("server.enableCSRF"):
+            self.xsrf_token
 
     def check_origin(self, origin):
         """Set up CORS."""

--- a/lib/streamlit/server/UploadFileRequestHandler.py
+++ b/lib/streamlit/server/UploadFileRequestHandler.py
@@ -44,10 +44,13 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self._file_mgr = file_mgr
 
     def set_default_headers(self):
-        self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken")
-        self.set_header("Access-Control-Allow-Origin", Report.get_url(config.get_option("browser.serverAddress")))
-        self.set_header("Vary", "Origin")
-        self.set_header("Access-Control-Allow-Credentials", "true")
+        if config.get_option("server.enableXSRF"):
+            self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken")
+            self.set_header("Access-Control-Allow-Origin", Report.get_url(config.get_option("browser.serverAddress")))
+            self.set_header("Vary", "Origin")
+            self.set_header("Access-Control-Allow-Credentials", "true")
+        elif routes.allow_cross_origin_requests():
+            self.set_header("Access-Control-Allow-Origin", "*")
 
 
     def options(self):

--- a/lib/streamlit/server/UploadFileRequestHandler.py
+++ b/lib/streamlit/server/UploadFileRequestHandler.py
@@ -44,7 +44,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self._file_mgr = file_mgr
 
     def set_default_headers(self):
-        if config.get_option("server.enableXSRF"):
+        if config.get_option("server.enableCSRF"):
             self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken")
             self.set_header("Access-Control-Allow-Origin", Report.get_url(config.get_option("browser.serverAddress")))
             self.set_header("Vary", "Origin")

--- a/lib/streamlit/server/UploadFileRequestHandler.py
+++ b/lib/streamlit/server/UploadFileRequestHandler.py
@@ -44,7 +44,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self._file_mgr = file_mgr
 
     def set_default_headers(self):
-        if config.get_option("server.enableCSRF"):
+        if config.get_option("server.enableCSRFProtection"):
             self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken")
             self.set_header("Access-Control-Allow-Origin", Report.get_url(config.get_option("browser.serverAddress")))
             self.set_header("Vary", "Origin")

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -133,7 +133,11 @@ class HealthHandler(_SpecialRequestHandler):
             self.write("ok")
             self.set_status(200)
 
-            # Manually set the _xsrf token when rechecking health.
+            # Tornado will set the _xsrf cookie automatically for the page on
+            # request for the document. However, if the server is reset and
+            # server.enableCSRF is updated, the browser does not reload the document.
+            # Manually setting the cooking on /healthz since it is pinged when the
+            # browser is disconnected from the server.
             if config.get_option("server.enableCSRF"):
                 self.set_cookie("_xsrf", self.xsrf_token)
 

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -132,6 +132,11 @@ class HealthHandler(_SpecialRequestHandler):
         if self._callback():
             self.write("ok")
             self.set_status(200)
+
+            # Manually set the _xsrf token when rechecking health.
+            if config.get_option("server.enableCSRF"):
+                self.set_cookie("_xsrf", self.xsrf_token)
+
         else:
             # 503 = SERVICE_UNAVAILABLE
             self.set_status(503)

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -136,7 +136,7 @@ class HealthHandler(_SpecialRequestHandler):
             # Tornado will set the _xsrf cookie automatically for the page on
             # request for the document. However, if the server is reset and
             # server.enableCSRF is updated, the browser does not reload the document.
-            # Manually setting the cooking on /healthz since it is pinged when the
+            # Manually setting the cookie on /healthz since it is pinged when the
             # browser is disconnected from the server.
             if config.get_option("server.enableCSRF"):
                 self.set_cookie("_xsrf", self.xsrf_token)

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -135,10 +135,10 @@ class HealthHandler(_SpecialRequestHandler):
 
             # Tornado will set the _xsrf cookie automatically for the page on
             # request for the document. However, if the server is reset and
-            # server.enableCSRF is updated, the browser does not reload the document.
+            # server.enableCSRFProtection is updated, the browser does not reload the document.
             # Manually setting the cookie on /healthz since it is pinged when the
             # browser is disconnected from the server.
-            if config.get_option("server.enableCSRF"):
+            if config.get_option("server.enableCSRFProtection"):
                 self.set_cookie("_xsrf", self.xsrf_token)
 
         else:

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -29,9 +29,9 @@ LOGGER = get_logger(__name__)
 def allow_cross_origin_requests():
     """True if cross-origin requests are allowed.
 
-    We only allow cross-origin requests when using the Node server. This is
-    only needed when using the Node server anyway, since in that case we
-    have a dev port and the prod port, which count as two origins.
+    We only allow cross-origin requests when CORS protection has been disabled
+    with server.enableCORS=False or if using the Node server. When using the
+    Node server, we have a dev and prod port, which count as two origins.
 
     """
     return not config.get_option("server.enableCORS") or config.get_option(

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -446,6 +446,20 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         response = self.fetch("/healthz")
         self.assertEqual(503, response.code)
 
+    def test_healthz_without_csrf(self):
+        config._set_option("server.enableCSRF", False, "test")
+        response = self.fetch("/healthz")
+        self.assertEqual(200, response.code)
+        self.assertEqual(b"ok", response.body)
+        self.assertNotIn("Set-Cookie", response.headers)
+
+    def test_healthz_with_csrf(self):
+        config._set_option("server.enableCSRF", True, "test")
+        response = self.fetch("/healthz")
+        self.assertEqual(200, response.code)
+        self.assertEqual(b"ok", response.body)
+        self.assertIn("Set-Cookie", response.headers)
+
 
 class PortRotateAHundredTest(unittest.TestCase):
     """Tests port rotation handles a MAX_PORT_SEARCH_RETRIES attempts then sys exits"""

--- a/lib/tests/streamlit/Server_test.py
+++ b/lib/tests/streamlit/Server_test.py
@@ -463,14 +463,14 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(503, response.code)
 
     def test_healthz_without_csrf(self):
-        config._set_option("server.enableCSRF", False, "test")
+        config._set_option("server.enableCSRFProtection", False, "test")
         response = self.fetch("/healthz")
         self.assertEqual(200, response.code)
         self.assertEqual(b"ok", response.body)
         self.assertNotIn("Set-Cookie", response.headers)
 
     def test_healthz_with_csrf(self):
-        config._set_option("server.enableCSRF", True, "test")
+        config._set_option("server.enableCSRFProtection", True, "test")
         response = self.fetch("/healthz")
         self.assertEqual(200, response.code)
         self.assertEqual(b"ok", response.body)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -302,7 +302,7 @@ class ConfigTest(unittest.TestCase):
                 "server.baseUrlPath",
                 "server.cookieSecret",
                 "server.enableCORS",
-                "server.enableXSRF",
+                "server.enableCSRF",
                 "server.folderWatchBlacklist",
                 "server.fileWatcherType",
                 "server.headless",
@@ -353,8 +353,8 @@ class ConfigTest(unittest.TestCase):
             "server.port does not work when global.developmentMode is true.",
         )
 
-    def test_check_conflicts_server_xsrf(self):
-        config._set_option("server.enableXSRF", True, "test")
+    def test_check_conflicts_server_csrf(self):
+        config._set_option("server.enableCSRF", True, "test")
         config._set_option("server.enableCORS", True, "test")
         with patch("streamlit.config.LOGGER") as patched_logger:
             config._check_conflicts()

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -302,7 +302,7 @@ class ConfigTest(unittest.TestCase):
                 "server.baseUrlPath",
                 "server.cookieSecret",
                 "server.enableCORS",
-                "server.enableCSRF",
+                "server.enableCSRFProtection",
                 "server.enableWebsocketCompression",
                 "server.folderWatchBlacklist",
                 "server.fileWatcherType",
@@ -355,7 +355,7 @@ class ConfigTest(unittest.TestCase):
         )
 
     def test_check_conflicts_server_csrf(self):
-        config._set_option("server.enableCSRF", True, "test")
+        config._set_option("server.enableCSRFProtection", True, "test")
         config._set_option("server.enableCORS", True, "test")
         with patch("streamlit.config.LOGGER") as patched_logger:
             config._check_conflicts()

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -299,9 +299,10 @@ class ConfigTest(unittest.TestCase):
                 "s3.region",
                 "s3.secretAccessKey",
                 "s3.url",
-                "server.enableCORS",
                 "server.baseUrlPath",
                 "server.cookieSecret",
+                "server.enableCORS",
+                "server.enableXSRF",
                 "server.folderWatchBlacklist",
                 "server.fileWatcherType",
                 "server.headless",
@@ -351,6 +352,13 @@ class ConfigTest(unittest.TestCase):
             str(e.value),
             "server.port does not work when global.developmentMode is true.",
         )
+
+    def test_check_conflicts_server_xsrf(self):
+        config._set_option("server.enableXSRF", True, "test")
+        config._set_option("server.enableCORS", True, "test")
+        with patch("streamlit.config.LOGGER") as patched_logger:
+            config._check_conflicts()
+            patched_logger.warning.assert_called_once()
 
     def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")


### PR DESCRIPTION
**Issue:** Fixes #1565 

**Description:** 
This adds a configuration to enable streamlit developers to disable CSRF. Because this configuration can be changed, updated communications between server and client side to update `_xsrf` cookie and HTTP settings required for CSRF.
1. Server side: Add a config to toggle CSRF. By default, CSRF is enabled.
2. Server side: Add a conflict check for CORS and CSRF
3. Session Communication: When disconnected, GET `/healthz` will be called. Update endpoint to set `xsrf` cookie.
4. Client side: Create a base `HttpRequest` class to handle settings supporting CSRF
5. Client side: Update HttpRequest CSRF upon initialization
6. Client side: On connection state change, clear `xsrf` cookie. This handles the case when server is updated to disable CSRF.


**Notes**
To support CSRF, the following headers are required in http requests:
self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken")


In order to send cookies in http requests, the following must be done:
1. `withCredentials` must be allowed and set to `true`.
2. `Access-Control-Allow-Origin` cannot be `*`

In order to validate requests with the cookie to header approach:
1. Send cookie with CSRF token. Tornado sets the cookie under `_xsrf`
2. Ensure header for token is allowed and sent. Tornado uses the header `X-XSRFToken`.
---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
