### PR TITLE
Fixed incorrect word in (multi)select docs

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -1851,7 +1851,7 @@ class DeltaGenerator(object):
         label : str
             A short label explaining to the user what this select widget is for.
         options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
-            Labels for the radio options. This will be cast to str internally
+            Labels for the select options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         default: [str] or None
             List of default values.
@@ -2003,7 +2003,7 @@ class DeltaGenerator(object):
         label : str
             A short label explaining to the user what this select widget is for.
         options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
-            Labels for the radio options. This will be cast to str internally
+            Labels for the select options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         index : int
             The index of the preselected option on first render.


### PR DESCRIPTION
**Issue:** None Just a fix in the docs

**Description:** 
My change in https://github.com/streamlit/streamlit/pull/1785/files#diff-9cd67e8248e5ba7bf4a76f18b17788baL1854 accidentally called (multi)select options "radio" options. This commit changes it back.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
