### PR TITLE
Fix PollingFileWatcher tests

### DIFF
--- a/lib/tests/streamlit/watcher/PollingFileWatcher_test.py
+++ b/lib/tests/streamlit/watcher/PollingFileWatcher_test.py
@@ -39,47 +39,41 @@ class PollingFileWatcherTest(unittest.TestCase):
 
     def test_file_watch_and_callback(self):
         """Test that when a file is modified, the callback is called."""
-        cb_marker = mock.Mock()
-
-        def cb(x):
-            cb_marker()
+        callback = mock.Mock()
 
         self.mock_os.stat = lambda x: FakeStat(101)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "1"
 
-        ro = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", cb)
+        watcher = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", callback)
 
         try:
             time.sleep(2 * PollingFileWatcher._POLLING_PERIOD_SECS)
         except AssertionError:
             pass
-        cb_marker.assert_not_called()
+        callback.assert_not_called()
 
         self.mock_os.stat = lambda x: FakeStat(102)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "2"
 
         time.sleep(4 * PollingFileWatcher._POLLING_PERIOD_SECS)
-        cb_marker.assert_called_once()
+        callback.assert_called_once()
 
-        ro.close()
+        watcher.close()
 
     def test_callback_not_called_if_same_mtime(self):
         """Test that we ignore files with same mtime."""
-        cb_marker = mock.Mock()
-
-        def cb(x):
-            cb_marker()
+        callback = mock.Mock()
 
         self.mock_os.stat = lambda x: FakeStat(101)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "1"
 
-        ro = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", cb)
+        watcher = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", callback)
 
         try:
             time.sleep(2 * PollingFileWatcher._POLLING_PERIOD_SECS)
         except AssertionError:
             pass
-        cb_marker.assert_not_called()
+        callback.assert_not_called()
 
         # self.os.stat = lambda x: FakeStat(102)  # Same mtime!
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "2"
@@ -89,27 +83,24 @@ class PollingFileWatcherTest(unittest.TestCase):
             time.sleep(2 * PollingFileWatcher._POLLING_PERIOD_SECS)
         except AssertionError:
             pass
-        cb_marker.assert_not_called()
+        callback.assert_not_called()
 
-        ro.close()
+        watcher.close()
 
     def test_callback_not_called_if_same_md5(self):
         """Test that we ignore files with same md5."""
-        cb_marker = mock.Mock()
-
-        def cb(x):
-            cb_marker()
+        callback = mock.Mock()
 
         self.mock_os.stat = lambda x: FakeStat(101)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "1"
 
-        ro = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", cb)
+        watcher = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", callback)
 
         try:
             time.sleep(2 * PollingFileWatcher._POLLING_PERIOD_SECS)
         except AssertionError:
             pass
-        cb_marker.assert_not_called()
+        callback.assert_not_called()
 
         self.mock_os.stat = lambda x: FakeStat(102)
         # Same MD5:
@@ -120,9 +111,9 @@ class PollingFileWatcherTest(unittest.TestCase):
             time.sleep(2 * PollingFileWatcher._POLLING_PERIOD_SECS)
         except AssertionError:
             pass
-        cb_marker.assert_not_called()
+        callback.assert_not_called()
 
-        ro.close()
+        watcher.close()
 
     def test_multiple_watchers_same_file(self):
         """Test that we can have multiple watchers of the same file."""
@@ -147,23 +138,23 @@ class PollingFileWatcherTest(unittest.TestCase):
 
         modify_mock_file()
 
-        cb1 = mock.Mock()
-        cb2 = mock.Mock()
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
 
-        watcher1 = PollingFileWatcher.PollingFileWatcher(filename, cb1)
-        watcher2 = PollingFileWatcher.PollingFileWatcher(filename, cb2)
+        watcher1 = PollingFileWatcher.PollingFileWatcher(filename, callback1)
+        watcher2 = PollingFileWatcher.PollingFileWatcher(filename, callback2)
 
         sleep()
 
-        cb1.assert_not_called()
-        cb2.assert_not_called()
+        callback1.assert_not_called()
+        callback2.assert_not_called()
 
         # "Modify" our file
         modify_mock_file()
         sleep()
 
