### PR TITLE
Remove duplicated sentence in docs

### DIFF
--- a/docs/tutorial/create_a_data_explorer_app.md
+++ b/docs/tutorial/create_a_data_explorer_app.md
@@ -189,10 +189,6 @@ the data type of the input. If it isn't doing what you expect you can use a
 specialized command like [`st.dataframe`](../api.html#streamlit.dataframe)
 instead. For a full list, see [API reference](../api.md).
 
-Alternatively, you could use a specialized statement, like
-[`st.dataframe()`](../api.html#streamlit.dataframe), to add a specific
-dataset to your app.
-
 ## Draw a histogram
 
 Now that you've had a chance to take a look at the dataset and observe what's


### PR DESCRIPTION
This is a small docs edit, removing a sentence in `create_a_data_explorer_app.md` that basically contained the same information (a bit less) than the sentence before.