### PR TITLE
Upgrade ProtobufJS and fix build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ protobuf:
 		echo ; \
 		./node_modules/protobufjs/bin/pbjs \
 			../proto/streamlit/proto/*.proto \
-			-t static-module --es6 \
+			-t static-module --wrap es6 \
 	) > ./src/autogen/proto.js
 
 	@# Typescript type declarations for our generated protobufs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "numbro": "^2.3.1",
     "plotly.js": "^1.54.7",
     "prismjs": "^1.21.0",
-    "protobufjs": "~6.9.0",
+    "protobufjs": "^6.10.1",
     "query-string": "^6.13.1",
     "react": "^16.13.1",
     "react-color": "^2.18.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14091,10 +14091,10 @@ prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-protobufjs@~6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.9.0.tgz#c08b2bf636682598e6fabbf0edb0b1256ff090bd"
-  integrity sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==
+protobufjs@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
+  integrity sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
Due to a change in ProtobufJS, we have to change the way we wrap ES6 modules
to fix compilation. The commit that caused the issue is:

https://github.com/protobufjs/protobuf.js/commit/6698d592436ff6b71ee91ff7da000bc6f5d15011