### PR TITLE
Stop requiring watchdog when installing Streamlit on Macs

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -50,5 +50,7 @@ toml = "*"
 tornado = ">=5.0"
 tzlocal = "*"
 validators = "*"
-watchdog = "*"
+# watchdog will not install on MacOS without xcode tools, so don't require it.
+# Without it, we fall back to our polling file watcher to detect when apps are changed.
+watchdog = {version = "*", platform_system = "Darwin"}
 gitpython = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -50,7 +50,7 @@ toml = "*"
 tornado = ">=5.0"
 tzlocal = "*"
 validators = "*"
-# watchdog will not install on MacOS without xcode tools, so don't require it.
-# Without it, we fall back to our polling file watcher to detect when apps are changed.
-watchdog = {version = "*", platform_system = "Darwin"}
+# Don't require watchdog on MacOS, since it'll fail without xcode tools.
+# Without watchdog, we fallback to a polling file watcher to check for app changes.
+watchdog = {version = "*", markers = "platform_system != 'Darwin'"}
 gitpython = "*"

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -1,7 +1,5 @@
 import os
-import platform
 import setuptools
-import subprocess
 import sys
 
 from setuptools.command.install import install
@@ -32,18 +30,6 @@ pipfile = Project(chdir=False).parsed_pipfile
 
 packages = pipfile["packages"].copy()
 requirements = convert_deps_to_pip(packages, r=False)
-
-# Check whether xcode tools are available before making watchdog a
-# dependency (only if the current system is a Mac).
-if platform.system() == "Darwin":
-    has_xcode = subprocess.call(["xcode-select", "--version"], shell=False) == 0
-    has_gcc = subprocess.call(["gcc", "--version"], shell=False) == 0
-
-    if not (has_xcode and has_gcc):
-        try:
-            requirements.remove("watchdog")
-        except ValueError:
-            pass
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
Fixes #283 

Pros: No one will ever have a problem installing Streamlit on Macs due to watchdog again
Cons: Mac users will use the slower(?) poll-based file watcher by default.
But we show them a command line warning, advising them to install watchdog themselves with `xcode-select --install; pip install watchdog`

The old check in `setup.py` was only run when a user installs Streamlit from source, but most of the time (e.g. `pip install streamlit`) will install from the binary wheelfile, so the check in `setup.py` will go unused. See #2452 for more information.