### PR TITLE
Don't memoize config._server_headless

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -450,22 +450,24 @@ def _server_cookie_secret():
 
 
 @_create_option("server.headless", type_=bool)
-@util.memoize
 def _server_headless():
     """If false, will attempt to open a browser window on start.
 
     Default: false unless (1) we are on a Linux box where DISPLAY is unset, or
     (2) server.liveSave is set.
     """
-    is_live_save_on = get_option("server.liveSave")
-    is_linux = env_util.IS_LINUX_OR_BSD
-    has_display_env = not os.getenv("DISPLAY")
-    is_running_in_editor_plugin = (
-        os.getenv("IS_RUNNING_IN_STREAMLIT_EDITOR_PLUGIN") is not None
-    )
-    return (
-        is_live_save_on or (is_linux and has_display_env) or is_running_in_editor_plugin
-    )
+    if get_option("server.liveSave"):
+        return True
+
+    if env_util.IS_LINUX_OR_BSD and not os.getenv("DISPLAY"):
+        # We're running in Linux and DISPLAY is unset
+        return True
+
+    if os.getenv("IS_RUNNING_IN_STREAMLIT_EDITOR_PLUGIN") is not None:
+        # We're running within the Streamlit Atom plugin
+        return True
+
+    return False
 
 
 @_create_option("server.liveSave", type_=bool, visibility="hidden")


### PR DESCRIPTION
When we memoize any computed config option, we introduce global state that doesn't get reset across tests. This was triggering test failures in ConfigTest.py.

(This also reorganizes the `config_test. _server_headless` function for clarity.)