### PR TITLE
[File uploader] Single upload reruns only once

### DIFF
--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -110,7 +110,7 @@ class FileUploader extends React.PureComponent<Props, State> {
     const multipleFiles = element.get("multipleFiles")
 
     if (!multipleFiles && this.state.files.length) {
-      // Only one file is allowed. Delete existing file.
+      // Only one file is allowed. Remove existing file
       this.removeFile(this.state.files[0].id || "")
     }
 

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -111,7 +111,7 @@ class FileUploader extends React.PureComponent<Props, State> {
 
     if (!multipleFiles && this.state.files.length) {
       // Only one file is allowed. Delete existing file.
-      this.delete(this.state.files[0].id || "")
+      this.removeFile(this.state.files[0].id || "")
     }
 
     // Too many files were uploaded. Upload the first eligible file
@@ -158,7 +158,8 @@ class FileUploader extends React.PureComponent<Props, State> {
         e => this.onUploadProgress(e, file),
         file.cancelToken
           ? file.cancelToken.token
-          : axios.CancelToken.source().token
+          : axios.CancelToken.source().token,
+        !this.props.element.get("multipleFiles")
       )
       .then(() => {
         this.setState(state => {

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -31,8 +31,8 @@ export class FileUploadClient extends HttpClient {
    * @param files: the files to upload.
    * @param onUploadProgress: an optional function that will be called repeatedly with progress events during the upload.
    * @param cancelToken: an optional axios CancelToken that can be used to cancel the in-progress upload.
+   * @param replace: an optional boolean to indicate if the file should replace existing files associated with the widget.
    */
-
   public async uploadFiles(
     widgetId: string,
     files: ExtendedFile[],

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -37,11 +37,13 @@ export class FileUploadClient extends HttpClient {
     widgetId: string,
     files: ExtendedFile[],
     onUploadProgress?: (progressEvent: any) => void,
-    cancelToken?: CancelToken
+    cancelToken?: CancelToken,
+    replace?: boolean
   ): Promise<void> {
     const form = new FormData()
     form.append("sessionId", SessionInfo.current.sessionId)
     form.append("widgetId", widgetId)
+    if (replace) form.append("replace", "true")
     for (const file of files) {
       form.append(file.id || file.name, file, file.name)
     }

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -247,7 +247,7 @@ class Server(object):
         self._report = None  # type: Optional[Report]
         self._preheated_session_id = None  # type: Optional[str]
 
-    def on_files_updated(self, file_id):
+    def on_files_updated(self, session_id):
         """Event handler for UploadedFileManager.on_file_added.
 
         When a file is uploaded by a user, schedule a re-run of the
@@ -259,14 +259,13 @@ class Server(object):
             The file that was just uploaded.
 
         """
-        session_id, widget_id = file_id
         session_info = self._get_session_info(session_id)
         if session_info is not None:
             session_info.session.request_rerun()
         else:
             # If an uploaded file doesn't belong to an existing session,
             # remove it so it doesn't stick around forever.
-            self._uploaded_file_mgr.remove_files(session_id, widget_id)
+            self._uploaded_file_mgr.remove_session_files(session_id)
 
     def _get_session_info(self, session_id):
         """Return the SessionInfo with the given id, or None if no such

--- a/lib/streamlit/server/upload_file_request_handler.py
+++ b/lib/streamlit/server/upload_file_request_handler.py
@@ -114,6 +114,8 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             self.send_error(400, reason=str(e))
             return
 
+        LOGGER.debug(f"{len(files)} file(s) received for session {session_id} widget {widget_id}")
+
         # Create an UploadedFile object for each file.
         uploaded_files = []
         for id, flist in files.items():
@@ -131,11 +133,18 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             self.send_error(400, reason="Expected at least 1 file, but got 0")
             return
 
-        self._file_mgr.add_files(
+        replace = self.get_argument("replace", "false")
+
+        update_files = (
+            self._file_mgr.replace_files if replace == "true" else self._file_mgr.add_files
+        )
+        update_files(
             session_id=session_id,
             widget_id=widget_id,
             files=uploaded_files,
         )
+
+        LOGGER.debug(f"{len(files)} file(s) uploaded for session {session_id} widget {widget_id}. replace {replace}")
 
         self.set_status(200)
 


### PR DESCRIPTION
[Single file uploader should not cause 2 reruns](https://www.notion.so/streamlit/Consolidate-the-single-file-replacement-scenario-f043003337e748fcbb196a0bda33e2ad). Previously updating on delete and on add. Now when replacing a file, delete and add is one action

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
