### PR TITLE
Migrate Spinner to Baseweb

### DIFF
--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -126,3 +126,6 @@ $alert-error-text-color: rgb(157, 41, 45);
 $alert-warning-background-color: change-color($yellow, $alpha: 0.2);
 $alert-warning-border-color: change-color($yellow, $alpha: 0.8);
 $alert-warning-text-color: rgb(148, 124, 45);
+
+// FileUploader
+$file-uploader-spinner-size: $font-size-sm * 0.8;

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -156,10 +156,19 @@ class FileUploader extends React.PureComponent<Props, State> {
       <div className="uploadStatus uploadProgress">
         <span className="body">
           <Spinner
-            size={SCSS_VARS["$font-size-sm"]}
+            size={SCSS_VARS["$file-uploader-spinner-size"]}
             color={SCSS_VARS.$secondary}
-          />{" "}
-          Uploading...
+            overrides={{
+              Svg: {
+                // Hardcoding since FileUploader is being converted
+                style: {
+                  verticalAlign: "baseline",
+                  marginRight: "0.375rem",
+                },
+              },
+            }}
+          />
+          <span>Uploading...</span>
         </span>
         <Button color="link" onClick={this.cancelCurrentUpload}>
           Cancel

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -23,7 +23,9 @@ import { FileUploadClient } from "lib/FileUploadClient"
 import { WidgetStateManager } from "lib/WidgetStateManager"
 import { fileUploaderOverrides } from "lib/widgetTheme"
 import React from "react"
-import { Button, Spinner } from "reactstrap"
+import { Button } from "reactstrap"
+import { Spinner } from "baseui/spinner"
+import { SCSS_VARS } from "autogen/scssVariables"
 import "./FileUploader.scss"
 
 export interface Props {
@@ -153,7 +155,11 @@ class FileUploader extends React.PureComponent<Props, State> {
     return (
       <div className="uploadStatus uploadProgress">
         <span className="body">
-          <Spinner color="secondary" size="sm" /> Uploading...
+          <Spinner
+            size={SCSS_VARS["$font-size-sm"]}
+            color={SCSS_VARS.$secondary}
+          />{" "}
+          Uploading...
         </span>
         <Button color="link" onClick={this.cancelCurrentUpload}>
           Cancel


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1866

**Description:**
Migrate Spinner to Baseweb. Spinner look and feel is slightly different.

* Spinner is set to the font size
* Spinner includes a track for the "loading bar" to run on.
* loading bar is thinner.

**Before**
![spinner_before](https://user-images.githubusercontent.com/69432/91084822-6ad63380-e601-11ea-843e-277f5e73458c.png)

**After**
![spinner_after](https://user-images.githubusercontent.com/69432/91084844-70337e00-e601-11ea-8424-2b8a0cdf9dd0.png)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
