### PR TITLE
Convert themes to config and add baseweb dark mode

### DIFF
--- a/frontend/src/components/core/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/SettingsDialog.tsx
@@ -24,7 +24,7 @@ import Modal, {
   ModalFooter,
   ModalButton,
 } from "components/shared/Modal"
-import { Theme } from "theme"
+import { ThemeConfig } from "theme"
 import { UserSettings } from "./UserSettings"
 
 export interface Props {
@@ -33,7 +33,7 @@ export interface Props {
   onSave: (settings: UserSettings) => void
   settings: UserSettings
   allowRunOnSave: boolean
-  allowedThemes: Theme[]
+  allowedThemes: ThemeConfig[]
 }
 
 /**
@@ -44,7 +44,6 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
 
   constructor(props: Props) {
     super(props)
-
     // Holds the settings that will be saved when the "save" button is clicked.
     this.state = { ...this.props.settings }
 

--- a/frontend/src/components/core/StreamlitDialog/UserSettings.ts
+++ b/frontend/src/components/core/StreamlitDialog/UserSettings.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Theme } from "theme"
+import { ThemeConfig } from "theme"
 
 export interface UserSettings {
   /**
@@ -36,5 +36,5 @@ export interface UserSettings {
   /**
    * Active theme
    */
-  activeTheme: Theme
+  activeTheme: ThemeConfig
 }

