### PR TITLE
Fix location of RTD overlay

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -618,3 +618,9 @@ hr {
     left: auto;
   }
 }
+
+.rst-versions {
+  margin: 0 auto !important;
+  margin-left: max(-550px, -50vw) !important;
+  left: 50vw !important;
+}


### PR DESCRIPTION
Fixes issue with RTD overlay, where the overlay would float more left than the edge of the left sidebar menu. Tested on Chrome moving the window to various sizes, appears to work as expected per this build:

https://docs.streamlit.io/en/fix_rtd_overlay_css/