### PR TITLE
Migrate Tooltip to BaseWeb

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ import { fromJS, List } from "immutable"
 import classNames from "classnames"
 // Other local imports.
 import ReportView from "components/core/ReportView/"
-import { StatusWidget } from "components/core/StatusWidget/"
+import StatusWidget from "components/core/StatusWidget"
 import MainMenu from "components/core/MainMenu/"
 import {
   DialogProps,

--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { shallow } from "enzyme"
+import { ConnectionState } from "lib/ConnectionState"
+import { ReportRunState } from "lib/ReportRunState"
+import { SessionEventDispatcher } from "lib/SessionEventDispatcher"
+import { SessionEvent } from "autogen/proto"
+
+import StatusWidget, { StatusWidgetProps } from "./StatusWidget"
+
+const getProps = (
+  propOverrides: Partial<StatusWidgetProps> = {}
+): StatusWidgetProps => ({
+  connectionState: ConnectionState.CONNECTED,
+  sessionEventDispatcher: new SessionEventDispatcher(),
+  reportRunState: ReportRunState.RUNNING,
+  rerunReport: (alwaysRerun: boolean) => {},
+  stopReport: () => {},
+  ...propOverrides,
+})
+
+describe("Tooltip element", () => {
+  it("renders a Tooltip", () => {
+    const wrapper = shallow(<StatusWidget {...getProps()} />)
+
+    expect(wrapper.find("#ReportStatus").exists()).toBeTruthy()
+  })
+
+  it("renders its tooltip when disconnected", () => {
+    const wrapper = shallow(
+      <StatusWidget
+        {...getProps({ connectionState: ConnectionState.CONNECTING })}
+      />
+    )
+
+    expect(wrapper.find("Tooltip").exists()).toBeTruthy()
+  })
+
+  it("renders its tooltip when connecting", () => {
+    const wrapper = shallow(
+      <StatusWidget
+        {...getProps({ connectionState: ConnectionState.CONNECTING })}
+      />
+    )
+
+    expect(wrapper.find("Tooltip").exists()).toBeTruthy()
+  })
+
+  it("renders its tooltip when disconnected", () => {
+    const wrapper = shallow(
+      <StatusWidget
+        {...getProps({
+          connectionState: ConnectionState.DISCONNECTED_FOREVER,
+        })}
+      />
+    )
+
+    expect(wrapper.find("Tooltip").exists()).toBeTruthy()
+  })
+
+  it("renders its tooltip when running and minimized", () => {
+    const wrapper = shallow(<StatusWidget {...getProps()} />)
+    expect(wrapper.find("Tooltip").exists()).toBeFalsy()
+
+    wrapper.setState({ statusMinimized: true })
+    expect(wrapper.find("Tooltip").exists()).toBeTruthy()
+  })
+
+  it("does not render its tooltip when connected", () => {
+    const wrapper = shallow(
+      <StatusWidget
+        {...getProps({ connectionState: ConnectionState.CONNECTED })}
+      />
+    )
+
+    expect(wrapper.find("Tooltip").exists()).toBeFalsy()
+  })
+
+  it("does not render its tooltip when static", () => {
+    const wrapper = shallow(
+      <StatusWidget
+        {...getProps({ connectionState: ConnectionState.STATIC })}
+      />
+    )
+
+    expect(wrapper.find("Tooltip").exists()).toBeFalsy()
+  })
+
+  it("sets and unsets the sessionEventConnection", () => {
+    const sessionEventDispatcher = new SessionEventDispatcher()
+    const connectSpy = jest.fn()
+    const disconnectSpy = jest.fn()
+    sessionEventDispatcher.onSessionEvent.connect = connectSpy.mockImplementation(
+      () => ({
+        disconnect: disconnectSpy,
+      })
+    )
+
+    const wrapper = shallow<StatusWidget>(
+      <StatusWidget {...getProps({ sessionEventDispatcher })} />
+    )
+
+    expect(connectSpy).toBeCalled()
+
+    wrapper.unmount()
+
+    expect(disconnectSpy).toBeCalled()
+  })
+
+  it("Calls stopReport when clicked", () => {
+    const stopReport = jest.fn()
+    const wrapper = shallow<StatusWidget>(
+      <StatusWidget {...getProps({ stopReport })} />
+    )
+
+    wrapper.find("Button").simulate("click")
+
+    expect(stopReport).toBeCalled()
+  })
+
+  it("shows the rerun button when report changes", () => {
+    const sessionEventDispatcher = new SessionEventDispatcher()
+    const rerunReport = jest.fn()
+
+    const wrapper = shallow<StatusWidget>(
+      <StatusWidget
+        {...getProps({
+          rerunReport,
+          sessionEventDispatcher,
+          reportRunState: ReportRunState.NOT_RUNNING,
+        })}
+      />
+    )
+
+    sessionEventDispatcher.handleSessionEventMsg(
+      new SessionEvent({
+        reportChangedOnDisk: true,
+        reportWasManuallyStopped: null,
+        scriptCompilationException: null,
+      })
+    )
+
+    expect(wrapper.find("Button").length).toEqual(2)
+
+    wrapper
+      .find("Button")
+      .at(0)
+      .simulate("click")
+    expect(rerunReport).toBeCalledWith(false)
+  })
+
+  it("shows the always rerun button when report changes", () => {
+    const sessionEventDispatcher = new SessionEventDispatcher()
+    const rerunReport = jest.fn()
+
+    const wrapper = shallow<StatusWidget>(
+      <StatusWidget
+        {...getProps({
+          rerunReport,
+          sessionEventDispatcher,
+          reportRunState: ReportRunState.NOT_RUNNING,
+        })}
+      />
+    )
+
+    sessionEventDispatcher.handleSessionEventMsg(
+      new SessionEvent({
+        reportChangedOnDisk: true,
+        reportWasManuallyStopped: null,
+        scriptCompilationException: null,
+      })
+    )
+
+    expect(wrapper.find("Button").length).toEqual(2)
+
+    wrapper
+      .find("Button")
+      .at(1)
+      .simulate("click")
+    expect(rerunReport).toBeCalledWith(true)
+  })
+})

--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -123,7 +123,7 @@ describe("Tooltip element", () => {
     expect(disconnectSpy).toBeCalled()
   })
 
-  it("Calls stopReport when clicked", () => {
+  it("calls stopReport when clicked", () => {
     const stopReport = jest.fn()
     const wrapper = shallow<StatusWidget>(
       <StatusWidget {...getProps({ stopReport })} />

--- a/frontend/src/components/core/StatusWidget/StatusWidget.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.tsx
@@ -19,7 +19,8 @@ import { RERUN_PROMPT_MODAL_DIALOG } from "lib/baseconsts"
 import React, { PureComponent, ReactNode } from "react"
 import { HotKeys } from "react-hotkeys"
 import { CSSTransition } from "react-transition-group"
-import { Button, UncontrolledTooltip } from "reactstrap"
+import { Button } from "reactstrap"
+import Tooltip, { Placement } from "components/shared/Tooltip"
 import { SignalConnection } from "typed-signals"
 
 import { ConnectionState } from "lib/ConnectionState"
@@ -38,7 +39,7 @@ import iconRunning from "assets/img/icon_running.gif"
 import "./StatusWidget.scss"
 
 /** Component props */
-interface Props {
+export interface StatusWidgetProps {
   /** State of our connection to the server. */
   connectionState: ConnectionState
 
@@ -105,7 +106,7 @@ const PROMPT_DISPLAY_HOVER_TIMEOUT_MS = 1.0 * 1000
  * connection status, the run-state of our report, and transient report-related
  * events.
  */
-export class StatusWidget extends PureComponent<Props, State> {
+class StatusWidget extends PureComponent<StatusWidgetProps, State> {
   /** onSessionEvent signal connection */
   private sessionEventConn?: SignalConnection
 
@@ -117,7 +118,7 @@ export class StatusWidget extends PureComponent<Props, State> {
     [key: string]: (keyEvent?: KeyboardEvent) => void
   }
 
-  constructor(props: Props) {
+  constructor(props: StatusWidgetProps) {
     super(props)
 
     this.state = {
@@ -136,7 +137,9 @@ export class StatusWidget extends PureComponent<Props, State> {
   }
 
   /** Called by React on prop changes */
-  public static getDerivedStateFromProps(props: Props): Partial<State> | null {
+  public static getDerivedStateFromProps(
+    props: StatusWidgetProps
+  ): Partial<State> | null {
     // Reset transient event-related state when prop changes
     // render that state irrelevant
     if (props.reportRunState === ReportRunState.RUNNING) {
@@ -262,7 +265,10 @@ export class StatusWidget extends PureComponent<Props, State> {
     }
 
     return (
-      <div>
+      <Tooltip
+        content={() => <div>{ui.tooltip}</div>}
+        placement={Placement.BOTTOM}
+      >
         <div
           id="ConnectionStatus"
           className={this.state.statusMinimized ? "minimized" : ""}
@@ -270,10 +276,7 @@ export class StatusWidget extends PureComponent<Props, State> {
           <Icon className="icon" type={ui.icon} />
           <label>{ui.label}</label>
         </div>
-        <UncontrolledTooltip placement="bottom" target="ConnectionStatus">
-          {ui.tooltip}
-        </UncontrolledTooltip>
-      </div>
+      </Tooltip>
     )
   }
 
@@ -287,6 +290,10 @@ export class StatusWidget extends PureComponent<Props, State> {
       this.handleStopReportClick
     )
 
+    const runningIcon = (
+      <img className="ReportRunningIcon" src={iconRunning} alt="Running..." />
+    )
+
     return (
       <div
         id="ReportStatus"
@@ -294,20 +301,18 @@ export class StatusWidget extends PureComponent<Props, State> {
           this.state.statusMinimized ? "report-is-running-minimized" : ""
         }
       >
-        <img
-          className="ReportRunningIcon"
-          src={iconRunning}
-          alt="Running..."
-        />
+        {this.state.statusMinimized ? (
+          <Tooltip
+            placement={Placement.BOTTOM}
+            content={() => <div>This script is currently running</div>}
+          >
+            {runningIcon}
+          </Tooltip>
+        ) : (
+          runningIcon
+        )}
         <label>Running...</label>
         {stopButton}
-        {this.state.statusMinimized ? (
-          <UncontrolledTooltip placement="bottom" target="ReportStatus">
-            This script is currently running
-          </UncontrolledTooltip>
-        ) : (
-          ""
-        )}
       </div>
     )
   }
@@ -419,3 +424,5 @@ export class StatusWidget extends PureComponent<Props, State> {
     }
   }
 }
+
+export default StatusWidget

--- a/frontend/src/components/core/StatusWidget/index.tsx
+++ b/frontend/src/components/core/StatusWidget/index.tsx
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export * from "./StatusWidget"
+export { default } from "./StatusWidget"

--- a/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { shallow } from "enzyme"
+import { PLACEMENT } from "baseui/tooltip"
+
+import Tooltip, { Placement, TooltipProps } from "./Tooltip"
+
+const getProps = (
+  propOverrides: Partial<TooltipProps> = {}
+): TooltipProps => ({
+  placement: Placement.AUTO,
+  content: () => {},
+  children: null,
+  ...propOverrides,
+})
+
+describe("Tooltip element", () => {
+  it("renders a Tooltip", () => {
+    const wrapper = shallow(<Tooltip {...getProps()}></Tooltip>)
+
+    expect(wrapper.find("StatefulTooltip").exists()).toBeTruthy()
+  })
+
+  it("renders its children", () => {
+    const wrapper = shallow(
+      <Tooltip {...getProps()}>
+        <div className="foo" />
+      </Tooltip>
+    )
+
+    expect(wrapper.find(".foo").exists()).toBeTruthy()
+  })
+
+  it("sets its placement", () => {
+    const wrapper = shallow(
+      <Tooltip {...getProps({ placement: Placement.BOTTOM })} />
+    )
+
+    expect(wrapper.find("StatefulTooltip").prop("placement")).toEqual(
+      PLACEMENT.bottom
+    )
+  })
+
+  it("sets the same content", () => {
+    const content = <span className="foo" />
+    const wrapper = shallow(<Tooltip {...getProps({ content })} />)
+
+    expect(wrapper.find("StatefulTooltip").prop("content")).toEqual(content)
+  })
+})

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -1,0 +1,67 @@
+import React, { ReactElement, ReactNode } from "react"
+import { StatefulTooltip, ACCESSIBILITY_TYPE, PLACEMENT } from "baseui/tooltip"
+
+export enum Placement {
+  AUTO = "auto",
+  TOPLEFT = "topLeft",
+  TOP = "top",
+  TOPRIGHT = "topRight",
+  RIGHTTOP = "rightTop",
+  RIGHT = "right",
+  RIGHTBOTTOM = "rightBottom",
+  BOTTOMRIGHT = "bottomRight",
+  BOTTOM = "bottom",
+  BOTTOMLEFT = "bottomLeft",
+  LEFTBOTTOM = "leftBottom",
+  LEFT = "left",
+  LEFTTOP = "leftTop",
+}
+
+export interface TooltipProps {
+  content: ReactNode
+  placement: Placement
+  children: ReactNode
+}
+
+function Tooltip({
+  content,
+  placement,
+  children,
+}: TooltipProps): ReactElement {
+  return (
+    <StatefulTooltip
+      content={content}
+      placement={PLACEMENT[placement]}
+      accessibilityType={ACCESSIBILITY_TYPE.tooltip}
+      showArrow
+      overrides={{
+        Arrow: {
+          style: {
+            backgroundColor: "black",
+            opacity: 0.9,
+          },
+        },
+        Body: {
+          style: {
+            backgroundColor: "black",
+            borderRadius: "0.25rem",
+            opacity: 0.9,
+          },
+        },
+        Inner: {
+          style: {
+            backgroundColor: "transparent",
+            color: "white",
+            fontSize: "0.875rem",
+            fontWeight: "normal",
+          },
+        },
+      }}
+    >
+      {/* BaseWeb does manipulates its child, so we create a wrapper div for protection */}
+      <div>{children}</div>
+    </StatefulTooltip>
+  )
+}
+
+export default Tooltip

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -38,19 +38,16 @@ function Tooltip({
         Arrow: {
           style: {
             backgroundColor: "black",
-            opacity: 0.9,
           },
         },
         Body: {
           style: {
-            backgroundColor: "black",
             borderRadius: "0.25rem",
-            opacity: 0.9,
           },
         },
         Inner: {
           style: {
-            backgroundColor: "transparent",
+            backgroundColor: "black",
             color: "white",
             fontSize: "0.875rem",
             fontWeight: "normal",

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -3,18 +3,18 @@ import { StatefulTooltip, ACCESSIBILITY_TYPE, PLACEMENT } from "baseui/tooltip"
 
 export enum Placement {
   AUTO = "auto",
-  TOPLEFT = "topLeft",
+  TOP_LEFT = "topLeft",
   TOP = "top",
-  TOPRIGHT = "topRight",
-  RIGHTTOP = "rightTop",
+  TOP_RIGHT = "topRight",
+  RIGHT_TOP = "rightTop",
   RIGHT = "right",
-  RIGHTBOTTOM = "rightBottom",
-  BOTTOMRIGHT = "bottomRight",
+  RIGHT_BOTTOM = "rightBottom",
+  BOTTOM_RIGHT = "bottomRight",
   BOTTOM = "bottom",
-  BOTTOMLEFT = "bottomLeft",
-  LEFTBOTTOM = "leftBottom",
+  BOTTOM_LEFT = "bottomLeft",
+  LEFT_BOTTOM = "leftBottom",
   LEFT = "left",
-  LEFTTOP = "leftTop",
+  LEFT_TOP = "leftTop",
 }
 
 export interface TooltipProps {
@@ -55,7 +55,7 @@ function Tooltip({
         },
       }}
     >
-      {/* BaseWeb does manipulates its child, so we create a wrapper div for protection */}
+      {/* BaseWeb manipulates its child, so we create a wrapper div for protection */}
       <div>{children}</div>
     </StatefulTooltip>
   )

--- a/frontend/src/components/shared/Tooltip/index.tsx
+++ b/frontend/src/components/shared/Tooltip/index.tsx
@@ -1,0 +1,1 @@
+export { default, Placement } from "./Tooltip"


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1861

**Description:**
* Tooltip is now in Baseweb
* Extra tests and conforming interface provided to `StatusWidget`

** Before **
![tooltip_before](https://user-images.githubusercontent.com/69432/91073842-8553e100-e5f0-11ea-9a14-f8aba48bdeff.png)

** After**
![tooltip_after](https://user-images.githubusercontent.com/69432/91074462-702b8200-e5f1-11ea-9afb-75a5214a3dd2.png)

Note the opaque-ness. This is due to the simplicity in the arrow from baseweb (it's actually a 45 degree rotated square).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
