### PR TITLE
Add slack notifications for nightly CircleCI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,9 +196,6 @@ workflows:
           flaky: true
           requires:
             - cypress-flaky-approval
-      - slack/status:
-          fail_only: true
-          failure_message: ":blobonfire: Nightly job has failed!"
 
   create-nightly-tag:
     triggers:
@@ -337,6 +334,15 @@ jobs:
             - ~/.nvm
             - ~/.cache
 
+      - slack/status:
+          fail_only: true
+          failure_message: ":blobonfire: Nightly job failed to release"
+          filters:
+            tags:
+              only: /^([0-9]+\.){3}dev[0-9]+/
+            branches:
+              ignore: /.*/
+
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").
   python-3-6:
@@ -390,6 +396,10 @@ jobs:
             git tag -a $TAG -m "Streamlit nightly $TAG"
             git push origin $TAG
 
+      - slack/status:
+          fail_only: true
+          failure_message: ":blobonfire: Nightly job failed to create a tag"
+
   nightly-release:
     docker:
       - image: circleci/python:3.8.1
@@ -439,6 +449,10 @@ jobs:
           name: upload to pypi
           command: |
             make distribute
+
+      - slack/status:
+          fail_only: true
+          failure_message: ":blobonfire: Nightly job failed to release"
 
   cypress:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,8 +335,7 @@ jobs:
             - ~/.cache
 
       - when:
-          condition:
-            - equal: [/^([0-9]+\.){3}dev[0-9]+/, <<pipeline.git.tag>>]
+          condition: <<pipeline.git.tag>>
           steps:
             - slack/status:
                 fail_only: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,7 @@ jobs:
 
       - slack/status:
           fail_only: true
+          failure_message: ":blobonfire: Nightly job has failed!"
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,10 +171,6 @@ workflows:
           filters:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/
-          jobs:
-            - slack/status:
-                fail_only: true
-                failure_message: ":blobonfire: Nightly job has failed!"
       - cypress: # Non flaky Cypress tests
           requires:
             - python-3-8
@@ -200,6 +196,9 @@ workflows:
           flaky: true
           requires:
             - cypress-flaky-approval
+      - slack/status:
+          fail_only: true
+          failure_message: ":blobonfire: Nightly job has failed!"
 
   create-nightly-tag:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2.1
-
+orbs:
+  slack: circleci/slack@3.4.2
 commands:
   pre-cache:
     steps:
@@ -332,6 +333,9 @@ jobs:
           paths:
             - ~/.nvm
             - ~/.cache
+
+      - slack/status:
+          fail_only: true
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
           steps:
             - slack/status:
                 fail_only: true
-                failure_message: ":blobonfire: Nightly job failed to release"
+                failure_message: ":blobonfire: Nightly job failed on unit tests"
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").
@@ -530,3 +530,10 @@ jobs:
 
       - store_artifacts: &store_snapshots
           path: frontend/cypress/snapshots
+
+      - when:
+          condition: <<pipeline.git.tag>>
+          steps:
+            - slack/status:
+                fail_only: true
+                failure_message: ":blobonfire: Nightly job failed on E2E tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,10 @@ workflows:
           filters:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/
+          jobs:
+            - slack/status:
+                fail_only: true
+                failure_message: ":blobonfire: Nightly job has failed!"
       - cypress: # Non flaky Cypress tests
           requires:
             - python-3-8
@@ -333,10 +337,6 @@ jobs:
           paths:
             - ~/.nvm
             - ~/.cache
-
-      - slack/status:
-          fail_only: true
-          failure_message: ":blobonfire: Nightly job has failed!"
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,14 +334,13 @@ jobs:
             - ~/.nvm
             - ~/.cache
 
-      - slack/status:
-          fail_only: true
-          failure_message: ":blobonfire: Nightly job failed to release"
-          filters:
-            tags:
-              only: /^([0-9]+\.){3}dev[0-9]+/
-            branches:
-              ignore: /.*/
+      - when:
+          condition:
+            - equal: [/^([0-9]+\.){3}dev[0-9]+/, <<pipeline.git.tag>>]
+          steps:
+            - slack/status:
+                fail_only: true
+                failure_message: ":blobonfire: Nightly job failed to release"
 
   # The following inherits from python-3-8. In a few cases, steps are skipped
   # based on the name of the current job (see, e.g., "Run frontend tests").

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -294,7 +294,6 @@ class ConfigTest(unittest.TestCase):
                 "s3.accessKeyId",
                 "s3.bucket",
                 "s3.keyPrefix",
-                "s3.profile",
                 "s3.region",
                 "s3.secretAccessKey",
                 "s3.url",

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -294,6 +294,7 @@ class ConfigTest(unittest.TestCase):
                 "s3.accessKeyId",
                 "s3.bucket",
                 "s3.keyPrefix",
+                "s3.profile",
                 "s3.region",
                 "s3.secretAccessKey",
                 "s3.url",


### PR DESCRIPTION
**Description:** Add slack notifications for nightly CircleCI failures with [slack orb](https://circleci.com/orbs/registry/orb/circleci/slack)

This fires slack notifications assuming all workflow jobs triggered with a tag are for nightly releases. 

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
