### PR TITLE
Remove remaining references to Python 2

### DIFF
--- a/lib/streamlit/ScriptRunner.py
+++ b/lib/streamlit/ScriptRunner.py
@@ -269,8 +269,8 @@ class ScriptRunner(object):
                 # Don't inherit any flags or "future" statements.
                 flags=0,
                 dont_inherit=1,
-                # Parameter not supported in Python2:
-                # optimize=-1,
+                # Use the default optimization options.
+                optimize=-1,
             )
 
         except BaseException as e:

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -107,21 +107,8 @@ def _get_signature(f):
 
 
 def _unwrap_decorated_func(f):
-    if hasattr(f, "func_closure"):
-        try:
-            # Python 2 way.
-            while getattr(f, "func_closure"):
-                contents = f.func_closure[0].cell_contents
-                if not callable(contents):
-                    break
-                f = contents
-            return f
-        except AttributeError:
-            pass
-
     if hasattr(f, "__wrapped__"):
         try:
-            # Python 3 way.
             while getattr(f, "__wrapped__"):
                 contents = f.__wrapped__
                 if not callable(contents):
@@ -131,6 +118,6 @@ def _unwrap_decorated_func(f):
         except AttributeError:
             pass
 
-    # Fall back to original function, though it's unlikely we'll reach 
+    # Fall back to original function, though it's unlikely we'll reach
     # this part of the code.
     return f

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -14,16 +14,10 @@
 
 import sys
 import unittest
+from io import StringIO
 
 import matplotlib
 from mock import patch
-
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
 
 from streamlit import bootstrap
 from streamlit import config


### PR DESCRIPTION
Fixes #1477 

The strings "Python 2" and "Python2" no longer appear in the codebase