### PR TITLE
Fix some doc links that currently hit invalid pages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 # Changelog
 
-This page lists highlights, bug fixes, and known issues for official Streamlit releases. If you're looking for information about nightly releases, beta features, or experimental features, see [Try pre-release features](api.md#pre-release-features).
+This page lists highlights, bug fixes, and known issues for official Streamlit releases. If you're looking for information about nightly releases, beta features, or experimental features, see [Try pre-release features](api.html#pre-release-features).
 
 ```eval_rst
 .. tip::

--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -111,7 +111,7 @@ At line:1 char:1
 
 To resolve this issue, add [Python to the Windows system PATH](https://datatofish.com/add-python-to-windows-path/).
 
-After adding Python to your Windows PATH, you should then be able to follow the instructions in our [Get Started](../getting_started.md#install-streamlit) section.
+After adding Python to your Windows PATH, you should then be able to follow the instructions in our [Get Started](../getting_started.html#install-streamlit) section.
 
 ## Check #7 [Windows]: Do you need Build Tools for Visual Studio installed?
 


### PR DESCRIPTION
Linking a `.md` file with a URL anchor/fragment unfortunately doesn't
work, so the few places where we're doing this are hitting RTD's 404
page.