### PR TITLE
Consolidate reruns for multiple file uploads

### DIFF
--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -62,4 +62,17 @@ export class FileUploadClient extends HttpClient {
       { method: "DELETE" }
     )
   }
+
+  public async updateFileCount(
+    widgetId: string,
+    fileCount: number
+  ): Promise<void> {
+    await this.request(
+      `upload_file/${SessionInfo.current.sessionId}/${widgetId}`,
+      {
+        method: "PUT",
+        data: { totalFiles: fileCount },
+      }
+    )
+  }
 }

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -336,17 +336,10 @@ class Server(object):
                 dict(cache=self._message_cache),
             ),
             (
-                # Tornado doesn't allow body in DELETE requests.
-                # Passing lookup values in URL
                 make_url_path_regex(
                     base,
-                    "/upload_file/(?P<session_id>.*)/(?P<widget_id>.*)/(?P<file_id>[0-9]*)?",
+                    "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
                 ),
-                UploadFileRequestHandler,
-                dict(file_mgr=self._uploaded_file_mgr),
-            ),
-            (
-                make_url_path_regex(base, "upload_file"),
                 UploadFileRequestHandler,
                 dict(file_mgr=self._uploaded_file_mgr),
             ),

--- a/lib/streamlit/server/upload_file_request_handler.py
+++ b/lib/streamlit/server/upload_file_request_handler.py
@@ -44,14 +44,14 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self._file_mgr = file_mgr
 
     def set_default_headers(self):
-        self.set_header("Access-Control-Allow-Methods", "POST, DELETE")
+        self.set_header("Access-Control-Allow-Methods", "POST, PUT, DELETE")
         self.set_header("Access-Control-Allow-Headers", "Content-Type")
         if config.get_option("server.enableXsrfProtection"):
-            self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken, Content-Type")
             self.set_header(
                 "Access-Control-Allow-Origin",
                 Report.get_url(config.get_option("browser.serverAddress")),
             )
+            self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken, Content-Type")
             self.set_header("Vary", "Origin")
             self.set_header("Access-Control-Allow-Credentials", "true")
         elif routes.allow_cross_origin_requests():
@@ -96,7 +96,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         # Convert bytes to string
         return arg[0].decode("utf-8")
 
-    def post(self):
+    def post(self, **kwargs):
         args = {}  # type: Dict[str, List[bytes]]
         files = {}  # type: Dict[str, List[Any]]
 
@@ -114,7 +114,9 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             self.send_error(400, reason=str(e))
             return
 
-        LOGGER.debug(f"{len(files)} file(s) received for session {session_id} widget {widget_id}")
+        LOGGER.debug(
+            f"{len(files)} file(s) received for session {session_id} widget {widget_id}"
+        )
 
         # Create an UploadedFile object for each file.
         uploaded_files = []
@@ -132,11 +134,12 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         if len(uploaded_files) == 0:
             self.send_error(400, reason="Expected at least 1 file, but got 0")
             return
-
         replace = self.get_argument("replace", "false")
 
         update_files = (
-            self._file_mgr.replace_files if replace == "true" else self._file_mgr.add_files
+            self._file_mgr.replace_files
+            if replace == "true"
+            else self._file_mgr.add_files
         )
         update_files(
             session_id=session_id,
@@ -144,9 +147,25 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             files=uploaded_files,
         )
 
-        LOGGER.debug(f"{len(files)} file(s) uploaded for session {session_id} widget {widget_id}. replace {replace}")
+        LOGGER.debug(
+            f"{len(files)} file(s) uploaded for session {session_id} widget {widget_id}. replace {replace}"
+        )
 
         self.set_status(200)
+
+    def put(self, session_id, widget_id, **kwargs):
+        if self.request.body:
+            data = tornado.escape.json_decode(self.request.body)
+            if "totalFiles" in data.keys():
+                self._file_mgr.update_file_count(
+                    session_id=session_id,
+                    widget_id=widget_id,
+                    file_count=data["totalFiles"],
+                )
+                self.set_status(200)
+                return
+
+        self.send_error(400, reason="Nothing to update")
 
     def delete(self, session_id, widget_id, file_id):
         if session_id is None or widget_id is None or file_id is None:

--- a/lib/streamlit/server/upload_file_request_handler.py
+++ b/lib/streamlit/server/upload_file_request_handler.py
@@ -153,7 +153,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
 
         self.set_status(200)
 
-    def put(self, session_id, widget_id, **kwargs):
+    def put(self, session_id: str, widget_id: str, **kwargs):
         if self.request.body:
             data = tornado.escape.json_decode(self.request.body)
             if "totalFiles" in data.keys():

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -105,7 +105,7 @@ class UploadedFileManager(object):
         self._add_files(session_id, widget_id, files)
         self._on_files_updated(session_id, widget_id)
 
