### PR TITLE
S4a metadata postMessage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -110,7 +110,6 @@ const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
 declare global {
   interface Window {
     streamlitDebug: any
-    streamlitShareMetadata: Record<string, unknown>
   }
 }
 
@@ -509,6 +508,9 @@ export class App extends PureComponent<Props, State> {
     document.title = `${reportName} · Streamlit`
     handleFavicon(`${process.env.PUBLIC_URL}/favicon.png`)
 
+    MetricsManager.current.setMetadata(
+      this.props.s4aCommunication.currentState.streamlitShareMetadata
+    )
     MetricsManager.current.setReportHash(newReportHash)
     MetricsManager.current.clearDeltaCounter()
 

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -15,6 +15,15 @@
  * limitations under the License.
  */
 
+export type StreamlitShareMetadata = {
+  hostedAt?: string
+  creatorId?: string
+  owner?: string
+  branch?: string
+  repo?: string
+  mainModule?: string
+}
+
 export type IMenuItem =
   | {
       type: "text"
@@ -35,6 +44,10 @@ export type IHostToGuestMessage = {
   | {
       type: "UPDATE_FROM_QUERY_PARAMS"
       queryParams: string
+    }
+  | {
+      type: "SET_METADATA"
+      metadata: StreamlitShareMetadata
     }
 )
 

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -22,6 +22,7 @@ import { CLOUD_COMM_WHITELIST } from "urls"
 
 import {
   IMenuItem,
+  StreamlitShareMetadata,
   IHostToGuestMessage,
   IGuestToHostMessage,
   VersionedMessage,
@@ -30,6 +31,7 @@ import {
 interface State {
   queryParams: string
   items: IMenuItem[]
+  streamlitShareMetadata: StreamlitShareMetadata
 }
 
 export interface S4ACommunicationHOC {
@@ -56,6 +58,7 @@ function withS4ACommunication(
   function ComponentWithS4ACommunication(props: any): ReactElement {
     const [items, setItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
+    const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -85,6 +88,9 @@ function withS4ACommunication(
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
           setQueryParams(message.queryParams)
         }
+        if (message.type === "SET_METADATA") {
+          setStreamlitShareMetadata(message.metadata)
+        }
       }
 
       window.addEventListener("message", receiveMessage)
@@ -101,6 +107,7 @@ function withS4ACommunication(
             currentState: {
               items,
               queryParams,
+              streamlitShareMetadata,
             },
             connect: () => {
               sendS4AMessage({

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -117,12 +117,11 @@ test("tracks events immediately after initialized", () => {
 })
 
 test("tracks host data when in an iFrame", () => {
-  window.parent.streamlitShareMetadata = {
+  const mm = getMetricsManagerForTest()
+  mm.setMetadata({
     hostedAt: "S4A",
     k: "v",
-  }
-
-  const mm = getMetricsManagerForTest()
+  })
   mm.initialize({ gatherUsageStats: true })
   mm.enqueue("ev1", { data1: 11 })
 

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -21,7 +21,6 @@ import { initializeSegment } from "vendor/Segment"
 import { StreamlitShareMetadata } from "hocs/withS4ACommunication/types"
 import { IS_DEV_ENV, IS_SHARED_REPORT } from "./baseconsts"
 import { logAlways } from "./log"
-import { isInChildFrame } from "./utils"
 
 /**
  * The analytics is the Segment.io object. It is initialized in Segment.ts
@@ -234,7 +233,7 @@ export class MetricsManager {
 
   // Use the tracking data injected by S4A if the app is hosted there
   private getHostTrackingData(): StreamlitShareMetadata {
-    if (isInChildFrame() && this.metadata) {
+    if (this.metadata) {
       return pick(this.metadata, [
         "hostedAt",
         "owner",

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -16,9 +16,9 @@
  */
 
 import { pick } from "lodash"
-
 import { SessionInfo } from "lib/SessionInfo"
 import { initializeSegment } from "vendor/Segment"
+import { StreamlitShareMetadata } from "hocs/withS4ACommunication/types"
 import { IS_DEV_ENV, IS_SHARED_REPORT } from "./baseconsts"
 import { logAlways } from "./log"
 import { isInChildFrame } from "./utils"
@@ -82,6 +82,8 @@ export class MetricsManager {
    */
   private reportHash = "Not initialized"
 
+  private metadata: StreamlitShareMetadata = {}
+
   /**
    * Singleton MetricsManager object. The reason we're using a singleton here
    * instead of just exporting a module-level instance is so we can easily
@@ -103,7 +105,7 @@ export class MetricsManager {
 
       const userTraits: any = {
         ...MetricsManager.getInstallationData(),
-        ...MetricsManager.getHostTrackingData(),
+        ...this.getHostTrackingData(),
       }
 
       // Only record the user's email if they entered a non-empty one.
@@ -178,7 +180,7 @@ export class MetricsManager {
   private send(evName: string, evData: Record<string, unknown> = {}): void {
     const data = {
       ...evData,
-      ...MetricsManager.getHostTrackingData(),
+      ...this.getHostTrackingData(),
       ...MetricsManager.getInstallationData(),
       reportHash: this.reportHash,
       dev: IS_DEV_ENV,
@@ -226,10 +228,14 @@ export class MetricsManager {
     }
   }
 
+  public setMetadata(metadata: StreamlitShareMetadata): void {
+    this.metadata = metadata
+  }
+
   // Use the tracking data injected by S4A if the app is hosted there
-  private static getHostTrackingData(): Record<string, unknown> {
-    if (isInChildFrame() && window.parent.streamlitShareMetadata) {
-      return pick(window.parent.streamlitShareMetadata, [
+  private getHostTrackingData(): StreamlitShareMetadata {
+    if (isInChildFrame() && this.metadata) {
+      return pick(this.metadata, [
         "hostedAt",
         "owner",
         "repo",


### PR DESCRIPTION
**Issue:** Split out from #2819 

**Description:** Handles receiving metadata for metrics through the postMessage api, instead of the window object, which is no longer available in s4a
