### PR TITLE
Make config.{get_option, set_option, get_options_for_section, parse_config_file} thread-safe

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1088,15 +1088,20 @@ CONFIG_FILENAMES = [
 ]
 
 
-def parse_config_file(force=False):
+def parse_config_file(force_reparse=False):
     """Parse the config file and update config parameters."""
     global _config_file_has_been_parsed
 
     # Avoid grabbing the lock in the case where there's nothing for us to do.
-    if _config_file_has_been_parsed and force == False:
+    if _config_file_has_been_parsed and not force_reparse:
         return
 
     with _config_lock:
+        # Short-circuit if config files were parsed while we were waiting on
+        # the lock.
+        if _config_file_has_been_parsed and not force_reparse:
+            return
+
         _config_file_has_been_parsed = False
 
         # Values set in files later in the CONFIG_FILENAMES list overwrite those

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -46,4 +46,4 @@ with patch(
     config_path = file_util.get_streamlit_file_path("config.toml")
     path_exists.side_effect = lambda path: path == config_path
 
-    config.parse_config_file(force=True)
+    config.parse_config_file(force_reparse=True)


### PR DESCRIPTION
This needs to be done since it'll soon be possible for config files to
be reloaded on file change, so we'll need to ensure that threads trying
to access/change config options don't try to do so when config.toml
files are being re-parsed.
