### PR TITLE
Remove doc and test for st.plotly_chart(matplotlib figure) since that…

### DIFF
--- a/lib/streamlit/DeltaGenerator.py
+++ b/lib/streamlit/DeltaGenerator.py
@@ -1314,13 +1314,9 @@ class DeltaGenerator(object):
         Parameters
         ----------
         figure_or_data : plotly.graph_objs.Figure, plotly.graph_objs.Data,
-            dict/list of plotly.graph_objs.Figure/Data, or
-            matplotlib.figure.Figure
+            dict/list of plotly.graph_objs.Figure/Data
 
             See https://plot.ly/python/ for examples of graph descriptions.
-
-            If a Matplotlib Figure, converts it to a Plotly figure and displays
-            it.
 
         width : int
             Deprecated. If != 0 (default), will show an alert.

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -558,24 +558,6 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         self.assertNotEqual(el.plotly_chart.figure.config, "")
         self.assertEqual(el.plotly_chart.use_container_width, True)
 
-    def test_st_plotly_chart_mpl(self):
-        """Test st.plotly_chart can handle Matplotlib figures."""
-        import matplotlib
-        import matplotlib.pyplot as plt
-
-        if matplotlib.get_backend().lower() != "agg":
-            plt.switch_backend("agg")
-
-        fig = plt.figure()
-        plt.plot([10, 20, 30])
-        st.plotly_chart(fig)
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.plotly_chart.HasField("url"), False)
-        self.assertNotEqual(el.plotly_chart.figure.spec, "")
-        self.assertNotEqual(el.plotly_chart.figure.config, "")
-        self.assertEqual(el.plotly_chart.use_container_width, False)
-
     def test_st_plotly_chart_sharing(self):
         """Test st.plotly_chart when sending data to Plotly's service."""
         import plotly.graph_objs as go


### PR DESCRIPTION
Remove doc and test for st.plotly_chart(matplotlib figure) since that's been deprecated by Plotly.

See https://github.com/plotly/plotly.py/issues/1568

Fixes CI tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
