### PR TITLE
Indicate widgets need to have labels

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -31,7 +31,7 @@ class FileUploaderMixin:
 
         Parameters
         ----------
-        label : str or None
+        label : str
             A short label explaining to the user what this file uploader is for.
 
         type : str or list of str or None

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -37,7 +37,7 @@ class NumberInputMixin:
 
         Parameters
         ----------
-        label : str or None
+        label : str
             A short label explaining to the user what this input is for.
         min_value : int or float or None
             The minimum permitted value.

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -43,7 +43,7 @@ class SelectSliderMixin:
 
         Parameters
         ----------
-        label : str or None
+        label : str
             A short label explaining to the user what this slider is for.
         options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
             Labels for the slider options. All options will be cast to str

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -48,7 +48,7 @@ class SliderMixin:
 
         Parameters
         ----------
-        label : str or None
+        label : str
             A short label explaining to the user what this slider is for.
         min_value : a supported type or None
             The minimum permitted value.


### PR DESCRIPTION
Fixes #2584 by removing the `or None` from the label docstring. Additionally, removed this in several other places per @nthmost comment that "widgets have labels"