### PR TITLE
Components: send "key" and "default" to frontend

### DIFF
--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -109,9 +109,14 @@ class CustomComponent:
         if len(args) > 0:
             raise MarshallComponentException(f"Argument '{args[0]}' needs a label")
 
+        # In addition to the custom kwargs passed to the component, we also
+        # send the special 'default' and 'key' params to the component
+        # frontend.
+        all_args = dict(kwargs, **{"default": default, "key": key})
+
         json_args = {}
         special_args = []
-        for arg_name, arg_val in kwargs.items():
+        for arg_name, arg_val in all_args.items():
             if type_util.is_bytes_like(arg_val):
                 bytes_arg = SpecialArg()
                 bytes_arg.key = arg_name

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -214,15 +214,12 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
     """Test invocation of a custom component object."""
 
     def assertJSONEqual(self, a, b):
-        """Asserts that two JSON objects (strings or dicts) are equal."""
-        # Ensure both arguments are strings
-        str_a = a if isinstance(a, str) else json.dumps(a)
-        str_b = b if isinstance(b, str) else json.dumps(b)
-
-        # Convert string -> dict -> back to string, but with sorted keys
-        sorted_a = json.dumps(json.loads(str_a), sort_keys=True)
-        sorted_b = json.dumps(json.loads(str_b), sort_keys=True)
-        self.assertEqual(sorted_a, sorted_b)
+        """Asserts that two JSON objects are equal. If either arg is a
+        string, it will be first converted to"""
+        # Ensure both objects are dicts.
+        dict_a = a if isinstance(a, dict) else json.loads(a)
+        dict_b = b if isinstance(b, dict) else json.loads(b)
+        self.assertEqual(dict_a, dict_b)
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
With this PR, the special "key" and "default" params are now sent to the ComponentInstance on the frontend.

(If these values are null/None, they'll still be included in the params that get sent to the frontend.)

This is literally a two-line change - the rest of the code is just new tests.