### PR TITLE
Upgrade elliptic to 6.5.4 or later

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -170,6 +170,7 @@
   "resolutions": {
     "bl": "^2.2.1",
     "dot-prop": "^4.2.1",
+    "elliptic": "^6.5.4",
     "esm": "^3.1.0",
     "handlebars": "^4.4.5",
     "https-proxy-agent": "^2.2.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7316,7 +7316,7 @@ elementary-circuits-directed-graph@^1.0.4:
   dependencies:
     strongly-connected-components "^1.0.1"
 
-elliptic@^6.5.3:
+elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==


### PR DESCRIPTION
Details: https://github.com/advisories/GHSA-r9p9-mrjm-926w