### PR TITLE
Extract a shared radio component for use within our UI

### DIFF
--- a/frontend/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/src/components/shared/Radio/Radio.test.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2020 Streamlit Inc.
+ * Copyright 2018-2021 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/src/components/shared/Radio/Radio.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { mount } from "lib/test_util"
+
+import { Radio as UIRadio, RadioGroup } from "baseui/radio"
+import { Radio as RadioProto } from "autogen/proto"
+import Radio, { Props } from "./Radio"
+
+jest.mock("lib/WidgetStateManager")
+
+const getProps = (props: Partial<RadioProto> = {}): Props => ({
+  width: 0,
+  disabled: false,
+  value: 0,
+  onChange: (selectedIndex: number) => {},
+  options: ["a", "b", "c"],
+  label: "Label",
+  ...props,
+})
+
+describe("Radio widget", () => {
+  const props = getProps()
+  const wrapper = mount(<Radio {...props} />)
+
+  it("renders without crashing", () => {
+    expect(wrapper.find(RadioGroup).length).toBe(1)
+    expect(wrapper.find(UIRadio).length).toBe(3)
+  })
+
+  it("should have correct className and style", () => {
+    const wrappedDiv = wrapper.find("div").first()
+
+    const { className, style } = wrappedDiv.props()
+    // @ts-ignore
+    const splittedClassName = className.split(" ")
+
+    expect(splittedClassName).toContain("row-widget")
+    expect(splittedClassName).toContain("stRadio")
+
+    // @ts-ignore
+    expect(style.width).toBe(getProps().width)
+  })
+
+  it("should render a label", () => {
+    expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.label)
+  })
+
+  it("should have a default value", () => {
+    expect(wrapper.find(RadioGroup).prop("value")).toBe(props.value.toString())
+  })
+
+  it("could be disabled", () => {
+    expect(wrapper.find(RadioGroup).prop("disabled")).toBe(props.disabled)
+  })
+
+  it("should have the correct options", () => {
+    const options = wrapper.find(UIRadio)
+
+    options.forEach((option, index) => {
+      expect(option.prop("value")).toBe(index.toString())
+      expect(option.prop("children")).toBe(props.options[index])
+    })
+  })
+
+  it("should show a message when there are no options to be shown", () => {
+    const props = getProps({
+      options: [],
+    })
+    const wrapper = mount(<Radio {...props} />)
+
+    expect(wrapper.find(UIRadio).length).toBe(1)
+    expect(wrapper.find(UIRadio).prop("children")).toBe(
+      "No options to select."
+    )
+  })
+
+  it("should select just one option and set the value", () => {
+    // @ts-ignore
+    wrapper.find(RadioGroup).prop("onChange")({
+      target: {
+        value: "1",
+      },
+    } as React.ChangeEvent<HTMLInputElement>)
+    wrapper.update()
+
+    expect(wrapper.find(RadioGroup).prop("value")).toBe("1")
+  })
+})

--- a/frontend/src/components/shared/Radio/Radio.tsx
+++ b/frontend/src/components/shared/Radio/Radio.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2020 Streamlit Inc.
+ * Copyright 2018-2021 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/components/shared/Radio/Radio.tsx
+++ b/frontend/src/components/shared/Radio/Radio.tsx
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { withTheme } from "emotion-theming"
+import { Radio as UIRadio, RadioGroup } from "baseui/radio"
+import { StyledWidgetLabel } from "components/widgets/BaseWidget"
+import { Theme } from "theme"
+
+export interface Props {
+  disabled: boolean
+  theme: Theme
+  width: number
+  value: number
+  onChange: (selectedIndex: number) => any
+  options: any[]
+  label: string
+}
+
+interface State {
+  /**
+   * The value specified by the user via the UI. If the user didn't touch this
+   * widget's UI, the default value is used.
+   */
+  value: number
+}
+
+class Radio extends React.PureComponent<Props, State> {
+  public state: State = {
+    value: this.props.value,
+  }
+
+  private onChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const selectedIndex = parseInt(e.target.value, 10)
+    this.setState({ value: selectedIndex }, () =>
+      this.props.onChange(selectedIndex)
+    )
+  }
+
+  public render = (): React.ReactNode => {
+    const { disabled, theme, width, options } = this.props
+    const { colors, fontSizes, radii } = theme
+    const style = { width }
+    let isDisabled = disabled
+
+    if (options.length === 0) {
+      options.push("No options to select.")
+      isDisabled = true
+    }
+
+    return (
+      <div className="row-widget stRadio" style={style}>
+        <StyledWidgetLabel>{this.props.label}</StyledWidgetLabel>
+        <RadioGroup
+          onChange={this.onChange}
+          value={this.state.value.toString()}
+          disabled={isDisabled}
+        >
+          {options.map((option: string, index: number) => (
+            <UIRadio
+              key={index}
+              value={index.toString()}
+              overrides={{
+                Root: {
+                  style: ({ $isFocused }: { $isFocused: boolean }) => ({
+                    marginBottom: 0,
+                    marginTop: 0,
+                    paddingRight: fontSizes.twoThirdSmDefault,
+                    backgroundColor: $isFocused ? colors.lightestGray : "",
+                    borderTopLeftRadius: radii.md,
+                    borderTopRightRadius: radii.md,
+                    borderBottomLeftRadius: radii.md,
+                    borderBottomRightRadius: radii.md,
+                  }),
+                },
+                RadioMarkInner: {
+                  style: ({ $checked }: { $checked: boolean }) => ({
+                    height: $checked ? "6px" : "16px",
+                    width: $checked ? "6px" : "16px",
+                  }),
+                },
+                Label: {
+                  style: {
+                    color: colors.bodyText,
+                  },
+                },
+              }}
+            >
+              {option}
+            </UIRadio>
+          ))}
+        </RadioGroup>
+      </div>
+    )
+  }
+}
+
+export default withTheme(Radio)

