### PR TITLE
Initialize widgets from WidgetStateManager on reruns

### DIFF
--- a/e2e/scripts/st_container.py
+++ b/e2e/scripts/st_container.py
@@ -21,3 +21,10 @@ container.write("Line 2")
 with container:
     "Line 3"
 st.write("Line 4")
+
+# Ensure widget states persist when React nodes shift
+if st.button("Step 2: Press me"):
+    st.header("Pressed!")
+c = st.beta_container()
+if c.checkbox("Step 1: Check me"):
+    c.title("Checked!")

--- a/e2e/specs/st_container.spec.ts
+++ b/e2e/specs/st_container.spec.ts
@@ -23,17 +23,26 @@ describe("st.container", () => {
   });
 
   it("permits multiple out-of-order elements", () => {
-    cy.get(".element-container .stMarkdown p")
+    cy.get(".stMarkdown p")
       .eq(0)
       .contains("Line 2");
-    cy.get(".element-container .stMarkdown p")
+    cy.get(".stMarkdown p")
       .eq(1)
       .contains("Line 3");
-    cy.get(".element-container .stMarkdown p")
+    cy.get(".stMarkdown p")
       .eq(2)
       .contains("Line 1");
-    cy.get(".element-container .stMarkdown p")
+    cy.get(".stMarkdown p")
       .eq(3)
       .contains("Line 4");
+  });
+
+  it("persists widget state across reruns", () => {
+    cy.get(".stCheckbox").click({ multiple: true });
+    cy.get("h1").contains("Checked!");
+
+    cy.get(".stButton button").click();
+    cy.get("h2").contains("Pressed!");
+    cy.get(".stCheckbox input").should("have.attr", "aria-checked", "true");
   });
 });

