### PR TITLE
Fix machine id for analytics

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -63,6 +63,8 @@ describe("App", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
+      installationIdV1: "iid1",
+      installationIdV2: "iid2",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine: "command line",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -381,6 +381,8 @@ export class App extends PureComponent<Props, State> {
       streamlitVersion: environmentInfo.streamlitVersion,
       pythonVersion: environmentInfo.pythonVersion,
       installationId: userInfo.installationId,
+      installationIdV1: userInfo.installationIdV1,
+      installationIdV2: userInfo.installationIdV2,
       authorEmail: userInfo.email,
       maxCachedMessageAge: config.maxCachedMessageAge,
       commandLine: initializeMsg.commandLine,

--- a/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
+++ b/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
@@ -29,6 +29,8 @@ function setSessionInfo(
     streamlitVersion: "sv",
     pythonVersion: "pv",
     installationId: "iid",
+    installationIdV1: "iid1",
+    installationIdV2: "iid2",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
     commandLine,

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
@@ -49,6 +49,8 @@ describe("withMapboxToken", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
+      installationIdV1: "iid1",
+      installationIdV2: "iid2",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine,

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -38,6 +38,8 @@ describe("FileUploadClient", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
+      installationIdV1: "iid1",
+      installationIdV2: "iid2",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine: "command line",

--- a/frontend/src/lib/HttpClient.test.ts
+++ b/frontend/src/lib/HttpClient.test.ts
@@ -34,6 +34,8 @@ describe("HttpClient", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
+      installationIdV1: "iid1",
+      installationIdV2: "iid2",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine: "command line",

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -26,6 +26,8 @@ beforeEach(() => {
     streamlitVersion: "sv",
     pythonVersion: "pv",
     installationId: "iid",
+    installationIdV1: "iid1",
+    installationIdV2: "iid2",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
     commandLine: "command line",
@@ -91,6 +93,12 @@ test("enqueues events before initialization", () => {
 
   expect(mm.track.mock.calls.length).toBe(3)
   expect(mm.identify.mock.calls.length).toBe(1)
+  expect(mm.identify.mock.calls[0][0]).toBe(SessionInfo.current.installationId)
+  expect(mm.identify.mock.calls[0][1]).toMatchObject({
+    authoremail: SessionInfo.current.authorEmail,
+    machineIdV1: SessionInfo.current.installationIdV1,
+    machineIdV2: SessionInfo.current.installationIdV2,
+  })
 })
 
 test("tracks events immediately after initialized", () => {

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -199,7 +199,11 @@ export class MetricsManager {
   // Wrap analytics methods for mocking:
   // eslint-disable-next-line class-methods-use-this
   private identify(id: string, data: Record<string, unknown>): void {
-    analytics.identify(id, data)
+    if (IS_DEV_ENV) {
+      logAlways("[Dev mode] Not tracking identify: ", id, data)
+    } else {
+      analytics.identify(id, data)
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -97,11 +97,15 @@ export class MetricsManager {
     if (this.actuallySendMetrics || IS_SHARED_REPORT) {
       // Segment will not initialize if this is rendered with SSR
       initializeSegment()
+
       // Only record the user's email if they entered a non-empty one.
       const userTraits: any = {}
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
       }
+
+      userTraits.machineIdV1 = SessionInfo.current.installationIdV1
+      userTraits.machineIdV2 = SessionInfo.current.installationIdV2
       this.identify(SessionInfo.current.installationId, userTraits)
       this.sendPendingEvents()
     }

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -200,7 +200,7 @@ export class MetricsManager {
   // eslint-disable-next-line class-methods-use-this
   private identify(id: string, data: Record<string, unknown>): void {
     if (IS_DEV_ENV) {
-      logAlways("[Dev mode] Not tracking identify: ", id, data)
+      logAlways("[Dev mode] Not sending id: ", id, data)
     } else {
       analytics.identify(id, data)
     }

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -20,6 +20,8 @@ export interface Args {
   streamlitVersion?: string | null
   pythonVersion?: string | null
   installationId?: string | null
+  installationIdV1?: string | null
+  installationIdV2?: string | null
   authorEmail?: string | null
   maxCachedMessageAge?: number | null
   commandLine?: string | null
@@ -35,6 +37,10 @@ export class SessionInfo {
   public readonly pythonVersion: string
 
   public readonly installationId: string
+
+  public readonly installationIdV1: string
+
+  public readonly installationIdV2: string
 
   public readonly authorEmail: string
 
@@ -83,6 +89,8 @@ export class SessionInfo {
     streamlitVersion,
     pythonVersion,
     installationId,
+    installationIdV1,
+    installationIdV2,
     authorEmail,
     maxCachedMessageAge,
     commandLine,
@@ -93,6 +101,8 @@ export class SessionInfo {
       streamlitVersion == null ||
       pythonVersion == null ||
       installationId == null ||
+      installationIdV1 == null ||
+      installationIdV2 == null ||
       authorEmail == null ||
       maxCachedMessageAge == null ||
       commandLine == null ||
@@ -105,6 +115,8 @@ export class SessionInfo {
     this.streamlitVersion = streamlitVersion
     this.pythonVersion = pythonVersion
     this.installationId = installationId
+    this.installationIdV1 = installationIdV1
+    this.installationIdV2 = installationIdV2
     this.authorEmail = authorEmail
     this.maxCachedMessageAge = maxCachedMessageAge
     this.commandLine = commandLine

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -54,19 +54,11 @@ _LOGGER = _logger.get_logger("root")
 
 # Give the package a version.
 import pkg_resources as _pkg_resources
-import uuid as _uuid
 from typing import Any, List, Tuple, Type
 
 # This used to be pkg_resources.require('streamlit') but it would cause
 # pex files to fail. See #394 for more details.
 __version__ = _pkg_resources.get_distribution("streamlit").version
-
-# Deterministic Unique Streamlit User ID
-from streamlit import metrics_util as _metrics_util
-
-__installation_id_v1__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, _metrics_util.get_machine_id_v1()))
-__installation_id_v2__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, _metrics_util.get_machine_id_v2()))
-__installation_id__  = __installation_id_v2__
 
 import contextlib as _contextlib
 import re as _re

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -55,9 +55,6 @@ _LOGGER = _logger.get_logger("root")
 # Give the package a version.
 import pkg_resources as _pkg_resources
 import uuid as _uuid
-import subprocess
-import platform
-import os
 from typing import Any, List, Tuple, Type
 
 # This used to be pkg_resources.require('streamlit') but it would cause
@@ -65,24 +62,11 @@ from typing import Any, List, Tuple, Type
 __version__ = _pkg_resources.get_distribution("streamlit").version
 
 # Deterministic Unique Streamlit User ID
-if (
-    platform.system() == "Linux"
-    and os.path.isfile("/etc/machine-id") == False
-    and os.path.isfile("/var/lib/dbus/machine-id") == False
-):
-    print("Generate machine-id")
-    subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])
+from streamlit import metrics_util as _metrics_util
 
-machine_id = str(_uuid.getnode())
-if os.path.isfile("/etc/machine-id"):
-    with open("/etc/machine-id", "r") as f:
-        machine_id = f.read()
-elif os.path.isfile("/var/lib/dbus/machine-id"):
-    with open("/var/lib/dbus/machine-id", "r") as f:
-        machine_id = f.read()
-
-__installation_id__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, machine_id))
-
+__installation_id_v1__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, _metrics_util.get_machine_id_v1()))
+__installation_id_v2__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, _metrics_util.get_machine_id_v2()))
+__installation_id__  = __installation_id_v2__
 
 import contextlib as _contextlib
 import re as _re

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -4,6 +4,8 @@ import subprocess
 import threading
 import uuid
 
+from typing import Optional
+
 from streamlit import file_util
 
 def _get_machine_id_v1():
@@ -62,13 +64,13 @@ class Installation:
 
     def __init__(self):
         self._lock = threading.Lock()
-        self.installation_id = None
-        self.installation_id_v1 = None
-        self.installation_id_v2 = None
+        self.installation_id = ""
+        self.installation_id_v1 = ""
+        self.installation_id_v2 = ""
 
     def create_ids(self) -> None:
-        with self._lock:
-            if not self.installation_id:
+        if not self.installation_id:
+            with self._lock:
                 self.installation_id_v1 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v1()))
                 self.installation_id_v2 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v2()))
                 self.installation_id  = self.installation_id_v2

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -9,11 +9,18 @@ from typing import Optional
 from streamlit import file_util
 
 def _get_machine_id_v1():
-    """Generate the prior machine ID that we used as a unique identifier for a user while tracking
-    metrics in Segment.  This ID is broken in different ways in some Linux distros and Docker images.
-    - sometimes our machine ID is just a hash of '', which means many machines map to the same ID
-    - sometimes our machine ID is a hash of the same string, when running in a Docker container
+    """Generate the prior machine ID
+
+    This is a unique identifier for a user while tracking metrics in Segment,
+    that is broken in different ways in some Linux distros and Docker images.
+    - at times just a hash of '', which means many machines map to the same ID
+    - at times a hash of the same string, when running in a Docker container
     - we run a sudo command, which is weird and bad in all sorts of ways
+
+    We'll track multiple versions of this ID for a few months after which
+    we'll remove this version. The goal is to determine a ratio between them
+    that we can use to normalize our metrics.
+
     """
     if (
         platform.system() == "Linux"
@@ -34,9 +41,13 @@ def _get_machine_id_v1():
     return machine_id
 
 def _get_machine_id_v2():
-    """Generate the new machine ID that we'll as a unique identifier for a user while tracking
-    metrics in Segment. Instead of relying on a hardware address in the container or host we'll
-    generate a UUID and store it in the Streamlit hidden folder."""
+    """Generate the new machine ID
+
+    This is a unique identifier for a user while tracking metrics in Segment.
+    Instead of relying on a hardware address in the container or host we'll
+    generate a UUID and store it in the Streamlit hidden folder.
+
+    """
     filepath = file_util.get_streamlit_file_path(".stable_random_id")
     stable_id = None
 

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -1,12 +1,13 @@
 import os
 import platform
 import subprocess
-import uuid as _uuid
+import threading
+import uuid
 
 from streamlit import file_util
 
-def get_machine_id_v1():
-    """TODO"""
+def _get_machine_id_v1():
+    """Get the old machine id"""
     if (
         platform.system() == "Linux"
         and os.path.isfile("/etc/machine-id") == False
@@ -15,7 +16,7 @@ def get_machine_id_v1():
         print("Generate machine-id")
         subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])
 
-    machine_id = str(_uuid.getnode())
+    machine_id = str(uuid.getnode())
     if os.path.isfile("/etc/machine-id"):
         with open("/etc/machine-id", "r") as f:
             machine_id = f.read()
@@ -26,18 +27,48 @@ def get_machine_id_v1():
 
     return machine_id
 
-def get_machine_id_v2():
-    """TODO"""
+def _get_machine_id_v2():
+    """Get the new machine id"""
     filepath = file_util.get_streamlit_file_path(".stable_random_id")
     stable_id = None
 
     if os.path.exists(filepath):
         with file_util.streamlit_read(filepath) as input:
             stable_id = input.read()
-    
+
     if not stable_id:
-        stable_id = str(_uuid.uuid4())
+        stable_id = str(uuid.uuid4())
         with file_util.streamlit_write(filepath) as output:
             output.write(stable_id)
 
     return stable_id
+
+
+class Installation:
+    _instance_lock = threading.Lock()
+    _instance = None  # type: Optional[Installation]
+
+    @classmethod
+    def instance(cls) -> "Installation":
+        """Returns the singleton Installation"""
+        # We use a double-checked locking optimization to avoid the overhead
+        # of acquiring the lock in the common case:
+        # https://en.wikipedia.org/wiki/Double-checked_locking
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = Installation()
+        return cls._instance
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.installation_id = None
+        self.installation_id_v1 = None
+        self.installation_id_v2 = None
+
+    def create_ids(self) -> None:
+        with self._lock:
+            if not self.installation_id:
+                self.installation_id_v1 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v1()))
+                self.installation_id_v2 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v2()))
+                self.installation_id  = self.installation_id_v2

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -1,0 +1,43 @@
+import os
+import platform
+import subprocess
+import uuid as _uuid
+
+from streamlit import file_util
+
+def get_machine_id_v1():
+    """TODO"""
+    if (
+        platform.system() == "Linux"
+        and os.path.isfile("/etc/machine-id") == False
+        and os.path.isfile("/var/lib/dbus/machine-id") == False
+    ):
+        print("Generate machine-id")
+        subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])
+
+    machine_id = str(_uuid.getnode())
+    if os.path.isfile("/etc/machine-id"):
+        with open("/etc/machine-id", "r") as f:
+            machine_id = f.read()
+
+    elif os.path.isfile("/var/lib/dbus/machine-id"):
+        with open("/var/lib/dbus/machine-id", "r") as f:
+            machine_id = f.read()
+
+    return machine_id
+
+def get_machine_id_v2():
+    """TODO"""
+    filepath = file_util.get_streamlit_file_path(".stable_random_id")
+    stable_id = None
+
+    if os.path.exists(filepath):
+        with file_util.streamlit_read(filepath) as input:
+            stable_id = input.read()
+    
+    if not stable_id:
+        stable_id = str(_uuid.uuid4())
+        with file_util.streamlit_write(filepath) as output:
+            output.write(stable_id)
+
+    return stable_id

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -8,17 +8,17 @@ from typing import Optional
 
 from streamlit import file_util
 
-def _get_machine_id_v1():
-    """Generate the prior machine ID
+def _get_machine_id():
+    """Get the machine ID
 
-    This is a unique identifier for a user while tracking metrics in Segment,
+    This is a unique identifier for a user for tracking metrics in Segment,
     that is broken in different ways in some Linux distros and Docker images.
     - at times just a hash of '', which means many machines map to the same ID
     - at times a hash of the same string, when running in a Docker container
     - we run a sudo command, which is weird and bad in all sorts of ways
 
-    We'll track multiple versions of this ID for a few months after which
-    we'll remove this version. The goal is to determine a ratio between them
+    We'll track multiple IDs in Segment for a few months after which
+    we'll remove this one. The goal is to determine a ratio between them
     that we can use to normalize our metrics.
 
     """
@@ -40,10 +40,10 @@ def _get_machine_id_v1():
 
     return machine_id
 
-def _get_machine_id_v2():
-    """Generate the new machine ID
+def _get_stable_random_id():
+    """Get a stable random ID
 
-    This is a unique identifier for a user while tracking metrics in Segment.
+    This is a unique identifier for a user for tracking metrics in Segment.
     Instead of relying on a hardware address in the container or host we'll
     generate a UUID and store it in the Streamlit hidden folder.
 
@@ -80,8 +80,8 @@ class Installation:
         return cls._instance
 
     def __init__(self):
-        self.installation_id_v1 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v1()))
-        self.installation_id_v2 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v2()))
+        self.installation_id_v1 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id()))
+        self.installation_id_v2 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_stable_random_id()))
 
     @property
     def installation_id(self):

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -44,8 +44,6 @@ import streamlit.elements.exception_proto as exception_proto
 
 LOGGER = get_logger(__name__)
 
