### PR TITLE
Implement st.stop() functionality

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -148,6 +148,14 @@ With widgets, Streamlit allows you to bake interactivity directly into your apps
 .. autofunction:: streamlit.beta_color_picker
 ```
 
+## Control Flow
+
+By default, Streamlit apps execute the script entirely, but we allow some functionality to handle control flow in your applications.
+
+```eval_rst
+.. autofunction:: streamlit.stop
+```
+
 ## Add widgets to sidebar
 
 Not only can you add interactivity to your report with widgets, you can organize them into a sidebar with `st.sidebar.[element_name]`. Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app. The only elements that aren't supported are: `st.write` (you

--- a/e2e/scripts/st_stop.py
+++ b/e2e/scripts/st_stop.py
@@ -1,0 +1,21 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+st.text("Text before stop")
+
+st.stop()
+
+st.text("Text after stop")

--- a/e2e/scripts/st_stop.py
+++ b/e2e/scripts/st_stop.py
@@ -16,6 +16,9 @@ import streamlit as st
 
 st.text("Text before stop")
 
-st.stop()
+# Since st.stop() throws an intentional exception, we want this to run
+# only in streamlit
+if st._is_running_with_streamlit:
+    st.stop()
 
 st.text("Text after stop")

--- a/e2e/specs/st_stop.spec.ts
+++ b/e2e/specs/st_stop.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="cypress" />
+
+describe("st.stop", () => {
+  before(() => {
+    cy.visit("http://localhost:3000/");
+  });
+
+  it("displays only one piece of text", () => {
+    cy.get(".element-container .stText").should("have.length", 1);
+  });
+
+  it("displays text before stop", () => {
+    cy.get(".element-container .stText").should("contain", "Text before stop");
+  });
+});

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -103,6 +103,7 @@ from streamlit import type_util as _type_util
 from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
 from streamlit.report_thread import add_report_ctx as _add_report_ctx
 from streamlit.report_thread import get_report_ctx as _get_report_ctx
+from streamlit.script_runner import StopException
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import BlockPath_pb2 as _BlockPath_pb2
 from streamlit.proto import ForwardMsg_pb2 as _ForwardMsg_pb2
@@ -701,3 +702,18 @@ def _maybe_print_repl_warning():
                 ),
                 script_name,
             )
+
+def stop():
+    """Stops excecution immediately. Streamlit will not run any statements
+    after `st.stop()`. We recommend rendering a message prior to calling this
+    to indicate the execution has stopped and why.
+
+    Example
+    -------
+
+    >>> st.write('This string will be written')
+    >>> st.stop()
+    >>> st.write('This string will NOT be written')
+
+    """
+    raise StopException()

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -703,10 +703,12 @@ def _maybe_print_repl_warning():
                 script_name,
             )
 
+
 def stop():
     """Stops excecution immediately. Streamlit will not run any statements
     after `st.stop()`. We recommend rendering a message prior to calling this
-    to indicate the execution has stopped and why.
+    to indicate the execution has stopped and why. When run outside of
+    Streamlit, it will raise an Exception
 
     Example
     -------

--- a/lib/tests/streamlit/stop_test.py
+++ b/lib/tests/streamlit/stop_test.py
@@ -1,0 +1,24 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from tests import testutil
+from streamlit.script_runner import StopException
+import streamlit as st
+
+
+class StopTest(testutil.DeltaGeneratorTestCase):
+    def test_stop(self):
+        with pytest.raises(StopException) as exc_message:
+            st.stop()


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/168

**Description:** 
Implements an `st.stop()` functionality including unit and e2e tests.

**Docs**
Stops excecution immediately. Streamlit will not run any statements
after `st.stop()`. We recommend rendering a message prior to calling this
to indicate the execution has stopped and why.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
