### PR TITLE
Add source distribution type to our release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ distribution:
 # Removes existing packages and creates distribution files in dist/.
 clean-package:
 	rm -rfv lib/dist
-	distribution
+	package
 
 .PHONY: package
 # Create Python distribution files in dist/.

--- a/Makefile
+++ b/Makefile
@@ -157,17 +157,22 @@ install:
 develop:
 	cd lib ; python setup.py develop
 
-.PHONY: wheel
-# Create a Python wheel file in dist/.
-wheel:
+.PHONY: distribution
+# Create Python distribution files in dist/.
+distribution:
 	# Get rid of the old build folder to make sure that we delete old js and css.
 	rm -rfv lib/build
-	cd lib ; python setup.py bdist_wheel --universal
-	# cd lib ; python setup.py bdist_wheel sdist
+	cd lib ; python setup.py bdist_wheel --universal sdist
+
+.PHONY: clean-package
+# Removes existing packages and creates distribution files in dist/.
+clean-package:
+	rm -rfv lib/dist
+	distribution
 
 .PHONY: package
-# Create a Python wheel file in dist/.
-package: mini-devel frontend install wheel
+# Create Python distribution files in dist/.
+package: mini-devel frontend install distribution
 
 
 .PHONY: clean
@@ -328,7 +333,7 @@ loc:
 # Distributes the package to PyPi
 distribute:
 	cd lib/dist; \
-		twine upload $$(ls -t *.whl | head -n 1)
+		twine upload $$(ls -t *.(whl|tar.gz) | head -n 1)
 
 .PHONY: notices
 # Rebuild the NOTICES file.

--- a/lib/MANIFEST.in
+++ b/lib/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
+include Pipfile
 include streamlit/config/config.yaml
 recursive-include streamlit/static *

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -4,9 +4,16 @@ import setuptools
 import subprocess
 import sys
 
-from pipenv.project import Project
-from pipenv.utils import convert_deps_to_pip
 from setuptools.command.install import install
+
+try:
+    from pipenv.project import Project
+    from pipenv.utils import convert_deps_to_pip
+except:
+    exit_msg = (
+        "pipenv is required to package Streamlit. Please install pipenv and try again"
+    )
+    sys.exit(exit_msg)
 
 VERSION = "0.69.2"  # PEP-440
 

--- a/lib/tests/streamlit/report_test.py
+++ b/lib/tests/streamlit/report_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for Report.py."""
+"""Unit tests for report.py."""
 
 from unittest.mock import patch
 import copy


### PR DESCRIPTION
**Issue:** Closes #2126

**Description:** 
Creates a source distribution build for releases. In order to use the source distribution, users must have `pipenv` installed. The below error message will be thrown if installing the `package.tar.gz` and `pipenv` is not available 
![image](https://user-images.githubusercontent.com/24946400/96789971-0b5b9080-13c4-11eb-9479-b6df93164cab.png)


Of note, this changes our `make wheel` to `make distribution`


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
