### PR TITLE
[WIP] Show a clean error message on 'with st.not_container'

### DIFF
--- a/e2e/scripts/st_container.py
+++ b/e2e/scripts/st_container.py
@@ -28,3 +28,6 @@ if st.button("Step 2: Press me"):
 c = st.beta_container()
 if c.checkbox("Step 1: Check me"):
     c.title("Checked!")
+
+with st.text("Only containers can use `with` syntax"):
+    st.text("So this should show an error")

--- a/e2e/specs/st_container.spec.js
+++ b/e2e/specs/st_container.spec.js
@@ -43,4 +43,11 @@ describe("st.container", () => {
     cy.get("h2").contains("Pressed!");
     cy.get(".stCheckbox input").should("have.attr", "aria-checked", "true");
   });
+
+  it("restricts `with` syntax to containers", () => {
+    cy.get(".element-container .stException").should(
+      "contain",
+      "This command cannot have child elements."
+    );
+  });
 });

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -184,7 +184,7 @@ class DeltaGenerator(
 
     def __enter__(self):
         # with block started
-        if self._cursor.is_locked:
+        if self._cursor and self._cursor.is_locked:
             raise StreamlitAPIException(
                 "This command cannot have child elements. "
                 + "So it cannot be used as the root of a `with` block."

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -184,6 +184,12 @@ class DeltaGenerator(
 
     def __enter__(self):
         # with block started
+        if self._cursor.is_locked:
+            raise StreamlitAPIException(
+                "This command cannot have child elements. "
+                + "So it cannot be used as the root of a `with` block."
+            )
+
         ctx = get_report_ctx()
         if ctx:
             ctx.dg_stack.append(self)


### PR DESCRIPTION
## For pr preview, try:
```
with st.text("Only containers can use `with` syntax"):
    st.text("So this should show an error")
```

## Results in
<img width="746" alt="Screen Shot 2020-10-30 at 9 51 29 AM" src="https://user-images.githubusercontent.com/856034/97750762-82b0b480-1a95-11eb-9941-e02c9eb359bc.png">