### PR TITLE
Fix merge issue w/ st.set_page_config and `output_format` param

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -73,7 +73,7 @@ def set_page_config(
             width=-1,  # Always use full width for favicons
             clamp=False,
             channels="RGB",
-            format="JPEG",
+            output_format="JPEG",
             image_id="favicon",
             allow_emoji=True,
         )


### PR DESCRIPTION
We just merged #1794 , which was working off an older version of the develop/ branch. Unfortunately, this did not include the latest changes from #1784 , which changed the name of an internal parameter. There were no merge conflicts, but the integration test for set_page_config failed, leading us to detect this.