### PR TITLE
Fix st.write exception handling

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -407,9 +407,8 @@ def write(*args, **kwargs):
 
         flush_buffer()
 
-    except Exception:
-        _, exc, exc_tb = _sys.exc_info()
-        exception(exc, exc_tb)  # noqa: F821
+    except Exception as exc:
+        exception(exc)
 
 
 def experimental_show(*args):

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -184,7 +184,12 @@ class StreamlitWriteTest(unittest.TestCase):
 
     def test_exception(self):
         """Test st.write that raises an exception."""
-        with patch("streamlit.markdown") as m, patch("streamlit.exception") as e:
+        # We patch streamlit.exception to observe it, but we also make sure
+        # it's still called (via side_effect). This ensures that it's called
+        # with the proper arguments.
+        with patch("streamlit.markdown") as m, patch(
+            "streamlit.exception", side_effect=st.exception
+        ) as e:
             m.side_effect = Exception("some exception")
             st.write("some text")
 


### PR DESCRIPTION
If an exception is thrown within `st.write`, pass the correct arguments to `st.exception`.

In our unit tests, we _were_ testing that `st.exception` was called in this circumstance, but we weren't actually validating that it was being called with sane arguments, which was leading to broken tracebacks in user code.

Fixes #1496