### PR TITLE
[RFC]: Use appdirs for platform-specific configuration directories.

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -27,6 +27,7 @@ sphinx-rtd-theme = "*"
 # IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
 # And if you do add one, make the required version as general as possible.
 altair = ">=3.2.0"
+appdirs = "*"
 astor = "*"
 base58 = "*"
 blinker = "*"

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -959,6 +959,7 @@ def parse_config_file(force=False):
     # $CWD/.streamlit/config.toml if it exists.
     config_filenames = [
         file_util.get_streamlit_file_path("config.toml"),
+        file_util.get_streamlit_home_file_path("config.toml"),
         file_util.get_project_streamlit_file_path("config.toml"),
     ]
 

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -14,10 +14,11 @@
 
 import contextlib
 import errno
+import fnmatch
 import io
 import os
 
-import fnmatch
+import appdirs
 
 from streamlit import env_util
 from streamlit import util
@@ -128,6 +129,17 @@ def get_assets_dir():
 
 
 def get_streamlit_file_path(*filepath):
+    """Return the full path to a file in the appropriate platform-specific dir.
+
+    This doesn't guarantee that the file (or its directory) exists.
+    """
+    return os.path.join(
+        appdirs.user_config_dir(CONFIG_FOLDER_NAME),
+        *filepath,
+    )
+
+
+def get_streamlit_home_file_path(*filepath):
     """Return the full path to a file in ~/.streamlit.
 
     This doesn't guarantee that the file (or its directory) exists.


### PR DESCRIPTION
Hello.

Submitting this to see if you'd be amenable to it.

This PR allows reading configs via [appdirs](https://pypi.org/project/appdirs/), which allows folks to put it in the appropriate platform-specific directory.

(E.g. on Linux, `~/.config/streamlit` rather than `~/.streamlit`).

Is this something you'd be interested in?
