### PR TITLE
Deprecate st.image format in favor of output_format

### DIFF
--- a/e2e/scripts/st_image.py
+++ b/e2e/scripts/st_image.py
@@ -15,5 +15,18 @@
 import streamlit as st
 import numpy as np
 
+st.set_option("deprecation.showImageFormat", True)
 img = np.repeat(0, 10000).reshape(100, 100)
-st.image(img, caption="Black Square")
+st.image(img, caption="Black Square with deprecated format", format="JPEG", width=100)
+
+st.set_option("deprecation.showImageFormat", False)
+st.image(img, caption="Black Square with deprecated format", format="JPEG", width=100)
+
+st.image(img, caption="Black Square as JPEG", output_format="JPEG", width=100)
+
+st.image(img, caption="Black Square as PNG", output_format="PNG", width=100)
+
+st.image(img, caption="Black Square with no output format specified", width=100)
+
+transparent_img = np.zeros((100, 100, 4), dtype=np.uint8)
+st.image(transparent_img, caption="Transparent Black Square", width=100)

--- a/e2e/specs/st_image.spec.ts
+++ b/e2e/specs/st_image.spec.ts
@@ -34,4 +34,48 @@ describe("st.image", () => {
       "Black Square"
     );
   });
+
+  it("shows deprecation warning", () => {
+    cy.get(".stImage")
+      .first()
+      .closest(".element-container")
+      .prev()
+      .should("contain", "ImageFormatWarning");
+  });
+
+  it("hides deprecation warning", () => {
+    cy.get(".stImage")
+      .eq(1)
+      .closest(".element-container")
+      .prev()
+      .should("not.contain", "ImageFormatWarning");
+  });
+
+  it("displays a JPEG image when specified", () => {
+    cy.get(".element-container .stImage img")
+      .eq(2)
+      .should("have.attr", "src")
+      .should("match", /^.*\.jpeg$/);
+  });
+
+  it("displays a PNG image when specified", () => {
+    cy.get(".element-container .stImage img")
+      .eq(3)
+      .should("have.attr", "src")
+      .should("match", /^.*\.png$/);
+  });
+
+  it("displays a JPEG image when not specified with no alpha channel", () => {
+    cy.get(".element-container .stImage img")
+      .eq(4)
+      .should("have.attr", "src")
+      .should("match", /^.*\.jpeg$/);
+  });
+
+  it("displays a PNG image when not specified with alpha channel", () => {
+    cy.get(".element-container .stImage img")
+      .eq(5)
+      .should("have.attr", "src")
+      .should("match", /^.*\.png$/);
+  });
 });

--- a/examples/images.py
+++ b/examples/images.py
@@ -207,7 +207,7 @@ si = StreamlitImages()
 st.header("individual image bytes")
 filename = "image.png"
 data = si.get_images().get(filename)
-st.image(data, caption=filename, format="png")
+st.image(data, caption=filename, output_format="PNG")
 
 # Display a list of images
 st.header("list images")
@@ -216,7 +216,7 @@ captions = []
 for filename, data in si.get_images().items():
     images.append(data)
     captions.append(filename)
-st.image(images, caption=captions, format="png")
+st.image(images, caption=captions, output_format="PNG")
 
 st.header("PIL Image")
 data = []
@@ -235,17 +235,17 @@ captions = []
 for i, c in data:
     images.append(i)
     captions.append(c)
-st.image(images, caption=captions, format="png")
+st.image(images, caption=captions, output_format="PNG")
 
 st.header("Bytes IO Image")
 image = io.BytesIO(si.get_images()["image.png"])
-st.image(image, caption=str(type(image)), format="png")
+st.image(image, caption=str(type(image)), output_format="PNG")
 
 st.header("From a file")
-st.image("/tmp/image.png", caption="/tmp/image.png", format="png")
+st.image("/tmp/image.png", caption="/tmp/image.png", output_format="PNG")
 
 st.header("From open")
-st.image(open("/tmp/image.png", "rb").read(), caption="from read", format="png")
+st.image(open("/tmp/image.png", "rb").read(), caption="from read", output_format="PNG")
 
 st.header("Numpy arrays")
 image = Image.open(io.BytesIO(si.get_images()["image.png"]))
@@ -268,7 +268,7 @@ captions = []
 for i, c in data:
     images.append(i)
     captions.append(c)
-st.image(images, caption=captions, format="png")
+st.image(images, caption=captions, output_format="PNG")
 
 try:
     st.header("opencv")
@@ -277,7 +277,7 @@ try:
     image = np.fromstring(si.get_images()["image.png"], np.uint8)
 
     img = cv2.imdecode(image, cv2.IMREAD_UNCHANGED)