-Installation.instance.create_ids()
-
 class ReportSessionState(Enum):
     REPORT_NOT_RUNNING = "REPORT_NOT_RUNNING"
     REPORT_IS_RUNNING = "REPORT_IS_RUNNING"
@@ -81,6 +79,8 @@ class ReportSession(object):
             The server's UploadedFileManager.
 
         """
+        Installation.instance().create_ids()
+
         # Each ReportSession has a unique string ID.
         self.id = str(uuid.uuid4())
 

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -79,8 +79,6 @@ class ReportSession(object):
             The server's UploadedFileManager.
 
         """
-        Installation.instance().create_ids()
-
         # Each ReportSession has a unique string ID.
         self.id = str(uuid.uuid4())
 

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -383,9 +383,9 @@ class ReportSession(object):
             self._state == ReportSessionState.REPORT_IS_RUNNING
         )
 
-        imsg.user_info.installation_id = Installation.instance.installation_id
-        imsg.user_info.installation_id_v1 = Installation.instance.installation_id_v1
-        imsg.user_info.installation_id_v2 = Installation.instance.installation_id_v2
+        imsg.user_info.installation_id = Installation.instance().installation_id
+        imsg.user_info.installation_id_v1 = Installation.instance().installation_id_v1
+        imsg.user_info.installation_id_v2 = Installation.instance().installation_id_v2
         if Credentials.get_current().activation:
             imsg.user_info.email = Credentials.get_current().activation.email
         else:

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -19,14 +19,12 @@ from enum import Enum
 import tornado.gen
 import tornado.ioloop
 
