### PR TITLE
Redesign Expander

### DIFF
--- a/e2e/specs/st_expander.spec.ts
+++ b/e2e/specs/st_expander.spec.ts
@@ -24,7 +24,7 @@ describe("st.expander", () => {
     cy.visit("http://localhost:3000/");
   });
 
-  it("displays epxander + regular containers properly", () => {
+  it("displays expander + regular containers properly", () => {
     cy.get(".stBlock")
       .first()
       .within(() => {

--- a/e2e/specs/st_expander.spec.ts
+++ b/e2e/specs/st_expander.spec.ts
@@ -17,28 +17,28 @@
 
 /// <reference types="cypress" />
 
-const toggleIdentifier = "small[data-toggle]";
+const expanderHeaderIdentifier = ".streamlit-expanderHeader";
 
-describe("st.collapsible_container", () => {
+describe("st.expander", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
   });
 
-  it("displays collapsible + regular containers properly", () => {
+  it("displays epxander + regular containers properly", () => {
     cy.get(".stBlock")
       .first()
       .within(() => {
-        cy.get(toggleIdentifier).should("not.exist");
+        cy.get(expanderHeaderIdentifier).should("not.exist");
       });
     cy.get(".stBlock")
       .eq(1)
       .within(() => {
-        cy.get(toggleIdentifier).should("exist");
+        cy.get(expanderHeaderIdentifier).should("exist");
       });
     cy.get(".stBlock")
       .eq(2)
       .within(() => {
-        cy.get(toggleIdentifier).should("exist");
+        cy.get(expanderHeaderIdentifier).should("exist");
       });
   });
 
@@ -47,25 +47,29 @@ describe("st.collapsible_container", () => {
     cy.get(".stBlock")
       .eq(1)
       .within(() => {
-        let toggle = cy.get(toggleIdentifier);
-        toggle.should("exist");
-        toggle.should("have.text", "Hide");
-        toggle.click();
+        const expanderHeader = cy.get(expanderHeaderIdentifier);
+        expanderHeader.should("exist");
 
-        toggle = cy.get(toggleIdentifier);
-        toggle.should("have.text", "Show");
+        let toggle = cy.get("svg[title='Collapse']");
+        toggle.should("exist");
+        expanderHeader.click();
+
+        toggle = cy.get("svg[title='Expand']");
+        toggle.should("exist");
       });
     // Starts collapsed
     cy.get(".stBlock")
       .eq(2)
       .within(() => {
-        let toggle = cy.get(toggleIdentifier);
-        toggle.should("exist");
-        toggle.should("have.text", "Show");
-        toggle.click();
+        let expanderHeader = cy.get(expanderHeaderIdentifier);
+        expanderHeader.should("exist");
 
-        toggle = cy.get(toggleIdentifier);
-        toggle.should("have.text", "Hide");
+        let toggle = cy.get("svg[title='Expand']");
+        toggle.should("exist");
+        expanderHeader.click();
+
+        toggle = cy.get("svg[title='Collapse']");
+        toggle.should("exist");
       });
   });
 });

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -141,7 +141,12 @@ class Block extends PureComponent<Props> {
     deltaBlock: IBlock
   ): ReactNode {
     const BlockType = deltaBlock.expandable ? this.WithExpandableBlock : Block
-    const optionalProps = deltaBlock.expandable ? deltaBlock.expandable : {}
+    const optionalProps = deltaBlock.expandable
+      ? {
+          empty: !element.size,
+          ...deltaBlock.expandable,
+        }
+      : {}
     let style: any = { width }
     if (deltaBlock.column) {
       style = {

--- a/frontend/src/hocs/withExpandable/withExpandable.scss
+++ b/frontend/src/hocs/withExpandable/withExpandable.scss
@@ -7,3 +7,20 @@
     }
   }
 }
+
+.streamlit-expander {
+  &.empty {
+    div[aria-expanded="true"] + .streamlit-expanderContent {
+      color: $gray-dark;
+      font-style: italic;
+      font-size: $font-size-sm;
+      text-align: center;
+      padding-bottom: 1rem;
+      padding-top: 1rem;
+
+      &:before {
+        content: "empty";
+      }
+    }
+  }
+}

--- a/frontend/src/hocs/withExpandable/withExpandable.scss
+++ b/frontend/src/hocs/withExpandable/withExpandable.scss
@@ -1,0 +1,9 @@
+@import "src/assets/css/variables";
+
+.streamlit-expanderHeader {
+  &:hover {
+    svg {
+      fill: $primary;
+    }
+  }
+}

--- a/frontend/src/hocs/withExpandable/withExpandable.test.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.test.tsx
@@ -17,7 +17,8 @@
 
 import React, { ComponentType } from "react"
 import { shallow } from "enzyme"
-import withExpandable, { Props, StyledToggle } from "./withExpandable"
+import { StatelessAccordion } from "baseui/accordion"
+import withExpandable, { Props } from "./withExpandable"
 
 const testComponent: ComponentType = () => <div>test</div>
 
@@ -44,10 +45,9 @@ describe("withExpandable HOC", () => {
     const WithHoc = withExpandable(testComponent)
     // @ts-ignore
     const wrapper = shallow(<WithHoc {...props} />)
-    const toggleHeader = wrapper.find(StyledToggle)
+    const accordion = wrapper.find(StatelessAccordion)
 
-    expect(toggleHeader.exists()).toBeTruthy()
-    expect(toggleHeader.text()).toEqual("Hide")
+    expect(accordion.prop("expanded").length).toBe(1)
   })
 
   it("should render a collapsed component", () => {
@@ -57,8 +57,8 @@ describe("withExpandable HOC", () => {
     const WithHoc = withExpandable(testComponent)
     // @ts-ignore
     const wrapper = shallow(<WithHoc {...props} />)
-    const toggleHeader = wrapper.find(StyledToggle)
+    const accordion = wrapper.find(StatelessAccordion)
 
-    expect(toggleHeader.text()).toEqual("Show")
+    expect(accordion.prop("expanded").length).toBe(0)
   })
 })

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -16,8 +16,8 @@
  */
 
 import React, { ComponentType, ReactElement, useEffect, useState } from "react"
-import { styled } from "styletron-react"
-import { colors, variables } from "lib/widgetTheme"
+import { StatelessAccordion as Accordion, Panel } from "baseui/accordion"
+import { colors } from "lib/widgetTheme"
 
 export interface Props {
   expandable: boolean
@@ -28,35 +28,6 @@ export interface Props {
 type ComponentProps = {
   expanded: boolean
 }
-
-export const AnimatedComponentWrapper = styled(
-  "div",
-  ({ expanded }: ComponentProps) => ({
-    maxHeight: expanded ? "100vh" : 0,
-    overflow: "hidden",
-    transitionProperty: "max-height",
-    transitionDuration: "0.5s",
-    transitionTimingFunction: "ease-in-out",
-  })
-)
-
-export const StyledHeader = styled("div", ({ expanded }: ComponentProps) => ({
-  display: "flex",
-  justifyContent: "space-between",
-  cursor: "pointer",
-  borderWidth: 0,
-  borderBottomWidth: expanded ? "1px" : 0,
-  borderStyle: "solid",
-  borderColor: colors.grayLighter,
-  marginBottom: variables.spacer,
-  transitionProperty: "border-bottom-width",
-  transitionDuration: "0.5s",
-  transitionTimingFunction: "ease-in-out",
-}))
-
-export const StyledToggle = styled("small", {
-  color: colors.gray,
-})
 
 function withExpandable(
   WrappedComponent: ComponentType<any>
@@ -72,17 +43,33 @@ function withExpandable(
     const toggle = (): void => toggleExpanded(!expanded)
 
     return (
-      <>
-        <StyledHeader expanded={expanded}>
-          <div>{label}</div>
-          <StyledToggle onClick={toggle} role="button" data-toggle>
-            {expanded ? "Hide" : "Show"}
-          </StyledToggle>
-        </StyledHeader>
-        <AnimatedComponentWrapper expanded={expanded}>
+      <Accordion
+        onChange={toggle}
+        expanded={expanded ? ["panel"] : []}
+        overrides={{
+          Content: {
+            style: { backgroundColor: colors.transparent },
+          },
+          PanelContainer: {
+            style: { marginLeft: "0 !important" },
+          },
+          Header: {
+            style: {
+              display: "flex",
+              justifyContent: "flex-end",
+              flexDirection: "row-reverse",
+              paddingLeft: 0,
+            },
+          },
+          ToggleIcon: {
+            style: { marginRight: ".5rem" },
+          },
+        }}
+      >
+        <Panel title={label} key="panel">
           <WrappedComponent {...componentProps} />
-        </AnimatedComponentWrapper>
-      </>
+        </Panel>
+      </Accordion>
     )
   }
 

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -18,6 +18,7 @@
 import React, { ComponentType, ReactElement, useEffect, useState } from "react"
 import { StatelessAccordion as Accordion, Panel } from "baseui/accordion"
 import { colors } from "lib/widgetTheme"
+import "./withExpandable.scss"
 
 export interface Props {
   expandable: boolean
@@ -60,6 +61,7 @@ function withExpandable(
               flexDirection: "row-reverse",
               paddingLeft: 0,
             },
+            props: { className: "streamlit-expanderHeader" },
           },
           ToggleIcon: {
             style: { marginRight: ".5rem" },

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { ComponentType, ReactElement, useEffect, useState } from "react"
+import classNames from "classnames"
 import { StatelessAccordion as Accordion, Panel } from "baseui/accordion"
 import { colors } from "lib/widgetTheme"
 import "./withExpandable.scss"
@@ -24,17 +25,19 @@ export interface Props {
   expandable: boolean
   label: string
   expanded: boolean
-}
-
-type ComponentProps = {
-  expanded: boolean
+  empty: boolean
 }
 
 function withExpandable(
   WrappedComponent: ComponentType<any>
 ): ComponentType<any> {
   const ExpandableComponent = (props: Props): ReactElement => {
-    const { label, expanded: initialExpanded, ...componentProps } = props
+    const {
+      label,
+      expanded: initialExpanded,
+      empty,
+      ...componentProps
+    } = props
 
     const [expanded, toggleExpanded] = useState<boolean>(initialExpanded)
     useEffect(() => {
@@ -50,6 +53,7 @@ function withExpandable(
         overrides={{
           Content: {
             style: { backgroundColor: colors.transparent },
+            props: { className: "streamlit-expanderContent" },
           },
           PanelContainer: {
             style: { marginLeft: "0 !important" },
@@ -65,6 +69,11 @@ function withExpandable(
           },
           ToggleIcon: {
             style: { marginRight: ".5rem" },
+          },
+          Root: {
+            props: {
+              className: classNames("streamlit-expander", { empty: empty }),
+            },
           },
         }}
       >

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -72,7 +72,7 @@ function withExpandable(
           },
           Root: {
             props: {
-              className: classNames("streamlit-expander", { empty: empty }),
+              className: classNames("streamlit-expander", { empty }),
             },
           },
         }}

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -483,6 +483,7 @@ class DeltaGenerator(
         expandable_proto.label = label
 
         block_proto = Block_pb2.Block()
+        block_proto.allow_empty = True
         block_proto.expandable.CopyFrom(expandable_proto)
 
         return self._block(block_proto=block_proto)


### PR DESCRIPTION
**Description:** 

### Use BaseWeb's accordion for the expander.
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/24946400/94963092-959b8d80-04c5-11eb-923f-9592ef3596ee.gif)

### Display empty expander with empty text inside like empty `st.table`
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/24946400/94977251-f2a73b80-04e5-11eb-98f0-13b834fd04e3.gif)


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
