### PR TITLE
Set z-index of balloons to 1000000 

### DIFF
--- a/frontend/src/components/elements/Balloons/Balloons.scss
+++ b/frontend/src/components/elements/Balloons/Balloons.scss
@@ -18,6 +18,7 @@
   position: fixed;
   bottom: 0;
   margin-left: -68px; /* Center 136px-wide image */
+  z-index: 1000000;
 
   /* If modifying the duration, you should also modify Balloons.js */
   animation-duration: 0.3s, 1s, 1s;


### PR DESCRIPTION
For issue https://github.com/streamlit/streamlit/issues/1916
Set frontend/src/components/Balloons/Balloons.scss 

style .balloons > .balloon to have z-index of 1000000

## Before contributing (PLEASE READ!)

⚠️ **If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, and then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers, and (4) your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
