### PR TITLE
Reset session info when connection state is not connected

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -272,6 +272,10 @@ export class App extends PureComponent<Props, State> {
       this.setState({ dialog: null })
     } else {
       setCookie("_xsrf", "")
+
+      if (SessionInfo.isSet()) {
+        SessionInfo.clearSession()
+      }
     }
   }
 
@@ -470,7 +474,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Handler for ForwardMsg.newReport messages
+   * Handler for ForwardMsg.newReport messages. This runs on each rerun
    * @param newReportProto a NewReport protobuf
    */
   handleNewReport = (newReportProto: NewReport): void => {
@@ -525,7 +529,6 @@ export class App extends PureComponent<Props, State> {
    */
   handleOneTimeInitialization = (initialize: Initialize): void => {
     SessionInfo.current = SessionInfo.fromInitializeMessage(initialize)
-
     const config = initialize.config as Config
 
     MetricsManager.current.initialize({

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -22,6 +22,25 @@ test("Throws an error when used before initialization", () => {
   expect(() => SessionInfo.current).toThrow()
 })
 
+test("Clears session info", () => {
+  SessionInfo.current = new SessionInfo({
+    sessionId: "sessionId",
+    streamlitVersion: "sv",
+    pythonVersion: "pv",
+    installationId: "iid",
+    installationIdV1: "iid1",
+    installationIdV2: "iid2",
+    authorEmail: "ae",
+    maxCachedMessageAge: 2,
+    commandLine: "command line",
+    userMapboxToken: "mpt",
+  })
+  expect(SessionInfo.isSet()).toBe(true)
+
+  SessionInfo.clearSession()
+  expect(SessionInfo.isSet()).toBe(false)
+})
+
 test("Can be initialized from a protobuf", () => {
   const MESSAGE = new Initialize({
     userInfo: {

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -85,6 +85,10 @@ export class SessionInfo {
     return this.current.commandLine === "streamlit hello"
   }
 
+  public static clearSession(): void {
+    SessionInfo.singleton = undefined
+  }
+
   /** Create a SessionInfo from the relevant bits of an initialize message. */
   public static fromInitializeMessage(initialize: Initialize): SessionInfo {
     const environmentInfo = initialize.environmentInfo as EnvironmentInfo


### PR DESCRIPTION
**Issue:** Fixes #2363 

**Description:** 
Previously, we had an initialize message that was run on each new session. This was removed in #2317 and now all the initialization is done only once per page load. 

This is a change from our previous metrics and causes issues for file uploader. Reverting back to the previous behavior so that each new session is re-initializated. Instead of tracking state on the server side like before, we now clear out SessionInfo (stored on the client side) when the client is no longer connected with the server.

This does not address any changes to metrics to improve our initialization/optimization of metrics. It is only a revert back to previous behavior. Any metric changes can be handled by a separate issue. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
