### PR TITLE
Inject tracking data

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,7 +111,7 @@ const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
 declare global {
   interface Window {
     streamlitDebug: any
-    streamlitTracking: Record<string, unknown>
+    streamlitShareMetadata: Record<string, unknown>
   }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,7 +111,7 @@ const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
 declare global {
   interface Window {
     streamlitDebug: any
-    streamlitTracking: any
+    streamlitTracking: Record<string, unknown>
   }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,6 +111,7 @@ const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
 declare global {
   interface Window {
     streamlitDebug: any
+    streamlitTracking: any
   }
 }
 

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -20,8 +20,6 @@
 import { SessionInfo } from "lib/SessionInfo"
 import { getMetricsManagerForTest } from "lib/MetricsManagerTestUtils"
 
-import { MetricsManager } from "./MetricsManager"
-
 beforeEach(() => {
   SessionInfo.current = new SessionInfo({
     sessionId: "sessionId",
@@ -116,23 +114,22 @@ test("tracks events immediately after initialized", () => {
   expect(mm.track.mock.calls.length).toBe(3)
 })
 
-test("tracks host data when on S4A", () => {
+test("tracks host data when in an iFrame", () => {
   window.parent.streamlitTracking = {
     hosted: "S4A",
     k: "v",
   }
-  const hostData = MetricsManager.getHostTrackingData()
-  expect(hostData).toStrictEqual({ hosted: "S4A" })
 
   const mm = getMetricsManagerForTest()
   mm.initialize({ gatherUsageStats: true })
-
-  expect(mm.track.mock.calls.length).toBe(0)
   mm.enqueue("ev1", { data1: 11 })
-  expect(mm.track.mock.calls.length).toBe(1)
+
   expect(mm.track.mock.calls[0][1]).toMatchObject({
     hosted: "S4A",
     data1: 11,
+  })
+  expect(mm.track.mock.calls[0][1]).not.toMatchObject({
+    k: "v",
   })
 })
 

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -20,6 +20,8 @@
 import { SessionInfo } from "lib/SessionInfo"
 import { getMetricsManagerForTest } from "lib/MetricsManagerTestUtils"
 
+import { MetricsManager } from "./MetricsManager"
+
 beforeEach(() => {
   SessionInfo.current = new SessionInfo({
     sessionId: "sessionId",
@@ -112,6 +114,26 @@ test("tracks events immediately after initialized", () => {
   expect(mm.track.mock.calls.length).toBe(2)
   mm.enqueue("ev3", { data3: 13 })
   expect(mm.track.mock.calls.length).toBe(3)
+})
+
+test("tracks host data when on S4A", () => {
+  window.parent.streamlitTracking = {
+    hosted: "S4A",
+    k: "v",
+  }
+  const hostData = MetricsManager.getHostTrackingData()
+  expect(hostData).toStrictEqual({ hosted: "S4A" })
+
+  const mm = getMetricsManagerForTest()
+  mm.initialize({ gatherUsageStats: true })
+
+  expect(mm.track.mock.calls.length).toBe(0)
+  mm.enqueue("ev1", { data1: 11 })
+  expect(mm.track.mock.calls.length).toBe(1)
+  expect(mm.track.mock.calls[0][1]).toMatchObject({
+    hosted: "S4A",
+    data1: 11,
+  })
 })
 
 test("increments deltas", () => {

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -117,7 +117,7 @@ test("tracks events immediately after initialized", () => {
 })
 
 test("tracks host data when in an iFrame", () => {
-  window.parent.streamlitTracking = {
+  window.parent.streamlitShareMetadata = {
     hosted: "S4A",
     k: "v",
   }

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -20,6 +20,10 @@
 import { SessionInfo } from "lib/SessionInfo"
 import { getMetricsManagerForTest } from "lib/MetricsManagerTestUtils"
 
+jest.mock("lib/utils", () => ({
+  isInChildFrame: jest.fn(x => true),
+}))
+
 beforeEach(() => {
   SessionInfo.current = new SessionInfo({
     sessionId: "sessionId",
@@ -96,8 +100,6 @@ test("enqueues events before initialization", () => {
   expect(mm.identify.mock.calls[0][0]).toBe(SessionInfo.current.installationId)
   expect(mm.identify.mock.calls[0][1]).toMatchObject({
     authoremail: SessionInfo.current.authorEmail,
-    machineIdV1: SessionInfo.current.installationIdV1,
-    machineIdV2: SessionInfo.current.installationIdV2,
   })
 })
 
@@ -124,12 +126,30 @@ test("tracks host data when in an iFrame", () => {
   mm.initialize({ gatherUsageStats: true })
   mm.enqueue("ev1", { data1: 11 })
 
+  expect(mm.identify.mock.calls[0][1]).toMatchObject({
+    hosted: "S4A",
+  })
   expect(mm.track.mock.calls[0][1]).toMatchObject({
     hosted: "S4A",
     data1: 11,
   })
   expect(mm.track.mock.calls[0][1]).not.toMatchObject({
     k: "v",
+  })
+})
+
+test("tracks installation data", () => {
+  const mm = getMetricsManagerForTest()
+  mm.initialize({ gatherUsageStats: true })
+  mm.enqueue("ev1", { data1: 11 })
+
+  expect(mm.identify.mock.calls[0][1]).toMatchObject({
+    machineIdV1: SessionInfo.current.installationIdV1,
+    machineIdV2: SessionInfo.current.installationIdV2,
+  })
+  expect(mm.track.mock.calls[0][1]).toMatchObject({
+    machineIdV1: SessionInfo.current.installationIdV1,
+    machineIdV2: SessionInfo.current.installationIdV2,
   })
 })
 

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -216,10 +216,7 @@ export class MetricsManager {
 
   // Use the tracking data injected by S4A if the app is hosted there
   private static getHostTrackingData(): Record<string, unknown> {
-    if (
-      window.location.origin.toLowerCase().endsWith(".streamlit.io") &&
-      window.parent.streamlitTracking
-    ) {
+    if (window.parent.streamlitTracking) {
       return pick(window.parent.streamlitTracking, [
         "hosted",
         "owner",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -102,6 +102,9 @@ export class MetricsManager {
 
       // Only record the user's email if they entered a non-empty one.
       const userTraits: any = this.getHostTrackingData()
+      logAlways("core initialize")
+      logAlways(userTraits)
+
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
       }
@@ -112,7 +115,7 @@ export class MetricsManager {
       this.sendPendingEvents()
     }
 
-    logAlways("Gather usage stats: ", this.actuallySendMetrics)
+    logAlways("Gather usage rhone stats: ", this.actuallySendMetrics)
   }
 
   public enqueue(evName: string, evData: Record<string, unknown> = {}): void {
@@ -182,6 +185,9 @@ export class MetricsManager {
       streamlitVersion: SessionInfo.current.streamlitVersion,
     }
 
+    logAlways("core send")
+    logAlways(data)
+
     // Don't actually track events when in dev mode, just print them instead.
     // This is just to keep us from tracking too many events and having to pay
     // for all of them.
@@ -205,13 +211,13 @@ export class MetricsManager {
     if (IS_DEV_ENV) {
       logAlways("[Dev mode] Not sending id: ", id, data)
     } else {
-      analytics.identify(id, data)
+      // analytics.identify(id, data)
     }
   }
 
   // eslint-disable-next-line class-methods-use-this
   private track(evName: string, data: Record<string, unknown>): void {
-    analytics.track(evName, data)
+    // analytics.track(evName, data)
   }
 
   // Use the tracking data injected by S4A if the app is hosted there

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -21,6 +21,7 @@ import { SessionInfo } from "lib/SessionInfo"
 import { initializeSegment } from "vendor/Segment"
 import { IS_DEV_ENV, IS_SHARED_REPORT } from "./baseconsts"
 import { logAlways } from "./log"
+import { isInChildFrame } from "./utils"
 
 /**
  * The analytics is the Segment.io object. It is initialized in Segment.ts
@@ -100,14 +101,16 @@ export class MetricsManager {
       // Segment will not initialize if this is rendered with SSR
       initializeSegment()
 
+      const userTraits: any = {
+        ...MetricsManager.getInstallationData(),
+        ...MetricsManager.getHostTrackingData(),
+      }
+
       // Only record the user's email if they entered a non-empty one.
-      const userTraits: any = MetricsManager.getHostTrackingData()
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
       }
 
-      userTraits.machineIdV1 = SessionInfo.current.installationIdV1
-      userTraits.machineIdV2 = SessionInfo.current.installationIdV2
       this.identify(SessionInfo.current.installationId, userTraits)
       this.sendPendingEvents()
     }
@@ -176,6 +179,7 @@ export class MetricsManager {
     const data = {
       ...evData,
       ...MetricsManager.getHostTrackingData(),
+      ...MetricsManager.getInstallationData(),
       reportHash: this.reportHash,
       dev: IS_DEV_ENV,
       source: "browser",
@@ -214,9 +218,17 @@ export class MetricsManager {
     analytics.track(evName, data)
   }
 
+  // Get the installation IDs from the session
+  private static getInstallationData(): Record<string, unknown> {
+    return {
+      machineIdV1: SessionInfo.current.installationIdV1,
+      machineIdV2: SessionInfo.current.installationIdV2,
+    }
+  }
+
   // Use the tracking data injected by S4A if the app is hosted there
   private static getHostTrackingData(): Record<string, unknown> {
-    if (window.parent.streamlitTracking) {
+    if (isInChildFrame() && window.parent.streamlitTracking) {
       return pick(window.parent.streamlitTracking, [
         "hosted",
         "owner",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -102,7 +102,6 @@ export class MetricsManager {
 
       // Only record the user's email if they entered a non-empty one.
       const userTraits: any = this.getHostTrackingData()
-      logAlways("core initialize: ", userTraits)
 
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
@@ -183,8 +182,6 @@ export class MetricsManager {
       source: "browser",
       streamlitVersion: SessionInfo.current.streamlitVersion,
     }
-
-    logAlways("core send: ", data)
 
     // Don't actually track events when in dev mode, just print them instead.
     // This is just to keep us from tracking too many events and having to pay

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -228,8 +228,8 @@ export class MetricsManager {
 
   // Use the tracking data injected by S4A if the app is hosted there
   private static getHostTrackingData(): Record<string, unknown> {
-    if (isInChildFrame() && window.parent.streamlitTracking) {
-      return pick(window.parent.streamlitTracking, [
+    if (isInChildFrame() && window.parent.streamlitShareMetadata) {
+      return pick(window.parent.streamlitShareMetadata, [
         "hosted",
         "owner",
         "repo",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -102,8 +102,7 @@ export class MetricsManager {
 
       // Only record the user's email if they entered a non-empty one.
       const userTraits: any = this.getHostTrackingData()
-      logAlways("core initialize")
-      logAlways(userTraits)
+      logAlways("core initialize: ", userTraits)
 
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
@@ -115,7 +114,7 @@ export class MetricsManager {
       this.sendPendingEvents()
     }
 
-    logAlways("Gather usage rhone stats: ", this.actuallySendMetrics)
+    logAlways("Gather usage stats: ", this.actuallySendMetrics)
   }
 
   public enqueue(evName: string, evData: Record<string, unknown> = {}): void {
@@ -185,8 +184,7 @@ export class MetricsManager {
       streamlitVersion: SessionInfo.current.streamlitVersion,
     }
 
-    logAlways("core send")
-    logAlways(data)
+    logAlways("core send: ", data)
 
     // Don't actually track events when in dev mode, just print them instead.
     // This is just to keep us from tracking too many events and having to pay
@@ -223,7 +221,8 @@ export class MetricsManager {
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): Record<string, unknown> {
     if (
-      window.location.origin.toLowerCase().endsWith(".streamlit.io") &&
+      // window.location.origin.toLowerCase().endsWith(".streamlit.io") &&
+      window.location.origin.toLowerCase().endsWith(".streamlit.test") &&
       window.parent.streamlitTracking
     ) {
       return pick(window.parent.streamlitTracking, [

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -101,7 +101,7 @@ export class MetricsManager {
       initializeSegment()
 
       // Only record the user's email if they entered a non-empty one.
-      const userTraits: any = this.getHostTrackingData()
+      const userTraits: any = MetricsManager.getHostTrackingData()
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
       }
@@ -175,7 +175,7 @@ export class MetricsManager {
   private send(evName: string, evData: Record<string, unknown> = {}): void {
     const data = {
       ...evData,
-      ...this.getHostTrackingData(),
+      ...MetricsManager.getHostTrackingData(),
       reportHash: this.reportHash,
       dev: IS_DEV_ENV,
       source: "browser",
@@ -215,7 +215,7 @@ export class MetricsManager {
   }
 
   // Use the tracking data injected by S4A if the app is hosted there
-  private getHostTrackingData(): Record<string, unknown> {
+  private static getHostTrackingData(): Record<string, unknown> {
     if (
       window.location.origin.toLowerCase().endsWith(".streamlit.io") &&
       window.parent.streamlitTracking

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -102,7 +102,6 @@ export class MetricsManager {
 
       // Only record the user's email if they entered a non-empty one.
       const userTraits: any = this.getHostTrackingData()
-
       if (SessionInfo.current.authorEmail !== "") {
         userTraits.authoremail = SessionInfo.current.authorEmail
       }
@@ -206,20 +205,19 @@ export class MetricsManager {
     if (IS_DEV_ENV) {
       logAlways("[Dev mode] Not sending id: ", id, data)
     } else {
-      // analytics.identify(id, data)
+      analytics.identify(id, data)
     }
   }
 
   // eslint-disable-next-line class-methods-use-this
   private track(evName: string, data: Record<string, unknown>): void {
-    // analytics.track(evName, data)
+    analytics.track(evName, data)
   }
 
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): Record<string, unknown> {
     if (
-      // window.location.origin.toLowerCase().endsWith(".streamlit.io") &&
-      window.location.origin.toLowerCase().endsWith(".streamlit.test") &&
+      window.location.origin.toLowerCase().endsWith(".streamlit.io") &&
       window.parent.streamlitTracking
     ) {
       return pick(window.parent.streamlitTracking, [

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -57,6 +57,14 @@ export function isEmbeddedInIFrame(): boolean {
 }
 
 /**
+ * Returns true if the frameElement and parent parameters indicate that we're in an
+ * iframe.
+ */
+export function isInChildFrame(): boolean {
+  return window.parent !== window && !!window.frameElement
+}
+
+/**
  * A helper function to make an ImmutableJS
  * info element from the given text.
  */


### PR DESCRIPTION
What
- We need to inject s4a data into user apps so it gets sent along as tracking data to Segment.
- Users should be prevented from injecting this data and messing up our metrics.
- Data needs to be injected early in the app lifecycle, before any tracking data is sent.

How
- Set a global variable on the window object from s4a, and then the core application will be able to do something like `window.parent.trackingData`

Data to inject:
- hosted: s4a/s4t/localhost
- user id: users database id in s4a, hashed for security reasons
- github owner
- github repo
- github branch
- github path

Note
- I snuck in a change to add the installation id to the event tracking
