### PR TITLE
Don't add license headers for files in "node_modules" and "cypress" folders

### DIFF
--- a/scripts/add_license_headers.py
+++ b/scripts/add_license_headers.py
@@ -35,6 +35,8 @@ EXCLUDE_PATTERNS = [
     "/gen/",
     "/static/",
     "/vendor/",
+    "/node_modules/",
+    "/cypress/",
     "/react-app-env.d.ts",
     "/css/variables.scss",  # scss-to-json doesn't like our normal header.
 ]


### PR DESCRIPTION
Added `node_modules` and `cypress` folders to `EXCLUDE_PATTERNS`.