### PR TITLE
Fix server.cookieSecret config option.

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -395,7 +395,7 @@ _create_option(
 )
 
 
-@_create_option("server.cookieSecret")
+@_create_option("server.cookieSecret", type_=str)
 @util.memoize
 def _server_cookie_secret():
     """Symmetric key used to produce signed cookies. If deploying on multiple
@@ -403,9 +403,7 @@ def _server_cookie_secret():
 
     Default: Randomly generated secret key.
     """
-    cookie_secret = os.getenv("STREAMLIT_COOKIE_SECRET")
-    cookie_secret = cookie_secret if cookie_secret else secrets.token_hex()
-    return cookie_secret
+    return secrets.token_hex()
 
 
 @_create_option("server.headless", type_=bool)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -28,8 +28,6 @@ from streamlit import config
 from streamlit import env_util
 from streamlit.ConfigOption import ConfigOption
 
-os.environ["STREAMLIT_COOKIE_SECRET"] = "chocolatechip"
-
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
 
@@ -475,11 +473,6 @@ class ConfigTest(unittest.TestCase):
         config.set_option("global.developmentMode", False)
         config.set_option("server.port", 1234)
         self.assertEqual(1234, config.get_option("browser.serverPort"))
-
-    def test_server_cookie_secret(self):
-        self.assertEqual("chocolatechip", config.get_option("server.cookieSecret"))
-
-        del os.environ["STREAMLIT_COOKIE_SECRET"]
 
     def test_server_headless_via_liveSave(self):
         config.set_option("server.liveSave", True)


### PR DESCRIPTION
The config option...
1. ...shouldn't read environment variables. This happens automatically.
2. ...should specify a type.
3. ...doesn't have to include a test for its specific environment variable. Environment variables and the config system are already tested elsewhere.
