### PR TITLE
Update error handling for diffmazing_cropper

### DIFF
--- a/scripts/diffmazing_cropper.sh
+++ b/scripts/diffmazing_cropper.sh
@@ -21,29 +21,13 @@ then
 fi
 
 
-if [ $# -eq 0 ]
-then
-  echo ""
-  echo "Usage"
-  echo "  $0 <diff files to convert>"
-  echo ""
-  echo "Example"
-  echo "  $0 ~/downloads/*.diff.png"
-  echo ""
-  exit -1
-fi
-
-
-has_convert=$(command -v convert)
-if ! [ "$has_convert" ]
-then
+has_convert=$(command -v convert) || {
   echo ""
   echo "Missing dependency."
   echo "Please install ImageMagick first."
   echo ""
   exit -1
-fi
-
+}
 
 
 tmp_dir="$(mktemp -d -t streamlit_cropped_diffs-XXXXX)"


### PR DESCRIPTION
**Description:** 
Looks like usage check is duplicated.

`has_convert=$(command -v convert)` is failing silently instead of returning a value for the if else. Using or as an alternative to error handling

---

**Contribution License Agreement**

By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
