### PR TITLE
Update DateInput to handle dates below 100

### DIFF
--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -122,4 +122,15 @@ describe("DateInput widget", () => {
       new Date("2030/02/06")
     )
   })
+
+  it("should handle dates with years less than 100", () => {
+    const props = getProps({
+      min: "0001/01/01",
+    })
+    const wrapper = shallow(<DateInput {...props} />)
+
+    expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
+      new Date("0001-01-01T00:00:00")
+    )
+  })
 })

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -123,13 +123,24 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("should handle dates with years less than 100", () => {
+  it("should handle min dates with years less than 100", () => {
     const props = getProps({
       min: "0001/01/01",
     })
     const wrapper = shallow(<DateInput {...props} />)
 
     expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
+      new Date("0001-01-01T00:00:00")
+    )
+  })
+
+  it("should handle max dates with years less than 100", () => {
+    const props = getProps({
+      max: "0001/01/01",
+    })
+    const wrapper = shallow(<DateInput {...props} />)
+
+    expect(wrapper.find(UIDatePicker).prop("maxDate")).toStrictEqual(
       new Date("0001-01-01T00:00:00")
     )
   })

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -41,6 +41,7 @@ interface State {
   isRange: boolean
 }
 
+// Date format for communication (protobuf) support
 const DATE_FORMAT = "YYYY/MM/DD"
 
 class DateInput extends React.PureComponent<Props, State> {

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -85,7 +85,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
     const style = { width }
     const label = element.get("label")
-    const minDate = new Date(element.get("min"))
+    const minDate = moment(element.get("min"), "YYYY/MM/DD").toDate()
     const maxDate = this.getMaxDate()
 
     return (

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -41,6 +41,8 @@ interface State {
   isRange: boolean
 }
 
+const DATE_FORMAT = "YYYY/MM/DD"
+
 class DateInput extends React.PureComponent<Props, State> {
   public state: State = {
     values: this.props.element
@@ -60,7 +62,7 @@ class DateInput extends React.PureComponent<Props, State> {
     this.props.widgetMgr.setStringArrayValue(
       widgetId,
       this.state.values.map((value: Date) =>
-        moment(value as Date).format("YYYY/MM/DD")
+        moment(value as Date).format(DATE_FORMAT)
       ),
       source
     )
@@ -76,7 +78,9 @@ class DateInput extends React.PureComponent<Props, State> {
     const { element } = this.props
     const maxDate = element.get("max")
 
-    return maxDate && maxDate.length > 0 ? new Date(maxDate) : undefined
+    return maxDate && maxDate.length > 0
+      ? moment(maxDate, DATE_FORMAT).toDate()
+      : undefined
   }
 
   public render = (): React.ReactNode => {
@@ -85,7 +89,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
     const style = { width }
     const label = element.get("label")
-    const minDate = moment(element.get("min"), "YYYY/MM/DD").toDate()
+    const minDate = moment(element.get("min"), DATE_FORMAT).toDate()
     const maxDate = this.getMaxDate()
 
     return (


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1616

**Description:**

The Date constructor makes assumptions based on the input string that are
inconsistent. When the year is set to below 100, it assumes the year is a
suffix of 19 or 20. (e.g. '0099' returns 1999 year and '0001' returns 2001
year).

This change avoids it by using moment to parse a specific syntax (YYYY/MM/DD) for both min and max dates

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
