### PR TITLE
config: client.showTracebacks

### DIFF
--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -23,7 +23,6 @@ import math
 import os
 import pickle
 import shutil
-import struct
 import textwrap
 import threading
 import time
@@ -35,8 +34,8 @@ from cachetools import TTLCache
 from streamlit import config
 from streamlit import file_util
 from streamlit import util
+from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIWarning
-from streamlit.errors import StreamlitDeprecationWarning
 from streamlit.hashing import Context
 from streamlit.hashing import update_hash
 from streamlit.hashing import HashReason
@@ -323,7 +322,7 @@ def _read_from_cache(
         )
 
     except CachedObjectMutationError as e:
-        st.exception(CachedObjectMutationWarning(e))
+        handle_uncaught_app_exception(CachedObjectMutationWarning(e))
         return e.cached_value
 
     except CacheKeyNotFoundError as e:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -354,6 +354,16 @@ _create_option(
     scriptable=True,
 )
 
+_create_option(
+    "client.showTracebacks",
+    description="""Controls whether uncaught app exceptions are displayed in
+        the browser. (By default, Streamlit displays app exceptions and their
+        tracebacks.)""",
+    default_val=True,
+    type_=bool,
+    scriptable=True,
+)
+
 # Config Section: Runner #
 
 _create_section("runner", "Settings for how Streamlit executes your script")

--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import os
-import traceback
 
 import streamlit as st
+from streamlit import config
+from streamlit.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 # Extract the streamlit package path
@@ -24,6 +27,23 @@ _streamlit_dir = os.path.dirname(st.__file__)
 # Make it absolute, resolve aliases, and ensure there's a trailing path
 # separator
 _streamlit_dir = os.path.join(os.path.realpath(_streamlit_dir), "")
+
+
+def handle_uncaught_app_exception(e: BaseException) -> None:
+    """Handle an exception that originated from a user app.
+    By default, we show exceptions directly in the browser. However,
+    if the user has disabled client tracebacks, we display a generic
+    warning in the frontend instead.
+    """
+    if config.get_option("client.showTracebacks"):
+        LOGGER.debug(e)
+        st.exception(e)
+        # TODO: Clean up the stack trace, so it doesn't include ScriptRunner.
+    else:
+        # Use LOGGER.error, rather than LOGGER.debug, since we don't
+        # show debug logs by default.
+        LOGGER.error("Uncaught app exception", exc_info=e)
+        st.error("Whoops - something went wrong! An error has been logged.")
 
 
 def _is_in_streamlit_package(file):

--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -28,6 +28,12 @@ _streamlit_dir = os.path.dirname(st.__file__)
 # separator
 _streamlit_dir = os.path.join(os.path.realpath(_streamlit_dir), "")
 
