### PR TITLE
Implement Google Tag Manager

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -13,6 +13,18 @@
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}">
 
 <head>
+
+  <!-- Google Tag Manager -->
+  <script>(function (w, d, s, l, i) {
+      w[l] = w[l] || []; w[l].push({
+        'gtm.start':
+          new Date().getTime(), event: 'gtm.js'
+      }); var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-TXFLBCM');</script>
+  <!-- End Google Tag Manager -->
+
   <meta charset="utf-8">
   {{ metatags }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -109,6 +121,11 @@
 </head>
 
 <body class="wy-body-for-nav">
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TXFLBCM" height="0" width="0"
+      style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
   {% block extrabody %} {% endblock %}
   <div class="wy-grid-for-nav">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,6 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 
 html_theme_options = {
-    "analytics_id": "UA-122023594-3",
     "logo_only": True,
     "style_nav_header_background": "#ffffff",
 }


### PR DESCRIPTION
PR adds Google Tag Manager to the Sphinx template, removing the base Google Analytics tracking provided by the template. In the beginning, this will functionally have no change to data collected, but over time will help us better implement rules that inform how to optimize the docs for maximum usefulness