### PR TITLE
Fix file uploader docs + change to getvalue

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -69,11 +69,11 @@ class FileUploaderMixin:
         >>> uploaded_file = st.file_uploader("Choose a file")
         >>> if uploaded_file is not None:
         ...     # To read file as bytes:
-        ...     bytes_data = uploaded_file.read()
+        ...     bytes_data = uploaded_file.getvalue()
         ...     st.write(bytes_data)
         >>>
         ...     # To convert to a string based IO:
-        ...     stringio = StringIO(uploaded_file.decode("utf-8"))
+        ...     stringio = StringIO(uploaded_file.getvalue().decode("utf-8"))
         ...     st.write(stringio)
         >>>
         ...     # To read file as string:


### PR DESCRIPTION
1. Have to read the BytesIO in order to decode it 🤦‍♀️ 
2. Let's use `getvalue` instead of `read` in the event someone wants to copy all 3 examples into an app. `read` requires a buffer reset while `getvalue` does not. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