--- a/frontend/src/components/shared/Radio/index.tsx
+++ b/frontend/src/components/shared/Radio/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./Radio"

--- a/frontend/src/components/shared/Radio/index.tsx
+++ b/frontend/src/components/shared/Radio/index.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2020 Streamlit Inc.
+ * Copyright 2018-2021 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.test.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2020 Streamlit Inc.
+ * Copyright 2018-2021 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2020 Streamlit Inc.
+ * Copyright 2018-2021 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.tsx
@@ -16,17 +16,13 @@
  */
 
 import React from "react"
-import { withTheme } from "emotion-theming"
-import { Radio as UIRadio, RadioGroup } from "baseui/radio"
+import UIRadio from "components/shared/Radio"
 import { Radio as RadioProto } from "autogen/proto"
 import { WidgetStateManager, Source } from "lib/WidgetStateManager"
-import { StyledWidgetLabel } from "components/widgets/BaseWidget"
-import { Theme } from "theme"
 
 export interface Props {
   disabled: boolean
   element: RadioProto
-  theme: Theme
   widgetMgr: WidgetStateManager
   width: number
 }
@@ -61,68 +57,27 @@ class Radio extends React.PureComponent<Props, State> {
     this.props.widgetMgr.setIntValue(widgetId, this.state.value, source)
   }
 
-  private onChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = parseInt(e.target.value, 10)
-    this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
+  private onChange = (selectedIndex: number): void => {
+    this.setState({ value: selectedIndex }, () =>
+      this.setWidgetValue({ fromUi: true })
+    )
   }
 
   public render = (): React.ReactNode => {
-    const { disabled, element, theme, width } = this.props
-    const { colors, fontSizes, radii } = theme
-    const style = { width }
-    let { options } = element
-    let isDisabled = disabled
-
-    if (options.length === 0) {
-      options = ["No options to select."]
-      isDisabled = true
-    }
+    const { disabled, element, width } = this.props
+    const { options, label } = element
 
     return (
-      <div className="row-widget stRadio" style={style}>
-        <StyledWidgetLabel>{this.props.element.label}</StyledWidgetLabel>
-        <RadioGroup
-          onChange={this.onChange}
-          value={this.state.value.toString()}
-          disabled={isDisabled}
-        >
-          {options.map((option: string, index: number) => (
-            <UIRadio
-              key={index}
-              value={index.toString()}
-              overrides={{
-                Root: {
-                  style: ({ $isFocused }: { $isFocused: boolean }) => ({
-                    marginBottom: 0,
-                    marginTop: 0,
-                    paddingRight: fontSizes.twoThirdSmDefault,
-                    backgroundColor: $isFocused ? colors.lightestGray : "",
-                    borderTopLeftRadius: radii.md,
-                    borderTopRightRadius: radii.md,
-                    borderBottomLeftRadius: radii.md,
-                    borderBottomRightRadius: radii.md,
-                  }),
-                },
-                RadioMarkInner: {
-                  style: ({ $checked }: { $checked: boolean }) => ({
-                    height: $checked ? "6px" : "16px",
-                    width: $checked ? "6px" : "16px",
-                  }),
-                },
-                Label: {
-                  style: {
-                    color: colors.bodyText,
-                  },
-                },
-              }}
-            >
-              {option}
-            </UIRadio>
-          ))}
-        </RadioGroup>
-      </div>
+      <UIRadio
+        label={label}
+        onChange={this.onChange}
+        options={options}
+        width={width}
+        disabled={disabled}
+        value={this.state.value}
+      />
     )
   }
 }
 
-export default withTheme(Radio)
+export default Radio

--- a/frontend/src/components/widgets/Radio/index.tsx
+++ b/frontend/src/components/widgets/Radio/index.tsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2020 Streamlit Inc.
+ * Copyright 2018-2021 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Create a Radio that does not need to deal with widgetMgr or element. This is for us to use while sharing the same visuals as what st.radio outputs

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
