### PR TITLE
Fix a typo in getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -41,7 +41,7 @@ you're working on.
 $ pip install streamlit
 ```
 
-Now run the hello world app just to make sure everything it's working:
+Now run the hello world app just to make sure everything is working:
 
 ```bash
 $ streamlit hello


### PR DESCRIPTION
Fixed a simple typo in the docs (getting_started.md).