### PR TITLE
Rename deploying to manually deploying

### DIFF
--- a/docs/streamlit_faq.md
+++ b/docs/streamlit_faq.md
@@ -8,7 +8,7 @@ Here are some frequently asked questions about Streamlit and Streamlit Component
 
    If you are supplying a Mapbox token, but the resulting `pydeck_chart` doesn't show your custom Mapbox styles, please check that you are adding the Mapbox token to the Streamlit `config.toml` configuration file. Streamlit DOES NOT read Mapbox tokens from inside of a PyDeck specification (i.e. from inside of the Streamlit app). Please see this [forum thread](https://discuss.streamlit.io/t/deprecation-warning-deckgl-pydeck-maps-to-require-mapbox-token-for-production-usage/2982/10) for more information.
 
-## Deploying Streamlit
+## Manually Deploying Streamlit
 
 1. **How do I deploy Streamlit on a domain so it appears to run on a regular port (i.e. port 80)?**
 

--- a/docs/streamlit_faq.md
+++ b/docs/streamlit_faq.md
@@ -8,7 +8,7 @@ Here are some frequently asked questions about Streamlit and Streamlit Component
 
    If you are supplying a Mapbox token, but the resulting `pydeck_chart` doesn't show your custom Mapbox styles, please check that you are adding the Mapbox token to the Streamlit `config.toml` configuration file. Streamlit DOES NOT read Mapbox tokens from inside of a PyDeck specification (i.e. from inside of the Streamlit app). Please see this [forum thread](https://discuss.streamlit.io/t/deprecation-warning-deckgl-pydeck-maps-to-require-mapbox-token-for-production-usage/2982/10) for more information.
 
-## Manually Deploying Streamlit
+## Manually deploying Streamlit
 
 1. **How do I deploy Streamlit on a domain so it appears to run on a regular port (i.e. port 80)?**
 


### PR DESCRIPTION
Change the heading in the FAQ section from 'Deploying Streamlit' to 'Manually Deploying Streamlit' 