### PR TITLE
Bump component-lib to v1.1.0

### DIFF
--- a/component-lib/package.json
+++ b/component-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-component-lib",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Support code for Streamlit Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Has been published to npm (https://www.npmjs.com/package/streamlit-component-lib). This version adds support for bytes.