### PR TITLE
Streamlit.loadStreamlitCSS is a public, opt-in function

### DIFF
--- a/components_beta/examples/CustomDataframe/frontend/src/index.tsx
+++ b/components_beta/examples/CustomDataframe/frontend/src/index.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import CustomDataframe from "./CustomDataframe"
+import { Streamlit } from "./streamlit"
+
+// Load the default Streamlit CSS
+Streamlit.loadStreamlitCSS()
 
 ReactDOM.render(
   <React.StrictMode>

--- a/components_beta/examples/CustomDataframe/frontend/src/streamlit/streamlit.ts
+++ b/components_beta/examples/CustomDataframe/frontend/src/streamlit/streamlit.ts
@@ -64,12 +64,25 @@ export class Streamlit {
   private static lastFrameHeight?: number
 
   /**
+   * Load Streamlit stylesheet and fonts. This is optional! Call this
+   * function near the top of your component if you'd like a default
+   * Streamlit look and feel.
+   */
+  public static loadStreamlitCSS = (): void => {
+    const params = new URLSearchParams(window.location.search)
+    const streamlitUrl = params.get("streamlitUrl")
+    const link = document.createElement("link")
+    link.rel = "stylesheet"
+    link.href = streamlitUrl + "assets/streamlit.css"
+    document.head.appendChild(link)
+  }
+
+  /**
    * Tell Streamlit that the component is ready to start receiving data.
    * Streamlit will defer emitting RENDER events until it receives the
    * COMPONENT_READY message.
    */
   public static setComponentReady = (): void => {
-    Streamlit.loadStreamlitCSS()
     if (!Streamlit.registeredMessageListener) {
       // Register for message events if we haven't already
       window.addEventListener("message", Streamlit.onMessageEvent)
@@ -130,18 +143,6 @@ export class Streamlit {
         Streamlit.onRenderMessage(event.data)
         break
     }
-  }
-
-  /**
-   * Load Streamlit stylesheet and fonts.
-   */
-  private static loadStreamlitCSS = (): void => {
-    const params = new URLSearchParams(window.location.search)
-    const streamlitUrl = params.get("streamlitUrl")
-    const link = document.createElement("link")
-    link.rel = "stylesheet"
-    link.href = streamlitUrl + "assets/streamlit.css"
-    document.head.appendChild(link)
   }
 
   /**

--- a/components_beta/examples/RadioButton/frontend/src/index.tsx
+++ b/components_beta/examples/RadioButton/frontend/src/index.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import RadioButton from "./RadioButton"
+import { Streamlit } from "./streamlit"
+
+// Load the default Streamlit CSS
+Streamlit.loadStreamlitCSS()
 
 ReactDOM.render(
   <React.StrictMode>

--- a/components_beta/examples/RadioButton/frontend/src/streamlit/streamlit.ts
+++ b/components_beta/examples/RadioButton/frontend/src/streamlit/streamlit.ts
@@ -64,12 +64,25 @@ export class Streamlit {
   private static lastFrameHeight?: number
 
   /**
+   * Load Streamlit stylesheet and fonts. This is optional! Call this
+   * function near the top of your component if you'd like a default
+   * Streamlit look and feel.
+   */
+  public static loadStreamlitCSS = (): void => {
+    const params = new URLSearchParams(window.location.search)
+    const streamlitUrl = params.get("streamlitUrl")
+    const link = document.createElement("link")
+    link.rel = "stylesheet"
+    link.href = streamlitUrl + "assets/streamlit.css"
+    document.head.appendChild(link)
+  }
+
+  /**
    * Tell Streamlit that the component is ready to start receiving data.
    * Streamlit will defer emitting RENDER events until it receives the
    * COMPONENT_READY message.
    */
   public static setComponentReady = (): void => {
-    Streamlit.loadStreamlitCSS()
     if (!Streamlit.registeredMessageListener) {
       // Register for message events if we haven't already
       window.addEventListener("message", Streamlit.onMessageEvent)
@@ -130,18 +143,6 @@ export class Streamlit {
         Streamlit.onRenderMessage(event.data)
         break
     }
-  }
-
-  /**
-   * Load Streamlit stylesheet and fonts.
-   */
-  private static loadStreamlitCSS = (): void => {
-    const params = new URLSearchParams(window.location.search)
-    const streamlitUrl = params.get("streamlitUrl")
-    const link = document.createElement("link")
-    link.rel = "stylesheet"
-    link.href = streamlitUrl + "assets/streamlit.css"
-    document.head.appendChild(link)
   }
 
   /**

--- a/components_beta/examples/SelectableDataTable/frontend/src/index.tsx
+++ b/components_beta/examples/SelectableDataTable/frontend/src/index.tsx
@@ -1,5 +1,9 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import SelectableDataTable from "./SelectableDataTable"
+import { Streamlit } from "./streamlit"
+
+// Load the default Streamlit CSS
+Streamlit.loadStreamlitCSS()
 
 ReactDOM.render(<SelectableDataTable />, document.getElementById("root"))

--- a/components_beta/examples/SelectableDataTable/frontend/src/streamlit/streamlit.ts
+++ b/components_beta/examples/SelectableDataTable/frontend/src/streamlit/streamlit.ts
@@ -64,12 +64,25 @@ export class Streamlit {
   private static lastFrameHeight?: number
 
   /**
+   * Load Streamlit stylesheet and fonts. This is optional! Call this
+   * function near the top of your component if you'd like a default
+   * Streamlit look and feel.
+   */
+  public static loadStreamlitCSS = (): void => {
+    const params = new URLSearchParams(window.location.search)
+    const streamlitUrl = params.get("streamlitUrl")
+    const link = document.createElement("link")
+    link.rel = "stylesheet"
+    link.href = streamlitUrl + "assets/streamlit.css"
+    document.head.appendChild(link)
+  }
+
+  /**
    * Tell Streamlit that the component is ready to start receiving data.
    * Streamlit will defer emitting RENDER events until it receives the
    * COMPONENT_READY message.
    */
   public static setComponentReady = (): void => {
-    Streamlit.loadStreamlitCSS()
     if (!Streamlit.registeredMessageListener) {
       // Register for message events if we haven't already
       window.addEventListener("message", Streamlit.onMessageEvent)
@@ -130,18 +143,6 @@ export class Streamlit {
         Streamlit.onRenderMessage(event.data)
         break
     }
-  }
-
-  /**
-   * Load Streamlit stylesheet and fonts.
-   */
-  private static loadStreamlitCSS = (): void => {
-    const params = new URLSearchParams(window.location.search)
-    const streamlitUrl = params.get("streamlitUrl")
-    const link = document.createElement("link")
-    link.rel = "stylesheet"
-    link.href = streamlitUrl + "assets/streamlit.css"
-    document.head.appendChild(link)
   }
 
   /**

--- a/components_beta/template-reactless/my_component/frontend/src/index.tsx
+++ b/components_beta/template-reactless/my_component/frontend/src/index.tsx
@@ -1,5 +1,8 @@
 import { Streamlit, RenderData } from "./streamlit"
 
+// Load the default Streamlit CSS
+Streamlit.loadStreamlitCSS()
+
 // Add text and a button to the DOM. (You could also add these directly
 // to index.html.)
 const textDiv = document.body.appendChild(document.createElement("div"))

--- a/components_beta/template-reactless/my_component/frontend/src/streamlit/streamlit.ts
+++ b/components_beta/template-reactless/my_component/frontend/src/streamlit/streamlit.ts
@@ -64,12 +64,25 @@ export class Streamlit {
   private static lastFrameHeight?: number
 
   /**
+   * Load Streamlit stylesheet and fonts. This is optional! Call this
+   * function near the top of your component if you'd like a default
+   * Streamlit look and feel.
+   */
+  public static loadStreamlitCSS = (): void => {
+    const params = new URLSearchParams(window.location.search)
+    const streamlitUrl = params.get("streamlitUrl")
+    const link = document.createElement("link")
+    link.rel = "stylesheet"
+    link.href = streamlitUrl + "assets/streamlit.css"
+    document.head.appendChild(link)
+  }
+
+  /**
    * Tell Streamlit that the component is ready to start receiving data.
    * Streamlit will defer emitting RENDER events until it receives the
    * COMPONENT_READY message.
    */
   public static setComponentReady = (): void => {
-    Streamlit.loadStreamlitCSS()
     if (!Streamlit.registeredMessageListener) {
       // Register for message events if we haven't already
       window.addEventListener("message", Streamlit.onMessageEvent)
@@ -130,18 +143,6 @@ export class Streamlit {
         Streamlit.onRenderMessage(event.data)
         break
     }
-  }
-
-  /**
-   * Load Streamlit stylesheet and fonts.
-   */
-  private static loadStreamlitCSS = (): void => {
-    const params = new URLSearchParams(window.location.search)
-    const streamlitUrl = params.get("streamlitUrl")
-    const link = document.createElement("link")
-    link.rel = "stylesheet"
-    link.href = streamlitUrl + "assets/streamlit.css"
-    document.head.appendChild(link)
   }
 
   /**

--- a/components_beta/template/my_component/frontend/src/index.tsx
+++ b/components_beta/template/my_component/frontend/src/index.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import MyComponent from "./MyComponent"
+import { Streamlit } from "./streamlit"
+
+// Load the default Streamlit CSS
+Streamlit.loadStreamlitCSS()
 
 ReactDOM.render(
   <React.StrictMode>

--- a/components_beta/template/my_component/frontend/src/streamlit/streamlit.ts
+++ b/components_beta/template/my_component/frontend/src/streamlit/streamlit.ts
@@ -64,12 +64,25 @@ export class Streamlit {
   private static lastFrameHeight?: number
 
   /**
+   * Load Streamlit stylesheet and fonts. This is optional! Call this
+   * function near the top of your component if you'd like a default
+   * Streamlit look and feel.
+   */
+  public static loadStreamlitCSS = (): void => {
+    const params = new URLSearchParams(window.location.search)
+    const streamlitUrl = params.get("streamlitUrl")
+    const link = document.createElement("link")
+    link.rel = "stylesheet"
+    link.href = streamlitUrl + "assets/streamlit.css"
+    document.head.appendChild(link)
+  }
+
+  /**
    * Tell Streamlit that the component is ready to start receiving data.
    * Streamlit will defer emitting RENDER events until it receives the
    * COMPONENT_READY message.
    */
   public static setComponentReady = (): void => {
-    Streamlit.loadStreamlitCSS()
     if (!Streamlit.registeredMessageListener) {
       // Register for message events if we haven't already
       window.addEventListener("message", Streamlit.onMessageEvent)
@@ -130,18 +143,6 @@ export class Streamlit {
         Streamlit.onRenderMessage(event.data)
         break
     }
-  }
-
-  /**
-   * Load Streamlit stylesheet and fonts.
-   */
-  private static loadStreamlitCSS = (): void => {
-    const params = new URLSearchParams(window.location.search)
-    const streamlitUrl = params.get("streamlitUrl")
-    const link = document.createElement("link")
-    link.rel = "stylesheet"
-    link.href = streamlitUrl + "assets/streamlit.css"
-    document.head.appendChild(link)
   }
 
   /**


### PR DESCRIPTION
Rather than calling `Streamlit.loadStreamlitCSS` automatically, we expose it as a public function that plugins can call if they want to. (We don't want to mandate that components use the Streamlit CSS.)