### PR TITLE
Rerun scripts on config file change

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -606,9 +606,7 @@ export class App extends PureComponent<Props, State> {
       this.props.theme.addThemes([])
 
       if (!isPresetThemeActive) {
-        const autoTheme = createAutoTheme()
-        this.props.theme.setTheme(autoTheme)
-        window.localStorage.removeItem(LocalStore.ACTIVE_THEME)
+        this.props.theme.setTheme(createAutoTheme())
       }
     }
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -608,10 +608,7 @@ export class App extends PureComponent<Props, State> {
       if (!isPresetThemeActive) {
         const autoTheme = createAutoTheme()
         this.props.theme.setTheme(autoTheme)
-        window.localStorage.setItem(
-          LocalStore.ACTIVE_THEME,
-          JSON.stringify(autoTheme)
-        )
+        window.localStorage.removeItem(LocalStore.ACTIVE_THEME)
       }
     }
   }

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -98,6 +98,9 @@ class ReportSession(object):
         self._local_sources_watcher = LocalSourcesWatcher(
             self._report, self._on_source_file_changed
         )
+        self._stop_config_listener = config.on_config_parsed(
+            self._on_source_file_changed, force_connect=True
+        )
         self._storage = None
         self._maybe_reuse_previous_run = False
         self._run_on_save = config.get_option("server.runOnSave")
@@ -147,6 +150,7 @@ class ReportSession(object):
 
             self._state = ReportSessionState.SHUTDOWN_REQUESTED
             self._local_sources_watcher.close()
+            self._stop_config_listener()
 
     def enqueue(self, msg):
         """Enqueue a new ForwardMsg to our browser queue.

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -302,3 +302,9 @@ class BootstrapPrintTest(unittest.TestCase):
             f"Failed to load {SECRETS_FILE_LOC}",
             exc_info=mock_exception,
         )
+
+    @patch("streamlit.bootstrap.watch_file")
+    def test_install_config_watcher(self, patched_watch_file):
+        with patch("os.path.exists", return_value=True):
+            bootstrap._install_config_watchers()
+        self.assertEqual(patched_watch_file.call_count, 2)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -623,20 +623,26 @@ class ConfigTest(unittest.TestCase):
 
         mock_callback = MagicMock(return_value=None)
 
-        with patch.object(config, "_config_options", new=config_options):
-            with patch.object(config._on_config_parsed, "connect") as patched_connect:
-                mock_callback.reset_mock()
-                config.on_config_parsed(mock_callback, connect_signal)
+        with patch.object(config, "_config_options", new=config_options), patch.object(
+            config._on_config_parsed, "connect"
+        ) as patched_connect, patch.object(
+            config._on_config_parsed, "disconnect"
+        ) as patched_disconnect:
+            mock_callback.reset_mock()
+            disconnect_callback = config.on_config_parsed(mock_callback, connect_signal)
 
-                if connect_signal:
-                    patched_connect.assert_called_once()
-                    mock_callback.assert_not_called()
-                elif config_options:
-                    patched_connect.assert_not_called()
-                    mock_callback.assert_called_once()
-                else:
-                    patched_connect.assert_called_once()
-                    mock_callback.assert_not_called()
+            if connect_signal:
+                patched_connect.assert_called_once()
+                mock_callback.assert_not_called()
+            elif config_options:
+                patched_connect.assert_not_called()
+                mock_callback.assert_called_once()
+            else:
+                patched_connect.assert_called_once()
+                mock_callback.assert_not_called()
+
+            disconnect_callback()
+            patched_disconnect.assert_called_once()
 
 
 class ConfigLoadingTest(unittest.TestCase):


### PR DESCRIPTION
There's still a bit of polish to do here. Most notably, we're currently just
naively reloading the script whenever the config gets re-parsed, which is fine,
but we want to additionally give the user a heads up when they change config
options that require a full server restart.
