### PR TITLE
Release 0.76

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,20 @@ This page lists highlights, bug fixes, and known issues for official Streamlit r
       $ pip install --upgrade streamlit
 ```
 
+## Version 0.76.0
+
+_Release date: February 4, 2021_
+
+**Notable Changes**
+
+- 🎨 [`st.color_picker`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.color_picker) is now out of beta. This means the old beta_color_picker function, which was marked as deprecated for the past 3 months, has now been replaced with color_picker.
+- 🐍 Display a warning when a Streamlit script is run directly as `python script.py`.
+- [`st.image`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.image)'s `use_column_width` now defaults to an `auto` option which will resize the image to the column width if the image exceeds the column width.
+- ✂️ Fixed bugs ([2437](https://github.com/streamlit/streamlit/issues/2437) and [2247](https://github.com/streamlit/streamlit/issues/2247)) with content getting cut off within a [`st.beta_expander`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.beta_expander)
+- 📜 Fixed a [bug](https://github.com/streamlit/streamlit/issues/2543) in [`st.dataframe`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.dataframe) where the scrollbar overlapped with the contents in the last column.
+- 💾 Fixed a [bug](https://github.com/streamlit/streamlit/issues/2561) for [`st.file_uploader`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.file_uploader) where file data returned was not the most recently uploaded file.
+- ➕ Fixed bugs ([2086](https://github.com/streamlit/streamlit/issues/2086) and [2556](https://github.com/streamlit/streamlit/issues/2556)) where some LaTeX commands were not rendering correctly.
+
 ## Version 0.75.0
 
 _Release date: January 21, 2021_
@@ -26,7 +40,7 @@ _Release date: January 21, 2021_
   previously would clear the component at the end of the script. It has now been
   updated to clear the component instantly.
 - 🛹 Previously in wide mode, we had thin margins around the webpage. This has
-  now been increased to provide a better user experience.
+  now been increased to provide a better visual experience.
 
 ## Version 0.74.0
 

--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -35,7 +35,7 @@ pip install --upgrade streamlit
 streamlit version
 ```
 
-...and then verify that the version number printed is `0.75.0`.
+...and then verify that the version number printed is `0.76.0`.
 
 **Try reproducing the issue now.** If not fixed, keep reading on.
 

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -76,7 +76,7 @@ describe("st.file_uploader", () => {
     });
   });
 
-  it("uploads single file only", () => {
+  it("uploads and delete single file only", () => {
     const fileName1 = "file1.txt";
     const fileName2 = "file2.txt";
 
@@ -135,11 +135,19 @@ describe("st.file_uploader", () => {
         cy.get("[data-testid='stText']")
           .first()
           .should("contain.text", file2);
+
+        // Can delete
+        cy.get("[data-testid='fileDeleteBtn'] button")
+          .first()
+          .click();
+        cy.get("[data-testid='stText']")
+          .first()
+          .should("contain.text", "No upload");
       });
     });
   });
 
