### PR TITLE
Pause Dependabot updates for non-security-related issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
-    # Pause Dependabot updates
+    # Pause Dependabot updates. Security updates are unaffected
     open-pull-requests-limit: 0
 
     reviewers:
@@ -21,7 +21,7 @@ updates:
     directory: "/lib"
     schedule:
       interval: "daily"
-    # Pause Dependabot updates
+    # Pause Dependabot updates. Security updates are unaffected
     open-pull-requests-limit: 0
 
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+    # Pause Dependabot updates
+    open-pull-requests-limit: 0
 
     reviewers:
       - "streamlit/core"
@@ -19,6 +21,8 @@ updates:
     directory: "/lib"
     schedule:
       interval: "daily"
+    # Pause Dependabot updates
+    open-pull-requests-limit: 0
 
     reviewers:
       - "streamlit/core"


### PR DESCRIPTION
Right now, we are actively not accepting dependabot updates without testing, and we do not have the time to fully test them, so we should pause them.

Note: From the [docs](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit)

> This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.

so we should still be getting valid security updates