### PR TITLE
Update active theme when editing custom theme

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -160,6 +160,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
+    "prop-types": "^15.7.2",
     "react-scripts": "4.0.1",
     "scss-to-json": "^2.0.0",
     "source-map-explorer": "^2.4.2",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -253,7 +253,6 @@ describe("App.handleNewReport", () => {
 
     // @ts-ignore
     expect(props.theme.setTheme).toHaveBeenCalled()
-    expect(wrapper.state("userSettings").activeTheme.name).toBe("carl")
 
     // @ts-ignore
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe("carl")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -994,7 +994,10 @@ export class App extends PureComponent<Props, State> {
           embedded: isEmbeddedInIFrame(),
           isFullScreen,
           setFullScreen: this.handleFullScreen,
-          ...this.props.theme,
+          activeTheme: this.props.theme.activeTheme,
+          availableThemes: this.props.theme.availableThemes,
+          setTheme: this.props.theme.setTheme,
+          addThemes: this.props.theme.addThemes,
         }}
       >
         <HotKeys

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -156,6 +156,8 @@ export class App extends PureComponent<Props, State> {
 
   private readonly componentRegistry: ComponentRegistry
 
+  static contextType = PageLayoutContext
+
   constructor(props: Props) {
     super(props)
 
@@ -170,7 +172,6 @@ export class App extends PureComponent<Props, State> {
       userSettings: {
         wideMode: false,
         runOnSave: false,
-        activeTheme: this.props.theme.activeTheme,
       },
       layout: PageConfig.Layout.CENTERED,
       initialSidebarState: PageConfig.SidebarState.AUTO,
@@ -569,12 +570,6 @@ export class App extends PureComponent<Props, State> {
       // ignore that.
       if (themeInput.setAsDefault) {
         this.props.theme.setTheme(customTheme)
-        this.setState({
-          userSettings: {
-            ...this.state.userSettings,
-            activeTheme: customTheme,
-          },
-        })
       }
     } else if (!themeInput) {
       // Remove the custom theme menu option.
@@ -694,7 +689,7 @@ export class App extends PureComponent<Props, State> {
    */
   saveSettings = (newSettings: UserSettings): void => {
     const { runOnSave: prevRunOnSave } = this.state.userSettings
-    const { runOnSave, activeTheme } = newSettings
+    const { runOnSave } = newSettings
 
     this.setState({ userSettings: newSettings })
 
@@ -703,8 +698,6 @@ export class App extends PureComponent<Props, State> {
       backMsg.type = "setRunOnSave"
       this.sendBackMsg(backMsg)
     }
-
-    this.props.theme.setTheme(activeTheme)
   }
 
   /**
@@ -936,7 +929,6 @@ export class App extends PureComponent<Props, State> {
       allowRunOnSave: this.state.allowRunOnSave,
       onSave: this.saveSettings,
       onClose: () => {},
-      allowedThemes: this.props.theme.availableThemes,
       developerMode: this.state.developerMode,
     }
     this.openDialog(newDialog)
@@ -1002,7 +994,7 @@ export class App extends PureComponent<Props, State> {
           embedded: isEmbeddedInIFrame(),
           isFullScreen,
           setFullScreen: this.handleFullScreen,
-          activeTheme: this.props.theme.activeTheme,
+          ...this.props.theme,
         }}
       >
         <HotKeys

--- a/frontend/src/components/core/PageLayoutContext/index.tsx
+++ b/frontend/src/components/core/PageLayoutContext/index.tsx
@@ -25,7 +25,7 @@ export interface Props {
   initialSidebarState: PageConfig.SidebarState
   embedded: boolean
   isFullScreen: boolean
-  setFullScreen: (value: boolean) => any
+  setFullScreen: (value: boolean) => void
   activeTheme: ThemeConfig
   setTheme: (theme: ThemeConfig) => void
   availableThemes: ThemeConfig[]

--- a/frontend/src/components/core/PageLayoutContext/index.tsx
+++ b/frontend/src/components/core/PageLayoutContext/index.tsx
@@ -17,9 +17,22 @@
 
 import React from "react"
 import { PageConfig } from "autogen/proto"
-import { baseTheme } from "theme"
+import { baseTheme, ThemeConfig } from "theme"
 
-export default React.createContext({
+export interface Props {
+  wideMode: boolean
+  layout: PageConfig.Layout
+  initialSidebarState: PageConfig.SidebarState
+  embedded: boolean
+  isFullScreen: boolean
+  setFullScreen: (value: boolean) => any
+  activeTheme: ThemeConfig
+  setTheme: (theme: ThemeConfig) => void
+  availableThemes: ThemeConfig[]
+  addThemes: (themes: ThemeConfig[]) => void
+}
+
+export default React.createContext<Props>({
   wideMode: false,
   layout: PageConfig.Layout.CENTERED,
   initialSidebarState: PageConfig.SidebarState.AUTO,
@@ -27,4 +40,7 @@ export default React.createContext({
   isFullScreen: false,
   setFullScreen: (value: boolean) => {},
   activeTheme: baseTheme,
+  setTheme: (theme: ThemeConfig) => {},
+  availableThemes: [],
+  addThemes: (themes: ThemeConfig[]) => {},
 })

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
@@ -20,12 +20,15 @@ import { CustomThemeConfig } from "autogen/proto"
 import { mount, shallow } from "lib/test_util"
 import ColorPicker from "components/shared/ColorPicker"
 import UISelectbox from "components/shared/Dropdown"
-import { darkTheme, toThemeInput } from "theme"
+import { baseTheme } from "theme"
+import { fonts } from "theme/primitives/typography"
 import ThemeCreator, { Props } from "./ThemeCreator"
 
+const mockSetTheme = jest.fn()
+const mockAddThemes = jest.fn()
+
 const getProps = (extend?: Partial<Props>): Props => ({
-  themeInput: toThemeInput(darkTheme.emotion),
-  updateThemeInput: jest.fn(),
+  hasCustomTheme: false,
   ...extend,
 })
 
@@ -38,34 +41,80 @@ Object.assign(navigator, {
 window.HTMLElement.prototype.scrollIntoView = jest.fn()
 
 describe("Renders ThemeCreator", () => {
-  const props = getProps()
-  const wrapper = shallow(<ThemeCreator {...props} />)
+  beforeEach(() =>
+    jest.spyOn(React, "useContext").mockImplementation(() => ({
+      activeTheme: baseTheme,
+      setTheme: mockSetTheme,
+      availableThemes: [],
+      addThemes: mockAddThemes,
+    }))
+  )
 
-  it("renders closed theme creator without crashing", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders closed theme creator without custom theme", () => {
+    const props = getProps()
+    const wrapper = shallow(<ThemeCreator {...props} />)
     expect(wrapper).toMatchSnapshot()
+    expect(wrapper.find("Button").prop("children")).toBe(
+      "Create a new Custom Theme"
+    )
+  })
+
+  it("Renders closed theme creator with custom theme", () => {
+    const props = getProps({ hasCustomTheme: true })
+    const wrapper = shallow(<ThemeCreator {...props} />)
+    expect(wrapper.find("Button").prop("children")).toBe(
+      "Edit Existing Custom Theme"
+    )
   })
 
   it("Renders opened theme creator", () => {
+    const props = getProps()
+    const wrapper = shallow(<ThemeCreator {...props} />)
     wrapper.find("Button").simulate("click")
     expect(wrapper).toMatchSnapshot()
   })
 })
 
 describe("Opened ThemeCreator", () => {
-  const props = getProps()
-  const wrapper = mount(<ThemeCreator {...props} />)
-  wrapper.find("Button").simulate("click")
+  beforeEach(() =>
+    jest.spyOn(React, "useContext").mockImplementation(() => ({
+      activeTheme: baseTheme,
+      setTheme: mockSetTheme,
+      availableThemes: [],
+      addThemes: mockAddThemes,
+    }))
+  )
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
   it("should update theme on color change", () => {
-    const colorpicker = wrapper.find(ColorPicker)
+    const props = getProps()
+    const wrapper = mount(<ThemeCreator {...props} />)
+    wrapper.find("Button").simulate("click")
 
+    const colorpicker = wrapper.find(ColorPicker)
     expect(colorpicker).toHaveLength(5)
-    colorpicker.at(0).prop("onChange")("color")
-    expect(props.updateThemeInput).toHaveBeenCalled()
-    expect(props.updateThemeInput.mock.calls[0][0].primaryColor).toBe("color")
+
+    colorpicker.at(0).prop("onChange")("pink")
+    expect(mockAddThemes).toHaveBeenCalled()
+    expect(mockAddThemes.mock.calls[1][0][0].emotion.colors.primary).toBe(
+      "pink"
+    )
+
+    expect(mockSetTheme).toHaveBeenCalled()
+    expect(mockSetTheme.mock.calls[1][0].emotion.colors.primary).toBe("pink")
   })
 
   it("should update theme on font change", () => {
+    const props = getProps()
+    const wrapper = mount(<ThemeCreator {...props} />)
+    wrapper.find("Button").simulate("click")
     const selectbox = wrapper.find(UISelectbox)
     const { options } = selectbox.props()
 
@@ -73,24 +122,36 @@ describe("Opened ThemeCreator", () => {
       Object.keys(CustomThemeConfig.FontFamily).length
     )
 
-    selectbox.prop("onChange")(1)
-    expect(props.updateThemeInput).toHaveBeenCalled()
-    expect(props.updateThemeInput.mock.calls[1][0].font).toBe(1)
+    selectbox.prop("onChange")(2)
+    expect(mockAddThemes).toHaveBeenCalled()
+    expect(
+      mockAddThemes.mock.calls[1][0][0].emotion.genericFonts.bodyFont
+    ).toBe(fonts.monospace)
+
+    expect(mockSetTheme).toHaveBeenCalled()
+    expect(mockSetTheme.mock.calls[1][0].emotion.genericFonts.bodyFont).toBe(
+      fonts.monospace
+    )
   })
 
   it("should copy to clipboard", () => {
-    const themeInput = wrapper.prop("themeInput")
+    const { colors } = baseTheme.emotion
+    const props = getProps()
+    const wrapper = mount(<ThemeCreator {...props} />)
+    wrapper.find("Button").simulate("click")
     const copyBtn = wrapper.find("Button")
 
     expect(copyBtn.prop("children")).toBe("Copy Theme to Clipboard")
     copyBtn.simulate("click")
+    // TODO: Karrie; fix font expected result
+    // font="sans serif"
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`[theme]
-primaryColor="${themeInput.primaryColor}"
-secondaryColor="${themeInput.secondaryColor}"
-backgroundColor="${themeInput.backgroundColor}"
-secondaryBackgroundColor="${themeInput.secondaryBackgroundColor}"
-textColor="${themeInput.textColor}"
-font="${themeInput.font}"
+primaryColor="${colors.primary}"
+secondaryColor="${colors.secondary}"
+backgroundColor="${colors.bgColor}"
+secondaryBackgroundColor="${colors.secondaryBg}"
+textColor="${colors.bodyText}"
+font="0"
 `)
   })
 })

--- a/frontend/src/components/core/StreamlitDialog/UserSettings.ts
+++ b/frontend/src/components/core/StreamlitDialog/UserSettings.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { ThemeConfig } from "theme"
-
 export interface UserSettings {
   /**
    * If true, the report will be rendered with a wider column size
@@ -32,9 +30,4 @@ export interface UserSettings {
    * a 'setRunOnSave' message will be sent back to the server.
    */
   runOnSave: boolean
-
-  /**
-   * Active theme
-   */
-  activeTheme: ThemeConfig
 }

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
@@ -45,19 +45,7 @@ exports[`SettingsDialog renders without crashing 1`] = `
       value={0}
     />
     <ThemeCreator
-      label="Edit Existing Custom Theme"
-      themeInput={
-        Object {
-          "backgroundColor": "#FFFFFF",
-          "font": 0,
-          "name": "Light",
-          "primaryColor": "#f63366",
-          "secondaryBackgroundColor": "#f0f2f6",
-          "secondaryColor": "#a3a8b8",
-          "textColor": "#262730",
-        }
-      }
-      updateThemeInput={[Function]}
+      hasCustomTheme={true}
     />
   </ModalBody>
 </Modal>

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreator.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreator.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
   <StyledThemeCreator>
     <StyledThemeColorPicker
       disabled={false}
-      key="primaryColor"
       label="Primary color"
       onChange={[Function]}
       showValue={true}
@@ -19,7 +18,6 @@ exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
     </StyledThemeDesc>
     <StyledThemeColorPicker
       disabled={false}
-      key="secondaryColor"
       label="Secondary color"
       onChange={[Function]}
       showValue={true}
@@ -30,40 +28,36 @@ exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
     </StyledThemeDesc>
     <StyledThemeColorPicker
       disabled={false}
-      key="backgroundColor"
       label="Background color"
       onChange={[Function]}
       showValue={true}
-      value="#0E1117"
+      value="#FFFFFF"
     />
     <StyledThemeDesc>
       Background color for the main container.
     </StyledThemeDesc>
     <StyledThemeColorPicker
       disabled={false}
-      key="secondaryBackgroundColor"
       label="Secondary background color"
       onChange={[Function]}
       showValue={true}
-      value="#262730"
+      value="#F0F2F6"
     />
     <StyledThemeDesc>
       Used as the background for most widgets. Examples of widgets with this background are st.sidebar, st.text_input, st.date_input.
     </StyledThemeDesc>
     <StyledThemeColorPicker
       disabled={false}
-      key="textColor"
       label="Text color"
       onChange={[Function]}
       showValue={true}
-      value="#FAFAFA"
+      value="#262730"
     />
     <StyledThemeDesc>
       Font color for the page
     </StyledThemeDesc>
     <Selectbox
       disabled={false}
-      key="font"
       label="Font family"
       onChange={[Function]}
       options={
@@ -94,13 +88,13 @@ exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
 </StyledThemeCreatorWrapper>
 `;
 
-exports[`Renders ThemeCreator renders closed theme creator without crashing 1`] = `
+exports[`Renders ThemeCreator renders closed theme creator without custom theme 1`] = `
 <StyledThemeCreatorWrapper>
   <Button
     kind="link"
     onClick={[Function]}
   >
-    Edit theme
+    Create a new Custom Theme
   </Button>
 </StyledThemeCreatorWrapper>
 `;

--- a/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -134,6 +134,26 @@ describe("Selectbox widget", () => {
       },
     ])
   })
+
+  it("should update value if new value provided from parent", () => {
+    // @ts-ignore
+    wrapper.find(UISelect).prop("onChange")({
+      value: [{ label: "b", value: "1" }],
+      option: { label: "b", value: "1" },
+      type: "select",
+    })
+
+    expect(wrapper.find(UISelect).prop("value")).toContainEqual({
+      label: "b",
+      value: "1",
+    })
+
+    wrapper.setProps({ value: "2" })
+    expect(wrapper.find(UISelect).prop("value")).toContainEqual({
+      label: "c",
+      value: "2",
+    })
+  })
 })
 
 describe("Selectbox widget with optional props", () => {

--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -48,6 +48,15 @@ class Selectbox extends React.PureComponent<Props, State> {
     value: this.props.value,
   }
 
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (
+      prevProps.value !== this.props.value &&
+      this.state.value !== this.props.value
+    ) {
+      this.setState({ value: this.props.value })
+    }
+  }
+
   private onChange = (params: OnChangeParams): void => {
     if (params.value.length === 0) {
       logWarning("No value selected!")


### PR DESCRIPTION
Squeezed in a refactor since we're going deeper with our theme info

1. When editing custom theme, update dropdown. Allow parent to override current value. 
2. Remove theme from UserSettings
3. Add theme props to PageLayoutContext


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
