### PR TITLE
Heading Anchors Initial Concept

### DIFF
--- a/frontend/src/components/elements/Markdown/Markdown.tsx
+++ b/frontend/src/components/elements/Markdown/Markdown.tsx
@@ -24,6 +24,7 @@ import "assets/css/write.scss"
 export interface Props {
   width: number
   element: ImmutableMap<string, any>
+  anchor?: string
 }
 
 /**
@@ -32,13 +33,20 @@ export interface Props {
 class Markdown extends React.PureComponent<Props> {
   public render(): ReactNode {
     const { element, width } = this.props
+
     const body = element.get("body")
+    const anchor = element.get("anchor")
+    const allowHTML = element.get("allowHtml")
+
     const styleProp = { width }
 
-    const allowHTML = element.get("allowHtml")
     return (
       <div className="markdown-text-container stMarkdown" style={styleProp}>
-        <StreamlitMarkdown source={body} allowHTML={allowHTML} />
+        <StreamlitMarkdown
+          source={body}
+          anchor={anchor}
+          allowHTML={allowHTML}
+        />
       </div>
     )
   }

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -61,7 +61,7 @@ class MarkdownMixin:
 
         return dg._enqueue("markdown", markdown_proto)  # type: ignore
 
-    def header(dg, body):
+    def header(dg, body, anchor=None):
         """Display text in header formatting.
 
         Parameters
@@ -80,9 +80,15 @@ class MarkdownMixin:
         """
         header_proto = MarkdownProto()
         header_proto.body = "## %s" % _clean_text(body)
+
+        if anchor is None:
+            header_proto.anchor = _clean_text(body)
+        else:
+            header_proto.anchor = _clean_text(anchor)
+
         return dg._enqueue("markdown", header_proto)  # type: ignore
 
-    def subheader(dg, body):
+    def subheader(dg, body, anchor=None):
         """Display text in subheader formatting.
 
         Parameters
@@ -101,6 +107,12 @@ class MarkdownMixin:
         """
         subheader_proto = MarkdownProto()
         subheader_proto.body = "### %s" % _clean_text(body)
+
+        if anchor is None:
+            subheader_proto.anchor = _clean_text(body)
+        else:
+            subheader_proto.anchor = _clean_text(anchor)
+
         return dg._enqueue("markdown", subheader_proto)  # type: ignore
 
     def code(dg, body, language="python"):
@@ -136,7 +148,7 @@ class MarkdownMixin:
         code_proto.body = _clean_text(markdown)
         return dg._enqueue("markdown", code_proto)  # type: ignore
 
-    def title(dg, body):
+    def title(dg, body, anchor=None):
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not
@@ -158,6 +170,12 @@ class MarkdownMixin:
         """
         title_proto = MarkdownProto()
         title_proto.body = "# %s" % _clean_text(body)
+
+        if anchor is None:
+            title_proto.anchor = _clean_text(body)
+        else:
+            title_proto.anchor = _clean_text(anchor)
+
         return dg._enqueue("markdown", title_proto)  # type: ignore
 
     def latex(dg, body):

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -9,7 +9,6 @@ from typing import Optional, Any
 def _clean_text(text):
     return textwrap.dedent(str(text)).strip()
 
-
 def _build_duplicate_widget_message(
     widget_func_name: str, user_key: Optional[str] = None
 ) -> str:

--- a/lib/streamlit/hello/hello.py
+++ b/lib/streamlit/hello/hello.py
@@ -81,6 +81,10 @@ def run():
 
     if demo_name == "—":
         show_code = False
+        st.title("Streamlit Title")
+        st.title('Streamlit Title with passed anchor', 'here is the passed anchor')
+        st.header('Streamlit Header')
+        st.subheader('Streamlit Subheader')
         st.write("# Welcome to Streamlit! 👋")
     else:
         show_code = st.sidebar.checkbox("Show code", True)

--- a/proto/streamlit/proto/Markdown.proto
+++ b/proto/streamlit/proto/Markdown.proto
@@ -20,6 +20,7 @@ syntax = "proto3";
 message Markdown {
   // Content to display.
   string body = 1;
+  string anchor = 16;
 
   bool allow_html = 2;
 }


### PR DESCRIPTION
@nthmost 

A lot missing here, but wanting clarification on features:

**Question 1**
On lines 66–87 of StreamlitMarkdown.tsx, I have passed the anchor prop into the StreamlitMarkdown component, but am not sure the best way to read the anchor prop from the heading renderer.

Do you have any guidance on this? The current implementation works, but it doesn’t seem sustainable to have this function here.

**Question2**
Do I add:
string anchor = 3; 
in Markdown.proto, or is this considered an optional value since it applies to specific elements?