### PR TITLE
Add sphinx_rtd_theme to conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 
 import recommonmark
 from recommonmark.transform import AutoStructify
+import sphinx_rtd_theme
 
 # -- Path setup --------------------------------------------------------------
 
@@ -60,6 +61,7 @@ extensions = [
     "recommonmark",
     "stoutput",
     "sphinx_markdown_tables",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 pipenv
 mypy-protobuf
 sphinx_markdown_tables
+sphinx-rtd-theme


### PR DESCRIPTION
Per [RTD installation docs](https://sphinx-rtd-theme.readthedocs.io/en/latest/#installation), we're supposed to have imported the theme. Worked before because we weren't doing any mods, but now that we modify the theme files, we get a failure.