### PR TITLE
More subdomain from share to static

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ For example:
 
 ```rst
 .. output::
-   https://share.streamlit.io/0.25.0-22EmZ/index.html?id=YHHvgDnAdo5JKQivWhK6tE
+   https://static.streamlit.io/0.25.0-22EmZ/index.html?id=YHHvgDnAdo5JKQivWhK6tE
    height: 200px
 ```
 
@@ -93,7 +93,7 @@ or simply:
 
 ```rst
 .. output::
-   https://share.streamlit.io/0.25.0-22EmZ/index.html?id=YHHvgDnAdo5JKQivWhK6tE
+   https://static.streamlit.io/0.25.0-22EmZ/index.html?id=YHHvgDnAdo5JKQivWhK6tE
 ```
 
 You can use this directive "as is" inside pydoc strings and ReStructuredText
@@ -103,7 +103,7 @@ files. To use it in Markdown files, though, you need to do the following:
 
     ```eval_rst
     .. output::
-       https://share.streamlit.io/0.25.0-22EmZ/index.html?id=YHHvgDnAdo5JKQivWhK6tE
+       https://static.streamlit.io/0.25.0-22EmZ/index.html?id=YHHvgDnAdo5JKQivWhK6tE
     ```
 
     An this is Markdown again.

--- a/docs/_ext/stoutput.py
+++ b/docs/_ext/stoutput.py
@@ -12,10 +12,10 @@ class StOutput(Directive):
     --------
 
         .. output::
-        https://share.streamlit.io/0.25.0-2EdmD/index.html?id=jD8gaXYmw8WZeSNQbko9p
+        https://static.streamlit.io/0.25.0-2EdmD/index.html?id=jD8gaXYmw8WZeSNQbko9p
 
         .. output::
-        https://share.streamlit.io/0.25.0-2EdmD/index.html?id=jD8gaXYmw8WZeSNQbko9p
+        https://static.streamlit.io/0.25.0-2EdmD/index.html?id=jD8gaXYmw8WZeSNQbko9p
         height: 5rem; border: 1px solid red;
 
     """

--- a/lib/streamlit/elements/altair.py
+++ b/lib/streamlit/elements/altair.py
@@ -59,7 +59,7 @@ class AltairMixin:
         >>> st.line_chart(chart_data)
 
         .. output::
-           https://share.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8
+           https://static.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8
            height: 220px
 
         """
@@ -103,7 +103,7 @@ class AltairMixin:
         >>> st.area_chart(chart_data)
 
         .. output::
-           https://share.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt
+           https://static.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt
            height: 220px
 
         """
@@ -147,7 +147,7 @@ class AltairMixin:
         >>> st.bar_chart(chart_data)
 
         .. output::
-           https://share.streamlit.io/0.50.0-td2L/index.html?id=5U5bjR2b3jFwnJdDfSvuRk
+           https://static.streamlit.io/0.50.0-td2L/index.html?id=5U5bjR2b3jFwnJdDfSvuRk
            height: 220px
 
         """
@@ -193,7 +193,7 @@ class AltairMixin:
         >>> st.altair_chart(c, use_container_width=True)
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
            height: 200px
 
         Examples of Altair charts can be found at

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -56,7 +56,7 @@ class BokehMixin:
         >>> st.bokeh_chart(p, use_container_width=True)
 
         .. output::
-           https://share.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp
+           https://static.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp
            height: 600px
 
         """

--- a/lib/streamlit/elements/data_frame_proto.py
+++ b/lib/streamlit/elements/data_frame_proto.py
@@ -59,7 +59,7 @@ class DataFrameMixin:
         >>> st.dataframe(df)  # Same as st.write(df)
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ
            height: 330px
 
         >>> st.dataframe(df, 200, 100)
@@ -74,7 +74,7 @@ class DataFrameMixin:
         >>> st.dataframe(df.style.highlight_max(axis=0))
 
         .. output::
-           https://share.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby
+           https://static.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby
            height: 285px
 
         """
@@ -82,10 +82,7 @@ class DataFrameMixin:
         marshall_data_frame(data, data_frame_proto)
 
         return dg._enqueue(  # type: ignore
-            "data_frame",
-            data_frame_proto,
-            element_width=width,
-            element_height=height,
+            "data_frame", data_frame_proto, element_width=width, element_height=height,
         )
 
     def table(dg, data=None):
