### PR TITLE
Fix hashing code run from CWD

### DIFF
--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -320,7 +320,7 @@ class _CodeHasher:
         if file_is_blacklisted:
             return False
         return file_util.file_is_in_folder_glob(
-            filepath, self._get_main_script_directory()
+            filepath, os.path.abspath(self._get_main_script_directory())
         ) or file_util.file_in_pythonpath(filepath)
 
     def _to_bytes(self, obj, context):


### PR DESCRIPTION
Issue: #1797 

When running a script that uses Streamlit's caching from the current working directory, hashes of Python functions don't respond to code changes. What happens is that `_get_main_script_directory()` returns `'.'`. `filepath` is always an absolute path, so the subdirectory check `file_util.file_is_in_folder_glob()` always fails. This causes the hashing code to silently fall back on the codepath for library functions, which only considers their name and module. As a result, user functions hashed in this situation always have the same hash value, regardless of their content.

Sorry, but the contribution guidelines (apart from the license agreement) seem a bit heavy-handed for this one-line fix. If there are major objections to this PR, please just close it.