### PR TITLE
Improve explanation of "unused" protobuf fields

### DIFF
--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -26,6 +26,7 @@ message Block {
   bool allow_empty = 5;
 
   message Vertical {
+    // Protos need to have some content in them
     bool unused = 1;
   }
 

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -26,7 +26,7 @@ message Block {
   bool allow_empty = 5;
 
   message Vertical {
-    // Protos need to have some content in them
+    // Protos cannot be empty, so we set a dummy field
     bool unused = 1;
   }
 

--- a/proto/streamlit/proto/Empty.proto
+++ b/proto/streamlit/proto/Empty.proto
@@ -18,5 +18,6 @@ syntax = "proto3";
 
 // A python empty.
 message Empty {
+  // Protos cannot be empty, so we set a dummy field
   bool unused = 1;
 }


### PR DESCRIPTION
Karrie: 

> This unused name confused me. When I first read this, I assumed you were reclassifying columns to be a vertical layout which puzzled me. But I guess you just needed a dummy name to check if it exists?

Tim: 

> in Block.proto, why does the Vertical block type have a bool unused = 1; field?