### PR TITLE
iFrame Feature-Policy

### DIFF
--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -125,6 +125,96 @@ const SANDBOX_POLICY = [
   // "allow-top-navigation-by-user-activation",
 ].join(" ")
 
+/**
+ * Our iframe `allow` policy options.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#Attributes
+ */
+const FEATURE_POLICY = [
+  // Controls whether the current document is allowed to gather information about the acceleration of the device through the Accelerometer interface.
+  "accelerometer",
+
+  // Controls whether the current document is allowed to gather information about the amount of light in the environment around the device through the AmbientLightSensor interface.
+  //"ambient-light-sensor",
+
+  // Controls whether the current document is allowed to autoplay media requested through the HTMLMediaElement interface. When this policy is disabled and there were no user gestures, the Promise returned by HTMLMediaElement.play() will reject with a DOMException. The autoplay attribute on <audio> and <video> elements will be ignored.
+  // "autoplay",
+
+  // Controls whether the use of the Battery Status API is allowed. When this policy is disabled, the Promise returned by Navigator.getBattery() will reject with a NotAllowedError DOMException.
+  //"battery",
+
+  // Controls whether the current document is allowed to use video input devices. When this policy is disabled, the Promise returned by getUserMedia() will reject with a NotAllowedError DOMException.
+  "camera",
+
+  // Controls whether or not the current document is permitted to use the getDisplayMedia() method to capture screen contents. When this policy is disabled, the promise returned by getDisplayMedia() will reject with a NotAllowedError if permission is not obtained to capture the display's contents.
+  // "display-capture",
+
+  // Controls whether the current document is allowed to set document.domain. When this policy is disabled, attempting to set document.domain will fail and cause a SecurityError DOMException to be be thrown.
+  "document-domain",
+
+  // Controls whether the current document is allowed to use the Encrypted Media Extensions API (EME). When this policy is disabled, the Promise returned by Navigator.requestMediaKeySystemAccess() will reject with a DOMException.
+  "encrypted-media",
+
+  // Controls whether tasks should execute in frames while they're not being rendered (e.g. if an iframe is hidden or display: none).
+  //"execution-while-not-rendered",
+
+  // Controls whether tasks should execute in frames while they're outside of the visible viewport.
+  //"execution-while-out-of-viewport",
+
+  // Controls whether the current document is allowed to use Element.requestFullScreen(). When this policy is disabled, the returned Promise rejects with a TypeError DOMException.
+  // "fullscreen",
+
+  // Controls whether the current document is allowed to use the Geolocation Interface. When this policy is disabled, calls to getCurrentPosition() and watchPosition() will cause those functions' callbacks to be invoked with a PositionError code of PERMISSION_DENIED.
+  "geolocation",
+
+  // Controls whether the current document is allowed to gather information about the orientation of the device through the Gyroscope interface.
+  "gyroscope",
+
+  // Controls whether the current document is allowed to show layout animations.
+  //"layout-animations",
+
+  // Controls whether the current document is allowed to display images in legacy formats.
+  //"legacy-image-formats",
+
+  // Controls whether the current document is allowed to gather information about the orientation of the device through the Magnetometer interface.
+  "magnetometer",
+
+  // Controls whether the current document is allowed to use audio input devices. When this policy is disabled, the Promise returned by MediaDevices.getUserMedia() will reject with a NotAllowedError.
+  "microphone",
+
+  // Controls whether the current document is allowed to use the Web MIDI API. When this policy is disabled, the Promise returned by Navigator.requestMIDIAccess() will reject with a DOMException.
+  "midi",
+
+  // Controls the availability of mechanisms that enables the page author to take control over the behavior of spatial navigation, or to cancel it outright.
+  // "navigation-override",
+
+  // Controls whether the current document is allowed to download and display large images.
+  //"oversized-images",
+
+  // Controls whether the current document is allowed to use the Payment Request API. When this policy is enabled, the PaymentRequest() constructor will throw a SecurityError DOMException.
+  "payment",
+
+  // Controls whether the current document is allowed to play a video in a Picture-in-Picture mode via the corresponding API.
+  "picture-in-picture",
+
+  // Controls whether the current document is allowed to use the Web Authentication API to retreive already stored public-key credentials, i.e. via navigator.credentials.get({publicKey: ..., ...}).
+  //"publickey-credentials-get",
+
+  // Controls whether the current document is allowed to make synchronous XMLHttpRequest requests.
+  "sync-xhr",
+
+  // Controls whether the current document is allowed to use the WebUSB API.
+  "usb",
+
+  // Controls whether the current document is allowed to use the WebVR API. When this policy is disabled, the Promise returned by Navigator.getVRDisplays() will reject with a DOMException. Keep in mind that the WebVR standard is in the process of being replaced with WebXR.
+  //"vr ",
+
+  // Controls whether the current document is allowed to use Wake Lock API to indicate that device should not enter power-saving mode.
+  //"wake-lock",
+
+  // Controls whether or not the current document is allowed to use the WebXR Device API to interact with a WebXR session.
+  "xr-spatial-tracking",
+].join("; ")
+
 // TODO: catch errors and display them in render()
 
 export class ComponentInstance extends React.PureComponent<Props, State> {
@@ -354,6 +444,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
     // TODO: make sure horizontal scrolling still works!
     return (
       <iframe
+        allow={FEATURE_POLICY}
         ref={this.iframeRef}
         src={src}
         width={this.props.width}


### PR DESCRIPTION
Adds a Feature-Policy to component iframes. This is required for things like camera and microphone access.

We should audit this list before ship to see if there's anything else we *don't* want to allow.