### PR TITLE
Have st.number_input warn user of mismatched type and format string

### DIFF
--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -91,14 +91,20 @@ class NumberInputMixin:
             if format is None:
                 format = "%d" if int_value else "%0.2f"
 
+            # Warn user if they format an int type as a float or vice versa.
             if format in ["%d", "%u", "%i"] and float_value:
-                # Warn user to check if displaying float as int was really intended.
                 import streamlit as st
 
                 st.warning(
-                    "Warning: NumberInput value below is float, but format {} displays as integer.".format(
-                        format
-                    )
+                    "Warning: NumberInput value below has type float,"
+                    " but format {} displays as integer.".format(format)
+                )
+            elif format[-1] == "f" and int_value:
+                import streamlit as st
+
+                st.warning(
+                    "Warning: NumberInput value below has type int so is"
+                    " displayed as int despite format string {}.".format(format)
                 )
 
             if step is None:

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -55,7 +55,7 @@ class NumberInputMixin:
         format : str or None
             A printf-style format string controlling how the interface should
             display numbers. Output must be purely numeric. This does not impact
-            the return value. Valid formatters: %d %e %f %g %i
+            the return value. Valid formatters: %d %e %f %g %i %u
         key : str
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -97,14 +97,14 @@ class NumberInputMixin:
 
                 st.warning(
                     "Warning: NumberInput value below has type float,"
-                    " but format {} displays as integer.".format(format)
+                    f" but format {format} displays as integer."
                 )
             elif format[-1] == "f" and int_value:
                 import streamlit as st
 
                 st.warning(
                     "Warning: NumberInput value below has type int so is"
-                    " displayed as int despite format string {}.".format(format)
+                    f" displayed as int despite format string {format}."
                 )
 
             if step is None:

--- a/lib/tests/streamlit/number_input_test.py
+++ b/lib/tests/streamlit/number_input_test.py
@@ -19,6 +19,7 @@ import pytest
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber
+from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.proto.NumberInput_pb2 import NumberInput
 from tests import testutil
 
@@ -35,7 +36,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         st.number_input("Label", value=0.5)
         c = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(NumberInput.FLOAT, c.data_type)
-        
+
     def test_min_value_zero_sets_default_value(self):
         st.number_input("Label", 0, 10)
         c = self.get_delta_from_queue().new_element.number_input
@@ -123,6 +124,26 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
             st.number_input("any label", format="%" + char)
             c = self.get_delta_from_queue().new_element.number_input
             self.assertEqual(c.format, "%" + char)
+
+    def test_warns_on_float_type_with_int_format(self):
+        st.number_input("the label", value=5.0, format="%d")
+
+        c = self.get_delta_from_queue(-2).new_element.alert
+        self.assertEqual(c.format, AlertProto.WARNING)
+        self.assertEqual(
+            c.body,
+            "Warning: NumberInput value below has type float, but format %d displays as integer.",
+        )
+
+    def test_warns_on_int_type_with_float_format(self):
+        st.number_input("the label", value=5, format="%0.2f")
+
+        c = self.get_delta_from_queue(-2).new_element.alert
+        self.assertEqual(c.format, AlertProto.WARNING)
+        self.assertEqual(
+            c.body,
+            "Warning: NumberInput value below has type int so is displayed as int despite format string %0.2f.",
+        )
 
     def test_error_on_unsupported_formatters(self):
         UNSUPPORTED = "pAn"


### PR DESCRIPTION
This makes the case where a user creates a `st.number_input` with `int` type and `float` format string behave analogously to the case with a `float` type / `int` format string.

Closes #1809