### PR TITLE
Move show_config to the new config_util.py

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -911,10 +911,10 @@ def is_manually_set(option_name):
 
 def show_config():
     """Print all config options to the terminal."""
-    # The function call below isn't thread safe, but we let it slide since
-    # it is only used to print out config options when running
-    # `streamlit config show`.
-    config_util.show_config(_section_descriptions, cast(ConfigOptions, _config_options))
+    with _config_lock:
+        config_util.show_config(
+            _section_descriptions, cast(ConfigOptions, _config_options)
+        )
 
 
 # Load Config Files #

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -1,0 +1,115 @@
+import toml
+from typing import Dict
+
+import click
+
+from streamlit.config_option import ConfigOption
+
+
+def show_config(
+    section_descriptions: Dict[str, str],
+    config_options: Dict[str, ConfigOption],
+) -> None:
+    """Print the given config sections/options to the terminal."""
+    SKIP_SECTIONS = ("_test",)
+
+    out = []
+    out.append(
+        _clean(
+            """
+        # Below are all the sections and options you can have in
+        ~/.streamlit/config.toml.
+    """
+        )
+    )
+
+    def append_desc(text):
+        out.append(click.style(text, bold=True))
+
+    def append_comment(text):
+        out.append(click.style(text))
+
+    def append_section(text):
+        out.append(click.style(text, bold=True, fg="green"))
+
+    def append_setting(text):
+        out.append(click.style(text, fg="green"))
+
+    def append_newline():
+        out.append("")
+
+    for section, section_description in section_descriptions.items():
+        if section in SKIP_SECTIONS:
+            continue
+
+        append_newline()
+        append_section("[%s]" % section)
+        append_newline()
+
+        for key, option in config_options.items():
+            if option.section != section:
+                continue
+
+            if option.visibility == "hidden":
+                continue
+
+            if option.is_expired():
+                continue
+
+            key = option.key.split(".")[1]
+            description_paragraphs = _clean_paragraphs(option.description)
+
+            for i, txt in enumerate(description_paragraphs):
+                if i == 0:
+                    append_desc("# %s" % txt)
+                else:
+                    append_comment("# %s" % txt)
+
+            toml_default = toml.dumps({"default": option.default_val})
+            toml_default = toml_default[10:].strip()
+
+            if len(toml_default) > 0:
+                append_comment("# Default: %s" % toml_default)
+            else:
+                # Don't say "Default: (unset)" here because this branch applies
+                # to complex config settings too.
+                pass
+
+            if option.deprecated:
+                append_comment("#")
+                append_comment("# " + click.style("DEPRECATED.", fg="yellow"))
+                append_comment(
+                    "# %s" % "\n".join(_clean_paragraphs(option.deprecation_text))
+                )
+                append_comment(
+                    "# This option will be removed on or after %s."
+                    % option.expiration_date
+                )
+                append_comment("#")
+
+            option_is_manually_set = (
+                option.where_defined != ConfigOption.DEFAULT_DEFINITION
+            )
+
+            if option_is_manually_set:
+                append_comment("# The value below was set in %s" % option.where_defined)
+
+            toml_setting = toml.dumps({key: option.value})
+
+            if len(toml_setting) == 0:
+                toml_setting = "#%s =\n" % key
+
+            append_setting(toml_setting)
+
+    click.echo("\n".join(out))
+
+
+def _clean(txt):
+    """Replace all whitespace with a single space."""
+    return " ".join(txt.split()).strip()
+
+
+def _clean_paragraphs(txt):
+    paragraphs = txt.split("\n\n")
+    cleaned_paragraphs = [_clean(x) for x in paragraphs]
+    return cleaned_paragraphs

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -351,33 +351,6 @@ class ConfigTest(unittest.TestCase):
         keys = sorted(config._config_options.keys())
         self.assertEqual(config_options, keys)
 
-    def test_clean_paragraphs(self):
-        # from https://www.lipsum.com/
-        input = textwrap.dedent(
-            """
-            Lorem              ipsum dolor sit amet,
-            consectetur adipiscing elit.
-
-               Curabitur ac fermentum eros.
-
-            Maecenas                   libero est,
-                    ultricies
-            eget ligula eget,    """
-        )
-
-        truth = [
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-            "Curabitur ac fermentum eros.",
-            "Maecenas libero est, ultricies eget ligula eget,",
-        ]
-
-        result = config._clean_paragraphs(input)
-        self.assertEqual(truth, result)
-
-    def test_clean(self):
-        result = config._clean(" clean    this         text  ")
-        self.assertEqual("clean this text", result)
-
     def test_check_conflicts_server_port(self):
         config._set_option("global.developmentMode", True, "test")
         config._set_option("server.port", 1234, "test")

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -1,0 +1,48 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config Util Unittest."""
+import textwrap
+import unittest
+
+from streamlit import config_util
+
+
+class ConfigUtilTest(unittest.TestCase):
+    def test_clean(self):
+        result = config_util._clean(" clean    this         text  ")
+        self.assertEqual("clean this text", result)
+
+    def test_clean_paragraphs(self):
+        # from https://www.lipsum.com/
+        input = textwrap.dedent(
+            """
+            Lorem              ipsum dolor sit amet,
+            consectetur adipiscing elit.
+
+               Curabitur ac fermentum eros.
+
+            Maecenas                   libero est,
+                    ultricies
+            eget ligula eget,    """
+        )
+
+        truth = [
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            "Curabitur ac fermentum eros.",
+            "Maecenas libero est, ultricies eget ligula eget,",
+        ]
+
+        result = config_util._clean_paragraphs(input)
+        self.assertEqual(truth, result)


### PR DESCRIPTION
config.py is the longest .py file we have, and I was about to add more
stuff to it, so I thought it was about time to try to split it up.

It's actually pretty hard to move things out of this file given all its
dependencies, but at the very least one of the longest functions was
easily movable, and the new stuff I'm about to add can go into
config_util.