-  it("uploads multiple files", () => {
+  it("uploads and delete multiple files", () => {
     const fileName1 = "file1.txt";
     const fileName2 = "file2.txt";
 
@@ -147,7 +155,6 @@ describe("st.file_uploader", () => {
     // in Cypress (!!) using Cypress.Promise.all is buggy. See:
     // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__fixtures/cypress/integration/multiple-fixtures-spec.js
     // Why can’t I use async / await?
-    // If you’re a modern JS programmer you might hear “asynchronous” and think: why can’t I just use async/await instead of learning some proprietary API?
     // https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous
     cy.fixture(fileName1).then(file1 => {
       cy.fixture(fileName2).then(file2 => {
@@ -197,6 +204,15 @@ describe("st.file_uploader", () => {
         cy.get("[data-testid='stFileUploader']")
           .last()
           .matchImageSnapshot("multi_file_uploader-uploaded");
+
+        // Delete the second file. The second file is on top because it was
+        // most recently uploaded. The first file should still exist.
+        cy.get("[data-testid='fileDeleteBtn'] button")
+          .first()
+          .click();
+        cy.get("[data-testid='stText']")
+          .last()
+          .should("contain.text", file1);
       });
     });
   });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-browser",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/frontend/src/components/widgets/FileUploader/UploadedFile.tsx
+++ b/frontend/src/components/widgets/FileUploader/UploadedFile.tsx
@@ -117,9 +117,11 @@ const UploadedFile = ({
         </StyledUploadedFileName>
         <UploadedFileStatus file={file} progress={progress} />
       </StyledUploadedFileData>
-      <Button onClick={() => onDelete(file.id || "")} kind={Kind.MINIMAL}>
-        <Icon content={Clear} size="lg" />
-      </Button>
+      <div data-testid="fileDeleteBtn">
+        <Button onClick={() => onDelete(file.id || "")} kind={Kind.MINIMAL}>
+          <Icon content={Clear} size="lg" />
+        </Button>
+      </div>
     </StyledUploadedFile>
   )
 }

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -92,7 +92,7 @@ describe("FileUploadClient Upload", () => {
     ]
 
     await expect(
-      uploader.uploadFiles("widgetId", files)
+      uploader.uploadFiles("widgetId", files, 2)
     ).resolves.toBeUndefined()
   })
 
@@ -106,7 +106,7 @@ describe("FileUploadClient Upload", () => {
       new File(["file2"], "file2.txt"),
     ]
 
-    await expect(uploader.uploadFiles("widgetId", files)).rejects.toEqual(
+    await expect(uploader.uploadFiles("widgetId", files, 2)).rejects.toEqual(
       new Error("Request failed with status code 400")
     )
   })

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -27,7 +27,7 @@ except:
     )
     sys.exit(exit_msg)
 
-VERSION = "0.75.0"  # PEP-440
+VERSION = "0.76.0"  # PEP-440
 
 NAME = "streamlit"
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -69,6 +69,8 @@ import threading as _threading
 import traceback as _traceback
 import urllib.parse as _parse
 
+import click as _click
+
 from streamlit import code_util as _code_util
 from streamlit import env_util as _env_util
 from streamlit import source_util as _source_util
@@ -497,18 +499,11 @@ def _maybe_print_use_warning():
     if not _use_warning_has_been_displayed:
         _use_warning_has_been_displayed = True
 
+        warning = _click.style("Warning:", bold=True, fg="yellow")
+
         if _env_util.is_repl():
             _LOGGER.warning(
-                _textwrap.dedent(
-                    """
-
-                Will not generate Streamlit app
-
-                  To generate an app, use Streamlit in a file and run it with:
-                  $ streamlit run [FILE_NAME] [ARGUMENTS]
-
-                """
-                )
+                f"\n  {warning} to view a Streamlit app on a browser, use Streamlit in a file and\n  run it with the following command:\n\n    streamlit run [FILE_NAME] [ARGUMENTS]"
             )
 
         elif not _is_running_with_streamlit and _config.get_option(
@@ -517,16 +512,7 @@ def _maybe_print_use_warning():
             script_name = _sys.argv[0]
 
             _LOGGER.warning(
-                _textwrap.dedent(
-                    f"""
-
-                Will not generate Streamlit App
-
-                  To generate an App, run this file with:
-                  $ streamlit run {script_name} [ARGUMENTS]
-
-                """
-                )
+                f"\n  {warning} to view this Streamlit app on a browser, run it with the following\n  command:\n\n    streamlit run {script_name} [ARGUMENTS]"
             )
 
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -197,8 +197,6 @@ def _beta_warning(func, date):
     return wrapped
 
 
-beta_set_page_config = _beta_warning(set_page_config, "2021-01-06")
-beta_color_picker = _beta_warning(_main.color_picker, "January 28, 2021")
 beta_container = _main.beta_container  # noqa: E221
 beta_expander = _main.beta_expander  # noqa: E221
 beta_columns = _main.beta_columns  # noqa: E221

--- a/lib/tests/streamlit/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/upload_file_request_handler_test.py
@@ -152,6 +152,8 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.file_mgr.add_files("session1", "widget1", [file1])
         self.file_mgr.add_files("session2", "widget2", [file2])
+        self.file_mgr.update_file_count("session1", "widget1", 1)
+        self.file_mgr.update_file_count("session2", "widget2", 1)
 
         response = self.fetch(f"/upload_file/session1/widget1/1234", method="DELETE")
         self.assertEqual(200, response.code)
@@ -256,6 +258,8 @@ class UploadFileRequestHandlerInvalidSessionTest(tornado.testing.AsyncHTTPTestCa
 
         self.file_mgr.add_files("session1", "widget1", [file1])
         self.file_mgr.add_files("session2", "widget2", [file2])
+        self.file_mgr.update_file_count("session1", "widget1", 1)
+        self.file_mgr.update_file_count("session2", "widget2", 1)
 
         response = self.fetch(f"/upload_file/session1/widget1/1234", method="DELETE")
         self.assertEqual(404, response.code)

--- a/lib/tests/streamlit/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/uploaded_file_manager_test.py
@@ -87,3 +87,10 @@ class UploadedFileManagerTest(unittest.TestCase):
         self.assertIsNone(self.mgr.get_files("session1", "widget1"))
         self.assertIsNone(self.mgr.get_files("session1", "widget2"))
         self.assertEqual([file1], self.mgr.get_files("session2", "widget"))
+
+    def test_replace_widget_files(self):
+        self.mgr.add_files("session1", "widget", [file1])
+        self.mgr.replace_files("session1", "widget", [file2])
+
+        self.assertEqual(len(self.mgr.get_files("session1", "widget")), 1)
+        self.assertEqual([file2], self.mgr.get_files("session1", "widget"))


### PR DESCRIPTION
Currently blocked by
- [x] #2704 
- [x] #127 

## Version 0.76.0

_Release date: February 4, 2021_

**Notable Changes**
- 🎨 [`st.color_picker`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.color_picker) is now out of beta.
- 🐍 Display a warning when a Streamlit script is run directly as `python script.py`.
- [`st.image`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.image)'s `use_column_width` now defaults to an `auto` option which will resize the image to the column width if the image exceeds the column width.
- ✂️ Fixed bugs ([2437](https://github.com/streamlit/streamlit/issues/2437) and [2247](https://github.com/streamlit/streamlit/issues/2247)) with content getting cut off within a [`st.beta_expander`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.beta_expander)
- 📜 Fixed a [bug](https://github.com/streamlit/streamlit/issues/2543) in [`st.dataframe`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.dataframe) where the scrollbar overlapped with the contents in the last column.
- 💾 Fixed a [bug](https://github.com/streamlit/streamlit/issues/2561) for [`st.file_uploader`](https://docs.streamlit.io/en/0.76.0/api.html#streamlit.file_uploader) where file data returned was not the most recently uploaded file.
- Fixed bugs ([2086](https://github.com/streamlit/streamlit/issues/2086) and [2556](https://github.com/streamlit/streamlit/issues/2556)) where some LaTeX commands were not rendering correctly.