### PR TITLE
ReportContext: simplify constructor

### DIFF
--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -31,7 +31,6 @@ class ReportContext:
         enqueue: Callable[[ForwardMsg], None],
         query_string: str,
         widgets: Widgets,
-        widget_ids_this_run: "_StringSet",
         uploaded_file_mgr: UploadedFileManager,
     ):
         """Construct a ReportContext.
@@ -46,9 +45,6 @@ class ReportContext:
             The URL query string for this run.
         widgets : Widgets
             The Widgets state object for the report.
-        widget_ids_this_run : _StringSet
-            The set of widget IDs that have been assigned in the
-            current report run. This set is cleared at the start of each run.
         uploaded_file_mgr : UploadedFileManager
             The manager for files uploaded by all users.
 
@@ -58,7 +54,7 @@ class ReportContext:
         self._enqueue = enqueue
         self.query_string = query_string
         self.widgets = widgets
-        self.widget_ids_this_run = widget_ids_this_run
+        self.widget_ids_this_run = _StringSet()
         self.uploaded_file_mgr = uploaded_file_mgr
         # set_page_config is allowed at most once, as the very first st.command
         self._set_page_config_allowed = True
@@ -165,7 +161,6 @@ class ReportThread(threading.Thread):
             query_string=query_string,
             widgets=widgets,
             uploaded_file_mgr=uploaded_file_mgr,
-            widget_ids_this_run=_StringSet(),
         )
 
 

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, patch
 import unittest
 
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.report_thread import ReportContext
+from streamlit.uploaded_file_manager import UploadedFileManager
+from streamlit.widgets import Widgets
 
 
 class ReportContextTest(unittest.TestCase):
@@ -25,7 +26,9 @@ class ReportContextTest(unittest.TestCase):
         """st.set_page_config must be called at most once"""
 
         fake_enqueue = lambda msg: None
-        ctx = ReportContext("TestSessionID", fake_enqueue, "", None, None, None)
+        ctx = ReportContext(
+            "TestSessionID", fake_enqueue, "", Widgets(), UploadedFileManager()
+        )
 
         msg = ForwardMsg()
         msg.page_config_changed.title = "foo"
@@ -38,7 +41,9 @@ class ReportContextTest(unittest.TestCase):
         """st.set_page_config must be called before other st commands"""
 
         fake_enqueue = lambda msg: None
-        ctx = ReportContext("TestSessionID", fake_enqueue, "", None, None, None)
+        ctx = ReportContext(
+            "TestSessionID", fake_enqueue, "", Widgets(), UploadedFileManager()
+        )
 
         markdown_msg = ForwardMsg()
         markdown_msg.delta.new_element.markdown.body = "foo"
@@ -54,7 +59,9 @@ class ReportContextTest(unittest.TestCase):
         """st.set_page_config should be allowed after a rerun"""
 
         fake_enqueue = lambda msg: None
-        ctx = ReportContext("TestSessionID", fake_enqueue, "", None, MagicMock(), None)
+        ctx = ReportContext(
+            "TestSessionID", fake_enqueue, "", Widgets(), UploadedFileManager()
+        )
 
         msg = ForwardMsg()
         msg.page_config_changed.title = "foo"

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -29,6 +29,7 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.StaticManifest_pb2 import StaticManifest
 from streamlit.errors import StreamlitAPIException
+from streamlit.widgets import Widgets
 from tests.mock_storage import MockStorage
 import streamlit as st
 
@@ -165,7 +166,9 @@ class ReportSessionSerializationTest(tornado.testing.AsyncTestCase):
         rs._report.report_id = "TestReportID"
 
         orig_ctx = get_report_ctx()
-        ctx = ReportContext("TestSessionID", rs._report.enqueue, "", None, None, None)
+        ctx = ReportContext(
+            "TestSessionID", rs._report.enqueue, "", Widgets(), UploadedFileManager()
+        )
         add_report_ctx(ctx=ctx)
 
         rs._scriptrunner = MagicMock()

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -63,7 +63,6 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                     enqueue=self.report_queue.enqueue,
                     query_string="",
                     widgets=Widgets(),
-                    widget_ids_this_run=_StringSet(),
                     uploaded_file_mgr=UploadedFileManager(),
                 ),
             )


### PR DESCRIPTION
ReportContext now constructs its own `widget_ids_this_run`. This doesn't change any behavior - ReportContext was only ever passed its own copy of this object. (`ReportThread` is the only non-test code that constructs a ReportContext.)

(This also cleans up a few instances where tests were incorrectly constructing ReportContexts with `null` values for non-nullable members.)
