### PR TITLE
Disable/Remove scroll when in full screen mode

### DIFF
--- a/frontend/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.test.tsx
@@ -39,6 +39,7 @@ const getProps = (elementProps: object = {}): Props => ({
     ...elementProps,
   }),
   width: 0,
+  isFullScreen: false,
 })
 
 describe("ImageList Element", () => {
@@ -116,6 +117,23 @@ describe("ImageList Element", () => {
     wrapper.find(".stImage img").forEach((imgWrapper, id) => {
       // @ts-ignore
       expect(imgWrapper.prop("src")).toBe(imgs[id].url)
+    })
+  })
+
+  describe("fullScreen", () => {
+    const props = { ...getProps(), isFullScreen: true, height: 100 }
+    const wrapper = shallow(<ImageList {...props} />)
+
+    it("should not have a caption", () => {
+      expect(wrapper.find(".stImage .caption").length).toBe(0)
+    })
+
+    it("should have the proper style", () => {
+      const fullScreenAppearance = { height: 100, "object-fit": "contain" }
+
+      wrapper.find(".stImage img").forEach(imgWrapper => {
+        expect(imgWrapper.prop("style")).toStrictEqual(fullScreenAppearance)
+      })
     })
   })
 })

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -26,6 +26,8 @@ import "./ImageList.scss"
 
 export interface Props {
   width: number
+  height?: number
+  isFullScreen: boolean
   element: ImmutableMap<string, any>
 }
 
