### PR TITLE
namespace custom components into `streamlit.components.v1`

### DIFF
--- a/components_beta/examples/CustomDataframe/custom_dataframe.py
+++ b/components_beta/examples/CustomDataframe/custom_dataframe.py
@@ -1,10 +1,8 @@
-import streamlit as st
 import pandas as pd
 
-_custom_dataframe = st.declare_component(
-    "custom_dataframe",
-    url="http://localhost:3001",
-)
+from streamlit.components.v1 import declare_component
+
+_custom_dataframe = declare_component("custom_dataframe", url="http://localhost:3001",)
 
 
 def custom_dataframe(data, key=None):

--- a/components_beta/examples/RadioButton/radio_button.py
+++ b/components_beta/examples/RadioButton/radio_button.py
@@ -1,13 +1,7 @@
-"""
-Re-implements the Streamlit radio button as a custom component.
-"""
-
 import streamlit as st
+from streamlit.components.v1 import declare_component
 
-_radio_button = st.declare_component(
-    "radio_button",
-    url="http://localhost:3001",
-)
+_radio_button = declare_component("radio_button", url="http://localhost:3001",)
 
 
 def custom_radio_button(label, options, default, key=None):

--- a/components_beta/examples/SelectableDataTable/selectable_data_table.py
+++ b/components_beta/examples/SelectableDataTable/selectable_data_table.py
@@ -1,7 +1,9 @@
-import streamlit as st
 import pandas as pd
 
