### PR TITLE
Remove the theme.name option

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -195,7 +195,6 @@ describe("App.handleNewReport", () => {
       allowRunOnSave: false,
     },
     customTheme: {
-      name: "carl",
       primary: "red",
     },
     initialize: {
@@ -259,18 +258,18 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).toHaveBeenCalled()
 
     // @ts-ignore
-    expect(props.theme.setTheme.mock.calls[0][0].name).toBe("carl")
+    expect(props.theme.setTheme.mock.calls[0][0].name).toBe("Custom Theme")
   })
 
   it("sets custom theme again if custom theme active", () => {
     window.localStorage.setItem(
       LocalStore.ACTIVE_THEME,
-      JSON.stringify({ ...lightTheme, name: "carl" })
+      JSON.stringify({ ...lightTheme, name: "Custom Theme" })
     )
     const props = getProps()
     props.theme.activeTheme = {
       ...lightTheme,
-      name: "carl",
+      name: "Custom Theme",
     }
     const wrapper = shallow(<App {...props} />)
 
@@ -286,7 +285,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).toHaveBeenCalled()
 
     // @ts-ignore
-    expect(props.theme.setTheme.mock.calls[0][0].name).toBe("carl")
+    expect(props.theme.setTheme.mock.calls[0][0].name).toBe("Custom Theme")
   })
 
   it("removes custom theme from options if none is received from the server", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -26,7 +26,7 @@ import { ConnectionState } from "lib/ConnectionState"
 import { MetricsManager } from "lib/MetricsManager"
 import { getMetricsManagerForTest } from "lib/MetricsManagerTestUtils"
 import { SessionInfo, Args as SessionInfoArgs } from "lib/SessionInfo"
-import { createAutoTheme, lightTheme } from "theme"
+import { CUSTOM_THEME_NAME, createAutoTheme, lightTheme } from "theme"
 import { App, Props } from "./App"
 import MainMenu from "./components/core/MainMenu"
 
@@ -258,18 +258,18 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).toHaveBeenCalled()
 
     // @ts-ignore
