### PR TITLE
S4A messages for metadata and modals

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -626,6 +626,7 @@ export class App extends PureComponent<Props, State> {
    */
   closeDialog = (): void => {
     this.setState({ dialog: undefined })
+    this.props.s4aCommunication.onModalReset()
   }
 
   /**
@@ -917,12 +918,13 @@ export class App extends PureComponent<Props, State> {
       "streamlit-wide": userSettings.wideMode,
     })
 
-    const renderedDialog: React.ReactNode = dialog
-      ? StreamlitDialog({
-          ...dialog,
-          onClose: this.closeDialog,
-        })
-      : null
+    const renderedDialog: React.ReactNode =
+      dialog && !this.props.s4aCommunication.currentState.forcedModalClose
+        ? StreamlitDialog({
+            ...dialog,
+            onClose: this.closeDialog,
+          })
+        : null
 
     // Attach and focused props provide a way to handle Global Hot Keys
     // https://github.com/greena13/react-hotkeys/issues/41

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -110,7 +110,6 @@ const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
 declare global {
   interface Window {
     streamlitDebug: any
-    streamlitShareMetadata: Record<string, unknown>
   }
 }
 
@@ -509,6 +508,9 @@ export class App extends PureComponent<Props, State> {
     document.title = `${reportName} · Streamlit`
     handleFavicon(`${process.env.PUBLIC_URL}/favicon.png`)
 
+    MetricsManager.current.setMetadata(
+      this.props.s4aCommunication.currentState.streamlitShareMetadata
+    )
     MetricsManager.current.setReportHash(newReportHash)
     MetricsManager.current.clearDeltaCounter()
 

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -15,6 +15,15 @@
  * limitations under the License.
  */
 
+export type StreamlitShareMetadata = {
+  hostedAt?: string
+  creatorId?: string
+  owner?: string
+  branch?: string
+  repo?: string
+  mainModule?: string
+}
+
 export type IMenuItem =
   | {
       type: "text"
@@ -35,6 +44,10 @@ export type IHostToGuestMessage = {
   | {
       type: "UPDATE_FROM_QUERY_PARAMS"
       queryParams: string
+    }
+  | {
+      type: "SET_METADATA"
+      metadata: StreamlitShareMetadata
     }
 )
 

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -49,6 +49,9 @@ export type IHostToGuestMessage = {
       type: "SET_METADATA"
       metadata: StreamlitShareMetadata
     }
+  | {
+      type: "CLOSE_MODALS"
+    }
 )
 
 export type IGuestToHostMessage =

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -22,6 +22,7 @@ import { CLOUD_COMM_WHITELIST } from "urls"
 
 import {
   IMenuItem,
+  StreamlitShareMetadata,
   IHostToGuestMessage,
   IGuestToHostMessage,
   VersionedMessage,
@@ -30,6 +31,7 @@ import {
 interface State {
   queryParams: string
   items: IMenuItem[]
+  streamlitShareMetadata: StreamlitShareMetadata
 }
 
 export interface S4ACommunicationHOC {
@@ -56,6 +58,7 @@ function withS4ACommunication(
   function ComponentWithS4ACommunication(props: any): ReactElement {
     const [items, setItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
+    const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -85,6 +88,9 @@ function withS4ACommunication(
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
           setQueryParams(message.queryParams)
         }
+        if (message.type === "SET_METADATA") {
+          setStreamlitShareMetadata(message.metadata)
+        }
       }
 
       window.addEventListener("message", receiveMessage)
@@ -101,6 +107,7 @@ function withS4ACommunication(
             currentState: {
               items,
               queryParams,
+              streamlitShareMetadata,
             },
             connect: () => {
               sendS4AMessage({

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -69,7 +69,6 @@ function withS4ACommunication(
         let origin
         const message: VersionedMessage<IHostToGuestMessage> | any = event.data
         const json = JSON.stringify(message)
-        logAlways(`Got message: ${json}`)
 
         try {
           const url = new URL(event.origin)
@@ -78,6 +77,7 @@ function withS4ACommunication(
         } catch (e) {
           origin = event.origin
         }
+        logAlways(`Got message: ${json} from origin: ${origin}`)
 
         if (
           !origin ||

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -68,7 +68,6 @@ function withS4ACommunication(
       function receiveMessage(event: MessageEvent): void {
         let origin
         const message: VersionedMessage<IHostToGuestMessage> | any = event.data
-        const json = JSON.stringify(message)
 
         try {
           const url = new URL(event.origin)
@@ -77,7 +76,6 @@ function withS4ACommunication(
         } catch (e) {
           origin = event.origin
         }
-        logAlways(`Got message: ${json} from origin: ${origin}`)
 
         if (
           !origin ||

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -68,6 +68,7 @@ function withS4ACommunication(
       function receiveMessage(event: MessageEvent): void {
         let origin
         const message: VersionedMessage<IHostToGuestMessage> | any = event.data
+        logAlways(`Got message: ${message}`)
 
         try {
           const url = new URL(event.origin)

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -68,7 +68,8 @@ function withS4ACommunication(
       function receiveMessage(event: MessageEvent): void {
         let origin
         const message: VersionedMessage<IHostToGuestMessage> | any = event.data
-        logAlways(`Got message: ${message}`)
+        const json = JSON.stringify(message)
+        logAlways(`Got message: ${json}`)
 
         try {
           const url = new URL(event.origin)

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -20,6 +20,7 @@ import hoistNonReactStatics from "hoist-non-react-statics"
 
 import { CLOUD_COMM_WHITELIST } from "urls"
 
+import { logAlways } from "lib/log"
 import {
   IMenuItem,
   StreamlitShareMetadata,
@@ -97,6 +98,7 @@ function withS4ACommunication(
         }
 
         if (message.type === "CLOSE_MODAL") {
+          logAlways("Received message to close modals")
           setForcedModalClose(true)
         }
       }

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -32,12 +32,14 @@ interface State {
   queryParams: string
   items: IMenuItem[]
   streamlitShareMetadata: StreamlitShareMetadata
+  forcedModalClose: boolean
 }
 
 export interface S4ACommunicationHOC {
   currentState: State
   connect: () => void
   sendMessage: (message: IGuestToHostMessage) => void
+  onModalReset: () => void
 }
 
 const S4A_COMM_VERSION = 1
@@ -59,6 +61,7 @@ function withS4ACommunication(
     const [items, setItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
+    const [forcedModalClose, setForcedModalClose] = useState(false)
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -88,8 +91,13 @@ function withS4ACommunication(
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
           setQueryParams(message.queryParams)
         }
+
         if (message.type === "SET_METADATA") {
           setStreamlitShareMetadata(message.metadata)
+        }
+
+        if (message.type === "CLOSE_MODAL") {
+          setForcedModalClose(true)
         }
       }
 
@@ -108,11 +116,15 @@ function withS4ACommunication(
               items,
               queryParams,
               streamlitShareMetadata,
+              forcedModalClose,
             },
             connect: () => {
               sendS4AMessage({
                 type: "GUEST_READY",
               })
+            },
+            onModalReset: () => {
+              setForcedModalClose(false)
             },
             sendMessage: sendS4AMessage,
           } as S4ACommunicationHOC

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -117,12 +117,11 @@ test("tracks events immediately after initialized", () => {
 })
 
 test("tracks host data when in an iFrame", () => {
-  window.parent.streamlitShareMetadata = {
+  const mm = getMetricsManagerForTest()
+  mm.setMetadata({
     hostedAt: "S4A",
     k: "v",
-  }
-
-  const mm = getMetricsManagerForTest()
+  })
   mm.initialize({ gatherUsageStats: true })
   mm.enqueue("ev1", { data1: 11 })
 

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -233,9 +233,7 @@ export class MetricsManager {
 
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): StreamlitShareMetadata {
-    logAlways("Checking for metadata")
     if (this.metadata) {
-      logAlways("Received metadata for tracking")
       return pick(this.metadata, [
         "hostedAt",
         "owner",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -235,6 +235,9 @@ export class MetricsManager {
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): StreamlitShareMetadata {
     logAlways("Checking for metadata")
+    if (isInChildFrame()) {
+      logAlways("In a child frame")
+    }
     if (isInChildFrame() && this.metadata) {
       logAlways("Received metadata for tracking")
       return pick(this.metadata, [

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -16,9 +16,9 @@
  */
 
 import { pick } from "lodash"
-
 import { SessionInfo } from "lib/SessionInfo"
 import { initializeSegment } from "vendor/Segment"
+import { StreamlitShareMetadata } from "hocs/withS4ACommunication/types"
 import { IS_DEV_ENV, IS_SHARED_REPORT } from "./baseconsts"
 import { logAlways } from "./log"
 import { isInChildFrame } from "./utils"
@@ -82,6 +82,8 @@ export class MetricsManager {
    */
   private reportHash = "Not initialized"
 
+  private metadata: StreamlitShareMetadata = {}
+
   /**
    * Singleton MetricsManager object. The reason we're using a singleton here
    * instead of just exporting a module-level instance is so we can easily
@@ -103,7 +105,7 @@ export class MetricsManager {
 
       const userTraits: any = {
         ...MetricsManager.getInstallationData(),
-        ...MetricsManager.getHostTrackingData(),
+        ...this.getHostTrackingData(),
       }
 
       // Only record the user's email if they entered a non-empty one.
@@ -178,7 +180,7 @@ export class MetricsManager {
   private send(evName: string, evData: Record<string, unknown> = {}): void {
     const data = {
       ...evData,
-      ...MetricsManager.getHostTrackingData(),
+      ...this.getHostTrackingData(),
       ...MetricsManager.getInstallationData(),
       reportHash: this.reportHash,
       dev: IS_DEV_ENV,
@@ -226,10 +228,14 @@ export class MetricsManager {
     }
   }
 
+  public setMetadata(metadata: StreamlitShareMetadata): void {
+    this.metadata = metadata
+  }
+
   // Use the tracking data injected by S4A if the app is hosted there
-  private static getHostTrackingData(): Record<string, unknown> {
-    if (isInChildFrame() && window.parent.streamlitShareMetadata) {
-      return pick(window.parent.streamlitShareMetadata, [
+  private getHostTrackingData(): StreamlitShareMetadata {
+    if (isInChildFrame() && this.metadata) {
+      return pick(this.metadata, [
         "hostedAt",
         "owner",
         "repo",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -21,7 +21,6 @@ import { initializeSegment } from "vendor/Segment"
 import { StreamlitShareMetadata } from "hocs/withS4ACommunication/types"
 import { IS_DEV_ENV, IS_SHARED_REPORT } from "./baseconsts"
 import { logAlways } from "./log"
-import { isInChildFrame } from "./utils"
 
 /**
  * The analytics is the Segment.io object. It is initialized in Segment.ts
@@ -235,10 +234,7 @@ export class MetricsManager {
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): StreamlitShareMetadata {
     logAlways("Checking for metadata")
-    if (isInChildFrame()) {
-      logAlways("In a child frame")
-    }
-    if (isInChildFrame() && this.metadata) {
+    if (this.metadata) {
       logAlways("Received metadata for tracking")
       return pick(this.metadata, [
         "hostedAt",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -235,6 +235,7 @@ export class MetricsManager {
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): StreamlitShareMetadata {
     if (isInChildFrame() && this.metadata) {
+      logAlways("Received metadata for tracking")
       return pick(this.metadata, [
         "hostedAt",
         "owner",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -234,6 +234,7 @@ export class MetricsManager {
 
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): StreamlitShareMetadata {
+    logAlways("Checking for metadata")
     if (isInChildFrame() && this.metadata) {
       logAlways("Received metadata for tracking")
       return pick(this.metadata, [


### PR DESCRIPTION
**Issue:** Clubhouse 2022 and 2301

**Description:** Adds message handling for metrics metadata and for request to close all modals. Metadata messaging is changed to accommodate running on different domains. Modal closing is added so cloud can avoid bugs caused by multiple modals being open at once.
