### PR TITLE
Update mono### overrides for sidebar to more specific theme overrides

### DIFF
--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -512,26 +512,62 @@ const themeOverrides = {
 
 export const mainWidgetTheme = createTheme(mainThemePrimitives, themeOverrides)
 
-export const sidebarWidgetTheme = createTheme(
-  {
-    ...mainThemePrimitives,
-
+export const sidebarWidgetTheme = createTheme(mainThemePrimitives, {
+  ...themeOverrides,
+  colors: {
+    ...themeOverrides.colors,
     // Override gray values based on what is actually used in BaseWeb, and the
     // way we want it to match our Bootstrap theme.
-    mono100: white, // Popup menu
-    mono200: white, // Text input, text area, selectbox
-    mono300: white, // Disabled widget background
-    mono400: grayLight, // Slider track
+    // mono100 overrides
+    datepickerBackground: white,
+    calendarBackground: white,
+    tickFill: white,
+    tickMarkFillDisabled: white,
+    menuFill: white,
+    tagNeutralSolidFont: white,
+    tableHeadBackgroundColor: white,
+    tableBackground: white,
+    tableFilterBackground: white,
+    tooltipText: white,
+
+    // mono200 overrides
+    buttonDisabledFill: white,
+    fileUploaderBackgroundColor: white,
+    listBodyFill: white,
+    tickFillHover: white,
+    inputFillDisabled: white,
+    inputFillActive: white,
+    menuFillHover: white,
+    tabBarFill: white,
+    tagNeutralSolidDisabled: white,
+    tagNeutralLightDisabled: white,
+    tagNeutralOutlinedDisabled: white,
+    tagNeutralOutlinedFontHover: white,
+    tableStripedBackground: white,
+    tableFilterFooterBackground: white,
+
+    // mono300 overrides
+    toggleTrackFillDisabled: white,
+    tickFillActive: white,
+    sliderTrackFillDisabled: white,
+    inputBorder: white,
+    inputFill: white,
+    inputEnhanceFill: white,
+    inputEnhancerFillDisabled: white,
+    tagNeutralSolidHover: white,
+    tagNeutralLightBackground: white,
+    tagNeutralLightHover: white,
+
+    // mono400 overrides
+    buttonDisabledSpinnerBackground: grayLight,
+    toggleTrackFill: grayLight,
+    sliderTrackFill: grayLight,
+    sliderHandleInnerFill: grayLight,
+    sliderHandleInnerFillDisabled: grayLight,
+    tagNeutralSolidActive: grayLight,
+    tagNeutralLightActive: grayLight,
   },
-  {
-    ...themeOverrides,
-    colors: {
-      ...themeOverrides.colors,
-      inputFill: white,
-      inputFillActive: white,
-    },
-  }
-)
+})
 
 // Log the widget theme just for debug purposes.
 logMessage("mainWidgetTheme", mainWidgetTheme)

--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -531,7 +531,6 @@ export const sidebarWidgetTheme = createTheme(mainThemePrimitives, {
     tickFillHover: white,
     inputFillDisabled: white,
     inputFillActive: white,
-    menuFillHover: white,
 
     // mono300 overrides
     toggleTrackFillDisabled: white,

--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -524,27 +524,14 @@ export const sidebarWidgetTheme = createTheme(mainThemePrimitives, {
     tickFill: white,
     tickMarkFillDisabled: white,
     menuFill: white,
-    tagNeutralSolidFont: white,
-    tableHeadBackgroundColor: white,
-    tableBackground: white,
-    tableFilterBackground: white,
-    tooltipText: white,
 
     // mono200 overrides
     buttonDisabledFill: white,
     fileUploaderBackgroundColor: white,
-    listBodyFill: white,
     tickFillHover: white,
     inputFillDisabled: white,
     inputFillActive: white,
     menuFillHover: white,
-    tabBarFill: white,
-    tagNeutralSolidDisabled: white,
-    tagNeutralLightDisabled: white,
-    tagNeutralOutlinedDisabled: white,
-    tagNeutralOutlinedFontHover: white,
-    tableStripedBackground: white,
-    tableFilterFooterBackground: white,
 
     // mono300 overrides
     toggleTrackFillDisabled: white,
@@ -554,9 +541,6 @@ export const sidebarWidgetTheme = createTheme(mainThemePrimitives, {
     inputFill: white,
     inputEnhanceFill: white,
     inputEnhancerFillDisabled: white,
-    tagNeutralSolidHover: white,
-    tagNeutralLightBackground: white,
-    tagNeutralLightHover: white,
 
     // mono400 overrides
     buttonDisabledSpinnerBackground: grayLight,
@@ -564,8 +548,6 @@ export const sidebarWidgetTheme = createTheme(mainThemePrimitives, {
     sliderTrackFill: grayLight,
     sliderHandleInnerFill: grayLight,
     sliderHandleInnerFillDisabled: grayLight,
-    tagNeutralSolidActive: grayLight,
-    tagNeutralLightActive: grayLight,
   },
 })
 


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/220

**Description:**
The `mono###` variables were generically overridden in the sidebar. While it may worked, we started seeing some pieces of UI show visual degradation. Specifically, the issue references the select box hover color being non-existent. This PR will address that. I recommend looking at each commit specifically to identify what I did. I did the following:

1. I looked at Base UI's [Light Theme Variables](https://github.com/uber/baseweb/blob/v9.71.0/src/themes/light-theme/color-component-tokens.js) specifically from 9.71.0 (as identified by the [yarn.lock file](https://github.com/streamlit/streamlit/blob/develop/frontend/yarn.lock#L3993)) to identify all use cases of `mono100`, `mono200`, `mono300`, and `mono400` and replaced them all with the theme overrides in the `widgetTheme.ts`.
2. I then removed the theme overrides for components we do not use as I think we should decide on look and feel _before_ adding them into the project.
3. I then removed the culprit theme variable to the issue. In this case, the `menuFillHover`.

**UI Changes**

**Main Streamlit Select Box (Unchanged)**
![Main Streamlit Select Box](https://user-images.githubusercontent.com/69432/88350623-7daacf00-cd08-11ea-929c-cd26d25fa8cd.png)

**Sidebar Streamlit Select Box (Changed)**

![Sidebar Streamlit Select Box](https://user-images.githubusercontent.com/69432/88350674-a5019c00-cd08-11ea-9b46-89fdd559a94d.png)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
