### PR TITLE
Validate customTheme config options

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1204,11 +1204,11 @@ def _validate_theme() -> None:
     optional_theme_options = {"name", "setAsDefault", "font"}
     reserved_theme_names = {"auto", "dark", "light"}
 
-    theme_opts = get_options_for_section("customTheme")
+    theme_opts = get_options_for_section("theme")
 
     theme_name = cast(str, theme_opts["name"])
     if theme_name and theme_name.lower() in reserved_theme_names:
-        raise RuntimeError('customTheme.name cannot be "Auto", "Dark", or "Light".')
+        raise RuntimeError('theme.name cannot be "Auto", "Dark", or "Light".')
 
     required_opts = set(theme_opts.keys()) - optional_theme_options
     theme_fully_defined = all([bool(theme_opts[k]) for k in required_opts])
@@ -1218,8 +1218,8 @@ def _validate_theme() -> None:
         return
     else:
         raise RuntimeError(
-            "customTheme options only partially defined. To specify a theme, "
-            " please set all required options."
+            "Theme options only partially defined. To specify a theme, please"
+            " set all required options."
         )
 
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -757,6 +757,7 @@ _create_section("theme", "Settings to define a custom theme for your Streamlit a
 _create_option(
     "theme.name",
     description="Theme name displayed in the UI for theme selection.",
+    default_val="Custom Theme",
 )
 
 _create_option(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -756,7 +756,11 @@ _create_section("theme", "Settings to define a custom theme for your Streamlit a
 
 _create_option(
     "theme.name",
-    description="Theme name displayed in the UI for theme selection.",
+    description="""
+        The theme name displayed in the UI for theme selection. Note that this
+        cannot be "Auto", "Dark", or "Light" as they conflict with the names
+        of default themes.
+        """,
     default_val="Custom Theme",
 )
 

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -15,6 +15,7 @@
 import sys
 import uuid
 from enum import Enum
+from typing import cast
 
 import tornado.gen
 import tornado.ioloop
@@ -639,7 +640,7 @@ def _populate_custom_theme_msg(msg: CustomThemeConfig) -> None:
     custom_theme_opts = config.get_options_for_section("theme")
     required_opts = set(custom_theme_opts.keys()) - OPTIONAL_CONFIG_OPTIONS
 
-    theme_name = custom_theme_opts["name"]
+    theme_name = cast(str, custom_theme_opts["name"])
     if theme_name and theme_name.lower() in RESERVED_THEME_NAMES:
         raise RuntimeError('theme.name cannot be "Auto", "Dark", or "Light".')
 

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -621,7 +621,7 @@ def _populate_config_msg(msg: Config) -> None:
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:
-    theme_opts = config.get_options_for_section("customTheme")
+    theme_opts = config.get_options_for_section("theme")
 
     # A theme is either fully specified or not defined at all, so it's
     # sufficient to check this one property.
@@ -635,12 +635,12 @@ def _populate_theme_msg(msg: CustomThemeConfig) -> None:
             setattr(msg, to_snake_case(option_name), option_val)
 
     font_map = {
-        "sans serif": msg.FontFamily.SANS_SERIF,
+        "sans-serif": msg.FontFamily.SANS_SERIF,
         "serif": msg.FontFamily.SERIF,
         "monospace": msg.FontFamily.MONOSPACE,
     }
     msg.font = font_map.get(
-        config.get_option("customTheme.font"),
+        config.get_option("theme.font"),
         msg.FontFamily.SANS_SERIF,
     )
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -29,11 +29,11 @@ from streamlit.config_option import ConfigOption
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
 REQUIRED_THEME_OPTIONS = [
-    "customTheme.primary",
-    "customTheme.secondary",
-    "customTheme.backgroundColor",
-    "customTheme.secondaryBackground",
-    "customTheme.bodyText",
+    "theme.primaryColor",
+    "theme.secondaryColor",
+    "theme.backgroundColor",
+    "theme.secondaryBackgroundColor",
+    "theme.textColor",
 ]
 
 
@@ -445,25 +445,25 @@ class ConfigTest(unittest.TestCase):
     def test_validate_theme_angry_with_partial_config(self):
         for opt in REQUIRED_THEME_OPTIONS:
             config._set_option(opt, "foo", "test")
-        config._set_option("customTheme.bodyText", None, "test")
+        config._set_option("theme.textColor", None, "test")
 
         with pytest.raises(RuntimeError) as e:
             config._validate_theme()
         self.assertEqual(
             str(e.value),
-            "customTheme options only partially defined. To specify a theme, "
+            "Theme options only partially defined. To specify a theme,"
             " please set all required options.",
         )
 
     def test_validate_theme_explodes_with_reserved_name(self):
         for opt in REQUIRED_THEME_OPTIONS:
             config._set_option(opt, "foo", "test")
-        config._set_option("customTheme.name", "Auto", "test")
+        config._set_option("theme.name", "Auto", "test")
 
         with pytest.raises(RuntimeError) as e:
             config._validate_theme()
         self.assertEqual(
-            str(e.value), 'customTheme.name cannot be "Auto", "Dark", or "Light".'
+            str(e.value), 'theme.name cannot be "Auto", "Dark", or "Light".'
         )
 
     def test_maybe_convert_to_number(self):

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -28,6 +28,13 @@ from streamlit.config_option import ConfigOption
 
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
+REQUIRED_THEME_OPTIONS = [
+    "customTheme.primary",
+    "customTheme.secondary",
+    "customTheme.backgroundColor",
+    "customTheme.secondaryBackground",
+    "customTheme.bodyText",
+]
 
 
 class ConfigTest(unittest.TestCase):
@@ -424,6 +431,40 @@ class ConfigTest(unittest.TestCase):
         config._set_option("s3.url", relative_url, "test")
         config._check_conflicts()
         self.assertEqual("//" + relative_url, config.get_option("s3.url"))
+
+    def test_validate_theme_happy_with_no_theme_set(self):
+        for opt in REQUIRED_THEME_OPTIONS:
+            config._set_option(opt, None, "test")
+        config._validate_theme()
+
+    def test_validate_theme_okay_with_theme_fully_set(self):
+        for opt in REQUIRED_THEME_OPTIONS:
+            config._set_option(opt, "foo", "test")
+        config._validate_theme()
+
+    def test_validate_theme_angry_with_partial_config(self):
+        for opt in REQUIRED_THEME_OPTIONS:
+            config._set_option(opt, "foo", "test")
+        config._set_option("customTheme.bodyText", None, "test")
+
+        with pytest.raises(RuntimeError) as e:
+            config._validate_theme()
+        self.assertEqual(
+            str(e.value),
+            "customTheme options only partially defined. To specify a theme, "
+            " please set all required options.",
+        )
+
+    def test_validate_theme_explodes_with_reserved_name(self):
+        for opt in REQUIRED_THEME_OPTIONS:
+            config._set_option(opt, "foo", "test")
+        config._set_option("customTheme.name", "Auto", "test")
+
+        with pytest.raises(RuntimeError) as e:
+            config._validate_theme()
+        self.assertEqual(
+            str(e.value), 'customTheme.name cannot be "Auto", "Dark", or "Light".'
+        )
 
     def test_maybe_convert_to_number(self):
         self.assertEqual(1234, config._maybe_convert_to_number("1234"))

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -287,8 +287,12 @@ class ReportSessionNewReportTest(tornado.testing.AsyncTestCase):
 
 class PopulateCustomThemeMsgTest(unittest.TestCase):
     @patch("streamlit.report_session.config")
-    def test_can_leave_all_required_options_unset(self, patched_config):
+    def test_no_custom_theme_prop_if_no_theme(self, patched_config):
         patched_config.get_options_for_section.side_effect = (
+            # We technically only need to set backgroundColor := None here
+            # since that's all that _populate_theme_msg checks (see the comment
+            # in report_session._populate_theme_msg), but we set all required
+            # theme opts to None here since that's what happens in practice.
             _mock_get_options_for_section(
                 {
                     "primaryColor": None,

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -215,11 +215,11 @@ def _mock_get_options_for_section(overrides=None):
     theme_opts = {
         "name": "foo",
         "setAsDefault": True,
-        "primary": "coral",
-        "secondary": "grey",
+        "primaryColor": "coral",
+        "secondaryColor": "grey",
         "backgroundColor": "white",
-        "secondaryBackground": "blue",
-        "bodyText": "black",
+        "secondaryBackgroundColor": "blue",
+        "textColor": "black",
         "font": "serif",
     }
 
@@ -291,11 +291,11 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         patched_config.get_options_for_section.side_effect = (
             _mock_get_options_for_section(
                 {
-                    "primary": None,
-                    "secondary": None,
+                    "primaryColor": None,
+                    "secondaryColor": None,
                     "backgroundColor": None,
-                    "secondaryBackground": None,
-                    "bodyText": None,
+                    "secondaryBackgroundColor": None,
+                    "textColor": None,
                 }
             )
         )


### PR DESCRIPTION
This entails throwing an error when
* The theme name specified is reserved ("Auto", "Dark", or "Light")
* The theme config does not specify all required options