### PR TITLE
WidgetStateManager: don't return `Long` for int values

### DIFF
--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -203,5 +203,34 @@ describe("Widget State Manager", () => {
         JSON.stringify(MOCK_DATA.floatArray)
       )
     })
+
+    it("setIntValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
+      widgetMgr.setIntValue(MOCK_DATA.widgetId, Number.MAX_SAFE_INTEGER, {
+        fromUi: true,
+      })
+
+      expect(widgetMgr.getIntValue(MOCK_DATA.widgetId)).toBe(
+        Number.MAX_SAFE_INTEGER
+      )
+
+      widgetMgr.setIntValue(MOCK_DATA.widgetId, Number.MIN_SAFE_INTEGER, {
+        fromUi: true,
+      })
+
+      expect(widgetMgr.getIntValue(MOCK_DATA.widgetId)).toBe(
+        Number.MIN_SAFE_INTEGER
+      )
+    })
+
+    it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
+      const values = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
+      widgetMgr.setIntArrayValue(MOCK_DATA.widgetId, values, {
+        fromUi: true,
+      })
+
+      expect(widgetMgr.getIntArrayValue(MOCK_DATA.widgetId)).toStrictEqual(
+        values
+      )
+    })
   })
 })

--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -97,11 +97,9 @@ describe("Widget State Manager", () => {
     widgetMgr.setIntArrayValue(MOCK_DATA.widgetId, MOCK_DATA.intArray, {
       fromUi: true,
     })
-    expect(widgetMgr.getIntArrayValue(MOCK_DATA.widgetId)).toEqual([
-      { low: 1, high: 0, unsigned: false },
-      { low: 25, high: 0, unsigned: false },
-      { low: 50, high: 0, unsigned: false },
-    ])
+    expect(widgetMgr.getIntArrayValue(MOCK_DATA.widgetId)).toEqual(
+      MOCK_DATA.intArray
+    )
   })
 
   it("sets float array value correctly", () => {

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -32,10 +32,17 @@ export interface Source {
 }
 
 /**
- * Require that a number | Long is a number. If the value is a Long, throw
- * an Error.
+ * Require that a `number | Long` is a `number`. If the value is a `Long`,
+ * throw an Error.
+ *
+ * Our "intValue" and "intArrayValue" widget protobuf values represent values
+ * with sint64, because sint32 is too small to represent the full range of
+ * JavaScript int values. Protobufjs uses `number | Long` to represent
+ * sint64. However, we're never putting Longs *into* int and intArrays -
+ * because none of our widgets use Longs - so we'll never get a Long back out.
+ * This function documents and asserts that.
  */
-function requireNumber(value: number | Long): number {
+function requireNumberInt(value: number | Long): number {
   if (typeof value === "number") {
     return value
   }
@@ -94,7 +101,7 @@ export class WidgetStateManager {
   public getIntValue(widgetId: string): number | undefined {
     const state = this.getWidgetStateProto(widgetId)
     if (state != null && state.value === "intValue") {
-      return requireNumber(state.intValue)
+      return requireNumberInt(state.intValue)
     }
 
     return undefined
@@ -195,7 +202,7 @@ export class WidgetStateManager {
       state.intArrayValue != null &&
       state.intArrayValue.value != null
     ) {
-      return state.intArrayValue.value.map(requireNumber)
+      return state.intArrayValue.value.map(requireNumberInt)
     }
 
     return undefined

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -32,6 +32,18 @@ export interface Source {
 }
 
 /**
+ * Require that a number | Long is a number. If the value is a Long, throw
+ * an Error.
+ */
+function requireNumber(value: number | Long): number {
+  if (typeof value === "number") {
+    return value
+  }
+
+  throw new Error(`Expected a number, but got a Long: ${value}`)
+}
+
+/**
  * Manages widget values, and sends widget update messages back to the server.
  */
 export class WidgetStateManager {
@@ -79,10 +91,10 @@ export class WidgetStateManager {
     this.maybeSendUpdateWidgetsMessage(source)
   }
 
-  public getIntValue(widgetId: string): number | Long | undefined {
+  public getIntValue(widgetId: string): number | undefined {
     const state = this.getWidgetStateProto(widgetId)
     if (state != null && state.value === "intValue") {
-      return state.intValue
+      return requireNumber(state.intValue)
     }
 
     return undefined
@@ -175,7 +187,7 @@ export class WidgetStateManager {
     this.maybeSendUpdateWidgetsMessage(source)
   }
 
-  public getIntArrayValue(widgetId: string): (number | Long)[] | undefined {
+  public getIntArrayValue(widgetId: string): number[] | undefined {
     const state = this.getWidgetStateProto(widgetId)
     if (
       state != null &&
@@ -183,7 +195,7 @@ export class WidgetStateManager {
       state.intArrayValue != null &&
       state.intArrayValue.value != null
     ) {
-      return state.intArrayValue.value
+      return state.intArrayValue.value.map(requireNumber)
     }
 
     return undefined

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -35,9 +35,9 @@ export interface Source {
  * Require that a `number | Long` is a `number`. If the value is a `Long`,
  * throw an Error.
  *
- * Our "intValue" and "intArrayValue" widget protobuf values represent values
- * with sint64, because sint32 is too small to represent the full range of
- * JavaScript int values. Protobufjs uses `number | Long` to represent
+ * Our "intValue" and "intArrayValue" widget protobuf fields represent their
+ * values with sint64, because sint32 is too small to represent the full range
+ * of JavaScript int values. Protobufjs uses `number | Long` to represent
  * sint64. However, we're never putting Longs *into* int and intArrays -
  * because none of our widgets use Longs - so we'll never get a Long back out.
  * This function documents and asserts that.

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -32,7 +32,7 @@ export interface Source {
 }
 
 /**
- * Coerce a `number | Long` a `number`.
+ * Coerce a `number | Long` to a `number`.
  *
  * Our "intValue" and "intArrayValue" widget protobuf fields represent their
  * values with sint64, because sint32 is too small to represent the full range

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -41,7 +41,7 @@ export interface Source {
  * because none of our widgets use Longs - so we'll never get a Long back out.
  *
  * If the given value cannot be converted to `number` without a loss of
- * precision, throw an error instead.
+ * precision (which should not be possible!), throw an error instead.
  */
 function requireNumberInt(value: number | Long): number {
   if (typeof value === "number") {


### PR DESCRIPTION
Our "intValue" and "intArrayValue" widget protobuf values represent values with sint64, because sint32 is too small to represent the full range of JavaScript int values. 

Protobufjs uses `number | Long` to represent sint64. However, we're never putting Longs *into* int and intArrays - because none of our widgets use Longs - so we'll never get a Long back out.

This changes the return value of `getIntValue` and `getIntArrayValue` to `number`, and asserts that a `Long` is never returned.

There's also a couple simple tests that verify we can pass MIN_SAFE_INT and MAX_SAFE_INT to these functions.