### PR TITLE
Rerender Maybe components when they're first disabled

### DIFF
--- a/frontend/src/components/core/Maybe/Maybe.test.tsx
+++ b/frontend/src/components/core/Maybe/Maybe.test.tsx
@@ -56,6 +56,17 @@ describe("The Maybe component", () => {
       expect(spyShouldComponentUpdate).toHaveBeenCalled()
       expect(spyRender).toHaveBeenCalled()
     })
+
+    it("should call render() when a Maybe is first disabled", () => {
+      const spyShouldComponentUpdate = jest.spyOn(
+        Maybe.prototype,
+        "shouldComponentUpdate"
+      )
+      const spyRender = jest.spyOn(Maybe.prototype, "render")
+      component.setProps({ name: "new name", enable: false })
+      expect(spyShouldComponentUpdate).toHaveBeenCalled()
+      expect(spyRender).toHaveBeenCalled()
+    })
   })
 
   describe("when enable is false", () => {

--- a/frontend/src/components/core/Maybe/Maybe.tsx
+++ b/frontend/src/components/core/Maybe/Maybe.tsx
@@ -30,7 +30,10 @@ class Maybe extends React.Component<Props, State> {
     nextState: Readonly<State>,
     nextContext: any
   ): boolean {
-    return nextProps.enable
+    // We have our component update if either props.enable or nextProps.enable
+    // is true to ensure that we rerender in the case that an Element is
+    // removed by replacing it with an empty one (so goes from enabled->disabled).
+    return this.props.enable || nextProps.enable
   }
 
   public render(): React.ReactNode {


### PR DESCRIPTION
\#2395 ended up being caused by this since we don't rerender placeholder
components created by `st.empty()` when react props/state change as a
performance optimization, but we need to do so when replacing an
existing component with an empty one to get rid of what's currently
drawn on screen.

Closes #2395