### PR TITLE
component-lib 1.1.1

### DIFF
--- a/component-lib/package.json
+++ b/component-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-component-lib",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Support code for Streamlit Components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I screwed up when publishing 1.1.0, and it does not have the send-and-receive-bytes functionality. The latest published version does.