-from streamlit import __installation_id__
-from streamlit import __installation_id_v1__
-from streamlit import __installation_id_v2__
 from streamlit import __version__
 from streamlit import caching
 from streamlit import config
 from streamlit import url_util
 from streamlit.media_file_manager import media_file_manager
+from streamlit.metrics_util import Installation
 from streamlit.report import Report
 from streamlit.script_request_queue import RerunData
 from streamlit.script_request_queue import ScriptRequest
@@ -46,6 +44,7 @@ import streamlit.elements.exception_proto as exception_proto
 
 LOGGER = get_logger(__name__)
 
+Installation.instance.create_ids()
 
 class ReportSessionState(Enum):
     REPORT_NOT_RUNNING = "REPORT_NOT_RUNNING"
@@ -384,9 +383,9 @@ class ReportSession(object):
             self._state == ReportSessionState.REPORT_IS_RUNNING
         )
 
-        imsg.user_info.installation_id = __installation_id__
-        imsg.user_info.installation_id_v1 = __installation_id_v1__
-        imsg.user_info.installation_id_v2 = __installation_id_v2__
+        imsg.user_info.installation_id = Installation.instance.installation_id
+        imsg.user_info.installation_id_v1 = Installation.instance.installation_id_v1
+        imsg.user_info.installation_id_v2 = Installation.instance.installation_id_v2
         if Credentials.get_current().activation:
             imsg.user_info.email = Credentials.get_current().activation.email
         else:

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -20,6 +20,8 @@ import tornado.gen
 import tornado.ioloop
 
 from streamlit import __installation_id__
