### PR TITLE
Warn if the user edits a [server] config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1067,6 +1067,7 @@ def get_config_options(
         if _config_options and not force_reparse:
             return _config_options
 
+        old_options = _config_options
         _config_options = copy.deepcopy(_config_options_template)
 
         # Values set in files later in the CONFIG_FILENAMES list overwrite those
@@ -1082,6 +1083,18 @@ def get_config_options(
 
         for opt_name, opt_val in options_from_flags.items():
             _set_option(opt_name, opt_val, _DEFINED_BY_FLAG)
+
+        if old_options and config_util.server_option_changed(
+            old_options, _config_options
+        ):
+            # Import logger locally to prevent circular references.
+            from streamlit.logger import get_logger
+
+            LOGGER = get_logger(__name__)
+            LOGGER.warning(
+                "An update to the [server] config option section was detected."
+                " To have these changes be reflected, please restart streamlit."
+            )
 
         _on_config_parsed.send()
         return _config_options

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -33,11 +33,6 @@ from streamlit import theme
 from streamlit import util
 from streamlit.config_option import ConfigOption
 
-# TODO(vincent): Change the Dict type annotation below to OrderedDict once
-# Python 3.7 is required. Python currently gets confused at seeing OrderedDict
-# as a type annotation.
-ConfigOptions = Dict[str, ConfigOption]
-
 # Config System Global State #
 
 # Descriptions of each of the possible config sections.
@@ -56,10 +51,10 @@ _config_lock = threading.RLock()
 # to `streamlit run`, etc. Note that this and _config_options below are
 # OrderedDicts to ensure stable ordering when printed using
 # `streamlit config show`.
-_config_options_template: ConfigOptions = OrderedDict()
+_config_options_template: Dict[str, ConfigOption] = OrderedDict()
 
 # Stores the current state of config options.
-_config_options: Optional[ConfigOptions] = None
+_config_options: Optional[Dict[str, ConfigOption]] = None
 
 
 # Indicates that a config option was defined by the user.
@@ -224,7 +219,7 @@ def _delete_option(key):
     """
     try:
         del _config_options_template[key]
-        del cast(ConfigOptions, _config_options)[key]
+        del cast(Dict[str, ConfigOption], _config_options)[key]
     except Exception:
         pass
 
@@ -909,11 +904,11 @@ def is_manually_set(option_name):
     )
 
 
-def show_config():
+def show_config() -> None:
     """Print all config options to the terminal."""
     with _config_lock:
         config_util.show_config(
-            _section_descriptions, cast(ConfigOptions, _config_options)
+            _section_descriptions, cast(Dict[str, ConfigOption], _config_options)
         )
 
 
@@ -1031,7 +1026,7 @@ CONFIG_FILENAMES = [
 
 def get_config_options(
     force_reparse=False, options_from_flags: Optional[Dict[str, Any]] = None
-) -> ConfigOptions:
+) -> Dict[str, ConfigOption]:
     """Create and return a dict mapping config option names to their values,
     returning a cached dict if possible.
 
@@ -1053,7 +1048,7 @@ def get_config_options(
 
     Returns
     ----------
-    ConfigOptions
+    Dict[str, ConfigOption]
         An ordered dict that maps config option names to their values.
     """
     global _config_options

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -1,9 +1,26 @@
 import toml
-from typing import Dict
+from typing import Any, Dict
 
 import click
 
 from streamlit.config_option import ConfigOption
+
+
+def server_option_changed(
+    old_options: Dict[str, ConfigOption], new_options: Dict[str, ConfigOption]
+) -> bool:
+    """Return True if and only if an option in the server section differs
+    between old_options and new_options."""
+    for opt_name in old_options.keys():
+        if not opt_name.startswith("server"):
+            continue
+
+        old_val = old_options[opt_name].value
+        new_val = new_options[opt_name].value
+        if old_val != new_val:
+            return True
+
+    return False
 
 
 def show_config(

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -1,5 +1,5 @@
 import toml
-from typing import Any, Dict
+from typing import Dict
 
 import click
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -861,3 +861,38 @@ class ConfigLoadingTest(unittest.TestCase):
 
             self.assertEqual(None, config.get_option("s3.bucket"))
             self.assertEqual("accessKeyId", config.get_option("s3.accessKeyId"))
+
+    @patch("streamlit.logger.get_logger")
+    def test_config_options_warn_on_server_change(self, get_logger):
+        """Test that a warning is logged if a user changes a config file in the
+        server section."""
+
+        global_config_path = "/mock/home/folder/.streamlit/config.toml"
+        makedirs_patch = patch("streamlit.config.os.makedirs")
+        makedirs_patch.return_value = True
+        pathexists_patch = patch("streamlit.config.os.path.exists")
+        pathexists_patch.side_effect = lambda path: path == global_config_path
+        mock_logger = get_logger()
+
+        global_config = """
+        [server]
+        address = "localhost"
+        """
+        open_patch = patch("streamlit.config.open", mock_open(read_data=global_config))
+
+        with open_patch, makedirs_patch, pathexists_patch:
+            config.get_config_options()
+
+        global_config = """
+        [server]
+        address = "streamlit.io"
+        """
+        open_patch = patch("streamlit.config.open", mock_open(read_data=global_config))
+
+        with open_patch, makedirs_patch, pathexists_patch:
+            config.get_config_options(force_reparse=True)
+
+        mock_logger.warning.assert_any_call(
+            "An update to the [server] config option section was detected."
+            " To have these changes be reflected, please restart streamlit."
+        )


### PR DESCRIPTION
We can't always automatically apply these without a full server restart,
so we should bug the user to reboot streamlit.
    
Note that warning for all server config options is overly broad, but
it's certainly better to over-warn users than under-warn them in this
case.