### PR TITLE
Optimize updates of file upload progress

### DIFF
--- a/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -56,7 +56,10 @@ function ProgressBar({
     Bar: {
       style: ({ $theme }: { $theme: any }) => ({
         width,
-        margin: theme.spacing.none,
+        marginTop: theme.spacing.none,
+        marginBottom: theme.spacing.none,
+        marginRight: theme.spacing.none,
+        marginLeft: theme.spacing.none,
         height: heightMap[size],
         backgroundColor: $theme.colors.progressbarTrackFill,
       }),


### PR DESCRIPTION
**Issue:** Fixes #2404 

**Description:** 
In safari, the progress bar was not showing up when a file was uploaded. It looks like this was possibly happening due to rapid updates. This change optimizes the update of the file.progress, reducing the constant updates that was occurring. 

Files that are uploaded quickly may not display a progress bar but this change should improve for longer uploading files.

Also squeezed in a fix to a warning in Safari regarding short hand styles.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