+from streamlit import __installation_id_v1__
+from streamlit import __installation_id_v2__
 from streamlit import __version__
 from streamlit import caching
 from streamlit import config
@@ -383,6 +385,8 @@ class ReportSession(object):
         )
 
         imsg.user_info.installation_id = __installation_id__
+        imsg.user_info.installation_id_v1 = __installation_id_v1__
+        imsg.user_info.installation_id_v2 = __installation_id_v2__
         if Credentials.get_current().activation:
             imsg.user_info.email = Credentials.get_current().activation.email
         else:

--- a/lib/tests/streamlit/metrics_util_test.py
+++ b/lib/tests/streamlit/metrics_util_test.py
@@ -1,0 +1,105 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+
+from streamlit import metrics_util
+
+MAC = "mac"
+UUID = "uuid"
+FILENAME = "/some/id/file"
+mock_get_path = MagicMock(return_value=FILENAME)
+
+class MetricsUtilTest(unittest.TestCase):
+    def setUp(self):
+        self.patch1 = patch("streamlit.file_util.os.stat")
+        self.os_stat = self.patch1.start()
+
+    def tearDown(self):
+        self.patch1.stop()
+
+    def test_machine_id_from_etc(self):
+        """Test getting the machine id from /etc"""
+        file_data = "etc"
+
+        with patch("streamlit.metrics_util.platform.system", return_value=False):
+            with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC):
+                with patch(
+                    "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
+                ), patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
+                    path_isfile = lambda path: path == "/etc/machine-id"
+                    
+                    machine_id = metrics_util._get_machine_id_v1()
+        self.assertEqual(machine_id, file_data)
+
+    def test_machine_id_from_dbus(self):
+        """Test getting the machine id from /var/lib/dbus"""
+        file_data = "dbus"
+
+        with patch("streamlit.metrics_util.platform.system", return_value=False):
+            with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC):
+                with patch(
+                    "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
+                ), patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
+                    path_isfile = lambda path: path == "/var/lib/dbus/machine-id"
+                    
+                    machine_id = metrics_util._get_machine_id_v1()
+        self.assertEqual(machine_id, file_data)
+
+    def test_machine_id_from_node(self):
+        """Test getting the machine id as the mac address"""
+
+        with patch("streamlit.metrics_util.platform.system", return_value=False):
+            with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC):
+                with patch("streamlit.metrics_util.os.path.isfile", return_value=False):
+                    machine_id = metrics_util._get_machine_id_v1()
+        self.assertEqual(machine_id, MAC)
+
+    @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
+    def test_stable_id_not_exists(self):
+        """Test creating a stable id """
+
+        with patch("streamlit.metrics_util.os.path.exists", return_value=False):
+            with patch("streamlit.metrics_util.uuid.uuid4", return_value=UUID):
+                with patch("streamlit.file_util.open", mock_open()) as open, patch(
+                    "streamlit.util.os.makedirs"
+                ) as makedirs:
+                    machine_id = metrics_util._get_machine_id_v2()
+                    open().write.assert_called_once_with(UUID)
+        self.assertEqual(machine_id, UUID)
+
+    @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
+    def test_stable_id_exists_and_valid(self):
+        """Test getting a stable valid id """
+
+        with patch("streamlit.metrics_util.os.path.exists", return_value=True):
+            with patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open:
+                machine_id = metrics_util._get_machine_id_v2()
+                open().read.assert_called_once()
+        self.assertEqual(machine_id, UUID)
+
+    @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
+    def test_stable_id_exists_and_invalid(self):
+        """Test getting a stable invalid id """
+
+        with patch("streamlit.metrics_util.os.path.exists", return_value=True):
+            with patch("streamlit.metrics_util.uuid.uuid4", return_value=UUID):
+                with patch("streamlit.file_util.open", mock_open(read_data="")) as open, patch(
+                    "streamlit.util.os.makedirs"
+                ) as makedirs:
+                    machine_id = metrics_util._get_machine_id_v2()
+                    open().read.assert_called_once()
+                    open().write.assert_called_once_with(UUID)
+        self.assertEqual(machine_id, UUID)

