### PR TITLE
Fix formatting of st.file_uploader docstring

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -56,15 +56,15 @@ class FileUploaderMixin:
         ...     # To read file as bytes:
         ...     bytes_data = uploaded_file.read()
         ...     st.write(bytes_data)
-
+        >>>
         ...     # To convert to a string based IO:
         ...     stringio = StringIO(uploaded_file.decode("utf-8"))
         ...     st.write(stringio)
-
+        >>>
         ...     # To read file as string:
         ...     string_data = stringio.read()
         ...     st.write(string_data)
-
+        >>>
         ...     # Can be used wherever a "file-like" object is accepted:
         ...     dataframe = pd.read_csv(uploaded_file)
         ...     st.write(dataframe)


### PR DESCRIPTION
Before:
![](https://i.imgur.com/O2nxkls.png)

After:
![](https://i.imgur.com/5USjCF8.png)

(incidentally, I hate everything about python's docstring code formatting)
