### PR TITLE
Fix report_session_test

### DIFF
--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -241,7 +241,7 @@ class ReportSessionNewReportTest(tornado.testing.AsyncTestCase):
         rs._report.report_id = "testing _enqueue_new_report"
 
         orig_ctx = get_report_ctx()
-        ctx = ReportContext("TestSessionID", rs._report.enqueue, "", None, None, None)
+        ctx = ReportContext("TestSessionID", rs._report.enqueue, "", None, None)
         add_report_ctx(ctx=ctx)
 
         rs._on_scriptrunner_event(ScriptRunnerEvent.SCRIPT_STARTED)


### PR DESCRIPTION
Apparently a constructor signature changed on `develop`, causing a newly added
test in `report_session_test` to fail.