### PR TITLE
Replace usages of mock with stdlib unittest.mock.

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -5,7 +5,6 @@ verify_ssl = true
 
 [dev-packages]
 flake8 = "*"
-mock = "*"
 mypy = "==0.761"
 mypy-protobuf = ">=1.17"
 parameterized = "*"

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -17,9 +17,8 @@ Global pytest fixtures. This file is automatically run by pytest before tests
 are executed.
 """
 
+from unittest.mock import patch, mock_open
 import os
-
-from mock import patch, mock_open
 
 # Do not import any Streamlit modules here! See below for details.
 

--- a/lib/tests/mock_storage.py
+++ b/lib/tests/mock_storage.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
 import hashlib
 
 import tornado.gen
-import mock
 
 from streamlit.storage.abstract_storage import AbstractStorage
 

--- a/lib/tests/server_test_case.py
+++ b/lib/tests/server_test_case.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
+
 import tornado.testing
 import tornado.web
 import tornado.websocket

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -15,9 +15,9 @@
 import sys
 import unittest
 from io import StringIO
+from unittest.mock import patch
 
 import matplotlib
-from mock import patch
 
 from streamlit import bootstrap
 from streamlit import config

--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 """st.caching unit tests."""
+from unittest.mock import patch
 import threading
 import unittest
 import pytest
 import types
-
-from mock import patch
 
 from streamlit import caching
 from streamlit import hashing

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -14,15 +14,15 @@
 
 """Unit tests for the Streamlit CLI."""
 
+from unittest import mock
+from unittest.mock import MagicMock, patch
 import unittest
 
 import os
 
 import requests
 import requests_mock
-import mock
 from click.testing import CliRunner
-from mock import patch, MagicMock
 from parameterized import parameterized
 from testfixtures import tempdir
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 """Config System Unittest."""
+from unittest.mock import MagicMock, mock_open, patch
 import copy
 import os
 import textwrap
 import unittest
 
 import pytest
-from mock import MagicMock
-from mock import mock_open
-from mock import patch
 from parameterized import parameterized
 
 from streamlit import config

--- a/lib/tests/streamlit/credentials_test.py
+++ b/lib/tests/streamlit/credentials_test.py
@@ -16,13 +16,10 @@
 import os
 import textwrap
 import unittest
-from parameterized import parameterized
+from unittest.mock import MagicMock, call, mock_open, patch
 
+from parameterized import parameterized
 import pytest
-from mock import MagicMock
-from mock import call
-from mock import mock_open
-from mock import patch
 
 from streamlit import file_util
 from streamlit import config

--- a/lib/tests/streamlit/data_frame_proto_test.py
+++ b/lib/tests/streamlit/data_frame_proto_test.py
@@ -14,6 +14,7 @@
 
 """Unit test for data_frame_proto."""
 
+from unittest.mock import patch
 import json
 import unittest
 
@@ -23,7 +24,6 @@ import pytest
 import streamlit.elements.data_frame_proto as data_frame_proto
 
 from google.protobuf import json_format
-from mock import patch
 from streamlit.proto.DataFrame_pb2 import AnyArray
 from streamlit.proto.DataFrame_pb2 import CSSStyle
 from streamlit.proto.DataFrame_pb2 import CellStyle

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -14,8 +14,8 @@
 
 """DeltaGenerator Unittest."""
 
+from unittest import mock
 import json
-import mock
 import unittest
 
 try:

--- a/lib/tests/streamlit/file_uploader_test.py
+++ b/lib/tests/streamlit/file_uploader_test.py
@@ -14,7 +14,7 @@
 
 """file_uploader unit test."""
 
-from mock import patch
+from unittest.mock import patch
 
 import streamlit as st
 from streamlit import config

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock
 import errno
 import os
 import pytest

--- a/lib/tests/streamlit/forward_msg_cache_test.py
+++ b/lib/tests/streamlit/forward_msg_cache_test.py
@@ -14,12 +14,11 @@
 
 """Unit tests for MessageCache"""
 
+from unittest.mock import MagicMock
 import unittest
 
-from mock import MagicMock
-
-from streamlit import report_session
 from streamlit import config
+from streamlit import report_session
 from streamlit.forward_msg_cache import ForwardMsgCache
 from streamlit.forward_msg_cache import create_reference_msg
 from streamlit.forward_msg_cache import populate_hash_if_needed

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -29,6 +29,7 @@ import unittest
 import urllib
 from io import BytesIO
 from io import StringIO
+from unittest.mock import patch, MagicMock
 
 import altair.vegalite.v3
 import numpy as np
@@ -36,7 +37,6 @@ import pandas as pd
 import pytest
 import sqlalchemy as db
 import torch
-from mock import patch, MagicMock
 from parameterized import parameterized
 
 try:

--- a/lib/tests/streamlit/keras_test.py
+++ b/lib/tests/streamlit/keras_test.py
@@ -14,8 +14,8 @@
 
 """Keras unit test."""
 
+from unittest.mock import patch
 import unittest
-from mock import patch
 
 try:
     from tensorflow.python.keras.utils import vis_utils

--- a/lib/tests/streamlit/media_file_manager_test.py
+++ b/lib/tests/streamlit/media_file_manager_test.py
@@ -14,8 +14,8 @@
 
 """Unit tests for MediaFileManager"""
 
+from unittest import mock
 import unittest
-import mock
 import random
 import time
 

--- a/lib/tests/streamlit/metrics_test.py
+++ b/lib/tests/streamlit/metrics_test.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 """Metrics Module Unittest."""
+from unittest.mock import call, patch
 import unittest
 
 import pytest
 
 import streamlit.metrics
-
-from mock import call, patch
-
 from streamlit import config
 
 

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
 import unittest
 
 import tornado.gen
 import tornado.testing
-from mock import MagicMock, patch
 
 from streamlit.report_session import ReportSession
 from streamlit.report_session import ReportSessionState

--- a/lib/tests/streamlit/report_test.py
+++ b/lib/tests/streamlit/report_test.py
@@ -14,10 +14,10 @@
 
 """Unit tests for Report.py."""
 
+from unittest.mock import patch
 import copy
 import unittest
 
-from mock import patch
 from parameterized import parameterized
 
 from streamlit import config

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -14,16 +14,15 @@
 
 """Server.py unit tests"""
 
+from unittest import mock
+from unittest.mock import MagicMock, patch
 import unittest
 
-import mock
 import pytest
 import tornado.testing
 import tornado.web
 import tornado.websocket
 import errno
-from mock import MagicMock
-from mock import patch
 from tornado import gen
 
 import streamlit.server.server

--- a/lib/tests/streamlit/show_test.py
+++ b/lib/tests/streamlit/show_test.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
 import unittest
 
-from mock import patch
 from parameterized import parameterized
 
 import streamlit as st

--- a/lib/tests/streamlit/storage/s3_storage_test.py
+++ b/lib/tests/streamlit/storage/s3_storage_test.py
@@ -16,10 +16,9 @@
 
 Copyright 2019 Streamlit Inc. All rights reserved.
 """
