### PR TITLE
Wrap blocks based on percentage of total columns a column takes

### DIFF
--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -69,6 +69,7 @@ $line-height-tight: 1.25;
 
 // Spacing
 $spacer: 1rem;
+$gutter: 1.5rem;
 
 // Overwrite other theme settings.
 $border-radius: 0.25rem;

--- a/frontend/src/components/core/Block/Block.scss
+++ b/frontend/src/components/core/Block/Block.scss
@@ -1,0 +1,5 @@
+.stBlock-horiz {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -146,8 +146,8 @@ class Block extends PureComponent<Props> {
     const optionalProps = deltaBlock.expandable ? deltaBlock.expandable : {}
     let style: any = { width }
     if (deltaBlock.column && deltaBlock.column.weight) {
-      // 500px will be the minimal viewport width used to determine the
-      // minimal fixed column width while accounting for column proportions.
+      // The minimal viewport width used to determine the minimal
+      // fixed column width while accounting for column proportions.
       // Randomly selected based on visual experimentation.
       const minViewportForColumns = 640
 

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -44,6 +44,8 @@ import {
 import Maybe from "components/core/Maybe/"
 import withExpandable from "hocs/withExpandable"
 
+import "./Block.scss"
+
 // Lazy-load elements.
 const Audio = React.lazy(() => import("components/elements/Audio/"))
 const Balloons = React.lazy(() => import("components/elements/Balloons/"))
@@ -106,7 +108,6 @@ class Block extends PureComponent<Props> {
       .toArray()
       .map((reportElement: ReportElement, index: number): ReactNode | null => {
         const element = reportElement.get("element")
-
         if (element instanceof List) {
           // Recursive case AKA a single container AKA node with children
           return this.renderBlock(
@@ -143,10 +144,20 @@ class Block extends PureComponent<Props> {
     const BlockType = deltaBlock.expandable ? this.WithExpandableBlock : Block
     const optionalProps = deltaBlock.expandable ? deltaBlock.expandable : {}
     let style: any = { width }
-    if (deltaBlock.column) {
+    if (deltaBlock.column && deltaBlock.column.weight) {
+      // 500px will be the minimal viewport width used to determine the
+      // minimal fixed column width while accounting for column proportions.
+      // Randomly selected based on visual experimentation.
+      const minViewportForColumns = 500
+
+      // When working with columns, width is driven by what percentage of space
+      // the column takes in relation to the total number of columns
+      const columnPercentage = deltaBlock.column.weight / width
+      const minColumnWidth = columnPercentage * minViewportForColumns
       style = {
         // Flex determines how much space is allocated to this column.
         flex: deltaBlock.column.weight,
+        minWidth: `max(${columnPercentage * 100}% - 8px, ${minColumnWidth}px)`,
       }
     }
     return (
@@ -426,10 +437,13 @@ class Block extends PureComponent<Props> {
   public render = (): ReactNode => {
     if (this.props.deltaBlock && this.props.deltaBlock.horizontal) {
       // Create a horizontal block as the parent for columns
-      // For now, all children are column blocks, so we can ignore `width`.
+      // For now, all children are column blocks, and `width` is driven by
+      // the total number of columns available.
       return (
-        <div className="stBlock-horiz" style={{ display: "flex", gap: "8px" }}>
-          {this.renderElements(0)}
+        <div className="stBlock-horiz">
+          {this.renderElements(
+            this.props.deltaBlock.horizontal.totalColumns || 0
+          )}
         </div>
       )
     }

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -25,6 +25,7 @@ import { makeElementWithInfoText } from "lib/utils"
 import { IForwardMsgMetadata, IBlock } from "autogen/proto"
 import { ReportElement, BlockElement, SimpleElement } from "lib/DeltaParser"
 import { FileUploadClient } from "lib/FileUploadClient"
+import { variables as stylingVariables } from "lib/widgetTheme"
 
 // Load (non-lazy) elements.
 import Alert from "components/elements/Alert/"
@@ -148,7 +149,7 @@ class Block extends PureComponent<Props> {
       // 500px will be the minimal viewport width used to determine the
       // minimal fixed column width while accounting for column proportions.
       // Randomly selected based on visual experimentation.
-      const minViewportForColumns = 500
+      const minViewportForColumns = 640
 
       // When working with columns, width is driven by what percentage of space
       // the column takes in relation to the total number of columns
@@ -157,7 +158,9 @@ class Block extends PureComponent<Props> {
       style = {
         // Flex determines how much space is allocated to this column.
         flex: deltaBlock.column.weight,
-        minWidth: `max(${columnPercentage * 100}% - 8px, ${minColumnWidth}px)`,
+        minWidth: `max(${columnPercentage * 100}% - ${
+          stylingVariables.gutter
+        }, ${minColumnWidth}px)`,
       }
     }
     return (
@@ -437,12 +440,12 @@ class Block extends PureComponent<Props> {
   public render = (): ReactNode => {
     if (this.props.deltaBlock && this.props.deltaBlock.horizontal) {
       // Create a horizontal block as the parent for columns
-      // For now, all children are column blocks, and `width` is driven by
-      // the total number of columns available.
+      // For now, all children are column blocks. For columns, `width` is
+      // driven by the total number of columns available.
       return (
         <div className="stBlock-horiz">
           {this.renderElements(
-            this.props.deltaBlock.horizontal.totalColumns || 0
+            this.props.deltaBlock.horizontal.totalWeight || 0
           )}
         </div>
       )

--- a/frontend/src/lib/widgetTheme.ts
+++ b/frontend/src/lib/widgetTheme.ts
@@ -35,10 +35,12 @@ const smallTextMargin = SCSS_VARS["$m2-3-font-size-sm"]
 const textMargin = SCSS_VARS["$font-size-sm"]
 const tinyTextMargin = SCSS_VARS["$m1-2-font-size-sm"]
 const spacer = SCSS_VARS.$spacer
+const gutter = SCSS_VARS.$gutter
 
 export const variables = {
   borderRadius,
   spacer,
+  gutter,
 }
 
 // Colors

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -415,7 +415,7 @@ class DeltaGenerator(
             return col_proto
 
         horiz_proto = Block_pb2.Block()
-        horiz_proto.horizontal.total_columns = sum(weights)
+        horiz_proto.horizontal.total_weight = sum(weights)
         row = self._block(horiz_proto)
         return [row._block(column_proto(w)) for w in weights]
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -415,7 +415,7 @@ class DeltaGenerator(
             return col_proto
 
         horiz_proto = Block_pb2.Block()
-        horiz_proto.horizontal.unused = True
+        horiz_proto.horizontal.total_columns = sum(weights)
         row = self._block(horiz_proto)
         return [row._block(column_proto(w)) for w in weights]
 

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -30,7 +30,7 @@ message Block {
   }
 
   message Horizontal {
-    int32 total_columns = 2;
+    double total_weight = 2;
   }
 
   message Column {

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -30,7 +30,7 @@ message Block {
   }
 
   message Horizontal {
-    bool unused = 2;
+    int32 total_columns = 2;
   }
 
   message Column {


### PR DESCRIPTION
**Issue:** #2052 

**Description:** Give each column a min-width that is proportional to the total number of columns

Side note, this would not be compatible with IE/Edge 18 and below. Full compatibility [here](https://caniuse.com/?search=max())

![New features in Streamlit 0 67 · Streamlit](https://user-images.githubusercontent.com/24946400/94731117-3f4a1580-0332-11eb-8b5e-8242c4b8fde6.gif)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
