### PR TITLE
Fixing monospace up

### DIFF
--- a/frontend/src/components/core/MainMenu/styled-components.ts
+++ b/frontend/src/components/core/MainMenu/styled-components.ts
@@ -115,4 +115,6 @@ export const StyledMenuItem = styled.li<StyledMenuItemProps>(
 export const StyledMenuItemLabel = styled.span(({ theme }) => ({
   marginRight: theme.spacing.md,
   flexGrow: 1,
+  // We do not want to change the font for this based on theme.
+  fontFamily: theme.fonts.sansSerif,
 }))

--- a/frontend/src/components/core/ReportView/styled-components.ts
+++ b/frontend/src/components/core/ReportView/styled-components.ts
@@ -88,6 +88,8 @@ export const StyledReportViewBlockContainer = styled.div<
 
 export const StyledReportViewFooterLink = styled.a(({ theme }) => ({
   color: theme.colors.gray50,
+  // We do not want to change the font for this based on theme.
+  fontFamily: theme.fonts.sansSerif,
   transition: "color 300ms",
   "&:hover": {
     textDecoration: "underline",

--- a/frontend/src/components/elements/DataFrame/styled-components.ts
+++ b/frontend/src/components/elements/DataFrame/styled-components.ts
@@ -43,7 +43,7 @@ export const StyledDataFrameContainer = styled.div<
 const StyledDataFrameCell = styled.div(({ theme }) => ({
   padding: theme.spacing.sm,
   fontSize: theme.fontSizes.smDefault,
-  fontFamily: theme.fonts.mono,
+  fontFamily: theme.fonts.monospace,
   textAlign: "right",
   lineHeight: theme.lineHeights.none,
 }))
@@ -109,7 +109,7 @@ export const StyledFixup = styled.div<StyledFixupProps>(
 )
 
 export const StyledEmptyDataframe = styled.div(({ theme }) => ({
-  fontFamily: theme.fonts.mono,
+  fontFamily: theme.fonts.monospace,
   color: theme.colors.darkGray,
   fontStyle: "italic",
   fontSize: theme.fontSizes.smDefault,

--- a/frontend/src/components/elements/DocString/styled-components.ts
+++ b/frontend/src/components/elements/DocString/styled-components.ts
@@ -33,7 +33,7 @@ export const StyledDocContainer = styled.span<StyledDocContainerProps>(
   ({ theme, width }) => ({
     backgroundColor: theme.colors.docStringContainerBackground,
     padding: `${theme.spacing.sm} ${theme.spacing.lg}`,
-    fontFamily: theme.fonts.mono,
+    fontFamily: theme.fonts.monospace,
     fontSize: theme.fontSizes.smDefault,
     overflowX: "auto",
     width,

--- a/frontend/src/components/elements/ImageList/styled-components.ts
+++ b/frontend/src/components/elements/ImageList/styled-components.ts
@@ -23,7 +23,7 @@ export const StyledImageContainer = styled.div(({ theme }) => ({
 }))
 
 export const StyledCaption = styled.div(({ theme }) => ({
-  fontFamily: theme.fonts.mono,
+  fontFamily: theme.fonts.monospace,
   fontSize: theme.fontSizes.smDefault,
   textAlign: "center",
 }))

--- a/frontend/src/components/elements/Table/styled-components.ts
+++ b/frontend/src/components/elements/Table/styled-components.ts
@@ -20,7 +20,7 @@ import { Theme } from "theme"
 
 export const StyledTableContainer = styled.div(({ theme }) => ({
   fontSize: theme.fontSizes.smDefault,
-  fontFamily: theme.fonts.mono,
+  fontFamily: theme.fonts.monospace,
   textAlign: "right",
   padding: theme.spacing.sm,
   lineHeight: theme.lineHeights.table,

--- a/frontend/src/components/elements/Text/styled-components.ts
+++ b/frontend/src/components/elements/Text/styled-components.ts
@@ -18,7 +18,7 @@
 import styled from "@emotion/styled"
 
 export const StyledText = styled.div(({ theme }) => ({
-  fontFamily: theme.fonts.mono,
+  fontFamily: theme.fonts.monospace,
   whiteSpace: "pre",
   fontSize: theme.fontSizes.smDefault,
   overflowX: "auto",

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -269,7 +269,7 @@ class Slider extends React.PureComponent<Props, State> {
             },
             Tick: {
               style: {
-                fontFamily: fonts.mono,
+                fontFamily: fonts.monospace,
                 fontSize: fontSizes.smDefault,
               },
             },

--- a/frontend/src/components/widgets/Slider/styled-components.ts
+++ b/frontend/src/components/widgets/Slider/styled-components.ts
@@ -23,7 +23,7 @@ export interface StyledThumbValueProps {
 
 export const StyledThumbValue = styled.div<StyledThumbValueProps>(
   ({ isDisabled, theme }) => ({
-    fontFamily: theme.fonts.mono,
+    fontFamily: theme.fonts.monospace,
     fontSize: theme.fontSizes.smDefault,
     paddingBottom: theme.fontSizes.twoThirdSmDefault,
     color: isDisabled ? theme.colors.gray : theme.colors.primary,
@@ -50,5 +50,5 @@ export const StyledTickBarItem = styled.div(({ theme }) => ({
   lineHeight: theme.lineHeights.base,
   fontWeight: "normal",
   fontSize: theme.fontSizes.smDefault,
-  fontFamily: theme.fonts.mono,
+  fontFamily: theme.fonts.monospace,
 }))

--- a/frontend/src/theme/primitives/typography.ts
+++ b/frontend/src/theme/primitives/typography.ts
@@ -17,13 +17,13 @@
 
 export const fonts = {
   sansSerif: "IBM Plex Sans, sans-serif",
-  mono: "IBM Plex Mono, monospace",
+  monospace: "IBM Plex Mono, monospace",
   serif: "IBM Plex Serif, serif",
 }
 
 export const genericFonts = {
   bodyFont: fonts.sansSerif,
-  codeFont: fonts.mono,
+  codeFont: fonts.monospace,
   headingFont: fonts.sansSerif,
 }
 

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -16,11 +16,11 @@
  */
 import { CustomThemeConfig } from "autogen/proto"
 import { LocalStore } from "lib/storageUtils"
-import { darkTheme, lightTheme } from "theme"
-import baseTheme from "./baseTheme"
+import { baseTheme, darkTheme, lightTheme } from "theme"
 import {
   AUTO_THEME,
   computeSpacingStyle,
+  createEmotionTheme,
   createTheme,
   getDefaultTheme,
   getSystemTheme,
@@ -60,9 +60,13 @@ describe("createTheme", () => {
     expect(customTheme.name).toBe("my theme")
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
-    expect(customTheme.emotion.genericFonts.bodyFont).toBe("serif")
+    expect(customTheme.emotion.genericFonts.bodyFont).toBe(
+      baseTheme.emotion.fonts.serif
+    )
     // If it is not provided, use the default
-    expect(customTheme.emotion.colors.bgColor).toBe(baseTheme.colors.bgColor)
+    expect(customTheme.emotion.colors.bgColor).toBe(
+      baseTheme.emotion.colors.bgColor
+    )
   })
 
   it("createTheme returns a theme based on a different theme", () => {
@@ -76,7 +80,9 @@ describe("createTheme", () => {
     expect(customTheme.name).toBe("my theme")
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
-    expect(customTheme.emotion.genericFonts.bodyFont).toBe("serif")
+    expect(customTheme.emotion.genericFonts.bodyFont).toBe(
+      baseTheme.emotion.fonts.serif
+    )
     // If it is not provided, use the default
     expect(customTheme.emotion.colors.bgColor).toBe(
       darkTheme.emotion.colors.bgColor
@@ -170,5 +176,55 @@ describe("getSystemTheme", () => {
     })
 
     expect(getSystemTheme().name).toBe("Dark")
+  })
+})
+
+describe("createEmotionTheme", () => {
+  it("sets to light when matchMedia does not match dark", () => {
+    const themeInput: Partial<CustomThemeConfig> = {
+      name: "my theme",
+      font: CustomThemeConfig.FontFamily.MONOSPACE,
+      primary: "red",
+      secondary: "yellow",
+      backgroundColor: "pink",
+      secondaryBackground: "blue",
+      bodyText: "orange",
+    }
+
+    const theme = createEmotionTheme(themeInput)
+
+    expect(theme.colors.primary).toBe("red")
+    expect(theme.colors.secondary).toBe("yellow")
+    expect(theme.colors.bgColor).toBe("pink")
+    expect(theme.colors.secondaryBg).toBe("blue")
+    expect(theme.colors.bodyText).toBe("orange")
+    expect(theme.genericFonts.bodyFont).toBe(theme.fonts.monospace)
+    expect(theme.genericFonts.headingFont).toBe(theme.fonts.monospace)
+    expect(theme.genericFonts.codeFont).toBe(theme.fonts.monospace)
+  })
+
+  it("defaults to base if missing value", () => {
+    const themeInput: Partial<CustomThemeConfig> = {
+      name: "my theme",
+      primary: "red",
+      secondary: "yellow",
+    }
+
+    const theme = createEmotionTheme(themeInput)
+
+    expect(theme.colors.primary).toBe("red")
+    expect(theme.colors.secondary).toBe("yellow")
+    expect(theme.colors.bgColor).toBe(baseTheme.emotion.colors.bgColor)
+    expect(theme.colors.secondaryBg).toBe(baseTheme.emotion.colors.secondaryBg)
+    expect(theme.colors.bodyText).toBe(baseTheme.emotion.colors.bodyText)
+    expect(theme.genericFonts.bodyFont).toBe(
+      baseTheme.emotion.genericFonts.bodyFont
+    )
+    expect(theme.genericFonts.headingFont).toBe(
+      baseTheme.emotion.genericFonts.headingFont
+    )
+    expect(theme.genericFonts.codeFont).toBe(
+      baseTheme.emotion.genericFonts.codeFont
+    )
   })
 })

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -98,8 +98,8 @@ describe("getDefaultTheme", () => {
     })
   })
 
-  it("sets default when nothing is available", () => {
-    expect(getDefaultTheme().name).toBe("Light")
+  it("sets default to auto when nothing is available", () => {
+    expect(getDefaultTheme().name).toBe(AUTO_THEME)
   })
 
   it("sets default when value in localstorage is available", () => {
@@ -119,9 +119,11 @@ describe("getDefaultTheme", () => {
       })
     )
 
-    // Gets system theme which is Light
-    // Utility does not reassign theme name
-    expect(getDefaultTheme().name).toBe("Light")
+    const defaultTheme = getDefaultTheme()
+    expect(defaultTheme.name).toBe(AUTO_THEME)
+    expect(defaultTheme.emotion.colors.bgColor).toBe(
+      lightTheme.emotion.colors.bgColor
+    )
   })
 
   it("sets default when OS is dark", () => {
@@ -135,7 +137,11 @@ describe("getDefaultTheme", () => {
         ...matchMediaFillers,
       })),
     })
-    expect(getDefaultTheme().name).toBe("Dark")
+    const defaultTheme = getDefaultTheme()
+    expect(defaultTheme.name).toBe(AUTO_THEME)
+    expect(defaultTheme.emotion.colors.bgColor).toBe(
+      darkTheme.emotion.colors.bgColor
+    )
   })
 })
 

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -244,14 +244,21 @@ const createEmotionTheme = (
   themeInput: Partial<ICustomThemeConfig>,
   baseThemeConfig = baseTheme
 ): Theme => {
+  const { genericColors, genericFonts, fonts } = baseThemeConfig.emotion
+
   const { name, font, ...customColors } = themeInput
+  const parsedFont = font
+    ? (camelcase(
+        CustomThemeConfig.FontFamily[font].toString()
+      ) as keyof typeof fonts)
+    : undefined
+
   // Mapping from CustomThemeConfig to color primitives
   const {
     secondaryBackground: secondaryBg,
     backgroundColor: bgColor,
     ...paletteColors
   } = customColors
-  const { genericColors, genericFonts } = baseThemeConfig.emotion
   const newGenericColors = {
     ...genericColors,
     ...(paletteColors as { [key: string]: string }),
@@ -265,9 +272,10 @@ const createEmotionTheme = (
     genericColors: newGenericColors,
     genericFonts: {
       ...genericFonts,
-      ...(font && {
+      ...(parsedFont && {
         // Get the name of the enum key (i.e. serif) instead of the value (i.e. 1).
-        bodyFont: camelcase(CustomThemeConfig.FontFamily[font].toString()),
+        bodyFont: fonts[parsedFont],
+        headingFont: fonts[parsedFont],
       }),
     },
   }

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -26,6 +26,7 @@ import { CustomThemeConfig, ICustomThemeConfig } from "autogen/proto"
 import { logError } from "lib/log"
 import {
   baseTheme,
+  createAutoTheme,
   darkTheme,
   lightTheme,
   Theme,
@@ -287,20 +288,16 @@ export const createTheme = (
 }
 
 export const getSystemTheme = (): ThemeConfig => {
-  if (
-    window.matchMedia &&
+  return window.matchMedia &&
     window.matchMedia("(prefers-color-scheme: dark)").matches
-  ) {
-    return darkTheme
-  }
-  return lightTheme
+    ? darkTheme
+    : lightTheme
 }
 
 export const getDefaultTheme = (): ThemeConfig => {
   // Priority for default theme
   // 1. Previous user preference
   // 2. OS preference
-  // 3. Light theme
   const storedTheme = window.localStorage.getItem(LocalStore.ACTIVE_THEME)
   const parsedTheme = storedTheme
     ? (JSON.parse(storedTheme) as ThemeConfig)
@@ -311,7 +308,7 @@ export const getDefaultTheme = (): ThemeConfig => {
   // but checking in case!
   return parsedTheme && parsedTheme.name !== AUTO_THEME
     ? parsedTheme
-    : getSystemTheme()
+    : createAutoTheme()
 }
 
 const whiteSpace = /\s+/

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -247,11 +247,12 @@ export const createEmotionTheme = (
   const { genericColors, genericFonts, fonts } = baseThemeConfig.emotion
 
   const { name, font, ...customColors } = themeInput
-  const parsedFont = font
-    ? (camelcase(
-        CustomThemeConfig.FontFamily[font].toString()
-      ) as keyof typeof fonts)
-    : undefined
+  const parsedFont =
+    font !== null && font !== undefined // font can be 0 for sans serif
+      ? (camelcase(
+          CustomThemeConfig.FontFamily[font].toString()
+        ) as keyof typeof fonts)
+      : undefined
 
   // Mapping from CustomThemeConfig to color primitives
   const {

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -240,7 +240,7 @@ export const createEmotionColors = (genericColors: {
   tableGray: genericColors.gray40,
 })
 
-const createEmotionTheme = (
+export const createEmotionTheme = (
   themeInput: Partial<ICustomThemeConfig>,
   baseThemeConfig = baseTheme
 ): Theme => {

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -809,7 +809,7 @@ _create_option(
 _create_option(
     "customTheme.font",
     description="""
-        Font family (serif | sans serif | mono) for the page. Will not impact
+        Font family (serif | sans serif | monospace) for the page. Will not impact
         code areas.
         """,
     default_val="sans serif",

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -637,7 +637,7 @@ def _populate_custom_theme_msg(msg: CustomThemeConfig) -> None:
         font_map = {
             "sans serif": msg.FontFamily.SANS_SERIF,
             "serif": msg.FontFamily.SERIF,
-            "mono": msg.FontFamily.MONO,
+            "monospace": msg.FontFamily.MONOSPACE,
         }
         msg.font = font_map.get(
             config.get_option("customTheme.font"),

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -87,7 +87,7 @@ message CustomThemeConfig {
   enum FontFamily {
     SANS_SERIF = 0;
     SERIF = 1;
-    MONO = 2;
+    MONOSPACE = 2;
   }
 
   string name = 1;


### PR DESCRIPTION
From product review
1. monospace is the name of the font, not mono. Selecting mono doesn't work today
2. The title font looks different from the body font
3. Note: The hamburger menu and the bottom 'Made with Streamlit' should not change(chrome shouldn't change fonts)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
