### PR TITLE
Don't reload theme on every app rerun

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -20,7 +20,7 @@ import { ReactWrapper } from "enzyme"
 import cloneDeep from "lodash/cloneDeep"
 import { LocalStore } from "lib/storageUtils"
 import { shallow, mount } from "lib/test_util"
-import { ForwardMsg, NewReport } from "autogen/proto"
+import { CustomThemeConfig, ForwardMsg, NewReport } from "autogen/proto"
 import { IMenuItem } from "hocs/withS4ACommunication/types"
 import { ConnectionState } from "lib/ConnectionState"
 import { MetricsManager } from "lib/MetricsManager"
@@ -195,7 +195,7 @@ describe("App.handleNewReport", () => {
       allowRunOnSave: false,
     },
     customTheme: {
-      primary: "red",
+      primaryColor: "red",
     },
     initialize: {
       userInfo: {
@@ -291,6 +291,7 @@ describe("App.handleNewReport", () => {
   it("removes custom theme from options if none is received from the server", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "someHash" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
@@ -309,6 +310,7 @@ describe("App.handleNewReport", () => {
   it("Does not change dark/light/auto preference when removing custom theme", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "someHash" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
 
@@ -332,9 +334,10 @@ describe("App.handleNewReport", () => {
     const props = getProps()
     props.theme.activeTheme = {
       ...lightTheme,
-      name: "carl",
+      name: CUSTOM_THEME_NAME,
     }
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "someHash" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
@@ -350,6 +353,55 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).toHaveBeenCalled()
     // @ts-ignore
     expect(props.theme.setTheme.mock.calls[0][0]).toEqual(createAutoTheme())
+  })
+
+  it("changes theme if custom theme received from server has different hash", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+
+    const customThemeConfig = new CustomThemeConfig({ primaryColor: "blue" })
+    // @ts-ignore
+    const themeHash = wrapper.instance().createThemeHash(customThemeConfig)
+    wrapper.setState({ themeHash })
+
+    // @ts-ignore
+    wrapper.instance().handleNewReport(NEW_REPORT)
+
+    expect(props.theme.addThemes).toHaveBeenCalled()
+    expect(props.theme.setTheme).toHaveBeenCalled()
+  })
+
+  it("does nothing if custom theme received from server has matching hash", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+
+    const customThemeConfig = new CustomThemeConfig(
+      NEW_REPORT_JSON.customTheme
+    )
+    // @ts-ignore
+    const themeHash = wrapper.instance().createThemeHash(customThemeConfig)
+    wrapper.setState({ themeHash })
+
+    // @ts-ignore
+    wrapper.instance().handleNewReport(NEW_REPORT)
+
+    expect(props.theme.addThemes).not.toHaveBeenCalled()
+    expect(props.theme.setTheme).not.toHaveBeenCalled()
+  })
+
+  it("does nothing if no theme received from server with no previous theme", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+
+    const newReportJson = cloneDeep(NEW_REPORT_JSON)
+    // @ts-ignore
+    newReportJson.customTheme = null
+
+    // @ts-ignore
+    wrapper.instance().handleNewReport(new NewReport(newReportJson))
+
+    expect(props.theme.addThemes).not.toHaveBeenCalled()
+    expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
   it("performs one-time initialization", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -584,14 +584,12 @@ export class App extends PureComponent<Props, State> {
     }
 
     const themeInputEntries = Object.entries(themeInput)
+    // Ensure that our themeInput fields are in a consistent order when
+    // stringified below. Sorting an array of arrays in javascript sorts by the
+    // 0th element of the inner arrays, uses the 1st element to tiebreak, and
+    // so on.
     themeInputEntries.sort()
-
-    const concatenatedTheme: string = themeInputEntries.reduce(
-      (themeStr: string, [themeOptName, themeOptVal]) =>
-        `${themeStr},${themeOptName}:${themeOptVal}`,
-      ""
-    )
-    return hashString(concatenatedTheme)
+    return hashString(themeInputEntries.join(":"))
   }
 
   processThemeInput(themeInput: CustomThemeConfig): void {


### PR DESCRIPTION
Currently, the theme reloads on app rerun when a user changes the value of a
widget, which is because we're applying the theme in the config file
without taking into account whether that theme has actually changed.

This doesn't work well if a user was playing around with colors in the
theme creator dialog, so we should instead only make custom-theme
related changes if a theme config option was actually modified.