@@ -109,7 +106,7 @@ class DataFrameMixin:
         >>> st.table(df)
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq
            height: 480px
 
         """

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -81,7 +81,7 @@ class PydeckMixin:
         ... ))
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i
            height: 530px
 
         """

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -91,7 +91,7 @@ class GraphvizMixin:
         ''')
 
         .. output::
-           https://share.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL
+           https://static.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL
            height: 400px
 
         """

--- a/lib/streamlit/elements/image_proto.py
+++ b/lib/streamlit/elements/image_proto.py
@@ -99,7 +99,7 @@ class ImageMixin:
         ...          use_column_width=True)
 
         .. output::
-           https://share.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk
+           https://static.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk
            height: 630px
 
         """

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -28,7 +28,7 @@ class JsonMixin:
         ... })
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS
            height: 280px
 
         """

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -63,7 +63,7 @@ class MapMixin:
         >>> st.map(df)
 
         .. output::
-           https://share.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH
+           https://static.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH
            height: 600px
 
         """

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -50,7 +50,7 @@ class MarkdownMixin:
         >>> st.markdown('Streamlit is **_really_ cool**.')
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS
            height: 50px
 
         """
@@ -74,7 +74,7 @@ class MarkdownMixin:
         >>> st.header('This is a header')
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj
            height: 100px
 
         """
@@ -95,7 +95,7 @@ class MarkdownMixin:
         >>> st.subheader('This is a subheader')
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ
            height: 100px
 
         """
@@ -124,7 +124,7 @@ class MarkdownMixin:
         >>> st.code(code, language='python')
 
         .. output::
-           https://share.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2
+           https://static.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2
            height: 100px
 
         """
@@ -152,7 +152,7 @@ class MarkdownMixin:
         >>> st.title('This is a title')
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj
            height: 100px
 
         """
@@ -185,7 +185,7 @@ class MarkdownMixin:
         ...     ''')
 
         .. output::
-           https://share.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4
+           https://static.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4
            height: 75px
 
         """

--- a/lib/streamlit/elements/media_proto.py
+++ b/lib/streamlit/elements/media_proto.py
@@ -50,7 +50,7 @@ class MediaMixin:
         >>> st.audio(audio_bytes, format='audio/ogg')
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb
            height: 400px
 
         """
@@ -84,7 +84,7 @@ class MediaMixin:
         >>> st.video(video_bytes)
 
         .. output::
-           https://share.streamlit.io/0.61.0-yRE1/index.html?id=LZLtVFFTf1s41yfPExzRu8
+           https://static.streamlit.io/0.61.0-yRE1/index.html?id=LZLtVFFTf1s41yfPExzRu8
            height: 600px
 
         .. note::

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -120,7 +120,7 @@ class PlotlyMixin:
         >>> st.plotly_chart(fig, use_container_width=True)
 
         .. output::
-           https://share.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ
+           https://static.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ
            height: 400px
 
         """

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -63,7 +63,7 @@ class PyplotMixin:
         >>> st.pyplot(fig)
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB
            height: 530px
 
         Notes

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -16,7 +16,7 @@ class TextMixin:
         >>> st.text('This is some text.')
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1
            height: 50px
 
         """

--- a/lib/streamlit/elements/vega_lite.py
+++ b/lib/streamlit/elements/vega_lite.py
@@ -27,12 +27,7 @@ LOGGER = get_logger(__name__)
 
 class VegaLiteMixin:
     def vega_lite_chart(
-        dg,
-        data=None,
-        spec=None,
-        width=0,
-        use_container_width=False,
-        **kwargs,
+        dg, data=None, spec=None, width=0, use_container_width=False, **kwargs,
     ):
         """Display a chart using the Vega-Lite library.
 
@@ -81,7 +76,7 @@ class VegaLiteMixin:
         ... })
 
         .. output::
-           https://share.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
+           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
            height: 200px
 
         Examples of Vega-Lite usage without Streamlit can be found at

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -86,7 +86,7 @@ class WriteMixin:
         >>> write('Hello, *World!* :sunglasses:')
 
         ..  output::
-            https://share.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE
+            https://static.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE
             height: 50px
 
         As mentioned earlier, `st.write()` also accepts other data formats, such as
@@ -99,7 +99,7 @@ class WriteMixin:
         ... }))
 
         ..  output::
-            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD
+            https://static.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD
             height: 250px
 
         Finally, you can pass in multiple arguments to do things like:
@@ -108,7 +108,7 @@ class WriteMixin:
         >>> st.write('Below is a DataFrame:', data_frame, 'Above is a dataframe.')
 
         ..  output::
-            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1
+            https://static.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1
             height: 300px
 
         Oh, one more thing: `st.write` accepts chart objects too! For example:
@@ -127,7 +127,7 @@ class WriteMixin:
         >>> st.write(c)
 
         ..  output::
-            https://share.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
+            https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
             height: 200px
 
         """
@@ -153,8 +153,7 @@ class WriteMixin:
         def flush_buffer():
             if string_buffer:
                 dg.markdown(
-                    " ".join(string_buffer),
-                    unsafe_allow_html=unsafe_allow_html,
+                    " ".join(string_buffer), unsafe_allow_html=unsafe_allow_html,
                 )
                 string_buffer[:] = []
 


### PR DESCRIPTION
Move Streamlit examples from share.streamlit.io to static.streamlit.io to clean up their function. Spot checked the first 20 or so by copying the new URL into the browser, as well as looking at the rendered API page to ensure iframes were loading.