### PR TITLE
Fix empty deploy page

### DIFF
--- a/docs/deploy_streamlit_app.md
+++ b/docs/deploy_streamlit_app.md
@@ -1,1 +1,3 @@
 # Deploy a Streamlit app
+
+Streamlit sharing is coming soon! Sign up for the beta at [https://www.streamlit.io/sharing-sign-up](https://www.streamlit.io/sharing-sign-up)

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -43,6 +43,7 @@ class FileUploaderMixin:
             - If allow_multiple_files is True, returns a list with the
               uploaded files as UploadedFile objects. If no files were
               uploaded, returns an empty list.
+
             The UploadedFile class is a subclass of BytesIO, and therefore
             it is "file-like". This means you can pass them anywhere where
             a file is expected.


### PR DESCRIPTION
Put temporary message on deploy page pointing to Streamlit share sign-up. Also fixes warning message for improper spacing for markdown.

Later this week, will have more full deploy page

Fixes #2135 