### PR TITLE
Pin setuptools to <= 49.6.0

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -13,7 +13,7 @@ pytest = "*"
 pytest-cov = "*"
 requests-mock = "*"
 # Hardcode setuptools - issue opened https://github.com/pypa/setuptools/issues/2366
-setuptools= "<=49.6.0"
+setuptools= "==49.6.0"
 testfixtures = "*"
 twine = "*"
 wheel = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -13,7 +13,7 @@ pytest = "*"
 pytest-cov = "*"
 requests-mock = "*"
 # Hardcode setuptools - issue opened https://github.com/pypa/setuptools/issues/2366
-setuptools= "==49.6.0"
+setuptools = "<=49.6.0"
 testfixtures = "*"
 twine = "*"
 wheel = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -12,6 +12,8 @@ pipenv = "*"
 pytest = "*"
 pytest-cov = "*"
 requests-mock = "*"
+# Hardcode setuptools - issue opened https://github.com/pypa/setuptools/issues/2366
+setuptools= "<=49.6.0"
 testfixtures = "*"
 twine = "*"
 wheel = "*"


### PR DESCRIPTION
**Issue:** setuptools version 50.0 seems to have several issues and is failing our CI. Created an issue for `setup.py develop`. See [setuptools issue 2355](https://github.com/pypa/setuptools/issues/2355). 

This looks to fail occasionally on CI based on what version gets installed? Always fails locally with version 50.0

**Description:** 
1. Pin setuptool to version 49.6.0 or earlier.
2. Created issue #1945 to unpin once resolved


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
