### PR TITLE
Pin opencv-python to 4.4.0.44

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -8,7 +8,7 @@ graphviz
 keras
 matplotlib
 mysqlclient
-# 2020.11.2: The opencv-python 4.4.0.46 (the latest) doesn't have pre-built wheels
+# 2020.11.2: opencv-python 4.4.0.46 (the latest) doesn't have pre-built wheels
 # for our Docker Linux version. A full compile takes ages - long enough that
 # CircleCI times out - so we're pinning to a lower version. Please remove this
 # version pin in the future!

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -8,7 +8,11 @@ graphviz
 keras
 matplotlib
 mysqlclient
-opencv-python
+# 2020.11.2: The opencv-python 4.4.0.46 (the latest) doesn't have pre-built wheels
+# for our Docker Linux version. A full compile takes ages - long enough that
+# CircleCI times out - so we're pinning to a lower version. Please remove this
+# version pin in the future!
+opencv-python==4.4.0.44
 plotly
 prometheus-client
 psycopg2-binary


### PR DESCRIPTION
opencv-python 4.4.0.46 (the latest) doesn't have pre-built wheels for our Docker Linux version. A full compile takes ages - long enough that CircleCI times out - so temporarily pin to a lower version.