### PR TITLE
Lazy import S3Storage, so boto3 isn't always imported

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -451,7 +451,7 @@ def _server_headless():
     )
 
 
-@_create_option("server.liveSave", type_=bool)
+@_create_option("server.liveSave", type_=bool, visibility="hidden")
 def _server_live_save():
     """Immediately share the app in such a way that enables live
     monitoring, and post-run analysis.

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -616,6 +616,7 @@ class ReportSession(object):
             sharing_mode = config.get_option("global.sharingMode")
             if sharing_mode == "s3":
                 from streamlit.storage.s3_storage import S3Storage
+
                 self._storage = S3Storage()
             elif sharing_mode == "file":
                 self._storage = FileStorage()

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -38,7 +38,6 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.server.server_util import serialize_forward_msg
 from streamlit.storage.file_storage import FileStorage
-from streamlit.storage.s3_storage import S3Storage
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 import streamlit.elements.exception_proto as exception_proto
 
@@ -616,6 +615,7 @@ class ReportSession(object):
         if self._storage is None:
             sharing_mode = config.get_option("global.sharingMode")
             if sharing_mode == "s3":
+                from streamlit.storage.s3_storage import S3Storage
                 self._storage = S3Storage()
             elif sharing_mode == "file":
                 self._storage = FileStorage()


### PR DESCRIPTION
Fixes #2373

We moved boto3 and botocore to dev-dependencies, but this broke our imports since report_session was always looking for S3Storage. S3Storage is only needed when the server.liveSave config option is enabled.

server.liveSave is now a hidden option, just like global.sharingMode
