### PR TITLE
Refactor st.set_favicon, and implement st.set_page_title

### DIFF
--- a/e2e/scripts/st_set_favicon.py
+++ b/e2e/scripts/st_set_favicon.py
@@ -1,0 +1,17 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+st.beta_set_favicon(":shark:")

--- a/e2e/scripts/st_set_page_title.py
+++ b/e2e/scripts/st_set_page_title.py
@@ -1,0 +1,17 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+st.beta_set_page_title("Heya, world?")

--- a/e2e/specs/st_set_favicon.spec.ts
+++ b/e2e/specs/st_set_favicon.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="cypress" />
+
+describe("st.set_favicon", () => {
+  before(() => {
+    cy.visit("http://localhost:3000/");
+  });
+
+  it("displays a title", () => {
+    cy.get("link[rel='shortcut icon']")
+      .invoke("attr", "href")
+      .should("contain", "https://twemoji.maxcdn.com/2/72x72/1f988.png");
+  });
+});

--- a/e2e/specs/st_set_page_title.spec.ts
+++ b/e2e/specs/st_set_page_title.spec.ts
@@ -22,7 +22,7 @@ describe("st.set_page_title", () => {
     cy.visit("http://localhost:3000/");
   });
 
-  it("set the page title", () => {
+  it("sets the page title", () => {
     cy.title().should("eq", "Heya, world? · Streamlit");
   });
 });

--- a/e2e/specs/st_set_page_title.spec.ts
+++ b/e2e/specs/st_set_page_title.spec.ts
@@ -17,14 +17,12 @@
 
 /// <reference types="cypress" />
 
