### PR TITLE
Reformat with latest black version

### DIFF
--- a/docs/api-examples-source/widget.slider.py
+++ b/docs/api-examples-source/widget.slider.py
@@ -11,7 +11,8 @@ st.write("Values:", values)
 
 st.subheader("Time slider")
 appointment = st.slider(
-    "Schedule your appointment:", value=(time(11, 30), time(12, 45)),
+    "Schedule your appointment:",
+    value=(time(11, 30), time(12, 45)),
 )
 st.write("You're scheduled for:", appointment)
 

--- a/e2e/scripts/st_experimental_set_query_params.py
+++ b/e2e/scripts/st_experimental_set_query_params.py
@@ -18,5 +18,7 @@ set_query_params = st.button("Set current query params")
 
 if set_query_params:
     st.experimental_set_query_params(
-        show_map=True, number_of_countries=2, selected=["asia", "america"],
+        show_map=True,
+        number_of_countries=2,
+        selected=["asia", "america"],
     )

--- a/e2e/scripts/st_pydeck_chart.py
+++ b/e2e/scripts/st_pydeck_chart.py
@@ -33,7 +33,10 @@ st.pydeck_chart(
     pdk.Deck(
         map_style="mapbox://styles/mapbox/light-v9",
         initial_view_state=pdk.ViewState(
-            latitude=37.76, longitude=-122.4, zoom=11, pitch=50,
+            latitude=37.76,
+            longitude=-122.4,
+            zoom=11,
+            pitch=50,
         ),
         layers=[
             pdk.Layer(

--- a/examples/video.py
+++ b/examples/video.py
@@ -54,7 +54,9 @@ if len(files) == 0:
 
 else:
     filename = st.selectbox(
-        "Select a video file from your home directory (%s) to play" % avdir, files, 0,
+        "Select a video file from your home directory (%s) to play" % avdir,
+        files,
+        0,
     )
 
     st.video(os.path.join(avdir, filename))

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -71,8 +71,7 @@ class CliTest(unittest.TestCase):
         self.assertTrue("File does not exist" in result.output)
 
     def test_run_not_allowed_file_extension(self):
-        """streamlit run should fail if a not allowed file extension is passed.
-        """
+        """streamlit run should fail if a not allowed file extension is passed."""
 
         result = self.runner.invoke(cli, ["run", "file_name.doc"])
 
@@ -102,8 +101,8 @@ class CliTest(unittest.TestCase):
     @tempdir()
     def test_run_non_existing_url(self, temp_dir):
         """streamlit run should fail if a non existing but valid
-         url is passed.
-         """
+        url is passed.
+        """
 
         with patch("validators.url", return_value=True), patch(
             "streamlit.cli._main_run"

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -52,14 +52,16 @@ class DeclareComponentTest(unittest.TestCase):
         from component_test_data import component as init_component
 
         self.assertEqual(
-            "component_test_data.foo", init_component.name,
+            "component_test_data.foo",
+            init_component.name,
         )
 
         # Test a component defined in a module within a package
         from component_test_data.outer_module import component as outer_module_component
 
         self.assertEqual(
-            "component_test_data.outer_module.foo", outer_module_component.name,
+            "component_test_data.outer_module.foo",
+            outer_module_component.name,
         )
 
         # Test a component defined in module within a nested package
@@ -68,7 +70,8 @@ class DeclareComponentTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            "component_test_data.nested.inner_module.foo", inner_module_component.name,
+            "component_test_data.nested.inner_module.foo",
+            inner_module_component.name,
         )
 
     def test_only_path(self):
@@ -322,7 +325,8 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(404, response.code)
         self.assertEqual(
-            b"components_test.test read error: Invalid content", response.body,
+            b"components_test.test read error: Invalid content",
+            response.body,
         )
 
 

--- a/lib/tests/streamlit/data_frame_proto_test.py
+++ b/lib/tests/streamlit/data_frame_proto_test.py
@@ -48,8 +48,7 @@ class DataFrameProtoTest(unittest.TestCase):
     """Test streamlit.data_frame_proto."""
 
     def test_marshall_data_frame(self):
-        """Test streamlit.data_frame_proto.marshall_data_frame.
-        """
+        """Test streamlit.data_frame_proto.marshall_data_frame."""
         pass
 
     def test_is_pandas_styler(self):

--- a/lib/tests/streamlit/dataframe_dimensions_test.py
+++ b/lib/tests/streamlit/dataframe_dimensions_test.py
@@ -26,23 +26,19 @@ class DeltaGeneratorDataframeTest(testutil.DeltaGeneratorTestCase):
     """
 
     def test_no_dimensions(self):
-        """When no dimension parameters are passed
-        """
+        """When no dimension parameters are passed"""
         self._do_test(lambda fn, df: fn(df), 0, 0)
 
     def test_with_dimensions(self):
-        """When dimension parameter are passed
-        """
+        """When dimension parameter are passed"""
         self._do_test(lambda fn, df: fn(df, 10, 20), 10, 20)
 
     def test_with_height_only(self):
-        """When only height parameter is passed
-        """
+        """When only height parameter is passed"""
         self._do_test(lambda fn, df: fn(df, height=20), 0, 20)
 
     def test_with_width_only(self):
-        """When only width parameter is passed
-        """
+        """When only width parameter is passed"""
         self._do_test(lambda fn, df: fn(df, width=20), 20, 0)
 
     def _do_test(self, fn, expectedWidth, expectedHeight):

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -401,7 +401,9 @@ class HashTest(unittest.TestCase):
         tempdir = tempfile.TemporaryDirectory()
 
         model = tf.keras.models.Sequential(
-            [tf.keras.layers.Dense(512, activation="relu", input_shape=(784,)),]
+            [
+                tf.keras.layers.Dense(512, activation="relu", input_shape=(784,)),
+            ]
         )
         model.save(tempdir.name)
 
@@ -477,7 +479,8 @@ class HashTest(unittest.TestCase):
         id_hash_func = {types.GeneratorType: id}
 
         self.assertEqual(
-            get_hash(g, hash_funcs=id_hash_func), get_hash(g, hash_funcs=id_hash_func),
+            get_hash(g, hash_funcs=id_hash_func),
+            get_hash(g, hash_funcs=id_hash_func),
         )
 
         unique_hash_func = {types.GeneratorType: lambda x: time.time()}
@@ -572,7 +575,8 @@ class HashTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            hash_engine(auth_url), hash_engine("%s=%s" % (url, params_foo)),
+            hash_engine(auth_url),
+            hash_engine("%s=%s" % (url, params_foo)),
         )
         self.assertNotEqual(
             hash_engine("%s=%s" % (url, params_foo)),

--- a/lib/tests/streamlit/image_proto_test.py
+++ b/lib/tests/streamlit/image_proto_test.py
@@ -94,10 +94,22 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            (IMAGES["img_32_32_3_rgb"]["np"], "png",),
-            (IMAGES["img_32_32_3_bgr"]["np"], "png",),
-            (IMAGES["img_64_64_rgb"]["np"], "jpeg",),
-            (IMAGES["img_32_32_3_rgba"]["np"], "jpeg",),
+            (
+                IMAGES["img_32_32_3_rgb"]["np"],
+                "png",
+            ),
+            (
+                IMAGES["img_32_32_3_bgr"]["np"],
+                "png",
+            ),
+            (
+                IMAGES["img_64_64_rgb"]["np"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_32_32_3_rgba"]["np"],
+                "jpeg",
+            ),
         ]
     )
     def test_marshall_images(self, data_in, format):
@@ -131,14 +143,38 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            (IMAGES["img_32_32_3_rgb"]["np"], "jpeg",),
-            (IMAGES["img_32_32_3_bgr"]["np"], "jpeg",),
-            (IMAGES["img_64_64_rgb"]["np"], "jpeg",),
-            (IMAGES["img_32_32_3_rgba"]["np"], "png",),
-            (IMAGES["img_32_32_3_rgb"]["pil"], "jpeg",),
-            (IMAGES["img_32_32_3_bgr"]["pil"], "jpeg",),
-            (IMAGES["img_64_64_rgb"]["pil"], "jpeg",),
-            (IMAGES["img_32_32_3_rgba"]["pil"], "png",),
+            (
+                IMAGES["img_32_32_3_rgb"]["np"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_32_32_3_bgr"]["np"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_64_64_rgb"]["np"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_32_32_3_rgba"]["np"],
+                "png",
+            ),
+            (
+                IMAGES["img_32_32_3_rgb"]["pil"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_32_32_3_bgr"]["pil"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_64_64_rgb"]["pil"],
+                "jpeg",
+            ),
+            (
+                IMAGES["img_32_32_3_rgba"]["pil"],
+                "png",
+            ),
         ]
     )
     def test_marshall_images_with_auto_output_format(self, data_in, expected_format):
@@ -153,12 +189,30 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            (IMAGES["img_32_32_3_rgb"]["np"], "/media/",),
-            ("https://streamlit.io/test.png", "https://streamlit.io/test.png",),
-            ("<svg fake></svg>", "data:image/svg+xml,<svg fake></svg>",),
-            ("\n<svg fake></svg>", "data:image/svg+xml,\n<svg fake></svg>",),
-            ("🦈", "🦈",),
-            (":shark:", ":shark:",),
+            (
+                IMAGES["img_32_32_3_rgb"]["np"],
+                "/media/",
+            ),
+            (
+                "https://streamlit.io/test.png",
+                "https://streamlit.io/test.png",
+            ),
+            (
+                "<svg fake></svg>",
+                "data:image/svg+xml,<svg fake></svg>",
+            ),
+            (
+                "\n<svg fake></svg>",
+                "data:image/svg+xml,\n<svg fake></svg>",
+            ),
+            (
+                "🦈",
+                "🦈",
+            ),
+            (
+                ":shark:",
+                ":shark:",
+            ),
         ]
     )
     def test_image_to_url(self, image, expected_prefix):

