### PR TITLE
File uploader size display - Base 2 vs Base 10

### DIFF
--- a/frontend/src/lib/FileHelper.test.ts
+++ b/frontend/src/lib/FileHelper.test.ts
@@ -15,16 +15,29 @@
  * limitations under the License.
  */
 
-import { getSizeDisplay, sizeConverter, FileSizes } from "./FileHelper"
+import {
+  getSizeDisplay,
+  sizeConverter,
+  FileSizes,
+  BYTE_CONVERSION_SIZE,
+} from "./FileHelper"
 
 describe("getSizeDisplay", () => {
   test("it shows unit", async () => {
-    expect(getSizeDisplay(1024, FileSizes.Byte)).toEqual("1.0KB")
-    expect(getSizeDisplay(1024 * 1024, FileSizes.Byte)).toEqual("1.0MB")
-    expect(getSizeDisplay(1024 * 1024 * 1024, FileSizes.Byte)).toEqual("1.0GB")
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte)).toEqual(
+      "1.0KB"
+    )
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE ** 2, FileSizes.Byte)).toEqual(
+      "1.0MB"
+    )
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE ** 3, FileSizes.Byte)).toEqual(
+      "1.0GB"
+    )
 
     expect(getSizeDisplay(10, FileSizes.GigaByte)).toEqual("10.0GB")
-    expect(getSizeDisplay(1024, FileSizes.MegaByte)).toEqual("1.0GB")
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.MegaByte)).toEqual(
+      "1.0GB"
+    )
   })
 
   test("it has unusual values", async () => {
@@ -35,9 +48,15 @@ describe("getSizeDisplay", () => {
   })
 
   test("it truncates to the right amount of decimals", async () => {
-    expect(getSizeDisplay(1024, FileSizes.Byte)).toEqual("1.0KB")
-    expect(getSizeDisplay(1024, FileSizes.Byte, 0)).toEqual("1KB")
-    expect(getSizeDisplay(1024, FileSizes.Byte, 3)).toEqual("1.000KB")
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte)).toEqual(
+      "1.0KB"
+    )
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte, 0)).toEqual(
+      "1KB"
+    )
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte, 3)).toEqual(
+      "1.000KB"
+    )
   })
 
   test("it rounds up to the next unit", async () => {
@@ -50,32 +69,50 @@ describe("getSizeDisplay", () => {
 describe("sizeConverter", () => {
   test("it converts up to the bigger unit", async () => {
     expect(sizeConverter(0.5, FileSizes.KiloByte, FileSizes.MegaByte)).toEqual(
-      0.5 / 1024
+      0.5 / BYTE_CONVERSION_SIZE
     )
-    expect(sizeConverter(1024, FileSizes.Byte, FileSizes.KiloByte)).toEqual(1)
     expect(
-      sizeConverter(1024 ** 2, FileSizes.KiloByte, FileSizes.GigaByte)
+      sizeConverter(BYTE_CONVERSION_SIZE, FileSizes.Byte, FileSizes.KiloByte)
+    ).toEqual(1)
+    expect(
+      sizeConverter(
+        BYTE_CONVERSION_SIZE ** 2,
+        FileSizes.KiloByte,
+        FileSizes.GigaByte
+      )
     ).toEqual(1)
     expect(sizeConverter(1, FileSizes.MegaByte, FileSizes.GigaByte)).toEqual(
-      1 / 1024
+      1 / BYTE_CONVERSION_SIZE
     )
   })
 
   test("it converts down to the smaller unit", async () => {
     expect(sizeConverter(0.5, FileSizes.GigaByte, FileSizes.MegaByte)).toEqual(
-      512
+      BYTE_CONVERSION_SIZE * 0.5
     )
     expect(
-      sizeConverter(1024, FileSizes.GigaByte, FileSizes.KiloByte)
-    ).toEqual(1024 ** 3)
+      sizeConverter(
+        BYTE_CONVERSION_SIZE,
+        FileSizes.GigaByte,
+        FileSizes.KiloByte
+      )
+    ).toEqual(BYTE_CONVERSION_SIZE ** 3)
     expect(
-      sizeConverter(1024 ** 2, FileSizes.MegaByte, FileSizes.KiloByte)
-    ).toEqual(1024 ** 3)
-    expect(sizeConverter(1, FileSizes.KiloByte, FileSizes.Byte)).toEqual(1024)
+      sizeConverter(
+        BYTE_CONVERSION_SIZE ** 2,
+        FileSizes.MegaByte,
+        FileSizes.KiloByte
+      )
+    ).toEqual(BYTE_CONVERSION_SIZE ** 3)
+    expect(sizeConverter(1, FileSizes.KiloByte, FileSizes.Byte)).toEqual(
+      BYTE_CONVERSION_SIZE
+    )
   })
 
   test("it handles unusual cases", async () => {
-    expect(sizeConverter(1024, FileSizes.Byte, FileSizes.Byte)).toEqual(1024)
+    expect(
+      sizeConverter(BYTE_CONVERSION_SIZE, FileSizes.Byte, FileSizes.Byte)
+    ).toEqual(BYTE_CONVERSION_SIZE)
     expect(() =>
       sizeConverter(-1, FileSizes.GigaByte, FileSizes.GigaByte)
     ).toThrowError()

--- a/frontend/src/lib/FileHelper.ts
+++ b/frontend/src/lib/FileHelper.ts
@@ -1,4 +1,5 @@
 import { CancelTokenSource } from "axios"
+import { isFromWindows } from "lib/utils"
 
 export interface ExtendedFile extends File {
   id?: string
@@ -23,7 +24,10 @@ export enum FileSizes {
   Byte = "b",
 }
 
-export const BYTE_CONVERSION_SIZE = 1024
+// There is a shift towards displaying storage in base 10 vs base 2
+// but Windows is still displaying things in base 2. This does not handle
+// all cases but for simplicity general rule is to use base 2 for Windows.
+export const BYTE_CONVERSION_SIZE = isFromWindows() ? 1024 : 1000
 const sizeUnitSequence = [
   FileSizes.GigaByte,
   FileSizes.MegaByte,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -118,6 +118,13 @@ export function isFromMac(): boolean {
 }
 
 /**
+ * Tests if the app is running from a Windows
+ */
+export function isFromWindows(): boolean {
+  return /^Win/i.test(navigator.platform)
+}
+
+/**
  * Returns cookie value
  */
 export function getCookie(name: string): string | undefined {


### PR DESCRIPTION
**Issue:** Closes #2431

**Description:** There isn't a consensus as to whether or not storage should be displayed in the [metric system (i.e. kilobytes - base 10) or the IEC system (i.e. kibibytes - base 2)](https://en.wikipedia.org/wiki/Kilobyte). The file explorer for [Ubuntu](https://wiki.ubuntu.com/UnitsPolicy) and [recent Mac OS](https://support.apple.com/en-us/HT201402) uses the metric system whereas Windows is still using IEC. This can cause a disconnect when you upload a file from your file explorer to Streamlit if we are displaying the file size in a different unit. We should try to align our file size display with that of the user's file explorer.

Adding a conditional check based on OS to determine if we will display file sizes in base 2 or base 10. This check is not perfect and solely for simplicity.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
