### PR TITLE
Add a pause for file uploading E2E test

### DIFF
--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -97,6 +97,9 @@ describe("st.file_uploader", () => {
     // Yes, this actually is the recommended way to load multiple fixtures
     // in Cypress (!!) using Cypress.Promise.all is buggy. See:
     // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__fixtures/cypress/integration/multiple-fixtures-spec.js
+    // Why can’t I use async / await?
+    // If you’re a modern JS programmer you might hear “asynchronous” and think: why can’t I just use async/await instead of learning some proprietary API?
+    // https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous
     cy.fixture(fileName1).then(file1 => {
       cy.fixture(fileName2).then(file2 => {
         const files = [
@@ -154,9 +157,12 @@ describe("st.file_uploader", () => {
     const fileName1 = "file1.txt";
     const fileName2 = "file2.txt";
 
-    // Yes, this actually is the recommended way to load multiple fixtures
+    // Yes, this is the recommended way to load multiple fixtures
     // in Cypress (!!) using Cypress.Promise.all is buggy. See:
     // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__fixtures/cypress/integration/multiple-fixtures-spec.js
+    // Why can’t I use async / await?
+    // If you’re a modern JS programmer you might hear “asynchronous” and think: why can’t I just use async/await instead of learning some proprietary API?
+    // https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous
     cy.fixture(fileName1).then(file1 => {
       cy.fixture(fileName2).then(file2 => {
         const files = [
@@ -170,7 +176,12 @@ describe("st.file_uploader", () => {
             force: true,
             subjectType: "drag-n-drop",
             events: ["dragenter", "drop"]
-          })
+          });
+        // Give some time for the first file to upload
+        cy.wait(500);
+
+        cy.get("[data-testid='stFileUploadDropzone']")
+          .eq(1)
           .attachFile(files[1], {
             force: true,
             subjectType: "drag-n-drop",

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -192,6 +192,7 @@ describe("st.file_uploader", () => {
             events: ["dragenter", "drop"]
           });
 
+        // Wait for the HTTP request to complete
         cy.wait("@uploadFile");
 
         // The widget should show the names of the uploaded files in reverse

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -20,6 +20,8 @@ describe("st.file_uploader", () => {
     Cypress.Cookies.defaults({
       preserve: ["_xsrf"]
     });
+    cy.server();
+    cy.route("POST", "**/upload_file").as("uploadFile");
 
     cy.visit("http://localhost:3000/");
 
@@ -177,8 +179,10 @@ describe("st.file_uploader", () => {
             subjectType: "drag-n-drop",
             events: ["dragenter", "drop"]
           });
-        // Give some time for the first file to upload
-        cy.wait(500);
+
+        cy.get(".uploadedFileName").each(uploadedFileName => {
+          cy.get(uploadedFileName).should("have.text", fileName1);
+        });
 
         cy.get("[data-testid='stFileUploadDropzone']")
           .eq(1)
@@ -187,6 +191,8 @@ describe("st.file_uploader", () => {
             subjectType: "drag-n-drop",
             events: ["dragenter", "drop"]
           });
+
+        cy.wait("@uploadFile");
 
         // The widget should show the names of the uploaded files in reverse
         // order
@@ -198,7 +204,7 @@ describe("st.file_uploader", () => {
         // The script should have printed the contents of the two files
         // into an st.text. (This tests that the upload actually went
         // through.)
-        const content = [file1, file2].sort().join("\n");
+        const content = [file1, file2].join("\n");
         cy.get("[data-testid='stText']")
           .last()
           .should("have.text", content);


### PR DESCRIPTION
Our E2E test is reversing the order of the files uploaded intermittently. This could be happening too fast in certain runs. Adding a pause between file uploads. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
