### PR TITLE
Remove redundant install direction

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,8 +17,6 @@ Before you get started, you're going to need a few things:
 - Your favorite IDE or text editor
 - [Python 3.6 or later](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installing/)
-- [Streamlit](index.md) — This one's kind of important, so don't forget to
-  install.
 
 If you haven't already, take a few minutes to read through [Main
 concepts](main_concepts.md) to understand Streamlit's data flow model.


### PR DESCRIPTION
At the place where this line occurs, it mentions as a pre-requisite to "make sure you install Streamlit". But then in the next section, we talk about installing Streamlit into a virtual environment.