### PR TITLE
Permit set_page_config when the ReportContext is reused on a rerun

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -41,7 +41,6 @@ from streamlit.storage.file_storage import FileStorage
 from streamlit.storage.s3_storage import S3Storage
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 import streamlit.elements.exception_proto as exception_proto
-from streamlit.errors import StreamlitAPIException
 
 LOGGER = get_logger(__name__)
 
@@ -108,9 +107,6 @@ class ReportSession(object):
 
         self._scriptrunner = None
 
-        # set_page_config is allowed at most once, as the very first st.command
-        self._set_page_config_allowed = True
-
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
 
     def flush_browser_queue(self):
@@ -174,17 +170,6 @@ class ReportSession(object):
 
             if scriptrunner is not None:
                 scriptrunner.maybe_handle_execution_control_request()
-
-        if msg.HasField("page_config_changed") and not self._set_page_config_allowed:
-            raise StreamlitAPIException(
-                "`beta_set_page_config()` can only be called once per app, "
-                + "and must be called as the first Streamlit command in your script.\n\n"
-                + "For more information refer to the [docs]"
-                + "(https://docs.streamlit.io/en/stable/api.html#streamlit.beta_set_page_config)."
-            )
-
-        if msg.HasField("delta") or msg.HasField("page_config_changed"):
-            self._set_page_config_allowed = False
 
         self._report.enqueue(msg)
 

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -58,7 +58,6 @@ class ReportContext(object):
         self.widgets = widgets
         self.widget_ids_this_run = widget_ids_this_run
         self.uploaded_file_mgr = uploaded_file_mgr
-
         # set_page_config is allowed at most once, as the very first st.command
         self._set_page_config_allowed = True
 
@@ -66,6 +65,8 @@ class ReportContext(object):
         self.cursors = {}
         self.widget_ids_this_run.clear()
         self.query_string = query_string
+        # Permit set_page_config when the ReportContext is reused on a rerun
+        self._set_page_config_allowed = True
 
     def enqueue(self, msg):
         if msg.HasField("page_config_changed") and not self._set_page_config_allowed:

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -15,6 +15,7 @@
 import threading
 
 from streamlit.logger import get_logger
+from streamlit.errors import StreamlitAPIException
 
 LOGGER = get_logger(__name__)
 
@@ -52,16 +53,33 @@ class ReportContext(object):
         # cursor (type AbstractCursor).
         self.cursors = {}
         self.session_id = session_id
-        self.enqueue = enqueue
+        self._enqueue = enqueue
         self.query_string = query_string
         self.widgets = widgets
         self.widget_ids_this_run = widget_ids_this_run
         self.uploaded_file_mgr = uploaded_file_mgr
 
+        # set_page_config is allowed at most once, as the very first st.command
+        self._set_page_config_allowed = True
+
     def reset(self, query_string=""):
         self.cursors = {}
         self.widget_ids_this_run.clear()
         self.query_string = query_string
+
+    def enqueue(self, msg):
+        if msg.HasField("page_config_changed") and not self._set_page_config_allowed:
+            raise StreamlitAPIException(
+                "`beta_set_page_config()` can only be called once per app, "
+                + "and must be called as the first Streamlit command in your script.\n\n"
+                + "For more information refer to the [docs]"
+                + "(https://docs.streamlit.io/en/stable/api.html#streamlit.beta_set_page_config)."
+            )
+
+        if msg.HasField("delta") or msg.HasField("page_config_changed"):
+            self._set_page_config_allowed = False
+
+        self._enqueue(msg)
 
 
 class _WidgetIDSet(object):

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -35,3 +35,19 @@ class ReportContextTest(unittest.TestCase):
         ctx.enqueue(markdown_msg)
         with self.assertRaises(StreamlitAPIException):
             ctx.enqueue(msg)
+
+    def test_set_page_config_reset(self):
+        """st.set_page_config should be allowed after a rerun"""
+
+        fake_enqueue = lambda msg: None
+        ctx = ReportContext("TestSessionID", fake_enqueue, "", None, MagicMock(), None)
+
+        msg = ForwardMsg()
+        msg.page_config_changed.title = "foo"
+
+        ctx.enqueue(msg)
+        ctx.reset()
+        try:
+            ctx.enqueue(msg)
+        except StreamlitAPIException:
+            self.fail("set_page_config should have succeeded after reset!")


### PR DESCRIPTION
Fixes #1883 . Preview changes at https://substantial-quill.herokuapp.com/
Compared to the 0.65.1: https://calm-wave-95641.herokuapp.com/ (hold down Down Arrow key to see bug)

Explanation of bug:

When a rerun occurs, the ScriptRunner does not call start() again, 
so the same ReportThread -- and thus same ReportContext -- are used.
That means enqueue(set_page_config) fails.

A rerun occurs when we modify a value while the script is still running.

Proof: On 0.65.1, it consistently repros locally with very fast switching (holding down down arrow key on the RadioButton example), and also when adding `time.sleep(5)` to the app and then making a change.