-        self.assertEqual(cb1.call_count, 1)
-        self.assertEqual(cb2.call_count, 1)
+        self.assertEqual(callback1.call_count, 1)
+        self.assertEqual(callback2.call_count, 1)
 
         # Close watcher1. Only watcher2's callback should be called after this.
         watcher1.close()
@@ -172,8 +163,8 @@ class PollingFileWatcherTest(unittest.TestCase):
         modify_mock_file()
         sleep()
 
-        self.assertEqual(cb1.call_count, 1)
-        self.assertEqual(cb2.call_count, 2)
+        self.assertEqual(callback1.call_count, 1)
+        self.assertEqual(callback2.call_count, 2)
 
         watcher2.close()
 
@@ -182,8 +173,8 @@ class PollingFileWatcherTest(unittest.TestCase):
 
         # Both watchers are now closed, so their callback counts
         # should not have increased.
-        self.assertEqual(cb1.call_count, 1)
-        self.assertEqual(cb2.call_count, 2)
+        self.assertEqual(callback1.call_count, 1)
+        self.assertEqual(callback2.call_count, 2)
 
 
 class FakeStat(object):

--- a/lib/tests/streamlit/watcher/PollingFileWatcher_test.py
+++ b/lib/tests/streamlit/watcher/PollingFileWatcher_test.py
@@ -30,7 +30,7 @@ class PollingFileWatcherTest(unittest.TestCase):
         self.util_patcher = mock.patch("streamlit.watcher.PollingFileWatcher.util")
         self.os_patcher = mock.patch("streamlit.watcher.PollingFileWatcher.os")
         self.mock_util = self.util_patcher.start()
-        self.os = self.os_patcher.start()
+        self.mock_os = self.os_patcher.start()
 
     def tearDown(self):
         super(PollingFileWatcherTest, self).tearDown()
@@ -44,7 +44,7 @@ class PollingFileWatcherTest(unittest.TestCase):
         def cb(x):
             cb_marker()
 
-        self.os.stat = lambda x: FakeStat(101)
+        self.mock_os.stat = lambda x: FakeStat(101)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "1"
 
         ro = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", cb)
@@ -55,7 +55,7 @@ class PollingFileWatcherTest(unittest.TestCase):
             pass
         cb_marker.assert_not_called()
 
-        self.os.stat = lambda x: FakeStat(102)
+        self.mock_os.stat = lambda x: FakeStat(102)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "2"
 
         time.sleep(4 * PollingFileWatcher._POLLING_PERIOD_SECS)
@@ -70,7 +70,7 @@ class PollingFileWatcherTest(unittest.TestCase):
         def cb(x):
             cb_marker()
 
-        self.os.stat = lambda x: FakeStat(101)
+        self.mock_os.stat = lambda x: FakeStat(101)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "1"
 
         ro = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", cb)
@@ -100,7 +100,7 @@ class PollingFileWatcherTest(unittest.TestCase):
         def cb(x):
             cb_marker()
 
-        self.os.stat = lambda x: FakeStat(101)
+        self.mock_os.stat = lambda x: FakeStat(101)
         self.mock_util.calc_md5_with_blocking_retries = lambda x: "1"
 
         ro = PollingFileWatcher.PollingFileWatcher("/this/is/my/file.py", cb)
@@ -111,7 +111,7 @@ class PollingFileWatcherTest(unittest.TestCase):
             pass
         cb_marker.assert_not_called()
 
-        self.os.stat = lambda x: FakeStat(102)
+        self.mock_os.stat = lambda x: FakeStat(102)
         # Same MD5:
         # self.mock_util.calc_md5_with_blocking_retries = lambda x: '2'
 
@@ -131,7 +131,7 @@ class PollingFileWatcherTest(unittest.TestCase):
         mod_count = [0]
 
         def modify_mock_file():
-            self.os.stat = lambda x: FakeStat(mod_count[0])
+            self.mock_os.stat = lambda x: FakeStat(mod_count[0])
             self.mock_util.calc_md5_with_blocking_retries = (
                 lambda x: "%d" % mod_count[0]
             )


### PR DESCRIPTION
PollingFileWatcher_test no longer relies on `time.sleep` or threads. These are now handled by mocks, so the tests should be deterministic (and faster!)

Fixes #132