-    def get_files(self, session_id, widget_id):
+    def get_files(self, session_id: str, widget_id: str):
         """Return the file list with the given ID, or None if the ID doesn't exist.
 
         Parameters
@@ -124,15 +124,8 @@ class UploadedFileManager(object):
             file_list = self._files_by_id.get(files_by_widget, None)
         return file_list
 
-    def remove_file(self, session_id, widget_id, file_id):
-        """Remove the file list with the given ID, if it exists.
-        Parameters
-        ----------
-        session_id : str
-            The session ID of the report that owns the file.
-        widget_id : str
-            The widget ID of the FileUploader that created the file.
-        """
+    def remove_file(self, session_id: str, widget_id: str, file_id: str):
+        """Remove the file list with the given ID, if it exists."""
         files_by_widget = session_id, widget_id
         with self._files_lock:
             file_list = self._files_by_id[files_by_widget]
@@ -142,7 +135,7 @@ class UploadedFileManager(object):
             if len(file_list) != len(self._files_by_id[files_by_widget]):
                 self._on_files_updated(session_id, widget_id)
 
-    def _remove_files(self, session_id, widget_id):
+    def _remove_files(self, session_id: str, widget_id: str):
         """Remove the file list for the provided widget in the
         provided session, if it exists.
 
@@ -153,7 +146,7 @@ class UploadedFileManager(object):
         with self._files_lock:
             self._files_by_id.pop(files_by_widget, None)
 
-    def remove_files(self, session_id, widget_id):
+    def remove_files(self, session_id: str, widget_id: str):
         """Remove the file list for the provided widget in the
         provided session, if it exists.
 
@@ -167,7 +160,7 @@ class UploadedFileManager(object):
         self._remove_files(session_id, widget_id)
         self._on_files_updated(session_id, widget_id)
 
-    def remove_session_files(self, session_id):
+    def remove_session_files(self, session_id: str):
         """Remove all files that belong to the given report.
 
         Parameters
@@ -184,7 +177,12 @@ class UploadedFileManager(object):
             if files_id[0] == session_id:
                 self.remove_files(*files_id)
 
-    def replace_files(self, session_id, widget_id, files):
+    def replace_files(
+        self,
+        session_id: str,
+        widget_id: str,
+        files: List[UploadedFile],
+    ):
         """Removes the file list for the provided widget in the
         provided session, if it exists and add the provided files
         to the widget in the session
@@ -202,7 +200,12 @@ class UploadedFileManager(object):
         self._add_files(session_id, widget_id, files)
         self._on_files_updated(session_id, widget_id)
 
-    def update_file_count(self, session_id, widget_id, file_count):
+    def update_file_count(
+        self,
+        session_id: str,
+        widget_id: str,
+        file_count: int,
+    ):
         files_by_widget = session_id, widget_id
         self._file_counts_by_id[files_by_widget] = file_count
         self._on_files_updated(session_id, widget_id)

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -37,6 +37,7 @@ class UploadedFileManager(object):
 
     def __init__(self):
         self._files_by_id = {}  # type: Dict[Tuple[str, str], List[UploadedFile] ]
+        self._file_counts_by_id: Dict[Tuple[str, str], int] = {}
         # Prevents concurrent access to the _files_by_id dict.
         # In remove_session_files(), we iterate over the dict's keys. It's
         # an error to mutate a dict while iterating; this lock prevents that.
@@ -51,10 +52,26 @@ class UploadedFileManager(object):
             """
         )
 
-    def _on_files_updated(self, session_id):
-        self.on_files_updated.send(session_id)
+    def _on_files_updated(self, session_id: str, widget_id: str):
+        files_by_widget = session_id, widget_id
+        if files_by_widget in self._file_counts_by_id:
+            expected_file_count: int = self._file_counts_by_id[files_by_widget]
+            actual_file_count: int = (
+                len(self._files_by_id[files_by_widget])
+                if files_by_widget in self._files_by_id
+                else 0
+            )
+            if expected_file_count == actual_file_count:
+                self.on_files_updated.send(session_id)
+        else:
+            self.on_files_updated.send(session_id)
 
-    def _add_files(self, session_id, widget_id, files):
+    def _add_files(
+        self,
+        session_id: str,
+        widget_id: str,
+        files: List[UploadedFile],
+    ):
         """
         Add a list of files to the FileManager. Does not emit any signals
         """
@@ -65,7 +82,12 @@ class UploadedFileManager(object):
                 files = file_list + files
             self._files_by_id[files_by_widget] = files
 
-    def add_files(self, session_id, widget_id, files):
+    def add_files(
+        self,
+        session_id: str,
+        widget_id: str,
+        files: List[UploadedFile],
+    ):
         """Add a list of files to the FileManager.
 
         The "on_file_added" Signal will be emitted after the list is added.
@@ -79,8 +101,9 @@ class UploadedFileManager(object):
         files : List[UploadedFile]
             The files to add.
         """
+
         self._add_files(session_id, widget_id, files)
