### PR TITLE
Fix broken link in 0.68 changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,7 @@ _Release date: October 8, 2020_
 
 - ⌗ Introducing new layout options for Streamlit! Move aside, vertical layout.
   Make a little space for... horizontal layout! Check out our
-  [blog post](blog.streamlit.io/introducing-new-layout-options-for-streamlit).
+  [blog post](https://blog.streamlit.io/introducing-new-layout-options-for-streamlit).
 - 💾 File uploader redesigned with new functionality for multiple files uploads
   and better support for working with uploaded files. This may cause breaking
   changes. Please see the new api in our


### PR DESCRIPTION
If we're patching to 0.68.1 soon anyways, it'd be nice for this blog post link to work xP