### PR TITLE
Upgrade nightly to use large (8gb)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,7 +431,7 @@ jobs:
     docker:
       - image: circleci/python:3.8.1
 
-    resource_class: medium+
+    resource_class: large
 
     working_directory: ~/repo
 


### PR DESCRIPTION
**Issue:** [Nightly failure](https://app.circleci.com/pipelines/github/streamlit/streamlit/5181/workflows/7e8cdc4e-ae25-452d-926b-fc56657bcc0d/jobs/13139)

**Description:** `yarn build` sets the memory usage to 8gb but our docker image is capped at 6gb. Upgrading to be in sync

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