-        self._on_files_updated(session_id)
+        self._on_files_updated(session_id, widget_id)
 
     def get_files(self, session_id, widget_id):
         """Return the file list with the given ID, or None if the ID doesn't exist.
@@ -96,9 +119,9 @@ class UploadedFileManager(object):
         -------
         list of UploadedFile or None
         """
-        files_id = session_id, widget_id
+        files_by_widget = session_id, widget_id
         with self._files_lock:
-            file_list = self._files_by_id.get(files_id, None)
+            file_list = self._files_by_id.get(files_by_widget, None)
         return file_list
 
     def remove_file(self, session_id, widget_id, file_id):
@@ -116,7 +139,8 @@ class UploadedFileManager(object):
             self._files_by_id[files_by_widget] = [
                 file for file in file_list if file.id != file_id
             ]
-        self._on_files_updated(session_id)
+            if len(file_list) != len(self._files_by_id[files_by_widget]):
+                self._on_files_updated(session_id, widget_id)
 
     def _remove_files(self, session_id, widget_id):
         """Remove the file list for the provided widget in the
@@ -124,9 +148,10 @@ class UploadedFileManager(object):
 
         Does not emit any signals.
         """
-        files_id = session_id, widget_id
+        files_by_widget = session_id, widget_id
+        self.update_file_count(session_id, widget_id, 0)
         with self._files_lock:
-            self._files_by_id.pop(files_id, None)
+            self._files_by_id.pop(files_by_widget, None)
 
     def remove_files(self, session_id, widget_id):
         """Remove the file list for the provided widget in the
@@ -140,7 +165,7 @@ class UploadedFileManager(object):
             The widget ID of the FileUploader that created the file.
         """
         self._remove_files(session_id, widget_id)
-        self._on_files_updated(session_id)
+        self._on_files_updated(session_id, widget_id)
 
     def remove_session_files(self, session_id):
         """Remove all files that belong to the given report.
@@ -175,4 +200,9 @@ class UploadedFileManager(object):
         """
         self._remove_files(session_id, widget_id)
         self._add_files(session_id, widget_id, files)
-        self._on_files_updated(session_id)
+        self._on_files_updated(session_id, widget_id)
+
+    def update_file_count(self, session_id, widget_id, file_count):
+        files_by_widget = session_id, widget_id
+        self._file_counts_by_id[files_by_widget] = file_count
+        self._on_files_updated(session_id, widget_id)

--- a/lib/tests/streamlit/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/upload_file_request_handler_test.py
@@ -75,6 +75,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             file.name: file,
             "sessionId": (None, "fooReport"),
             "widgetId": (None, "barWidget"),
+            "totalFiles": (None, "1"),
         }
         response = self._upload_files(params)
         self.assertEqual(200, response.code)
@@ -97,6 +98,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             file3.name: file3,
             "sessionId": (None, "fooReport"),
             "widgetId": (None, "barWidget"),
+            "totalFiles": (None, "1"),
         }
         response = self._upload_files(params)
         self.assertEqual(200, response.code)
@@ -116,6 +118,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "image.png": ("image.png", b"1234"),
             "sessionId": (None, "fooReport"),
             # "widgetId": (None, 'barWidget'),
+            "totalFiles": (None, "1"),
         }
 
         response = self._upload_files(params)
@@ -128,6 +131,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             # "image.png": ("image.png", b"1234"),
             "sessionId": (None, "fooReport"),
             "widgetId": (None, "barWidget"),
+            "totalFiles": (None, "1"),
         }
         response = self._upload_files(params)
         self.assertEqual(400, response.code)

--- a/lib/tests/streamlit/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/uploaded_file_manager_test.py
@@ -35,11 +35,13 @@ class UploadedFileManagerTest(unittest.TestCase):
     def test_add_file(self):
         self.assertIsNone(self.mgr.get_files("non-report", "non-widget"))
 
+        self.mgr.update_file_count("session", "widget", 1)
         self.mgr.add_files("session", "widget", [file1])
         self.assertEqual([file1], self.mgr.get_files("session", "widget"))
         self.assertEqual(len(self.filemgr_events), 1)
 
         # Add another file with the same ID
+        self.mgr.update_file_count("session", "widget", 2)
         self.mgr.add_files("session", "widget", [file2])
         self.assertEqual([file1, file2], self.mgr.get_files("session", "widget"))
         self.assertEqual(len(self.filemgr_events), 2)


### PR DESCRIPTION
**Issue:** Closes #2329

**Description:** Not an ideal implementation but resolves the need to consolidate reruns for multiple files uploaded. [Full specs available here](https://www.notion.so/streamlit/Consolidate-reruns-for-multiple-file-uploads-97e07fc4474a452ab7cd35dfda70b9d6)

1. Prior to uploading files, send over the total number of files that has been uploaded to the specific widget. 
2. Server will track how many files should be associated to the widget in the session.
3. Server will trigger a rerun only if the number of files that have been received by the server matches with how many files have been uploaded by the user. 
4. When deleting or canceling an upload, send a request updating the number of expected files.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
