### PR TITLE
Add unix socket

### DIFF
--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -26,7 +26,7 @@ from streamlit import env_util
 from streamlit import util
 from streamlit.report import Report
 from streamlit.logger import get_logger
-from streamlit.server.server import Server
+from streamlit.server.server import Server, server_address_is_unix_socket
 
 LOGGER = get_logger(__name__)
 
@@ -148,6 +148,9 @@ def _on_server_start(server):
         if config.is_manually_set("browser.serverAddress"):
             addr = config.get_option("browser.serverAddress")
         elif config.is_manually_set("server.address"):
+            if server_address_is_unix_socket():
+                # Don't open browser when server address is an unix socket
+                return
             addr = config.get_option("server.address")
         else:
             addr = "localhost"
@@ -179,7 +182,7 @@ def _print_url(is_running_hello):
             ("URL", Report.get_url(config.get_option("browser.serverAddress")))
         ]
 
-    elif config.is_manually_set("server.address"):
+    elif config.is_manually_set("server.address") and not server_address_is_unix_socket():
         named_urls = [
             ("URL", Report.get_url(config.get_option("server.address"))),
         ]

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -182,7 +182,9 @@ def _print_url(is_running_hello):
             ("URL", Report.get_url(config.get_option("browser.serverAddress")))
         ]
 
-    elif config.is_manually_set("server.address") and not server_address_is_unix_socket():
+    elif (
+        config.is_manually_set("server.address") and not server_address_is_unix_socket()
+    ):
         named_urls = [
             ("URL", Report.get_url(config.get_option("server.address"))),
         ]

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -77,6 +77,10 @@ TORNADO_SETTINGS = {
 # up to MAX_PORT_SEARCH_RETRIES.
 MAX_PORT_SEARCH_RETRIES = 100
 
+# When server.address starts with this prefix, the server will bind
+# to an unix socket.
+UNIX_SOCKET_PREFIX = "unix://"
+
 
 class SessionInfo(object):
     """Type stored in our _session_info_by_id dict.
@@ -119,7 +123,7 @@ def server_port_is_manually_set():
 
 def server_address_is_unix_socket():
     address = config.get_option("server.address")
-    return address and address.startswith("unix://")
+    return address and address.startswith(UNIX_SOCKET_PREFIX)
 
 def start_listening(app):
     """Makes the server start listening at the configured port.
@@ -141,7 +145,7 @@ def start_listening(app):
 
 def start_listening_unix_socket(http_server):
     address = config.get_option("server.address")
-    file_name = os.path.expanduser(address[7:])
+    file_name = os.path.expanduser(address[len(UNIX_SOCKET_PREFIX):])
 
     unix_socket = tornado.netutil.bind_unix_socket(file_name)
     http_server.add_socket(unix_socket)

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -121,9 +121,11 @@ class RetriesExceeded(Exception):
 def server_port_is_manually_set():
     return config.is_manually_set("server.port")
 
+
 def server_address_is_unix_socket():
     address = config.get_option("server.address")
     return address and address.startswith(UNIX_SOCKET_PREFIX)
+
 
 def start_listening(app):
     """Makes the server start listening at the configured port.
@@ -145,7 +147,7 @@ def start_listening(app):
 
 def start_listening_unix_socket(http_server):
     address = config.get_option("server.address")
-    file_name = os.path.expanduser(address[len(UNIX_SOCKET_PREFIX):])
+    file_name = os.path.expanduser(address[len(UNIX_SOCKET_PREFIX) :])
 
     unix_socket = tornado.netutil.bind_unix_socket(file_name)
     http_server.add_socket(unix_socket)

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import threading
 import socket
 import sys
@@ -131,8 +132,8 @@ def start_listening(app):
 
     address = config.get_option("server.address")
 
-    if address.startswith("unix://"):
-        file_name = address[7:]
+    if address and address.startswith("unix://"):
+        file_name = os.path.expanduser(address[7:])
         start_listening_unix_socket(http_server, file_name)
     else:
         start_listening_tcp_socket(http_server, address)

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Server.py unit tests"""
-
+import os
 from unittest import mock
 from unittest.mock import MagicMock, patch
 import unittest
@@ -548,6 +548,35 @@ class PortRotateOneTest(unittest.TestCase):
                 patched__set_option.assert_called_with(
                     "server.port", 8501, config.ConfigOption.STREAMLIT_DEFINITION
                 )
+
+
+class UnixSocketTest(unittest.TestCase):
+    """Tests start_listening uses a unix socket when socket.address starts with
+       unix:// """
+
+    def get_httpserver(self):
+        httpserver = mock.MagicMock()
+
+        httpserver.add_socket = mock.Mock()
+
+        return httpserver
+
+    def test_unix_socket(self):
+        app = mock.MagicMock()
+
+        os.environ["HOME"] = "/home/koen"
+
+        config.set_option("server.address", "unix://~/fancy-test/testasd")
+        some_socket = object()
+
+        with patch.object(
+            tornado.httpserver, "HTTPServer", return_value=self.get_httpserver()
+        ) as mock_server, patch.object(
+            tornado.netutil, "bind_unix_socket", return_value=some_socket) as bind_unix_socket:
+            start_listening(app)
+
+            bind_unix_socket.assert_called_with("/home/koen/fancy-test/testasd")
+            mock_server.add_socket.assert_called_with(some_socket)
 
 
 class MetricsHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -564,8 +564,6 @@ class UnixSocketTest(unittest.TestCase):
     def test_unix_socket(self):
         app = mock.MagicMock()
 
-        os.environ["HOME"] = "/home/koen"
-
         config.set_option("server.address", "unix://~/fancy-test/testasd")
         some_socket = object()
 
@@ -574,10 +572,14 @@ class UnixSocketTest(unittest.TestCase):
             tornado.httpserver, "HTTPServer", return_value=mock_server
         ), patch.object(
             tornado.netutil, "bind_unix_socket", return_value=some_socket
-        ) as bind_unix_socket:
+        ) as bind_unix_socket, patch.dict(
+            os.environ, {"HOME": "/home/superfakehomedir"}
+        ):
             start_listening(app)
 
