### PR TITLE
Remove Tensorflow requirement for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,11 @@ commands:
           command: |
             ${SUDO} apt-get install -y unixodbc-dev
 
+      - run:
+          name: Install graphviz dependencies
+          command: |
+            ${SUDO} apt-get install -y libgvc6
+
       - run: &activate_virtualenv
           name: Create virtualenv
           command: |

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -21,6 +21,6 @@ seaborn
 setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions.
-tensorflow>2.0.0rc3
+tensorflow>2.2.0
 torch
 torchvision

--- a/lib/tests/streamlit/hashing_test.py
+++ b/lib/tests/streamlit/hashing_test.py
@@ -377,7 +377,6 @@ class HashTest(unittest.TestCase):
             f.seek(0)
             self.assertEqual(h1, get_hash(f))
 
-    @testutil.requires_tensorflow
     def test_keras_model(self):
         a = keras.applications.vgg16.VGG16(include_top=False, weights=None)
         b = keras.applications.vgg16.VGG16(include_top=False, weights=None)
@@ -388,7 +387,6 @@ class HashTest(unittest.TestCase):
         self.assertEqual(get_hash(a), get_hash(a))
         self.assertNotEqual(get_hash(a), get_hash(b))
 
-    @testutil.requires_tensorflow
     def test_tf_keras_model(self):
         a = tf.keras.applications.vgg16.VGG16(include_top=False, weights=None)
         b = tf.keras.applications.vgg16.VGG16(include_top=False, weights=None)
@@ -396,7 +394,6 @@ class HashTest(unittest.TestCase):
         self.assertEqual(get_hash(a), get_hash(a))
         self.assertNotEqual(get_hash(a), get_hash(b))
 
-    @testutil.requires_tensorflow
     def test_tf_saved_model(self):
         tempdir = tempfile.TemporaryDirectory()
 
@@ -433,7 +430,6 @@ class HashTest(unittest.TestCase):
         # stack due to an infinite recursion.)
         self.assertNotEqual(get_hash(MagicMock()), get_hash(MagicMock()))
 
-    @testutil.requires_tensorflow
     def test_tensorflow_session(self):
         tf_config = tf.compat.v1.ConfigProto()
         tf_session = tf.compat.v1.Session(config=tf_config)

--- a/lib/tests/streamlit/keras_test.py
+++ b/lib/tests/streamlit/keras_test.py
@@ -28,7 +28,6 @@ import streamlit as st
 from tests import testutil
 
 
-@testutil.requires_tensorflow
 class KerasTest(unittest.TestCase):
     """Test ability to marshall keras models."""
 
@@ -40,7 +39,9 @@ class KerasTest(unittest.TestCase):
         model.add(Flatten())
         model.add(Dense(8, activation="relu"))
 
-        with patch("streamlit.graphviz_chart") as graphviz_chart:
+        with patch(
+            "streamlit.delta_generator.DeltaGenerator.graphviz_chart"
+        ) as graphviz_chart:
             st.write(model)
 
             dot = vis_utils.model_to_dot(model)

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -53,22 +53,6 @@ def build_mock_config_is_manually_set(overrides_dict):
     return mock_config_is_manually_set
 
 
-def requires_tensorflow(func):
-    """Decorator indicating that a TestCase or test requires Tensorflow."""
-
-    @functools.wraps(func)
-    def inner(*args, **kwargs):
-        version = sys.version_info
-        if version.major == 3 and version.minor > 7:
-            args[0].skipTest(
-                "Requires Tensorflow, which doesn't support Python %d.%d"
-                % (version.major, version.minor)
-            )
-        func(*args, **kwargs)
-
-    return inner
-
-
 class DeltaGeneratorTestCase(unittest.TestCase):
     def setUp(self, override_root=True):
         self.report_queue = ReportQueue()


### PR DESCRIPTION
**Issue:** N/A

**Description:** 

In attempting to fix an issue with Tensorflow, I realized that users can upgrade tensorflow to support later versions of Python 3.8+. I removed the requirement to see how CI checks this.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
