### PR TITLE
Fix block-container styles for sidebar

### DIFF
--- a/frontend/src/components/core/ReportView/ReportView.tsx
+++ b/frontend/src/components/core/ReportView/ReportView.tsx
@@ -84,7 +84,6 @@ function ReportView(props: ReportViewProps): ReactElement {
     <StyledReportViewBlockContainer
       className="block-container"
       isWideMode={wideMode}
-      isEmbedded={embedded}
     >
       <Block
         node={node}

--- a/frontend/src/components/core/ReportView/styled-components.ts
+++ b/frontend/src/components/core/ReportView/styled-components.ts
@@ -62,18 +62,17 @@ export const StyledReportViewMain = styled.section<StyledReportViewMainProps>(
 
 export interface StyledReportViewBlockContainerProps {
   isWideMode: boolean
-  isEmbedded: boolean
 }
 
 export const StyledReportViewBlockContainer = styled.div<
   StyledReportViewBlockContainerProps
->(({ isEmbedded, isWideMode, theme }) => ({
+>(({ isWideMode, theme }) => ({
   flex: 1,
   width: theme.sizes.full,
-  paddingLeft: isEmbedded ? theme.spacing.none : theme.spacing.lg,
-  paddingRight: isEmbedded ? theme.spacing.none : theme.spacing.lg,
-  paddingTop: isEmbedded ? theme.spacing.none : "5rem",
-  paddingBottom: isEmbedded ? theme.spacing.none : "10rem",
+  paddingLeft: theme.inSidebar ? theme.spacing.none : theme.spacing.lg,
+  paddingRight: theme.inSidebar ? theme.spacing.none : theme.spacing.lg,
+  paddingTop: theme.inSidebar ? theme.spacing.none : "5rem",
+  paddingBottom: theme.inSidebar ? theme.spacing.none : "10rem",
   minWidth: isWideMode ? "auto" : undefined,
   maxWidth: isWideMode ? "initial" : theme.sizes.contentMaxWidth,
 }))


### PR DESCRIPTION
**Issue:** Fixes #2468 

**Description:**
ReportView should be styled based on if it is in the sidebar or not. Looking at v 0.68.0, embedded should only impact the header and not block container. 

A snapshot image exists but did not trigger a failure initially because of issue resolved in #2553.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