-            bind_unix_socket.assert_called_with("/home/koen/fancy-test/testasd")
+            bind_unix_socket.assert_called_with(
+                "/home/superfakehomedir/fancy-test/testasd"
+            )
             mock_server.add_socket.assert_called_with(some_socket)
 
 

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -569,10 +569,12 @@ class UnixSocketTest(unittest.TestCase):
         config.set_option("server.address", "unix://~/fancy-test/testasd")
         some_socket = object()
 
+        mock_server = self.get_httpserver()
         with patch.object(
-            tornado.httpserver, "HTTPServer", return_value=self.get_httpserver()
-        ) as mock_server, patch.object(
-            tornado.netutil, "bind_unix_socket", return_value=some_socket) as bind_unix_socket:
+            tornado.httpserver, "HTTPServer", return_value=mock_server
+        ), patch.object(
+            tornado.netutil, "bind_unix_socket", return_value=some_socket
+        ) as bind_unix_socket:
             start_listening(app)
 
             bind_unix_socket.assert_called_with("/home/koen/fancy-test/testasd")


### PR DESCRIPTION
**Issue:** 
This pull requests adds the feature to allow passing unix sockets via the `server.address` option ( https://github.com/streamlit/streamlit/issues/1664 )


**Description:** 
The changes are:
- Update `start_listening` to check if a unix socket is specified
- Add `start_listening_unix_socket`
- Add `UnixSocketTest`

Some extra changes were needed to prevent unwanted behaviour:
- Change `_on_server_start` to suppress the opening of the browser on streamlit server when unix socket is specified without browser.serverAddress because it doesn't make sense
- Change `_print_url` to prevent printing an invalid url (see 4)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
