### PR TITLE
Pin pandas to < 1.1.0

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -38,7 +38,10 @@ click = ">=7.0"
 enum-compat = "*"
 numpy = "*"
 packaging = "*"
-pandas = ">=0.21.0"
+# pandas 1.1.0 has breaking changes to its styling code. We're temporarily
+# pinning to < 1.1.0, and have an open issue to fix this here:
+# https://github.com/streamlit/streamlit/issues/1777
+pandas = ">=0.21.0, <1.1.0"
 pillow = ">=6.2.0"
 protobuf = ">=3.6.0"
 pyarrow = "*"


### PR DESCRIPTION
pandas 1.1.0 has breaking changes to its styling code. 

We're temporarily pinning to < 1.1.0, and have an open issue to fix this here: 
https://github.com/streamlit/streamlit/issues/1777