### PR TITLE
Fixed regression that broke for multiselect default

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -66,7 +66,7 @@ class MultiSelectMixin:
                     default_values, "pandas.core.series.Series"
                 ):
                     default_values = list(default_values)
-                elif not default_values:
+                elif not default_values or default_values in options:
                     default_values = [default_values]
                 else:
                     default_values = list(default_values)

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -114,6 +114,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             ((i for i in ("Tea", "Water")), [1, 2]),
             (np.array(["Coffee", "Tea"]), [0, 1]),
             (pd.Series(np.array(["Coffee", "Tea"])), [0, 1]),
+            ("Coffee", [0]),
         ]
     )
     def test_default_types(self, defaults, expected):


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/1733

**Description:**
This fixes a regression where a single default value raised an exception. If the default value is in the set of options, create a list with it.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
