### PR TITLE
Removed unnecessary config options from `craco.config.js`

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -1,4 +1,3 @@
-const webpack = require("webpack")
 const HardSourceWebpackPlugin = require("hard-source-webpack-plugin")
 
 module.exports = {
@@ -19,7 +18,7 @@ module.exports = {
     plugins: ["emotion"],
   },
   webpack: {
-    configure: (webpackConfig, { env, paths }) => {
+    configure: webpackConfig => {
       webpackConfig.resolve.mainFields = ["main", "module"]
 
       // HardSourceWebpackPlugin adds aggressive build caching
@@ -43,17 +42,5 @@ module.exports = {
 
       return webpackConfig
     },
-    plugins: [
-      // Hide critical dependency warnings from Webpack, as CircleCI treats them as errors.
-      // https://medium.com/tomincode/hiding-critical-dependency-warnings-from-webpack-c76ccdb1f6c1
-      // Remove after updating bokehjs to 2.0.0
-      // https://github.com/bokeh/bokeh/issues/9594#issuecomment-577227353
-      new webpack.ContextReplacementPlugin(/\/bokehjs\//, data => {
-        for (let i in data.dependencies) {
-          delete data.dependencies[i].critical
-        }
-        return data
-      }),
-    ],
   },
 }


### PR DESCRIPTION
As Bokeh has been upgraded to `2.0.0`, we don't need these config options anymore.