### PR TITLE
Allow Streamlit server to handle Range Requests

### DIFF
--- a/frontend/src/components/elements/Video/Video.test.tsx
+++ b/frontend/src/components/elements/Video/Video.test.tsx
@@ -102,11 +102,13 @@ describe("Video Element", () => {
     const videoElement: HTMLVideoElement = wrapper.find("video").getDOMNode()
 
     it("should set the current time to startTime on mount", () => {
+      videoElement.dispatchEvent(new Event("loadedmetadata"))
       expect(videoElement.currentTime).toBe(0)
     })
 
     it("should update the current time when startTime is changed", () => {
       wrapper.setProps(getProps({ startTime: 10 }))
+      videoElement.dispatchEvent(new Event("loadedmetadata"))
       expect(videoElement.currentTime).toBe(10)
     })
   })

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -33,7 +33,7 @@ export default function Video({ element, width }: VideoProps): ReactElement {
   const type = element.get("type")
   const url = element.get("url")
 
-  const setStartTime = () => {
+  const setStartTime: () => void = () => {
     if (videoRef.current) {
       videoRef.current.currentTime = element.get("startTime")
     }

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -33,9 +33,21 @@ export default function Video({ element, width }: VideoProps): ReactElement {
   const type = element.get("type")
   const url = element.get("url")
 
-  useEffect(() => {
+  const setStartTime = () => {
     if (videoRef.current) {
       videoRef.current.currentTime = element.get("startTime")
+    }
+  }
+
+  useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.addEventListener("loadedmetadata", setStartTime)
+    }
+
+    return () => {
+      if (videoRef.current) {
+        videoRef.current.removeEventListener("loadedmetadata", setStartTime)
+      }
     }
   }, [element])
 

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -33,20 +33,22 @@ export default function Video({ element, width }: VideoProps): ReactElement {
   const type = element.get("type")
   const url = element.get("url")
 
-  const setStartTime: () => void = () => {
-    if (videoRef.current) {
-      videoRef.current.currentTime = element.get("startTime")
-    }
-  }
-
   useEffect(() => {
-    if (videoRef.current) {
-      videoRef.current.addEventListener("loadedmetadata", setStartTime)
+    const videoNode = videoRef.current
+
+    const setStartTime: () => void = () => {
+      if (videoNode) {
+        videoNode.currentTime = element.get("startTime")
+      }
+    }
+
+    if (videoNode) {
+      videoNode.addEventListener("loadedmetadata", setStartTime)
     }
 
     return () => {
-      if (videoRef.current) {
-        videoRef.current.removeEventListener("loadedmetadata", setStartTime)
+      if (videoNode) {
+        videoNode.removeEventListener("loadedmetadata", setStartTime)
       }
     }
   }, [element])

--- a/lib/streamlit/media_file_manager.py
+++ b/lib/streamlit/media_file_manager.py
@@ -92,6 +92,10 @@ class MediaFile(object):
     def mimetype(self):
         return self._mimetype
 
+    @property
+    def content_size(self):
+        return len(self._content)
+
 
 class MediaFileManager(object):
     """In-memory file manager for MediaFile objects.

--- a/lib/streamlit/media_file_manager.py
+++ b/lib/streamlit/media_file_manager.py
@@ -201,12 +201,15 @@ class MediaFileManager(object):
 
         return mf
 
-    def get(self, mediafile_or_id):
+    def get(self, media_filename):
         """Returns MediaFile object for given file_id or MediaFile object.
 
         Raises KeyError if not found.
         """
-        return self._files_by_id[mediafile_or_id]
+        # Filename is {requested_hash}.{extension} but MediaFileManager
+        # is indexed by requested_hash.
+        hash = media_filename.split(".")[0]
+        return self._files_by_id[hash]
 
     def __contains__(self, mediafile_or_id):
         return mediafile_or_id in self._files_by_id

--- a/lib/streamlit/media_file_manager.py
+++ b/lib/streamlit/media_file_manager.py
@@ -123,13 +123,14 @@ class MediaFileManager(object):
         LOGGER.debug("Deleting expired files...")
 
         # Get a flat set of every file ID in the session ID map.
-        active_files = set()  # type: Set[MediaFile]
+        active_file_ids = set()  # type: Set[MediaFile]
 
         for files_by_coord in self._files_by_session_and_coord.values():
-            active_files = active_files.union(files_by_coord.values())
+            file_ids = map(lambda mf: mf.id, files_by_coord.values())
+            active_file_ids = active_file_ids.union(file_ids)
 
         for file_id, mf in list(self._files_by_id.items()):
-            if mf not in active_files:
+            if mf.id not in active_file_ids:
                 LOGGER.debug(f"Deleting File: {file_id}")
                 del self._files_by_id[file_id]
 

--- a/lib/streamlit/media_file_manager.py
+++ b/lib/streamlit/media_file_manager.py
@@ -126,7 +126,7 @@ class MediaFileManager(object):
         active_file_ids = set()  # type: Set[MediaFile]
 
         for files_by_coord in self._files_by_session_and_coord.values():
-            file_ids = map(lambda mf: mf.id, files_by_coord.values())
+            file_ids = map(lambda mf: mf.id, files_by_coord.values())  # type: ignore[no-any-return]
             active_file_ids = active_file_ids.union(file_ids)
 
         for file_id, mf in list(self._files_by_id.items()):

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -132,6 +132,8 @@ class ReportSession(object):
         """
         if self._state != ReportSessionState.SHUTDOWN_REQUESTED:
             LOGGER.debug("Shutting down (id=%s)", self.id)
+            # Clear any unused session files in upload file manager and media
+            # file manager
             self._uploaded_file_mgr.remove_session_files(self.id)
             media_file_manager.clear_session_files(self.id)
             media_file_manager.del_expired_files()

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -133,6 +133,8 @@ class ReportSession(object):
         if self._state != ReportSessionState.SHUTDOWN_REQUESTED:
             LOGGER.debug("Shutting down (id=%s)", self.id)
             self._uploaded_file_mgr.remove_session_files(self.id)
+            media_file_manager.clear_session_files(self.id)
+            media_file_manager.del_expired_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -341,6 +341,7 @@ class ScriptRunner(object):
         finally:
             self._widgets.reset_triggers()
             self.on_event.send(ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS)
+            media_file_manager.del_expired_files()
 
         # Use _log_if_error() to make sure we never ever ever stop running the
         # script without meaning to.

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -341,6 +341,8 @@ class ScriptRunner(object):
         finally:
             self._widgets.reset_triggers()
             self.on_event.send(ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS)
+            # delete expired files now that the script has run and files in use
+            # are marked as active
             media_file_manager.del_expired_files()
 
         # Use _log_if_error() to make sure we never ever ever stop running the

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -126,7 +126,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
             end = len(media.content)
 
         # content is bytes that work just by slicing supplied by start and end
-        yield media.content[start:end]
+        return media.content[start:end]
 
 
 class _SpecialRequestHandler(tornado.web.RequestHandler):

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -99,9 +99,9 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
     @classmethod
     def get_absolute_path(cls, root, path):
-        # Filename is {requested_hash}.{extension} but MediaFileManager
-        # is indexed by requested_hash.
-        return path.split(".")[0]
+        # All files are stored in memory, so the absolute path is just the
+        # path itself. In the MediaFileHandler, it's just the filename
+        return path
 
     @classmethod
     def get_content(cls, abspath, start=None, end=None):

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -348,7 +348,7 @@ class Server(object):
                 AssetsFileHandler,
                 {"path": "%s/" % file_util.get_assets_dir()},
             ),
-            (make_url_path_regex(base, "media/(.*)"), MediaFileHandler),
+            (make_url_path_regex(base, "media/(.*)"), MediaFileHandler, {"path": ""}),
             (
                 make_url_path_regex(base, "component/(.*)"),
                 ComponentRequestHandler,

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -36,7 +36,6 @@ from streamlit.config_option import ConfigOption
 from streamlit.forward_msg_cache import ForwardMsgCache
 from streamlit.forward_msg_cache import create_reference_msg
 from streamlit.forward_msg_cache import populate_hash_if_needed
-from streamlit.media_file_manager import media_file_manager
 from streamlit.report_session import ReportSession
 from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.logger import get_logger
@@ -232,8 +231,6 @@ class Server(object):
         self._ioloop = ioloop
         self._script_path = script_path
         self._command_line = command_line
-
-        media_file_manager.set_ioloop(ioloop=self._ioloop)
 
         # Mapping of ReportSession.id -> SessionInfo.
         self._session_info_by_id = {}

--- a/lib/tests/streamlit/media_file_manager_test.py
+++ b/lib/tests/streamlit/media_file_manager_test.py
@@ -23,7 +23,6 @@ from tornado.testing import AsyncTestCase
 
 from streamlit.media_file_manager import MediaFileManager
 from streamlit.media_file_manager import _calculate_file_id
-from streamlit.media_file_manager import KEEP_DELAY_SEC
 
 
 def random_coordinates():
@@ -153,7 +152,7 @@ class MediaFileManagerTest(AsyncTestCase):
         pretend_time_passed = self.get_mock_call_later()
         self.mfm.clear_session_files()
 
-        _time.return_value = KEEP_DELAY_SEC + 1
+        _time.return_value = 5 + 1
         pretend_time_passed[0]()
 
         # There should be only 0 file in MFM.
@@ -261,7 +260,7 @@ class MediaFileManagerTest(AsyncTestCase):
             len(self.mfm._files_by_session_and_coord), 0
         )  # Clears immediately
 
-        _time.return_value = KEEP_DELAY_SEC + 1
+        _time.return_value = 5 + 1
         pretend_time_passed[0]()
 
         self.assertEqual(len(self.mfm), 0)  # Now this is cleared too!

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -52,11 +52,9 @@ def _create_widget(id, states):
 class ScriptRunnerTest(AsyncTestCase):
     def setUp(self):
         super(ScriptRunnerTest, self).setUp()
-        media_file_manager.set_ioloop(self.io_loop)
 
     def tearDown(self):
         super(ScriptRunnerTest, self).tearDown()
-        media_file_manager.set_ioloop(None)
 
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""
@@ -522,10 +520,8 @@ def require_widgets_deltas(
 
     # If we get here, at least 1 runner hasn't yet completed before our
     # timeout. Create an error string for debugging.
-    err_string = (
-        "require_widgets_deltas() timed out after {}s ({}/{} runners complete)".format(
-            timeout, num_complete, len(runners)
-        )
+    err_string = "require_widgets_deltas() timed out after {}s ({}/{} runners complete)".format(
+        timeout, num_complete, len(runners)
     )
     for runner in runners:
         if len(runner.deltas()) < NUM_DELTAS:


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1804 #1294

**Description:**

Browsers are beginning to require Range Requests (notably Chrome and Safari) in order to display/set the start time effectively. This change fixes adds that functionality.

The Range Request is managed will in Tornado's `StaticFileHandler`, so I subclassed it and followed their convention for using the `MediaFileManager` vs an actual path.

We also remove the 5 second timer in favor of expiring files after a script completes running or when the session is disconnected.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
