### PR TITLE
Promote Config and CustomTheme protos to be children of NewReport

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -113,13 +113,13 @@ describe("App", () => {
 
     const fwMessage = new ForwardMsg()
     fwMessage.newReport = {
+      config: {},
       initialize: {
         environmentInfo: {
           streamlitVersion: "svv",
         },
         sessionId: "sessionId",
         userInfo: {},
-        config: {},
         sessionState: {},
       },
     }
@@ -186,19 +186,24 @@ describe("App", () => {
 
 describe("App.handleNewReport", () => {
   const NEW_REPORT_JSON = {
+    config: {
+      sharingEnabled: false,
+      gatherUsageStats: false,
+      maxCachedMessageAge: 0,
+      mapboxToken: "mapboxToken",
+      allowRunOnSave: false,
+    },
+    customTheme: {
+      name: "carl",
+      primary: "red",
+      setAsDefault: false,
+    },
     initialize: {
       userInfo: {
         installationId: "installationId",
         installationIdV1: "installationIdV1",
         installationIdV2: "installationIdV2",
         email: "email",
-      },
-      config: {
-        sharingEnabled: false,
-        gatherUsageStats: false,
-        maxCachedMessageAge: 0,
-        mapboxToken: "mapboxToken",
-        allowRunOnSave: false,
       },
       environmentInfo: {
         streamlitVersion: "streamlitVersion",
@@ -207,11 +212,6 @@ describe("App.handleNewReport", () => {
       sessionState: {
         runOnSave: false,
         reportIsRunning: false,
-      },
-      customTheme: {
-        name: "carl",
-        primary: "red",
-        setAsDefault: false,
       },
       sessionId: "sessionId",
       commandLine: "commandLine",
@@ -243,7 +243,7 @@ describe("App.handleNewReport", () => {
     const wrapper = shallow(<App {...props} />)
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
-    newReportJson.initialize.customTheme.setAsDefault = true
+    newReportJson.customTheme.setAsDefault = true
 
     // @ts-ignore
     wrapper.instance().handleNewReport(new NewReport(newReportJson))
@@ -268,7 +268,7 @@ describe("App.handleNewReport", () => {
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
-    newReportJson.initialize.customTheme = null
+    newReportJson.customTheme = null
 
     // @ts-ignore
     wrapper.instance().handleNewReport(new NewReport(newReportJson))
@@ -286,7 +286,7 @@ describe("App.handleNewReport", () => {
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
-    newReportJson.initialize.customTheme = null
+    newReportJson.customTheme = null
 
     // @ts-ignore
     wrapper.instance().handleNewReport(new NewReport(newReportJson))
@@ -311,7 +311,7 @@ describe("App.handleNewReport", () => {
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
-    newReportJson.initialize.customTheme = null
+    newReportJson.customTheme = null
 
     // @ts-ignore
     wrapper.instance().handleNewReport(new NewReport(newReportJson))

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { SessionInfo } from "lib/SessionInfo"
-import { Initialize } from "autogen/proto"
+import { NewReport } from "autogen/proto"
 
 test("Throws an error when used before initialization", () => {
   expect(() => SessionInfo.current).toThrow()
@@ -42,13 +42,7 @@ test("Clears session info", () => {
 })
 
 test("Can be initialized from a protobuf", () => {
-  const MESSAGE = new Initialize({
-    userInfo: {
-      installationId: "installationId",
-      installationIdV1: "installationIdV1",
-      installationIdV2: "installationIdV2",
-      email: "email",
-    },
+  const MESSAGE = new NewReport({
     config: {
       sharingEnabled: false,
       gatherUsageStats: false,
@@ -56,19 +50,27 @@ test("Can be initialized from a protobuf", () => {
       mapboxToken: "mapboxToken",
       allowRunOnSave: false,
     },
-    environmentInfo: {
-      streamlitVersion: "streamlitVersion",
-      pythonVersion: "pythonVersion",
+    initialize: {
+      userInfo: {
+        installationId: "installationId",
+        installationIdV1: "installationIdV1",
+        installationIdV2: "installationIdV2",
+        email: "email",
+      },
+      environmentInfo: {
+        streamlitVersion: "streamlitVersion",
+        pythonVersion: "pythonVersion",
+      },
+      sessionState: {
+        runOnSave: false,
+        reportIsRunning: false,
+      },
+      sessionId: "sessionId",
+      commandLine: "commandLine",
     },
-    sessionState: {
-      runOnSave: false,
-      reportIsRunning: false,
-    },
-    sessionId: "sessionId",
-    commandLine: "commandLine",
   })
 
-  const si = SessionInfo.fromInitializeMessage(MESSAGE)
+  const si = SessionInfo.fromNewReportMessage(MESSAGE)
   expect(si.sessionId).toEqual("sessionId")
   expect(si.streamlitVersion).toEqual("streamlitVersion")
   expect(si.pythonVersion).toEqual("pythonVersion")

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { Config, EnvironmentInfo, Initialize, UserInfo } from "autogen/proto"
+import {
+  Config,
+  EnvironmentInfo,
+  Initialize,
+  NewReport,
+  UserInfo,
+} from "autogen/proto"
 
 export interface Args {
   sessionId: string
@@ -91,10 +97,11 @@ export class SessionInfo {
   }
 
   /** Create a SessionInfo from the relevant bits of an initialize message. */
-  public static fromInitializeMessage(initialize: Initialize): SessionInfo {
-    const environmentInfo = initialize.environmentInfo as EnvironmentInfo
+  public static fromNewReportMessage(newReport: NewReport): SessionInfo {
+    const initialize = newReport.initialize as Initialize
+    const config = newReport.config as Config
     const userInfo = initialize.userInfo as UserInfo
-    const config = initialize.config as Config
+    const environmentInfo = initialize.environmentInfo as EnvironmentInfo
 
     return new SessionInfo({
       sessionId: initialize.sessionId,

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -363,9 +363,13 @@ class ReportSession(object):
     def _enqueue_new_report_message(self):
         self._report.generate_new_id()
         msg = ForwardMsg()
+
         msg.new_report.report_id = self._report.report_id
         msg.new_report.name = self._report.name
         msg.new_report.script_path = self._report.script_path
+
+        _populate_config_msg(msg.new_report.config)
+        _populate_theme_msg(msg.new_report.custom_theme)
 
         # git deploy params
         deploy_params = self.get_deploy_params()
@@ -381,8 +385,6 @@ class ReportSession(object):
         # to perform one-time initialization only once.
         imsg = msg.new_report.initialize
 
-        _populate_config_msg(imsg.config)
-        _populate_theme_msg(imsg.custom_theme)
         _populate_user_info_msg(imsg.user_info)
 
         imsg.environment_info.streamlit_version = __version__

--- a/lib/tests/streamlit/report_queue_test.py
+++ b/lib/tests/streamlit/report_queue_test.py
@@ -28,8 +28,8 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 # their general type.
 
 NEW_REPORT_MSG = ForwardMsg()
-NEW_REPORT_MSG.new_report.initialize.config.sharing_enabled = True
-NEW_REPORT_MSG.new_report.initialize.config.allow_run_on_save = True
+NEW_REPORT_MSG.new_report.config.sharing_enabled = True
+NEW_REPORT_MSG.new_report.config.allow_run_on_save = True
 
 TEXT_DELTA_MSG1 = ForwardMsg()
 TEXT_DELTA_MSG1.delta.new_element.text.body = "text1"
@@ -63,8 +63,8 @@ class ReportQueueTest(unittest.TestCase):
         queue = rq.flush()
         self.assertTrue(rq.is_empty())
         self.assertEqual(len(queue), 1)
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
-        self.assertTrue(queue[0].new_report.initialize.config.allow_run_on_save)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.allow_run_on_save)
 
     def test_enqueue_two(self):
         rq = ReportQueue()
@@ -79,7 +79,7 @@ class ReportQueueTest(unittest.TestCase):
 
         queue = rq.flush()
         self.assertEqual(len(queue), 2)
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
         )
@@ -103,7 +103,7 @@ class ReportQueueTest(unittest.TestCase):
 
         queue = rq.flush()
         self.assertEqual(len(queue), 3)
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
         )
@@ -131,7 +131,7 @@ class ReportQueueTest(unittest.TestCase):
 
         queue = rq.flush()
         self.assertEqual(len(queue), 2)
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
         )
@@ -156,7 +156,7 @@ class ReportQueueTest(unittest.TestCase):
 
         queue = rq.flush()
         self.assertEqual(len(queue), 3)
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
         )
@@ -194,7 +194,7 @@ class ReportQueueTest(unittest.TestCase):
 
         queue = rq.flush()
         self.assertEqual(len(queue), 3)
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
         self.assertEqual(
             make_delta_path(RootContainer.MAIN, (), 0), queue[1].metadata.delta_path
         )
@@ -248,7 +248,7 @@ class ReportQueueTest(unittest.TestCase):
 
         queue = rq.flush()
         self.assertEqual(5, len(queue))
-        self.assertTrue(queue[0].new_report.initialize.config.sharing_enabled)
+        self.assertTrue(queue[0].new_report.config.sharing_enabled)
 
         assert_deltas(RootContainer.MAIN, (), 1)
         assert_deltas(RootContainer.SIDEBAR, (0, 0, 1), 3)

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -273,14 +273,19 @@ class ReportSessionNewReportTest(tornado.testing.AsyncTestCase):
         new_report_msg = sent_messages[0].new_report
         self.assertEqual(new_report_msg.report_id, rs._report.report_id)
 
-        init_msg = new_report_msg.initialize
-        self.assertEqual(init_msg.HasField("config"), True)
-        self.assertEqual(init_msg.HasField("user_info"), True)
+        self.assertEqual(new_report_msg.HasField("config"), True)
+        self.assertEqual(
+            new_report_msg.config.allow_run_on_save,
+            config.get_option("server.allowRunOnSave"),
+        )
 
-        self.assertEqual(init_msg.HasField("custom_theme"), True)
-        self.assertEqual(init_msg.custom_theme.name, "foo")
-        self.assertEqual(init_msg.custom_theme.text_color, "black")
-        self.assertEqual(init_msg.custom_theme.set_as_default, True)
+        self.assertEqual(new_report_msg.HasField("custom_theme"), True)
+        self.assertEqual(new_report_msg.custom_theme.name, "foo")
+        self.assertEqual(new_report_msg.custom_theme.text_color, "black")
+        self.assertEqual(new_report_msg.custom_theme.set_as_default, True)
+
+        init_msg = new_report_msg.initialize
+        self.assertEqual(init_msg.HasField("user_info"), True)
 
         add_report_ctx(ctx=orig_ctx)
 
@@ -305,10 +310,10 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         )
 
         msg = ForwardMsg()
-        init_msg = msg.new_report.initialize
-        report_session._populate_theme_msg(init_msg.custom_theme)
+        new_report_msg = msg.new_report
+        report_session._populate_theme_msg(new_report_msg.custom_theme)
 
-        self.assertEqual(init_msg.HasField("custom_theme"), False)
+        self.assertEqual(new_report_msg.HasField("custom_theme"), False)
 
     @patch("streamlit.report_session.config")
     def test_can_specify_all_options(self, patched_config):
@@ -318,11 +323,11 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         )
 
         msg = ForwardMsg()
-        init_msg = msg.new_report.initialize
-        report_session._populate_theme_msg(init_msg.custom_theme)
+        new_report_msg = msg.new_report
+        report_session._populate_theme_msg(new_report_msg.custom_theme)
 
-        self.assertEqual(init_msg.HasField("custom_theme"), True)
-        self.assertEqual(init_msg.custom_theme.name, "foo")
-        self.assertEqual(init_msg.custom_theme.set_as_default, True)
-        self.assertEqual(init_msg.custom_theme.primary_color, "coral")
-        self.assertEqual(init_msg.custom_theme.background_color, "white")
+        self.assertEqual(new_report_msg.HasField("custom_theme"), True)
+        self.assertEqual(new_report_msg.custom_theme.name, "foo")
+        self.assertEqual(new_report_msg.custom_theme.set_as_default, True)
+        self.assertEqual(new_report_msg.custom_theme.primary_color, "coral")
+        self.assertEqual(new_report_msg.custom_theme.background_color, "white")

--- a/lib/tests/streamlit/report_test.py
+++ b/lib/tests/streamlit/report_test.py
@@ -29,7 +29,7 @@ from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from tests import testutil
 
 NEW_REPORT_MSG = ForwardMsg()
-NEW_REPORT_MSG.new_report.initialize.config.sharing_enabled = True
+NEW_REPORT_MSG.new_report.config.sharing_enabled = True
 NEW_REPORT_MSG.metadata.delta_path[:] = make_delta_path(RootContainer.MAIN, (), 0)
 
 TEXT_DELTA_MSG = ForwardMsg()

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -37,13 +37,22 @@ message NewReport {
   string script_path = 4;
 
   DeployParams deploy_params = 5;
+
+  // Config options that are (mostly) defined in the .streamlit/config.toml
+  // file.
+  Config config = 6;
+
+  // Theme configuration options defined in the .streamlit/config.toml file.
+  // See the "theme" config section.
+  CustomThemeConfig custom_theme = 7;
 }
 
-// Contains Streamlit configuration data, and the session state that existed
-// at the time the user connected.
+// Contains the session state that existed at the time the user connected.
+// The contents of this message don't change over the lifetime of the app by
+// definition.
 message Initialize {
   UserInfo user_info = 1;
-  Config config = 2;
+
   EnvironmentInfo environment_info = 3;
 
   // The session state at the time the connection was established
@@ -56,14 +65,10 @@ message Initialize {
   // This is used to associate uploaded files with the client that uploaded
   // them.
   string session_id = 6;
-
-  // Theme configuration options defined in the .streamlit/config.toml file.
-  // See the config section "customTheme".
-  CustomThemeConfig custom_theme = 7;
 }
 
 // App configuration options, initialized mainly from the
-// .streamlit/config.toml file. Does not change over the app's lifetime.
+// .streamlit/config.toml file.
 message Config {
   // True if saving is properly configured.
   bool sharing_enabled = 1;


### PR DESCRIPTION
These messages were originally children of `NewReport.Initialize`, but as
we're making the change to have (some) config options auto-reload on file
save, this shouldn't be the case anymore given the initialize message by
definition only contains things that never change.