-describe("st.set_favicon", () => {
+describe("st.set_page_title", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
   });
 
-  it("sets the page favicon", () => {
-    cy.get("link[rel='shortcut icon']")
-      .invoke("attr", "href")
-      .should("eq", "https://twemoji.maxcdn.com/2/72x72/1f988.png");
+  it("set the page title", () => {
+    cy.title().should("eq", "Heya, world? · Streamlit");
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ import {
   Initialize,
   ISessionState,
   NewReport,
+  ReportProperties,
   SessionEvent,
 } from "autogen/proto"
 
@@ -71,6 +72,8 @@ import "./App.scss"
 import "assets/css/header.scss"
 import { UserSettings } from "components/core/StreamlitDialog/UserSettings"
 import { ComponentRegistry } from "./components/widgets/CustomComponent"
+
+import { handleFavicon } from "components/elements/Favicon"
 
 import withScreencast, {
   ScreenCastHOC,
@@ -265,6 +268,8 @@ export class App extends PureComponent<Props, State> {
           this.handleNewReport(newReportMsg),
         delta: (deltaMsg: Delta) =>
           this.handleDeltaMsg(deltaMsg, msgProto.metadata),
+        updateReportProperties: (propertiesMsg: ReportProperties) =>
+          this.handleReportProperties(propertiesMsg),
         reportFinished: (status: ForwardMsg.ReportFinishedStatus) =>
           this.handleReportFinished(status),
         uploadReportProgress: (progress: string | number) =>
@@ -643,6 +648,12 @@ export class App extends PureComponent<Props, State> {
           }
         }
       }, ELEMENT_LIST_BUFFER_TIMEOUT_MS)
+    }
+  }
+
+  handleReportProperties(propertiesMsg: ReportProperties): void {
+    if (propertiesMsg.favicon) {
+      handleFavicon(propertiesMsg.favicon)
     }
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -652,6 +652,9 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleReportProperties(propertiesMsg: ReportProperties): void {
+    if (propertiesMsg.title) {
+      document.title = `${propertiesMsg.title} · Streamlit`
+    }
     if (propertiesMsg.favicon) {
       handleFavicon(propertiesMsg.favicon)
     }

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -54,7 +54,6 @@ const DeckGlChart = React.lazy(() =>
 const DeckGlJsonChart = React.lazy(() =>
   import("components/elements/DeckGlJsonChart/")
 )
-const Favicon = React.lazy(() => import("components/elements/Favicon/"))
 const GraphVizChart = React.lazy(() =>
   import("components/elements/GraphVizChart/")
 )
@@ -193,7 +192,7 @@ class Block extends PureComponent<Props> {
     )
 
     const elementType = element.get("type")
-    const isHidden = elementType === "empty" || elementType === "favicon"
+    const isHidden = elementType === "empty"
     const enable = this.shouldComponentBeEnabled(isHidden)
     const isStale = this.isComponentStale(enable, reportElement)
     const className = Block.getClassNames(isStale, isHidden)
@@ -280,7 +279,6 @@ class Block extends PureComponent<Props> {
       exception: (el: SimpleElement) => (
         <ExceptionElement element={el} width={width} />
       ),
-      favicon: (el: SimpleElement) => <Favicon element={el} />,
       graphvizChart: (el: SimpleElement) => (
         <GraphVizChart element={el} index={index} width={width} />
       ),

--- a/frontend/src/components/elements/Favicon/Favicon.test.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.test.tsx
@@ -15,34 +15,7 @@
  * limitations under the License.
  */
 
-import React from "react"
-import { mount } from "enzyme"
-import { fromJS } from "immutable"
-
-import { Favicon, Props } from "./Favicon"
-
-const getProps = (elementProps: Record<string, unknown> = {}): Props => ({
-  element: fromJS({
-    url: "https://streamlit.io/path/to/favicon.png",
-    ...elementProps,
-  }),
-})
-
-// Overwrite bounding box code for testing (https://stackoverflow.com/a/52146902)
-const mockedRect = {
-  x: 0,
-  y: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
-  top: 0,
-  width: 10,
-  height: 10,
-  toJSON: () => "",
-}
-const originalGetBBox = SVGElement.prototype.getBBox
-beforeEach(() => (SVGElement.prototype.getBBox = () => mockedRect))
-afterEach(() => (SVGElement.prototype.getBBox = originalGetBBox))
+import { handleFavicon } from "./Favicon"
 
 function getFaviconHref(): string {
   const faviconElement: HTMLLinkElement | null = document.querySelector(
@@ -53,61 +26,36 @@ function getFaviconHref(): string {
 
 document.head.innerHTML = `<link rel="shortcut icon" href="default.png">`
 
+const PIZZA_TWEMOJI_URL = "https://twemoji.maxcdn.com/2/72x72/1f355.png"
+
 test("is set up with the default favicon", () => {
   expect(getFaviconHref()).toBe("http://localhost/default.png")
 })
 
 describe("Favicon element", () => {
-  it("renders without crashing", () => {
-    const props = getProps()
-    const wrapper = mount(<Favicon {...props} />)
-
-    expect(wrapper.find(".stHidden")).toBeTruthy()
-  })
-
   it("should set the favicon in the DOM", () => {
-    const props = getProps()
-    mount(<Favicon {...props} />)
-
+    handleFavicon("https://streamlit.io/path/to/favicon.png")
     expect(getFaviconHref()).toBe("https://streamlit.io/path/to/favicon.png")
   })
 
   it("should accept /media urls from backend", () => {
-    const props = getProps({ url: "/media/1234567890.png" })
-    mount(<Favicon {...props} />)
-
+    handleFavicon("/media/1234567890.png")
     expect(getFaviconHref()).toBe("http://localhost/media/1234567890.png")
   })
 
-  const PIZZA_EMOJI_SVG = `data:image/svg+xml,
-  <svg version="1.2" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-    <text
-      style="transform: translate(50%, 50%) scale(10)"
-      dominant-baseline="central"
-      text-anchor="middle">
-      %F0%9F%8D%95
-    </text>
-  </svg>`.replace(/\n/g, "")
-
   it("should accept emojis directly", () => {
-    const props = getProps({ url: "🍕" })
-    mount(<Favicon {...props} />)
-
-    expect(getFaviconHref()).toBe(PIZZA_EMOJI_SVG)
+    handleFavicon("🍕")
+    expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
   it("should accept emoji shortcodes", () => {
-    const props = getProps({ url: ":pizza:" })
-    mount(<Favicon {...props} />)
-
-    expect(getFaviconHref()).toBe(PIZZA_EMOJI_SVG)
+    handleFavicon(":pizza:")
+    expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
-  it("should change the favicon when the props change", () => {
-    const props = getProps()
-    const wrapper = mount(<Favicon {...props} />)
-    wrapper.setProps(getProps({ url: "🍕" }))
-
-    expect(getFaviconHref()).toBe(PIZZA_EMOJI_SVG)
+  it("should update the favicon when it changes", () => {
+    handleFavicon("/media/1234567890.png")
+    handleFavicon(":pizza:")
+    expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 })

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -15,10 +15,25 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from "react"
-import { Map as ImmutableMap } from "immutable"
 import nodeEmoji from "node-emoji"
 import { buildMediaUri } from "lib/UriUtil"
+
+/**
+ * Set the provided url/emoji as the page favicon.
+ *
+ * @param {string} favicon may be an image url, or an emoji like 🍕 or :pizza:
+ */
+export function handleFavicon(favicon: string): void {
+  const emoji = extractEmoji(favicon)
+  if (emoji) {
+    // Set the
+    const codepoint = toCodePoint(emoji)
+    const emojiUrl = `https://twemoji.maxcdn.com/2/72x72/${codepoint}.png`
+    overwriteFavicon(emojiUrl)
+  } else {
+    overwriteFavicon(buildMediaUri(favicon))
+  }
+}
 
 // Update the favicon in the DOM with the specified image.
 function overwriteFavicon(imageUrl: string): void {
@@ -28,19 +43,6 @@ function overwriteFavicon(imageUrl: string): void {
   if (faviconElement) {
     faviconElement.href = imageUrl
   }
-}
-
-// An SVG for a full-sized emoji, encoded as a data URI
-function svgURI(emoji: string | null, scale: number): string {
-  return `data:image/svg+xml,
-  <svg version="1.2" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-    <text
-      style="transform: translate(50%, 50%) scale(${scale})"
-      dominant-baseline="central"
-      text-anchor="middle">
-      ${emoji}
-    </text>
-  </svg>`
 }
 
 // Return the emoji if it exists, or empty string otherwise
@@ -55,64 +57,24 @@ function extractEmoji(maybeEmoji: string): string {
   return ""
 }
 
-export interface Props {
-  element: ImmutableMap<string, any>
-}
-
-/**
- * Hidden element that overwrites the page's favicon with the provided image
- *
- * This has a complex lifecycle for emoji favicons, since it must first render
- * the emoji on the page to measure its dimensions, then hide it afterwards.
- */
-export const Favicon: React.FC<Props> = (props: Props) => {
-  const [render, setRender] = useState(true)
-  const [emoji, setEmoji] = useState("")
-  const [finalUrl, setFinalUrl] = useState("")
-  const textNode = useRef<SVGTextElement>(null)
-
-  // Re-render the entire component whenever the props are changed
-  // (aka user changed the favicon with st.beta_set_favicon)
-  useEffect(() => {
-    const url = props.element.get("url")
-    const emoji = extractEmoji(url)
-    if (emoji) {
-      setEmoji(emoji)
-      setRender(true)
+// We only need this one function of Twemoji to locate the CDN emoji image,
+// so we copy it instead of importing the whole library.
+// https://github.com/twitter/twemoji/blob/42f8843cb3aa1f9403d5479d7e3f7e01176ad08e/scripts/build.js#L571
+function toCodePoint(unicodeSurrogates: string, sep?: string): string {
+  var r = [],
+    c = 0,
+    p = 0,
+    i = 0
+  while (i < unicodeSurrogates.length) {
+    c = unicodeSurrogates.charCodeAt(i++)
+    if (p) {
+      r.push((0x10000 + ((p - 0xd800) << 10) + (c - 0xdc00)).toString(16))
+      p = 0
+    } else if (0xd800 <= c && c <= 0xdbff) {
+      p = c
     } else {
-      // Format: http://streamlit.io/favicon.ico or /media/blah.jpeg
-      // No need to render SVG
-      setFinalUrl(buildMediaUri(url))
-      setRender(false)
+      r.push(c.toString(16))
     }
-  }, [props.element])
-
-  // After a new emoji is rendered, measure its dimensions to generate the
-  // correctly scaled favicon, then hide the original emoji.
-  useEffect(() => {
-    if (emoji && textNode.current) {
-      const boundingBox = textNode.current.getBBox()
-      const scale = Math.min(100 / boundingBox.width, 100 / boundingBox.height)
-      setFinalUrl(svgURI(emoji, scale))
-      setRender(false)
-    }
-  }, [emoji])
-
-  // The above two are effects to prevent infinite re-rendering loops.
-  // This is an effect because it's a manual DOM manipulation.
-  useEffect(() => {
-    overwriteFavicon(finalUrl)
-  }, [finalUrl])
-
-  return render ? (
-    <svg
-      version="1.2"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <text ref={textNode}>{emoji}</text>
-    </svg>
-  ) : null
+  }
+  return r.join(sep || "-")
 }
-
-export default Favicon

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -26,7 +26,7 @@ import { buildMediaUri } from "lib/UriUtil"
 export function handleFavicon(favicon: string): void {
   const emoji = extractEmoji(favicon)
   if (emoji) {
-    // Set the
+    // Find the corresponding Twitter emoji on the CDN.
     const codepoint = toCodePoint(emoji)
     const emojiUrl = `https://twemoji.maxcdn.com/2/72x72/${codepoint}.png`
     overwriteFavicon(emojiUrl)

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -61,10 +61,10 @@ function extractEmoji(maybeEmoji: string): string {
 // so we copy it instead of importing the whole library.
 // https://github.com/twitter/twemoji/blob/42f8843cb3aa1f9403d5479d7e3f7e01176ad08e/scripts/build.js#L571
 function toCodePoint(unicodeSurrogates: string, sep?: string): string {
-  var r = [],
-    c = 0,
-    p = 0,
-    i = 0
+  const r = []
+  let c = 0
+  let p = 0
+  let i = 0
   while (i < unicodeSurrogates.length) {
     c = unicodeSurrogates.charCodeAt(i++)
     if (p) {

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1616,54 +1616,6 @@ class DeltaGenerator(object):
             scrolling=scrolling,
         )
 
-    def favicon(
-        self, element, image, clamp=False, channels="RGB", format="JPEG",
-    ):
-        """Set the page favicon to the specified image.
-
-        This supports the same parameters as `st.image`.
-
-        Note: This is a beta feature. See
-        https://docs.streamlit.io/en/latest/pre_release_features.html for more
-        information.
-
-        Parameters
-        ----------
-        image : numpy.ndarray, [numpy.ndarray], BytesIO, str, or [str]
-            Monochrome image of shape (w,h) or (w,h,1)
-            OR a color image of shape (w,h,3)
-            OR an RGBA image of shape (w,h,4)
-            OR a URL to fetch the image from
-        clamp : bool
-            Clamp image pixel values to a valid range ([0-255] per channel).
-            This is only meaningful for byte array images; the parameter is
-            ignored for image URLs. If this is not set, and an image has an
-            out-of-range value, an error will be thrown.
-        channels : 'RGB' or 'BGR'
-            If image is an nd.array, this parameter denotes the format used to
-            represent color information. Defaults to 'RGB', meaning
-            `image[:, :, 0]` is the red channel, `image[:, :, 1]` is green, and
-            `image[:, :, 2]` is blue. For images coming from libraries like
-            OpenCV you should set this to 'BGR', instead.
-        format : 'JPEG' or 'PNG'
-            This parameter specifies the image format to use when transferring
-            the image data. Defaults to 'JPEG'.
-
-        Example
-        -------
-        >>> from PIL import Image
-        >>> image = Image.open('sunrise.jpg')
-        >>>
-        >>> st.beta_set_favicon(image)
-
-        """
-        from .elements import image_proto
-
-        width = -1  # Always use full width for favicons
-        element.favicon.url = image_proto.image_to_url(
-            image, width, clamp, channels, format, image_id="favicon", allow_emoji=True
-        )
-
     @_with_element
     def audio(self, element, data, format="audio/wav", start_time=0):
         """Display an audio player.

--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -665,8 +665,8 @@ class DeltaGenerator(object):
 
         Parameters
         ----------
-        body : str
-            The text to display.
+        title : str
+            The text to render as a title.
 
         Example
         -------

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -640,6 +640,6 @@ def _maybe_print_repl_warning():
             )
 
 
-# Other st commands
+# Other Streamlit commands:
 beta_set_favicon = _set_favicon
 beta_set_page_title = _set_page_title

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -103,6 +103,7 @@ from streamlit.DeltaGenerator import DeltaGenerator as _DeltaGenerator
 from streamlit.ReportThread import add_report_ctx as _add_report_ctx
 from streamlit.ReportThread import get_report_ctx as _get_report_ctx
 from streamlit.commands.favicon import set_favicon as _set_favicon
+from streamlit.commands.page_title import set_page_title as _set_page_title
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import BlockPath_pb2 as _BlockPath_pb2
 
@@ -641,3 +642,4 @@ def _maybe_print_repl_warning():
 
 # Other st commands
 beta_set_favicon = _set_favicon
+beta_set_page_title = _set_page_title

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -102,6 +102,7 @@ from streamlit import type_util as _type_util
 from streamlit.DeltaGenerator import DeltaGenerator as _DeltaGenerator
 from streamlit.ReportThread import add_report_ctx as _add_report_ctx
 from streamlit.ReportThread import get_report_ctx as _get_report_ctx
+from streamlit.commands.favicon import set_favicon as _set_favicon
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import BlockPath_pb2 as _BlockPath_pb2
 
@@ -147,7 +148,6 @@ pydeck_chart = _main.pydeck_chart  # noqa: E221
 empty = _main.empty  # noqa: E221
 error = _main.error  # noqa: E221
 exception = _main.exception  # noqa: E221
-beta_set_favicon = _main.favicon  # noqa: E221
 file_uploader = _main.file_uploader  # noqa: E221
 graphviz_chart = _main.graphviz_chart  # noqa: E221
 header = _main.header  # noqa: E221
@@ -637,3 +637,7 @@ def _maybe_print_repl_warning():
                 ),
                 script_name,
             )
+
+
+# Other st commands
+beta_set_favicon = _set_favicon

--- a/lib/streamlit/commands/__init__.py
+++ b/lib/streamlit/commands/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/streamlit/commands/favicon.py
+++ b/lib/streamlit/commands/favicon.py
@@ -1,0 +1,69 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit.DeltaGenerator import _enqueue_message
+from streamlit.proto import ForwardMsg_pb2
+from streamlit.elements import image_proto
+
+
+def set_favicon(
+    image, clamp=False, channels="RGB", format="JPEG",
+):
+    """Set the page favicon to the specified image.
+
+    This supports the same parameters as `st.image`.
+
+    Note: This is a beta feature. See
+    https://docs.streamlit.io/en/latest/pre_release_features.html for more
+    information.
+
+    Parameters
+    ----------
+    image : numpy.ndarray, [numpy.ndarray], BytesIO, str, or [str]
+        Monochrome image of shape (w,h) or (w,h,1)
+        OR a color image of shape (w,h,3)
+        OR an RGBA image of shape (w,h,4)
+        OR a URL to fetch the image from
+    clamp : bool
+        Clamp image pixel values to a valid range ([0-255] per channel).
+        This is only meaningful for byte array images; the parameter is
+        ignored for image URLs. If this is not set, and an image has an
+        out-of-range value, an error will be thrown.
+    channels : 'RGB' or 'BGR'
+        If image is an nd.array, this parameter denotes the format used to
+        represent color information. Defaults to 'RGB', meaning
+        `image[:, :, 0]` is the red channel, `image[:, :, 1]` is green, and
+        `image[:, :, 2]` is blue. For images coming from libraries like
+        OpenCV you should set this to 'BGR', instead.
+    format : 'JPEG' or 'PNG'
+        This parameter specifies the image format to use when transferring
+        the image data. Defaults to 'JPEG'.
+
+    Example
+    -------
+    >>> from PIL import Image
+    >>> image = Image.open('sunrise.jpg')
+    >>>
+    >>> st.beta_set_favicon(image)
+
+    """
+
+    msg = ForwardMsg_pb2.ForwardMsg()
+
+    width = -1  # Always use full width for favicons
+    msg.update_report_properties.favicon = image_proto.image_to_url(
+        image, width, clamp, channels, format, image_id="favicon", allow_emoji=True
+    )
+
+    _enqueue_message(msg)

--- a/lib/streamlit/commands/favicon.py
+++ b/lib/streamlit/commands/favicon.py
@@ -20,9 +20,16 @@ from streamlit.elements import image_proto
 def set_favicon(
     image, clamp=False, channels="RGB", format="JPEG",
 ):
-    """Set the page favicon to the specified image.
+    """Set the page favicon to the specified image or emoji.
 
-    This supports the same parameters as `st.image`.
+    This supports all the same parameters as `st.image` such as numpy arrays
+    or URLs.
+
+    You can also use an emoji as a favicon, either directly or with a shortcode [1].
+    Emojis are rendered courtesy of Twemoji [2].
+
+    [1] https://www.webfx.com/tools/emoji-cheat-sheet/
+    [2] https://twemoji.twitter.com/
 
     Note: This is a beta feature. See
     https://docs.streamlit.io/en/latest/pre_release_features.html for more
@@ -35,6 +42,8 @@ def set_favicon(
         OR a color image of shape (w,h,3)
         OR an RGBA image of shape (w,h,4)
         OR a URL to fetch the image from
+        OR an emoji like '🦈'
+        OR an emoji shortcode like ':shark:'
     clamp : bool
         Clamp image pixel values to a valid range ([0-255] per channel).
         This is only meaningful for byte array images; the parameter is
@@ -52,10 +61,7 @@ def set_favicon(
 
     Example
     -------
-    >>> from PIL import Image
-    >>> image = Image.open('sunrise.jpg')
-    >>>
-    >>> st.beta_set_favicon(image)
+    >>> st.beta_set_favicon('https://docs.streamlit.io/en/latest/_static/logomark_website.png')
 
     """
 

--- a/lib/streamlit/commands/favicon.py
+++ b/lib/streamlit/commands/favicon.py
@@ -22,11 +22,9 @@ def set_favicon(
 ):
     """Set the page favicon to the specified image or emoji.
 
-    This supports all the same parameters as `st.image` such as numpy arrays
-    or URLs.
-
+    You can use the same image parameters as `st.image`, like URLs or numpy arrays.
     You can also use an emoji as a favicon, either directly or with a shortcode [1].
-    Emojis are rendered courtesy of Twemoji [2].
+    Favicon emojis are loaded from a CDN, courtesy of Twitter and MaxCDN [2].
 
     [1] https://www.webfx.com/tools/emoji-cheat-sheet/
     [2] https://twemoji.twitter.com/

--- a/lib/streamlit/commands/page_title.py
+++ b/lib/streamlit/commands/page_title.py
@@ -37,7 +37,5 @@ def set_page_title(title):
 
     """
     msg = ForwardMsg_pb2.ForwardMsg()
-
     msg.update_report_properties.title = title
-
     _enqueue_message(msg)

--- a/lib/streamlit/commands/page_title.py
+++ b/lib/streamlit/commands/page_title.py
@@ -1,0 +1,43 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit.DeltaGenerator import _enqueue_message
+from streamlit.proto import ForwardMsg_pb2
+
+
+def set_page_title(title):
+    """Set the page title.
+
+    This title is shown on the browser tab, NOT in the app. Contrast with
+    `st.title` which renders a title in-app but does not set the page title.
+
+    Note: This is a beta feature. See
+    https://docs.streamlit.io/en/latest/pre_release_features.html for more
+    information.
+
+    Parameters
+    ----------
+    title: str
+        The text to set as the page title.
+
+    Example
+    -------
+    >>> st.beta_set_page_title('Look up! 😉')
+
+    """
+    msg = ForwardMsg_pb2.ForwardMsg()
+
+    msg.update_report_properties.title = title
+
+    _enqueue_message(msg)

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -16,12 +16,13 @@
 
 syntax = "proto3";
 
+import "streamlit/proto/BlockPath.proto";
 import "streamlit/proto/Delta.proto";
 import "streamlit/proto/Initialize.proto";
 import "streamlit/proto/NewReport.proto";
+import "streamlit/proto/ReportProperties.proto";
 import "streamlit/proto/SessionEvent.proto";
 import "streamlit/proto/SessionState.proto";
-import "streamlit/proto/BlockPath.proto";
 
 // A message sent from Proxy to the browser
 message ForwardMsg {
@@ -47,6 +48,7 @@ message ForwardMsg {
     Initialize initialize = 3;
     NewReport new_report = 4;
     Delta delta = 5;
+    ReportProperties update_report_properties = 12;
     ReportFinishedStatus report_finished = 6;
 
     // Upload progress messages.
@@ -72,6 +74,8 @@ message ForwardMsg {
     // for this one. If the client does not have the referenced message
     // in its cache, it can retrieve it from the server.
     string ref_hash = 11;
+
+    // NEXT ID: 13
   }
 }
 

--- a/proto/streamlit/proto/ReportProperties.proto
+++ b/proto/streamlit/proto/ReportProperties.proto
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018-2020 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
-export { handleFavicon } from "./Favicon"
+syntax = "proto3";
+
+// Things that a developer can change about a report which are NOT elements.
+// Examples include the webpage favicon & title, or perhaps the theme.
+message ReportProperties {
+  string title = 1;
+
+  string favicon = 2;
+}


### PR DESCRIPTION
Notably, this:
1) Extracts the set_favicon logic out of DeltaGenerator, so it e.g. won't show up on an st.sidebar call
2) Uses the Twitter emoji CDN instead of the hand-rolled SVG text approach
3) Sets up the framework for other kinds of report metadata (I'm calling "ReportProperties", thinking like page favicon/title/theme -- basically streamlit framework calls that don't update a specific Element/Widget)

Also, we probably want to discuss from a product perspective the distinction between `st.title` and `st.set_page_title`. I think ideally setting st.title would also set the page title, but that's not implemented atm.