### PR TITLE
Release 0.62.1

### DIFF
--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -26,7 +26,7 @@ $ pip install --upgrade streamlit
 $ streamlit version
 ```
 
-...and then verify that the version number printed is `0.62.0`.
+...and then verify that the version number printed is `0.62.1`.
 
 **Try reproducing the issue now.** If not fixed, keep reading on.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-browser",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
+++ b/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
@@ -72,7 +72,8 @@ describe("MapboxToken", () => {
   test("Fetches remote token if userMapboxToken is empty", async () => {
     const remoteToken = "remoteMapboxToken"
 
-    axiosMock.onGet(TOKENS_URL).reply(200, { "mapbox-localhost": remoteToken })
+    //axiosMock.onGet(TOKENS_URL).reply(200, { "mapbox-localhost": remoteToken })
+    axiosMock.onGet(TOKENS_URL).reply(200, { mapbox: remoteToken })
 
     await expect(MapboxToken.get()).resolves.toEqual(remoteToken)
 
@@ -118,7 +119,8 @@ describe("MapboxToken", () => {
 
     const remoteToken = "remoteMapboxToken"
 
-    axiosMock.onGet(TOKENS_URL).reply(200, { "mapbox-localhost": remoteToken })
+    //axiosMock.onGet(TOKENS_URL).reply(200, { "mapbox-localhost": remoteToken })
+    axiosMock.onGet(TOKENS_URL).reply(200, { mapbox: remoteToken })
 
     await expect(MapboxToken.get()).resolves.toEqual(remoteToken)
 

--- a/frontend/src/hocs/withMapboxToken/MapboxToken.ts
+++ b/frontend/src/hocs/withMapboxToken/MapboxToken.ts
@@ -57,7 +57,7 @@ export class MapboxToken {
         // TODO: Replace this with the block below after October 1st 2020.
         MapboxToken.token = await this.fetchToken(TOKENS_URL, "mapbox")
         // if (this.isRunningLocal() && SessionInfo.isHello) {
-        //   MapboxToken.token = await this.fetchToken(TOKENS_URL, "mapbox")
+        //   MapboxToken.token = await this.fetchToken(TOKENS_URL, "mapbox-localhost")
         // } else {
         //   throw new MapboxTokenNotProvidedError("No Mapbox token provided")
         // }
@@ -75,7 +75,7 @@ export class MapboxToken {
   ): Promise<string> {
     try {
       const response = await axios.get(url)
-      const { "mapbox-localhost": token } = response.data
+      const { [tokenName]: token } = response.data
 
       if (token == null || token === "") {
         throw new Error(`Missing token "${tokenName}"`)

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -8,7 +8,7 @@ from pipenv.project import Project
 from pipenv.utils import convert_deps_to_pip
 from setuptools.command.install import install
 
-VERSION = "0.62.0"  # PEP-440
+VERSION = "0.62.1"  # PEP-440
 
 NAME = "streamlit"
 


### PR DESCRIPTION
Fix use of wrong mapbox token!

(Pay no mind to the number of commits. There are [only 4 commits in this](https://github.com/streamlit/streamlit/pull/1647/files/c4ace8cfdc69699effa4fd012fb1babc2bc9e036..cc483438167aa39a2e0a22835bbec3e3db4e1941). I just added the commits onto the 0.62.0 release we tagged)

Randy: this doesn't change anything in the docs. Github is just confused because I'm updating a tag. When I actually merge this with `develop` it won't have any doc changes.