### PR TITLE
Docs comment about Python 3.9 support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@
 [Streamlit](https://streamlit.io/) is an open-source Python library that makes it easy to create and share beautiful, custom web apps for machine learning and data science.
 In just a few minutes you can build and deploy powerful data apps - so let's get started!
 
-1. Make sure that you have [Python 3.6](https://www.python.org/downloads/) or greater installed.
+1. Make sure that you have [Python 3.6 - Python 3.8](https://www.python.org/downloads/) installed.
 2. Install Streamlit using [PIP](https://pip.pypa.io/en/stable/installing/) and run the 'hello world' app:
 
    ```shell

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@
 Before you get started, you're going to need a few things:
 
 - Your favorite IDE or text editor
-- [Python 3.6 or later](https://www.python.org/downloads/)
+- [Python 3.6 - 3.8](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installing/)
 
 If you haven't already, take a few minutes to read through [Main

--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -2,6 +2,17 @@
 
 If you're having problems running your Streamlit app, here are a few things to try out.
 
+## Check #0: Are you using a Streamlit-supported version of Python?
+
+Streamlit will maintain backwards-compatibility with earlier Python versions as practical,
+guaranteeing compatibility with _at least_ the last three minor versions of Python 3.
+
+As new versions of Python are released, we will try to be compatible with the new version as soon
+as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
+
+Streamlit currently supports versions 3.6, 3.7 and 3.8 of Python. Python 3.9 support is currently on-hold as we
+wait for [pyarrow to support Python 3.9](https://arrow.apache.org/docs/python/install.html#python-compatibility).
+
 ## Check #1: Is Streamlit running?
 
 On a Mac or Linux machine, type this on the terminal:


### PR DESCRIPTION
Related: #2001 #2233 

Change docs from saying "3.6 or greater" to specifying 3.6 - 3.8 directly. Additionally, add a note about Streamlit planning on supporting at least previous three minor versions of Python.