### PR TITLE
Add padding to lists

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -537,6 +537,14 @@ hr {
   bottom: 0.5rem !important;
 }
 
+/* Add small amount of padding to separate bullet points */
+.wy-plain-list-disc li,
+.rst-content .section ul li,
+.rst-content .toctree-wrapper ul li,
+article ul li {
+  padding: 2px;
+}
+
 /* 960 is where the RTD mobile/responsive theme kicks in to move nav to header */
 @media (min-width: 960px) {
   h1 {

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -541,6 +541,10 @@ hr {
 .wy-plain-list-disc li,
 .rst-content .section ul li,
 .rst-content .toctree-wrapper ul li,
+.wy-plain-list-decimal li,
+.rst-content .section ol li,
+.rst-content ol.arabic li,
+article ol li,
 article ul li {
   padding: 2px;
 }


### PR DESCRIPTION
Add padding to lists, to make each bullet or arabic numeral stand a little bit farther apart from one another. I chose to use `padding` instead of `padding-bottom` or similar to get the effect of doubling up the distance between each point, while also padding the first and last bullets slightly from their neighbor text above/below 

Looks correct to me based on this build:
https://docs.streamlit.io/en/add_padding_to_bullets/

