### PR TITLE
Nested `with` containers now do the right thing

### DIFF
--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -345,6 +345,17 @@ class DeltaGeneratorWithTest(testutil.DeltaGeneratorTestCase):
         msg = self.get_message_from_queue()
         self.assertEqual(msg.metadata.parent_block.path, [])
 
+    def test_nested_with(self):
+        with st.beta_container():
+            with st.beta_container():
+                st.markdown("Level 2 with")
+                msg = self.get_message_from_queue()
+                self.assertEqual(msg.metadata.parent_block.path, [0, 0])
+
+            st.markdown("Level 1 with")
+            msg = self.get_message_from_queue()
+            self.assertEqual(msg.metadata.parent_block.path, [0])
+
 
 class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
     """Test DeltaGenerator Text, Alert, Json, and Markdown Classes."""


### PR DESCRIPTION
- Track with as a stack instead of a pointer
- Hide private name "_parent" so Streamlit users don't see it

See: https://www.notion.so/streamlit/Product-Review-Due-8c0a583b6b944a5784980b39b79e0422?p=18cc011a669541cfba182225884ab68d