### PR TITLE
Bump Cypress to an "xlarge" VM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,7 +473,7 @@ jobs:
     docker:
       - image: circleci/python:3.7.4-stretch
 
-    resource_class: medium+
+    resource_class: xlarge
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Bumps our CircleCI Cypress resource_class to "xlarge" (from "medium+")

This is just a quick test to see if it makes a meaningful difference to our painfully slow Cypress job, which currently takes ~30m to run. We can discuss this next week, and roll it back if it's not helping enough.