### PR TITLE
Pyplot should invoke function for coordinates

### DIFF
--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -89,7 +89,7 @@ class PyplotMixin:
             dg.exception(PyplotGlobalUseWarning())  # type: ignore
 
         image_list_proto = ImageListProto()
-        marshall(dg._get_coordinates, image_list_proto, fig, clear_figure, **kwargs)  # type: ignore
+        marshall(dg._get_coordinates(), image_list_proto, fig, clear_figure, **kwargs)  # type: ignore
         return dg._enqueue("imgs", image_list_proto)  # type: ignore
 
 


### PR DESCRIPTION
Originally, Pyplot Mixin just sends the function to retrieve the coordinates rather than the coordinates themselves. This caused a problem for the MediaFileManager deleting files since the media was replacing at the "same coordinate"