--- a/lib/tests/streamlit/metrics_util_test.py
+++ b/lib/tests/streamlit/metrics_util_test.py
@@ -34,72 +34,74 @@ class MetricsUtilTest(unittest.TestCase):
         """Test getting the machine id from /etc"""
         file_data = "etc"
 
-        with patch("streamlit.metrics_util.platform.system", return_value=False):
-            with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC):
-                with patch(
-                    "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
-                ), patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
-                    path_isfile = lambda path: path == "/etc/machine-id"
-                    
-                    machine_id = metrics_util._get_machine_id_v1()
+        with patch("streamlit.metrics_util.platform.system", return_value=False),\
+             patch("streamlit.metrics_util.uuid.getnode", return_value=MAC),\
+             patch("streamlit.metrics_util.open", mock_open(read_data=file_data), create=True),\
+             patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
+
+            path_isfile = lambda path: path == "/etc/machine-id"
+
+            machine_id = metrics_util._get_machine_id_v1()
         self.assertEqual(machine_id, file_data)
 
     def test_machine_id_from_dbus(self):
         """Test getting the machine id from /var/lib/dbus"""
         file_data = "dbus"
 
-        with patch("streamlit.metrics_util.platform.system", return_value=False):
-            with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC):
-                with patch(
-                    "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
-                ), patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
-                    path_isfile = lambda path: path == "/var/lib/dbus/machine-id"
-                    
-                    machine_id = metrics_util._get_machine_id_v1()
+        with patch("streamlit.metrics_util.platform.system", return_value=False),\
+             patch("streamlit.metrics_util.uuid.getnode", return_value=MAC),\
+             patch("streamlit.metrics_util.open", mock_open(read_data=file_data), create=True),\
+             patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
+
+            path_isfile = lambda path: path == "/var/lib/dbus/machine-id"
+
+            machine_id = metrics_util._get_machine_id_v1()
         self.assertEqual(machine_id, file_data)
 
     def test_machine_id_from_node(self):
         """Test getting the machine id as the mac address"""
 