+from unittest.mock import patch
 import hashlib
 import unittest
-
-from mock import patch
 
 from streamlit.storage.s3_storage import S3Storage
 from streamlit.config import set_option

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -15,7 +15,7 @@
 """Streamlit Unit test."""
 from io import BytesIO
 
-from mock import patch
+from unittest.mock import patch
 import json
 import os
 import io

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -14,8 +14,8 @@
 
 import unittest
 from collections import namedtuple
+from unittest.mock import patch
 
-from mock import patch
 import plotly.graph_objs as go
 
 from streamlit import type_util

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -14,9 +14,9 @@
 
 import random
 import unittest
-from mock import patch
-from parameterized import parameterized
+from unittest.mock import patch
 
+from parameterized import parameterized
 
 from streamlit import util
 

--- a/lib/tests/streamlit/version_test.py
+++ b/lib/tests/streamlit/version_test.py
@@ -14,9 +14,9 @@
 
 """version unit test."""
 
+from unittest import mock
 import unittest
 
-import mock
 import requests_mock
 from packaging.version import Version as PkgVersion
 

--- a/lib/tests/streamlit/watcher/event_based_file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_file_watcher_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import unittest
-import mock
+from unittest import mock
+
 from watchdog import events
 
 from streamlit.watcher import event_based_file_watcher

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -71,7 +71,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         lso = local_sources_watcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
-        args = fob.call_args.args
+        args, _ = fob.call_args
         self.assertEqual(args[0], REPORT_PATH)
         method_type = type(self.setUp)
         self.assertEqual(type(args[1]), method_type)
@@ -107,12 +107,12 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         call_args_list = sort_args_list(fob.call_args_list)
 
-        args = call_args_list[0].args
+        args, _ = call_args_list[0]
         self.assertTrue("__init__.py" in args[0])
-        args = call_args_list[1].args
+        args, _ = call_args_list[1]
         self.assertEqual(args[0], DUMMY_MODULE_1_FILE)
         self.assertEqual(type(args[1]), method_type)
-        args = call_args_list[2].args
+        args, _ = call_args_list[2]
         self.assertEqual(args[0], DUMMY_MODULE_2_FILE)
         self.assertEqual(type(args[1]), method_type)
 
@@ -138,10 +138,10 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         call_args_list = sort_args_list(fob.call_args_list)
 
-        args = call_args_list[0].args
+        args, _ = call_args_list[0]
         self.assertTrue("__init__.py" in args[0])
 
-        args = call_args_list[1].args
+        args, _ = call_args_list[1]
         self.assertEqual(args[0], DUMMY_MODULE_1_FILE)
         self.assertEqual(type(args[1]), method_type)
 
@@ -149,7 +149,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         fob.reset_mock()
         lso.update_watched_modules()
 
-        args = fob.call_args.args
+        args, _ = fob.call_args
         self.assertEqual(args[0], DUMMY_MODULE_2_FILE)
         self.assertEqual(type(args[1]), method_type)
 

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -14,11 +14,10 @@
 
 """streamlit.LocalSourcesWatcher unit test."""
 
+from unittest.mock import patch
 import os
 import sys
 import unittest
-
-from mock import patch
 
 from streamlit import config
 from streamlit.report import Report

--- a/lib/tests/streamlit/watcher/polling_file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_file_watcher_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import time
 import unittest
 

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 import unittest
 
 from streamlit.watcher import util

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -14,8 +14,8 @@
 
 """Streamlit Unit test."""
 
-from mock import call, patch, Mock
 from collections import namedtuple
+from unittest.mock import call, patch, Mock
 
 import time
 import unittest


### PR DESCRIPTION
It looks like streamlit claims python_requires>=3.6,
so all versions should have this available.

I didn't see mock listed in test-requirements previously, just in the dev section of the Pipfile -- though to be honest I didn't run the steps I now see in contributing, I just created a dev environment for streamlit same as any other package, and in the process of another more useful thing I was going to contribute, saw that mock wasn't installed except by "accident" because other deps depend on it.

Hopefully this makes sense, though obviously if it isn't desired no worries.