### PR TITLE
Make log messages configurable

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -118,7 +118,7 @@ _is_running_with_streamlit = False
 
 
 def _update_logger():
-    _logger.set_log_level(_config.get_option("logger.logLevel").upper())
+    _logger.set_log_level(_config.get_option("logger.level").upper())
     _logger.update_formatter()
     _logger.init_tornado_logs()
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -117,15 +117,16 @@ from streamlit.caching import cache as cache  # noqa: F401
 _is_running_with_streamlit = False
 
 
-def _set_log_level():
-    _logger.set_log_level(_config.get_option("global.logLevel").upper())
+def _update_logger():
+    _logger.set_log_level(_config.get_option("logger.logLevel").upper())
+    _logger.setup_formatter(_LOGGER)
     _logger.init_tornado_logs()
 
 
 # Make this file only depend on config option in an asynchronous manner. This
 # avoids a race condition when another file (such as a test file) tries to pass
 # in an alternative config.
-_config.on_config_parsed(_set_log_level, True)
+_config.on_config_parsed(_update_logger, True)
 
 
 _main = _DeltaGenerator(container=_BlockPath_pb2.BlockPath.MAIN)

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -119,7 +119,7 @@ _is_running_with_streamlit = False
 
 def _update_logger():
     _logger.set_log_level(_config.get_option("logger.logLevel").upper())
-    _logger.setup_formatter(_LOGGER)
+    _logger.update_formatter()
     _logger.init_tornado_logs()
 
 

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -55,7 +55,7 @@ def _convert_config_option_to_click_option(config_option):
     description = config_option.description
     if config_option.deprecated:
         description += "\n {} - {}".format(
-            config_option.deprecation_text, config_option.deprecation_date
+            config_option.deprecation_text, config_option.expiration_date
         )
     envvar = "STREAMLIT_{}".format(to_snake_case(param).upper())
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -317,7 +317,10 @@ def _logger_log_level():
 
     Default: 'info'
     """
-    if get_option("global.developmentMode"):
+
+    if get_option("global.logLevel"):
+        return get_option("global.logLevel")
+    elif get_option("global.developmentMode"):
         return "debug"
     else:
         return "info"
@@ -326,7 +329,9 @@ def _logger_log_level():
 @_create_option("logger.messageFormat", type_=str)
 def _logger_message_format():
     """String format for logging messages. If logger.datetimeFormat is set,
-    logger messages will default to `%(asctime)s.%(msecs)03d %(message)s`
+    logger messages will default to `%(asctime)s.%(msecs)03d %(message)s`. See
+    [Python's documentation](https://docs.python.org/2.6/library/logging.html#formatter-objects)
+    for available attributes.
 
     Default: None
     """

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -327,7 +327,7 @@ def _logger_message_format():
 
         return DEFAULT_LOG_MESSAGE
     else:
-        return "%(asctime)s.%(msecs)03d %(message)s"
+        return "%(asctime)s %(message)s"
 
 
 # Config Section: Client #

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -243,9 +243,9 @@ _create_option(
     Default: 'info'
     """,
     deprecated=True,
-    deprecation_text="global.logLevel has been replaced with logger.logLevel",
-    expiration_date="2020-10-31",
-    replaced_by="logger.logLevel",
+    deprecation_text="global.logLevel has been replaced with logger.level",
+    expiration_date="2020-11-30",
+    replaced_by="logger.level",
 )
 
 
@@ -298,20 +298,7 @@ _create_option(
 _create_section("logger", "Settings to customize Streamlit log messages.")
 
 
-@_create_option("logger.datetimeFormat", type_=str)
-def _logger_datetime_format():
-    """Datetime format for date in logger message. Providing a datetime format
-    will automatically add a timestamp to all logger messages.
-
-    Default: None
-    """
-    if get_option("global.developmentMode"):
-        return "%Y-%m-%dT%H:%M:%SZ"
-    else:
-        return None
-
-
-@_create_option("logger.logLevel", type_=str)
+@_create_option("logger.level", type_=str)
 def _logger_log_level():
     """Level of logging: 'error', 'warning', 'info', or 'debug'.
 
@@ -336,11 +323,11 @@ def _logger_message_format():
     Default: None
     """
     if get_option("global.developmentMode"):
-        return "%(asctime)s.%(msecs)03d %(levelname) -7s " "%(name)s: %(message)s"
-    elif get_option("logger.datetimeFormat"):
-        return "%(asctime)s.%(msecs)03d %(message)s"
+        from streamlit.logger import DEFAULT_LOG_MESSAGE
+
+        return DEFAULT_LOG_MESSAGE
     else:
-        return None
+        return "%(asctime)s.%(msecs)03d %(message)s"
 
 
 # Config Section: Client #
@@ -869,7 +856,7 @@ def _set_option(key, value, where_defined):
     Parameters
     ----------
     key : str
-        The key of the option, like "logger.logLevel".
+        The key of the option, like "logger.level".
     value
         The value of the option.
     where_defined : str

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -19,9 +19,7 @@ import re
 import textwrap
 from typing import Any, Callable, Optional
 
-from streamlit.logger import get_logger
-
-LOGGER = get_logger(__name__)
+from streamlit.errors import DeprecationError
 
 
 class ConfigOption(object):
@@ -259,6 +257,9 @@ class ConfigOption(object):
                     % details
                 )
             else:
