### PR TITLE
Theming: Always pick the user choice upon reload

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -18,6 +18,7 @@
 import React from "react"
 import { ReactWrapper } from "enzyme"
 import cloneDeep from "lodash/cloneDeep"
+import { LocalStore } from "lib/storageUtils"
 import { shallow, mount } from "lib/test_util"
 import { ForwardMsg, NewReport } from "autogen/proto"
 import { IMenuItem } from "hocs/withS4ACommunication/types"
@@ -196,7 +197,6 @@ describe("App.handleNewReport", () => {
     customTheme: {
       name: "carl",
       primary: "red",
-      setAsDefault: false,
     },
     initialize: {
       userInfo: {
@@ -222,10 +222,15 @@ describe("App.handleNewReport", () => {
   afterEach(() => {
     const UnsafeSessionInfo = SessionInfo as any
     UnsafeSessionInfo.singleton = undefined
+    window.localStorage.clear()
   })
 
   it("adds custom theme to list of available themes", () => {
     const props = getProps()
+    window.localStorage.setItem(
+      LocalStore.ACTIVE_THEME,
+      JSON.stringify(lightTheme)
+    )
     const wrapper = shallow(<App {...props} />)
 
     // @ts-ignore
@@ -238,12 +243,11 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
-  it("sets custom theme as default if flag is set", () => {
+  it("sets custom theme as default if no user preference", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
-    newReportJson.customTheme.setAsDefault = true
 
     // @ts-ignore
     wrapper.instance().handleNewReport(new NewReport(newReportJson))
@@ -285,6 +289,7 @@ describe("App.handleNewReport", () => {
     const wrapper = shallow(<App {...props} />)
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
+
     // @ts-ignore
     newReportJson.customTheme = null
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -262,10 +262,6 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe("carl")
   })
 
-  xit("Does not change dark/light/auto preference when adding custom theme", () => {
-    // TODO: vincent
-  })
-
   it("removes custom theme from options if none is received from the server", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -574,6 +574,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   processThemeInput(themeInput: CustomThemeConfig): void {
+    // TODO: ideally we would only do this if theme input changes.
     if (themeInput) {
       const customTheme = createTheme(themeInput)
       // For now users can only add a custom theme.
@@ -587,10 +588,10 @@ export class App extends PureComponent<Props, State> {
         )
       }
 
-      // NOTE: This code needs to be fixed to handle the case where the user
-      // has their theme preference set to Auto/Dark/Light as we don't want to
-      // ignore that.
-      if (themeInput.setAsDefault) {
+      const userPreference = window.localStorage.getItem(
+        LocalStore.ACTIVE_THEME
+      )
+      if (userPreference === null) {
         this.props.theme.setTheme(customTheme)
       }
     } else if (!themeInput) {

--- a/frontend/src/components/core/StreamlitDialog/SettingsDialog.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/SettingsDialog.test.tsx
@@ -139,8 +139,6 @@ describe("SettingsDialog", () => {
     const { options } = selectbox.props()
 
     expect(options).toHaveLength(presetThemes.length + 1)
-
-    expect(wrapper.find("ThemeCreator").prop("hasCustomTheme")).toBe(true)
   })
 
   it("should show custom theme does not exists", () => {
@@ -153,8 +151,6 @@ describe("SettingsDialog", () => {
     const { options } = selectbox.props()
 
     expect(options).toHaveLength(presetThemes.length)
-
-    expect(wrapper.find("ThemeCreator").prop("hasCustomTheme")).toBe(false)
   })
 
   it("should hide theme creator if not developer mode", () => {

--- a/frontend/src/components/core/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/SettingsDialog.tsx
@@ -17,7 +17,7 @@
 
 import React, { ChangeEvent, PureComponent, ReactNode } from "react"
 import UISelectbox from "components/shared/Dropdown"
-import { createPresetThemes, ThemeConfig } from "theme"
+import { ThemeConfig } from "theme"
 import PageLayoutContext from "components/core/PageLayoutContext"
 import Modal, { ModalHeader, ModalBody } from "components/shared/Modal"
 import ThemeCreator from "./ThemeCreator"
@@ -54,8 +54,6 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
     const themeIndex = this.context.availableThemes.findIndex(
       (theme: ThemeConfig) => theme.name === this.context.activeTheme.name
     )
-    const hasCustomTheme =
-      this.context.availableThemes.length !== createPresetThemes().length
 
     return (
       <Modal isOpen onClose={this.handleCancelButtonClick}>
@@ -110,9 +108,7 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
                 onChange={this.handleThemeChange}
                 value={themeIndex}
               />
-              {this.props.developerMode && (
-                <ThemeCreator hasCustomTheme={hasCustomTheme} />
-              )}
+              {this.props.developerMode && <ThemeCreator />}
             </>
           ) : null}
         </ModalBody>

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
@@ -22,15 +22,10 @@ import ColorPicker from "components/shared/ColorPicker"
 import UISelectbox from "components/shared/Dropdown"
 import { baseTheme } from "theme"
 import { fonts } from "theme/primitives/typography"
-import ThemeCreator, { Props } from "./ThemeCreator"
+import ThemeCreator from "./ThemeCreator"
 
 const mockSetTheme = jest.fn()
 const mockAddThemes = jest.fn()
-
-const getProps = (extend?: Partial<Props>): Props => ({
-  hasCustomTheme: false,
-  ...extend,
-})
 
 Object.assign(navigator, {
   clipboard: {
@@ -55,14 +50,12 @@ describe("Renders ThemeCreator", () => {
   })
 
   it("renders closed theme creator without custom theme", () => {
-    const props = getProps()
-    const wrapper = shallow(<ThemeCreator {...props} />)
+    const wrapper = shallow(<ThemeCreator />)
     expect(wrapper).toMatchSnapshot()
   })
 
   it("Renders opened theme creator", () => {
-    const props = getProps()
-    const wrapper = shallow(<ThemeCreator {...props} />)
+    const wrapper = shallow(<ThemeCreator />)
     wrapper.find("Button").simulate("click")
     expect(wrapper).toMatchSnapshot()
   })
@@ -83,8 +76,7 @@ describe("Opened ThemeCreator", () => {
   })
 
   it("should update theme on color change", () => {
-    const props = getProps()
-    const wrapper = mount(<ThemeCreator {...props} />)
+    const wrapper = mount(<ThemeCreator />)
     wrapper.find("Button").simulate("click")
 
     const colorpicker = wrapper.find(ColorPicker)
@@ -101,8 +93,7 @@ describe("Opened ThemeCreator", () => {
   })
 
   it("should update theme on font change", () => {
-    const props = getProps()
-    const wrapper = mount(<ThemeCreator {...props} />)
+    const wrapper = mount(<ThemeCreator />)
     wrapper.find("Button").simulate("click")
     const selectbox = wrapper.find(UISelectbox)
     const { options } = selectbox.props()
@@ -124,8 +115,7 @@ describe("Opened ThemeCreator", () => {
   })
 
   it("should have font dropdown populated", () => {
-    const props = getProps()
-    const wrapper = mount(<ThemeCreator {...props} />)
+    const wrapper = mount(<ThemeCreator />)
     wrapper.find("Button").simulate("click")
     const selectbox = wrapper.find(UISelectbox)
     const { options, value } = selectbox.props()
@@ -138,8 +128,7 @@ describe("Opened ThemeCreator", () => {
 
   it("should copy to clipboard", () => {
     const { colors } = baseTheme.emotion
-    const props = getProps()
-    const wrapper = mount(<ThemeCreator {...props} />)
+    const wrapper = mount(<ThemeCreator />)
     wrapper.find("Button").simulate("click")
     const copyBtn = wrapper.find("Button")
 

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
@@ -58,17 +58,6 @@ describe("Renders ThemeCreator", () => {
     const props = getProps()
     const wrapper = shallow(<ThemeCreator {...props} />)
     expect(wrapper).toMatchSnapshot()
-    expect(wrapper.find("Button").prop("children")).toBe(
-      "Create a new Custom Theme"
-    )
-  })
-
-  it("Renders closed theme creator with custom theme", () => {
-    const props = getProps({ hasCustomTheme: true })
-    const wrapper = shallow(<ThemeCreator {...props} />)
-    expect(wrapper.find("Button").prop("children")).toBe(
-      "Edit Existing Custom Theme"
-    )
   })
 
   it("Renders opened theme creator", () => {
@@ -103,12 +92,12 @@ describe("Opened ThemeCreator", () => {
 
     colorpicker.at(0).prop("onChange")("pink")
     expect(mockAddThemes).toHaveBeenCalled()
-    expect(mockAddThemes.mock.calls[1][0][0].emotion.colors.primary).toBe(
+    expect(mockAddThemes.mock.calls[0][0][0].emotion.colors.primary).toBe(
       "pink"
     )
 
     expect(mockSetTheme).toHaveBeenCalled()
-    expect(mockSetTheme.mock.calls[1][0].emotion.colors.primary).toBe("pink")
+    expect(mockSetTheme.mock.calls[0][0].emotion.colors.primary).toBe("pink")
   })
 
   it("should update theme on font change", () => {
@@ -125,11 +114,11 @@ describe("Opened ThemeCreator", () => {
     selectbox.prop("onChange")(2)
     expect(mockAddThemes).toHaveBeenCalled()
     expect(
-      mockAddThemes.mock.calls[1][0][0].emotion.genericFonts.bodyFont
+      mockAddThemes.mock.calls[0][0][0].emotion.genericFonts.bodyFont
     ).toBe(fonts.monospace)
 
     expect(mockSetTheme).toHaveBeenCalled()
-    expect(mockSetTheme.mock.calls[1][0].emotion.genericFonts.bodyFont).toBe(
+    expect(mockSetTheme.mock.calls[0][0].emotion.genericFonts.bodyFont).toBe(
       fonts.monospace
     )
   })

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.test.tsx
@@ -143,7 +143,7 @@ describe("Opened ThemeCreator", () => {
     wrapper.find("Button").simulate("click")
     const copyBtn = wrapper.find("Button")
 
-    expect(copyBtn.prop("children")).toBe("Copy Theme to Clipboard")
+    expect(copyBtn.prop("children")).toBe("Copy theme to clipboard")
     copyBtn.simulate("click")
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`[theme]
 primaryColor="${colors.primary}"
@@ -153,5 +153,9 @@ secondaryBackgroundColor="${colors.secondaryBg}"
 textColor="${colors.bodyText}"
 font="sans serif"
 `)
+    expect(copyBtn.text()).toBe("Copied to clipboard ")
+    expect(wrapper.find("StyledSmall").text()).toBe(
+      "Paste copied theme to config.toml to save theme"
+    )
   })
 })

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
@@ -18,10 +18,6 @@ import {
   StyledThemeDesc,
 } from "./styled-components"
 
-export interface Props {
-  hasCustomTheme: boolean
-}
-
 interface ThemeOptionBuilder {
   desc: string
   title: string
@@ -90,7 +86,7 @@ const themeBuilder: Record<string, ThemeOptionBuilder> = {
   },
 }
 
-const ThemeCreator = ({ hasCustomTheme }: Props): ReactElement => {
+const ThemeCreator = (): ReactElement => {
   const [copied, updateCopied] = React.useState(false)
   const [isOpen, openCreator] = React.useState(false)
   const themeCreator = React.useRef<HTMLDivElement>(null)
@@ -98,10 +94,7 @@ const ThemeCreator = ({ hasCustomTheme }: Props): ReactElement => {
     PageLayoutContext
   )
 
-  const themeInput = {
-    ...toThemeInput(activeTheme.emotion),
-    name: hasCustomTheme ? activeTheme.name : "Custom theme",
-  }
+  const themeInput = toThemeInput(activeTheme.emotion)
 
   const updateTheme = (customTheme: ThemeConfig): void => {
     addThemes([customTheme])

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
@@ -1,10 +1,12 @@
 import React, { ReactElement } from "react"
 import { toHex } from "color2k"
 import humanizeString from "humanize-string"
+import { Check } from "@emotion-icons/material-outlined"
 import { CustomThemeConfig } from "autogen/proto"
 import PageLayoutContext from "components/core/PageLayoutContext"
 import Button, { Kind } from "components/shared/Button"
 import UISelectbox from "components/shared/Dropdown"
+import Icon from "components/shared/Icon"
 import { createTheme, ThemeConfig, toThemeInput } from "theme"
 import {
   StyledButtonContainer,
@@ -89,13 +91,12 @@ const themeBuilder: Record<string, ThemeOptionBuilder> = {
 }
 
 const ThemeCreator = ({ hasCustomTheme }: Props): ReactElement => {
+  const [copied, updateCopied] = React.useState(false)
+  const [isOpen, openCreator] = React.useState(false)
   const themeCreator = React.useRef<HTMLDivElement>(null)
-  const {
-    availableThemes,
-    activeTheme,
-    addThemes,
-    setTheme,
-  } = React.useContext(PageLayoutContext)
+  const { activeTheme, addThemes, setTheme } = React.useContext(
+    PageLayoutContext
+  )
 
   const themeInput = {
     ...toThemeInput(activeTheme.emotion),
@@ -114,6 +115,7 @@ const ThemeCreator = ({ hasCustomTheme }: Props): ReactElement => {
       name: "Custom Theme",
     })
     updateTheme(customTheme)
+    updateCopied(false)
   }
 
   const config = `[theme]
@@ -127,8 +129,6 @@ font="${displayFontOption(
   ).toLowerCase()}"
 `
 
-  const [isOpen, openCreator] = React.useState(false)
-
   const toggleCreatorUI = (): void => {
     openCreator(true)
   }
@@ -141,6 +141,7 @@ font="${displayFontOption(
 
   const copyConfig = (): void => {
     navigator.clipboard.writeText(config)
+    updateCopied(true)
   }
 
   const renderThemeOption = (
@@ -188,9 +189,24 @@ font="${displayFontOption(
 
           <StyledButtonContainer>
             <Button onClick={copyConfig} kind={Kind.PRIMARY}>
-              Copy Theme to Clipboard
+              {copied ? (
+                <>
+                  {"Copied to clipboard "}
+                  <Icon
+                    content={Check}
+                    size="lg"
+                    color={activeTheme.emotion.colors.success}
+                  />
+                </>
+              ) : (
+                "Copy theme to clipboard"
+              )}
             </Button>
-            <StyledSmall>Copy TOML formatted config to clipboard</StyledSmall>
+            <StyledSmall>
+              {copied
+                ? "Paste copied theme to config.toml to save theme"
+                : "Copy the above settings in TOML format"}
+            </StyledSmall>
           </StyledButtonContainer>
         </>
       ) : (

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
@@ -73,7 +73,7 @@ const themeBuilder: Record<string, ThemeOptionBuilder> = {
   },
   font: {
     desc:
-      "Font family (serif | sans-serif | monospace) for the page. Will not impact the code areas.",
+      "Font family (serif | sans serif | monospace) for the page. Will not impact the code areas.",
     title: "Font family",
     options: Object.keys(CustomThemeConfig.FontFamily).map(font =>
       humanizeString(font)
@@ -111,6 +111,7 @@ const ThemeCreator = ({ hasCustomTheme }: Props): ReactElement => {
     const customTheme = createTheme({
       ...themeInput,
       [key]: newVal,
+      name: "Custom Theme",
     })
     updateTheme(customTheme)
   }
@@ -130,12 +131,6 @@ font="${displayFontOption(
 
   const toggleCreatorUI = (): void => {
     openCreator(true)
-    updateTheme({
-      ...activeTheme,
-      name: hasCustomTheme
-        ? availableThemes[availableThemes.length - 1].name
-        : "Custom Theme",
-    })
   }
 
   React.useEffect(() => {
@@ -180,7 +175,11 @@ font="${displayFontOption(
     <StyledThemeCreatorWrapper ref={themeCreator}>
       {isOpen ? (
         <>
-          <StyledHeader>Create Custom Theme</StyledHeader>
+          <StyledHeader>Edit active theme</StyledHeader>
+          <p>
+            Change settings below to see live changes to your active theme. To
+            discard changes and reload the original themes, refresh the page.
+          </p>
           <StyledThemeCreator>
             {Object.entries(themeInput).map(([themeOption, value]) =>
               renderThemeOption(themeOption, value as string)
@@ -196,9 +195,7 @@ font="${displayFontOption(
         </>
       ) : (
         <Button onClick={toggleCreatorUI} kind={Kind.LINK}>
-          {hasCustomTheme
-            ? "Edit Existing Custom Theme"
-            : "Create a new Custom Theme"}
+          Edit active theme
         </Button>
       )}
     </StyledThemeCreatorWrapper>

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
@@ -44,9 +44,7 @@ exports[`SettingsDialog renders without crashing 1`] = `
       }
       value={0}
     />
-    <ThemeCreator
-      hasCustomTheme={true}
-    />
+    <ThemeCreator />
   </ModalBody>
 </Modal>
 `;

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreator.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreator.test.tsx.snap
@@ -82,10 +82,10 @@ exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
       kind="primary"
       onClick={[Function]}
     >
-      Copy Theme to Clipboard
+      Copy theme to clipboard
     </Button>
     <StyledSmall>
-      Copy TOML formatted config to clipboard
+      Copy the above settings in TOML format
     </StyledSmall>
   </StyledButtonContainer>
 </StyledThemeCreatorWrapper>

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreator.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreator.test.tsx.snap
@@ -3,8 +3,11 @@
 exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
 <StyledThemeCreatorWrapper>
   <StyledHeader>
-    Create Custom Theme
+    Edit active theme
   </StyledHeader>
+  <p>
+    Change settings below to see live changes to your active theme. To discard changes and reload the original themes, refresh the page.
+  </p>
   <StyledThemeCreator>
     <StyledThemeColorPicker
       disabled={false}
@@ -71,7 +74,7 @@ exports[`Renders ThemeCreator Renders opened theme creator 1`] = `
       value={0}
     />
     <StyledThemeDesc>
-      Font family (serif | sans-serif | monospace) for the page. Will not impact the code areas.
+      Font family (serif | sans serif | monospace) for the page. Will not impact the code areas.
     </StyledThemeDesc>
   </StyledThemeCreator>
   <StyledButtonContainer>
@@ -94,7 +97,7 @@ exports[`Renders ThemeCreator renders closed theme creator without custom theme 
     kind="link"
     onClick={[Function]}
   >
-    Create a new Custom Theme
+    Edit active theme
   </Button>
 </StyledThemeCreatorWrapper>
 `;

--- a/frontend/src/components/shared/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/shared/ColorPicker/ColorPicker.tsx
@@ -48,6 +48,15 @@ class ColorPicker extends React.PureComponent<Props, State> {
     value: this.props.value,
   }
 
+  public componentDidUpdate(prevProps: Props): void {
+    if (
+      prevProps.value !== this.props.value &&
+      this.props.value !== this.state.value
+    ) {
+      this.setState({ value: this.props.value })
+    }
+  }
+
   private onChangeComplete = (color: ColorResult): void => {
     this.setState({ value: color.hex })
   }

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -780,16 +780,6 @@ _create_option(
 )
 
 _create_option(
-    "theme.setAsDefault",
-    description="""
-        Whether to set the custom theme to be the default theme for this
-        streamlit app if one is defined.
-        """,
-    default_val=True,
-    type_=bool,
-)
-
-_create_option(
     "theme.primaryColor",
     description="""
         Used to style primary interface elements. It's the color displayed
@@ -1220,7 +1210,7 @@ def on_config_parsed(func, force_connect=False):
 
 
 def _validate_theme() -> None:
-    optional_theme_options = {"name", "setAsDefault", "font"}
+    optional_theme_options = {"name", "font"}
     reserved_theme_names = {"auto", "dark", "light"}
 
     theme_opts = get_options_for_section("theme")

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -285,7 +285,6 @@ class ConfigTest(unittest.TestCase):
                 "client.displayEnabled",
                 "client.showErrorDetails",
                 "theme.name",
-                "theme.setAsDefault",
                 "theme.primaryColor",
                 "theme.secondaryColor",
                 "theme.backgroundColor",
@@ -535,7 +534,6 @@ class ConfigTest(unittest.TestCase):
 
         expected = {
             "name": "monokai",
-            "setAsDefault": True,
             "primaryColor": "000000",
             "secondaryColor": None,
             "secondaryBackgroundColor": None,

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -214,7 +214,6 @@ def _mock_get_options_for_section(overrides=None):
 
     theme_opts = {
         "name": "foo",
-        "setAsDefault": True,
         "primaryColor": "coral",
         "secondaryColor": "grey",
         "backgroundColor": "white",

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -281,7 +281,6 @@ class ReportSessionNewReportTest(tornado.testing.AsyncTestCase):
         self.assertEqual(new_report_msg.HasField("custom_theme"), True)
         self.assertEqual(new_report_msg.custom_theme.name, "foo")
         self.assertEqual(new_report_msg.custom_theme.text_color, "black")
-        self.assertEqual(new_report_msg.custom_theme.set_as_default, True)
 
         init_msg = new_report_msg.initialize
         self.assertEqual(init_msg.HasField("user_info"), True)
@@ -327,6 +326,5 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
 
         self.assertEqual(new_report_msg.HasField("custom_theme"), True)
         self.assertEqual(new_report_msg.custom_theme.name, "foo")
-        self.assertEqual(new_report_msg.custom_theme.set_as_default, True)
         self.assertEqual(new_report_msg.custom_theme.primary_color, "coral")
         self.assertEqual(new_report_msg.custom_theme.background_color, "white")

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -102,7 +102,6 @@ message CustomThemeConfig {
   string background_color = 5;
   string text_color = 6;
   FontFamily font = 7;
-  bool set_as_default = 8;
 }
 
 // Data that identifies the Streamlit app creator.


### PR DESCRIPTION
https://www.notion.so/streamlit/Draft-Product-Spec-v3-b67065c1a3c445978746a49b802d09b6
Removes need for setAsDefault. Auto shouldn't be saved as an user preference so this should still allow custom themes to show up if users are on Auto

### Option 2: Always pick the user choice upon reload: Preferred ✅

If there is no prior user choice, then pick the custom theme. 

- **Pros**
    - User is always right and knows what they want.
    - Makes for a less change-y user experience
- **Cons**
    - Users may not see custom theme added by the developer if it’s added after they set a preference
    - It becomes the developer's responsibility to educate the user on their new theme / updates

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
