### PR TITLE
Quick test to add conditional arrow dependency for extras_require

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -32,6 +32,11 @@ pipfile = Project(chdir=False).parsed_pipfile
 
 packages = pipfile["packages"].copy()
 requirements = convert_deps_to_pip(packages, r=False)
+requirements.remove("pyarrow")
+
+extras_require = {
+    ':python_version<"3.9"': ["pyarrow"]
+}
 
 # Check whether xcode tools are available before making watchdog a
 # dependency (only if the current system is a Mac).
@@ -84,4 +89,5 @@ setuptools.setup(
     cmdclass={
         "verify": VerifyVersionCommand,
     },
+    extras_require=extras_require,
 )


### PR DESCRIPTION
From my quick testing, this looks to work. I just created two wheels and changed the python version requirements to work around my existing environment and got these results:

My environment: python version 3.8.5

Python version mismatch with `extras_require = {':python_version<"3.5"': ["pyarrow"]}`
```Installing collected packages: blinker, six, protobuf, click, MarkupSafe, jinja2, ipython-genutils, traitlets, jupyter-core, pyrsistent, attrs, jsonschema, nbformat, tornado, pyzmq, python-dateutil, jupyter-client, appnope, decorator, pickleshare, pygments, ptyprocess, pexpect, wcwidth, prompt-toolkit, backcall, parso, jedi, ipython, ipykernel, prometheus-client, testpath, entrypoints, webencodings, pyparsing, packaging, bleach, jupyterlab-pygments, defusedxml, mistune, nest-asyncio, async-generator, nbclient, pandocfilters, nbconvert, terminado, pycparser, cffi, argon2-cffi, Send2Trash, notebook, widgetsnbextension, ipywidgets, numpy, pydeck, toolz, pytz, pandas, altair, smmap, gitdb, gitpython, watchdog, pillow, astor, validators, base58, tzlocal, toml, cachetools, urllib3, chardet, idna, certifi, requests, streamlit```

Python version match with `extras_require = {':python_version<"3.9"': ["pyarrow"]}`
```Installing collected packages: pyparsing, packaging, pytz, numpy, six, python-dateutil, pandas, click, tornado, tzlocal, astor, entrypoints, pyrsistent, attrs, jsonschema, MarkupSafe, jinja2, toolz, altair, **pyarrow**, blinker, watchdog, pillow, ipython-genutils, traitlets, decorator, pygments, ptyprocess, pexpect, parso, jedi, pickleshare, backcall, wcwidth, prompt-toolkit, appnope, ipython, jupyter-core, nbformat, pyzmq, jupyter-client, ipykernel, terminado, prometheus-client, testpath, webencodings, bleach, mistune, defusedxml, pandocfilters, async-generator, nest-asyncio, nbclient, jupyterlab-pygments, nbconvert, pycparser, cffi, argon2-cffi, Send2Trash, notebook, widgetsnbextension, ipywidgets, pydeck, idna, urllib3, chardet, certifi, requests, protobuf, cachetools, validators, base58, toml, smmap, gitdb, gitpython, streamlit```