### PR TITLE
Fix typo on "Use checkboxes to show/hide data"

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -173,7 +173,7 @@ if st.checkbox('Show dataframe'):
        np.random.randn(20, 3),
        columns=['a', 'b', 'c'])
 
-    st.line_chart(chart_data)
+    chart_data
 ```
 
 ### Use a selectbox for options


### PR DESCRIPTION
Since the name of the checkbox is 'Show dataframe', it should return a dataframe when the checkbox is clicked on. It returned a line chart before.

## Before contributing (PLEASE READ!)

⚠️ **If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer and tag @nthmost, then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers, and (4) your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.
#2928 

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.
- deleted `st.line_chart()` function in order to return just the dataframe

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
