### PR TITLE
docs: Add 21YunBox for deployment

### DIFF
--- a/docs/streamlit_faq.md
+++ b/docs/streamlit_faq.md
@@ -38,6 +38,8 @@ Here are some frequently asked questions about Streamlit and Streamlit Component
    - [How to Deploy Streamlit to a Free Amazon EC2 instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal
    - [Host Streamlit on Heroku](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst
    - [Host Streamlit on Azure](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson
+   - [Host Streamlit on 21YunBox](https://www.21yunbox.com/apps/streamlit/), by Toby Lei.
+     - [21YunBox](https://www.21yunbox.com/) provides blazing fast Chinese CDN, continuous deployment, one-click HTTPS and [other services like managed databases and backend web services](https://www.21yunbox.com/docs/v2/), providing an avenue to launch web projects in China.
 
 4. **Does Streamlit support the WSGI Protocol? (aka Can I deploy Streamlit with gunicorn?)**
 


### PR DESCRIPTION
Add 21YunBox for deployment in China

21YunBox supports on-click deployment for many open source projects already. Including VuePress, Gatsby, Django, Express.js and many others.