--- a/frontend/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.tsx
@@ -38,10 +38,10 @@ interface State {
 
 class Checkbox extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): boolean {
+  get initialValue(): boolean {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getBoolValue(widgetId)

--- a/frontend/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.tsx
@@ -38,7 +38,17 @@ interface State {
 
 class Checkbox extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): boolean {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getBoolValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -40,7 +40,17 @@ interface State {
 
 class ColorPicker extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): string {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getStringValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -40,10 +40,10 @@ interface State {
 
 class ColorPicker extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): string {
+  get initialValue(): string {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getStringValue(widgetId)

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -46,11 +46,11 @@ const DATE_FORMAT = "YYYY/MM/DD"
 
 class DateInput extends React.PureComponent<Props, State> {
   public state: State = {
-    values: this.initialValue(),
+    values: this.initialValue,
     isRange: this.props.element.get("isRange") || false,
   }
 
-  private initialValue(): Date[] {
+  get initialValue(): Date[] {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getStringArrayValue(widgetId)

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -46,11 +46,20 @@ const DATE_FORMAT = "YYYY/MM/DD"
 
 class DateInput extends React.PureComponent<Props, State> {
   public state: State = {
-    values: this.props.element
-      .get("default")
-      .toJS()
-      .map((val: string) => new Date(val)),
+    values: this.initialValue(),
     isRange: this.props.element.get("isRange") || false,
+  }
+
+  private initialValue(): Date[] {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getStringArrayValue(widgetId)
+    const stringArray =
+      storedValue !== undefined
+        ? storedValue
+        : // Otherwise, use the default value from the widget protobuf
+          this.props.element.get("default").toJS()
+    return stringArray.map((val: string) => new Date(val))
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -44,7 +44,17 @@ interface MultiselectOption {
 
 class Multiselect extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default").toArray(),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): number[] {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getIntArrayValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default").toArray()
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -44,10 +44,10 @@ interface MultiselectOption {
 
 class Multiselect extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): number[] {
+  get initialValue(): number[] {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getIntArrayValue(widgetId)

--- a/frontend/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.tsx
@@ -61,12 +61,12 @@ class NumberInput extends React.PureComponent<Props, State> {
 
     this.state = {
       dirty: false,
-      value: this.initialValue(),
-      formattedValue: this.formatValue(this.initialValue()),
+      value: this.initialValue,
+      formattedValue: this.formatValue(this.initialValue),
     }
   }
 
-  private initialValue(): number {
+  get initialValue(): number {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getIntValue(widgetId)

--- a/frontend/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.tsx
@@ -59,13 +59,21 @@ class NumberInput extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    const defaultValue = this.props.element.get("default")
-
     this.state = {
       dirty: false,
-      value: defaultValue,
-      formattedValue: this.formatValue(defaultValue),
+      value: this.initialValue(),
+      formattedValue: this.formatValue(this.initialValue()),
     }
+  }
+
+  private initialValue(): number {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getIntValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.tsx
@@ -38,7 +38,17 @@ interface State {
 
 class Radio extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): number {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getIntValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.tsx
@@ -38,10 +38,10 @@ interface State {
 
 class Radio extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): number {
+  get initialValue(): number {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getIntValue(widgetId)

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -44,10 +44,10 @@ interface SelectOption {
 
 class Selectbox extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): number {
+  get initialValue(): number {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getIntValue(widgetId)

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -44,7 +44,17 @@ interface SelectOption {
 
 class Selectbox extends React.PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): number {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getIntValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -55,10 +55,10 @@ class Slider extends React.PureComponent<Props, State> {
       DEBOUNCE_TIME_MS,
       this.setWidgetValueImmediately.bind(this)
     )
-    this.state = { value: this.defaultValue() }
+    this.state = { value: this.initialValue() }
   }
 
-  private defaultValue(): number[] {
+  private initialValue(): number[] {
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getFloatArrayValue(widgetId)
     return storedValue !== undefined

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -55,7 +55,15 @@ class Slider extends React.PureComponent<Props, State> {
       DEBOUNCE_TIME_MS,
       this.setWidgetValueImmediately.bind(this)
     )
-    this.state = { value: this.props.element.get("default").toJS() }
+    this.state = { value: this.defaultValue() }
+  }
+
+  private defaultValue(): number[] {
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getFloatArrayValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : this.props.element.get("default").toJS()
   }
 
   public componentDidMount = (): void => {

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -55,10 +55,10 @@ class Slider extends React.PureComponent<Props, State> {
       DEBOUNCE_TIME_MS,
       this.setWidgetValueImmediately.bind(this)
     )
-    this.state = { value: this.initialValue() }
+    this.state = { value: this.initialValue }
   }
 
-  private initialValue(): number[] {
+  get initialValue(): number[] {
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getFloatArrayValue(widgetId)
     return storedValue !== undefined

--- a/frontend/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.tsx
@@ -45,10 +45,10 @@ interface State {
 class TextArea extends React.PureComponent<Props, State> {
   public state: State = {
     dirty: false,
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): string {
+  get initialValue(): string {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getStringValue(widgetId)

--- a/frontend/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.tsx
@@ -45,7 +45,17 @@ interface State {
 class TextArea extends React.PureComponent<Props, State> {
   public state: State = {
     dirty: false,
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): string {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getStringValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.tsx
@@ -45,10 +45,10 @@ interface State {
 class TextInput extends React.PureComponent<Props, State> {
   public state: State = {
     dirty: false,
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): string {
+  get initialValue(): string {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getStringValue(widgetId)

--- a/frontend/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.tsx
@@ -45,7 +45,17 @@ interface State {
 class TextInput extends React.PureComponent<Props, State> {
   public state: State = {
     dirty: false,
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): string {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getStringValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/src/components/widgets/TimeInput/TimeInput.tsx
@@ -37,7 +37,17 @@ interface State {
 
 class TimeInput extends PureComponent<Props, State> {
   public state: State = {
-    value: this.props.element.get("default"),
+    value: this.initialValue(),
+  }
+
+  private initialValue(): string {
+    // If WidgetStateManager knew a value for this widget, initialize to that.
+    const widgetId: string = this.props.element.get("id")
+    const storedValue = this.props.widgetMgr.getStringValue(widgetId)
+    return storedValue !== undefined
+      ? storedValue
+      : // Otherwise, use the default value from the widget protobuf
+        this.props.element.get("default")
   }
 
   public componentDidMount(): void {

--- a/frontend/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/src/components/widgets/TimeInput/TimeInput.tsx
@@ -37,10 +37,10 @@ interface State {
 
 class TimeInput extends PureComponent<Props, State> {
   public state: State = {
-    value: this.initialValue(),
+    value: this.initialValue,
   }
 
-  private initialValue(): string {
+  get initialValue(): string {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     const widgetId: string = this.props.element.get("id")
     const storedValue = this.props.widgetMgr.getStringValue(widgetId)


### PR DESCRIPTION
Widgets where state may not yet be persisted:
- CustomComponents (have a different state lifecycle, needs more investigation)
- FileUploader (waiting for Karrie's big FileUploader PR to go in)

See: https://www.notion.so/streamlit/Product-Review-Due-8c0a583b6b944a5784980b39b79e0422?p=1d1cbcd1a848412db1ac566014606b89