### PR TITLE
Migrate Progress Bars to BaseWeb

### DIFF
--- a/e2e/specs/st_progress.spec.ts
+++ b/e2e/specs/st_progress.spec.ts
@@ -23,7 +23,7 @@ describe("st.progress", () => {
   });
 
   it("displays a progress bar", () => {
-    cy.get(".element-container .stProgress .progress-bar").should(
+    cy.get(".stProgress [role='progressbar']").should(
       "have.attr",
       "aria-valuenow",
       "50"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -283,7 +283,7 @@ export class App extends PureComponent<Props, State> {
           this.handlePageInfoChanged(pageInfo),
         reportFinished: (status: ForwardMsg.ReportFinishedStatus) =>
           this.handleReportFinished(status),
-        uploadReportProgress: (progress: string | number) =>
+        uploadReportProgress: (progress: number) =>
           this.handleUploadReportProgress(progress),
         reportUploaded: (url: string) => this.handleReportUploaded(url),
       })
@@ -293,7 +293,7 @@ export class App extends PureComponent<Props, State> {
     }
   }
 
-  handleUploadReportProgress = (progress: string | number): void => {
+  handleUploadReportProgress = (progress: number): void => {
     const newDialog: DialogProps = {
       type: DialogType.UPLOAD_PROGRESS,
       progress,

--- a/frontend/src/assets/css/theme.scss
+++ b/frontend/src/assets/css/theme.scss
@@ -129,14 +129,6 @@ pre {
   }
 }
 
-.progress {
-  background-color: $gray-lightest;
-}
-
-.progress-bar {
-  background-color: $blue;
-}
-
 .icon {
   width: 0.9rem;
   height: 0.9rem;

--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -104,6 +104,10 @@ $overlayBtn-opacity-active: 0.75;
 // Animation settings
 $normal-animation-duration: 300ms;
 
+// Progress Bar
+$progress-bar-height: 1rem;
+$progress-bar-margin: 0;
+
 // Code
 $code-color: $green;
 $kbd-color: $green;

--- a/frontend/src/components/core/Sidebar/Sidebar.scss
+++ b/frontend/src/components/core/Sidebar/Sidebar.scss
@@ -110,14 +110,6 @@
       font-weight: 300;
       text-transform: uppercase;
     }
-
-    .progress {
-      background-color: $gray-light;
-    }
-
-    .progress-bar {
-      background-color: $blue;
-    }
   }
 
   .sidebar-collapse-control {

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -17,14 +17,8 @@
 
 import CopyToClipboard from "react-copy-to-clipboard"
 import React, { ReactElement, ReactNode } from "react"
-import {
-  Button,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Progress,
-} from "reactstrap"
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap"
+import ProgressBar from "components/shared/ProgressBar"
 import { HotKeys } from "react-hotkeys"
 
 import {
@@ -273,7 +267,7 @@ function settingsDialog(props: SettingsProps): ReactElement {
 
 interface UploadProgressProps {
   type: DialogType.UPLOAD_PROGRESS
-  progress?: string | number
+  progress?: number
   onClose: PlainEventHandler
 }
 
@@ -288,7 +282,7 @@ function uploadProgressDialog(props: UploadProgressProps): ReactElement {
           Saving app snapshot...
         </div>
         <div>
-          <Progress animated value={props.progress} />
+          <ProgressBar value={props.progress || 0} />
         </div>
       </ModalBody>
     </BasicDialog>

--- a/frontend/src/components/elements/Progress/Progress.test.tsx
+++ b/frontend/src/components/elements/Progress/Progress.test.tsx
@@ -18,64 +18,30 @@
 import React from "react"
 import { shallow } from "enzyme"
 import { fromJS } from "immutable"
-import { timeout } from "lib/utils"
 
-import { Progress as UIProgress } from "reactstrap"
-import Progress, { Props, FAST_UPDATE_MS } from "./Progress"
+import Progress, { ProgressProps } from "./Progress"
 
-const getProps = (elementProps: Record<string, unknown> = {}): Props => ({
+const getProps = (
+  propOverrides: Record<string, unknown> = {}
+): ProgressProps => ({
   element: fromJS({
     value: 50,
-    ...elementProps,
   }),
   width: 0,
+  ...propOverrides,
 })
 
-describe("Progress Element", () => {
+describe("ProgressBar component", () => {
   it("renders without crashing", () => {
-    const props = getProps()
-    const wrapper = shallow(<Progress {...props} />)
+    const wrapper = shallow(<Progress {...getProps()} />)
 
-    expect(wrapper.find(UIProgress).length).toBe(1)
+    expect(wrapper.find("ProgressBar").length).toBe(1)
   })
 
-  it("moving backwards", () => {
-    const props = getProps()
-    const wrapper = shallow(<Progress {...props} />)
+  it("sets the value and width correctly", () => {
+    const wrapper = shallow(<Progress {...getProps({ width: 100 })} />)
 
-    expect(wrapper.instance().lastValue).toBe(50)
-
-    wrapper.setProps({
-      element: fromJS({
-        value: 49,
-      }),
-    })
-
-    expect(wrapper.instance().lastValue).toBe(49)
-    expect(wrapper.find(UIProgress).prop("value")).toBe(49)
-    expect(wrapper.find(UIProgress).prop("className")).toBe(
-      "stProgress without-transition"
-    )
-  })
-
-  it("moving forward", async () => {
-    const props = getProps()
-    const wrapper = shallow(<Progress {...props} />)
-
-    expect(wrapper.instance().lastValue).toBe(50)
-
-    await timeout(FAST_UPDATE_MS)
-
-    wrapper.setProps({
-      element: fromJS({
-        value: 51,
-      }),
-    })
-
-    expect(wrapper.instance().lastValue).toBe(51)
-    expect(wrapper.find(UIProgress).prop("value")).toBe(51)
-    expect(wrapper.find(UIProgress).prop("className")).toBe(
-      "stProgress with-transition"
-    )
+    expect(wrapper.find("ProgressBar").prop("value")).toEqual(50)
+    expect(wrapper.find("ProgressBar").prop("width")).toEqual(100)
   })
 })

--- a/frontend/src/components/shared/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/src/components/shared/ProgressBar/ProgressBar.test.tsx
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018-2020 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,19 +15,21 @@
  * limitations under the License.
  */
 
-@import "src/assets/css/variables";
+import React from "react"
+import { shallow } from "enzyme"
 
-// Reset the progress bar to 0 without animating on report re-run.
-.reportview-container {
-  .without-transition .progress-bar {
-    transition: none;
-  }
+import ProgressBar from "./ProgressBar"
 
-  .with-transition .progress-bar {
-    transition: width 0.1s linear;
-  }
+describe("ProgressBar component", () => {
+  it("renders without crashing", () => {
+    const wrapper = shallow(<ProgressBar value={50} width={100} />)
 
-  .stale-element .progress-bar {
-    background-color: transparent;
-  }
-}
+    expect(wrapper.find("ProgressBar").length).toBe(1)
+  })
+
+  it("sets the value correctly", () => {
+    const wrapper = shallow(<ProgressBar value={50} width={100} />)
+
+    expect(wrapper.find("ProgressBar").prop("value")).toEqual(50)
+  })
+})

--- a/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement } from "react"
+import { SCSS_VARS } from "autogen/scssVariables"
+import { ProgressBar as UIProgressBar } from "baseui/progress-bar"
+
+export interface ProgressBarProps {
+  width?: number
+  value: number
+}
+
+function ProgressBar({ value, width }: ProgressBarProps): ReactElement {
+  return (
+    <UIProgressBar
+      value={value}
+      overrides={{
+        Bar: {
+          style: ({ $theme }) => ({
+            width,
+            margin: SCSS_VARS["$progress-bar-margin"],
+            height: SCSS_VARS["$progress-bar-height"],
+            backgroundColor: $theme.colors.progressbarTrackFill,
+          }),
+        },
+        BarProgress: {
+          style: {
+            backgroundColor: SCSS_VARS.$blue,
+          },
+        },
+      }}
+    />
+  )
+}
+
+export default ProgressBar

--- a/frontend/src/components/shared/ProgressBar/index.tsx
+++ b/frontend/src/components/shared/ProgressBar/index.tsx
@@ -15,25 +15,4 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
-import { Map as ImmutableMap } from "immutable"
-import ProgressBar from "components/shared/ProgressBar"
-
-export interface ProgressProps {
-  width: number
-  element: ImmutableMap<string, any>
-}
-
-export const FAST_UPDATE_MS = 50
-
-function Progress({ element, width }: ProgressProps): ReactElement {
-  const value = element.get("value")
-
-  return (
-    <div className="stProgress">
-      <ProgressBar value={value} width={width} />
-    </div>
-  )
-}
-
-export default Progress
+export { default } from "./ProgressBar"

--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -517,6 +517,7 @@ const themeOverrides = {
     notificationWarningText: SCSS_VARS["$alert-warning-text-color"],
     notificationNegativeBackground: SCSS_VARS["$alert-error-background-color"],
     notificationNegativeText: SCSS_VARS["$alert-error-text-color"],
+    progressbarTrackFill: grayLightest,
   },
 }
 
@@ -557,6 +558,8 @@ export const sidebarWidgetTheme = createTheme(mainThemePrimitives, {
     sliderTrackFill: grayLight,
     sliderHandleInnerFill: grayLight,
     sliderHandleInnerFillDisabled: grayLight,
+
+    progressbarTrackFill: grayLight,
   },
 })
 


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1863

**Description:**
Remove Reactstrap support for Progress bars using BaseWeb. More or less an identical change

**Before**

![image](https://user-images.githubusercontent.com/69432/90692257-ab146b00-e229-11ea-93d8-80d612903ed0.png)

**After**

![image](https://user-images.githubusercontent.com/69432/90692168-7f918080-e229-11ea-8024-e6c95b86d922.png)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
