### PR TITLE
Gap is not supported across browsers, use padding instead

### DIFF
--- a/frontend/src/components/core/Block/Block.scss
+++ b/frontend/src/components/core/Block/Block.scss
@@ -1,5 +1,8 @@
 .stBlock-horiz {
   display: flex;
-  gap: 8px;
   flex-wrap: wrap;
+
+  .stBlock:not(:first-child) {
+    padding-left: 8px;
+  }
 }


### PR DESCRIPTION
**Issue:** Fixes #2330 

**Description:** `gap` is not well supported across browsers. Let's just use padding

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
