### PR TITLE
🔧 "Run on save" now defaults to true

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -467,9 +467,9 @@ def _server_live_save():
 def _server_run_on_save():
     """Automatically rerun script when the file is modified on disk.
 
-    Default: false
+    Default: true
     """
-    return False
+    return True
 
 
 @_create_option("server.allowRunOnSave", type_=bool, visibility="hidden")


### PR DESCRIPTION
See https://www.notion.so/streamlit/Always-Rerun-should-be-the-default-09fcc67fa96940a9b9447c18b48003d7:

## Background

Changing the source file of a Streamlit app brings this up:
![image](https://user-images.githubusercontent.com/856034/105518502-609a8d00-5ca6-11eb-9803-cef449673d27.png)

- Always rerun seems like a better default; most users want this behavior
- Some users do not want this behavior; we should allow them to
- There is an existing config option "server.runOnSave" which defaults to False
- server.runOnSave is true for S4A; this lets a git push to quickly update an S4A app.
    - There is a new config option "server.allowRunOnSave" which was hacked in for the S4A launch, preventing users from turning off this behavior.

## Proposal

DECISION: Change the default on the existing "server.runOnSave" to True.

Users can opt out by setting it to False.