-    expect(props.theme.setTheme.mock.calls[0][0].name).toBe("Custom Theme")
+    expect(props.theme.setTheme.mock.calls[0][0].name).toBe(CUSTOM_THEME_NAME)
   })
 
   it("sets custom theme again if custom theme active", () => {
     window.localStorage.setItem(
       LocalStore.ACTIVE_THEME,
-      JSON.stringify({ ...lightTheme, name: "Custom Theme" })
+      JSON.stringify({ ...lightTheme, name: CUSTOM_THEME_NAME })
     )
     const props = getProps()
     props.theme.activeTheme = {
       ...lightTheme,
-      name: "Custom Theme",
+      name: CUSTOM_THEME_NAME,
     }
     const wrapper = shallow(<App {...props} />)
 
@@ -285,7 +285,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).toHaveBeenCalled()
 
     // @ts-ignore
-    expect(props.theme.setTheme.mock.calls[0][0].name).toBe("Custom Theme")
+    expect(props.theme.setTheme.mock.calls[0][0].name).toBe(CUSTOM_THEME_NAME)
   })
 
   it("removes custom theme from options if none is received from the server", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -585,7 +585,7 @@ export class App extends PureComponent<Props, State> {
     )
 
     if (themeInput) {
-      const customTheme = createTheme(themeInput)
+      const customTheme = createTheme("Custom Theme", themeInput)
       if (!isPresetThemeActive) {
         // If the current theme is custom theme, update local store
         // in case the custom theme has changed

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,7 @@ import { ComponentRegistry } from "components/widgets/CustomComponent"
 import { handleFavicon } from "components/elements/Favicon"
 
 import {
+  CUSTOM_THEME_NAME,
   createAutoTheme,
   createPresetThemes,
   createTheme,
@@ -585,7 +586,7 @@ export class App extends PureComponent<Props, State> {
     )
 
     if (themeInput) {
-      const customTheme = createTheme("Custom Theme", themeInput)
+      const customTheme = createTheme(CUSTOM_THEME_NAME, themeInput)
       if (!isPresetThemeActive) {
         // If the current theme is custom theme, update local store
         // in case the custom theme has changed

--- a/frontend/src/ThemedApp.test.tsx
+++ b/frontend/src/ThemedApp.test.tsx
@@ -17,7 +17,7 @@
 
 import React from "react"
 import { shallow, mount } from "lib/test_util"
-import { AUTO_THEME, darkTheme, ThemeConfig } from "theme"
+import { AUTO_THEME_NAME, darkTheme, ThemeConfig } from "theme"
 import { LocalStore } from "lib/storageUtils"
 import ThemedApp from "./ThemedApp"
 import AppWithScreencast from "./App"
@@ -80,7 +80,7 @@ describe("ThemedApp", () => {
       .props()
       .theme.setTheme({
         ...darkTheme,
-        name: AUTO_THEME,
+        name: AUTO_THEME_NAME,
       })
     const updatedLocalStorage = window.localStorage.getItem(
       LocalStore.ACTIVE_THEME

--- a/frontend/src/ThemedApp.tsx
+++ b/frontend/src/ThemedApp.tsx
@@ -4,7 +4,7 @@ import { Global } from "@emotion/core"
 import ThemeProvider from "components/core/ThemeProvider"
 import { LocalStore } from "lib/storageUtils"
 import {
-  AUTO_THEME,
+  AUTO_THEME_NAME,
   ThemeConfig,
   getDefaultTheme,
   globalStyles,
@@ -29,7 +29,7 @@ const ThemedApp = (): JSX.Element => {
 
       // Only save to localStorage if it is not Auto since auto is the default.
       // Important to not save since it can change depending on time of day.
-      if (newTheme.name === AUTO_THEME) {
+      if (newTheme.name === AUTO_THEME_NAME) {
         window.localStorage.removeItem(LocalStore.ACTIVE_THEME)
       } else {
         window.localStorage.setItem(
@@ -41,11 +41,11 @@ const ThemedApp = (): JSX.Element => {
   }
 
   const updateAutoTheme = (): void => {
-    if (theme.name === AUTO_THEME) {
+    if (theme.name === AUTO_THEME_NAME) {
       updateTheme(createAutoTheme())
     }
     const constantThemes = availableThemes.filter(
-      theme => theme.name !== AUTO_THEME
+      theme => theme.name !== AUTO_THEME_NAME
     )
     setAvailableThemes([createAutoTheme(), ...constantThemes])
   }

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
@@ -23,10 +23,10 @@ import Sidebar, { SidebarProps } from "./Sidebar"
 
 const createSidebarTheme = (theme: ThemeConfig): ThemeConfig =>
   createTheme(
+    "Sidebar",
     {
       secondaryBackgroundColor: theme.emotion.colors.bgColor,
       backgroundColor: theme.emotion.colors.secondaryBg,
-      name: "Sidebar",
     },
     {
       ...theme,

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
@@ -7,7 +7,12 @@ import PageLayoutContext from "components/core/PageLayoutContext"
 import Button, { Kind } from "components/shared/Button"
 import UISelectbox from "components/shared/Dropdown"
 import Icon from "components/shared/Icon"
-import { createTheme, ThemeConfig, toThemeInput } from "theme"
+import {
+  CUSTOM_THEME_NAME,
+  createTheme,
+  ThemeConfig,
+  toThemeInput,
+} from "theme"
 import {
   StyledButtonContainer,
   StyledHeader,
@@ -103,7 +108,7 @@ const ThemeCreator = (): ReactElement => {
   }
 
   const onThemeOptionChange = (key: string, newVal: string): void => {
-    const customTheme = createTheme("Custom Theme", {
+    const customTheme = createTheme(CUSTOM_THEME_NAME, {
       ...themeInput,
       [key]: newVal,
     })

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreator.tsx
@@ -103,10 +103,9 @@ const ThemeCreator = (): ReactElement => {
   }
 
   const onThemeOptionChange = (key: string, newVal: string): void => {
-    const customTheme = createTheme({
+    const customTheme = createTheme("Custom Theme", {
       ...themeInput,
       [key]: newVal,
-      name: "Custom Theme",
     })
     updateTheme(customTheme)
     updateCopied(false)

--- a/frontend/src/theme/themeConfigs.ts
+++ b/frontend/src/theme/themeConfigs.ts
@@ -9,7 +9,7 @@ import base from "./baseTheme"
 import light from "./lightTheme"
 import dark from "./darkTheme"
 import { ThemeConfig } from "./types"
-import { AUTO_THEME, getSystemTheme } from "./utils"
+import { AUTO_THEME_NAME, getSystemTheme } from "./utils"
 
 export const baseTheme: ThemeConfig = {
   name: "base",
@@ -36,7 +36,7 @@ export const lightTheme: ThemeConfig = {
 
 export const createAutoTheme = (): ThemeConfig => ({
   ...getSystemTheme(),
-  name: AUTO_THEME,
+  name: AUTO_THEME_NAME,
 })
 
 // Update auto theme in case it has changed

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -19,7 +19,8 @@ import { LocalStore } from "lib/storageUtils"
 import { baseTheme, darkTheme, lightTheme } from "theme"
 import { fonts } from "theme/primitives/typography"
 import {
-  AUTO_THEME,
+  AUTO_THEME_NAME,
+  CUSTOM_THEME_NAME,
   computeSpacingStyle,
   createEmotionTheme,
   createTheme,
@@ -60,8 +61,8 @@ describe("createTheme", () => {
       secondaryBackgroundColor: "blue",
       font: CustomThemeConfig.FontFamily.SERIF,
     })
-    const customTheme = createTheme("Custom Theme", customThemeConfig)
-    expect(customTheme.name).toBe("Custom Theme")
+    const customTheme = createTheme(CUSTOM_THEME_NAME, customThemeConfig)
+    expect(customTheme.name).toBe(CUSTOM_THEME_NAME)
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe(
@@ -80,11 +81,11 @@ describe("createTheme", () => {
       font: CustomThemeConfig.FontFamily.SERIF,
     })
     const customTheme = createTheme(
-      "Custom Theme",
+      CUSTOM_THEME_NAME,
       customThemeConfig,
       darkTheme
     )
-    expect(customTheme.name).toBe("Custom Theme")
+    expect(customTheme.name).toBe(CUSTOM_THEME_NAME)
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe(
@@ -103,11 +104,11 @@ describe("createTheme", () => {
       font: CustomThemeConfig.FontFamily.SERIF,
     })
     const customTheme = createTheme(
-      "Custom Theme",
+      CUSTOM_THEME_NAME,
       customThemeConfig,
       darkTheme
     )
-    expect(customTheme.name).toBe("Custom Theme")
+    expect(customTheme.name).toBe(CUSTOM_THEME_NAME)
     expect(customTheme.emotion.colors.primary).toBe("#eee")
     expect(customTheme.emotion.colors.secondaryBg).toBe("#fc9231")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe(
@@ -135,7 +136,7 @@ describe("getDefaultTheme", () => {
   })
 
   it("sets default to auto when nothing is available", () => {
-    expect(getDefaultTheme().name).toBe(AUTO_THEME)
+    expect(getDefaultTheme().name).toBe(AUTO_THEME_NAME)
   })
 
   it("sets default when value in localstorage is available", () => {
@@ -151,12 +152,12 @@ describe("getDefaultTheme", () => {
       LocalStore.ACTIVE_THEME,
       JSON.stringify({
         ...darkTheme,
-        name: AUTO_THEME,
+        name: AUTO_THEME_NAME,
       })
     )
 
     const defaultTheme = getDefaultTheme()
-    expect(defaultTheme.name).toBe(AUTO_THEME)
+    expect(defaultTheme.name).toBe(AUTO_THEME_NAME)
     expect(defaultTheme.emotion.colors.bgColor).toBe(
       lightTheme.emotion.colors.bgColor
     )
@@ -174,7 +175,7 @@ describe("getDefaultTheme", () => {
       })),
     })
     const defaultTheme = getDefaultTheme()
-    expect(defaultTheme.name).toBe(AUTO_THEME)
+    expect(defaultTheme.name).toBe(AUTO_THEME_NAME)
     expect(defaultTheme.emotion.colors.bgColor).toBe(
       darkTheme.emotion.colors.bgColor
     )

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -56,13 +56,12 @@ describe("Styling utils", () => {
 describe("createTheme", () => {
   it("createTheme returns a theme", () => {
     const customThemeConfig = new CustomThemeConfig({
-      name: "my theme",
       primaryColor: "red",
       secondaryBackgroundColor: "blue",
       font: CustomThemeConfig.FontFamily.SERIF,
     })
-    const customTheme = createTheme(customThemeConfig)
-    expect(customTheme.name).toBe("my theme")
+    const customTheme = createTheme("Custom Theme", customThemeConfig)
+    expect(customTheme.name).toBe("Custom Theme")
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe(
@@ -76,13 +75,16 @@ describe("createTheme", () => {
 
   it("createTheme returns a theme based on a different theme", () => {
     const customThemeConfig = new CustomThemeConfig({
-      name: "my theme",
       primaryColor: "red",
       secondaryBackgroundColor: "blue",
       font: CustomThemeConfig.FontFamily.SERIF,
     })
-    const customTheme = createTheme(customThemeConfig, darkTheme)
-    expect(customTheme.name).toBe("my theme")
+    const customTheme = createTheme(
+      "Custom Theme",
+      customThemeConfig,
+      darkTheme
+    )
+    expect(customTheme.name).toBe("Custom Theme")
     expect(customTheme.emotion.colors.primary).toBe("red")
     expect(customTheme.emotion.colors.secondaryBg).toBe("blue")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe(
@@ -96,13 +98,16 @@ describe("createTheme", () => {
 
   it("createTheme handles hex values without #", () => {
     const customThemeConfig = new CustomThemeConfig({
-      name: "my theme",
       primaryColor: "eee",
       secondaryBackgroundColor: "fc9231",
       font: CustomThemeConfig.FontFamily.SERIF,
     })
-    const customTheme = createTheme(customThemeConfig, darkTheme)
-    expect(customTheme.name).toBe("my theme")
+    const customTheme = createTheme(
+      "Custom Theme",
+      customThemeConfig,
+      darkTheme
+    )
+    expect(customTheme.name).toBe("Custom Theme")
     expect(customTheme.emotion.colors.primary).toBe("#eee")
     expect(customTheme.emotion.colors.secondaryBg).toBe("#fc9231")
     expect(customTheme.emotion.genericFonts.bodyFont).toBe(

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -306,7 +306,7 @@ export const createEmotionTheme = (
   baseThemeConfig = baseTheme
 ): Theme => {
   const { genericColors, genericFonts } = baseThemeConfig.emotion
-  const { name, font, ...customColors } = themeInput
+  const { font, ...customColors } = themeInput
 
   const parsedFont = fontEnumToString(font)
 
@@ -356,6 +356,7 @@ export const createEmotionTheme = (
 }
 
 export const createTheme = (
+  themeName: string,
   themeInput: Partial<CustomThemeConfig>,
   baseThemeConfig?: ThemeConfig
 ): ThemeConfig => {
@@ -369,7 +370,7 @@ export const createTheme = (
 
   return {
     ...startingTheme,
-    name: themeInput.name || "Custom theme",
+    name: themeName,
     emotion,
     basewebTheme: createBaseUiTheme(emotion, startingTheme.primitives),
   }

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -37,7 +37,8 @@ import {
 } from "theme"
 import { fonts } from "./primitives/typography"
 
-export const AUTO_THEME = "Use System Setting"
+export const AUTO_THEME_NAME = "Use System Setting"
+export const CUSTOM_THEME_NAME = "Custom Theme"
 
 export const fontToEnum = (font: string): CustomThemeConfig.FontFamily => {
   const fontStyle = Object.keys(fonts).find(
@@ -407,7 +408,7 @@ export const getDefaultTheme = (): ThemeConfig => {
   // If local storage has Auto, refetch system theme as it may have changed
   // based on time of day. We shouldn't ever have this saved in our storage
   // but checking in case!
-  return parsedTheme && parsedTheme.name !== AUTO_THEME
+  return parsedTheme && parsedTheme.name !== AUTO_THEME_NAME
     ? parsedTheme
     : createAutoTheme()
 }

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -799,16 +799,6 @@ _create_option(
 _create_section("theme", "Settings to define a custom theme for your Streamlit app.")
 
 _create_option(
-    "theme.name",
-    description="""
-        The theme name displayed in the UI for theme selection. Note that this
-        cannot be "Auto", "Dark", or "Light" as they conflict with the names
-        of default themes.
-        """,
-    default_val="Custom Theme",
-)
-
-_create_option(
     "theme.primaryColor",
     description="""
         Used to style primary interface elements. It's the color displayed
@@ -1231,12 +1221,6 @@ def _validate_theme() -> None:
     LOGGER = get_logger(__name__)
 
     theme_opts = get_options_for_section("theme")
-    theme_name = cast(str, theme_opts["name"])
-
-    if theme_name and theme_name.lower() in theme.RESERVED_THEME_NAMES:
-        LOGGER.warning('theme.name cannot be "Auto", "Dark", or "Light".')
-        set_option("theme.name", "")
-
     if (
         theme.check_theme_completeness(theme_opts)
         == theme.ThemeCompleteness.PARTIALLY_DEFINED

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -299,7 +299,6 @@ class ConfigTest(unittest.TestCase):
                 "client.caching",
                 "client.displayEnabled",
                 "client.showErrorDetails",
-                "theme.name",
                 "theme.primaryColor",
                 "theme.secondaryColor",
                 "theme.backgroundColor",
@@ -455,43 +454,6 @@ class ConfigTest(unittest.TestCase):
             " please set all required options."
         )
 
-    @patch("streamlit.logger.get_logger")
-    def test_validate_theme_yells_with_reserved_name(self, patched_get_logger):
-        mock_logger = patched_get_logger()
-
-        for opt in REQUIRED_THEME_OPTIONS:
-            config._set_option(opt, "foo", "test")
-        config._set_option("theme.name", "Auto", "test")
-
-        config._validate_theme()
-
-        mock_logger.warning.assert_called_once_with(
-            'theme.name cannot be "Auto", "Dark", or "Light".'
-        )
-        self.assertEqual(config._config_options["theme.name"].value, "")
-
-    @patch("streamlit.logger.get_logger")
-    def test_validate_theme_warns_for_name_and_partial_theme(self, patched_get_logger):
-        mock_logger = patched_get_logger()
-
-        for opt in REQUIRED_THEME_OPTIONS:
-            config._set_option(opt, "foo", "test")
-        config._set_option("theme.name", "Auto", "test")
-        config._set_option("theme.textColor", None, "test")
-
-        config._validate_theme()
-
-        mock_logger.warning.assert_has_calls(
-            [
-                call('theme.name cannot be "Auto", "Dark", or "Light".'),
-                call(
-                    "Theme options only partially defined. To specify a theme,"
-                    " please set all required options."
-                ),
-            ]
-        )
-        self.assertEqual(config._config_options["theme.name"].value, "")
-
     def test_maybe_convert_to_number(self):
         self.assertEqual(1234, config._maybe_convert_to_number("1234"))
         self.assertEqual(1234.5678, config._maybe_convert_to_number("1234.5678"))
@@ -554,12 +516,10 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(str(e.value), 'Config key "doesnt.exist" not defined.')
 
     def test_get_options_for_section(self):
-        config._set_option("theme.name", "monokai", "test")
         config._set_option("theme.primaryColor", "000000", "test")
         config._set_option("theme.font", "serif", "test")
 
         expected = {
-            "name": "monokai",
             "primaryColor": "000000",
             "secondaryColor": None,
             "secondaryBackgroundColor": None,

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -213,7 +213,6 @@ def _mock_get_options_for_section(overrides=None):
         overrides = {}
 
     theme_opts = {
-        "name": "foo",
         "primaryColor": "coral",
         "secondaryColor": "grey",
         "backgroundColor": "white",
@@ -279,7 +278,6 @@ class ReportSessionNewReportTest(tornado.testing.AsyncTestCase):
         )
 
         self.assertEqual(new_report_msg.HasField("custom_theme"), True)
-        self.assertEqual(new_report_msg.custom_theme.name, "foo")
         self.assertEqual(new_report_msg.custom_theme.text_color, "black")
 
         init_msg = new_report_msg.initialize
@@ -299,7 +297,6 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
                     "backgroundColor": None,
                     "secondaryBackgroundColor": None,
                     "textColor": None,
-                    "name": None,
                 }
             )
         )
@@ -322,6 +319,5 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
         report_session._populate_theme_msg(new_report_msg.custom_theme)
 
         self.assertEqual(new_report_msg.HasField("custom_theme"), True)
-        self.assertEqual(new_report_msg.custom_theme.name, "foo")
         self.assertEqual(new_report_msg.custom_theme.primary_color, "coral")
         self.assertEqual(new_report_msg.custom_theme.background_color, "white")

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -95,13 +95,12 @@ message CustomThemeConfig {
     MONOSPACE = 2;
   }
 
-  string name = 1;
-  string primary_color = 2;
-  string secondary_color = 3;
-  string secondary_background_color = 4;
-  string background_color = 5;
-  string text_color = 6;
-  FontFamily font = 7;
+  string primary_color = 1;
+  string secondary_color = 2;
+  string secondary_background_color = 3;
+  string background_color = 4;
+  string text_color = 5;
+  FontFamily font = 6;
 }
 
 // Data that identifies the Streamlit app creator.


### PR DESCRIPTION
This is a task from the product launch review. Instead of letting
developers name their themes, we'll just give any custom theme the name
"Custom Theme" in the theme selector menu.