### PR TITLE
Remove useNode and update XSRF + CORS conflict

### DIFF
--- a/lib/streamlit/Report.py
+++ b/lib/streamlit/Report.py
@@ -270,8 +270,6 @@ def _get_browser_address_bar_port():
     server-browser websocket.
 
     """
-    if config.get_option("global.developmentMode") and config.get_option(
-        "global.useNode"
-    ):
+    if config.get_option("global.developmentMode"):
         return 3000
     return config.get_option("browser.serverPort")

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -990,13 +990,17 @@ def _check_conflicts():
     # XSRF conflicts
     if get_option("server.enableXsrfProtection"):
         if not get_option("server.enableCORS") or get_option("global.developmentMode"):
-            LOGGER.warning(
-                "In order to protect against CSRF attacks, we send a cookie with each request. "
-                "To do so, we must specify allowable origins which places a restriction on "
-                "cross origin resource sharing. We will prioritize 'server.enableXsrfProtection' "
-                "over 'server.enableCORS'. If cross origin resource sharing is required, please "
-                "disable 'server.enableXsrfProtection'."
-            )
+            LOGGER.warning("""
+Warning: the config option 'server.enableCORS=false' is not compatible with 'server.enableXsrfProtection=true'.
+As a result, 'server.enableCORS' is being overridden to 'true'.
+
+More information:
+In order to protect against CSRF attacks, we send a cookie with each request.
+To do so, we must specify allowable origins, which places a restriction on
+cross-origin resource sharing.
+
+If cross origin resource sharing is required, please disable server.enableXsrfProtection.
+            """)
 
 
 def _set_development_mode():

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -262,15 +262,6 @@ def _global_unit_test():
 
 
 _create_option(
-    "global.useNode",
-    description="""Whether to serve static content from node. Only applies when
-        developmentMode is True.""",
-    visibility="hidden",
-    default_val=True,
-    type_=bool,
-)
-
-_create_option(
     "global.metrics",
     description="Whether to serve prometheus metrics from /metrics.",
     visibility="hidden",
@@ -997,13 +988,14 @@ def _check_conflicts():
         )
 
     # XSRF conflicts
-
     if get_option("server.enableXsrfProtection"):
-        if not get_option("server.enableCORS") or get_option("global.useNode"):
+        if not get_option("server.enableCORS") or get_option("global.developmentMode"):
             LOGGER.warning(
-                "The config option 'server.enableXsrfProtection is not compatible with "
-                "'server.enableCORS'. If 'server.enableXsrfProtection' is on and 'server.enableCORS' "
-                "is off at the same time, we will prioritize 'server.enableXsrfProtection'."
+                "In order to protect against CSRF attacks, we send a cookie with each request. "
+                "To do so, we must specify allowable origins which places a restriction on "
+                "cross origin resource sharing. We will prioritize 'server.enableXsrfProtection' "
+                "over 'server.enableCORS'. If cross origin resource sharing is required, please "
+                "disable 'server.enableXsrfProtection'."
             )
 
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -316,9 +316,7 @@ class Server(object):
             (make_url_path_regex(base, "media/(.*)"), MediaFileHandler),
         ]
 
-        if config.get_option("global.developmentMode") and config.get_option(
-            "global.useNode"
-        ):
+        if config.get_option("global.developmentMode"):
             LOGGER.debug("Serving static content from the Node dev server")
         else:
             static_path = file_util.get_static_dir()

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -35,7 +35,7 @@ def allow_cross_origin_requests():
 
     """
     return not config.get_option("server.enableCORS") or config.get_option(
-        "global.useNode"
+        "global.developmentMode"
     )
 
 

--- a/lib/tests/streamlit/Report_test.py
+++ b/lib/tests/streamlit/Report_test.py
@@ -121,7 +121,7 @@ class ReportTest(unittest.TestCase):
         ]
     )
     def test_get_url(self, baseUrl, port, expected_url):
-        options = {"global.useNode": False, "server.headless": False}
+        options = {"server.headless": False, "global.developmentMode": False}
 
         if baseUrl:
             options["server.baseUrlPath"] = baseUrl

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -211,7 +211,7 @@ class BootstrapPrintTest(unittest.TestCase):
             {"browser.serverAddress": False}
         )
         mock_get_option = testutil.build_mock_config_get_option(
-            {"server.headless": False, "server.port": 9988, "global.useNode": False}
+            {"server.headless": False, "server.port": 9988, "global.developmentMode": False}
         )
 
         mock_get_internal_ip.return_value = "internal-ip"
@@ -235,7 +235,7 @@ class BootstrapPrintTest(unittest.TestCase):
                 "server.headless": False,
                 "server.baseUrlPath": "foo",
                 "server.port": 8501,
-                "global.useNode": False,
+                "global.developmentMode": False,
             }
         )
 
@@ -260,7 +260,7 @@ class BootstrapPrintTest(unittest.TestCase):
                 "server.headless": False,
                 "server.baseUrlPath": "foo",
                 "server.port": 8501,
-                "global.useNode": False,
+                "global.developmentMode": False,
             }
         )
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -285,7 +285,6 @@ class ConfigTest(unittest.TestCase):
                 "global.showWarningOnDirectExecution",
                 "global.suppressDeprecationWarnings",
                 "global.unitTest",
-                "global.useNode",
                 "runner.magicEnabled",
                 "runner.installTracer",
                 "runner.fixMatplotlib",


### PR DESCRIPTION
**Issue:** Fixes #1629 

**Description:** 
1. Removes `global.useNode` and replace with `global.developmentMode` if needed
2. Update the XSRF + CORS conflict warning message to be more informative

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