@@ -42,22 +44,32 @@ function getImageURI(imgProto: ImmutableMap<string, any>): string {
  */
 export class ImageList extends PureComponent<Props> {
   public render(): ReactNode {
-    const { element, width } = this.props
+    const { element, width, height, isFullScreen } = this.props
     // The width field in the proto sets the image width, but has special
     // cases for -1 and -2.
-    let imgWidth: number | undefined
+    let containerWidth: number | undefined
     const protoWidth = element.get("width")
+
     if (protoWidth === -1) {
       // Use the original image width.
-      imgWidth = undefined
+      containerWidth = undefined
     } else if (protoWidth === -2) {
       // Use the column width
-      imgWidth = width
+      containerWidth = width
     } else if (protoWidth > 0) {
       // Set the image width explicitly.
-      imgWidth = element.get("width")
+      containerWidth = element.get("width")
     } else {
       throw Error(`Invalid image width: ${protoWidth}`)
+    }
+
+    const imgStyle: any = {}
+
+    if (height && isFullScreen) {
+      imgStyle["height"] = height
+      imgStyle["object-fit"] = "contain"
+    } else {
+      imgStyle["width"] = containerWidth
     }
 
     return (
@@ -68,14 +80,12 @@ export class ImageList extends PureComponent<Props> {
             <div
               className="image-container stImage"
               key={idx}
-              style={{ width: imgWidth }}
+              style={{ width: containerWidth }}
             >
-              <img
-                style={{ width: imgWidth }}
-                src={getImageURI(img)}
-                alt={idx}
-              />
-              <div className="caption"> {img.get("caption")} </div>
+              <img style={imgStyle} src={getImageURI(img)} alt={idx} />
+              {!isFullScreen && (
+                <div className="caption"> {img.get("caption")} </div>
+              )}
             </div>
           ))}
       </div>

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -31,6 +31,11 @@ export interface Props {
   height?: number
 }
 
+enum WidthBehavior {
+  OriginalWidth = 1,
+  ColumnWidth = 2,
+}
+
 function getImageURI(imgProto: ImmutableMap<string, any>): string {
   if (imgProto.get("url").startsWith("/media")) {
     return buildHttpUri(get_base_uri_parts(), imgProto.get("url"))
@@ -50,10 +55,10 @@ export class ImageList extends PureComponent<Props> {
     let containerWidth: number | undefined
     const protoWidth = element.get("width")
 
-    if (protoWidth === -1) {
+    if (protoWidth === WidthBehavior.OriginalWidth) {
       // Use the original image width.
       containerWidth = undefined
-    } else if (protoWidth === -2) {
+    } else if (protoWidth === WidthBehavior.ColumnWidth) {
       // Use the column width
       containerWidth = width
     } else if (protoWidth > 0) {

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -26,9 +26,9 @@ import "./ImageList.scss"
 
 export interface Props {
   width: number
-  height?: number
   isFullScreen: boolean
   element: ImmutableMap<string, any>
+  height?: number
 }
 
 function getImageURI(imgProto: ImmutableMap<string, any>): string {

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -32,8 +32,8 @@ export interface Props {
 }
 
 enum WidthBehavior {
-  OriginalWidth = 1,
-  ColumnWidth = 2,
+  OriginalWidth = -1,
+  ColumnWidth = -2,
 }
 
 function getImageURI(imgProto: ImmutableMap<string, any>): string {

--- a/frontend/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
+++ b/frontend/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
@@ -21,9 +21,9 @@ import { SCSS_VARS } from "autogen/scssVariables"
 import "./FullScreenWrapper.scss"
 
 export type Size = {
-  height?: number
   width: number
   expanded: boolean
+  height?: number
 }
 
 /*
@@ -39,8 +39,8 @@ interface Props {
 
 interface State {
   expanded: boolean
-  fullwidth: number
-  fullheight: number
+  fullWidth: number
+  fullHeight: number
 }
 
 /*
@@ -51,7 +51,7 @@ interface State {
 class FullScreenWrapper extends PureComponent<Props, State> {
   static isFullScreen = false
 
-  public state: State = { expanded: false, fullwidth: 0, fullheight: 0 }
+  public state: State = { expanded: false, fullWidth: 0, fullHeight: 0 }
 
   componentDidMount(): void {
     this.updateWindowDimensions()
@@ -101,13 +101,13 @@ class FullScreenWrapper extends PureComponent<Props, State> {
       SCSS_VARS["$fullscreen-padding-top"]
     )
     this.setState({
-      fullwidth: window.innerWidth - padding * 2, // Left and right
-      fullheight: window.innerHeight - (padding + paddingTop), // Bottom and Top
+      fullWidth: window.innerWidth - padding * 2, // Left and right
+      fullHeight: window.innerHeight - (padding + paddingTop), // Bottom and Top
     })
   }
 
   public render(): JSX.Element {
-    const { expanded, fullwidth, fullheight } = this.state
+    const { expanded, fullWidth, fullHeight } = this.state
     const { children, width, height } = this.props
 
     let buttonClassName = "overlayBtn stButton-enter"
@@ -132,7 +132,7 @@ class FullScreenWrapper extends PureComponent<Props, State> {
           <Icon type={buttonImage} />
         </button>
         {expanded
-          ? children({ width: fullwidth, height: fullheight, expanded })
+          ? children({ width: fullWidth, height: fullHeight, expanded })
           : children({ width, height, expanded })}
       </div>
     )

--- a/frontend/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
+++ b/frontend/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
@@ -23,6 +23,7 @@ import "./FullScreenWrapper.scss"
 export type Size = {
   height?: number
   width: number
+  expanded: boolean
 }
 
 /*
@@ -131,8 +132,8 @@ class FullScreenWrapper extends PureComponent<Props, State> {
           <Icon type={buttonImage} />
         </button>
         {expanded
-          ? children({ width: fullwidth, height: fullheight })
-          : children({ width, height })}
+          ? children({ width: fullwidth, height: fullheight, expanded })
+          : children({ width, height, expanded })}
       </div>
     )
   }

--- a/frontend/src/hocs/withFullScreenWrapper/withFullScreenWrapper.tsx
+++ b/frontend/src/hocs/withFullScreenWrapper/withFullScreenWrapper.tsx
@@ -42,10 +42,11 @@ function withFullScreenWrapper(
 
       return (
         <FullScreenWrapper width={width} height={height}>
-          {({ width, height }) => (
+          {({ width, height, expanded }) => (
             <WrappedComponent
               width={width}
               height={height}
+              isFullScreen={expanded}
               {...passThroughProps}
             />
           )}


### PR DESCRIPTION
**Issue:** This PR fixes #1168 

**Description:**
When fullscreen:
- Adding `object-fit: contain`
- Hiding caption

When not fullscreen: remains the same

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
