### PR TITLE
Don't wait for unit tests before starting Cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,6 @@ workflows:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/
       - cypress: # Non flaky Cypress tests
-          requires:
-            - python-3-8
           filters:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/


### PR DESCRIPTION
python-3-8 typically takes 6 minutes to run; we might as well start running Cypress in parallel (which takes ~28min).

This way the maximum PR submission time goes down from 34 to 28 minutes.