### PR TITLE
Update default state for full screen wrapper

### DIFF
--- a/frontend/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
+++ b/frontend/src/components/shared/FullScreenWrapper/FullScreenWrapper.tsx
@@ -51,10 +51,15 @@ interface State {
 class FullScreenWrapper extends PureComponent<Props, State> {
   static isFullScreen = false
 
-  public state: State = { expanded: false, fullWidth: 0, fullHeight: 0 }
+  public constructor(props: Props) {
+    super(props)
+    this.state = {
+      expanded: false,
+      ...this.getWindowDimensions(),
+    }
+  }
 
   componentDidMount(): void {
-    this.updateWindowDimensions()
     window.addEventListener("resize", this.updateWindowDimensions)
     document.addEventListener("keydown", this.controlKeys, false)
   }
@@ -93,17 +98,22 @@ class FullScreenWrapper extends PureComponent<Props, State> {
     )
   }
 
-  updateWindowDimensions = (): void => {
+  getWindowDimensions = (): Pick<State, "fullWidth" | "fullHeight"> => {
     const padding = this.convertScssRemValueToPixels(
       SCSS_VARS["$fullscreen-padding"]
     )
     const paddingTop = this.convertScssRemValueToPixels(
       SCSS_VARS["$fullscreen-padding-top"]
     )
-    this.setState({
+
+    return {
       fullWidth: window.innerWidth - padding * 2, // Left and right
       fullHeight: window.innerHeight - (padding + paddingTop), // Bottom and Top
-    })
+    }
+  }
+
+  updateWindowDimensions = (): void => {
+    this.setState(this.getWindowDimensions())
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
**Issue:** Fixes #2220
The issues described were caused by the recreation of the component in the FullScreenWrapperHOC since we render a new component each time. Did not dig into the implementation of Plotly for additional details to see if this could be resolved there.

**Description:** 
We initialize the default fullHeight and fullWidth to 0 and then update these defaults to items based on the window screen. We should never have a default of 0 height and width and the window screen is available to us during initialization. Updated to set actual defaults.

**Components impacted:**
- VegaLiteChart
- Table
- PlotlyChart
- ImageList
- GraphVixChart
- DeckGIJsonChart
- DataFrame
- BokehChart

[Preview](https://share.streamlit.io/streamlit/core-previews/pr-2299)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
