### PR TITLE
Have plotly charts apply theme options

### DIFF
--- a/frontend/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -16,14 +16,16 @@
  */
 
 import React from "react"
-import { shallow } from "lib/test_util"
+import { mount } from "lib/test_util"
 import Plot from "react-plotly.js"
 
+import ThemeProvider from "components/core/ThemeProvider"
+import { darkTheme } from "theme"
 import { PlotlyChart as PlotlyChartProto } from "autogen/proto"
 import mock from "./mock"
 import { DEFAULT_HEIGHT, PlotlyChartProps } from "./PlotlyChart"
 
-jest.mock("react-plotly.js", () => jest.fn())
+jest.mock("react-plotly.js", () => jest.fn(() => null))
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { PlotlyChart } = require("./PlotlyChart")
@@ -42,7 +44,7 @@ const getProps = (
 describe("PlotlyChart Element", () => {
   it("renders without crashing", () => {
     const props = getProps()
-    const wrapper = shallow(<PlotlyChart {...props} />)
+    const wrapper = mount(<PlotlyChart {...props} />)
 
     expect(wrapper.find(Plot).length).toBe(1)
   })
@@ -54,7 +56,7 @@ describe("PlotlyChart Element", () => {
         height: 400,
         width: 400,
       }
-      const wrapper = shallow(<PlotlyChart {...props} />)
+      const wrapper = mount(<PlotlyChart {...props} />)
 
       expect(wrapper.find(Plot).props()).toMatchSnapshot()
     })
@@ -66,7 +68,7 @@ describe("PlotlyChart Element", () => {
         }),
         width: 400,
       }
-      const wrapper = shallow(<PlotlyChart {...props} />)
+      const wrapper = mount(<PlotlyChart {...props} />)
       expect(wrapper.find(Plot).props()).toMatchSnapshot()
     })
   })
@@ -79,7 +81,7 @@ describe("PlotlyChart Element", () => {
     })
 
     it("should render an iframe", () => {
-      const wrapper = shallow(<PlotlyChart {...props} />)
+      const wrapper = mount(<PlotlyChart {...props} />)
 
       expect(wrapper.find("iframe").length).toBe(1)
       expect(wrapper.find("iframe").props()).toMatchSnapshot()
@@ -93,10 +95,61 @@ describe("PlotlyChart Element", () => {
         height: 400,
         width: 500,
       }
-      const wrapper = shallow(<PlotlyChart {...propsWithHeight} />)
+      const wrapper = mount(<PlotlyChart {...propsWithHeight} />)
 
       // @ts-ignore
       expect(wrapper.find("iframe").prop("style").height).toBe(400)
+    })
+  })
+
+  describe("Theming", () => {
+    it("pulls default config values from theme", () => {
+      const props = getProps()
+      const wrapper = mount(
+        <ThemeProvider
+          theme={darkTheme.emotion}
+          baseuiTheme={darkTheme.basewebTheme}
+        >
+          <PlotlyChart {...props} />
+        </ThemeProvider>
+      )
+
+      const { layout } = wrapper
+        .find(Plot)
+        .first()
+        .props()
+      expect(layout.paper_bgcolor).toBe(darkTheme.emotion.colors.bgColor)
+      expect(layout.font.color).toBe(darkTheme.emotion.colors.bodyText)
+    })
+
+    it("has user specified config take priority", () => {
+      const props = getProps()
+
+      const spec = JSON.parse(props.element.figure.spec)
+      spec.layout = {
+        ...spec.layout,
+        paper_bgcolor: "orange",
+      }
+
+      props.element.figure.spec = JSON.stringify(spec)
+
+      const wrapper = mount(
+        <ThemeProvider
+          theme={darkTheme.emotion}
+          baseuiTheme={darkTheme.basewebTheme}
+        >
+          <PlotlyChart {...props} />
+        </ThemeProvider>
+      )
+
+      const { layout } = wrapper
+        .find(Plot)
+        .first()
+        .props()
+      expect(layout.paper_bgcolor).toBe("orange")
+      // Verify that things not overwritten by the user still fall back to the
+      // theme default.
+      expect(layout.font.color).toBe(darkTheme.emotion.colors.bodyText)
     })
   })
 })

--- a/frontend/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -21,6 +21,8 @@
  */
 
 import React, { ReactElement } from "react"
