### PR TITLE
Add float argument to progress docstring

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -2664,8 +2664,10 @@ class DeltaGenerator(object):
 
         Parameters
         ----------
-        value : int
-            The percentage complete: 0 <= value <= 100
+        value : int or float
+            0 <= value <= 100 for int
+
+            0.0 <= value <= 1.0 for float
 
         Example
         -------


### PR DESCRIPTION
Fixes #1589 

Adds recognition to docstring that it also accepts a float value:

![image](https://user-images.githubusercontent.com/2762787/84927752-44dd6180-b09b-11ea-882c-9eae834291db.png)
