### PR TITLE
Fixed misspelling in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@ More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contri
 
 **Contribution License Agreement**
 
-By submiting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
+By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


### PR DESCRIPTION
**Issue:** None (Just a Misspelling)

**Description:**
There's a misspelling in the License Agreement, and I'd like to fix it so my browser does not complain every time I create a pull request)

---

**Contribution License Agreement**

By *submitting* this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
