### PR TITLE
File uploader session check

### DIFF
--- a/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -25,7 +25,7 @@ import {
 import { mergeOverrides } from "baseui"
 import { Overrides } from "baseui/overrides"
 
-export enum Sizes {
+export enum Size {
   SMALL = "sm",
   MEDIUM = "md",
   LARGE = "lg",
@@ -36,13 +36,13 @@ export interface ProgressBarProps {
   width?: number
   value: number
   overrides?: Overrides<any>
-  size?: Sizes
+  size?: Size
 }
 
 function ProgressBar({
   value,
   width,
-  size = Sizes.MEDIUM,
+  size = Size.MEDIUM,
   overrides,
 }: ProgressBarProps): ReactElement {
   const theme: Theme = useTheme()

--- a/frontend/src/components/shared/ProgressBar/index.tsx
+++ b/frontend/src/components/shared/ProgressBar/index.tsx
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export { default, Sizes } from "./ProgressBar"
+export { default, Size } from "./ProgressBar"

--- a/frontend/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -18,7 +18,7 @@
 import React from "react"
 import { CloudUpload } from "@emotion-icons/material-outlined"
 import Icon from "components/shared/Icon"
-import { FileSizes, getSizeDisplay } from "lib/FileHelper"
+import { FileSize, getSizeDisplay } from "lib/FileHelper"
 import { Small } from "components/shared/TextElements"
 
 import {
@@ -48,7 +48,7 @@ const FileDropzoneInstructions = ({
         Drag and drop file{multiple ? "s" : ""} here
       </StyledFileDropzoneInstructionsStyledSpan>
       <Small>
-        {`Limit ${getSizeDisplay(maxSizeBytes, FileSizes.Byte, 0)} per file`}
+        {`Limit ${getSizeDisplay(maxSizeBytes, FileSize.Byte, 0)} per file`}
         {acceptedExtensions.length
           ? ` • ${acceptedExtensions
               .join(", ")

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -228,7 +228,7 @@ class FileUploader extends React.PureComponent<Props, State> {
     }
   }
 
-  private setError = (errorMessage: string) => {
+  private setError = (errorMessage: string): void => {
     this.setState({
       status: FileStatuses.ERROR,
       errorMessage,

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -22,8 +22,8 @@ import { FileUploader as FileUploaderProto } from "autogen/proto"
 
 import {
   ExtendedFile,
-  FileSizes,
-  FileStatuses,
+  FileSize,
+  FileStatus,
   getSizeDisplay,
   sizeConverter,
 } from "lib/FileHelper"
@@ -61,7 +61,7 @@ class FileUploader extends React.PureComponent<Props, State> {
       status: "READY",
       errorMessage: undefined,
       files: [],
-      maxSizeBytes: sizeConverter(maxMbs, FileSizes.MegaByte, FileSizes.Byte),
+      maxSizeBytes: sizeConverter(maxMbs, FileSize.MegaByte, FileSize.Byte),
     }
   }
 
@@ -80,8 +80,8 @@ class FileUploader extends React.PureComponent<Props, State> {
       this.setState({
         maxSizeBytes: sizeConverter(
           currentMaxSize,
-          FileSizes.MegaByte,
-          FileSizes.Byte
+          FileSize.MegaByte,
+          FileSize.Byte
         ),
       })
     }
@@ -89,7 +89,7 @@ class FileUploader extends React.PureComponent<Props, State> {
 
   public reset = (): void => {
     this.setState({
-      status: FileStatuses.READY,
+      status: FileStatus.READY,
       errorMessage: undefined,
       files: [],
     })
@@ -155,7 +155,7 @@ class FileUploader extends React.PureComponent<Props, State> {
 
   private uploadFile = (file: ExtendedFile, index: number): void => {
     file.progress = 1
-    file.status = FileStatuses.UPLOADING
+    file.status = FileStatus.UPLOADING
     const updatedFile = this.handleFile(file, index)
     this.props.uploadClient
       .uploadFiles(
@@ -176,7 +176,7 @@ class FileUploader extends React.PureComponent<Props, State> {
             if (file.id === existingFile.id) {
               delete file.progress
               delete file.cancelToken
-              file.status = FileStatuses.UPLOADED
+              file.status = FileStatus.UPLOADED
               return file
             }
             return existingFile
@@ -196,7 +196,7 @@ class FileUploader extends React.PureComponent<Props, State> {
   private rejectFiles = (rejectedFiles: FileRejection[]): void => {
     rejectedFiles.forEach((rejectedFile, index) => {
       Object.assign(rejectedFile.file, {
-        status: FileStatuses.ERROR,
+        status: FileStatus.ERROR,
         errorMessage: this.getErrorMessage(
           rejectedFile.errors[0].code,
           rejectedFile.file
@@ -214,7 +214,7 @@ class FileUploader extends React.PureComponent<Props, State> {
       case "file-too-large":
         return `File must be ${getSizeDisplay(
           this.state.maxSizeBytes,
-          FileSizes.Byte
+          FileSize.Byte
         )} or smaller.`
       case "file-invalid-type":
         return `${file.type} files are not allowed.`
@@ -230,7 +230,7 @@ class FileUploader extends React.PureComponent<Props, State> {
 
   private setError = (errorMessage: string): void => {
     this.setState({
-      status: FileStatuses.ERROR,
+      status: FileStatus.ERROR,
       errorMessage,
     })
   }
@@ -238,9 +238,9 @@ class FileUploader extends React.PureComponent<Props, State> {
   private delete = (fileId: string): void => {
     const file = this.state.files.find(file => file.id === fileId)
     if (fileId && file) {
-      file.status = FileStatuses.DELETING
       if (file.errorMessage) {
         this.removeFile(fileId)
+        return
       }
 
       if (file.cancelToken) {
@@ -258,7 +258,6 @@ class FileUploader extends React.PureComponent<Props, State> {
           }
         }
       )
-      this.setState({ files: this.state.files })
     } else {
       this.setError("File not found. Please try again.")
     }
@@ -270,8 +269,8 @@ class FileUploader extends React.PureComponent<Props, State> {
         const filteredFiles = state.files.filter(file => file.id !== fileId)
         return {
           status: filteredFiles.length
-            ? FileStatuses.UPLOADED
-            : FileStatuses.READY,
+            ? FileStatus.UPLOADED
+            : FileStatus.READY,
           errorMessage: undefined,
           files: filteredFiles,
         }

--- a/frontend/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -21,7 +21,7 @@ import { mount, shallow } from "lib/test_util"
 import { Small } from "components/shared/TextElements"
 import ProgressBar from "components/shared/ProgressBar"
 import Button from "components/shared/Button"
-import { FileStatuses } from "lib/FileHelper"
+import { FileStatus } from "lib/FileHelper"
 
 import UploadedFile, { Props, FileStatus } from "./UploadedFile"
 
@@ -55,7 +55,7 @@ describe("FileStatus widget", () => {
 
   it("should show error", () => {
     const props = getProps({
-      file: { status: FileStatuses.ERROR, ...blobFile },
+      file: { status: FileStatus.ERROR, ...blobFile },
     })
     const wrapper = shallow(<FileStatus {...props} />)
     const errorMessageWrapper = wrapper.find("StyledErrorMessage")
@@ -64,7 +64,7 @@ describe("FileStatus widget", () => {
 
   it("should show deleting", () => {
     const props = getProps({
-      file: { status: FileStatuses.DELETING, ...blobFile },
+      file: { status: FileStatus.DELETING, ...blobFile },
     })
     const wrapper = shallow(<FileStatus {...props} />)
     const statusWrapper = wrapper.find(Small)
@@ -75,7 +75,7 @@ describe("FileStatus widget", () => {
     const props = getProps({
       file: {
         size: 2000,
-        status: FileStatuses.UPLOADED,
+        status: FileStatus.UPLOADED,
         ...blobFile,
       },
     })

--- a/frontend/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -23,7 +23,7 @@ import ProgressBar from "components/shared/ProgressBar"
 import Button from "components/shared/Button"
 import { FileStatus } from "lib/FileHelper"
 
-import UploadedFile, { Props, FileStatus } from "./UploadedFile"
+import UploadedFile, { Props, UploadedFileStatus } from "./UploadedFile"
 
 const blobFile = new File(["Text in a file!"], "filename.txt", {
   type: "text/plain",
@@ -40,14 +40,14 @@ const getProps = (props: Partial<Props> = {}): Props => ({
 describe("FileStatus widget", () => {
   it("renders without crashing", () => {
     const props = getProps()
-    const wrapper = shallow(<FileStatus {...props} />)
+    const wrapper = shallow(<UploadedFileStatus {...props} />)
 
     expect(wrapper).toBeDefined()
   })
 
   it("should show progress bar", () => {
     const props = getProps({ progress: 40 })
-    const wrapper = shallow(<FileStatus {...props} />)
+    const wrapper = shallow(<UploadedFileStatus {...props} />)
     const progressBarWrapper = wrapper.find(ProgressBar)
 
     expect(progressBarWrapper.length).toBe(1)
@@ -57,7 +57,7 @@ describe("FileStatus widget", () => {
     const props = getProps({
       file: { status: FileStatus.ERROR, ...blobFile },
     })
-    const wrapper = shallow(<FileStatus {...props} />)
+    const wrapper = shallow(<UploadedFileStatus {...props} />)
     const errorMessageWrapper = wrapper.find("StyledErrorMessage")
     expect(errorMessageWrapper.length).toBe(1)
   })
@@ -66,7 +66,7 @@ describe("FileStatus widget", () => {
     const props = getProps({
       file: { status: FileStatus.DELETING, ...blobFile },
     })
-    const wrapper = shallow(<FileStatus {...props} />)
+    const wrapper = shallow(<UploadedFileStatus {...props} />)
     const statusWrapper = wrapper.find(Small)
     expect(statusWrapper.text()).toBe("Removing file")
   })
@@ -74,13 +74,13 @@ describe("FileStatus widget", () => {
   it("should show size", () => {
     const props = getProps({
       file: {
+        ...blobFile,
         size: 2000,
         status: FileStatus.UPLOADED,
-        ...blobFile,
       },
     })
 
-    const wrapper = shallow(<FileStatus {...props} />)
+    const wrapper = shallow(<UploadedFileStatus {...props} />)
     const statusWrapper = wrapper.find(Small)
     expect(statusWrapper.text()).toBe("2.0KB")
   })

--- a/frontend/src/components/widgets/FileUploader/UploadedFile.tsx
+++ b/frontend/src/components/widgets/FileUploader/UploadedFile.tsx
@@ -23,12 +23,12 @@ import {
 } from "@emotion-icons/material-outlined"
 import Button, { Kind } from "components/shared/Button"
 import Icon from "components/shared/Icon"
-import ProgressBar, { Sizes } from "components/shared/ProgressBar"
+import ProgressBar, { Size } from "components/shared/ProgressBar"
 import { Small, Kind as TextKind } from "components/shared/TextElements"
 import {
   ExtendedFile,
-  FileSizes,
-  FileStatuses,
+  FileSize,
+  FileStatus,
   getSizeDisplay,
 } from "lib/FileHelper"
 import {
@@ -47,20 +47,20 @@ export interface Props {
   onDelete: (id: string) => void
 }
 
-export interface FileStatusProps {
+export interface UploadedFileStatusProps {
   file: ExtendedFile
   progress?: number
 }
 
-export const FileStatus = ({
+export const UploadedFileStatus = ({
   file,
   progress,
-}: FileStatusProps): React.ReactElement | null => {
+}: UploadedFileStatusProps): React.ReactElement | null => {
   if (progress) {
     return (
       <ProgressBar
         value={progress}
-        size={Sizes.SMALL}
+        size={Size.SMALL}
         overrides={{
           Bar: {
             style: {
@@ -73,7 +73,7 @@ export const FileStatus = ({
     )
   }
 
-  if (file.status === FileStatuses.ERROR) {
+  if (file.status === FileStatus.ERROR) {
     return (
       <StyledFileError>
         <StyledErrorMessage data-testid="stUploadedFileErrorMessage">
@@ -86,15 +86,15 @@ export const FileStatus = ({
     )
   }
 
-  if (file.status === FileStatuses.UPLOADED) {
+  if (file.status === FileStatus.UPLOADED) {
     return (
       <Small kind={TextKind.SECONDARY}>
-        {getSizeDisplay(file.size, FileSizes.Byte)}
+        {getSizeDisplay(file.size, FileSize.Byte)}
       </Small>
     )
   }
 
-  if (file.status === FileStatuses.DELETING) {
+  if (file.status === FileStatus.DELETING) {
     return <Small kind={TextKind.SECONDARY}>Removing file</Small>
   }
 
@@ -115,7 +115,7 @@ const UploadedFile = ({
         <StyledUploadedFileName className="uploadedFileName" title={file.name}>
           {file.name}
         </StyledUploadedFileName>
-        <FileStatus file={file} progress={progress} />
+        <UploadedFileStatus file={file} progress={progress} />
       </StyledUploadedFileData>
       <Button onClick={() => onDelete(file.id || "")} kind={Kind.MINIMAL}>
         <Icon content={Clear} size="lg" />

--- a/frontend/src/lib/FileHelper.test.ts
+++ b/frontend/src/lib/FileHelper.test.ts
@@ -18,103 +18,99 @@
 import {
   getSizeDisplay,
   sizeConverter,
-  FileSizes,
+  FileSize,
   BYTE_CONVERSION_SIZE,
 } from "./FileHelper"
 
 describe("getSizeDisplay", () => {
   test("it shows unit", async () => {
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte)).toEqual(
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSize.Byte)).toEqual(
       "1.0KB"
     )
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE ** 2, FileSizes.Byte)).toEqual(
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE ** 2, FileSize.Byte)).toEqual(
       "1.0MB"
     )
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE ** 3, FileSizes.Byte)).toEqual(
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE ** 3, FileSize.Byte)).toEqual(
       "1.0GB"
     )
 
-    expect(getSizeDisplay(10, FileSizes.GigaByte)).toEqual("10.0GB")
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.MegaByte)).toEqual(
+    expect(getSizeDisplay(10, FileSize.GigaByte)).toEqual("10.0GB")
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSize.MegaByte)).toEqual(
       "1.0GB"
     )
   })
 
   test("it has unusual values", async () => {
-    expect(() => getSizeDisplay(-100, FileSizes.Byte)).toThrow(
+    expect(() => getSizeDisplay(-100, FileSize.Byte)).toThrow(
       "Size must be greater than or equal to 0"
     )
-    expect(getSizeDisplay(0, FileSizes.Byte, -1)).toEqual("0B")
+    expect(getSizeDisplay(0, FileSize.Byte, -1)).toEqual("0B")
   })
 
   test("it truncates to the right amount of decimals", async () => {
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte)).toEqual(
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSize.Byte)).toEqual(
       "1.0KB"
     )
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte, 0)).toEqual(
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSize.Byte, 0)).toEqual(
       "1KB"
     )
-    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSizes.Byte, 3)).toEqual(
+    expect(getSizeDisplay(BYTE_CONVERSION_SIZE, FileSize.Byte, 3)).toEqual(
       "1.000KB"
     )
   })
 
   test("it rounds up to the next unit", async () => {
-    expect(getSizeDisplay(500, FileSizes.Byte)).toEqual("500.0B")
-    expect(getSizeDisplay(800, FileSizes.Byte)).toEqual("0.8KB")
-    expect(getSizeDisplay(501, FileSizes.GigaByte)).toEqual("501.0GB")
+    expect(getSizeDisplay(500, FileSize.Byte)).toEqual("500.0B")
+    expect(getSizeDisplay(800, FileSize.Byte)).toEqual("0.8KB")
+    expect(getSizeDisplay(501, FileSize.GigaByte)).toEqual("501.0GB")
   })
 })
 
 describe("sizeConverter", () => {
   test("it converts up to the bigger unit", async () => {
-    expect(sizeConverter(0.5, FileSizes.KiloByte, FileSizes.MegaByte)).toEqual(
+    expect(sizeConverter(0.5, FileSize.KiloByte, FileSize.MegaByte)).toEqual(
       0.5 / BYTE_CONVERSION_SIZE
     )
     expect(
-      sizeConverter(BYTE_CONVERSION_SIZE, FileSizes.Byte, FileSizes.KiloByte)
+      sizeConverter(BYTE_CONVERSION_SIZE, FileSize.Byte, FileSize.KiloByte)
     ).toEqual(1)
     expect(
       sizeConverter(
         BYTE_CONVERSION_SIZE ** 2,
-        FileSizes.KiloByte,
-        FileSizes.GigaByte
+        FileSize.KiloByte,
+        FileSize.GigaByte
       )
     ).toEqual(1)
-    expect(sizeConverter(1, FileSizes.MegaByte, FileSizes.GigaByte)).toEqual(
+    expect(sizeConverter(1, FileSize.MegaByte, FileSize.GigaByte)).toEqual(
       1 / BYTE_CONVERSION_SIZE
     )
   })
 
   test("it converts down to the smaller unit", async () => {
-    expect(sizeConverter(0.5, FileSizes.GigaByte, FileSizes.MegaByte)).toEqual(
+    expect(sizeConverter(0.5, FileSize.GigaByte, FileSize.MegaByte)).toEqual(
       BYTE_CONVERSION_SIZE * 0.5
     )
     expect(
-      sizeConverter(
-        BYTE_CONVERSION_SIZE,
-        FileSizes.GigaByte,
-        FileSizes.KiloByte
-      )
+      sizeConverter(BYTE_CONVERSION_SIZE, FileSize.GigaByte, FileSize.KiloByte)
     ).toEqual(BYTE_CONVERSION_SIZE ** 3)
     expect(
       sizeConverter(
         BYTE_CONVERSION_SIZE ** 2,
-        FileSizes.MegaByte,
-        FileSizes.KiloByte
+        FileSize.MegaByte,
+        FileSize.KiloByte
       )
     ).toEqual(BYTE_CONVERSION_SIZE ** 3)
-    expect(sizeConverter(1, FileSizes.KiloByte, FileSizes.Byte)).toEqual(
+    expect(sizeConverter(1, FileSize.KiloByte, FileSize.Byte)).toEqual(
       BYTE_CONVERSION_SIZE
     )
   })
 
   test("it handles unusual cases", async () => {
     expect(
-      sizeConverter(BYTE_CONVERSION_SIZE, FileSizes.Byte, FileSizes.Byte)
+      sizeConverter(BYTE_CONVERSION_SIZE, FileSize.Byte, FileSize.Byte)
     ).toEqual(BYTE_CONVERSION_SIZE)
     expect(() =>
-      sizeConverter(-1, FileSizes.GigaByte, FileSizes.GigaByte)
+      sizeConverter(-1, FileSize.GigaByte, FileSize.GigaByte)
     ).toThrowError()
   })
 })

--- a/frontend/src/lib/FileHelper.ts
+++ b/frontend/src/lib/FileHelper.ts
@@ -9,7 +9,7 @@ export interface ExtendedFile extends File {
   progress?: number
 }
 
-export enum FileStatuses {
+export enum FileStatus {
   ERROR = "ERROR",
   DELETING = "DELETING",
   READY = "READY",
@@ -17,7 +17,7 @@ export enum FileStatuses {
   UPLOADED = "UPLOADED",
 }
 
-export enum FileSizes {
+export enum FileSize {
   GigaByte = "gb",
   KiloByte = "kb",
   MegaByte = "mb",
@@ -29,19 +29,19 @@ export enum FileSizes {
 // all cases but for simplicity general rule is to use base 2 for Windows.
 export const BYTE_CONVERSION_SIZE = isFromWindows() ? 1024 : 1000
 const sizeUnitSequence = [
-  FileSizes.GigaByte,
-  FileSizes.MegaByte,
-  FileSizes.KiloByte,
-  FileSizes.Byte,
+  FileSize.GigaByte,
+  FileSize.MegaByte,
+  FileSize.KiloByte,
+  FileSize.Byte,
 ]
 
 export const getSizeDisplay = (
   size: number,
-  unit: FileSizes,
+  unit: FileSize,
   rounding = 1
 ): string => {
   if (!unit) {
-    unit = FileSizes.Byte
+    unit = FileSize.Byte
   }
 
   if (rounding < 0) {
@@ -66,8 +66,8 @@ export const getSizeDisplay = (
 
 export const sizeConverter = (
   size: number,
-  inputUnit: FileSizes,
-  outputUnit: FileSizes
+  inputUnit: FileSize,
+  outputUnit: FileSize
 ): number => {
   if (size < 0) {
     throw Error("Size must be 0 or greater")

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -43,7 +43,10 @@ from streamlit.components.v1.components import ComponentRegistry
 from streamlit.components.v1.components import ComponentRequestHandler
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.server.upload_file_request_handler import UploadFileRequestHandler
+from streamlit.server.upload_file_request_handler import (
+    UploadFileRequestHandler,
+    UPLOAD_FILE_ROUTE,
+)
 from streamlit.server.routes import AddSlashHandler
 from streamlit.server.routes import AssetsFileHandler
 from streamlit.server.routes import DebugHandler
@@ -336,7 +339,7 @@ class Server(object):
             (
                 make_url_path_regex(
                     base,
-                    "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
+                    UPLOAD_FILE_ROUTE,
                 ),
                 UploadFileRequestHandler,
                 dict(

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -339,7 +339,10 @@ class Server(object):
                     "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
                 ),
                 UploadFileRequestHandler,
-                dict(file_mgr=self._uploaded_file_mgr),
+                dict(
+                    file_mgr=self._uploaded_file_mgr,
+                    get_session_info=self._get_session_info,
+                ),
             ),
             (
                 make_url_path_regex(base, "assets/(.*)"),

--- a/lib/streamlit/server/upload_file_request_handler.py
+++ b/lib/streamlit/server/upload_file_request_handler.py
@@ -24,6 +24,7 @@ from streamlit.logger import get_logger
 from streamlit.report import Report
 from streamlit.server import routes
 
+
 LOGGER = get_logger(__name__)
 
 
@@ -32,16 +33,23 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
     Implements the POST and DELETE /upload_file endpoint.
     """
 
-    def initialize(self, file_mgr):
+    def initialize(self, file_mgr, get_session_info):
         """
         Parameters
         ----------
         file_mgr : UploadedFileManager
             The server's singleton UploadedFileManager. All file uploads
             go here.
+        get_session_info: Server.get_session_info. Used to validate session IDs
 
         """
         self._file_mgr = file_mgr
+        self._get_session_info = get_session_info
+
+    def _validate_request(self, session_id: str):
+        if self._get_session_info(session_id) is None:
+            return False
+        return True
 
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Methods", "POST, PUT, DELETE")
@@ -110,6 +118,9 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         try:
             session_id = self._require_arg(args, "sessionId")
             widget_id = self._require_arg(args, "widgetId")
+            if not self._validate_request(session_id):
+                raise Exception("Session '%s' invalid" % session_id)
+
         except Exception as e:
             self.send_error(400, reason=str(e))
             return
@@ -154,6 +165,10 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self.set_status(200)
 
     def put(self, session_id: str, widget_id: str, **kwargs):
+        if self._validate_request(session_id) is None:
+            self.send_error(404)
+            return
+
         if self.request.body:
             data = tornado.escape.json_decode(self.request.body)
             if "totalFiles" in data.keys():
@@ -168,7 +183,9 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         self.send_error(400, reason="Nothing to update")
 
     def delete(self, session_id, widget_id, file_id):
-        if session_id is None or widget_id is None or file_id is None:
+        if not all(
+            [session_id, widget_id, file_id, self._validate_request(session_id)]
+        ):
             self.send_error(404)
             return
 

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -92,6 +92,7 @@ class UploadedFileManager(object):
         Add a list of files to the FileManager. Does not emit any signals
         """
         files_by_widget = session_id, widget_id
+
         with self._files_lock:
             file_list = self._files_by_id.get(files_by_widget, None)
             if file_list:

--- a/lib/tests/streamlit/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/upload_file_request_handler_test.py
@@ -24,7 +24,10 @@ import tornado.websocket
 from parameterized import parameterized
 
 from streamlit.logger import get_logger
-from streamlit.server.upload_file_request_handler import UploadFileRequestHandler
+from streamlit.server.upload_file_request_handler import (
+    UploadFileRequestHandler,
+    UPLOAD_FILE_ROUTE,
+)
 from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.uploaded_file_manager import UploadedFileRec
 
@@ -50,7 +53,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         return tornado.web.Application(
             [
                 (
-                    "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
+                    UPLOAD_FILE_ROUTE,
                     UploadFileRequestHandler,
                     dict(
                         file_mgr=self.file_mgr,
@@ -193,7 +196,7 @@ class UploadFileRequestHandlerInvalidSessionTest(tornado.testing.AsyncHTTPTestCa
         return tornado.web.Application(
             [
                 (
-                    "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
+                    UPLOAD_FILE_ROUTE,
                     UploadFileRequestHandler,
                     dict(
                         file_mgr=self.file_mgr,

--- a/lib/tests/streamlit/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/upload_file_request_handler_test.py
@@ -46,17 +46,16 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     def get_app(self):
         self.file_mgr = UploadedFileManager()
+        self._get_session_info = lambda x: True
         return tornado.web.Application(
             [
                 (
-                    "/upload_file/(.*)/(.*)/([0-9]*)?",
+                    "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
                     UploadFileRequestHandler,
-                    dict(file_mgr=self.file_mgr),
-                ),
-                (
-                    "/upload_file",
-                    UploadFileRequestHandler,
-                    dict(file_mgr=self.file_mgr),
+                    dict(
+                        file_mgr=self.file_mgr,
+                        get_session_info=self._get_session_info,
+                    ),
                 ),
             ]
         )
@@ -182,4 +181,78 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             f"/upload_file/{session_id}/{widget_id}/{file_id}", method="DELETE"
         )
 
+        self.assertEqual(404, response.code)
+
+
+class UploadFileRequestHandlerInvalidSessionTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests the /upload_file endpoint."""
+
+    def get_app(self):
+        self.file_mgr = UploadedFileManager()
+        self._get_session_info = lambda x: None
+        return tornado.web.Application(
+            [
+                (
+                    "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?/?(?P<file_id>[0-9]*)?",
+                    UploadFileRequestHandler,
+                    dict(
+                        file_mgr=self.file_mgr,
+                        get_session_info=self._get_session_info,
+                    ),
+                ),
+            ]
+        )
+
+    def _upload_files(self, params):
+        # We use requests.Request to construct our multipart/form-data request
+        # here, because they are absurdly fiddly to compose, and Tornado
+        # doesn't include a utility for building them. We then use self.fetch()
+        # to actually send the request to the test server.
+        req = requests.Request(
+            method="POST", url=self.get_url("/upload_file"), files=params
+        ).prepare()
+
+        return self.fetch(
+            "/upload_file", method=req.method, headers=req.headers, body=req.body
+        )
+
+    def test_upload_one_file(self):
+        """Uploading a file should populate our file_mgr."""
+        file = MockFile("filename", b"123")
+        params = {
+            file.name: file.data,
+            "sessionId": (None, "fooReport"),
+            "widgetId": (None, "barWidget"),
+            "totalFiles": (None, "1"),
+        }
+        response = self._upload_files(params)
+        self.assertEqual(400, response.code)
+        self.assertIsNone(self.file_mgr.get_files("fooReport", "barWidget"))
+
+    def test_upload_multiple_files(self):
+        file_1 = MockFile("file1", b"123")
+        file_2 = MockFile("file2", b"456")
+        file_3 = MockFile("file3", b"789")
+
+        params = {
+            file_1.name: file_1.data,
+            file_2.name: file_2.data,
+            file_3.name: file_3.data,
+            "sessionId": (None, "fooReport"),
+            "widgetId": (None, "barWidget"),
+            "totalFiles": (None, "1"),
+        }
+        response = self._upload_files(params)
+        self.assertEqual(400, response.code)
+        self.assertIsNone(self.file_mgr.get_files("fooReport", "barWidget"))
+
+    def test_delete_file(self):
+        """File should be able to be deleted successfully"""
+        file1 = UploadedFileRec("1234", "name", "type", b"1234")
+        file2 = UploadedFileRec("4567", "name", "type", b"1234")
+
+        self.file_mgr.add_files("session1", "widget1", [file1])
+        self.file_mgr.add_files("session2", "widget2", [file2])
+
+        response = self.fetch(f"/upload_file/session1/widget1/1234", method="DELETE")
         self.assertEqual(404, response.code)


### PR DESCRIPTION
**Issue:** #2418

**Description:** Previously, when receiving a request, we check if a session ID is available or not. If one is provided, we add the file to the file manager. Only when we trigger a rerun will we validate if the session the files are saved under is a valid session. With this change, we will only save the file if the session is valid. This is to provide some additional security when XSRF protections are disabled.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
