### PR TITLE
Add type annotations to DeltaGenerator mixins

### DIFF
--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -1,9 +1,26 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from .utils import _clean_text
 
 
 class AlertMixin:
-    def error(dg, body):
+    def error(self, body):
         """Display error message.
 
         Parameters
@@ -19,9 +36,9 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = _clean_text(body)
         alert_proto.format = AlertProto.ERROR
-        return dg._enqueue("alert", alert_proto)  # type: ignore
+        return self.dg._enqueue("alert", alert_proto)
 
-    def warning(dg, body):
+    def warning(self, body):
         """Display warning message.
 
         Parameters
@@ -37,9 +54,9 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = _clean_text(body)
         alert_proto.format = AlertProto.WARNING
-        return dg._enqueue("alert", alert_proto)  # type: ignore
+        return self.dg._enqueue("alert", alert_proto)
 
-    def info(dg, body):
+    def info(self, body):
         """Display an informational message.
 
         Parameters
@@ -55,9 +72,9 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = _clean_text(body)
         alert_proto.format = AlertProto.INFO
-        return dg._enqueue("alert", alert_proto)  # type: ignore
+        return self.dg._enqueue("alert", alert_proto)
 
-    def success(dg, body):
+    def success(self, body):
         """Display a success message.
 
         Parameters
@@ -73,4 +90,9 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = _clean_text(body)
         alert_proto.format = AlertProto.SUCCESS
