### PR TITLE
Allow SelectBoxes, Radio Buttons, and MultiSelect to use DataFrames

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -1850,9 +1850,9 @@ class DeltaGenerator(object):
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
-        options : list, tuple, numpy.ndarray, or pandas.Series
-            Labels for the select options. This will be cast to str internally
-            by default.
+        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+            Labels for the radio options. This will be cast to str internally
+            by default. For pandas.DataFrame, the first column is selected.
         default: [str] or None
             List of default values.
         format_func : function
@@ -1936,9 +1936,9 @@ class DeltaGenerator(object):
         ----------
         label : str
             A short label explaining to the user what this radio group is for.
-        options : list, tuple, numpy.ndarray, or pandas.Series
+        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
             Labels for the radio options. This will be cast to str internally
-            by default.
+            by default. For pandas.DataFrame, the first column is selected.
         index : int
             The index of the preselected option on first render.
         format_func : function
@@ -2002,9 +2002,9 @@ class DeltaGenerator(object):
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
-        options : list, tuple, numpy.ndarray, or pandas.Series
-            Labels for the select options. This will be cast to str internally
-            by default.
+        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+            Labels for the radio options. This will be cast to str internally
+            by default. For pandas.DataFrame, the first column is selected.
         index : int
             The index of the preselected option on first render.
         format_func : function

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -47,7 +47,7 @@ from streamlit.proto.NumberInput_pb2 import NumberInput
 from streamlit.proto.Slider_pb2 import Slider
 from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.logger import get_logger
-from streamlit.type_util import is_type
+from streamlit.type_util import is_type, ensure_iterable
 
 LOGGER = get_logger(__name__)
 
@@ -1888,6 +1888,7 @@ class DeltaGenerator(object):
            `GitHub issue #1059 <https://github.com/streamlit/streamlit/issues/1059>`_ for updates on the issue.
 
         """
+        options = ensure_iterable(options)
 
         # Perform validation checks and return indices base on the default values.
         def _check_and_convert_to_indices(options, default_values):
@@ -1968,6 +1969,8 @@ class DeltaGenerator(object):
         ...     st.write("You didn\'t select comedy.")
 
         """
+        options = ensure_iterable(options)
+
         if not isinstance(index, int):
             raise StreamlitAPIException(
                 "Radio Value has invalid type: %s" % type(index).__name__
@@ -2027,6 +2030,8 @@ class DeltaGenerator(object):
         >>> st.write('You selected:', option)
 
         """
+        options = ensure_iterable(options)
+
         if not isinstance(index, int):
             raise StreamlitAPIException(
                 "Selectbox Value has invalid type: %s" % type(index).__name__

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -261,4 +261,8 @@ def ensure_iterable(obj):
     if is_dataframe(obj):
         return obj.iloc[:, 0]
 
-    return obj
+    try:
+        iter(obj)
+        return obj
+    except:
+        raise

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -245,9 +245,10 @@ Offending object:
 
 
 def ensure_iterable(obj):
-    """Try to convert different formats to something iterable. In reality,
-    most inputs should be iterable, but if we have a DataFrame, we can just
-    select the first column to iterate over.
+    """Try to convert different formats to something iterable. Most inputs
+    are assumed to be iterable, but if we have a DataFrame, we can just
+    select the first column to iterate over. If the input is not iterable,
+    a TypeError is raised.
 
     Parameters
     ----------

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -80,6 +80,10 @@ _DATAFRAME_COMPATIBLE_TYPES = (
 )  # type: Tuple[type, ...]
 
 
+def is_dataframe(obj):
+    return is_type(obj, _PANDAS_DF_TYPE_STR)
+
+
 def is_dataframe_like(obj):
     return any(is_type(obj, t) for t in _DATAFRAME_LIKE_TYPES)
 
@@ -238,3 +242,23 @@ Offending object:
 ```"""
             % {"type": type(df), "object": df,}
         )
+
+
+def ensure_iterable(obj):
+    """Try to convert different formats to something iterable. In reality,
+    most inputs should be iterable, but if we have a DataFrame, we can just
+    select the first column to iterate over.
+
+    Parameters
+    ----------
+    obj : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+
+    Returns
+    -------
+    iterable
+
+    """
+    if is_dataframe(obj):
+        return obj.iloc[:, 0]
+
+    return obj

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -40,6 +40,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             (["male", "female"], ["male", "female"]),
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
+            (pd.DataFrame({"options": ["male", "female"]}), ["male", "female"]),
         ]
     )
     def test_option_types(self, options, proto_options):

--- a/lib/tests/streamlit/radio_test.py
+++ b/lib/tests/streamlit/radio_test.py
@@ -54,6 +54,7 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
             (["male", "female"], ["male", "female"]),
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
+            (pd.DataFrame({"options": ["male", "female"]}), ["male", "female"]),
         ]
     )
     def test_option_types(self, options, proto_options):

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """selectbox unit tests."""
-
+import pytest
 import numpy as np
 import pandas as pd
 from parameterized import parameterized
@@ -65,6 +65,11 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.label, "the label")
         self.assertEqual(c.default, 0)
         self.assertEqual(c.options, proto_options)
+
+    def test_not_iterable_option_types(self):
+        """Test that it supports different types of options."""
+        with pytest.raises(TypeError):
+            st.selectbox("the label", 123)
 
     def test_cast_options_to_string(self):
         """Test that it casts options to string."""

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -54,6 +54,7 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
             (["male", "female"], ["male", "female"]),
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
+            (pd.DataFrame({"options": ["male", "female"]}), ["male", "female"]),
         ]
     )
     def test_option_types(self, options, proto_options):


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/78

**Description:**
When a DataFrame is sent as an argument, the component will select options from the first column.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
