### PR TITLE
[File uploader] Add blurb about resetting buffer with seek

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -46,7 +46,8 @@ class FileUploaderMixin:
 
             The UploadedFile class is a subclass of BytesIO, and therefore
             it is "file-like". This means you can pass them anywhere where
-            a file is expected.
+            a file is expected. As a subclass of BytesIO, make sure to
+            reset the buffer after reading it with `UploadedFile.seek(0)`.
 
         Examples
         --------


### PR DESCRIPTION
**Description:** Couple questions came in from the forums [here](https://discuss.streamlit.io/t/create-multiple-dataframes-from-csv-files-loaded-via-the-multi-file-uploader/6258/5) and [here](https://discuss.streamlit.io/t/emptydataerror-no-columns-to-parse-from-file/6247/6) regarding an empty buffer on rerun. This is because we are now returning the same buffer. We do not reset the buffer on rerun but may [re-evaluate](https://www.notion.so/streamlit/Automatically-reset-buffer-when-file-is-read-Review-again-e9d22a74ea2f430592c3dfd20e52da36). In the meantime, clarifying in our docs



---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