-        with patch("streamlit.metrics_util.platform.system", return_value=False):
-            with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC):
-                with patch("streamlit.metrics_util.os.path.isfile", return_value=False):
-                    machine_id = metrics_util._get_machine_id_v1()
+        with patch("streamlit.metrics_util.platform.system", return_value=False),\
+             patch("streamlit.metrics_util.uuid.getnode", return_value=MAC),\
+             patch("streamlit.metrics_util.os.path.isfile", return_value=False):
+
+            machine_id = metrics_util._get_machine_id_v1()
         self.assertEqual(machine_id, MAC)
 
     @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
     def test_stable_id_not_exists(self):
         """Test creating a stable id """
 
-        with patch("streamlit.metrics_util.os.path.exists", return_value=False):
-            with patch("streamlit.metrics_util.uuid.uuid4", return_value=UUID):
-                with patch("streamlit.file_util.open", mock_open()) as open, patch(
-                    "streamlit.util.os.makedirs"
-                ) as makedirs:
-                    machine_id = metrics_util._get_machine_id_v2()
-                    open().write.assert_called_once_with(UUID)
+        with patch("streamlit.metrics_util.os.path.exists", return_value=False),\
+             patch("streamlit.metrics_util.uuid.uuid4", return_value=UUID),\
+             patch("streamlit.file_util.open", mock_open()) as open,\
+             patch("streamlit.util.os.makedirs") as makedirs:
+
+            machine_id = metrics_util._get_machine_id_v2()
+            open().write.assert_called_once_with(UUID)
         self.assertEqual(machine_id, UUID)
 
     @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
     def test_stable_id_exists_and_valid(self):
         """Test getting a stable valid id """
 
