### PR TITLE
Fix punctuation in tech docs

### DIFF
--- a/docs/advanced_concepts.md
+++ b/docs/advanced_concepts.md
@@ -1,7 +1,7 @@
 # Cookbook
 
 Now that you've mastered Streamlit's main concepts, let's take a look at some
-advanced functionality, like styling data, adjusting the order of elements in a
+advanced functionality like styling data, adjusting the order of elements in a
 report, and adding animations.
 
 ```eval_rst


### PR DESCRIPTION
**Issue:** Fixes #2902 .

**Description:** Remove the second comma in the first sentence of the Cookbook docs
![image](https://user-images.githubusercontent.com/55991846/110078525-297cc880-7d88-11eb-8039-028d9538eaa5.png)

![image](https://user-images.githubusercontent.com/55991846/110078678-63e66580-7d88-11eb-828e-8ebea4570f98.png)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
