### PR TITLE
Switch CC docs statement to include ArrowTable

### DIFF
--- a/docs/develop_streamlit_components.md
+++ b/docs/develop_streamlit_components.md
@@ -255,4 +255,4 @@ Check out the [CustomDataframe](https://github.com/streamlit/component-template/
 
 You send data from the frontend to Python via the `Streamlit.setComponentValue()` API (which is part of the template code). Unlike arg-passing from Python → frontend, **this API takes a single value**. If you want to return multiple values, you'll need to wrap them in an `Array` or `Object`.
 
-Custom Components can currently _only_ send JSON-serializable data from the frontend to Python. We'll be adding support for returning `ArrowTable` from the frontend in the near future!
+Custom Components can send JSON-serializable data from the frontend to Python, as well as [Apache Arrow](http://arrow.apache.org/) `ArrowTable`s to represent dataframes.


### PR DESCRIPTION
Brief comment to change statement from "only supports JSON-serializable data" to include `ArrowTable` for dataframe representation.