### PR TITLE
Update active theme on custom theme selection

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -253,6 +253,7 @@ describe("App.handleNewReport", () => {
 
     // @ts-ignore
     expect(props.theme.setTheme).toHaveBeenCalled()
+    expect(wrapper.state("userSettings").activeTheme.name).toBe("carl")
 
     // @ts-ignore
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe("carl")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -565,6 +565,12 @@ export class App extends PureComponent<Props, State> {
       // ignore that.
       if (themeInput.setAsDefault) {
         this.props.theme.setTheme(customTheme)
+        this.setState({
+          userSettings: {
+            ...this.state.userSettings,
+            activeTheme: customTheme,
+          },
+        })
       }
     } else if (!themeInput) {
       // Remove the custom theme menu option.


### PR DESCRIPTION
We're setting the theme to custom if one exists but we forgot to update the user settings for the activeTheme selector in settings menu

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
