### PR TITLE
Reorganize support links by relative importance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,10 +34,10 @@
   :maxdepth: 2
   :hidden:
 
-  changelog
+  Discussion forum <https://discuss.streamlit.io/>
   troubleshooting/index
   Frequently Asked Questions <streamlit_faq>
-  Community forum <https://discuss.streamlit.io/>
+  changelog
   Source code & issue tracker <https://github.com/streamlit/streamlit/>
 
 ```


### PR DESCRIPTION
As part of reorganizing docs by persona and use-case, change link order in Support section to better reflect expectation of users likelihood of clicking