-        with patch("streamlit.metrics_util.os.path.exists", return_value=True):
-            with patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open:
-                machine_id = metrics_util._get_machine_id_v2()
-                open().read.assert_called_once()
+        with patch("streamlit.metrics_util.os.path.exists", return_value=True),\
+             patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open:
+
+            machine_id = metrics_util._get_machine_id_v2()
+            open().read.assert_called_once()
         self.assertEqual(machine_id, UUID)
 
     @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
     def test_stable_id_exists_and_invalid(self):
         """Test getting a stable invalid id """
 
-        with patch("streamlit.metrics_util.os.path.exists", return_value=True):
-            with patch("streamlit.metrics_util.uuid.uuid4", return_value=UUID):
-                with patch("streamlit.file_util.open", mock_open(read_data="")) as open, patch(
-                    "streamlit.util.os.makedirs"
-                ) as makedirs:
-                    machine_id = metrics_util._get_machine_id_v2()
-                    open().read.assert_called_once()
-                    open().write.assert_called_once_with(UUID)
+        with patch("streamlit.metrics_util.os.path.exists", return_value=True),\
+             patch("streamlit.metrics_util.uuid.uuid4", return_value=UUID),\
+             patch("streamlit.file_util.open", mock_open(read_data="")) as open,\
+             patch("streamlit.util.os.makedirs") as makedirs:
+
+            machine_id = metrics_util._get_machine_id_v2()
+            open().read.assert_called_once()
+            open().write.assert_called_once_with(UUID)
         self.assertEqual(machine_id, UUID)

--- a/lib/tests/streamlit/metrics_util_test.py
+++ b/lib/tests/streamlit/metrics_util_test.py
@@ -41,7 +41,7 @@ class MetricsUtilTest(unittest.TestCase):
 
             path_isfile = lambda path: path == "/etc/machine-id"
 
