### PR TITLE
Install test requirements using Pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ pipenv-dev-install: lib/Pipfile
 
 .PHONY: pipenv-test-install
 pipenv-test-install: lib/test-requirements.txt
+	# Installing from a requirements file copies the packages into
+	# the Pipfile so we revert these changes after the install.
 	cd lib ; \
 		cp Pipfile Pipfile.bkp ; \
 		pipenv install --dev --skip-lock --sequential -r test-requirements.txt ; \

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,10 @@ pipenv-dev-install: lib/Pipfile
 
 .PHONY: pipenv-test-install
 pipenv-test-install: lib/test-requirements.txt
-	cd lib; \
-		pip install -r test-requirements.txt
+	cd lib ; \
+		cp Pipfile Pipfile.bkp ; \
+		pipenv install --dev --skip-lock --sequential -r test-requirements.txt ; \
+		mv Pipfile.bkp Pipfile
 
 .PHONY: pylint
 # Run "black", our Python formatter, to verify that our source files


### PR DESCRIPTION
Installing from a requirements file copies the packages into the Pipfile so we revert these changes after the install.