### PR TITLE
Update demos.py, move streamlit import into code

### DIFF
--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -14,10 +14,11 @@
 
 import urllib.error
 
-import streamlit as st
 
 
 def intro():
+    import streamlit as st
+
     st.sidebar.success("Select a demo above.")
 
     st.markdown(
@@ -49,6 +50,7 @@ def intro():
 # compact code.
 # fmt: off
 def mapping_demo():
+    import streamlit as st
     import pandas as pd
     import pydeck as pdk
 
@@ -127,6 +129,7 @@ def mapping_demo():
 # compact code.
 # fmt: off
 def fractal_demo():
+    import streamlit as st
     import numpy as np
 
     # Interactive Streamlit elements, like these sliders, return their value.
@@ -183,6 +186,7 @@ def fractal_demo():
 # compact code.
 # fmt: off
 def plotting_demo():
+    import streamlit as st
     import time
     import numpy as np
 
@@ -213,6 +217,7 @@ def plotting_demo():
 # compact code.
 # fmt: off
 def data_frame_demo():
+    import streamlit as st
     import pandas as pd
     import altair as alt
 


### PR DESCRIPTION
**Issue:** 
Importing of streamlit as st not shown in the section of code in the hello.py demos because it was declared globally

**Description:** 
This PR makes the trivial but kinda helpful move of moving those declarations inside the demo functions so that if you copy and paste the code being shown in 'show code' it will actually run, rather than throwing a 'st not found' error. I've run the updated one locally to ensure I didn't miss something important about the way the import works with the #fmt stuff, seems to work as before.

---

**Contribution License Agreement**

By submiting this pull request I agree that all contributions to this project are made under the Apache 2.0 license.
