### PR TITLE
[Color Picker] Optimize rerun on close and move out of beta

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -145,7 +145,7 @@ With widgets, Streamlit allows you to bake interactivity directly into your apps
 .. autofunction:: streamlit.date_input
 .. autofunction:: streamlit.time_input
 .. autofunction:: streamlit.file_uploader
-.. autofunction:: streamlit.beta_color_picker
+.. autofunction:: streamlit.color_picker
 ```
 
 ## Control flow

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -191,7 +191,7 @@ _Release date: May 05, 2020_
 **Highlights:**
 
 - 🎨 New color-picker widget! Use it with
-  [`st.beta_color_picker()`](https://docs.streamlit.io/en/latest/api.html#streamlit.beta_color_picker)
+  [`st.beta_color_picker()`](https://docs.streamlit.io/en/0.69.0/api.html#streamlit.beta_color_picker)
 - 🧪 Introducing `st.beta_*` and `st.experimental_*` function prefixes, for faster
   Streamlit feature releases. See
   [docs](https://docs.streamlit.io/en/latest/api.html#pre-release-features) for more info.

--- a/e2e/scripts/st_color_picker.py
+++ b/e2e/scripts/st_color_picker.py
@@ -14,8 +14,8 @@
 
 import streamlit as st
 
-c1 = st.beta_color_picker("Default Color")
+c1 = st.color_picker("Default Color")
 st.write("Color 1", c1)
 
-c2 = st.beta_color_picker("New Color", "#EB144C")
+c2 = st.color_picker("New Color", "#EB144C")
 st.write("Color 2", c2)

--- a/e2e/specs/st_color_picker.spec.js
+++ b/e2e/specs/st_color_picker.spec.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-describe("st.beta_color_picker", () => {
+describe("st.color_picker", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
   });

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -61,12 +61,11 @@ class ColorPicker extends React.PureComponent<Props, State> {
   }
 
   private onChangeComplete = (color: ColorResult): void => {
-    this.setState(
-      {
-        value: color.hex,
-      },
-      () => this.setWidgetValue({ fromUi: true })
-    )
+    this.setState({ value: color.hex })
+  }
+
+  private onColorClose = (): void => {
+    this.setWidgetValue({ fromUi: true })
   }
 
   public render = (): React.ReactNode => {
@@ -81,6 +80,7 @@ class ColorPicker extends React.PureComponent<Props, State> {
       <div className="Widget stColorPicker" style={style}>
         <label>{element.label}</label>
         <UIPopover
+          onClose={this.onColorClose}
           content={() => (
             <ChromePicker
               color={value}

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -156,10 +156,7 @@ vega_lite_chart = _main.vega_lite_chart  # noqa: E221
 video = _main.video  # noqa: E221
 warning = _main.warning  # noqa: E221
 write = _main.write  # noqa: E221
-beta_color_picker = _main.beta_color_picker  # noqa: E221
-beta_container = _main.beta_container  # noqa: E221
-beta_expander = _main.beta_expander  # noqa: E221
-beta_columns = _main.beta_columns  # noqa: E221
+color_picker = _main.color_picker  # noqa: E221
 
 # Config
 
@@ -201,6 +198,10 @@ def _beta_warning(func, date):
 
 
 beta_set_page_config = _beta_warning(set_page_config, "2021-01-06")
+beta_color_picker = _beta_warning(_main.color_picker, "January 28, 2021")
+beta_container = _main.beta_container  # noqa: E221
+beta_expander = _main.beta_expander  # noqa: E221
+beta_columns = _main.beta_columns  # noqa: E221
 
 
 def set_option(key, value):

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -6,7 +6,7 @@ from .utils import _get_widget_ui_value
 
 
 class ColorPickerMixin:
-    def beta_color_picker(dg, label, value=None, key=None):
+    def color_picker(dg, label, value=None, key=None):
         """Display a color picker widget.
 
         Note: This is a beta feature. See
@@ -33,7 +33,7 @@ class ColorPickerMixin:
 
         Example
         -------
-        >>> color = st.beta_color_picker('Pick A Color', '#00f900')
+        >>> color = st.color_picker('Pick A Color', '#00f900')
         >>> st.write('The current color is', color)
 
         """

--- a/lib/tests/streamlit/color_picker_test.py
+++ b/lib/tests/streamlit/color_picker_test.py
@@ -23,7 +23,7 @@ from parameterized import parameterized
 class ColorPickerTest(testutil.DeltaGeneratorTestCase):
     def test_just_label(self):
         """Test that it can be called with no value."""
-        st.beta_color_picker("the label")
+        st.color_picker("the label")
 
         c = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(c.label, "the label")
@@ -32,7 +32,7 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
     @parameterized.expand([("#333333", "#333333"), ("#333", "#333"), (None, "#000000")])
     def test_value_types(self, arg_value, proto_value):
         """Test that it supports different types of values."""
-        st.beta_color_picker("the label", arg_value)
+        st.color_picker("the label", arg_value)
 
         c = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(c.label, "the label")
@@ -41,9 +41,9 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
     def test_invalid_value_type_error(self):
         """Tests that when the value type is invalid, an exception is generated"""
         with pytest.raises(StreamlitAPIException) as exc_message:
-            st.beta_color_picker("the label", 1234567)
+            st.color_picker("the label", 1234567)
 
     def test_invalid_string(self):
         """Tests that when the string doesn't match regex, an exception is generated"""
         with pytest.raises(StreamlitAPIException) as exc_message:
-            st.beta_color_picker("the label", "#invalid-string")
+            st.color_picker("the label", "#invalid-string")


### PR DESCRIPTION
**Issue:** 
Fixes #1811 
Fixes #2273 

**Description:** 
- Update widget value on popover close instead of on color selection
- Move `color_picker` out of beta. `beta_color_picker` supported until 1/28/2021.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
