### PR TITLE
Fix font parsing + typo in config copy

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "cypress-circleci-reporter": "^0.1.2",
     "d3": "^5.16.0",
     "d3-graphviz": "^2.6.1",
+    "decamelize": "^5.0.0",
     "deck.gl": "^8.2.5",
     "dompurify": "^2.1.1",
     "emotion-theming": "^10.0.27",

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
@@ -88,7 +88,7 @@ describe("Opened ThemeCreator", () => {
 primaryColor="${themeInput.primaryColor}"
 secondaryColor="${themeInput.secondaryColor}"
 backgroundColor="${themeInput.backgroundColor}"
-secondaryBackgroundColor=${themeInput.secondaryBackgroundColor}
+secondaryBackgroundColor="${themeInput.secondaryBackgroundColor}"
 textColor="${themeInput.textColor}"
 font="${themeInput.font}"
 `)

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
@@ -87,7 +87,7 @@ const ThemeCreator = ({
 primaryColor="${themeInput.primaryColor}"
 secondaryColor="${themeInput.secondaryColor}"
 backgroundColor="${themeInput.backgroundColor}"
-secondaryBackgroundColor=${themeInput.secondaryBackgroundColor}
+secondaryBackgroundColor="${themeInput.secondaryBackgroundColor}"
 textColor="${themeInput.textColor}"
 font="${themeInput.font}"
 `

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`SettingsDialog renders without crashing 1`] = `
       themeInput={
         Object {
           "backgroundColor": "#FFFFFF",
-          "font": "IBM Plex Sans, sans-serif",
+          "font": 0,
           "name": "Light",
           "primaryColor": "#f63366",
           "secondaryBackgroundColor": "#f0f2f6",

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -32,6 +32,7 @@ import { buildHttpUri } from "lib/UriUtil"
 import { WidgetStateManager } from "lib/WidgetStateManager"
 import React from "react"
 import { darkTheme, lightTheme, toThemeInput } from "theme"
+import { fonts } from "theme/primitives/typography"
 import {
   COMPONENT_READY_WARNING_TIME_MS,
   ComponentInstance,
@@ -268,7 +269,10 @@ describe("ComponentInstance", () => {
 
     // We should get the theme object in our receiveForwardMsg callback.
     expect(mc.receiveForwardMsg).toHaveBeenLastCalledWith(
-      renderMsg(jsonArgs, [], false, toThemeInput(darkTheme.emotion)),
+      renderMsg(jsonArgs, [], false, {
+        ...toThemeInput(darkTheme.emotion),
+        font: fonts.sansSerif,
+      }),
       "*"
     )
   })
@@ -500,7 +504,7 @@ function renderMsg(
   args: { [name: string]: any },
   dataframes: any[],
   disabled = false,
-  theme = toThemeInput(lightTheme.emotion)
+  theme = { ...toThemeInput(lightTheme.emotion), font: fonts.sansSerif }
 ): any {
   return forwardMsg(StreamlitMessageType.RENDER, {
     args,

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -34,7 +34,7 @@ import { Timer } from "lib/Timer"
 import { Source, WidgetStateManager } from "lib/WidgetStateManager"
 import queryString from "query-string"
 import React, { createRef, ReactNode } from "react"
-import { toThemeInput, Theme } from "theme"
+import { fontEnumToString, toThemeInput, Theme } from "theme"
 import { COMMUNITY_URL, COMPONENT_DEVELOPER_URL } from "urls"
 import { ComponentRegistry } from "./ComponentRegistry"
 import { ComponentMessageType, StreamlitMessageType } from "./enums"
@@ -274,6 +274,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
    */
   private sendRenderMessage = (): void => {
     const { theme } = this.props
+    const themeInput = toThemeInput(theme)
 
     // NB: if you change or remove any of the arguments here, you'll break
     // existing components. You can *add* more arguments safely, but any
@@ -282,7 +283,10 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       args: this.curArgs,
       dfs: this.curDataframeArgs,
       disabled: this.props.disabled,
-      theme: toThemeInput(theme),
+      theme: {
+        ...themeInput,
+        font: fontEnumToString(themeInput.font),
+      },
     })
   }
 

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -17,11 +17,14 @@
 import { CustomThemeConfig } from "autogen/proto"
 import { LocalStore } from "lib/storageUtils"
 import { baseTheme, darkTheme, lightTheme } from "theme"
+import { fonts } from "theme/primitives/typography"
 import {
   AUTO_THEME,
   computeSpacingStyle,
   createEmotionTheme,
   createTheme,
+  fontEnumToString,
+  fontToEnum,
   getDefaultTheme,
   getSystemTheme,
   isColor,
@@ -281,14 +284,38 @@ describe("createEmotionTheme", () => {
 
 describe("toComponentTheme", () => {
   it("converts from emotion theme to what a custom component expects", () => {
-    const { colors, genericFonts } = lightTheme.emotion
+    const { colors } = lightTheme.emotion
     expect(toThemeInput(lightTheme.emotion)).toEqual({
       primaryColor: colors.primary,
       secondaryColor: colors.secondary,
       backgroundColor: colors.bgColor,
       secondaryBackgroundColor: colors.secondaryBg,
       textColor: colors.bodyText,
-      font: genericFonts.bodyFont,
+      font: CustomThemeConfig.FontFamily.SANS_SERIF,
     })
+  })
+})
+
+describe("converting font <> enum", () => {
+  it("fontEnumToString converts to enum", () => {
+    expect(fontEnumToString(CustomThemeConfig.FontFamily.SANS_SERIF)).toBe(
+      fonts.sansSerif
+    )
+    expect(fontEnumToString(CustomThemeConfig.FontFamily.SERIF)).toBe(
+      fonts.serif
+    )
+    expect(fontEnumToString(CustomThemeConfig.FontFamily.MONOSPACE)).toBe(
+      fonts.monospace
+    )
+  })
+
+  it("fontToEnum converts to string", () => {
+    expect(fontToEnum(fonts.monospace)).toBe(
+      CustomThemeConfig.FontFamily.MONOSPACE
+    )
+    expect(fontToEnum(fonts.sansSerif)).toBe(
+      CustomThemeConfig.FontFamily.SANS_SERIF
+    )
+    expect(fontToEnum(fonts.serif)).toBe(CustomThemeConfig.FontFamily.SERIF)
   })
 })

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6694,6 +6694,11 @@ decamelize@^2.0.0:
   dependencies:
     xregexp "4.0.0"
 
+decamelize@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.0.tgz#88358157b010ef133febfd27c18994bd80c6215b"
+  integrity sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==
+
 decimal.js@^10.2.0:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"


### PR DESCRIPTION
1. Change up toThemeInput to use font enum instead of font string
2. Fix typo with the outputted config

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
