### PR TITLE
Link to the Streamlit Cheat Sheet from our docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@
   api
   streamlit_configuration
   develop_streamlit_components
+  API Cheat Sheet <https://share.streamlit.io/daniellewisdl/streamlit-cheat-sheet/app.py>
 
 .. toctree::
   :caption: Support

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@
   api
   streamlit_configuration
   develop_streamlit_components
-  API Cheat Sheet <https://share.streamlit.io/daniellewisdl/streamlit-cheat-sheet/app.py>
+  API cheat sheet <https://share.streamlit.io/daniellewisdl/streamlit-cheat-sheet/app.py>
 
 .. toctree::
   :caption: Support


### PR DESCRIPTION
I was recently reminded of the outsized impact of cheat sheets, so wanted to increase the visibility of this one https://share.streamlit.io/daniellewisdl/streamlit-cheat-sheet/app.py

I know we don't control this resource, but this is basically perfect afaict; it's a Streamlit app hosted on S4A that showcases exactly how to use Streamlit's various APIs, in a succinct manner. I'm also open to reaching out to see if we can clone their work exactly and then release the same thing, but that seems more roundabout than just linking to their app directly.