### PR TITLE
Theming - Fail gracefully for invalid colors

### DIFF
--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -101,7 +101,9 @@ describe("createTheme", () => {
     expect(customTheme.name).toBe("my theme")
     expect(customTheme.emotion.colors.primary).toBe("#eee")
     expect(customTheme.emotion.colors.secondaryBg).toBe("#fc9231")
-    expect(customTheme.emotion.genericFonts.bodyFont).toBe("serif")
+    expect(customTheme.emotion.genericFonts.bodyFont).toBe(
+      customTheme.emotion.fonts.serif
+    )
     // If it is not provided, use the default
     expect(customTheme.emotion.colors.bgColor).toBe(
       darkTheme.emotion.colors.bgColor

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -24,6 +24,7 @@ import {
   createTheme,
   getDefaultTheme,
   getSystemTheme,
+  isColor,
 } from "./utils"
 
 const matchMediaFillers = {
@@ -76,6 +77,24 @@ describe("createTheme", () => {
     expect(customTheme.name).toBe("my theme")
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
+    expect(customTheme.emotion.genericFonts.bodyFont).toBe("serif")
+    // If it is not provided, use the default
+    expect(customTheme.emotion.colors.bgColor).toBe(
+      darkTheme.emotion.colors.bgColor
+    )
+  })
+
+  it("createTheme handles hex values without #", () => {
+    const customThemeConfig = new CustomThemeConfig({
+      name: "my theme",
+      primary: "eee",
+      secondaryBackground: "fc9231",
+      font: CustomThemeConfig.FontFamily.SERIF,
+    })
+    const customTheme = createTheme(customThemeConfig, darkTheme)
+    expect(customTheme.name).toBe("my theme")
+    expect(customTheme.emotion.colors.primary).toBe("#eee")
+    expect(customTheme.emotion.colors.secondaryBg).toBe("#fc9231")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe("serif")
     // If it is not provided, use the default
     expect(customTheme.emotion.colors.bgColor).toBe(
@@ -170,5 +189,33 @@ describe("getSystemTheme", () => {
     })
 
     expect(getSystemTheme().name).toBe("Dark")
+  })
+})
+
+describe("isColor", () => {
+  // https://www.w3schools.com/cssref/css_colors_legal.asp
+  it("works with valid colors", () => {
+    expect(isColor("#fff")).toBe(true)
+    expect(isColor("#ffffff")).toBe(true)
+    expect(isColor("#ffffff0")).toBe(true)
+    expect(isColor("#000")).toBe(true)
+    expect(isColor("#000000")).toBe(true)
+    expect(isColor("#fafafa")).toBe(true)
+    expect(isColor("red")).toBe(true)
+    expect(isColor("coral")).toBe(true)
+    expect(isColor("transparent")).toBe(true)
+    expect(isColor("rgb(0,0,0)")).toBe(true)
+    expect(isColor("rgb(-1, 0, -255)")).toBe(true)
+    expect(isColor("rgba(0,0,0,.5)")).toBe(true)
+    expect(isColor("hsl(120,50%,40%)")).toBe(true)
+    expect(isColor("hsl(120,50%,40%, .4)")).toBe(true)
+    expect(isColor("currentColor")).toBe(true)
+  })
+
+  it("works with invalid colors", () => {
+    expect(isColor("fff")).toBe(false)
+    expect(isColor("cookies are delicious")).toBe(false)
+    expect(isColor("")).toBe(false)
+    expect(isColor("hsl(120,50,40)")).toBe(false)
   })
 })

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -240,17 +240,35 @@ export const createEmotionColors = (genericColors: {
   tableGray: genericColors.gray40,
 })
 
+export const isColor = (strColor: string): boolean => {
+  const s = new Option().style
+  s.color = strColor
+  return s.color !== ""
+}
+
 const createEmotionTheme = (
   themeInput: Partial<ICustomThemeConfig>,
   baseThemeConfig = baseTheme
 ): Theme => {
   const { name, font, ...customColors } = themeInput
+  const parsedColors = Object.entries(customColors).reduce(
+    (colors: Record<string, string>, [key, color]) => {
+      if (isColor(color)) {
+        colors[key] = color
+      } else if (isColor(`#${color}`)) {
+        colors[key] = `#${color}`
+      }
+      return colors
+    },
+    {}
+  )
+
   // Mapping from CustomThemeConfig to color primitives
   const {
     secondaryBackground: secondaryBg,
     backgroundColor: bgColor,
     ...paletteColors
-  } = customColors
+  } = parsedColors
   const { genericColors, genericFonts } = baseThemeConfig.emotion
   const newGenericColors = {
     ...genericColors,


### PR DESCRIPTION
Would have preferred to put a check on the server side right at the configuration option and throw an error but could not find a package that would check for legal valid css colors. Given how many options there are, this is now happening on the client side and will fail gracefully

1. If it is a hex value without a `#`, try to fix it
2. If it is not a valid color, remove it to prevent any possible error happening. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
