### PR TITLE
Combine GitHub links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@
   troubleshooting/index
   Frequently Asked Questions < https://github.com/streamlit/streamlit/wiki/FAQ>
   Community forum < https://discuss.streamlit.io/>
-  Source code & Issue tracker <https://github.com/streamlit/streamlit/>
+  Source code & issue tracker <https://github.com/streamlit/streamlit/>
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,7 @@
   troubleshooting/index
   Frequently Asked Questions < https://github.com/streamlit/streamlit/wiki/FAQ>
   Community forum < https://discuss.streamlit.io/>
-  Bug tracker <https://github.com/streamlit/streamlit/issues>
-  GitHub <https://github.com/streamlit/streamlit>
+  Source code & Issue tracker <https://github.com/streamlit/streamlit/>
 
 ```
 


### PR DESCRIPTION
With the addition of the Components docs, the left-nav is much longer. While this only saves a single line, it does remove the redundancy of having the same basic link right next to each other.