### PR TITLE
Revert "🔧 "Run on save" now defaults to true"

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -467,9 +467,9 @@ def _server_live_save():
 def _server_run_on_save():
     """Automatically rerun script when the file is modified on disk.
 
-    Default: true
+    Default: false
     """
-    return True
+    return False
 
 
 @_create_option("server.allowRunOnSave", type_=bool, visibility="hidden")


### PR DESCRIPTION
Based on review with product, revert for now and release once this change has been communicated out to our users and a pre-determined waiting time has passed.

This could potentially break users workflow, in particular if users hit an API with a limit without any caching. Frequent reruns could throttle their workflow.