-    st.image(img, format="png")
+    st.image(img, output_format="PNG")
 except Exception:
     pass
 
@@ -313,4 +313,4 @@ captions = []
 for i, c in data:
     images.append(i)
     captions.append(c)
-st.image(images, caption=captions, clamp=True, format="png")
+st.image(images, caption=captions, clamp=True, output_format="PNG")

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -584,6 +584,14 @@ _create_option(
     type_=bool,
 )
 
+_create_option(
+    "deprecation.showImageFormat",
+    description="Set to false to disable the deprecation warning for the image format parameter.",
+    default_val="True",
+    scriptable="True",
+    type_=bool,
+)
+
 # Config Section: S3 #
 
 _create_section("s3", 'Configuration for when global.sharingMode is set to "s3".')

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -285,6 +285,26 @@ text_io = io.TextIOWrapper(file_buffer)
             """
 
 
+class ImageFormatWarning(StreamlitDeprecationWarning):
+    def __init__(self, format):
+        self.format = format
+
+        super(ImageFormatWarning, self).__init__(
+            msg=self._get_message(), config_option="deprecation.showImageFormat"
+        )
+
+    def _get_message(self):
+        return f"""
+The `format` parameter for `st.image` has been deprecated and will be removed
+or repurposed in the future. We recommend changing to the new `output_format`
+parameter to future-proof your code. For the parameter,
+`format="{self.format}"`, please use `output_format="{self.format}"` instead.
+
+See [https://github.com/streamlit/streamlit/issues/1137](https://github.com/streamlit/streamlit/issues/1137)
+for more information.
+            """
+
+
 class DeltaGenerator(object):
     """Creator of Delta protobuf messages.
 
@@ -1516,7 +1536,8 @@ class DeltaGenerator(object):
         use_column_width=False,
         clamp=False,
         channels="RGB",
-        format="JPEG",
+        output_format="auto",
+        **kwargs,
     ):
         """Display an image or list of images.
 
@@ -1549,9 +1570,12 @@ class DeltaGenerator(object):
             `image[:, :, 0]` is the red channel, `image[:, :, 1]` is green, and
             `image[:, :, 2]` is blue. For images coming from libraries like
             OpenCV you should set this to 'BGR', instead.
-        format : 'JPEG' or 'PNG'
-            This parameter specifies the image format to use when transferring
-            the image data. Defaults to 'JPEG'.
+        output_format : 'JPEG', 'PNG', or 'auto'
+            This parameter specifies the format to use when transferring the
+            image data. Photos should use the JPEG format for lossy compression
+            while diagrams should use the PNG format for lossless compression.
+            Defaults to 'auto' which identifies the compression type based
+            on the type and format of the image argument.
 
         Example
         -------
@@ -1568,6 +1592,14 @@ class DeltaGenerator(object):
         """
         from .elements import image_proto
 
+        format = kwargs.get("format")
+        if format != None:
+            # override output compression type if specified
+            output_format = format
+
+            if config.get_option("deprecation.showImageFormat"):
+                self.exception(ImageFormatWarning(format))
+
         if use_column_width:
             width = -2
         elif width is None:
@@ -1583,7 +1615,7 @@ class DeltaGenerator(object):
             element.imgs,
             clamp,
             channels,
-            format,
+            output_format,
         )
 
     @_with_element

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -64,7 +64,7 @@ def marshall(coordinates, new_element_proto, fig=None, clear_figure=True, **kwar
         new_element_proto.imgs,
         False,
         channels="RGB",
-        format="PNG",
+        output_format="PNG",
     )
 
     # Clear the figure after rendering it. This means that subsequent

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -275,6 +275,7 @@ class ConfigTest(unittest.TestCase):
                 "client.caching",
                 "client.displayEnabled",
                 "deprecation.showfileUploaderEncoding",
+                "deprecation.showImageFormat",
                 "global.developmentMode",
                 "global.disableWatchdogWarning",
                 "global.logLevel",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -311,7 +311,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         """Test st.image with PIL image."""
         img = Image.new("RGB", (64, 64), color="red")
 
-        st.image(img, caption="some caption", width=100, format="PNG")
+        st.image(img, caption="some caption", width=100, output_format="PNG")
 
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.imgs.width, 100)
@@ -341,7 +341,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             width=200,
             use_column_width=True,
             clamp=True,
-            format="PNG",
+            output_format="PNG",
         )
 
         el = self.get_delta_from_queue().new_element


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1137

**Description:** 
The format parameter is a little bit confusing. Renaming it to output_format
has clearer meaning. In addition, we allow a output_format="auto" which
decides the proper output format based on input type and whether an alpha
channel exists

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
