### PR TITLE
Add global GTM container

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -25,6 +25,17 @@
     })(window, document, 'script', 'dataLayer', 'GTM-TXFLBCM');</script>
   <!-- End Google Tag Manager -->
 
+  <!-- Google Tag Manager -->
+  <script>(function (w, d, s, l, i) {
+      w[l] = w[l] || []; w[l].push({
+        'gtm.start':
+          new Date().getTime(), event: 'gtm.js'
+      }); var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-52GRQSL');</script>
+  <!-- End Google Tag Manager -->
+
   <meta charset="utf-8">
   {{ metatags }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
As part of the analytics implementation work, adding a second GTM container for development purposes. This will allow implementors to create rules separate from current tracking. When cut-over ready to happen, can submit another PR to remove the original GTM container