-_selectable_data_table = st.declare_component(
+import streamlit as st
+from streamlit.components.v1 import declare_component
+
+_selectable_data_table = declare_component(
     "selectable_data_table", url="http://localhost:3001",
 )
 

--- a/components_beta/template-reactless/my_component/__init__.py
+++ b/components_beta/template-reactless/my_component/__init__.py
@@ -1,5 +1,5 @@
 import os
-import streamlit as st
+from streamlit.components.v1 import declare_component
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
@@ -7,19 +7,19 @@ import streamlit as st
 # release process.)
 _RELEASE = False
 
-# Declare a Streamlit component. `st.declare_component` returns a function
+# Declare a Streamlit component. `declare_component` returns a function
 # that is used to create instances of the component. We're naming this
 # function "_component_func", with an underscore prefix, because we don't want
 # to expose it directly to users. Instead, we will create a custom wrapper
 # function, below, that will serve as our component's public API.
 
-# It's worth noting that this call to `st.declare_component` is the
+# It's worth noting that this call to `declare_component` is the
 # *only thing* you need to do to create the binding between Streamlit and
 # your component frontend. Everything else we do in this file is simply a
 # best practice.
 
 if not _RELEASE:
-    _component_func = st.declare_component(
+    _component_func = declare_component(
         # We give the component a simple, descriptive name ("my_component"
         # does not fit this bill, so please choose something better for your
         # own component :)
@@ -35,12 +35,12 @@ else:
     # build directory:
     parent_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(parent_dir, "frontend/build")
-    _component_func = st.declare_component("my_component", path=build_dir)
+    _component_func = declare_component("my_component", path=build_dir)
 
 
 # Create a wrapper function for the component. This is an optional
 # best practice - we could simply expose the component function returned by
-# `st.declare_component` and call it done. The wrapper allows us to customize
+# `declare_component` and call it done. The wrapper allows us to customize
 # our component's API: we can pre-process its input args, post-process its
 # output value, and add a docstring for users.
 def my_component(name, key=None):
@@ -81,6 +81,8 @@ def my_component(name, key=None):
 # During development, we can run this just as we would any other Streamlit
 # app: `$ streamlit run my_component/__init__.py`
 if not _RELEASE:
+    import streamlit as st
+
     st.subheader("Component with constant args")
 
     # Create an instance of our component with a constant `name` arg, and

--- a/components_beta/template/my_component/__init__.py
+++ b/components_beta/template/my_component/__init__.py
@@ -1,5 +1,5 @@
 import os
-import streamlit as st
+from streamlit.components.v1 import declare_component
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
@@ -7,19 +7,19 @@ import streamlit as st
 # release process.)
 _RELEASE = False
 
-# Declare a Streamlit component. `st.declare_component` returns a function
+# Declare a Streamlit component. `declare_component` returns a function
 # that is used to create instances of the component. We're naming this
 # function "_component_func", with an underscore prefix, because we don't want
 # to expose it directly to users. Instead, we will create a custom wrapper
 # function, below, that will serve as our component's public API.
 
-# It's worth noting that this call to `st.declare_component` is the
+# It's worth noting that this call to `declare_component` is the
 # *only thing* you need to do to create the binding between Streamlit and
 # your component frontend. Everything else we do in this file is simply a
 # best practice.
 
 if not _RELEASE:
-    _component_func = st.declare_component(
+    _component_func = declare_component(
         # We give the component a simple, descriptive name ("my_component"
         # does not fit this bill, so please choose something better for your
         # own component :)
@@ -35,12 +35,12 @@ else:
     # build directory:
     parent_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(parent_dir, "frontend/build")
-    _component_func = st.declare_component("my_component", path=build_dir)
+    _component_func = declare_component("my_component", path=build_dir)
 
 
 # Create a wrapper function for the component. This is an optional
 # best practice - we could simply expose the component function returned by
-# `st.declare_component` and call it done. The wrapper allows us to customize
+# `declare_component` and call it done. The wrapper allows us to customize
 # our component's API: we can pre-process its input args, post-process its
 # output value, and add a docstring for users.
 def my_component(name, key=None):
@@ -81,6 +81,8 @@ def my_component(name, key=None):
 # During development, we can run this just as we would any other Streamlit
 # app: `$ streamlit run my_component/__init__.py`
 if not _RELEASE:
+    import streamlit as st
+
     st.subheader("Component with constant args")
 
     # Create an instance of our component with a constant `name` arg, and

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -109,7 +109,6 @@ from streamlit.util import functools_wraps as _functools_wraps
 # Modules that the user should have access to. These are imported with "as"
 # syntax pass mypy checking with implicit_reexport disabled.
 from streamlit.caching import cache as cache  # noqa: F401
-from streamlit.components import declare_component as declare_component
 
 # This is set to True inside cli._main_run(), and is False otherwise.
 # If False, we should assume that DeltaGenerator functions are effectively

--- a/lib/streamlit/components/v1/__init__.py
+++ b/lib/streamlit/components/v1/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modules that the user should have access to. These are imported with "as"
+# syntax pass mypy checking with implicit_reexport disabled.
+from .components import declare_component as declare_component
+
+# `st.html` and `st.iframe` are considered part of Custom Components,
+# so they appear in this `streamlit.components.v1` namespace.
+# If you're distributing a Custom Component that uses one of these methods,
+# you should write `streamlit.components.v1.html()` instead of `st.html()`
+# in order to future-proof your Custom Component against API changes.
+import streamlit
+
+html = streamlit.html
+iframe = streamlit.iframe

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -16,7 +16,7 @@
 import json
 import mimetypes
 import os
-from typing import Any, Dict, Optional, Type, Union, Callable
+from typing import Any, Dict, Optional, Type, Union
 import threading
 import inspect
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -38,8 +38,8 @@ from streamlit.MediaFileManager import media_file_manager
 from streamlit.ReportSession import ReportSession
 from streamlit.UploadedFileManager import UploadedFileManager
 from streamlit.logger import get_logger
-from streamlit.components import ComponentRegistry
-from streamlit.components import ComponentRequestHandler
+from streamlit.components.v1.components import ComponentRegistry
+from streamlit.components.v1.components import ComponentRequestHandler
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.server.UploadFileRequestHandler import UploadFileRequestHandler

--- a/lib/tests/streamlit/component_test_data/__init__.py
+++ b/lib/tests/streamlit/component_test_data/__init__.py
@@ -1,3 +1,3 @@
-import streamlit as st
+from streamlit.components.v1 import declare_component
 
-component = st.declare_component("foo", url="http://not.a.url")
+component = declare_component("foo", url="http://not.a.url")

--- a/lib/tests/streamlit/component_test_data/nested/inner_module.py
+++ b/lib/tests/streamlit/component_test_data/nested/inner_module.py
@@ -1,3 +1,3 @@
-import streamlit as st
+from streamlit.components.v1 import declare_component
 
-component = st.declare_component("foo", url="http://not.a.url")
+component = declare_component("foo", url="http://not.a.url")

--- a/lib/tests/streamlit/component_test_data/outer_module.py
+++ b/lib/tests/streamlit/component_test_data/outer_module.py
@@ -1,3 +1,3 @@
-import streamlit as st
+from streamlit.components.v1 import declare_component
 
-component = st.declare_component("foo", url="http://not.a.url")
+component = declare_component("foo", url="http://not.a.url")

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -24,8 +24,11 @@ import tornado.testing
 import tornado.web
 
 from streamlit import StreamlitAPIException
-from streamlit.components import ComponentRegistry, CustomComponent
-from streamlit.components import declare_component as declare_component
+from streamlit.components.v1.components import (
+    ComponentRegistry,
+    CustomComponent,
+    declare_component,
+)
 from tests.testutil import DeltaGeneratorTestCase
 
 URL = "http://not.a.real.url:3001"
@@ -33,7 +36,7 @@ PATH = "not/a/real/path"
 
 
 class DeclareComponentTest(unittest.TestCase):
-    """Test st.declare_component."""
+    """Test declare_component."""
 
     def tearDown(self) -> None:
         ComponentRegistry._instance = None
@@ -73,7 +76,9 @@ class DeclareComponentTest(unittest.TestCase):
         def isdir(path):
             return path == PATH or path == os.path.abspath(PATH)
 
-        with mock.patch("streamlit.components.os.path.isdir", side_effect=isdir):
+        with mock.patch(
+            "streamlit.components.v1.components.os.path.isdir", side_effect=isdir
+        ):
             component = declare_component("test", path=PATH)
 
         self.assertEqual(PATH, component.path)
@@ -114,7 +119,7 @@ class DeclareComponentTest(unittest.TestCase):
         )
 
     def test_declared_in_main_module(self):
-        """If st.declare_component is called in the main module, then
+        """If declare_component is called in the main module, then
         the component name should be the filename of that module."""
         # TODO!
         pass
@@ -132,7 +137,9 @@ class ComponentRegistryTest(unittest.TestCase):
             return path == test_path
 
         registry = ComponentRegistry.instance()
-        with mock.patch("streamlit.components.os.path.isdir", side_effect=isdir):
+        with mock.patch(
+            "streamlit.components.v1.components.os.path.isdir", side_effect=isdir
+        ):
             registry.register_component(
                 CustomComponent("test_component", path=test_path)
             )
@@ -174,7 +181,9 @@ class ComponentRegistryTest(unittest.TestCase):
             return path in (test_path_1, test_path_2)
 
         registry = ComponentRegistry.instance()
-        with mock.patch("streamlit.components.os.path.isdir", side_effect=isdir):
+        with mock.patch(
+            "streamlit.components.v1.components.os.path.isdir", side_effect=isdir
+        ):
             registry.register_component(CustomComponent("test_component", test_path_1))
             registry.register_component(CustomComponent("test_component", test_path_1))
             self.assertEqual(test_path_1, registry.get_component_path("test_component"))


### PR DESCRIPTION
`declare_component, `html`, and `iframe` are now in the `streamlit.components.v1` namespace.

(`st.html` and `st.iframe` still exist, as discussed.)