### PR TITLE
Add json5 to handle NaN + infinity and more

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "dompurify": "^2.1.1",
     "hoist-non-react-statics": "^3.3.2",
     "immutable": "^4.0.0-rc.12",
+    "json5": "^2.1.3",
     "katex": "^0.11.1",
     "lodash": "^4.17.19",
     "mapbox-gl": "^1.11.1",

--- a/frontend/src/components/elements/Json/Json.test.tsx
+++ b/frontend/src/components/elements/Json/Json.test.tsx
@@ -46,4 +46,16 @@ describe("JSON element", () => {
       shallow(<Json {...props} />)
     }).toThrow(SyntaxError)
   })
+
+  it("renders json with NaN and infinity values", () => {
+    const props = getProps({
+      body: `{
+      "numbers":[ -1e27, NaN, Infinity, -Infinity, 2.2822022,-2.2702775],
+    }`,
+    })
+    const wrapper = shallow(<Json {...props} />)
+    expect(wrapper).toBeDefined()
+    const elem = wrapper.get(0)
+    expect(elem.props.className.includes("stJson")).toBeTruthy()
+  })
 })

--- a/frontend/src/components/elements/Json/Json.tsx
+++ b/frontend/src/components/elements/Json/Json.tsx
@@ -16,8 +16,8 @@
  */
 
 import React, { ReactElement } from "react"
-
 import ReactJson from "react-json-view"
+import JSON5 from "json5"
 import { Json as JsonProto } from "autogen/proto"
 
 import "assets/css/write.scss"
@@ -37,11 +37,15 @@ export default function Json({ width, element }: JsonProps): ReactElement {
   try {
     bodyObject = JSON.parse(element.body)
   } catch (e) {
-    // If content fails to parse as Json, rebuild the error message
-    // to show where the problem occurred.
-    const pos = parseInt(e.message.replace(/[^0-9]/g, ""), 10)
-    e.message += `\n${element.body.substr(0, pos + 1)} ← here`
-    throw e
+    try {
+      bodyObject = JSON5.parse(element.body)
+    } catch (json5Error) {
+      // If content fails to parse as Json, rebuild the error message
+      // to show where the problem occurred.
+      const pos = parseInt(e.message.replace(/[^0-9]/g, ""), 10)
+      e.message += `\n${element.body.substr(0, pos + 1)} ← here`
+      throw e
+    }
   }
   return (
     <div className="json-text-container stJson" style={styleProp}>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10798,7 +10798,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.1.2:
+json5@^2.1.0, json5@^2.1.2, json5@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==


### PR DESCRIPTION
**Issue:** #2038 

**Description:** JSON specs do not support NaN but it is supported in JS. Adding [JSON5 library](https://json5.org/) that provides additional JSON parsing support (including NaN).

JSON5.parse is slightly slower than JSON.parse so using as a fallback.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
