### PR TITLE
Fix RTD build process, other bugs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,10 @@ sphinx:
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats:
+  - htmlzip
+  - pdf
+  # - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ sphinx:
 formats:
   - htmlzip
   - pdf
-  - epub
+  # - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ sphinx:
 formats:
   - htmlzip
   - pdf
-  # - epub
+  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,33 +1,14 @@
-{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
-
-{# Support for Sphinx 1.3+ page_source_suffix, but don't break old builds. #}
-
-{% if page_source_suffix %}
-{% set suffix = page_source_suffix %}
-{% else %}
-{% set suffix = source_suffix %}
-{% endif %}
-
-{% if meta is defined and meta is not none %}
-{% set check_meta = True %}
-{% else %}
-{% set check_meta = False %}
-{% endif %}
-
-{% if check_meta and 'github_url' in meta %}
-{% set display_github = True %}
-{% endif %}
-
-{% if check_meta and 'bitbucket_url' in meta %}
-{% set display_bitbucket = True %}
-{% endif %}
-
-{% if check_meta and 'gitlab_url' in meta %}
-{% set display_gitlab = True %}
-{% endif %}
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %} {# Support for Sphinx 1.3+
+page_source_suffix, but don't break old builds. #} {% if page_source_suffix %}
+{% set suffix = page_source_suffix %} {% else %} {% set suffix = source_suffix
+%} {% endif %} {% if meta is defined and meta is not none %} {% set check_meta
+= True %} {% else %} {% set check_meta = False %} {% endif %} {% if check_meta
+and 'github_url' in meta %} {% set display_github = True %} {% endif %} {% if
+check_meta and 'bitbucket_url' in meta %} {% set display_bitbucket = True %} {%
+endif %} {% if check_meta and 'gitlab_url' in meta %} {% set display_gitlab =
+True %} {% endif %}
 
 <div role="navigation" aria-label="breadcrumbs navigation">
-
   <ul class="wy-breadcrumbs">
     {% block breadcrumbs %}
     <li id="firsttier"><a href="{{ pathto(master_doc) }}">Docs</a> &raquo;</li>
@@ -35,57 +16,34 @@
     <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
     {% endfor %}
     <li id="secondtier">{{ title }}</li>
-    {% endblock %}
-    {% block breadcrumbs_aside %}
-    <li class="wy-breadcrumbs-aside">
-      {% if hasdoc(pagename) %}
-      {% if display_github %}
-      {% if check_meta and 'github_url' in meta %}
-      <!-- User defined GitHub URL -->
-      <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
-      {% else %}
-      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}"
-        class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
-      {% endif %}
-      {% elif display_bitbucket %}
-      {% if check_meta and 'bitbucket_url' in meta %}
-      <!-- User defined Bitbucket URL -->
-      <a href="{{ meta['bitbucket_url'] }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
-      {% else %}
-      <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}?mode={{ theme_vcs_pageview_mode|default("view") }}"
-        class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
-      {% endif %}
-      {% elif display_gitlab %}
-      {% if check_meta and 'gitlab_url' in meta %}
-      <!-- User defined GitLab URL -->
-      <a href="{{ meta['gitlab_url'] }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
-      {% else %}
-      <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}"
-        class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
-      {% endif %}
-      {% elif show_source and source_url_prefix %}
-      <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>
-      {% elif show_source and has_source and sourcename %}
-      <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>
-      {% endif %}
-      {% endif %}
-    </li>
-    {% endblock %}
+    {% endblock %} {% block breadcrumbs_aside %} {% endblock %}
   </ul>
 