--- a/frontend/src/styled-components.ts
+++ b/frontend/src/styled-components.ts
@@ -19,6 +19,7 @@ import styled from "@emotion/styled"
 
 export const StyledApp = styled.div(({ theme }) => ({
   position: "absolute",
+  backgroundColor: theme.colors.bgColor,
   top: theme.spacing.none,
   left: theme.spacing.none,
   right: theme.spacing.none,

--- a/frontend/src/theme/baseTheme/index.ts
+++ b/frontend/src/theme/baseTheme/index.ts
@@ -31,7 +31,6 @@ import {
 import colors from "./themeColors"
 
 export default {
-  name: "base",
   inSidebar: false,
   breakpoints,
   colors,

--- a/frontend/src/theme/baseTheme/themeColors.ts
+++ b/frontend/src/theme/baseTheme/themeColors.ts
@@ -20,6 +20,7 @@ import { colors } from "../primitives/colors"
 
 const genericColors = {
   ...colors,
+  bgColor: colors.white,
   bodyText: colors.gray90,
   danger: "#9d292d",
   info: "#1e6777",

--- a/frontend/src/theme/baseui.ts
+++ b/frontend/src/theme/baseui.ts
@@ -18,6 +18,7 @@
 import {
   createTheme,
   lightThemePrimitives as lightBaseThemePrimitives,
+  darkThemePrimitives as darkBaseThemePrimitives,
 } from "baseui"
 import { transparentize } from "color2k"
 import lightTheme from "./lightTheme"
@@ -41,6 +42,37 @@ const fontStyles = {
 // - See node_modules/baseui/themes/creator.js for the mapping of values from
 // this file to output values.
 const lightThemePrimitives = {
+  ...lightBaseThemePrimitives,
+
+  primaryFontFamily: fonts.sansSerif,
+
+  primary100: colors.primary,
+  primary200: colors.primary,
+  primary300: colors.primary,
+  primary400: colors.primary,
+  primary500: colors.primary,
+  primary600: colors.primary,
+  primary700: colors.primary,
+
+  // Override gray values based on what is actually used in BaseWeb, and the
+  // way we want it to match our theme originating from Bootstrap.
+  mono100: colors.white, // Popup menu
+  mono200: colors.lightestGray, // Text input, text area, selectbox
+  mono300: colors.lightGray, // Disabled widget background
+  mono400: colors.lightGray, // Slider track
+  mono500: colors.gray, // Clicked checkbox and radio
+  mono600: colors.gray, // Disabled widget text
+  mono700: colors.gray, // Unselected checkbox and radio
+  mono800: colors.darkGray, // Selectbox text
+  mono900: colors.darkGray, // Not used, but just in case.
+  mono1000: colors.black,
+
+  rating200: "#FFE1A5",
+  rating400: "#FFC043",
+}
+
+// TODO: figure out colors
+const darkThemePrimitives = {
   ...lightBaseThemePrimitives,
 
   primaryFontFamily: fonts.sansSerif,
@@ -145,6 +177,9 @@ export const lightBaseUITheme = createTheme(
   lightThemePrimitives,
   themeOverrides
 )
+
+export const darkBaseUITheme = createTheme(darkThemePrimitives, themeOverrides)
+
 export const sidebarBaseUITheme = createTheme(lightThemePrimitives, {
   ...themeOverrides,
   colors: {

--- a/frontend/src/theme/baseui.ts
+++ b/frontend/src/theme/baseui.ts
@@ -73,7 +73,7 @@ const lightThemePrimitives = {
 
 // TODO: figure out colors
 const darkThemePrimitives = {
-  ...lightBaseThemePrimitives,
+  ...darkBaseThemePrimitives,
 
   primaryFontFamily: fonts.sansSerif,
 

--- a/frontend/src/theme/darkTheme/index.ts
+++ b/frontend/src/theme/darkTheme/index.ts
@@ -21,7 +21,6 @@ import colors from "./themeColors"
 
 export default {
   ...baseTheme,
-  name: "Dark",
   inSidebar: false,
   colors,
 }

--- a/frontend/src/theme/darkTheme/themeColors.ts
+++ b/frontend/src/theme/darkTheme/themeColors.ts
@@ -20,7 +20,8 @@ import { colors } from "../primitives/colors"
 
 const genericColors = {
   ...colors,
-  bodyText: colors.gray90,
+  bgColor: colors.gray100,
+  bodyText: colors.gray10,
   danger: "#9d292d",
   info: "#1e6777",
   success: "#176c36",

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { LightTheme, DarkTheme } from "baseui"
+import { lightBaseUITheme, darkBaseUITheme } from "./baseui"
 import base from "./baseTheme"
 import light from "./lightTheme"
 import dark from "./darkTheme"
@@ -29,7 +31,23 @@ export const darkTheme: Theme = dark
 export const sidebarTheme: Theme = sidebar
 
 export const AvailableTheme = {
-  lightTheme: light,
-  darkTheme: dark,
-  customTheme: base, // TODO: base, main or nothing?
+  lightTheme: {
+    name: "Light",
+    emotion: light,
+    base: LightTheme,
+    baseui: lightBaseUITheme,
+  },
+  darkTheme: {
+    name: "Dark",
+    emotion: dark,
+    base: DarkTheme,
+    baseui: darkBaseUITheme,
+  },
+  customTheme: {
+    // TODO: base, main or nothing?
+    name: "Custom",
+    emotion: base,
+    base: LightTheme,
+    baseui: lightBaseUITheme,
+  },
 }

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -34,20 +34,20 @@ export const AvailableTheme = {
   lightTheme: {
     name: "Light",
     emotion: light,
-    base: LightTheme,
-    baseui: lightBaseUITheme,
+    baseweb: LightTheme,
+    basewebTheme: lightBaseUITheme,
   },
   darkTheme: {
     name: "Dark",
     emotion: dark,
-    base: DarkTheme,
-    baseui: darkBaseUITheme,
+    baseweb: DarkTheme,
+    basewebTheme: darkBaseUITheme,
   },
   customTheme: {
     // TODO: base, main or nothing?
     name: "Custom",
     emotion: base,
-    base: LightTheme,
-    baseui: lightBaseUITheme,
+    baseweb: LightTheme,
+    basewebTheme: lightBaseUITheme,
   },
 }

--- a/frontend/src/theme/lightTheme/index.ts
+++ b/frontend/src/theme/lightTheme/index.ts
@@ -21,7 +21,6 @@ import colors from "./themeColors"
 
 export default {
   ...baseTheme,
-  name: "Light",
   inSidebar: false,
   colors,
 }

--- a/frontend/src/theme/lightTheme/themeColors.ts
+++ b/frontend/src/theme/lightTheme/themeColors.ts
@@ -20,6 +20,7 @@ import { colors } from "../primitives/colors"
 
 const genericColors = {
   ...colors,
+  bgColor: colors.white,
   bodyText: colors.gray90,
   danger: "#9d292d",
   info: "#1e6777",

--- a/frontend/src/theme/sidebarTheme/sidebarColors.ts
+++ b/frontend/src/theme/sidebarTheme/sidebarColors.ts
@@ -20,6 +20,7 @@ import { colors } from "../primitives/colors"
 
 const genericColors = {
   ...colors,
+  bgColor: colors.gray100,
   bodyText: colors.gray90,
   danger: "#9d292d",
   info: "#1e6777",

--- a/frontend/src/theme/types.ts
+++ b/frontend/src/theme/types.ts
@@ -23,8 +23,13 @@ export type Theme = typeof base
 export type ThemeConfig = {
   name: string
   emotion: Theme
-  base: typeof LightTheme
-  baseui: typeof lightBaseUITheme
+  // For use with the BaseProvider that adds a LayersManager and ThemeProvider.
+  // Unfortunately Theme is required.
+  baseweb: typeof LightTheme
+  // For use with Baseweb's ThemeProvider. This is required in order for us to
+  // create separate themes for in the children. Currently required to accomodate
+  // sidebar theming.
+  basewebTheme: typeof lightBaseUITheme
 }
 type IconSizes = typeof base.iconSizes
 type ThemeSpacings = typeof base.spacing

--- a/frontend/src/theme/types.ts
+++ b/frontend/src/theme/types.ts
@@ -15,9 +15,17 @@
  * limitations under the License.
  */
 
+import { LightTheme } from "baseui"
 import base from "./baseTheme"
+import { lightBaseUITheme } from "./baseui"
 
 export type Theme = typeof base
+export type ThemeConfig = {
+  name: string
+  emotion: Theme
+  base: typeof LightTheme
+  baseui: typeof lightBaseUITheme
+}
 type IconSizes = typeof base.iconSizes
 type ThemeSpacings = typeof base.spacing
 type ThemeColors = typeof base.colors


### PR DESCRIPTION
Support baseweb theming by converting Theme to a configuration object with information about the different components making up a theme.

Added dark mode from baseweb

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
