### PR TITLE
[WIP] Run Cypress tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,6 @@ workflows:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/
       - cypress: # Non flaky Cypress tests
-          requires:
-            - python-3-8
           filters:
             tags:
               only: /^([0-9]+\.){3}dev[0-9]+/
@@ -484,6 +482,8 @@ jobs:
       - image: circleci/python:3.7.4-stretch
 
     resource_class: xlarge
+
+    parallelism: 4
 
     working_directory: ~/repo
 

--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,5 +1,4 @@
 {
-  "projectId": "r53s63",
   "reporter": "mocha-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"
@@ -9,5 +8,6 @@
   "trashAssetsBeforeRuns": false,
   "viewportWidth": 1366,
   "viewportHeight": 768,
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "projectId": "m44heo"
 }

--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "r53s63",
   "reporter": "mocha-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "cy:open": "unset NODE_OPTIONS && cypress open --env devicePixelRatio=1",
     "cy:run": "unset NODE_OPTIONS && cypress run",
     "cy:run-flaky": "yarn cy:run --config integrationFolder=../e2e_flaky/specs",
-    "cy:run-all": "../scripts/run_e2e_tests.py -a",
+    "cy:run-all": "../scripts/run_e2e_tests.py -a -r -p",
     "cy:run-all-flaky": "yarn cy:run-all -f",
     "_cy:serve-and-run": "NODE_OPTIONS=--max_old_space_size=8192 start-server-and-test start http://localhost:3000",
     "cy:serve-and-run-all": "yarn _cy:serve-and-run -- cy:run-all",

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -56,15 +56,15 @@ class FileUploaderMixin:
         ...     # To read file as bytes:
         ...     bytes_data = uploaded_file.read()
         ...     st.write(bytes_data)
-
+        >>>
         ...     # To convert to a string based IO:
         ...     stringio = StringIO(uploaded_file.decode("utf-8"))
         ...     st.write(stringio)
-
+        >>>
         ...     # To read file as string:
         ...     string_data = stringio.read()
         ...     st.write(string_data)
-
+        >>>
         ...     # Can be used wherever a "file-like" object is accepted:
         ...     dataframe = pd.read_csv(uploaded_file)
         ...     st.write(dataframe)

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -119,7 +119,9 @@ class Context:
         flags = ["--config", f"integrationFolder={self.tests_dir}/specs"]
         if self.record_results:
             flags.append("--record")
+            flags.extend(["--key", "e75ccf30-bc2b-4b46-bc13-e751ce4357a2"])
         if self.parallel:
+            flags.extend(["--group", "4x-electron"])
             flags.append("--parallel")
         if self.update_snapshots:
             flags.extend(["--env", "updateSnapshots=true"])

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -99,6 +99,8 @@ class Context:
         # True if Cypress will record videos of our results.
         self.record_results = False
         # True if we're automatically updating snapshots.
+        self.parallel = False
+        # True if we're running tests across multiple machines.
         self.update_snapshots = False
         # Parent folder of the specs and scripts.
         # 'e2e' for tests we expect to pass or 'e2e_flaky' for tests with
@@ -117,6 +119,8 @@ class Context:
         flags = ["--config", f"integrationFolder={self.tests_dir}/specs"]
         if self.record_results:
             flags.append("--record")
+        if self.parallel:
+            flags.append("--parallel")
         if self.update_snapshots:
             flags.extend(["--env", "updateSnapshots=true"])
         return flags
@@ -338,6 +342,13 @@ def run_component_template_e2e_test(ctx: Context, template_dir: str) -> bool:
     "See https://docs.cypress.io/guides/dashboard/introduction.html for more details.",
 )
 @click.option(
+    "-p",
+    "--parallel",
+    is_flag=True,
+    help="Run tests in parallel across multiple machines. Requires --record-results"
+    "See https://docs.cypress.io/guides/guides/parallelization.html#Turning-on-parallelization.",
+)
+@click.option(
     "-u",
     "--update-snapshots",
     is_flag=True,
@@ -352,6 +363,7 @@ def run_component_template_e2e_test(ctx: Context, template_dir: str) -> bool:
 def run_e2e_tests(
     always_continue: bool,
     record_results: bool,
+    parallel: bool,
     update_snapshots: bool,
     flaky_tests: bool,
 ):
@@ -366,6 +378,7 @@ def run_e2e_tests(
     ctx = Context()
     ctx.always_continue = always_continue
     ctx.record_results = record_results
+    ctx.parallel = parallel
     ctx.update_snapshots = update_snapshots
     ctx.tests_dir_name = "e2e_flaky" if flaky_tests else "e2e"
 


### PR DESCRIPTION
Attempting to follow along https://www.cypress.io/blog/2018/09/05/run-end-to-end-tests-on-ci-faster/ , to get our Cypress tests running faster.

Right now, the long pole is a ~25 minute sequential run of tests after ~5 min of setup; with 4 instances the total Cypress runtime should ideally drop from 25+5=30min to 6+5=11min. 