-  {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-  <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="breadcrumb navigation">
+  {% if (theme_prev_next_buttons_location == 'top' or
+  theme_prev_next_buttons_location == 'both') and (next or prev) %}
+  <div
+    class="rst-breadcrumbs-buttons"
+    role="navigation"
+    aria-label="breadcrumb navigation"
+  >
     {% if next %}
-    <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}"
-      accesskey="n">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
-    {% endif %}
-    {% if prev %}
-    <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}"
-      accesskey="p"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
+    <a
+      href="{{ next.link|e }}"
+      class="btn btn-neutral float-right"
+      title="{{ next.title|striptags|e }}"
+      accesskey="n"
+      >{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span
+    ></a>
+    {% endif %} {% if prev %}
+    <a
+      href="{{ prev.link|e }}"
+      class="btn btn-neutral float-left"
+      title="{{ prev.title|striptags|e }}"
+      accesskey="p"
+      ><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a
+    >
     {% endif %}
   </div>
-  {% endif %}
-
-  {% include "searchbox.html" %}
+  {% endif %} {% include "searchbox.html" %}
   <hr />
 </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -145,7 +145,7 @@
             {% endif %}
             {% endif %}
 
-            {% include "searchbox.html" %}
+            <!-- {% include "searchbox.html" %} -->
 
             {% endblock %}
         </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,3 @@
-{%- extends "sphinx_rtd_theme/layout.html" %}
-
 {# TEMPLATE VAR SETTINGS #}
 {%- set url_root = pathto('', 1) %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
@@ -19,93 +17,93 @@
   {{ metatags }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% block htmltitle %}
-    <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
   {% endblock %}
 
   {# CSS #}
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
   <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- for css in css_files %}
-    {%- if css|attr("rel") %}
-      <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css" {% if css.title is not none %}
-        title="{{ css.title }}" {% endif %} />
-    {%- else %}
-      <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
-    {%- endif %}
+  {%- if css|attr("rel") %}
+  <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css" {% if css.title is not none %}
+    title="{{ css.title }}" {% endif %} />
+  {%- else %}
+  <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+  {%- endif %}
   {%- endfor %}
 
   {%- for cssfile in extra_css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+  <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
   {%- endfor %}
 
   {# FAVICON #}
   {% if favicon %}
-    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}" />
+  <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}" />
   {% endif %}
   {# CANONICAL URL #}
   {% if theme_canonical_url %}
-    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
+  <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
   {% endif %}
 
-  {# JAVASCRIPT #}
+  {# JAVASCRIPTS #}
   {%- block scripts %}
-    <!--[if lt IE 9]>
-      <script src="{{ pathto('_static/js/html5shiv.min.js', 1) }}"></script>
-    <![endif]-->
-    {%- if not embedded %}
-      {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherit more blocks directly from sphinx #}
-      {% if sphinx_version >= "1.8.0" %}
-        <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}"
-          src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
-        {%- for scriptfile in script_files %}
-          {{ js_tag(scriptfile) }}
-        {%- endfor %}
-      {% else %}
-        <script type="text/javascript">
-          var DOCUMENTATION_OPTIONS = {
-            URL_ROOT: '{{ url_root }}',
-            VERSION: '{{ release|e }}',
-            LANGUAGE: '{{ language }}',
-            COLLAPSE_INDEX: false,
-            FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE: {{ has_source| lower }},
-            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
+  <!--[if lt IE 9]>
+    <script src="{{ pathto('_static/js/html5shiv.min.js', 1) }}"></script>
+  <![endif]-->
+  {%- if not embedded %}
+  {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
+  {% if sphinx_version >= "1.8.0" %}
+  <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}"
+    src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+  {%- for scriptfile in script_files %}
+  {{ js_tag(scriptfile) }}
+  {%- endfor %}
+  {% else %}
+  <script type="text/javascript">
+    var DOCUMENTATION_OPTIONS = {
+      URL_ROOT: '{{ url_root }}',
+      VERSION: '{{ release|e }}',
+      LANGUAGE: '{{ language }}',
+      COLLAPSE_INDEX: false,
+      FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
+      HAS_SOURCE: {{ has_source| lower }},
+    SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
           };
-        </script>
-        {%- for scriptfile in script_files %}
-          <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
-        {%- endfor %}
-      {% endif %}
-      <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+  </script>
+  {%- for scriptfile in script_files %}
+  <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+  {%- endfor %}
+  {% endif %}
+  <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
 
-      {# OPENSEARCH #}
-      {%- if use_opensearch %}
-        <link rel="search" type="application/opensearchdescription+xml"
-          title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"
-          href="{{ pathto('_static/opensearch.xml', 1) }}" />
-      {%- endif %}
-    {%- endif %}
+  {# OPENSEARCH #}
+  {%- if use_opensearch %}
+  <link rel="search" type="application/opensearchdescription+xml"
+    title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"
+    href="{{ pathto('_static/opensearch.xml', 1) }}" />
+  {%- endif %}
+  {%- endif %}
   {%- endblock %}
 
   {%- block linktags %}
-    {%- if hasdoc('about') %}
-      <link rel="author" title="{{ _('About these documents') }}" href="{{ pathto('about') }}" />
-    {%- endif %}
-    {%- if hasdoc('genindex') %}
-      <link rel="index" title="{{ _('Index') }}" href="{{ pathto('genindex') }}" />
-    {%- endif %}
-    {%- if hasdoc('search') %}
-      <link rel="search" title="{{ _('Search') }}" href="{{ pathto('search') }}" />
-    {%- endif %}
-    {%- if hasdoc('copyright') %}
-      <link rel="copyright" title="{{ _('Copyright') }}" href="{{ pathto('copyright') }}" />
-    {%- endif %}
-    {%- if next %}
-      <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e }}" />
-    {%- endif %}
-    {%- if prev %}
-      <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
-    {%- endif %}
+  {%- if hasdoc('about') %}
+  <link rel="author" title="{{ _('About these documents') }}" href="{{ pathto('about') }}" />
+  {%- endif %}
+  {%- if hasdoc('genindex') %}
+  <link rel="index" title="{{ _('Index') }}" href="{{ pathto('genindex') }}" />
+  {%- endif %}
+  {%- if hasdoc('search') %}
+  <link rel="search" title="{{ _('Search') }}" href="{{ pathto('search') }}" />
+  {%- endif %}
+  {%- if hasdoc('copyright') %}
+  <link rel="copyright" title="{{ _('Copyright') }}" href="{{ pathto('copyright') }}" />
+  {%- endif %}
+  {%- if next %}
+  <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e }}" />
+  {%- endif %}
+  {%- if prev %}
+  <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
+  {%- endif %}
   {%- endblock %}
   {%- block extrahead %} {% endblock %}
 </head>
@@ -114,71 +112,65 @@
 
   {% block extrabody %} {% endblock %}
   <div class="wy-grid-for-nav">
-
-    {# SIDE NAV, GOES AWAY ON MOBILE #}
+    {# SIDE NAV, TOGGLES ON MOBILE #}
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
         <div class="wy-side-nav-search" {% if theme_style_nav_header_background %}
           style="background: {{theme_style_nav_header_background}}" {% endif %}>
           {% block sidebartitle %}
 
-            {# This is duplicated below. TODO: Unify #}
-            {% if logo and theme_logo_only %}
-            <a href="{{ pathto(master_doc) }}">
+          {% if logo and theme_logo_only %}
+          <a href="{{ pathto(master_doc) }}">
             {% else %}
-            <a href="{{ pathto(master_doc) }}" class="icon icon-home" alt="{{ _("Documentation Home") }}"> {{ project }}
-            {% endif %}
+            <a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ project }}
+              {% endif %}
 
               {% if logo %}
-                {# Not strictly valid HTML, but it's the only way to display/scale
-                 it properly, without weird scripting or heaps of work
-                #}
-                <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}" />
-              {% else %}
-                {{ project }}
+              {# Not strictly valid HTML, but it's the only way to display/scale
+               it properly, without weird scripting or heaps of work
+            #}
+              <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}" />
               {% endif %}
             </a>
 
             {% if theme_display_version %}
-              {%- set nav_version = version %}
-              {% if READTHEDOCS and current_version %}
-                {%- set nav_version = current_version %}
-              {% endif %}
-              {% if nav_version %}
-                <div class="version">
-                  {{ nav_version }}
-                </div>
-              {% endif %}
+            {%- set nav_version = version %}
+            {% if READTHEDOCS and current_version %}
+            {%- set nav_version = current_version %}
+            {% endif %}
+            {% if nav_version %}
+            <div class="version">
+              {{ nav_version }}
+            </div>
+            {% endif %}
             {% endif %}
 
-            <!-- {% include "searchbox.html" %} -->
+            {% include "searchbox.html" %}
 
-          {% endblock %}
+            {% endblock %}
         </div>
 
         {% block navigation %}
-          <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
-            {% block menu %}
-
-              {#
-                  The singlehtml builder doesn't handle this toctree call when the
-                  toctree is empty. Skip building this for now.
-              #}
-              {% if 'singlehtml' not in builder %}
-                {% set global_toc = toctree(maxdepth=theme_navigation_depth|int,
-                                                collapse=theme_collapse_navigation|tobool,
-                                                includehidden=theme_includehidden|tobool,
-                                                titles_only=theme_titles_only|tobool) %}
-              {% endif %}
-              {% if global_toc %}
-                {{ global_toc }}
-              {% else %}
-                <!-- Local TOC -->
-                <div class="local-toc">{{ toc }}</div>
-              {% endif %}
-
-            {% endblock %}
-          </div>
+        <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+          {% block menu %}
+          {#
+              The singlehtml builder doesn't handle this toctree call when the
+              toctree is empty. Skip building this for now.
+            #}
+          {% if 'singlehtml' not in builder %}
+          {% set global_toc = toctree(maxdepth=theme_navigation_depth|int,
+                                          collapse=theme_collapse_navigation|tobool,
+                                          includehidden=theme_includehidden|tobool,
+                                          titles_only=theme_titles_only|tobool) %}
+          {% endif %}
+          {% if global_toc %}
+          {{ global_toc }}
+          {% else %}
+          <!-- Local TOC -->
+          <div class="local-toc">{{ toc }}</div>
+          {% endif %}
+          {% endblock %}
+        </div>
         {% endblock %}
       </div>
     </nav>
@@ -188,58 +180,41 @@
       {# MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
       <nav class="wy-nav-top" aria-label="top navigation">
         {% block mobile_nav %}
-          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-
-          {# This is duplicated above. TODO: Unify #}
-          {% if logo and theme_logo_only %}
-          <a href="{{ pathto(master_doc) }}">
-          {% else %}
-          <a href="{{ pathto(master_doc) }}" class="icon icon-home" alt="{{ _("Documentation Home") }}"> {{ project }}
-          {% endif %}
-
-            {% if logo %}
-              {# Not strictly valid HTML, but it's the only way to display/scale
-               it properly, without weird scripting or heaps of work
-              #}
-              <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}" />
-            {% else %}
-              {{ project }}
-            {% endif %}
-          </a>
-
+        <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+        <a href="{{ pathto(master_doc) }}">{{ project }}</a>
         {% endblock %}
       </nav>
 
 
       <div class="wy-nav-content">
         {%- block content %}
-          {% if theme_style_external_links|tobool %}
-            <div class="rst-content style-external-links">
+        {% if theme_style_external_links|tobool %}
+        <div class="rst-content style-external-links">
           {% else %}
-            <div class="rst-content">
-              {% endif %}
-              {% include "breadcrumbs.html" %}
-                <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
-                {%- block document %}
-                  <div itemprop="articleBody">
-                    {% block body %}{% endblock %}
-                  </div>
-                  {% if self.comments()|trim %}
-                    <div class="articleComments">
-                      {% block comments %}{% endblock %}
-                    </div>
-                  {% endif %}
-                {%- endblock %}
+          <div class="rst-content">
+            {% endif %}
+            {% include "breadcrumbs.html" %}
+            <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+              {%- block document %}
+              <div itemprop="articleBody">
+                {% block body %}{% endblock %}
               </div>
-              {% include "footer.html" %}
+              {% if self.comments()|trim %}
+              <div class="articleComments">
+                {% block comments %}{% endblock %}
+              </div>
+              {% endif%}
             </div>
+            {%- endblock %}
+            {% include "footer.html" %}
+          </div>
           {%- endblock %}
-
-          {% include "versions.html" %}
         </div>
 
     </section>
+
   </div>
+  {% include "versions.html" %}
 
   <script type="text/javascript">
     jQuery(function () {
@@ -249,20 +224,21 @@
 
   {# Do not conflict with RTD insertion of analytics script #}
   {% if not READTHEDOCS %}
-    {% if theme_analytics_id %}
-      <!-- Theme Analytics -->
-      <script>
-        (function (i, s, o, g, r, a, m) {
-          i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-            (i[r].q = i[r].q || []).push(arguments)
-          }, i[r].l = 1 * new Date(); a = s.createElement(o),
-            m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+  {% if theme_analytics_id %}
+  <!-- Theme Analytics -->
+  <script>
+    (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-        ga('create', '{{ theme_analytics_id }}', 'auto');
-        ga('send', 'pageview');
-      </script>
-    {% endif %}
+    ga('create', '{{ theme_analytics_id }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+
+  {% endif %}
   {% endif %}
 
   {%- block footer %} {% endblock %}

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -471,7 +471,7 @@ hr {
 /* Injected Read-the-docs version box */
 
 .rst-versions {
-  position: absolute !important;
+  /* position: absolute !important; */
   background: var(--main-bg-color) !important;
   border: 1px solid transparent !important;
   border-radius: 5px !important;

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -154,6 +154,7 @@
 
 body.wy-body-for-nav {
   background: var(--main-bg-color);
+  overflow: hidden;
 }
 
 body,
@@ -167,7 +168,6 @@ input[type="text"],
 li {
   font-family: Graphik, sans-serif;
   color: var(--st-black);
-  overflow: hidden;
 }
 
 h1,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -351,7 +351,8 @@ strong {
   border-radius: 5px;
   padding: var(--normal-padding);
   margin: var(--normal-padding) 0;
-  overflow-x: auto;
+  /* overflow-x: auto;  */ /*RZ 20200702: this causes vertical scrollbar, disabling for now */
+  overflow: auto;
 }
 
 .rst-content pre.literal-block,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -154,7 +154,7 @@
 
 body.wy-body-for-nav {
   background: var(--main-bg-color);
-  overflow: hidden;
+  height: 100%;
 }
 
 body,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -351,8 +351,7 @@ strong {
   border-radius: 5px;
   padding: var(--normal-padding);
   margin: var(--normal-padding) 0;
-  overflow-x: auto;
-  overflow-y: hidden; /*RZ 20200702: specifying only x causes vertical scrollbar */
+  /* overflow-x: auto; RZ 20200702: specifying only x causes vertical scrollbar */
 }
 
 .rst-content pre.literal-block,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -470,7 +470,7 @@ hr {
 
 /* Injected Read-the-docs version box */
 
-/* .rst-versions {
+.rst-versions {
   position: absolute !important;
   background: var(--main-bg-color) !important;
   border: 1px solid transparent !important;
@@ -535,7 +535,7 @@ hr {
 .rst-versions.shift-up {
   border-color: var(--st-gray-50) !important;
   bottom: 0.5rem !important;
-} */
+}
 
 /* 960 is where the RTD mobile/responsive theme kicks in to move nav to header */
 @media (min-width: 960px) {

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -351,8 +351,8 @@ strong {
   border-radius: 5px;
   padding: var(--normal-padding);
   margin: var(--normal-padding) 0;
-  /* overflow-x: auto;  */ /*RZ 20200702: this causes vertical scrollbar, disabling for now */
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: hidden; /*RZ 20200702: specifying only x causes vertical scrollbar */
 }
 
 .rst-content pre.literal-block,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -167,6 +167,7 @@ input[type="text"],
 li {
   font-family: Graphik, sans-serif;
   color: var(--st-black);
+  overflow: hidden;
 }
 
 h1,
@@ -351,7 +352,7 @@ strong {
   border-radius: 5px;
   padding: var(--normal-padding);
   margin: var(--normal-padding) 0;
-  /* overflow-x: auto; RZ 20200702: specifying only x causes vertical scrollbar */
+  overflow-x: auto;
 }
 
 .rst-content pre.literal-block,

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -469,7 +469,7 @@ hr {
 
 /* Injected Read-the-docs version box */
 
-.rst-versions {
+/* .rst-versions {
   position: absolute !important;
   background: var(--main-bg-color) !important;
   border: 1px solid transparent !important;
@@ -534,7 +534,7 @@ hr {
 .rst-versions.shift-up {
   border-color: var(--st-gray-50) !important;
   bottom: 0.5rem !important;
-}
+} */
 
 /* 960 is where the RTD mobile/responsive theme kicks in to move nav to header */
 @media (min-width: 960px) {

--- a/docs/env_setup.sh
+++ b/docs/env_setup.sh
@@ -16,7 +16,7 @@ unzip protoc-3.11.4-linux-x86_64.zip
     ../proto/streamlit/proto/*.proto
 
 #duplicates make process for SASS-like variable substitution
-/home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/${READTHEDOCS_VERSION}/bin/python replace_vars.py css/custom.css _static/css/custom.css
+/home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/${READTHEDOCS_VERSION}/bin/python replace_vars.py ./css/custom.css ./_static/css/custom.css
 
 #re-run setup.py build process to make protobuf available
 #this is tremendously fragile, as ../lib is hardcoded in here

--- a/docs/env_setup.sh
+++ b/docs/env_setup.sh
@@ -16,6 +16,7 @@ unzip protoc-3.11.4-linux-x86_64.zip
     ../proto/streamlit/proto/*.proto
 
 #duplicates make process for SASS-like variable substitution
+mkdir –p ./_static/css
 /home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/${READTHEDOCS_VERSION}/bin/python replace_vars.py ./css/custom.css ./_static/css/custom.css
 
 #re-run setup.py build process to make protobuf available

--- a/docs/env_setup.sh
+++ b/docs/env_setup.sh
@@ -15,6 +15,9 @@ unzip protoc-3.11.4-linux-x86_64.zip
     --mypy_out=../lib \
     ../proto/streamlit/proto/*.proto
 
+#duplicates make process for SASS-like variable substitution
+/home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/${READTHEDOCS_VERSION}/bin/python replace_vars.py css/custom.css _static/css/custom.css
+
 #re-run setup.py build process to make protobuf available
 #this is tremendously fragile, as ../lib is hardcoded in here
 /home/docs/checkouts/readthedocs.org/user_builds/streamlit-streamlit/envs/${READTHEDOCS_VERSION}/bin/python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir ../lib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
-pipenv
-mypy-protobuf
-sphinx_markdown_tables
-sphinx-rtd-theme
+mypy-protobuf==1.20
+pipenv==2018.11.26
+recommonmark==0.6.0
+Sphinx==3.0.3
+sphinx-rtd-theme==0.4.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ pipenv==2018.11.26
 recommonmark==0.6.0
 Sphinx==3.0.3
 sphinx-rtd-theme==0.4.3
+sphinx_markdown_tables==0.0.12


### PR DESCRIPTION
PR addresses issues surrounding broken build on RTD `latest`, stemming from not specifying package versions for Sphinx. Local development was done with Sphinx 3.0.x, RTD defaults to 1.8.5 if you do not specify.

Additionally, disabled building epub, as our custom template broke that build. epub did not look good with the standard template, so no loss from disabling, and should we choose to do this in the future, we can build a specific theme.

Very slight changes to the CSS were required to remove double scroll bars vertically.

Finally, modifications by @tvst to `layout.html` were rolled back, as they were causing a conflict with Font-Awesome, causing issues around malformed icons, emdashes, and apostrophes. Additional clean up to a mobile/constrained theme can be made at a later date.