### PR TITLE
Upgrade pr-preview to use large (8gb)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,7 @@ jobs:
     docker:
       - image: circleci/python:3.8.1
 
-    resource_class: medium+
+    resource_class: large
 
     working_directory: ~/repo
 


### PR DESCRIPTION
**Issue:** Out of memory CircleCI job

**Description:** pr-preview does yarn build which we have slated for 8gb. Update resources to match

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
