### PR TITLE
Fix protobuf warnings

### DIFF
--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -14,6 +14,8 @@
  * limitations under the License.
 */
 
+syntax = "proto3";
+
 // Message types that are common to multiple protobufs.
 
 message StringArray {

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -18,13 +18,11 @@ syntax = "proto3";
 
 import "streamlit/proto/Common.proto";
 import "streamlit/proto/ArrowTable.proto";
-import "streamlit/proto/DataFrame.proto";
 
 // State for every widget in an app.
 message WidgetStates {
   repeated WidgetState widgets = 1;
 }
-
 
 // State for a single widget.
 message WidgetState {


### PR DESCRIPTION
- Add `syntax = "proto3"` declaration to Common.proto
- Remove unused import