### PR TITLE
Note about large num of options for multiselect

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1719,6 +1719,13 @@ class DeltaGenerator(object):
         >>>
         >>> st.write('You selected:', options)
 
+        .. note::
+           User experience can be degraded for large lists of `options` (100+), as this widget
+           is not designed to handle arbitrary text search efficiently. See this
+           `thread <https://discuss.streamlit.io/t/streamlit-loading-column-data-takes-too-much-time/1791>`_
+           on the Streamlit community forum for more information and
+           `GitHub issue #1059 <https://github.com/streamlit/streamlit/issues/1059>`_ for updates on the issue.
+
         """
 
         # Perform validation checks and return indices base on the default values.


### PR DESCRIPTION
Ref #1059 

Make a note in the docstring that performance will be degraded on the front-end when a large list of possible values are passed for a multiselect widget. The number of 100+ is just there as a conservatively low value for people to determine "large". The actual number is likely higher, but also likely a function of the hardware being used.

![image](https://user-images.githubusercontent.com/2762787/84934790-cfc35980-b0a5-11ea-9e4d-a7f43f5dae32.png)
