### PR TITLE
client.showTracebacks -> showErrorDetails (per product)

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -355,7 +355,7 @@ _create_option(
 )
 
 _create_option(
-    "client.showTracebacks",
+    "client.showErrorDetails",
     description="""Controls whether uncaught app exceptions are displayed in
         the browser. (By default, Streamlit displays app exceptions and their
         tracebacks.)""",

--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -28,20 +28,20 @@ _streamlit_dir = os.path.dirname(st.__file__)
 # separator
 _streamlit_dir = os.path.join(os.path.realpath(_streamlit_dir), "")
 
-# When client.showTracebacks is False, we show a generic warning in the
+# When client.showErrorDetails is False, we show a generic warning in the
 # frontend when we encounter an uncaught app exception.
 _GENERIC_UNCAUGHT_EXCEPTION_TEXT = (
-    "Whoops - something went wrong! An error has been logged."
+    "Whoops — something went wrong! An error has been logged."
 )
 
 
 def handle_uncaught_app_exception(e: BaseException) -> None:
     """Handle an exception that originated from a user app.
     By default, we show exceptions directly in the browser. However,
-    if the user has disabled client tracebacks, we display a generic
+    if the user has disabled client error details, we display a generic
     warning in the frontend instead.
     """
-    if config.get_option("client.showTracebacks"):
+    if config.get_option("client.showErrorDetails"):
         LOGGER.debug(e)
         st.exception(e)
         # TODO: Clean up the stack trace, so it doesn't include ScriptRunner.

--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -498,8 +498,10 @@ to suppress the warning.
         self.assertEqual(el.markdown.body, "hi")
 
     @parameterized.expand([(True,), (False,)])
-    def test_mutation_warning_text(self, show_tracebacks: bool):
-        with testutil.patch_config_options({"client.showTracebacks": show_tracebacks}):
+    def test_mutation_warning_text(self, show_error_details: bool):
+        with testutil.patch_config_options(
+            {"client.showErrorDetails": show_error_details}
+        ):
 
             @st.cache
             def mutation_warning_func():
@@ -509,7 +511,7 @@ to suppress the warning.
             a.append("mutated!")
             mutation_warning_func()
 
-            if show_tracebacks:
+            if show_error_details:
                 el = self.get_delta_from_queue(-1).new_element
                 self.assertEqual(el.exception.type, "CachedObjectMutationWarning")
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -275,7 +275,7 @@ class ConfigTest(unittest.TestCase):
                 "browser.serverPort",
                 "client.caching",
                 "client.displayEnabled",
-                "client.showTracebacks",
+                "client.showErrorDetails",
                 "deprecation.showfileUploaderEncoding",
                 "deprecation.showPyplotGlobalUse",
                 "deprecation.showImageFormat",

--- a/lib/tests/streamlit/error_util_test.py
+++ b/lib/tests/streamlit/error_util_test.py
@@ -25,10 +25,10 @@ from tests import testutil
 class ErrorUtilTest(unittest.TestCase):
     @patch("streamlit.exception")
     @patch("streamlit.error")
-    def test_uncaught_exception_show_tracebacks(self, mock_st_error, mock_st_exception):
-        """If client.showTracebacks is true, uncaught app errors print
+    def test_uncaught_exception_show_details(self, mock_st_error, mock_st_exception):
+        """If client.showErrorDetails is true, uncaught app errors print
         to the frontend."""
-        with testutil.patch_config_options({"client.showTracebacks": True}):
+        with testutil.patch_config_options({"client.showErrorDetails": True}):
             exc = RuntimeError("boom!")
             handle_uncaught_app_exception(exc)
 
@@ -37,10 +37,10 @@ class ErrorUtilTest(unittest.TestCase):
 
     @patch("streamlit.exception")
     @patch("streamlit.error")
-    def test_uncaught_exception_no_tracebacks(self, mock_st_error, mock_st_exception):
-        """If client.showTracebacks is false, uncaught app errors are logged,
+    def test_uncaught_exception_no_details(self, mock_st_error, mock_st_exception):
+        """If client.showErrorDetails is false, uncaught app errors are logged,
         and a generic error message is printed to the frontend."""
-        with testutil.patch_config_options({"client.showTracebacks": False}):
+        with testutil.patch_config_options({"client.showErrorDetails": False}):
             exc = RuntimeError("boom!")
             handle_uncaught_app_exception(exc)
 

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -142,9 +142,11 @@ class ScriptRunnerTest(AsyncTestCase):
         self._assert_text_deltas(scriptrunner, [])
 
     @parameterized.expand([(True,), (False,)])
-    def test_runtime_error(self, show_tracebacks: bool):
+    def test_runtime_error(self, show_error_details: bool):
         """Tests that we correctly handle scripts with runtime errors."""
-        with testutil.patch_config_options({"client.showTracebacks": show_tracebacks}):
+        with testutil.patch_config_options(
+            {"client.showErrorDetails": show_error_details}
+        ):
             scriptrunner = TestScriptRunner("runtime_error.py")
             scriptrunner.enqueue_rerun()
             scriptrunner.start()
@@ -166,7 +168,7 @@ class ScriptRunnerTest(AsyncTestCase):
             self._assert_num_deltas(scriptrunner, 2)
             self.assertEqual(elts[0].WhichOneof("type"), "text")
 
-            if show_tracebacks:
+            if show_error_details:
                 self.assertEqual(elts[1].WhichOneof("type"), "exception")
             else:
                 self.assertEqual(elts[1].WhichOneof("type"), "alert")

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -294,12 +294,14 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(el.alert.format, Alert.ERROR)
 
     @parameterized.expand([(True,), (False,)])
-    def test_st_exception(self, show_tracebacks: bool):
+    def test_st_exception(self, show_error_details: bool):
         """Test st.exception."""
-        # client.showTracebacks has no effect on code that calls
+        # client.showErrorDetails has no effect on code that calls
         # st.exception directly. This test should have the same result
         # regardless fo the config option.
-        with testutil.patch_config_options({"client.showTracebacks": show_tracebacks}):
+        with testutil.patch_config_options(
+            {"client.showErrorDetails": show_error_details}
+        ):
             e = RuntimeError("Test Exception")
             st.exception(e)
 


### PR DESCRIPTION
A simple rename: `client.showTracebacks` config option is now `client.showErrorDetails`. (This was requested here: https://github.com/streamlit/streamlit/pull/2770#issuecomment-782317571)

We haven't pushed a release that uses the "showTracebacks" name, so we can get away without a warning about a deprecated config option.