-        return dg._enqueue("alert", alert_proto)  # type: ignore
+        return self.dg._enqueue("alert", alert_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/altair.py
+++ b/lib/streamlit/elements/altair.py
@@ -17,7 +17,9 @@ Altair is a Python visualization library based on Vega-Lite,
 a nice JSON schema for expressing graphs and charts."""
 
 from datetime import date
+from typing import cast
 
+import streamlit
 from streamlit import type_util
 from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart as VegaLiteChartProto
 import streamlit.elements.vega_lite as vega_lite
@@ -28,7 +30,7 @@ from .utils import last_index_for_melted_dataframes
 
 
 class AltairMixin:
-    def line_chart(dg, data=None, width=0, height=0, use_container_width=True):
+    def line_chart(self, data=None, width=0, height=0, use_container_width=True):
         """Display a line chart.
 
         This is syntax-sugar around st.altair_chart. The main difference
@@ -74,9 +76,11 @@ class AltairMixin:
         marshall(vega_lite_chart_proto, chart, use_container_width)
         last_index = last_index_for_melted_dataframes(data)
 
-        return dg._enqueue("line_chart", vega_lite_chart_proto, last_index=last_index)  # type: ignore
+        return self.dg._enqueue(
+            "line_chart", vega_lite_chart_proto, last_index=last_index
+        )
 
-    def area_chart(dg, data=None, width=0, height=0, use_container_width=True):
+    def area_chart(self, data=None, width=0, height=0, use_container_width=True):
         """Display an area chart.
 
         This is just syntax-sugar around st.altair_chart. The main difference
@@ -121,9 +125,11 @@ class AltairMixin:
         marshall(vega_lite_chart_proto, chart, use_container_width)
         last_index = last_index_for_melted_dataframes(data)
 
-        return dg._enqueue("area_chart", vega_lite_chart_proto, last_index=last_index)  # type: ignore
+        return self.dg._enqueue(
+            "area_chart", vega_lite_chart_proto, last_index=last_index
+        )
 
-    def bar_chart(dg, data=None, width=0, height=0, use_container_width=True):
+    def bar_chart(self, data=None, width=0, height=0, use_container_width=True):
         """Display a bar chart.
 
         This is just syntax-sugar around st.altair_chart. The main difference
@@ -168,9 +174,11 @@ class AltairMixin:
         marshall(vega_lite_chart_proto, chart, use_container_width)
         last_index = last_index_for_melted_dataframes(data)
 
-        return dg._enqueue("bar_chart", vega_lite_chart_proto, last_index=last_index)  # type: ignore
+        return self.dg._enqueue(
+            "bar_chart", vega_lite_chart_proto, last_index=last_index
+        )
 
-    def altair_chart(dg, altair_chart, use_container_width=False):
+    def altair_chart(self, altair_chart, use_container_width=False):
         """Display a chart using the Altair library.
 
         Parameters
@@ -213,7 +221,12 @@ class AltairMixin:
             altair_chart,
             use_container_width=use_container_width,
         )
-        return dg._enqueue("vega_lite_chart", vega_lite_chart_proto)  # type: ignore
+        return self.dg._enqueue("vega_lite_chart", vega_lite_chart_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def _is_date_column(df, name):

--- a/lib/streamlit/elements/balloons.py
+++ b/lib/streamlit/elements/balloons.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/balloons.py
+++ b/lib/streamlit/elements/balloons.py
@@ -1,10 +1,25 @@
-import random
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+from typing import cast
+
+import streamlit
 from streamlit.proto.Balloons_pb2 import Balloons as BalloonsProto
 
 
 class BalloonsMixin:
-    def balloons(dg):
+    def balloons(self):
         """Draw celebratory balloons.
 
         Example
@@ -16,4 +31,9 @@ class BalloonsMixin:
         """
         balloons_proto = BalloonsProto()
         balloons_proto.show = True
-        return dg._enqueue("balloons", balloons_proto)  # type: ignore
+        return self.dg._enqueue("balloons", balloons_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -14,12 +14,15 @@
 
 """A Python wrapper around Bokeh."""
 
-from streamlit.proto.BokehChart_pb2 import BokehChart as BokehChartProto
 import json
+from typing import cast
+
+import streamlit
+from streamlit.proto.BokehChart_pb2 import BokehChart as BokehChartProto
 
 
 class BokehMixin:
-    def bokeh_chart(dg, figure, use_container_width=False):
+    def bokeh_chart(self, figure, use_container_width=False):
         """Display an interactive Bokeh chart.
 
         Bokeh is a charting library for Python. The arguments to this function
@@ -62,7 +65,12 @@ class BokehMixin:
         """
         bokeh_chart_proto = BokehChartProto()
         marshall(bokeh_chart_proto, figure, use_container_width)
-        return dg._enqueue("bokeh_chart", bokeh_chart_proto)  # type: ignore
+        return self.dg._enqueue("bokeh_chart", bokeh_chart_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(proto, figure, use_container_width):

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -1,9 +1,26 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from .utils import _get_widget_ui_value
 
 
 class ButtonMixin:
-    def button(dg, label, key=None):
+    def button(self, label, key=None):
         """Display a button widget.
 
         Parameters
@@ -37,4 +54,9 @@ class ButtonMixin:
         ui_value = _get_widget_ui_value("button", button_proto, user_key=key)
         current_value = ui_value if ui_value is not None else False
 
-        return dg._enqueue("button", button_proto, current_value)  # type: ignore
+        return self.dg._enqueue("button", button_proto, current_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -1,9 +1,26 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from .utils import _get_widget_ui_value
 
 
 class CheckboxMixin:
-    def checkbox(dg, label, value=False, key=None):
+    def checkbox(self, label, value=False, key=None):
         """Display a checkbox widget.
 
         Parameters
@@ -38,4 +55,9 @@ class CheckboxMixin:
 
         ui_value = _get_widget_ui_value("checkbox", checkbox_proto, user_key=key)
         current_value = ui_value if ui_value is not None else value
-        return dg._enqueue("checkbox", checkbox_proto, bool(current_value))  # type: ignore
+        return self.dg._enqueue("checkbox", checkbox_proto, bool(current_value))
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -1,12 +1,28 @@
-import re
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
+import re
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
 from .utils import _get_widget_ui_value
 
 
 class ColorPickerMixin:
-    def color_picker(dg, label, value=None, key=None):
+    def color_picker(self, label, value=None, key=None):
         """Display a color picker widget.
 
         Note: This is a beta feature. See
@@ -71,4 +87,9 @@ class ColorPickerMixin:
             "color_picker", color_picker_proto, user_key=key
         )
         current_value = ui_value if ui_value is not None else value
-        return dg._enqueue("color_picker", color_picker_proto, str(current_value))  # type: ignore
+        return self.dg._enqueue("color_picker", color_picker_proto, str(current_value))
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import re
 from typing import cast
 

--- a/lib/streamlit/elements/data_frame_proto.py
+++ b/lib/streamlit/elements/data_frame_proto.py
@@ -15,10 +15,12 @@
 """Helper functions to marshall a pandas.DataFrame into a proto.Dataframe."""
 
 import re
+from collections import namedtuple
+from typing import cast
+
 import tzlocal
 
-from collections import namedtuple
-
+import streamlit
 from streamlit import type_util
 from streamlit.logger import get_logger
 from streamlit.proto.DataFrame_pb2 import DataFrame as DataFrameProto
@@ -29,7 +31,7 @@ CSSStyle = namedtuple("CSSStyle", ["property", "value"])
 
 
 class DataFrameMixin:
-    def dataframe(dg, data=None, width=None, height=None):
+    def dataframe(self, data=None, width=None, height=None):
         """Display a dataframe as an interactive table.
 
         Parameters
@@ -81,11 +83,14 @@ class DataFrameMixin:
         data_frame_proto = DataFrameProto()
         marshall_data_frame(data, data_frame_proto)
 
-        return dg._enqueue(  # type: ignore
-            "data_frame", data_frame_proto, element_width=width, element_height=height,
+        return self.dg._enqueue(
+            "data_frame",
+            data_frame_proto,
+            element_width=width,
+            element_height=height,
         )
 
-    def table(dg, data=None):
+    def table(self, data=None):
         """Display a static table.
 
         This differs from `st.dataframe` in that the table in this case is
@@ -112,7 +117,12 @@ class DataFrameMixin:
         """
         table_proto = DataFrameProto()
         marshall_data_frame(data, table_proto)
-        return dg._enqueue("table", table_proto)  # type: ignore
+        return self.dg._enqueue("table", table_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall_data_frame(data, proto_df):
@@ -130,9 +140,6 @@ def marshall_data_frame(data, proto_df):
 
     # Convert df into an iterable of columns (each of type Series).
     df_data = (df.iloc[:, col] for col in range(len(df.columns)))
-
-    import numpy as np
-    import pandas as pd
 
     _marshall_table(df_data, proto_df.data)
     _marshall_index(df.columns, proto_df.columns)

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import cast, Any, Dict
+
+import streamlit
 import json
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as PydeckProto
 
 
 class PydeckMixin:
-    def pydeck_chart(dg, pydeck_obj=None, use_container_width=False):
+    def pydeck_chart(self, pydeck_obj=None, use_container_width=False):
         """Draw a chart using the PyDeck library.
 
         This supports 3D maps, point clouds, and more! More info about PyDeck
@@ -87,11 +90,18 @@ class PydeckMixin:
         """
         pydeck_proto = PydeckProto()
         marshall(pydeck_proto, pydeck_obj, use_container_width)
-        return dg._enqueue("deck_gl_json_chart", pydeck_proto)  # type: ignore
+        return self.dg._enqueue("deck_gl_json_chart", pydeck_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 # Map used when no data is passed.
-EMPTY_MAP = {"initialViewState": {"latitude": 0, "longitude": 0, "pitch": 0, "zoom": 1}}
+EMPTY_MAP: Dict[str, Any] = {
+    "initialViewState": {"latitude": 0, "longitude": 0, "pitch": 0, "zoom": 1}
+}
 
 
 def marshall(pydeck_proto, pydeck_obj, use_container_width):

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -16,6 +16,9 @@
 
 import inspect
 
+from typing import cast
+
+import streamlit
 from streamlit.proto.DocString_pb2 import DocString as DocStringProto
 from streamlit.logger import get_logger
 
@@ -28,7 +31,7 @@ CONFUSING_STREAMLIT_SIG_PREFIXES = ("(element, ",)
 
 
 class HelpMixin:
-    def help(dg, obj):
+    def help(self, obj):
         """Display object's doc string, nicely formatted.
 
         Displays the doc string for this object.
@@ -54,7 +57,12 @@ class HelpMixin:
         """
         doc_string_proto = DocStringProto()
         _marshall(doc_string_proto, obj)
-        return dg._enqueue("doc_string", doc_string_proto)  # type: ignore
+        return self.dg._enqueue("doc_string", doc_string_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def _marshall(doc_string_proto, obj):

--- a/lib/streamlit/elements/empty.py
+++ b/lib/streamlit/elements/empty.py
@@ -1,8 +1,25 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 
 
 class EmptyMixin:
-    def empty(dg):
+    def empty(self):
         """Insert a single-element container.
 
         Inserts a container into your app that can be used to hold a single element.
@@ -48,4 +65,9 @@ class EmptyMixin:
         empty_proto = EmptyProto()
         # The protobuf needs something to be set
         empty_proto.unused = True
-        return dg._enqueue("empty", empty_proto)  # type: ignore
+        return self.dg._enqueue("empty", empty_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/empty.py
+++ b/lib/streamlit/elements/empty.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/exception_proto.py
+++ b/lib/streamlit/elements/exception_proto.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import traceback
-from typing import Optional
+from typing import Optional, cast
 
+import streamlit
 from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
 from streamlit.error_util import get_nonstreamlit_traceback
 from streamlit.errors import MarkdownFormattedException
@@ -28,7 +28,7 @@ LOGGER = get_logger(__name__)
 
 
 class ExceptionMixin:
-    def exception(dg, exception):
+    def exception(self, exception):
         """Display an exception.
 
         Parameters
@@ -44,7 +44,12 @@ class ExceptionMixin:
         """
         exception_proto = ExceptionProto()
         marshall(exception_proto, exception)
-        return dg._enqueue("exception", exception_proto)  # type: ignore
+        return self.dg._enqueue("exception", exception_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(exception_proto, exception):

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -1,5 +1,21 @@
-from streamlit import config
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+from typing import cast
+
+import streamlit
+from streamlit import config
 from streamlit.errors import StreamlitDeprecationWarning
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
 from streamlit.report_thread import get_report_ctx
@@ -9,7 +25,7 @@ from ..uploaded_file_manager import UploadedFile
 
 class FileUploaderMixin:
     def file_uploader(
-        dg, label, type=None, accept_multiple_files=False, key=None, **kwargs
+        self, label, type=None, accept_multiple_files=False, key=None, **kwargs
     ):
         """Display a file uploader widget.
         By default, uploaded files are limited to 200MB. You can configure
@@ -96,7 +112,7 @@ class FileUploaderMixin:
         )
 
         if show_deprecation_warning and has_encoding:
-            dg.exception(FileUploaderEncodingWarning())  # type: ignore
+            self.dg.exception(FileUploaderEncodingWarning())
 
         file_uploader_proto = FileUploaderProto()
         file_uploader_proto.label = label
@@ -120,7 +136,12 @@ class FileUploaderMixin:
             files = [UploadedFile(rec) for rec in file_recs]
             return_value = files if accept_multiple_files else files[0]
 
-        return dg._enqueue("file_uploader", file_uploader_proto, return_value)  # type: ignore
+        return self.dg._enqueue("file_uploader", file_uploader_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 class FileUploaderEncodingWarning(StreamlitDeprecationWarning):

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -14,6 +14,9 @@
 
 """Streamlit support for GraphViz charts."""
 
+from typing import cast
+
+import streamlit
 from streamlit import type_util
 from streamlit.logger import get_logger
 from streamlit.proto.GraphVizChart_pb2 import GraphVizChart as GraphVizChartProto
@@ -23,7 +26,7 @@ LOGGER = get_logger(__name__)
 
 
 class GraphvizMixin:
-    def graphviz_chart(dg, figure_or_dot, use_container_width=False):
+    def graphviz_chart(self, figure_or_dot, use_container_width=False):
         """Display a graph using the dagre-d3 library.
 
         Parameters
@@ -87,7 +90,12 @@ class GraphvizMixin:
         """
         graphviz_chart_proto = GraphVizChartProto()
         marshall(graphviz_chart_proto, figure_or_dot, use_container_width)
-        return dg._enqueue("graphviz_chart", graphviz_chart_proto)  # type: ignore
+        return self.dg._enqueue("graphviz_chart", graphviz_chart_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(proto, figure_or_dot, use_container_width):

--- a/lib/streamlit/elements/iframe_proto.py
+++ b/lib/streamlit/elements/iframe_proto.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
 from typing import Optional
+from typing import cast
+
+import streamlit
+from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
 
 
 class IframeMixin:
     def _iframe(
-        dg,
+        self,
         src,
         width=None,
         height=None,
@@ -48,10 +51,10 @@ class IframeMixin:
             height=height,
             scrolling=scrolling,
         )
-        return dg._enqueue("iframe", iframe_proto)  # type: ignore
+        return self.dg._enqueue("iframe", iframe_proto)
 
     def _html(
-        dg,
+        self,
         html,
         width=None,
         height=None,
@@ -81,7 +84,12 @@ class IframeMixin:
             height=height,
             scrolling=scrolling,
         )
-        return dg._enqueue("iframe", iframe_proto)  # type: ignore
+        return self.dg._enqueue("iframe", iframe_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(

--- a/lib/streamlit/elements/image_proto.py
+++ b/lib/streamlit/elements/image_proto.py
@@ -14,22 +14,21 @@
 
 """Image marshalling."""
 
-import io
 import imghdr
+import io
 import mimetypes
-
-import numpy as np
-
-from PIL import Image, ImageFile
-
-from streamlit import config
-from streamlit.proto.Image_pb2 import ImageList as ImageListProto
-from streamlit.errors import StreamlitAPIException, StreamlitDeprecationWarning
-from streamlit.logger import get_logger
-from urllib.parse import quote
+from typing import cast
 from urllib.parse import urlparse
 
+import numpy as np
+from PIL import Image, ImageFile
+
+import streamlit
+from streamlit import config
+from streamlit.errors import StreamlitAPIException, StreamlitDeprecationWarning
+from streamlit.logger import get_logger
 from streamlit.media_file_manager import media_file_manager
+from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 
 LOGGER = get_logger(__name__)
 
@@ -42,7 +41,7 @@ MAXIMUM_CONTENT_WIDTH = 2 * 730
 
 class ImageMixin:
     def image(
-        dg,
+        self,
         image,
         caption=None,
         width=None,
@@ -110,7 +109,7 @@ class ImageMixin:
             output_format = format
 
             if config.get_option("deprecation.showImageFormat"):
-                dg.exception(ImageFormatWarning(format))  # type: ignore
+                self.dg.exception(ImageFormatWarning(format))
 
         if use_column_width:
             width = -2
@@ -121,7 +120,7 @@ class ImageMixin:
 
         image_list_proto = ImageListProto()
         marshall_images(
-            dg._get_delta_path_str(),  # type: ignore
+            self.dg._get_delta_path_str(),
             image,
             caption,
             width,
@@ -130,7 +129,12 @@ class ImageMixin:
             channels,
             output_format,
         )
-        return dg._enqueue("imgs", image_list_proto)  # type: ignore
+        return self.dg._enqueue("imgs", image_list_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 class ImageFormatWarning(StreamlitDeprecationWarning):

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -1,10 +1,26 @@
-import json
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import json
+from typing import cast
+
+import streamlit
 from streamlit.proto.Json_pb2 import Json as JsonProto
 
 
 class JsonMixin:
-    def json(dg, body):
+    def json(self, body):
         """Display object or string as a pretty-printed JSON string.
 
         Parameters
@@ -46,4 +62,9 @@ class JsonMixin:
 
         json_proto = JsonProto()
         json_proto.body = body
-        return dg._enqueue("json", json_proto)  # type: ignore
+        return self.dg._enqueue("json", json_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import json
 from typing import cast
 

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -17,16 +17,18 @@
 import copy
 import json
 from typing import Any, Dict
+from typing import cast
 
 import pandas as pd
 
-from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
+import streamlit
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
 
 
 class MapMixin:
-    def map(dg, data=None, zoom=None, use_container_width=True):
+    def map(self, data=None, zoom=None, use_container_width=True):
         """Display a map with points on it.
 
         This is a wrapper around st.pydeck_chart to quickly create scatterplot
@@ -70,7 +72,12 @@ class MapMixin:
         map_proto = DeckGlJsonChartProto()
         map_proto.json = to_deckgl_json(data, zoom)
         map_proto.use_container_width = use_container_width
-        return dg._enqueue("deck_gl_json_chart", map_proto)  # type: ignore
+        return self.dg._enqueue("deck_gl_json_chart", map_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 # Map used as the basis for st.map.

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -1,10 +1,27 @@
-from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit import type_util
+from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from .utils import _clean_text
 
 
 class MarkdownMixin:
-    def markdown(dg, body, unsafe_allow_html=False):
+    def markdown(self, body, unsafe_allow_html=False):
         """Display string formatted as Markdown.
 
         Parameters
@@ -59,9 +76,9 @@ class MarkdownMixin:
         markdown_proto.body = _clean_text(body)
         markdown_proto.allow_html = unsafe_allow_html
 
-        return dg._enqueue("markdown", markdown_proto)  # type: ignore
+        return self.dg._enqueue("markdown", markdown_proto)
 
-    def header(dg, body):
+    def header(self, body):
         """Display text in header formatting.
 
         Parameters
@@ -80,9 +97,9 @@ class MarkdownMixin:
         """
         header_proto = MarkdownProto()
         header_proto.body = "## %s" % _clean_text(body)
-        return dg._enqueue("markdown", header_proto)  # type: ignore
+        return self.dg._enqueue("markdown", header_proto)
 
-    def subheader(dg, body):
+    def subheader(self, body):
         """Display text in subheader formatting.
 
         Parameters
@@ -101,9 +118,9 @@ class MarkdownMixin:
         """
         subheader_proto = MarkdownProto()
         subheader_proto.body = "### %s" % _clean_text(body)
-        return dg._enqueue("markdown", subheader_proto)  # type: ignore
+        return self.dg._enqueue("markdown", subheader_proto)
 
-    def code(dg, body, language="python"):
+    def code(self, body, language="python"):
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -134,9 +151,9 @@ class MarkdownMixin:
             "body": body,
         }
         code_proto.body = _clean_text(markdown)
-        return dg._enqueue("markdown", code_proto)  # type: ignore
+        return self.dg._enqueue("markdown", code_proto)
 
-    def title(dg, body):
+    def title(self, body):
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not
@@ -158,9 +175,9 @@ class MarkdownMixin:
         """
         title_proto = MarkdownProto()
         title_proto.body = "# %s" % _clean_text(body)
-        return dg._enqueue("markdown", title_proto)  # type: ignore
+        return self.dg._enqueue("markdown", title_proto)
 
-    def latex(dg, body):
+    def latex(self, body):
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.
         r"""Display mathematical expressions formatted as LaTeX.
@@ -196,4 +213,9 @@ class MarkdownMixin:
 
         latex_proto = MarkdownProto()
         latex_proto.body = "$$\n%s\n$$" % _clean_text(body)
-        return dg._enqueue("markdown", latex_proto)  # type: ignore
+        return self.dg._enqueue("markdown", latex_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/media_proto.py
+++ b/lib/streamlit/elements/media_proto.py
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit import type_util
-
 import io
 import re
+from typing import cast
 
 from validators import url
 
+import streamlit
 from streamlit import type_util
+from streamlit.media_file_manager import media_file_manager
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
-from streamlit.media_file_manager import media_file_manager
 
 
 class MediaMixin:
-    def audio(dg, data, format="audio/wav", start_time=0):
+    def audio(self, data, format="audio/wav", start_time=0):
         """Display an audio player.
 
         Parameters
@@ -55,11 +55,11 @@ class MediaMixin:
 
         """
         audio_proto = AudioProto()
-        coordinates = dg._get_delta_path_str()  # type: ignore
+        coordinates = self.dg._get_delta_path_str()
         marshall_audio(coordinates, audio_proto, data, format, start_time)
-        return dg._enqueue("audio", audio_proto)  # type: ignore
+        return self.dg._enqueue("audio", audio_proto)
 
-    def video(dg, data, format="video/mp4", start_time=0):
+    def video(self, data, format="video/mp4", start_time=0):
         """Display a video player.
 
         Parameters
@@ -96,9 +96,14 @@ class MediaMixin:
 
         """
         video_proto = VideoProto()
-        coordinates = dg._get_delta_path_str()  # type: ignore
+        coordinates = self.dg._get_delta_path_str()
         marshall_video(coordinates, video_proto, data, format, start_time)
-        return dg._enqueue("video", video_proto)  # type: ignore
+        return self.dg._enqueue("video", video_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 # Regular expression explained at https://regexr.com/4n2l2 Covers any youtube

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -1,11 +1,28 @@
-from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.type_util import is_type, ensure_iterable
-from .utils import _get_widget_ui_value, NoValue
+from .utils import _get_widget_ui_value
 
 
 class MultiSelectMixin:
-    def multiselect(dg, label, options, default=None, format_func=str, key=None):
+    def multiselect(self, label, options, default=None, format_func=str, key=None):
         """Display a multiselect widget.
         The multiselect widget starts as empty.
 
@@ -89,4 +106,9 @@ class MultiSelectMixin:
         ui_value = _get_widget_ui_value("multiselect", multiselect_proto, user_key=key)
         current_value = ui_value.data if ui_value is not None else default_value
         return_value = [options[i] for i in current_value]
-        return dg._enqueue("multiselect", multiselect_proto, return_value)  # type: ignore
+        return self.dg._enqueue("multiselect", multiselect_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -1,14 +1,30 @@
-import numbers
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
+import numbers
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber, JSNumberBoundsException
+from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
 from .utils import _get_widget_ui_value, NoValue
 
 
 class NumberInputMixin:
     def number_input(
-        dg,
+        self,
         label,
         min_value=None,
         max_value=None,
@@ -199,4 +215,9 @@ class NumberInputMixin:
         )
 
         return_value = ui_value if ui_value is not None else value
-        return dg._enqueue("number_input", number_input_proto, return_value)  # type: ignore
+        return self.dg._enqueue("number_input", number_input_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import numbers
 from typing import cast
 

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -26,16 +26,18 @@ from streamlit.proto.PlotlyChart_pb2 import PlotlyChart as PlotlyChartProto
 
 LOGGER = get_logger(__name__)
 
-SHARING_MODES = {
-    # This means the plot will be sent to the Streamlit app rather than to
-    # Plotly.
-    "streamlit",
-    # The three modes below are for plots that should be hosted in Plotly.
-    # These are the names Plotly uses for them.
-    "private",
-    "public",
-    "secret",
-}
+SHARING_MODES = set(
+    [
+        # This means the plot will be sent to the Streamlit app rather than to
+        # Plotly.
+        "streamlit",
+        # The three modes below are for plots that should be hosted in Plotly.
+        # These are the names Plotly uses for them.
+        "private",
+        "public",
+        "secret",
+    ]
+)
 
 
 class PlotlyMixin:

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -16,32 +16,31 @@
 
 import json
 import urllib.parse
+from typing import cast
 
+import streamlit
 from streamlit import caching
 from streamlit import type_util
-
 from streamlit.logger import get_logger
 from streamlit.proto.PlotlyChart_pb2 import PlotlyChart as PlotlyChartProto
 
 LOGGER = get_logger(__name__)
 
-SHARING_MODES = set(
-    [
-        # This means the plot will be sent to the Streamlit app rather than to
-        # Plotly.
-        "streamlit",
-        # The three modes below are for plots that should be hosted in Plotly.
-        # These are the names Plotly uses for them.
-        "private",
-        "public",
-        "secret",
-    ]
-)
+SHARING_MODES = {
+    # This means the plot will be sent to the Streamlit app rather than to
+    # Plotly.
+    "streamlit",
+    # The three modes below are for plots that should be hosted in Plotly.
+    # These are the names Plotly uses for them.
+    "private",
+    "public",
+    "secret",
+}
 
 
 class PlotlyMixin:
     def plotly_chart(
-        dg,
+        self,
         figure_or_data,
         use_container_width=False,
         sharing="streamlit",
@@ -112,13 +111,17 @@ class PlotlyMixin:
         # NOTE: "figure_or_data" is the name used in Plotly's .plot() method
         # for their main parameter. I don't like the name, but it's best to
         # keep it in sync with what Plotly calls it.
-        import streamlit.elements.plotly_chart as plotly_chart
 
         plotly_chart_proto = PlotlyChartProto()
         marshall(
             plotly_chart_proto, figure_or_data, use_container_width, sharing, **kwargs
         )
-        return dg._enqueue("plotly_chart", plotly_chart_proto)  # type: ignore
+        return self.dg._enqueue("plotly_chart", plotly_chart_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(proto, figure_or_data, use_container_width, sharing, **kwargs):

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -1,9 +1,26 @@
-from streamlit.proto.Progress_pb2 import Progress as ProgressProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Progress_pb2 import Progress as ProgressProto
 
 
 class ProgressMixin:
-    def progress(dg, value):
+    def progress(self, value):
         """Display a progress bar.
 
         Parameters
@@ -49,4 +66,9 @@ class ProgressMixin:
                 "Progress Value has invalid type: %s" % type(value).__name__
             )
 
-        return dg._enqueue("progress", progress_proto)  # type: ignore
+        return self.dg._enqueue("progress", progress_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -15,20 +15,20 @@
 """Streamlit support for Matplotlib PyPlot charts."""
 
 import io
+from typing import cast
 
+import streamlit
+import streamlit.elements.image_proto as image_proto
 from streamlit import config
-from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.errors import StreamlitDeprecationWarning
 from streamlit.logger import get_logger
-
-import streamlit.elements.image_proto as image_proto
-
+from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 
 LOGGER = get_logger(__name__)
 
 
 class PyplotMixin:
-    def pyplot(dg, fig=None, clear_figure=None, **kwargs):
+    def pyplot(self, fig=None, clear_figure=None, **kwargs):
         """Display a matplotlib.pyplot figure.
 
         Parameters
@@ -86,11 +86,18 @@ class PyplotMixin:
         """
 
         if not fig and config.get_option("deprecation.showPyplotGlobalUse"):
-            dg.exception(PyplotGlobalUseWarning())  # type: ignore
+            self.dg.exception(PyplotGlobalUseWarning())
 
         image_list_proto = ImageListProto()
-        marshall(dg._get_delta_path_str(), image_list_proto, fig, clear_figure, **kwargs)  # type: ignore
-        return dg._enqueue("imgs", image_list_proto)  # type: ignore
+        marshall(
+            self.dg._get_delta_path_str(), image_list_proto, fig, clear_figure, **kwargs
+        )
+        return self.dg._enqueue("imgs", image_list_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(coordinates, image_list_proto, fig=None, clear_figure=True, **kwargs):

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -1,11 +1,28 @@
-from streamlit.proto.Radio_pb2 import Radio as RadioProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.type_util import ensure_iterable
 from .utils import _get_widget_ui_value, NoValue
 
 
 class RadioMixin:
-    def radio(dg, label, options, index=0, format_func=str, key=None):
+    def radio(self, label, options, index=0, format_func=str, key=None):
         """Display a radio button widget.
 
         Parameters
@@ -70,4 +87,9 @@ class RadioMixin:
             if len(options) > 0 and options[current_value] is not None
             else NoValue
         )
-        return dg._enqueue("radio", radio_proto, return_value)  # type: ignore
+        return self.dg._enqueue("radio", radio_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -1,12 +1,29 @@
-from streamlit.proto.Slider_pb2 import Slider as SliderProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.type_util import ensure_iterable
 from .utils import _get_widget_ui_value
 
 
 class SelectSliderMixin:
     def select_slider(
-        dg,
+        self,
         label,
         options=[],
         value=None,
@@ -116,4 +133,9 @@ class SelectSliderMixin:
 
         # If the original value was a list/tuple, so will be the output (and vice versa)
         return_value = tuple(current_value) if is_range_value else current_value[0]
-        return dg._enqueue("slider", slider_proto, return_value)  # type: ignore
+        return self.dg._enqueue("slider", slider_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -1,11 +1,28 @@
-from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.type_util import ensure_iterable
 from .utils import _get_widget_ui_value, NoValue
 
 
 class SelectboxMixin:
-    def selectbox(dg, label, options, index=0, format_func=str, key=None):
+    def selectbox(self, label, options, index=0, format_func=str, key=None):
         """Display a select widget.
 
         Parameters
@@ -65,4 +82,9 @@ class SelectboxMixin:
             if len(options) > 0 and options[current_value] is not None
             else NoValue
         )
-        return dg._enqueue("selectbox", selectbox_proto, return_value)  # type: ignore
+        return self.dg._enqueue("selectbox", selectbox_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from datetime import date, time, datetime, timedelta, timezone
 from typing import cast
 

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -1,15 +1,31 @@
-from datetime import date, time, datetime, timedelta, timezone
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from streamlit.proto.Slider_pb2 import Slider as SliderProto
+from datetime import date, time, datetime, timedelta, timezone
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
+from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from .utils import _get_widget_ui_value
 
 
 class SliderMixin:
     def slider(
-        dg,
+        self,
         label,
         min_value=None,
         max_value=None,
@@ -372,4 +388,9 @@ class SliderMixin:
             ]
         # If the original value was a list/tuple, so will be the output (and vice versa)
         return_value = current_value[0] if single_value else tuple(current_value)
-        return dg._enqueue("slider", slider_proto, return_value)  # type: ignore
+        return self.dg._enqueue("slider", slider_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -1,9 +1,26 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.proto.Text_pb2 import Text as TextProto
 from .utils import _clean_text
 
 
 class TextMixin:
-    def text(dg, body):
+    def text(self, body):
         """Write fixed-width and preformatted text.
 
         Parameters
@@ -22,4 +39,9 @@ class TextMixin:
         """
         text_proto = TextProto()
         text_proto.body = _clean_text(body)
-        return dg._enqueue("text", text_proto)  # type: ignore
+        return self.dg._enqueue("text", text_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -1,11 +1,28 @@
-from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
-from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
+from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
 from .utils import _get_widget_ui_value
 
 
 class TextWidgetsMixin:
-    def text_input(dg, label, value="", max_chars=None, key=None, type="default"):
+    def text_input(self, label, value="", max_chars=None, key=None, type="default"):
         """Display a single-line text input widget.
 
         Parameters
@@ -57,9 +74,9 @@ class TextWidgetsMixin:
 
         ui_value = _get_widget_ui_value("text_input", text_input_proto, user_key=key)
         current_value = ui_value if ui_value is not None else value
-        return dg._enqueue("text_input", text_input_proto, str(current_value))  # type: ignore
+        return self.dg._enqueue("text_input", text_input_proto, str(current_value))
 
-    def text_area(dg, label, value="", height=None, max_chars=None, key=None):
+    def text_area(self, label, value="", height=None, max_chars=None, key=None):
         """Display a multi-line text input widget.
 
         Parameters
@@ -109,4 +126,9 @@ class TextWidgetsMixin:
 
         ui_value = _get_widget_ui_value("text_area", text_area_proto, user_key=key)
         current_value = ui_value if ui_value is not None else value
-        return dg._enqueue("text_area", text_area_proto, str(current_value))  # type: ignore
+        return self.dg._enqueue("text_area", text_area_proto, str(current_value))
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from typing import cast
 
 import streamlit

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -1,13 +1,29 @@
-from datetime import datetime, date, time
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
-from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
+from datetime import datetime, date, time
+from typing import cast
+
+import streamlit
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
+from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
 from .utils import _get_widget_ui_value
 
 
 class TimeWidgetsMixin:
-    def time_input(dg, label, value=None, key=None):
+    def time_input(self, label, value=None, key=None):
         """Display a time input widget.
 
         Parameters
@@ -58,10 +74,15 @@ class TimeWidgetsMixin:
             if ui_value is not None
             else value
         )
-        return dg._enqueue("time_input", time_input_proto, current_value)  # type: ignore
+        return self.dg._enqueue("time_input", time_input_proto, current_value)
 
     def date_input(
-        dg, label, value=None, min_value=None, max_value=None, key=None,
+        self,
+        label,
+        value=None,
+        min_value=None,
+        max_value=None,
+        key=None,
     ):
         """Display a date input widget.
 
@@ -143,4 +164,9 @@ class TimeWidgetsMixin:
             value = [datetime.strptime(v, "%Y/%m/%d").date() for v in value]
 
         return_value = value[0] if single_value else tuple(value)
-        return dg._enqueue("date_input", date_input_proto, return_value)  # type: ignore
+        return self.dg._enqueue("date_input", date_input_proto, return_value)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from datetime import datetime, date, time
 from typing import cast
 

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import textwrap
 
 from streamlit import type_util

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import textwrap
 
 from streamlit import type_util

--- a/lib/streamlit/elements/vega_lite.py
+++ b/lib/streamlit/elements/vega_lite.py
@@ -15,19 +15,24 @@
 """A Python wrapper around Vega-Lite."""
 
 import json
+from typing import cast
 
-import streamlit.elements.lib.dicttools as dicttools
+import streamlit
 import streamlit.elements.data_frame_proto as data_frame_proto
-
-from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart as VegaLiteChartProto
+import streamlit.elements.lib.dicttools as dicttools
 from streamlit.logger import get_logger
+from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart as VegaLiteChartProto
 
 LOGGER = get_logger(__name__)
 
 
 class VegaLiteMixin:
     def vega_lite_chart(
-        dg, data=None, spec=None, use_container_width=False, **kwargs,
+        self,
+        data=None,
+        spec=None,
+        use_container_width=False,
+        **kwargs,
     ):
         """Display a chart using the Vega-Lite library.
 
@@ -87,7 +92,12 @@ class VegaLiteMixin:
             use_container_width=use_container_width,
             **kwargs,
         )
-        return dg._enqueue("vega_lite_chart", vega_lite_chart_proto)  # type: ignore
+        return self.dg._enqueue("vega_lite_chart", vega_lite_chart_proto)
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
 def marshall(proto, data=None, spec=None, use_container_width=False, **kwargs):

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -1,17 +1,3 @@
-# Copyright 2018-2020 Streamlit Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import json as json
 import types
 from typing import cast, Any, List, Tuple, Type

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -1,9 +1,24 @@
-import types
-import json as json
-import numpy as np
+# Copyright 2018-2020 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import json as json
+import types
 from typing import cast, Any, List, Tuple, Type
 
+import numpy as np
+
+import streamlit
 from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
 
@@ -131,18 +146,13 @@ class WriteMixin:
             height: 200px
 
         """
-        # Import dynamically, to resolve circular dependency
-        from streamlit.delta_generator import DeltaGenerator
-
-        # Cast self to DeltaGenerator, to resolve mypy type issues
-        dg = cast(DeltaGenerator, self)
         string_buffer = []  # type: List[str]
         unsafe_allow_html = kwargs.get("unsafe_allow_html", False)
 
         # This bans some valid cases like: e = st.empty(); e.write("a", "b").
         # BUT: 1) such cases are rare, 2) this rule is easy to understand,
         # and 3) this rule should be removed once we have st.container()
-        if not dg._is_top_level and len(args) > 1:
+        if not self.dg._is_top_level and len(args) > 1:
             raise StreamlitAPIException(
                 "Cannot replace a single element with multiple elements.\n\n"
                 "The `write()` method only supports multiple elements when "
@@ -152,8 +162,9 @@ class WriteMixin:
 
         def flush_buffer():
             if string_buffer:
-                dg.markdown(
-                    " ".join(string_buffer), unsafe_allow_html=unsafe_allow_html,
+                self.dg.markdown(
+                    " ".join(string_buffer),
+                    unsafe_allow_html=unsafe_allow_html,
                 )
                 string_buffer[:] = []
 
@@ -164,49 +175,54 @@ class WriteMixin:
             elif type_util.is_dataframe_like(arg):
                 flush_buffer()
                 if len(np.shape(arg)) > 2:
-                    dg.text(arg)
+                    self.dg.text(arg)
                 else:
-                    dg.dataframe(arg)
+                    self.dg.dataframe(arg)
             elif isinstance(arg, Exception):
                 flush_buffer()
-                dg.exception(arg)
+                self.dg.exception(arg)
             elif isinstance(arg, HELP_TYPES):
                 flush_buffer()
-                dg.help(arg)
+                self.dg.help(arg)
             elif type_util.is_altair_chart(arg):
                 flush_buffer()
-                dg.altair_chart(arg)
+                self.dg.altair_chart(arg)
             elif type_util.is_type(arg, "matplotlib.figure.Figure"):
                 flush_buffer()
-                dg.pyplot(arg)
+                self.dg.pyplot(arg)
             elif type_util.is_plotly_chart(arg):
                 flush_buffer()
-                dg.plotly_chart(arg)
+                self.dg.plotly_chart(arg)
             elif type_util.is_type(arg, "bokeh.plotting.figure.Figure"):
                 flush_buffer()
-                dg.bokeh_chart(arg)
+                self.dg.bokeh_chart(arg)
             elif type_util.is_graphviz_chart(arg):
                 flush_buffer()
-                dg.graphviz_chart(arg)
+                self.dg.graphviz_chart(arg)
             elif type_util.is_sympy_expession(arg):
                 flush_buffer()
-                dg.latex(arg)
+                self.dg.latex(arg)
             elif type_util.is_keras_model(arg):
                 from tensorflow.python.keras.utils import vis_utils
 
                 flush_buffer()
                 dot = vis_utils.model_to_dot(arg)
-                dg.graphviz_chart(dot.to_string())
+                self.dg.graphviz_chart(dot.to_string())
             elif isinstance(arg, (dict, list)):
                 flush_buffer()
-                dg.json(arg)
+                self.dg.json(arg)
             elif type_util.is_namedtuple(arg):
                 flush_buffer()
-                dg.json(json.dumps(arg._asdict()))
+                self.dg.json(json.dumps(arg._asdict()))
             elif type_util.is_pydeck(arg):
                 flush_buffer()
-                dg.pydeck_chart(arg)
+                self.dg.pydeck_chart(arg)
             else:
                 string_buffer.append("`%s`" % str(arg).replace("`", "\\`"))
 
         flush_buffer()
+
+    @property
+    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("streamlit.delta_generator.DeltaGenerator", self)


### PR DESCRIPTION
Our DeltaGenerator mixin classes access DeltaGenerator members, but the type system doesn't know that they're actually "part" of the DeltaGenerator class.

This PR adds a `self.dg` property to each mixin. It just does a mypy cast from self to DeltaGenerator. (And it avoids importing DeltaGenerator, to prevent circular import hell.)

This has two benefits:
- We get autocompletion for DG properties and methods from within the mixins
- We can stop disabling mypy via  `# type: ignore` within mixins