### PR TITLE
[Blocker] Place delta generator with blocks in report context

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -176,11 +176,6 @@ class DeltaGenerator(
         self._parent = parent
         self._block_type = block_type
 
-        # Stack of DGs used for the `with` block. The current one is at the end.
-        # NOTE: Only the main DG should ever reference this.
-        # You should use the computed property _active_dg instead.
-        self._with_dg_stack = [self]
-
         # Change the module of all mixin'ed functions to be st.delta_generator,
         # instead of the original module (e.g. st.elements.markdown)
         for mixin in self.__class__.__bases__:
@@ -190,11 +185,13 @@ class DeltaGenerator(
 
     def __enter__(self):
         # with block started
-        self._main_dg._with_dg_stack.append(self)
+        ctx = ensure_report_context()
+        ctx.dg_stack.append(self)
 
     def __exit__(self, type, value, traceback):
         # with block ended
-        self._main_dg._with_dg_stack.pop()
+        ctx = ensure_report_context()
+        ctx.dg_stack.pop()
         # Re-raise any exceptions
         return False
 
@@ -202,10 +199,12 @@ class DeltaGenerator(
     def _active_dg(self):
         if self == self._main_dg:
             # `st.button`: Use the current `with` dg (aka the top of the stack)
-            return self._with_dg_stack[-1]
-        else:
-            # `st.sidebar.button`: Ignore the `with` dg
-            return self
+            ctx = ensure_report_context()
+            if len(ctx.dg_stack) > 0:
+                return ctx.dg_stack[-1]
+
+        # `st.sidebar.button`: Ignore the `with` dg
+        return self
 
     @property
     def _main_dg(self):
@@ -777,11 +776,17 @@ def _value_or_dg(value, dg):
     return value
 
 
-def _enqueue_message(msg):
-    """Enqueues a ForwardMsg proto to send to the app."""
+def ensure_report_context():
     ctx = get_report_ctx()
 
     if ctx is None:
         raise NoSessionContext()
+
+    return ctx
+
+
+def _enqueue_message(msg):
+    """Enqueues a ForwardMsg proto to send to the app."""
+    ctx = ensure_report_context()
 
     ctx.enqueue(msg)

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import streamlit
 import threading
 
 from streamlit.logger import get_logger
@@ -218,3 +217,4 @@ def get_report_ctx():
 
 
 # Needed to avoid circular dependencies while running tests.
+import streamlit

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import streamlit
 import threading
 
 from streamlit.logger import get_logger
@@ -60,6 +61,7 @@ class ReportContext(object):
         self.uploaded_file_mgr = uploaded_file_mgr
         # set_page_config is allowed at most once, as the very first st.command
         self._set_page_config_allowed = True
+        # Stack of DGs used for the with block. The current one is at the end.
         self.dg_stack = []
 
     def reset(self, query_string=""):
@@ -216,4 +218,3 @@ def get_report_ctx():
 
 
 # Needed to avoid circular dependencies while running tests.
-import streamlit

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import streamlit
 import threading
 
 from streamlit.logger import get_logger
@@ -217,3 +216,4 @@ def get_report_ctx():
 
 
 # Needed to avoid circular dependencies while running tests.
+import streamlit

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import streamlit
 import threading
 
 from streamlit.logger import get_logger
@@ -60,6 +61,7 @@ class ReportContext(object):
         self.uploaded_file_mgr = uploaded_file_mgr
         # set_page_config is allowed at most once, as the very first st.command
         self._set_page_config_allowed = True
+        self.dg_stack = []
 
     def reset(self, query_string=""):
         self.cursors = {}
@@ -215,4 +217,3 @@ def get_report_ctx():
 
 
 # Needed to avoid circular dependencies while running tests.
-import streamlit

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -143,36 +143,42 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            (st.empty().empty, "streamlit.delta_generator", "empty", "()"),
-            (st.empty().text, "streamlit.delta_generator", "text", "(body)"),
+            (lambda: st.empty().empty, "streamlit.delta_generator", "empty", "()"),
+            (lambda: st.empty().text, "streamlit.delta_generator", "text", "(body)"),
             (
-                st.empty().markdown,
+                lambda: st.empty().markdown,
                 "streamlit.delta_generator",
                 "markdown",
                 "(body, unsafe_allow_html=False)",
             ),
             (
-                st.empty().checkbox,
+                lambda: st.empty().checkbox,
                 "streamlit.delta_generator",
                 "checkbox",
                 "(label, value=False, key=None)",
             ),
             (
-                st.empty().dataframe,
+                lambda: st.empty().dataframe,
                 "streamlit.delta_generator",
                 "dataframe",
                 "(data=None, width=None, height=None)",
             ),
             (
-                st.empty().add_rows,
+                lambda: st.empty().add_rows,
                 "streamlit.delta_generator",
                 "add_rows",
                 "(data=None, **kwargs)",
             ),
-            (st.write, "streamlit.delta_generator", "write", "(*args, **kwargs)"),
+            (
+                lambda: st.write,
+                "streamlit.delta_generator",
+                "write",
+                "(*args, **kwargs)",
+            ),
         ]
     )
-    def test_function_signatures(self, func, module, name, sig):
+    def test_function_signatures(self, lambda_func, module, name, sig):
+        func = lambda_func()
         self.assertEqual(module, func.__module__)
         self.assertEqual(name, func.__name__)
         actual_sig = signature(func)
@@ -243,7 +249,10 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
     def test_enqueue_null(self):
         # Test "Null" Delta generators
         dg = DeltaGenerator(container=None)
-        enqueue_fn = lambda x: None
+
+        def enqueue_fn(x):
+            return None
+
         new_dg = dg._enqueue("empty", EmptyProto())
         self.assertEqual(dg, new_dg)
 

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -169,7 +169,7 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
                 "add_rows",
                 "(data=None, **kwargs)",
             ),
