### PR TITLE
Display a warning when not run via `streamlit run`

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -520,7 +520,7 @@ def _maybe_print_use_warning():
 
             _LOGGER.warning(
                 _textwrap.dedent(
-                    """
+                    f"""
 
                 Will not generate Streamlit App
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -487,14 +487,17 @@ def _transparent_write(*args):
 # We want to show a warning when the user runs a Streamlit script without
 # 'streamlit run', but we need to make sure the warning appears only once no
 # matter how many times __init__ gets loaded.
-_repl_warning_has_been_displayed = False
+_use_warning_has_been_displayed = False
 
 
-def _maybe_print_repl_warning():
-    global _repl_warning_has_been_displayed
+def _maybe_print_use_warning():
+    """Print a warning if Streamlit is imported but not being run with `streamlit run`.
+    The warning is printed only once.
+    """
+    global _use_warning_has_been_displayed
 
-    if not _repl_warning_has_been_displayed:
-        _repl_warning_has_been_displayed = True
+    if not _use_warning_has_been_displayed:
+        _use_warning_has_been_displayed = True
 
         if _env_util.is_repl():
             _LOGGER.warning(
@@ -510,7 +513,9 @@ def _maybe_print_repl_warning():
                 )
             )
 
-        elif _config.get_option("global.showWarningOnDirectExecution"):
+        elif not _is_running_with_streamlit and _config.get_option(
+            "global.showWarningOnDirectExecution"
+        ):
             script_name = _sys.argv[0]
 
             _LOGGER.warning(
@@ -520,11 +525,10 @@ def _maybe_print_repl_warning():
                 Will not generate Streamlit App
 
                   To generate an App, run this file with:
-                  $ streamlit run %s [ARGUMENTS]
+                  $ streamlit run {script_name} [ARGUMENTS]
 
                 """
-                ),
-                script_name,
+                )
             )
 
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -15,6 +15,7 @@
 """Allows us to create and absorb changes (aka Deltas) to elements."""
 from typing import Optional, Iterable, List
 
+import streamlit as st
 from streamlit import caching
 from streamlit import cursor
 from streamlit import type_util
@@ -339,6 +340,9 @@ class DeltaGenerator(
         dg = self._active_dg
         # Warn if we're called from within an @st.cache function
         caching.maybe_show_cached_st_function_warning(dg, delta_type)
+
+        # Warn if an element is being changed but the user isn't running the streamlit server.
+        st._maybe_print_use_warning()
 
         # Some elements have a method.__name__ != delta_type in proto.
         # This really matters for line_chart, bar_chart & area_chart,

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -23,6 +23,7 @@ import pytest
 import re
 import textwrap
 import unittest
+import logging
 
 from google.protobuf import json_format
 import PIL.Image as Image
@@ -30,9 +31,11 @@ import numpy as np
 import pandas as pd
 from scipy.io import wavfile
 
+import streamlit as st
 from streamlit import __version__
 from streamlit.errors import StreamlitAPIException
 from streamlit.elements.pyplot import PyplotGlobalUseWarning
+from streamlit.logger import get_logger
 from streamlit.proto.Balloons_pb2 import Balloons
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from streamlit.proto.Alert_pb2 import Alert
@@ -42,7 +45,6 @@ from streamlit.media_file_manager import _calculate_file_id
 from streamlit.media_file_manager import STATIC_MEDIA_ENDPOINT
 
 from tests import testutil
-import streamlit as st
 
 
 def get_version():
@@ -84,6 +86,26 @@ class StreamlitTest(unittest.TestCase):
 
         with self.assertRaises(StreamlitAPIException):
             st.set_option("server.enableCORS", False)
+
+    def test_run_warning_presence(self):
+        """Using Streamlit without `streamlit run` produces a warning."""
+        with self.assertLogs(level=logging.WARNING) as logs:
+            st._is_running_with_streamlit = False
+            st._use_warning_has_been_displayed = False
+            st.write("Using delta generator")
+            output = "".join(logs.output)
+            # Warning produced exactly once
+            self.assertEqual(len(re.findall(r"streamlit run", output)), 1)
+
+    def test_run_warning_absence(self):
+        """Using Streamlit through the CLI produces no usage warning."""
+        with self.assertLogs(level=logging.WARNING) as logs:
+            st._is_running_with_streamlit = True
+            st._use_warning_has_been_displayed = False
+            st.write("Using delta generator")
+            # assertLogs is being used as a context manager, but it also checks that some log output was captured, so we have to let it capture something
+            get_logger("root").warning("irrelevant warning so assertLogs passes")
+            self.assertNotRegex("".join(logs.output), r"streamlit run")
 
 
 class StreamlitAPITest(testutil.DeltaGeneratorTestCase):


### PR DESCRIPTION
This functionality used to exist, but stopped being called at some point.
The check is executed in the DeltaGenerator, because that is one of the few
things that will almost certainly be used by a user who is just importing the library.

**Issue:** #127 