### PR TITLE
Fix for "streamlit run" - when no file extension is provided

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -204,10 +204,15 @@ def main_run(target, args=None, **kwargs):
 
     _, extension = os.path.splitext(target)
     if extension[1:] not in ACCEPTED_FILE_EXTENSIONS:
-        raise click.BadArgumentUsage(
-            "Streamlit requires raw Python (.py) files, not %s.\nFor more information, please see https://docs.streamlit.io"
-            % extension
-        )
+        if extension[1:] == "":
+            raise click.BadArgumentUsage(
+                "Streamlit requires raw Python (.py) files, but the provided file has no extension.\nFor more information, please see https://docs.streamlit.io"
+            )
+        else:    
+            raise click.BadArgumentUsage(
+                "Streamlit requires raw Python (.py) files, not %s.\nFor more information, please see https://docs.streamlit.io"
+                % extension
+            )
 
     if url(target):
         from streamlit.temporary_directory import TemporaryDirectory


### PR DESCRIPTION
Fixes #2107 

### What was the issue?
When the `streamlit run` command is executed with a filename that does not have an extension the error message shown on the CLI was incorrect as discussed in the Issue thread #2107 

### The fix
Problem was in the `cli.py` file where the run command is defined. In lines 206 to 210 where the extension is checked. 

When only the filename is provided without extension, checking only the `extension[1:] not in ACCEPTED_FILE_EXTENSIONS`  will result in an empty string because of the output from `os.path.splitext` returns empty string for the extension when none is provided. This behaviour is illustrated in the image below,

![image](https://user-images.githubusercontent.com/35622449/95372165-d3027f80-08f8-11eb-9a82-56cfb323096f.png)

This results in this weird error message `"Streamlit requires raw Python (.py) files, not ."` which does not make sense and might confuse some absolute beginners. 

The fix was to add another statement to check if there is an extension provided and display a proper error message when not.  