### PR TITLE
Stale bot setup

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# https://github.com/probot/stale
+
+# Limit to only `issues` or `pulls`
+only: pulls
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 14
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 1
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This pull request has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.


### PR DESCRIPTION
Pull requests that didn’t have any activity for 14 days will be labeled as `stale`, and will be closed on the next day.