### PR TITLE
Only empty containers that do not allow empty containers are displayed

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -610,7 +610,10 @@ export class App extends PureComponent<Props, State> {
           )
           // Could check whether container is now empty, and return null.
           // But we want to let empty columns take up sapce.
-          return reportElement.set("element", clearedElements)
+          return clearedElements.size > 0 ||
+            reportElement.getIn(["deltaBlock", "allowEmpty"])
+            ? reportElement.set("element", clearedElements)
+            : null
         }
 
         return reportElement.get("reportId") === reportId

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -366,6 +366,7 @@ class DeltaGenerator(
         def column_proto(weight):
             col_proto = Block_pb2.Block()
             col_proto.column.weight = weight
+            col_proto.allow_empty = True
             return col_proto
 
         horiz_proto = Block_pb2.Block()

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -23,6 +23,7 @@ message Block {
     Column column = 3;
     Expandable expandable = 4;
   }
+  bool allow_empty = 5;
 
   message Vertical {
     bool unused = 1;


### PR DESCRIPTION
**Issue:** #2017 

**Description:** Empty containers were always rendered as part of st.columns. This makes it so that the block must allow empty in order to be rendered.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
