### PR TITLE
setup.py: fix description and long-description

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,5 +1,0 @@
-# Streamlit
-
-This is the Python library for Streamlit. It includes the `streamlit`
-package which the user installs and loads as well as the "proxy" which
-communicates with the browser.

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -12,11 +12,19 @@ VERSION = "0.62.0"  # PEP-440
 
 NAME = "streamlit"
 
+DESCRIPTION = "The fastest way to build data apps in Python"
+
+LONG_DESCRIPTION = (
+    "Streamlit's open-source app framework is the easiest way "
+    "for data scientists and machine learning engineers to "
+    "create beautiful, performant apps in only a few hours! "
+    "All in pure Python. All for free."
+)
+
 pipfile = Project(chdir=False).parsed_pipfile
 
 packages = pipfile["packages"].copy()
 requirements = convert_deps_to_pip(packages, r=False)
-
 
 # Check whether xcode tools are available before making watchdog a
 # dependency (only if the current system is a Mac).
@@ -29,11 +37,6 @@ if platform.system() == "Darwin":
             requirements.remove("watchdog")
         except ValueError:
             pass
-
-
-def readme():
-    with open("README.md") as f:
-        return f.read()
 
 
 class VerifyVersionCommand(install):
@@ -54,8 +57,8 @@ class VerifyVersionCommand(install):
 setuptools.setup(
     name=NAME,
     version=VERSION,
-    description="Frontend library for machine learning engineers",
-    long_description=readme(),
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
     url="https://streamlit.io",
     author="Streamlit Inc",
     author_email="hello@streamlit.io",


### PR DESCRIPTION
Updates "description" and "long_description" in setup.py. (These are displayed in our PyPI page.)

"long_description" was previously reading a `lib/README.md` file that I don't think anyone ever read (and that is long-since outdated). I removed that file, since it doesn't reflect reality, and just inlined the long description.