### PR TITLE
Add Tim's Components video to docs

### DIFF
--- a/docs/streamlit_components.md
+++ b/docs/streamlit_components.md
@@ -11,6 +11,22 @@ Streamlit Components let you expand the functionality provided in the base Strea
 - Rendering Python objects having methods that output HTML, such as IPython [`__repr_html__`](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display)
 - Convenience functions for commonly-used web features like [GitHub gists and Pastebin](https://github.com/randyzwitch/streamlit-embedcode)
 
+Check out this [Streamlit Components Tutorial video](https://www.youtube.com/watch?v=BuD3gILJW-Q&feature=youtu.be) by Streamlit engineer Tim Conkling to get started:
+
+```eval_rst
+.. raw:: html
+
+  <div class='embed-container'><iframe
+    width="560"
+    height="315"
+    src="https://www.youtube.com/embed/BuD3gILJW-Q"
+    style="margin: 0 0 2rem 0;"
+    frameborder="0"
+    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen>
+  </iframe></div>
+```
+
 ```eval_rst
 .. note::
    The remainder of the documentation in this section is for users


### PR DESCRIPTION
Only change is to add a line and embed video

![image](https://user-images.githubusercontent.com/2762787/94466992-52bd7b00-0190-11eb-956a-e58ab9b96b6c.png)
