### PR TITLE
Specify Sphinx 3 as minimum version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ version = ".".join(st.__version__.split(".")[0:2])
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = "3.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
After talking to RTD support, the build error might be mismatching versions of Sphinx. Trying again with a minimum version of 3 (vs. 1.8.5 installed by default on RTD)