-            machine_id = metrics_util._get_machine_id_v1()
+            machine_id = metrics_util._get_machine_id()
         self.assertEqual(machine_id, file_data)
 
     def test_machine_id_from_dbus(self):
@@ -55,7 +55,7 @@ class MetricsUtilTest(unittest.TestCase):
 
             path_isfile = lambda path: path == "/var/lib/dbus/machine-id"
 
-            machine_id = metrics_util._get_machine_id_v1()
+            machine_id = metrics_util._get_machine_id()
         self.assertEqual(machine_id, file_data)
 
     def test_machine_id_from_node(self):
@@ -65,7 +65,7 @@ class MetricsUtilTest(unittest.TestCase):
              patch("streamlit.metrics_util.uuid.getnode", return_value=MAC),\
              patch("streamlit.metrics_util.os.path.isfile", return_value=False):
 
-            machine_id = metrics_util._get_machine_id_v1()
+            machine_id = metrics_util._get_machine_id()
         self.assertEqual(machine_id, MAC)
 
     @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
@@ -77,7 +77,7 @@ class MetricsUtilTest(unittest.TestCase):
              patch("streamlit.file_util.open", mock_open()) as open,\
              patch("streamlit.util.os.makedirs") as makedirs:
 
-            machine_id = metrics_util._get_machine_id_v2()
+            machine_id = metrics_util._get_stable_random_id()
             open().write.assert_called_once_with(UUID)
         self.assertEqual(machine_id, UUID)
 
@@ -88,7 +88,7 @@ class MetricsUtilTest(unittest.TestCase):
         with patch("streamlit.metrics_util.os.path.exists", return_value=True),\
              patch("streamlit.file_util.open", mock_open(read_data=UUID)) as open:
 
-            machine_id = metrics_util._get_machine_id_v2()
+            machine_id = metrics_util._get_stable_random_id()
             open().read.assert_called_once()
         self.assertEqual(machine_id, UUID)
 
@@ -101,7 +101,7 @@ class MetricsUtilTest(unittest.TestCase):
              patch("streamlit.file_util.open", mock_open(read_data="")) as open,\
              patch("streamlit.util.os.makedirs") as makedirs:
 
-            machine_id = metrics_util._get_machine_id_v2()
+            machine_id = metrics_util._get_stable_random_id()
             open().read.assert_called_once()
             open().write.assert_called_once_with(UUID)
         self.assertEqual(machine_id, UUID)

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open
 import unittest
 
 import tornado.gen
@@ -67,7 +67,9 @@ class ReportSessionTest(unittest.TestCase):
     @patch("streamlit.report_session.config")
     @patch("streamlit.report_session.Report")
     @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_enqueue_with_tracer(self, _1, _2, patched_config):
+    @patch("streamlit.util.os.makedirs")
+    @patch("streamlit.file_util.open", mock_open())
+    def test_enqueue_with_tracer(self, _1, _2, patched_config, _4):
         """Make sure there is no lock contention when tracer is on.
 
         When the tracer is set up, we want

--- a/proto/streamlit/proto/Initialize.proto
+++ b/proto/streamlit/proto/Initialize.proto
@@ -54,6 +54,8 @@ message Config {
 
 message UserInfo {
   string installation_id = 1;
+  string installation_id_v1 = 3;
+  string installation_id_v2 = 4;
   string email = 2;
 }
 


### PR DESCRIPTION
[Issue #1135](https://app.clubhouse.io/streamlit/story/1135/fix-user-id-and-report-hash)

1. If we have no ID in ~/.streamlit/.stable_random_id, create one

2. Read the ID from ~/.streamlit/.stable_random_id

3. __installation_id__ = str(_uuid.uuid5(_uuid.NAMESPACE_DNS, STABLE_RANDOM_ID)

4. Store the old __installation_id__ in a id_v1 field and the new __installation_id__ in a id_v2 field. Send both to Segment.

Note: I had issues mocking the creation of .stable_random_id from __init__.py  so moved it out of there