### PR TITLE
Remove AWS docs method from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,28 +183,6 @@ devel-docs: docs
 	cd docs/_build/html; \
 		python -m http.server 8000
 
-.PHONY: publish-docs
-# Build docs and push to prod.
-publish-docs: docs
-	cd docs/_build; \
-		aws s3 sync \
-				--acl public-read html s3://docs.streamlit.io \
-				--profile streamlit
-
-	# The line below uses the distribution ID obtained with
-	# $ aws cloudfront list-distributions | \
-	#     jq '.DistributionList.Items[] | \
-	#     select(.Aliases.Items[0] | \
-	#     contains("docs.streamlit.io")) | \
-	#     .Id'
-
-	aws cloudfront create-invalidation \
-		--distribution-id=E16K3UXOWYZ8U7 \
-		--paths \
-			'/*' \
-			'/tutorial/*' \
-		--profile streamlit
-
 .PHONY: protobuf
 # Recompile Protobufs for Python and Javascript.
 protobuf:


### PR DESCRIPTION
Fixes #1597 

Removes Makefile instructions for pushing the docs to AWS, which has been replaced by ReadtheDocs.