### PR TITLE
Force reinstall of setuptools to 49.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,9 @@ commands:
               source venv/bin/activate
               pip install --upgrade pip
               pip install "setuptools<=49.6.0"
+              pip show setuptools
               make setup
               make pipenv-install
-              pip show setuptools
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ commands:
               pip install "setuptools<=49.6.0"
               make setup
               make pipenv-install
+              pip show setuptools
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,10 +146,17 @@ commands:
               python -m venv venv
               source venv/bin/activate
               pip install --upgrade pip
-              pip install "setuptools<=49.6.0"
+              echo "finished pip install **********"
               pip show setuptools
               make setup
+              echo "finished make setup **********"
+              pip show setuptools
               make pipenv-install
+              echo "finished make pipenv-install **********"
+              pip show setuptools
+              pip install "setuptools<=49.6.0" --force-reinstall --no-cache-dir
+              echo "finished force installing setuptools again **********"
+              pip show setuptools
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.
@@ -271,6 +278,7 @@ jobs:
       - run: &make_develop
           name: Run make develop
           command: |
+            pip show setuptools
             make develop
 
       #################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,6 @@ commands:
               pip install "setuptools<=49.6.0"
               make setup
               make pipenv-install
-              pip show setuptools
               deactivate
             else
               # The virtualenv WAS restored from cache. Don't create a new one.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,10 @@ commands:
               pip install --upgrade pip
               make setup
               make pipenv-install
-              echo "finished make pipenv-install **********"
+              # Looks like the pinned setuptools is not being respected
+              # In the meantime, forcing a reinstall of setuptools to unblock
+              # TODO: Cleanup as part of GH #1963
+              pip install "setuptools<=49.6.0" --force-reinstall --no-cache-dir
               pip show setuptools
               deactivate
             else
@@ -271,7 +274,6 @@ jobs:
       - run: &make_develop
           name: Run make develop
           command: |
-            pip show setuptools
             make develop
 
       #################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,22 +67,22 @@ commands:
       - restore_cache: &restore_virtualenv
           name: Restore virtualenv from cache
           keys:
-            - v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
+            - v14-python-venv-{{ checksum "~/python_cache_key.md5" }}
 
       - restore_cache: &restore_nvm
           name: Restore nvm and node_modules from cache
           keys:
-            - v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+            - v14-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
 
       - restore_cache: &restore_make
           name: Restore make from cache
           keys:
-            - v13_make.bin-{{ checksum "~/make.md5" }}
+            - v14_make.bin-{{ checksum "~/make.md5" }}
 
       - restore_cache: &restore_dot
           name: Restore dot from cache
           keys:
-            - v13_dot.bin-{{ checksum "~/dot.md5" }}
+            - v14_dot.bin-{{ checksum "~/dot.md5" }}
 
   pre-make:
     steps:
@@ -252,13 +252,13 @@ jobs:
 
       - save_cache:
           name: Save make to cache
-          key: v13_make.bin-{{ checksum "~/make.md5" }}
+          key: v14_make.bin-{{ checksum "~/make.md5" }}
           paths:
             - make.bin
 
       - save_cache:
           name: Save dot to cache
-          key: v13_dot.bin-{{ checksum "~/dot.md5" }}
+          key: v14_dot.bin-{{ checksum "~/dot.md5" }}
           paths:
             - dot.bin
 
@@ -338,13 +338,13 @@ jobs:
       #################################################################
       - save_cache:
           name: Save virtualenv to cache
-          key: v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
+          key: v14-python-venv-{{ checksum "~/python_cache_key.md5" }}
           paths:
             - venv
 
       - save_cache:
           name: Save nvm and node_modules to cache
-          key: v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+          key: v14-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
           paths:
             - ~/.nvm
             - ~/.cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ commands:
               python -m venv venv
               source venv/bin/activate
               pip install --upgrade pip
+              pip install "setuptools<=49.6.0"
               make setup
               make pipenv-install
               deactivate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,22 +67,22 @@ commands:
       - restore_cache: &restore_virtualenv
           name: Restore virtualenv from cache
           keys:
-            - v14-python-venv-{{ checksum "~/python_cache_key.md5" }}
+            - v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
 
       - restore_cache: &restore_nvm
           name: Restore nvm and node_modules from cache
           keys:
