### PR TITLE
Migrate page config check to ReportContext

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -41,7 +41,6 @@ from streamlit.storage.file_storage import FileStorage
 from streamlit.storage.s3_storage import S3Storage
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 import streamlit.elements.exception_proto as exception_proto
-from streamlit.errors import StreamlitAPIException
 
 LOGGER = get_logger(__name__)
 
@@ -108,9 +107,6 @@ class ReportSession(object):
 
         self._scriptrunner = None
 
-        # set_page_config is allowed at most once, as the very first st.command
-        self._set_page_config_allowed = True
-
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
 
     def flush_browser_queue(self):
@@ -174,17 +170,6 @@ class ReportSession(object):
 
             if scriptrunner is not None:
                 scriptrunner.maybe_handle_execution_control_request()
-
-        if msg.HasField("page_config_changed") and not self._set_page_config_allowed:
-            raise StreamlitAPIException(
-                "`beta_set_page_config()` can only be called once per app, "
-                + "and must be called as the first Streamlit command in your script.\n\n"
-                + "For more information refer to the [docs]"
-                + "(https://docs.streamlit.io/en/stable/api.html#streamlit.beta_set_page_config)."
-            )
-
-        if msg.HasField("delta") or msg.HasField("page_config_changed"):
-            self._set_page_config_allowed = False
 
         self._report.enqueue(msg)
 

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -15,6 +15,7 @@
 import threading
 
 from streamlit.logger import get_logger
+from streamlit.errors import StreamlitAPIException
 
 LOGGER = get_logger(__name__)
 
@@ -52,16 +53,33 @@ class ReportContext(object):
         # cursor (type AbstractCursor).
         self.cursors = {}
         self.session_id = session_id
-        self.enqueue = enqueue
+        self._enqueue = enqueue
         self.query_string = query_string
         self.widgets = widgets
         self.widget_ids_this_run = widget_ids_this_run
         self.uploaded_file_mgr = uploaded_file_mgr
 
+        # set_page_config is allowed at most once, as the very first st.command
+        self._set_page_config_allowed = True
+
     def reset(self, query_string=""):
         self.cursors = {}
         self.widget_ids_this_run.clear()
         self.query_string = query_string
+
+    def enqueue(self, msg):
+        if msg.HasField("page_config_changed") and not self._set_page_config_allowed:
+            raise StreamlitAPIException(
+                "`beta_set_page_config()` can only be called once per app, "
+                + "and must be called as the first Streamlit command in your script.\n\n"
+                + "For more information refer to the [docs]"
+                + "(https://docs.streamlit.io/en/stable/api.html#streamlit.beta_set_page_config)."
+            )
+
+        if msg.HasField("delta") or msg.HasField("page_config_changed"):
+            self._set_page_config_allowed = False
+
+        self._enqueue(msg)
 
 
 class _WidgetIDSet(object):

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock, patch
+import unittest
+
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.errors import StreamlitAPIException
+from streamlit.report_thread import ReportContext
+
+
+class ReportContextTest(unittest.TestCase):
+    def test_set_page_config_immutable(self):
+        """st.set_page_config must be called at most once"""
+
+        fake_enqueue = lambda msg: None
+        ctx = ReportContext("TestSessionID", fake_enqueue, "", None, None, None)
+
+        msg = ForwardMsg()
+        msg.page_config_changed.title = "foo"
+
+        ctx.enqueue(msg)
+        with self.assertRaises(StreamlitAPIException):
+            ctx.enqueue(msg)
+
+    def test_set_page_config_first(self):
+        """st.set_page_config must be called before other st commands"""
+
+        fake_enqueue = lambda msg: None
+        ctx = ReportContext("TestSessionID", fake_enqueue, "", None, None, None)
+
+        markdown_msg = ForwardMsg()
+        markdown_msg.delta.new_element.markdown.body = "foo"
+
+        msg = ForwardMsg()
+        msg.page_config_changed.title = "foo"
+
+        ctx.enqueue(markdown_msg)
+        with self.assertRaises(StreamlitAPIException):
+            ctx.enqueue(msg)

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -107,35 +107,6 @@ class ReportSessionTest(unittest.TestCase):
         func.assert_not_called()
 
     @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_set_page_config_immutable(self, _1):
-        """st.set_page_config must be called at most once"""
-        file_mgr = MagicMock(spec=UploadedFileManager)
-        rs = ReportSession(None, "", "", file_mgr)
-
-        msg = ForwardMsg()
-        msg.page_config_changed.title = "foo"
-
-        rs.enqueue(msg)
-        with self.assertRaises(StreamlitAPIException):
-            rs.enqueue(msg)
-
-    @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_set_page_config_first(self, _1):
-        """st.set_page_config must be called before other st commands"""
-        file_mgr = MagicMock(spec=UploadedFileManager)
-        rs = ReportSession(None, "", "", file_mgr)
-
-        markdown_msg = ForwardMsg()
-        markdown_msg.delta.new_element.markdown.body = "foo"
-
-        msg = ForwardMsg()
-        msg.page_config_changed.title = "foo"
-
-        rs.enqueue(markdown_msg)
-        with self.assertRaises(StreamlitAPIException):
-            rs.enqueue(msg)
-
-    @patch("streamlit.report_session.LocalSourcesWatcher")
     def test_shutdown(self, _1):
         """Test that ReportSession.shutdown behaves sanely."""
         file_mgr = MagicMock(spec=UploadedFileManager)


### PR DESCRIPTION
This fixes the issue of set_page_config not working on heroku
Fixes #1857 