### PR TITLE
Fix indenting of configuration docs

### DIFF
--- a/docs/streamlit_configuration.md
+++ b/docs/streamlit_configuration.md
@@ -70,9 +70,9 @@ Streamlit provides four different ways to set configuration options:
    to do things like change the port the app is served from, disable run-on-save, and
    more:
 
-```bash
-streamlit run your_script.py --server.port 80
-```
+   ```bash
+   streamlit run your_script.py --server.port 80
+   ```
 
 ## View all configuration options
 


### PR DESCRIPTION
Should've caught this as part of #2036 