-            - v14-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+            - v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
 
       - restore_cache: &restore_make
           name: Restore make from cache
           keys:
-            - v14_make.bin-{{ checksum "~/make.md5" }}
+            - v13_make.bin-{{ checksum "~/make.md5" }}
 
       - restore_cache: &restore_dot
           name: Restore dot from cache
           keys:
-            - v14_dot.bin-{{ checksum "~/dot.md5" }}
+            - v13_dot.bin-{{ checksum "~/dot.md5" }}
 
   pre-make:
     steps:
@@ -146,16 +146,9 @@ commands:
               python -m venv venv
               source venv/bin/activate
               pip install --upgrade pip
-              echo "finished pip install **********"
-              pip show setuptools
               make setup
-              echo "finished make setup **********"
-              pip show setuptools
               make pipenv-install
               echo "finished make pipenv-install **********"
-              pip show setuptools
-              pip install "setuptools<=49.6.0" --force-reinstall --no-cache-dir
-              echo "finished force installing setuptools again **********"
               pip show setuptools
               deactivate
             else
@@ -260,13 +253,13 @@ jobs:
 
       - save_cache:
           name: Save make to cache
-          key: v14_make.bin-{{ checksum "~/make.md5" }}
+          key: v13_make.bin-{{ checksum "~/make.md5" }}
           paths:
             - make.bin
 
       - save_cache:
           name: Save dot to cache
-          key: v14_dot.bin-{{ checksum "~/dot.md5" }}
+          key: v13_dot.bin-{{ checksum "~/dot.md5" }}
           paths:
             - dot.bin
 
@@ -347,13 +340,13 @@ jobs:
       #################################################################
       - save_cache:
           name: Save virtualenv to cache
-          key: v14-python-venv-{{ checksum "~/python_cache_key.md5" }}
+          key: v13-python-venv-{{ checksum "~/python_cache_key.md5" }}
           paths:
             - venv
 
       - save_cache:
           name: Save nvm and node_modules to cache
-          key: v14-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
+          key: v13-nvm_node_modules-{{ checksum "~/yarn.lock.md5" }}
           paths:
             - ~/.nvm
             - ~/.cache

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ install:
 .PHONY: develop
 # Install Streamlit as links in your Python environment, pointing to local workspace.
 develop:
-	cd lib ; python setup.py develop
+	pip show setuptools; cd lib ; python setup.py develop
 
 .PHONY: wheel
 # Create a Python wheel file in dist/.

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ pipenv-dev-install: lib/Pipfile
 	# "more deterministic", per pipenv's documentation.
 	# (Omitting this flag is causing incorrect dependency version
 	# resolution on CircleCI.)
-	cd lib; \
-		pipenv install --dev --skip-lock --sequential
+	pip show setuptools; cd lib; \
+		pipenv install --dev --skip-lock --sequential; \
+		pip show setuptools
 
 .PHONY: pipenv-test-install
 pipenv-test-install: lib/test-requirements.txt
@@ -151,7 +152,7 @@ install:
 .PHONY: develop
 # Install Streamlit as links in your Python environment, pointing to local workspace.
 develop:
-	pip show setuptools; cd lib ; python setup.py develop
+	cd lib ; python setup.py develop
 
 .PHONY: wheel
 # Create a Python wheel file in dist/.

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,8 @@ pipenv-dev-install: lib/Pipfile
 	# "more deterministic", per pipenv's documentation.
 	# (Omitting this flag is causing incorrect dependency version
 	# resolution on CircleCI.)
-	pip show setuptools; cd lib; \
-		pipenv install --dev --skip-lock --sequential; \
-		pip show setuptools
+	cd lib; \
+		pipenv install --dev --skip-lock --sequential
 
 .PHONY: pipenv-test-install
 pipenv-test-install: lib/test-requirements.txt

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -18,6 +18,7 @@ pyodbc
 # Feel free to remove this dependency if the requirement is gone.
 scipy==1.4.1
 seaborn
+setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions.
 tensorflow>2.0.0rc3


### PR DESCRIPTION
**Issue:** CI is occasionally failing because in some instances it's still resolving to setuptools v50.0.3.

**Description:**
1. Pin setuptools in requirements.txt (this still looks flakey?)
2. ☝️  seems flakey still so let's force a reinstall of pinned setuptools after just in case.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
