### PR TITLE
Reset file uploader on disconnect

### DIFF
--- a/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -102,4 +102,12 @@ describe("FileUploader widget", () => {
     )
     expect(wrapper.find("div.uploadError").length).toBe(1)
   })
+
+  it("should reset on disconnect", () => {
+    const props = getProps()
+    const wrapper = shallow(<FileUploader {...props} />)
+    const resetSpy = jest.spyOn(wrapper.instance(), "reset")
+    wrapper.setProps({ disabled: true })
+    expect(resetSpy).toBeCalled()
+  })
 })

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -53,6 +53,17 @@ class FileUploader extends React.PureComponent<Props, State> {
     }
   }
 
+  public componentDidUpdate = (prevProps: Props): void => {
+    // Widgets are disabled if the app is not connected anymore.
+    // If the app disconnects from the server, a new session is created and users
+    // will lose access to the files they uploaded in their previous session.
+    // If we are reconnecting, reset the file uploader so that the widget is
+    // in sync with the new session.
+    if (prevProps.disabled !== this.props.disabled && this.props.disabled) {
+      this.reset()
+    }
+  }
+
   private dropHandler = (
     acceptedFiles: File[],
     rejectedFiles: File[],


### PR DESCRIPTION
**Issue:** Fixes #1552 

**Description:** 
The file uploader widget state is not always in sync with data available from the session. When the app disconnects from the server, reset the file uploader as a new session will be created on reconnect without any previously submitted files. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
