### PR TITLE
Add image format deprecation config with expiration

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -649,6 +649,17 @@ _create_option(
 )
 
 _create_option(
+    "deprecation.showImageFormat",
+    description="Set to false to disable the deprecation warning for the image format parameter.",
+    default_val="True",
+    scriptable="True",
+    type_=bool,
+    deprecated=True,
+    deprecation_text="The format parameter for st.image has been removed.",
+    expiration_date="2021-03-24",
+)
+
+_create_option(
     "deprecation.showPyplotGlobalUse",
     description="Set to false to disable the deprecation warning for using the global pyplot instance.",
     default_val="True",

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -277,6 +277,7 @@ class ConfigTest(unittest.TestCase):
                 "client.displayEnabled",
                 "client.showErrorDetails",
                 "deprecation.showfileUploaderEncoding",
+                "deprecation.showImageFormat",
                 "deprecation.showPyplotGlobalUse",
                 "global.developmentMode",
                 "global.disableWatchdogWarning",


### PR DESCRIPTION
Readded expiration date with deprecation text to avoid crashing on the user in the next release.