+import { useTheme } from "emotion-theming"
+import { Theme } from "theme"
 import {
   Figure as FigureProto,
   PlotlyChart as PlotlyChartProto,
@@ -59,6 +61,9 @@ export function PlotlyChart({
       spec.layout.width = propWidth
     }
 
+    const theme: Theme = useTheme()
+    spec.layout = layoutWithThemeDefaults(spec.layout, theme)
+
     return spec
   }
 
@@ -85,6 +90,34 @@ export function PlotlyChart({
       return renderFigure(element.figure as FigureProto)
     default:
       throw new Error(`Unrecognized PlotlyChart type: ${element.chart}`)
+  }
+}
+
+function layoutWithThemeDefaults(layout: any, theme: Theme): any {
+  const { colors, genericFonts, inSidebar } = theme
+  const themeBg = inSidebar ? colors.sidebarBg : colors.bgColor
+
+  const themeDefaults = {
+    font: {
+      color: colors.bodyText,
+      family: genericFonts.bodyFont,
+    },
+    paper_bgcolor: themeBg,
+    // TODO: Figure out what a reasonable default background color for this is.
+    //       The plotly default looks fine in Light mode but looks pretty janky
+    //       in Dark mode.
+    plot_bgcolor: undefined,
+  }
+
+  // Fill in theme defaults where the user didn't specify layout options.
+  return {
+    ...layout,
+    font: {
+      ...themeDefaults.font,
+      ...layout.font,
+    },
+    paper_bgcolor: layout.paper_bgcolor || themeDefaults.paper_bgcolor,
+    plot_bgcolor: layout.plot_bgcolor || themeDefaults.plot_bgcolor,
   }
 }
 

--- a/frontend/src/components/elements/PlotlyChart/__snapshots__/PlotlyChart.test.tsx.snap
+++ b/frontend/src/components/elements/PlotlyChart/__snapshots__/PlotlyChart.test.tsx.snap
@@ -4971,11 +4971,17 @@ Object {
   "frames": undefined,
   "layout": Object {
     "barmode": "overlay",
+    "font": Object {
+      "color": "#262730",
+      "family": "IBM Plex Sans, sans-serif",
+    },
     "height": 400,
     "hovermode": "closest",
     "legend": Object {
       "traceorder": "reversed",
     },
+    "paper_bgcolor": "#FFFFFF",
+    "plot_bgcolor": undefined,
     "template": Object {
       "data": Object {
         "bar": Array [
@@ -10782,10 +10788,16 @@ Object {
   "frames": undefined,
   "layout": Object {
     "barmode": "overlay",
+    "font": Object {
+      "color": "#262730",
+      "family": "IBM Plex Sans, sans-serif",
+    },
     "hovermode": "closest",
     "legend": Object {
       "traceorder": "reversed",
     },
+    "paper_bgcolor": "#FFFFFF",
+    "plot_bgcolor": undefined,
     "template": Object {
       "data": Object {
         "bar": Array [

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -464,30 +464,28 @@ function dataIsAnAppendOfPrev(
 }
 
 function configWithThemeDefaults(config: any, theme: Theme): any {
-  const textColor = theme.colors.bodyText
+  const { colors, genericFonts, inSidebar } = theme
   const themeFonts = {
-    labelFont: theme.genericFonts.bodyFont,
-    titleFont: theme.genericFonts.bodyFont,
+    labelFont: genericFonts.bodyFont,
+    titleFont: genericFonts.bodyFont,
   }
-  const themeBg = theme.inSidebar
-    ? theme.colors.sidebarBg
-    : theme.colors.bgColor
+  const themeBg = inSidebar ? colors.sidebarBg : colors.bgColor
 
   const themeDefaults = {
     background: themeBg,
     axis: {
-      labelColor: textColor,
-      titleColor: textColor,
+      labelColor: colors.bodyText,
+      titleColor: colors.bodyText,
       ...themeFonts,
     },
     legend: {
-      labelColor: textColor,
-      titleColor: textColor,
+      labelColor: colors.bodyText,
+      titleColor: colors.bodyText,
       ...themeFonts,
     },
     title: {
-      color: textColor,
-      subtitleColor: textColor,
+      color: colors.bodyText,
+      subtitleColor: colors.bodyText,
       ...themeFonts,
     },
   }


### PR DESCRIPTION
This isn't totally done yet as plotly has two background colors: the
"paper" background color and "plot" background color, and the default
plot background color looks fine in light mode but pretty silly in dark.

We could fix this by changing plotly chart style to match our other plot
types, but I'm not sure if we want to do that since it does end up being
a pretty drastic change from the plotly defaults. For now I just left a TODO
to circle back to this later.