--- a/lib/tests/streamlit/pydeck_test.py
+++ b/lib/tests/streamlit/pydeck_test.py
@@ -29,7 +29,13 @@ class PyDeckTest(testutil.DeltaGeneratorTestCase):
     def test_basic(self):
         """Test that pydeck object orks."""
 
-        st.pydeck_chart(pdk.Deck(layers=[pdk.Layer("ScatterplotLayer", data=df1),]))
+        st.pydeck_chart(
+            pdk.Deck(
+                layers=[
+                    pdk.Layer("ScatterplotLayer", data=df1),
+                ]
+            )
+        )
 
         el = self.get_delta_from_queue().new_element
         actual = json.loads(el.deck_gl_json_chart.json)

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -37,8 +37,7 @@ class ReportSessionTest(unittest.TestCase):
     @patch("streamlit.report_session.Report")
     @patch("streamlit.report_session.LocalSourcesWatcher")
     def test_enqueue_without_tracer(self, _1, _2, patched_config):
-        """Make sure we try to handle execution control requests.
-        """
+        """Make sure we try to handle execution control requests."""
 
         def get_option(name):
             if name == "server.runOnSave":

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -522,8 +522,10 @@ def require_widgets_deltas(
 
     # If we get here, at least 1 runner hasn't yet completed before our
     # timeout. Create an error string for debugging.
-    err_string = "require_widgets_deltas() timed out after {}s ({}/{} runners complete)".format(
-        timeout, num_complete, len(runners)
+    err_string = (
+        "require_widgets_deltas() timed out after {}s ({}/{} runners complete)".format(
+            timeout, num_complete, len(runners)
+        )
     )
     for runner in runners:
         if len(runner.deltas()) < NUM_DELTAS:

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -133,7 +133,8 @@ class ServerTest(ServerTestCase):
             session_infos = list(self.server._session_info_by_id.values())
             self.assertEqual(2, len(session_infos))
             self.assertNotEqual(
-                session_infos[0].session.id, session_infos[1].session.id,
+                session_infos[0].session.id,
+                session_infos[1].session.id,
             )
 
             # Close the first
@@ -199,7 +200,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     def test_forwardmsg_cacheable_flag(self):
         """Test that the metadata.cacheable flag is set properly on outgoing
-         ForwardMsgs."""
+        ForwardMsgs."""
         with self._patch_report_session():
             yield self.start_server_loop()
 
@@ -552,7 +553,7 @@ class PortRotateOneTest(unittest.TestCase):
 
 class UnixSocketTest(unittest.TestCase):
     """Tests start_listening uses a unix socket when socket.address starts with
-       unix:// """
+    unix://"""
 
     def get_httpserver(self):
         httpserver = mock.MagicMock()


### PR DESCRIPTION
**Issue:** Black released a [new version](https://black.readthedocs.io/en/stable/change_log.html#b0) which fails our lint check. Simply upgraded and ran black through our codebase.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
