### PR TITLE
Remove Python 3 reference, add reference to magics work in main file only

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -50,7 +50,7 @@ magicEnabled = false
 ```
 
 ```eval_rst
-.. important:: Right now, Magic only works on Python 3.
+.. important:: Right now, Magic only works in the main Python app file, not in imported files. See `GitHub issue #288 <https://github.com/streamlit/streamlit/issues/288>`_ for a discussion of the issues.
 ```
 
 ## Display text


### PR DESCRIPTION
Fixes https://github.com/streamlit/docs/issues/518

Remove "Python 3 only" reference (since now, Streamlit only supports 3.6+), change the note to mention that Magics only work from main file, not imported modules