+                from streamlit.logger import get_logger
+
+                LOGGER = get_logger(__name__)
                 LOGGER.warning(
                     textwrap.dedent(
                         """
@@ -288,11 +289,3 @@ class ConfigOption(object):
 def _parse_yyyymmdd_str(date_str: str) -> datetime.datetime:
     year, month, day = [int(token) for token in date_str.split("-", 2)]
     return datetime.datetime(year, month, day)
-
-
-class Error(Exception):
-    pass
-
-
-class DeprecationError(Error):
-    pass

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 
+class Error(Exception):
+    pass
+
+
+class DeprecationError(Error):
+    pass
+
+
 class NoStaticFiles(Exception):
     pass
 

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -65,13 +65,12 @@ def setup_formatter(logger):
 
     logger.streamlit_console_handler = logging.StreamHandler()
 
-    if development.is_development_mode:
-        logging.Formatter.converter = time.gmtime
-        formatter = logging.Formatter(
-            fmt=("%(asctime)s.%(msecs)03d %(levelname) -7s " "%(name)s: %(message)s"),
-            datefmt="%Y-%m-%dT%H:%M:%SZ",
-        )
-        logger.streamlit_console_handler.setFormatter(formatter)
+    logging.Formatter.converter = time.gmtime
+    formatter = logging.Formatter(
+        fmt=("%(asctime)s.%(msecs)03d %(levelname) -7s " "%(name)s: %(message)s"),
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+    )
+    logger.streamlit_console_handler.setFormatter(formatter)
 
     # Register the new console logger.
     logger.addHandler(logger.streamlit_console_handler)

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -78,6 +78,11 @@ def setup_formatter(logger):
     logger.addHandler(logger.streamlit_console_handler)
 
 
+def update_formatter():
+    for log in LOGGERS.values():
+        setup_formatter(log)
+
+
 def init_tornado_logs():
     """Initialize tornado logs."""
     global LOGGER

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -20,7 +20,9 @@ import sys
 import time
 from typing import Dict
 
+from streamlit.config import get_option as get_config_option
 from streamlit import development
+
 
 # Loggers for each name are saved here.
 LOGGERS = {}  # type: Dict[str, logging.Logger]
@@ -65,11 +67,11 @@ def setup_formatter(logger):
 
     logger.streamlit_console_handler = logging.StreamHandler()
 
-    logging.Formatter.converter = time.gmtime
-    formatter = logging.Formatter(
-        fmt=("%(asctime)s.%(msecs)03d %(levelname) -7s " "%(name)s: %(message)s"),
-        datefmt="%Y-%m-%dT%H:%M:%SZ",
-    )
+    message_format = get_config_option("logger.messageFormat")
+    datetime_format = get_config_option("logger.datetimeFormat")
+    if datetime_format:
+        logging.Formatter.converter = time.gmtime
+    formatter = logging.Formatter(fmt=message_format, datefmt=datetime_format,)
     logger.streamlit_console_handler.setFormatter(formatter)
 
     # Register the new console logger.

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -29,9 +29,7 @@ LOGGERS = {}  # type: Dict[str, logging.Logger]
 # The global log level is set here across all names.
 LOG_LEVEL = logging.INFO
 
-DEFAULT_LOG_MESSAGE = (
-    "%(asctime)s.%(msecs)03d %(levelname) -7s " "%(name)s: %(message)s"
-)
+DEFAULT_LOG_MESSAGE = "%(asctime)s %(levelname) -7s " "%(name)s: %(message)s"
 
 
 def set_log_level(level):
@@ -79,6 +77,7 @@ def setup_formatter(logger):
     else:
         message_format = DEFAULT_LOG_MESSAGE
     formatter = logging.Formatter(fmt=message_format)
+    formatter.default_msec_format = "%s.%03d"
     logger.streamlit_console_handler.setFormatter(formatter)
 
     # Register the new console logger.

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -191,7 +191,7 @@ class CliTest(unittest.TestCase):
             "server_headless": True,
             "browser_serverAddress": "localhost",
             "global_minCachedMessageSize": None,
-            "logger_logLevel": "error",
+            "logger_level": "error",
         }
 
         _apply_config_options_from_cli(kwargs)
@@ -212,7 +212,7 @@ class CliTest(unittest.TestCase):
                     "command-line argument or environment variable",
                 ),
                 mock.call(
-                    "logger.logLevel",
+                    "logger.level",
                     "error",
                     "command-line argument or environment variable",
                 ),

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -191,7 +191,7 @@ class CliTest(unittest.TestCase):
             "server_headless": True,
             "browser_serverAddress": "localhost",
             "global_minCachedMessageSize": None,
-            "global_logLevel": "error",
+            "logger_logLevel": "error",
         }
 
         _apply_config_options_from_cli(kwargs)
@@ -212,7 +212,7 @@ class CliTest(unittest.TestCase):
                     "command-line argument or environment variable",
                 ),
                 mock.call(
-                    "global.logLevel",
+                    "logger.logLevel",
                     "error",
                     "command-line argument or environment variable",
                 ),

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -259,6 +259,7 @@ class ConfigTest(unittest.TestCase):
                 "client",
                 "deprecation",
                 "global",
+                "logger",
                 "mapbox",
                 "runner",
                 "s3",
@@ -287,6 +288,9 @@ class ConfigTest(unittest.TestCase):
                 "global.showWarningOnDirectExecution",
                 "global.suppressDeprecationWarnings",
                 "global.unitTest",
+                "logger.datetimeFormat",
+                "logger.logLevel",
+                "logger.messageFormat",
                 "runner.magicEnabled",
                 "runner.installTracer",
                 "runner.fixMatplotlib",
@@ -353,12 +357,13 @@ class ConfigTest(unittest.TestCase):
             "server.port does not work when global.developmentMode is true.",
         )
 
-    def test_check_conflicts_server_csrf(self):
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_server_csrf(self, get_logger):
         config._set_option("server.enableXsrfProtection", True, "test")
         config._set_option("server.enableCORS", True, "test")
-        with patch("streamlit.config.LOGGER") as patched_logger:
-            config._check_conflicts()
-            patched_logger.warning.assert_called_once()
+        mock_logger = get_logger()
+        config._check_conflicts()
+        mock_logger.warning.assert_called_once()
 
     def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")
@@ -517,11 +522,11 @@ class ConfigTest(unittest.TestCase):
 
     def test_global_log_level_debug(self):
         config.set_option("global.developmentMode", True)
-        self.assertEqual("debug", config.get_option("global.logLevel"))
+        self.assertEqual("debug", config.get_option("logger.logLevel"))
 
     def test_global_log_level(self):
         config.set_option("global.developmentMode", False)
-        self.assertEqual("info", config.get_option("global.logLevel"))
+        self.assertEqual("info", config.get_option("logger.logLevel"))
 
     @parameterized.expand([(True, True), (True, False), (False, False), (False, True)])
     def test_on_config_parsed(self, config_parsed, connect_signal):

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -286,8 +286,7 @@ class ConfigTest(unittest.TestCase):
                 "global.showWarningOnDirectExecution",
                 "global.suppressDeprecationWarnings",
                 "global.unitTest",
-                "logger.datetimeFormat",
-                "logger.logLevel",
+                "logger.level",
                 "logger.messageFormat",
                 "runner.magicEnabled",
                 "runner.installTracer",
@@ -520,11 +519,11 @@ class ConfigTest(unittest.TestCase):
 
     def test_global_log_level_debug(self):
         config.set_option("global.developmentMode", True)
-        self.assertEqual("debug", config.get_option("logger.logLevel"))
+        self.assertEqual("debug", config.get_option("logger.level"))
 
     def test_global_log_level(self):
         config.set_option("global.developmentMode", False)
-        self.assertEqual("info", config.get_option("logger.logLevel"))
+        self.assertEqual("info", config.get_option("logger.level"))
 
     @parameterized.expand([(True, True), (True, False), (False, False), (False, True)])
     def test_on_config_parsed(self, config_parsed, connect_signal):

--- a/lib/tests/streamlit/logger_test.py
+++ b/lib/tests/streamlit/logger_test.py
@@ -18,7 +18,7 @@ import logging
 import unittest
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 
 from streamlit import logger


### PR DESCRIPTION
**Issue:** #447 

**Description:**
We currently show the timestamp in our logging message for development mode. This is a nice feature that users would like as well. Making this publicly accessible through a series of config options. 

Timestamp is required to be configurable to [prevent double timestamps in S4A](https://github.com/streamlit/s4t/pull/227).

This change also deprecates `global.logLevel` in favor of `logger.logLevel`, ending support for it in October 31, 2020

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