+# When client.showTracebacks is False, we show a generic warning in the
+# frontend when we encounter an uncaught app exception.
+_GENERIC_UNCAUGHT_EXCEPTION_TEXT = (
+    "Whoops - something went wrong! An error has been logged."
+)
+
 
 def handle_uncaught_app_exception(e: BaseException) -> None:
     """Handle an exception that originated from a user app.
@@ -43,7 +49,7 @@ def handle_uncaught_app_exception(e: BaseException) -> None:
         # Use LOGGER.error, rather than LOGGER.debug, since we don't
         # show debug logs by default.
         LOGGER.error("Uncaught app exception", exc_info=e)
-        st.error("Whoops - something went wrong! An error has been logged.")
+        st.error(_GENERIC_UNCAUGHT_EXCEPTION_TEXT)
 
 
 def _is_in_streamlit_package(file):

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -22,6 +22,7 @@ from blinker import Signal
 from streamlit import config
 from streamlit import magic
 from streamlit import source_util
+from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.media_file_manager import media_file_manager
 from streamlit.report_thread import ReportThread
 from streamlit.report_thread import get_report_ctx
@@ -338,13 +339,7 @@ class ScriptRunner(object):
             pass
 
         except BaseException as e:
-            # Show exceptions in the Streamlit report.
-            LOGGER.debug(e)
-            import streamlit as st
-
-            st.exception(e)  # This is OK because we're in the script thread.
-            # TODO: Clean up the stack trace, so it doesn't include
-            # ScriptRunner.
+            handle_uncaught_app_exception(e)
 
         finally:
             self._widgets.reset_triggers()

--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -13,17 +13,21 @@
 # limitations under the License.
 
 """st.caching unit tests."""
-from unittest.mock import patch, Mock
 import threading
-import unittest
 import types
+import unittest
+from unittest.mock import patch, Mock
 
+from parameterized import parameterized
+
+import streamlit as st
 from streamlit import caching
 from streamlit import hashing
 from streamlit.elements import exception
+from streamlit.error_util import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
+from streamlit.proto.Alert_pb2 import Alert
 from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
 from tests import testutil
-import streamlit as st
 
 
 class CacheTest(testutil.DeltaGeneratorTestCase):
@@ -32,6 +36,7 @@ class CacheTest(testutil.DeltaGeneratorTestCase):
         # Reset default values on teardown.
         st.caching._cache_info.cached_func_stack = []
         st.caching._cache_info.suppress_st_function_warning = 0
+        super().tearDown()
 
     def test_simple(self):
         @st.cache
@@ -492,22 +497,26 @@ to suppress the warning.
         el = self.get_delta_from_queue(-1).new_element
         self.assertEqual(el.markdown.body, "hi")
 
-    def test_mutation_warning_text(self):
-        @st.cache
-        def mutation_warning_func():
-            return []
+    @parameterized.expand([(True,), (False,)])
+    def test_mutation_warning_text(self, show_tracebacks: bool):
+        with testutil.patch_config_options({"client.showTracebacks": show_tracebacks}):
 
-        a = mutation_warning_func()
-        a.append("mutated!")
-        mutation_warning_func()
+            @st.cache
+            def mutation_warning_func():
+                return []
 
-        el = self.get_delta_from_queue(-1).new_element
-        self.assertEqual(el.exception.type, "CachedObjectMutationWarning")
+            a = mutation_warning_func()
+            a.append("mutated!")
+            mutation_warning_func()
 
-        self.assertEqual(
-            normalize_md(el.exception.message),
-            normalize_md(
-                """
+            if show_tracebacks:
+                el = self.get_delta_from_queue(-1).new_element
+                self.assertEqual(el.exception.type, "CachedObjectMutationWarning")
+
+                self.assertEqual(
+                    normalize_md(el.exception.message),
+                    normalize_md(
+                        """
 Return value of `mutation_warning_func()` was mutated between runs.
 
 By default, Streamlit\'s cache should be treated as immutable, or it may behave
@@ -525,12 +534,17 @@ doing so, annotate the function with `@st.cache(allow_output_mutation=True)`.
 
 For more information and detailed solutions check out [our
 documentation.](https://docs.streamlit.io/en/latest/caching.html)
-            """
-            ),
-        )
-        self.assertNotEqual(len(el.exception.stack_trace), 0)
-        self.assertEqual(el.exception.message_is_markdown, True)
-        self.assertEqual(el.exception.is_warning, True)
+                    """
+                    ),
+                )
+                self.assertNotEqual(len(el.exception.stack_trace), 0)
+                self.assertEqual(el.exception.message_is_markdown, True)
+                self.assertEqual(el.exception.is_warning, True)
+            else:
+                el = self.get_delta_from_queue(-1).new_element
+                self.assertEqual(el.WhichOneof("type"), "alert")
+                self.assertEqual(el.alert.format, Alert.ERROR)
+                self.assertEqual(el.alert.body, _GENERIC_UNCAUGHT_EXCEPTION_TEXT)
 
     def test_unhashable_type(self):
         @st.cache

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -275,6 +275,7 @@ class ConfigTest(unittest.TestCase):
                 "browser.serverPort",
                 "client.caching",
                 "client.displayEnabled",
+                "client.showTracebacks",
                 "deprecation.showfileUploaderEncoding",
                 "deprecation.showPyplotGlobalUse",
                 "deprecation.showImageFormat",

--- a/lib/tests/streamlit/error_util_test.py
+++ b/lib/tests/streamlit/error_util_test.py
@@ -15,11 +15,11 @@
 import unittest
 from unittest.mock import patch
 
-from streamlit import config
 from streamlit.error_util import (
     handle_uncaught_app_exception,
     _GENERIC_UNCAUGHT_EXCEPTION_TEXT,
 )
+from tests import testutil
 
 
 class ErrorUtilTest(unittest.TestCase):
@@ -28,21 +28,21 @@ class ErrorUtilTest(unittest.TestCase):
     def test_uncaught_exception_show_tracebacks(self, mock_st_error, mock_st_exception):
         """If client.showTracebacks is true, uncaught app errors print
         to the frontend."""
-        config.set_option("client.showTracebacks", True)
-        exc = RuntimeError("boom!")
-        handle_uncaught_app_exception(exc)
+        with testutil.patch_config_options({"client.showTracebacks": True}):
+            exc = RuntimeError("boom!")
+            handle_uncaught_app_exception(exc)
 
-        mock_st_error.assert_not_called()
-        mock_st_exception.assert_called_once_with(exc)
+            mock_st_error.assert_not_called()
+            mock_st_exception.assert_called_once_with(exc)
 
     @patch("streamlit.exception")
     @patch("streamlit.error")
     def test_uncaught_exception_no_tracebacks(self, mock_st_error, mock_st_exception):
         """If client.showTracebacks is false, uncaught app errors are logged,
         and a generic error message is printed to the frontend."""
-        config.set_option("client.showTracebacks", False)
-        exc = RuntimeError("boom!")
-        handle_uncaught_app_exception(exc)
+        with testutil.patch_config_options({"client.showTracebacks": False}):
+            exc = RuntimeError("boom!")
+            handle_uncaught_app_exception(exc)
 
-        mock_st_exception.assert_not_called()
-        mock_st_error.assert_called_once_with(_GENERIC_UNCAUGHT_EXCEPTION_TEXT)
+            mock_st_exception.assert_not_called()
+            mock_st_error.assert_called_once_with(_GENERIC_UNCAUGHT_EXCEPTION_TEXT)

--- a/lib/tests/streamlit/error_util_test.py
+++ b/lib/tests/streamlit/error_util_test.py
@@ -1,0 +1,47 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from streamlit import config
+from streamlit.error_util import handle_uncaught_app_exception
+
+
+class ErrorUtilTest(unittest.TestCase):
+    @patch("streamlit.exception")
+    @patch("streamlit.error")
+    def test_uncaught_exception_show_tracebacks(self, mock_st_error, mock_st_exception):
+        """If client.showTracebacks is true, uncaught app errors print
+        to the frontend."""
+        config.set_option("client.showTracebacks", True)
+        exc = RuntimeError("boom!")
+        handle_uncaught_app_exception(exc)
+
+        mock_st_error.assert_not_called()
+        mock_st_exception.assert_called_once_with(exc)
+
+    @patch("streamlit.exception")
+    @patch("streamlit.error")
+    def test_uncaught_exception_no_tracebacks(self, mock_st_error, mock_st_exception):
+        """If client.showTracebacks is false, uncaught app errors are logged,
+        and a generic error message is printed to the frontend."""
+        config.set_option("client.showTracebacks", False)
+        exc = RuntimeError("boom!")
+        handle_uncaught_app_exception(exc)
+
+        mock_st_exception.assert_not_called()
+        mock_st_error.assert_called_once_with(
+            "Whoops - something went wrong! An error has been logged."
+        )

--- a/lib/tests/streamlit/error_util_test.py
+++ b/lib/tests/streamlit/error_util_test.py
@@ -16,7 +16,10 @@ import unittest
 from unittest.mock import patch
 
 from streamlit import config
-from streamlit.error_util import handle_uncaught_app_exception
+from streamlit.error_util import (
+    handle_uncaught_app_exception,
+    _GENERIC_UNCAUGHT_EXCEPTION_TEXT,
+)
 
 
 class ErrorUtilTest(unittest.TestCase):
@@ -42,6 +45,4 @@ class ErrorUtilTest(unittest.TestCase):
         handle_uncaught_app_exception(exc)
 
         mock_st_exception.assert_not_called()
-        mock_st_error.assert_called_once_with(
-            "Whoops - something went wrong! An error has been logged."
-        )
+        mock_st_error.assert_called_once_with(_GENERIC_UNCAUGHT_EXCEPTION_TEXT)

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -17,12 +17,10 @@ from typing import List
 import os
 import sys
 import time
-import unittest
 
 from parameterized import parameterized
 from tornado.testing import AsyncTestCase
 
-from streamlit.media_file_manager import media_file_manager
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.report import Report

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -28,10 +28,11 @@ from google.protobuf import json_format
 import PIL.Image as Image
 import numpy as np
 import pandas as pd
+from parameterized import parameterized
 from scipy.io import wavfile
 
 import streamlit as st
-from streamlit import __version__, config
+from streamlit import __version__
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
@@ -292,24 +293,22 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(el.alert.body, "some error")
         self.assertEqual(el.alert.format, Alert.ERROR)
 
-    def test_st_exception(self):
+    @parameterized.expand([(True,), (False,)])
+    def test_st_exception(self, show_tracebacks: bool):
         """Test st.exception."""
-        for show_tracebacks in (True, False):
-            with self.subTest(f"showTracebacks={show_tracebacks}"):
-                # client.showTracebacks has no effect on code that calls
-                # st.exception directly. This test should have the same result
-                # regardless fo the config option.
-                config.set_option("client.showTracebacks", show_tracebacks)
+        # client.showTracebacks has no effect on code that calls
+        # st.exception directly. This test should have the same result
+        # regardless fo the config option.
+        with testutil.patch_config_options({"client.showTracebacks": show_tracebacks}):
+            e = RuntimeError("Test Exception")
+            st.exception(e)
 
-                e = RuntimeError("Test Exception")
-                st.exception(e)
-
-                el = self.get_delta_from_queue().new_element
-                self.assertEqual(el.exception.type, "RuntimeError")
-                self.assertEqual(el.exception.message, "Test Exception")
-                # We will test stack_trace when testing
-                # streamlit.elements.exception_element
-                self.assertEqual(el.exception.stack_trace, [])
+            el = self.get_delta_from_queue().new_element
+            self.assertEqual(el.exception.type, "RuntimeError")
+            self.assertEqual(el.exception.message, "Test Exception")
+            # We will test stack_trace when testing
+            # streamlit.elements.exception_element
+            self.assertEqual(el.exception.stack_trace, [])
 
     def test_st_header(self):
         """Test st.header."""

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 import streamlit as st
 from streamlit import type_util
+from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIException
 
 
@@ -190,8 +191,8 @@ class StreamlitWriteTest(unittest.TestCase):
         # with the proper arguments.
         with patch("streamlit.delta_generator.DeltaGenerator.markdown") as m, patch(
             "streamlit.delta_generator.DeltaGenerator.exception",
-            side_effect=st.exception,
-        ) as e:
+            side_effect=handle_uncaught_app_exception,
+        ):
             m.side_effect = Exception("some exception")
 
             with self.assertRaises(Exception):

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -15,15 +15,31 @@
 """Utility functions to use in our tests."""
 import threading
 import unittest
+from contextlib import contextmanager
+from typing import Any, Dict
+from unittest.mock import patch
 
 from streamlit import config
 from streamlit.report_queue import ReportQueue
 from streamlit.report_thread import ReportContext
 from streamlit.report_thread import add_report_ctx
 from streamlit.report_thread import get_report_ctx
-from streamlit.report_thread import _StringSet
 from streamlit.widgets import Widgets
 from streamlit.uploaded_file_manager import UploadedFileManager
+
+
+@contextmanager
+def patch_config_options(config_overrides: Dict[str, Any]):
+    """A context manager that overrides config options.
+
+    Example:
+    >>> with patch_config_options({"server.headless": True}):
+    ...     assert(config.get_option("server.headless") is True)
+    ...     # Other test code that relies on these options
+    """
+    mock_get_option = build_mock_config_get_option(config_overrides)
+    with patch.object(config, "get_option", new=mock_get_option):
+        yield
 
 
 def build_mock_config_get_option(overrides_dict):


### PR DESCRIPTION
Adds a new config option, `"client.showTracebacks"`. By default, it's `True`.

If the option is set to `False`, then uncaught exceptions in a Streamlit app will result in a generic "Something went wrong!" warning in the browser, rather than the exception and its traceback:

![image](https://user-images.githubusercontent.com/709022/107454016-11a38300-6b01-11eb-9624-56d22a4a02a7.png)

This logic happens in the `error_util.handle_uncaught_app_exception` function, rather than directly within ScriptRunner.

`scriptrunner_test`, `caching_test`, and `streamlit_test` have new tests that verify the right thing happens when exceptions are thrown in different circumstances with this config option turned on and off.

@asaini - the "whoops something blew up" text (see above) needs a product review.

Closes #1032