### PR TITLE
Lazy load the example iframes used in docs

### DIFF
--- a/docs/_ext/stoutput.py
+++ b/docs/_ext/stoutput.py
@@ -44,6 +44,7 @@ class StOutput(Directive):
             format="html",
             text="""
                 <iframe
+                    loading="lazy"
                     src="%(src)s&embed=true"
                     style="
                         width: 100%%;


### PR DESCRIPTION
See: https://web.dev/iframe-lazy-loading/

Currently: 13s to onload:
![](https://i.imgur.com/dIbIcRt.png)

With `loading="lazy"`: 0.7s to onload
![](https://i.imgur.com/YlXNV2J.png)

Lighthouse before
![](https://i.imgur.com/Y2VEtY0.png)

Lighthouse after
![](https://i.imgur.com/81P5cjF.png)