### PR TITLE
Protobuf data naming consistency

### DIFF
--- a/frontend/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.tsx
@@ -142,7 +142,7 @@ class NumberInput extends React.PureComponent<Props, State> {
       if (this.isIntData()) {
         widgetMgr.setIntValue(widgetId, valueToBeSaved, source)
       } else {
-        widgetMgr.setFloatValue(widgetId, valueToBeSaved, source)
+        widgetMgr.setDoubleValue(widgetId, valueToBeSaved, source)
       }
 
       this.setState({

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -68,7 +68,7 @@ describe("Slider widget", () => {
     jest.runAllTimers()
     wrapper.update()
 
-    expect(props.widgetMgr.setFloatArrayValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
       props.element.id,
       [5],
       { fromUi: false }
@@ -132,7 +132,7 @@ describe("Slider widget", () => {
       jest.runAllTimers()
       wrapper.update()
 
-      expect(props.widgetMgr.setFloatArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
         props.element.id,
         [10],
         { fromUi: true }
@@ -240,7 +240,7 @@ describe("Slider widget", () => {
       jest.runAllTimers()
       wrapper.update()
 
-      expect(props.widgetMgr.setFloatArrayValue).toHaveBeenCalledWith(
+      expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
         props.element.id,
         [1, 10],
         {

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -68,7 +68,7 @@ class Slider extends React.PureComponent<Props, State> {
 
   get initialValue(): number[] {
     const widgetId = this.props.element.id
-    const storedValue = this.props.widgetMgr.getFloatArrayValue(widgetId)
+    const storedValue = this.props.widgetMgr.getDoubleArrayValue(widgetId)
     return storedValue !== undefined ? storedValue : this.props.element.default
   }
 
@@ -96,7 +96,11 @@ class Slider extends React.PureComponent<Props, State> {
 
   private setWidgetValueImmediately = (source: Source): void => {
     const widgetId = this.props.element.id
-    this.props.widgetMgr.setFloatArrayValue(widgetId, this.state.value, source)
+    this.props.widgetMgr.setDoubleArrayValue(
+      widgetId,
+      this.state.value,
+      source
+    )
   }
 
   private getAllSliderRoles = (): Element[] => {

--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -23,10 +23,10 @@ const MOCK_DATA = {
   stringValue: "NOT_A_REAL_STRING_VALUE",
   booleanValue: true,
   intValue: 10,
-  floatValue: 0.1,
+  doubleValue: 0.1,
   stringArray: ["foo", "bar", "baz"],
   intArray: [1, 25, 50],
-  floatArray: [0.1, 0.25, 5],
+  doubleArray: [0.1, 0.25, 5],
   jsonValue: {
     foo: "bar",
     baz: "qux",
@@ -70,11 +70,11 @@ describe("Widget State Manager", () => {
   })
 
   it("sets float value correctly", () => {
-    widgetMgr.setFloatValue(MOCK_DATA.widgetId, MOCK_DATA.floatValue, {
+    widgetMgr.setDoubleValue(MOCK_DATA.widgetId, MOCK_DATA.doubleValue, {
       fromUi: true,
     })
-    expect(widgetMgr.getFloatValue(MOCK_DATA.widgetId)).toBe(
-      MOCK_DATA.floatValue
+    expect(widgetMgr.getDoubleValue(MOCK_DATA.widgetId)).toBe(
+      MOCK_DATA.doubleValue
     )
   })
 
@@ -103,11 +103,11 @@ describe("Widget State Manager", () => {
   })
 
   it("sets float array value correctly", () => {
-    widgetMgr.setFloatArrayValue(MOCK_DATA.widgetId, MOCK_DATA.floatArray, {
+    widgetMgr.setDoubleArrayValue(MOCK_DATA.widgetId, MOCK_DATA.doubleArray, {
       fromUi: true,
     })
-    expect(widgetMgr.getFloatArrayValue(MOCK_DATA.widgetId)).toEqual(
-      MOCK_DATA.floatArray
+    expect(widgetMgr.getDoubleArrayValue(MOCK_DATA.widgetId)).toEqual(
+      MOCK_DATA.doubleArray
     )
   })
 
@@ -158,11 +158,11 @@ describe("Widget State Manager", () => {
     })
 
     it("sets float value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_DATA.widgetId, MOCK_DATA.floatValue, {
+      widgetMgr.setJsonValue(MOCK_DATA.widgetId, MOCK_DATA.doubleValue, {
         fromUi: true,
       })
       expect(widgetMgr.getJsonValue(MOCK_DATA.widgetId)).toBe(
-        JSON.stringify(MOCK_DATA.floatValue)
+        JSON.stringify(MOCK_DATA.doubleValue)
       )
     })
 
@@ -194,11 +194,11 @@ describe("Widget State Manager", () => {
     })
 
     it("sets float array value as JSON correctly", () => {
-      widgetMgr.setJsonValue(MOCK_DATA.widgetId, MOCK_DATA.floatArray, {
+      widgetMgr.setJsonValue(MOCK_DATA.widgetId, MOCK_DATA.doubleArray, {
         fromUi: true,
       })
       expect(widgetMgr.getJsonValue(MOCK_DATA.widgetId)).toBe(
-        JSON.stringify(MOCK_DATA.floatArray)
+        JSON.stringify(MOCK_DATA.doubleArray)
       )
     })
 

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -16,9 +16,9 @@
  */
 
 import {
-  FloatArray,
+  DoubleArray,
   IArrowTable,
-  IntArray,
+  SInt64Array,
   StringArray,
   WidgetState,
   WidgetStates,
@@ -118,17 +118,21 @@ export class WidgetStateManager {
     this.maybeSendUpdateWidgetsMessage(source)
   }
 
-  public getFloatValue(widgetId: string): number | undefined {
+  public getDoubleValue(widgetId: string): number | undefined {
     const state = this.getWidgetStateProto(widgetId)
-    if (state != null && state.value === "floatValue") {
-      return state.floatValue
+    if (state != null && state.value === "doubleValue") {
+      return state.doubleValue
     }
 
     return undefined
   }
 
-  public setFloatValue(widgetId: string, value: number, source: Source): void {
-    this.createWidgetStateProto(widgetId).floatValue = value
+  public setDoubleValue(
+    widgetId: string,
+    value: number,
+    source: Source
+  ): void {
+    this.createWidgetStateProto(widgetId).doubleValue = value
     this.maybeSendUpdateWidgetsMessage(source)
   }
 
@@ -155,9 +159,9 @@ export class WidgetStateManager {
     value: string[],
     source: Source
   ): void {
-    this.createWidgetStateProto(
-      widgetId
-    ).stringArrayValue = StringArray.fromObject({ data: value })
+    this.createWidgetStateProto(widgetId).stringArrayValue = new StringArray({
+      data: value,
+    })
     this.maybeSendUpdateWidgetsMessage(source)
   }
 
@@ -175,28 +179,28 @@ export class WidgetStateManager {
     return undefined
   }
 
-  public getFloatArrayValue(widgetId: string): number[] | undefined {
+  public getDoubleArrayValue(widgetId: string): number[] | undefined {
     const state = this.getWidgetStateProto(widgetId)
     if (
       state != null &&
-      state.value === "floatArrayValue" &&
-      state.floatArrayValue != null &&
-      state.floatArrayValue.value != null
+      state.value === "doubleArrayValue" &&
+      state.doubleArrayValue != null &&
+      state.doubleArrayValue.data != null
     ) {
-      return state.floatArrayValue.value
+      return state.doubleArrayValue.data
     }
 
     return undefined
   }
 
-  public setFloatArrayValue(
+  public setDoubleArrayValue(
     widgetId: string,
     value: number[],
     source: Source
   ): void {
-    this.createWidgetStateProto(
-      widgetId
-    ).floatArrayValue = FloatArray.fromObject({ value })
+    this.createWidgetStateProto(widgetId).doubleArrayValue = new DoubleArray({
+      data: value,
+    })
     this.maybeSendUpdateWidgetsMessage(source)
   }
 
@@ -206,9 +210,9 @@ export class WidgetStateManager {
       state != null &&
       state.value === "intArrayValue" &&
       state.intArrayValue != null &&
-      state.intArrayValue.value != null
+      state.intArrayValue.data != null
     ) {
-      return state.intArrayValue.value.map(requireNumberInt)
+      return state.intArrayValue.data.map(requireNumberInt)
     }
 
     return undefined
@@ -219,8 +223,8 @@ export class WidgetStateManager {
     value: number[],
     source: Source
   ): void {
-    this.createWidgetStateProto(widgetId).intArrayValue = IntArray.fromObject({
-      value,
+    this.createWidgetStateProto(widgetId).intArrayValue = new SInt64Array({
+      data: value,
     })
     this.maybeSendUpdateWidgetsMessage(source)
   }

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -87,6 +87,6 @@ class MultiSelectMixin:
         multiselect_proto.options[:] = [str(format_func(option)) for option in options]
 
         ui_value = _get_widget_ui_value("multiselect", multiselect_proto, user_key=key)
-        current_value = ui_value.value if ui_value is not None else default_value
+        current_value = ui_value.data if ui_value is not None else default_value
         return_value = [options[i] for i in current_value]
         return dg._enqueue("multiselect", multiselect_proto, return_value)  # type: ignore

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -106,7 +106,7 @@ class SelectSliderMixin:
 
         ui_value = _get_widget_ui_value("slider", slider_proto, user_key=key)
         if ui_value:
-            current_value = getattr(ui_value, "value")
+            current_value = getattr(ui_value, "data")
         else:
             # Widget has not been used; fallback to the original value,
             current_value = slider_value

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -354,7 +354,7 @@ class SliderMixin:
 
         ui_value = _get_widget_ui_value("slider", slider_proto, user_key=key)
         if ui_value:
-            current_value = getattr(ui_value, "value")
+            current_value = getattr(ui_value, "data")
         else:
             # Widget has not been used; fallback to the original value,
             current_value = value

--- a/lib/tests/streamlit/data_frame_proto_test.py
+++ b/lib/tests/streamlit/data_frame_proto_test.py
@@ -24,13 +24,13 @@ import pytest
 import streamlit.elements.data_frame_proto as data_frame_proto
 
 from google.protobuf import json_format
+
+from streamlit.proto.Common_pb2 import Int32Array
 from streamlit.proto.DataFrame_pb2 import AnyArray
 from streamlit.proto.DataFrame_pb2 import CSSStyle
 from streamlit.proto.DataFrame_pb2 import CellStyle
 from streamlit.proto.DataFrame_pb2 import CellStyleArray
-from streamlit.proto.DataFrame_pb2 import DataFrame
 from streamlit.proto.DataFrame_pb2 import Index
-from streamlit.proto.DataFrame_pb2 import Int32Array
 from streamlit.proto.DataFrame_pb2 import Table
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart

--- a/lib/tests/streamlit/widgets_test.py
+++ b/lib/tests/streamlit/widgets_test.py
@@ -32,7 +32,7 @@ class WidgetTest(unittest.TestCase):
 
         _create_widget("trigger", states).trigger_value = True
         _create_widget("bool", states).bool_value = True
-        _create_widget("float", states).float_value = 0.5
+        _create_widget("float", states).double_value = 0.5
         _create_widget("int", states).int_value = 123
         _create_widget("string", states).string_value = "howdy!"
 

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+// Message types that are common to multiple protobufs.
+
+message StringArray {
+  repeated string data = 1;
+}
+
+message DoubleArray {
+  repeated double data = 1;
+}
+
+message Int32Array {
+  repeated int32 data = 1;
+}
+
+message Int64Array {
+  repeated int64 data = 1;
+}
+
+message SInt64Array {
+  repeated sint64 data = 1;
+}
+
+message UInt32Array {
+  repeated uint32 data = 1;
+}

--- a/proto/streamlit/proto/DataFrame.proto
+++ b/proto/streamlit/proto/DataFrame.proto
@@ -16,6 +16,8 @@
 
 syntax = "proto3";
 
+import "streamlit/proto/Common.proto";
+
 // Represents a pandas DataFrame.
 message DataFrame {
   // The data in the array.
@@ -105,26 +107,6 @@ message Int64Index {
 // https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Int64Index.html
 message Float64Index {
   DoubleArray data = 1;
-}
-
-message StringArray {
-  repeated string data = 1;
-}
-
-message DoubleArray {
-  repeated double data = 1;
-}
-
-message Int32Array {
-  repeated int32 data = 1;
-}
-
-message Int64Array {
-  repeated int64 data = 1;
-}
-
-message UInt32Array {
-  repeated uint32 data = 1;
 }
 
 message CSSStyle {

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -88,6 +88,12 @@ message UserInfo {
 
 // Data that identifies the Streamlit app's environment.
 // Does not change over the app lifetime.
+//
+// NB: unlike most of our protobuf data, the EnvironmentInfo message (and all
+// its ancestors' IDs) *must* maintain backward- and forward-compatibility.
+// When a Streamlit instance is updated to a new version, all connected clients
+// will be outdated. Those clients need to be able to read the
+// `streamlit_version` property so they can auto-update to the new version.
 message EnvironmentInfo {
   string streamlit_version = 1;
   string python_version = 2;

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -16,6 +16,7 @@
 
 syntax = "proto3";
 
+import "streamlit/proto/Common.proto";
 import "streamlit/proto/ArrowTable.proto";
 import "streamlit/proto/DataFrame.proto";
 
@@ -39,22 +40,14 @@ message WidgetState {
     bool trigger_value = 2;
 
     bool bool_value = 3;
-    double float_value = 4;
+    double double_value = 4;
     sint64 int_value = 5;
     string string_value = 6;
-    FloatArray float_array_value = 7;
-    IntArray int_array_value = 8;
+    DoubleArray double_array_value = 7;
+    SInt64Array int_array_value = 8;
     StringArray string_array_value = 9;
     string json_value = 10;
     ArrowTable arrow_value = 11;
     bytes bytes_value = 12;
   }
-}
-
-message FloatArray {
-  repeated double value = 1;
-}
-
-message IntArray {
-  repeated sint64 value = 1;
 }


### PR DESCRIPTION
- Consolidates our various "FooArray" message types into a "Common.proto" file
- WidgetStates correctly names its float_value and float_array_value oneofs (they're now double_value and double_array_value).
- All common Arrays name their data "data" (instead of a mix of "data" and "value")

(This means that WidgetState is no longer pulling in some of its non-Arrow datatypes from "ArrowTable.proto", which was the motivator behind the refactor.)