### PR TITLE
removed unneeded returns from Streamlit Hello

### DIFF
--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -108,7 +108,6 @@ def mapping_demo():
 
             Connection error: %s
         """ % e.reason)
-        return
 
     st.sidebar.markdown('### Map Layers')
     selected_layers = [
@@ -237,14 +236,12 @@ def data_frame_demo():
         """
             % e.reason
         )
-        return
 
     countries = st.multiselect(
         "Choose countries", list(df.index), ["China", "United States of America"]
     )
     if not countries:
         st.error("Please select at least one country.")
-        return
 
     data = df.loc[countries]
     data /= 1000000.0

--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -108,6 +108,7 @@ def mapping_demo():
 
             Connection error: %s
         """ % e.reason)
+        st.stop()
 
     st.sidebar.markdown('### Map Layers')
     selected_layers = [
@@ -236,13 +237,15 @@ def data_frame_demo():
         """
             % e.reason
         )
+        st.stop()
 
     countries = st.multiselect(
         "Choose countries", list(df.index), ["China", "United States of America"]
     )
     if not countries:
         st.error("Please select at least one country.")
-
+        st.stop()
+        
     data = df.loc[countries]
     data /= 1000000.0
     st.write("### Gross Agricultural Production ($B)", data.sort_index())


### PR DESCRIPTION
When copying the code out of the Streamlit Hello code box it wont run because of the "return" at the end of the functions:
```
try:
        df = get_UN_data()
    except urllib.error.URLError as e:  
```
and 
```
if not countries:
```
EDIT: per internal meeting replaced the returns with st.stop() at all 3 changed locations, decided not worth in depth fix