### PR TITLE
Note about OpenCV and MP4V codec

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -126,6 +126,9 @@ It's easy to embed images, videos, and audio files directly into your Streamlit 
 .. autofunction:: streamlit.image
 .. autofunction:: streamlit.audio
 .. autofunction:: streamlit.video
+
+.. note:: Some videos from OpenCV may not display if they are encoded using MP4V, as this codec is not widely supported
+   by browsers. Converting your video to H.264 will allow the video to be displayed in Streamlit. See this `StackOverflow post <https://stackoverflow.com/a/49535220/2394542>`_ or this `Streamlit forum post <https://discuss.streamlit.io/t/st-video-doesnt-show-opencv-generated-mp4/3193/2>`_ for more information.
 ```
 
 ## Display interactive widgets

--- a/docs/api.md
+++ b/docs/api.md
@@ -126,9 +126,6 @@ It's easy to embed images, videos, and audio files directly into your Streamlit 
 .. autofunction:: streamlit.image
 .. autofunction:: streamlit.audio
 .. autofunction:: streamlit.video
-
-.. note:: Some videos from OpenCV may not display if they are encoded using MP4V, as this codec is not widely supported
-   by browsers. Converting your video to H.264 will allow the video to be displayed in Streamlit. See this `StackOverflow post <https://stackoverflow.com/a/49535220/2394542>`_ or this `Streamlit forum post <https://discuss.streamlit.io/t/st-video-doesnt-show-opencv-generated-mp4/3193/2>`_ for more information.
 ```
 
 ## Display interactive widgets

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1593,6 +1593,13 @@ class DeltaGenerator(object):
            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=Wba9sZELKfKwXH4nDCCbMv
            height: 600px
 
+        .. note::
+           Some videos may not display if they are encoded using MP4V (which is an export option in OpenCV), as this codec is
+           not widely supported by browsers. Converting your video to H.264 will allow the video to be displayed in Streamlit.
+           See this `StackOverflow post <https://stackoverflow.com/a/49535220/2394542>`_ or this
+           `Streamlit forum post <https://discuss.streamlit.io/t/st-video-doesnt-show-opencv-generated-mp4/3193/2>`_
+           for more information.
+
         """
         from .elements import media_proto
 


### PR DESCRIPTION
Fixes #1580

Makes a note that the MP4V format in OpenCV will not be displayed in Streamlit, as this codec is not widely supported in browsers. 

Result:
![image](https://user-images.githubusercontent.com/2762787/84685672-a7522880-af08-11ea-964e-d4559f509c7a.png)

Forum Ref: 
https://discuss.streamlit.io/t/st-video-doesnt-show-opencv-generated-mp4/3193/3
https://discuss.streamlit.io/t/problem-with-displaying-a-recorded-video/3458/4