-            (st.write, "streamlit.delta_generator", "write", "(*args, **kwargs)",),
+            (st.write, "streamlit.delta_generator", "write", "(*args, **kwargs)"),
         ]
     )
     def test_function_signatures(self, func, module, name, sig):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -143,42 +143,36 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            (lambda: st.empty().empty, "streamlit.delta_generator", "empty", "()"),
-            (lambda: st.empty().text, "streamlit.delta_generator", "text", "(body)"),
+            (st.empty().empty, "streamlit.delta_generator", "empty", "()"),
+            (st.empty().text, "streamlit.delta_generator", "text", "(body)"),
             (
-                lambda: st.empty().markdown,
+                st.empty().markdown,
                 "streamlit.delta_generator",
                 "markdown",
                 "(body, unsafe_allow_html=False)",
             ),
             (
-                lambda: st.empty().checkbox,
+                st.empty().checkbox,
                 "streamlit.delta_generator",
                 "checkbox",
                 "(label, value=False, key=None)",
             ),
             (
-                lambda: st.empty().dataframe,
+                st.empty().dataframe,
                 "streamlit.delta_generator",
                 "dataframe",
                 "(data=None, width=None, height=None)",
             ),
             (
-                lambda: st.empty().add_rows,
+                st.empty().add_rows,
                 "streamlit.delta_generator",
                 "add_rows",
                 "(data=None, **kwargs)",
             ),
-            (
-                lambda: st.write,
-                "streamlit.delta_generator",
-                "write",
-                "(*args, **kwargs)",
-            ),
+            (st.write, "streamlit.delta_generator", "write", "(*args, **kwargs)",),
         ]
     )
-    def test_function_signatures(self, lambda_func, module, name, sig):
-        func = lambda_func()
+    def test_function_signatures(self, func, module, name, sig):
         self.assertEqual(module, func.__module__)
         self.assertEqual(name, func.__name__)
         actual_sig = signature(func)
@@ -249,10 +243,6 @@ class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):
     def test_enqueue_null(self):
         # Test "Null" Delta generators
         dg = DeltaGenerator(container=None)
-
-        def enqueue_fn(x):
-            return None
-
         new_dg = dg._enqueue("empty", EmptyProto())
         self.assertEqual(dg, new_dg)
 


### PR DESCRIPTION
By doing so, with blocks are now persisted per thread. This avoids conflicts when with blocks are used across multiple sessions.
