### PR TITLE
Rework config file parsing to unset removed options

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -228,7 +228,7 @@ def set_option(key, value):
         The new value to assign to this config option.
 
     """
-    opt = _config._config_options[key]
+    opt = _config._config_options_template[key]
     if opt.scriptable:
         _config.set_option(key, value)
         return

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1014,9 +1014,12 @@ def _set_option(key, value, where_defined):
         Tells the config system where this was set.
 
     """
-    config_options = cast(ConfigOptions, _config_options)
-    assert key in config_options, 'Key "%s" is not defined.' % key
-    config_options[key].set_value(value, where_defined)
+    assert (
+        _config_options is not None
+    ), "_config_options should always be populated here."
+    assert key in _config_options, 'Key "%s" is not defined.' % key
+
+    _config_options[key].set_value(value, where_defined)
 
 
 def _update_config_with_toml(raw_toml: str, where_defined: str) -> None:

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -69,7 +69,7 @@ def setup_formatter(logger):
 
     logger.streamlit_console_handler = logging.StreamHandler()
 
-    if config._config_file_has_been_parsed:
+    if config._config_options:
         # logger is required in ConfigOption.set_value
         # Getting the config option before the config file has been parsed
         # can create an infinite loop

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -181,7 +181,7 @@ def start_listening_tcp_socket(http_server):
                     if port == 3000:
                         port += 1
 
-                    config._set_option(
+                    config.set_option(
                         "server.port", port, ConfigOption.STREAMLIT_DEFINITION
                     )
                     call_count += 1

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -46,4 +46,6 @@ with patch(
     config_path = file_util.get_streamlit_file_path("config.toml")
     path_exists.side_effect = lambda path: path == config_path
 
-    config.parse_config_file(force_reparse=True)
+    # Force a reparse of our config options with CONFIG_FILE_CONTENTS so the
+    # result gets cached.
+    config.get_config_options(force_reparse=True)

--- a/lib/tests/streamlit/logger_test.py
+++ b/lib/tests/streamlit/logger_test.py
@@ -16,6 +16,7 @@
 
 import logging
 import unittest
+from collections import OrderedDict
 
 import pytest
 from unittest.mock import patch
@@ -23,6 +24,9 @@ from parameterized import parameterized
 
 from streamlit import logger
 from streamlit import config
+
+
+DUMMY_CONFIG_OPTIONS = OrderedDict()
 
 
 class LoggerTest(unittest.TestCase):
@@ -80,13 +84,13 @@ class LoggerTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("%(asctime)s.%(msecs)03d %(name)s: %(message)s", False),
-            ("%(asctime)s.%(msecs)03d %(name)s: %(message)s", True),
-            (None, False),
-            (None, True),
+            ("%(asctime)s.%(msecs)03d %(name)s: %(message)s", None),
+            ("%(asctime)s.%(msecs)03d %(name)s: %(message)s", DUMMY_CONFIG_OPTIONS),
+            (None, None),
+            (None, DUMMY_CONFIG_OPTIONS),
         ]
     )
-    def test_setup_log_formatter(self, messageFormat, config_parsed):
+    def test_setup_log_formatter(self, messageFormat, config_options):
         """Test streamlit.logger.setup_log_formatter."""
 
         LOGGER = logger.get_logger("test")
@@ -94,10 +98,10 @@ class LoggerTest(unittest.TestCase):
         config._set_option("logger.messageFormat", messageFormat, "test")
         config._set_option("logger.level", logging.DEBUG, "test")
 
-        with patch.object(config, "_config_file_has_been_parsed", new=config_parsed):
+        with patch.object(config, "_config_options", new=config_options):
             logger.setup_formatter(LOGGER)
             self.assertEqual(len(LOGGER.handlers), 1)
-            if config_parsed:
+            if config_options:
                 self.assertEqual(
                     LOGGER.handlers[0].formatter._fmt, messageFormat or "%(message)s"
                 )


### PR DESCRIPTION
`parse_config_file` (now named `get_config_options`) was previously
written in a way where naively rerunning the function would fail to
remove config options that were deleted from a file on initial load.

This commit restructures things to create a `_config_options_template`
when options are initially defined, then copy and update the template
when loading config options from files / cli flags.