### PR TITLE
Fix Jest warnings

### DIFF
--- a/frontend/src/components/shared/Modal/Modal.test.tsx
+++ b/frontend/src/components/shared/Modal/Modal.test.tsx
@@ -19,9 +19,14 @@ import React from "react"
 import { mount } from "lib/test_util"
 
 import Modal from "./Modal"
+import { BaseProvider, LightTheme } from "baseui"
 
 describe("Modal component", () => {
   it("renders without crashing", () => {
-    mount(<Modal isOpen />)
+    mount(
+      <BaseProvider theme={LightTheme}>
+        <Modal isOpen />
+      </BaseProvider>
+    )
   })
 })

--- a/frontend/src/components/shared/Modal/Modal.test.tsx
+++ b/frontend/src/components/shared/Modal/Modal.test.tsx
@@ -16,10 +16,10 @@
  */
 
 import React from "react"
-import { mount } from "lib/test_util"
-
-import Modal from "./Modal"
 import { BaseProvider, LightTheme } from "baseui"
+
+import { mount } from "lib/test_util"
+import Modal from "./Modal"
 
 describe("Modal component", () => {
   it("renders without crashing", () => {

--- a/frontend/src/components/shared/Modal/Modal.tsx
+++ b/frontend/src/components/shared/Modal/Modal.tsx
@@ -109,6 +109,7 @@ function Modal(props: ModalProps): ReactElement {
   return (
     <UIModal
       {...props}
+      unstable_ModalBackdropScroll={true}
       overrides={{
         ...props.overrides,
         DialogContainer: {

--- a/frontend/src/components/shared/Modal/Modal.tsx
+++ b/frontend/src/components/shared/Modal/Modal.tsx
@@ -109,6 +109,10 @@ function Modal(props: ModalProps): ReactElement {
   return (
     <UIModal
       {...props}
+      // From https://baseweb.design/components/modal:
+      // Makes modal scrollable while cursor is over the modal's backdrop.
+      // Will be removed and implemented as the default behavior in the
+      // next major version.
       unstable_ModalBackdropScroll={true}
       overrides={{
         ...props.overrides,

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -23,6 +23,7 @@ import TimezoneMock from "timezone-mock"
 import { WidgetStateManager } from "lib/WidgetStateManager"
 
 import Slider, { Props } from "./Slider"
+import { mainTheme } from "theme"
 
 jest.mock("lib/WidgetStateManager")
 
@@ -42,6 +43,7 @@ const getProps = (elementProps: Partial<SliderProto> = {}): Props => ({
   width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager(sendBackMsg),
+  theme: mainTheme,
 })
 
 describe("Slider widget", () => {
@@ -250,11 +252,16 @@ describe("Slider widget", () => {
       expect(new Date().getTimezoneOffset() === 0).toBeTruthy()
     })
 
-    const WEEK_IN_MICROS = 7 * 24 * 60 * 60 * 1000 * 1000
+    const DAYS_IN_MICROS = 24 * 60 * 60 * 1000 * 1000
+    const WEEK_IN_MICROS = 7 * DAYS_IN_MICROS
+
     const props = getProps({
+      // The default value should be divisible by step.
+      // Otherwise, we get a warning from `react-range`.
+      default: [0],
       min: 0,
       max: 4 * WEEK_IN_MICROS,
-      step: 24 * 60 * 60 * 1000 * 1000,
+      step: DAYS_IN_MICROS,
       format: "YYYY-MM-DD",
       dataType: SliderProto.DataType.DATETIME,
     })

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -16,14 +16,14 @@
  */
 
 import React from "react"
-import { mount } from "lib/test_util"
-import { Slider as SliderProto } from "autogen/proto"
 import { Slider as UISlider } from "baseui/slider"
 import TimezoneMock from "timezone-mock"
-import { WidgetStateManager } from "lib/WidgetStateManager"
 
-import Slider, { Props } from "./Slider"
+import { Slider as SliderProto } from "autogen/proto"
+import { mount } from "lib/test_util"
+import { WidgetStateManager } from "lib/WidgetStateManager"
 import { mainTheme } from "theme"
+import Slider, { Props } from "./Slider"
 
 jest.mock("lib/WidgetStateManager")
 

--- a/frontend/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -39,7 +39,7 @@ const getProps = (elementProps: Partial<TimeInputProto> = {}): Props => ({
   widgetMgr: new WidgetStateManager(sendBackMsg),
 })
 
-describe("TextInput widget", () => {
+describe("TimeInput widget", () => {
   const props = getProps()
   const wrapper = shallow(<TimeInput {...props} />)
 

--- a/frontend/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
@@ -20,6 +20,8 @@ import { mount } from "lib/test_util"
 import { ModalHeader, ModalFooter } from "components/shared/Modal"
 
 import ScreencastDialog, { Props } from "./ScreencastDialog"
+import { ReactWrapper } from "enzyme"
+import { BaseProvider, LightTheme } from "baseui"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   onClose: jest.fn(),
@@ -30,25 +32,32 @@ const getProps = (props: Partial<Props> = {}): Props => ({
 })
 
 describe("ScreencastDialog", () => {
-  it("renders without crashing", () => {
-    const props = getProps()
-    const wrapper = mount(<ScreencastDialog {...props} />)
+  const props = getProps()
+  let wrapper: ReactWrapper
 
+  beforeEach(() => {
+    wrapper = mount(
+      <BaseProvider theme={LightTheme}>
+        <ScreencastDialog {...props} />
+      </BaseProvider>
+    )
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  it("renders without crashing", () => {
     expect(wrapper.html()).not.toBeNull()
   })
 
   it("should render a header", () => {
-    const props = getProps()
-    const wrapper = mount(<ScreencastDialog {...props} />)
     const headerWrapper = wrapper.find(ModalHeader)
     expect(headerWrapper.props().children).toBe("Record a screencast")
   })
 
   describe("Modal body", () => {
     it("should have a record audio option to be selected", () => {
-      const props = getProps()
-      const wrapper = mount(<ScreencastDialog {...props} />)
-
       const labelWrapper = wrapper.find("StyledRecordAudioLabel")
 
       labelWrapper.find("input").simulate("change", {
@@ -64,9 +73,6 @@ describe("ScreencastDialog", () => {
     })
 
     it("should have the stop recording explanation message", () => {
-      const props = getProps()
-      const wrapper = mount(<ScreencastDialog {...props} />)
-
       expect(wrapper.find("StyledInstruction").text()).toBe(
         "Press Esc any time to stop recording."
       )
@@ -75,8 +81,6 @@ describe("ScreencastDialog", () => {
 
   describe("Modal footer", () => {
     it("should have an start button", () => {
-      const props = getProps()
-      const wrapper = mount(<ScreencastDialog {...props} />)
       const buttonWrapper = wrapper.find(ModalFooter).find("button")
 
       buttonWrapper.simulate("click")

--- a/frontend/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/ScreencastDialog/ScreencastDialog.test.tsx
@@ -16,12 +16,12 @@
  */
 
 import React from "react"
-import { mount } from "lib/test_util"
-import { ModalHeader, ModalFooter } from "components/shared/Modal"
-
-import ScreencastDialog, { Props } from "./ScreencastDialog"
-import { ReactWrapper } from "enzyme"
 import { BaseProvider, LightTheme } from "baseui"
+import { ReactWrapper } from "enzyme"
+
+import { ModalHeader, ModalFooter } from "components/shared/Modal"
+import { mount } from "lib/test_util"
+import ScreencastDialog, { Props } from "./ScreencastDialog"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   onClose: jest.fn(),

--- a/frontend/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
@@ -20,23 +20,36 @@ import { mount } from "lib/test_util"
 import { ModalHeader, ModalBody } from "components/shared/Modal"
 
 import UnsupportedBrowserDialog from "./UnsupportedBrowserDialog"
+import { BaseProvider, LightTheme } from "baseui"
 
 describe("UnsupportedBrowserDialog", () => {
   it("renders without crashing", () => {
-    const wrapper = mount(<UnsupportedBrowserDialog onClose={() => {}} />)
+    const wrapper = mount(
+      <BaseProvider theme={LightTheme}>
+        <UnsupportedBrowserDialog onClose={() => {}} />
+      </BaseProvider>
+    )
 
     expect(wrapper.html()).not.toBeNull()
   })
 
   it("should render a header", () => {
     const onClose = jest.fn()
-    const wrapper = mount(<UnsupportedBrowserDialog onClose={onClose} />)
+    const wrapper = mount(
+      <BaseProvider theme={LightTheme}>
+        <UnsupportedBrowserDialog onClose={onClose} />
+      </BaseProvider>
+    )
     const headerWrapper = wrapper.find(ModalHeader)
     expect(headerWrapper.props().children).toBe("Record a screencast")
   })
 
   it("should render a body with the correct message", () => {
-    const wrapper = mount(<UnsupportedBrowserDialog onClose={() => {}} />)
+    const wrapper = mount(
+      <BaseProvider theme={LightTheme}>
+        <UnsupportedBrowserDialog onClose={() => {}} />
+      </BaseProvider>
+    )
     const bodyWrapper = wrapper.find(ModalBody)
 
     expect(bodyWrapper.find("span[aria-label='Alien Monster']").text()).toBe(

--- a/frontend/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/UnsupportedBrowserDialog/UnsupportedBrowserDialog.test.tsx
@@ -16,11 +16,11 @@
  */
 
 import React from "react"
-import { mount } from "lib/test_util"
-import { ModalHeader, ModalBody } from "components/shared/Modal"
-
-import UnsupportedBrowserDialog from "./UnsupportedBrowserDialog"
 import { BaseProvider, LightTheme } from "baseui"
+
+import { ModalHeader, ModalBody } from "components/shared/Modal"
+import { mount } from "lib/test_util"
+import UnsupportedBrowserDialog from "./UnsupportedBrowserDialog"
 
 describe("UnsupportedBrowserDialog", () => {
   it("renders without crashing", () => {

--- a/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
@@ -20,6 +20,8 @@ import { mount } from "lib/test_util"
 import { ModalHeader, ModalBody } from "components/shared/Modal"
 
 import VideoRecordedDialog, { Props } from "./VideoRecordedDialog"
+import { ReactWrapper } from "enzyme"
+import { BaseProvider, LightTheme } from "baseui"
 
 URL.createObjectURL = jest.fn()
 
@@ -31,21 +33,31 @@ const getProps = (props: Partial<Props> = {}): Props => ({
 })
 
 describe("VideoRecordedDialog", () => {
-  it("renders without crashing", () => {
-    const wrapper = mount(<VideoRecordedDialog {...getProps()} />)
+  const props = getProps()
+  let wrapper: ReactWrapper
 
+  beforeEach(() => {
+    wrapper = mount(
+      <BaseProvider theme={LightTheme}>
+        <VideoRecordedDialog {...props} />
+      </BaseProvider>
+    )
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  it("renders without crashing", () => {
     expect(wrapper.html()).not.toBeNull()
   })
 
   it("should render a header", () => {
-    const props = getProps()
-    const wrapper = mount(<VideoRecordedDialog {...props} />)
     const headerWrapper = wrapper.find(ModalHeader)
     expect(headerWrapper.props().children).toBe("Next steps")
   })
 
   it("should render a video", () => {
-    const wrapper = mount(<VideoRecordedDialog {...getProps()} />)
     const bodyWrapper = wrapper.find(ModalBody)
 
     expect(bodyWrapper.find("StyledVideo").length).toBe(1)
@@ -53,8 +65,6 @@ describe("VideoRecordedDialog", () => {
   })
 
   it("should render a download button", () => {
-    const props = getProps()
-    const wrapper = mount(<VideoRecordedDialog {...props} />)
     const buttonWrapper = wrapper.find(ModalBody).find("Button")
 
     buttonWrapper.simulate("click")

--- a/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
@@ -16,12 +16,12 @@
  */
 
 import React from "react"
-import { mount } from "lib/test_util"
-import { ModalHeader, ModalBody } from "components/shared/Modal"
-
-import VideoRecordedDialog, { Props } from "./VideoRecordedDialog"
-import { ReactWrapper } from "enzyme"
 import { BaseProvider, LightTheme } from "baseui"
+import { ReactWrapper } from "enzyme"
+
+import { ModalHeader, ModalBody } from "components/shared/Modal"
+import { mount } from "lib/test_util"
+import VideoRecordedDialog, { Props } from "./VideoRecordedDialog"
 
 URL.createObjectURL = jest.fn()
 


### PR DESCRIPTION
Change list:
- Added a required `unstable_ModalBackdropScroll` prop to `Modal`.
- Wrapped modals in `BaseProvider`.
- Added `theme` to `getProps` to silence TS compiler.
- Fixed a warning that was caused by a default value of a slider that was not divisible by `step`.
- Did some slight refactoring.