### PR TITLE
Stop warn logs from being spammed every time a checkbox is rendered

### DIFF
--- a/frontend/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.tsx
@@ -98,19 +98,30 @@ class Checkbox extends React.PureComponent<Props, State> {
               }: {
                 $isFocusVisible: boolean
                 $checked: boolean
-              }) => ({
-                borderLeftWidth: "2px",
-                borderRightWidth: "2px",
-                borderTopWidth: "2px",
-                borderBottomWidth: "2px",
-                borderColor:
-                  $checked && !disabled ? colors.primary : colors.fadedText40,
-                outline: 0,
-                boxShadow:
-                  $isFocusVisible && $checked
-                    ? `0 0 0 0.2rem ${transparentize(colors.primary, 0.5)}`
-                    : "",
-              }),
+              }) => {
+                const borderColor =
+                  $checked && !disabled ? colors.primary : colors.fadedText40
+
+                return {
+                  outline: 0,
+                  boxShadow:
+                    $isFocusVisible && $checked
+                      ? `0 0 0 0.2rem ${transparentize(colors.primary, 0.5)}`
+                      : "",
+                  // This is painfully verbose, but baseweb seems to internally
+                  // use the long-hand version, which means we can't use the
+                  // shorthand names here as if we do we'll end up with warn
+                  // logs spamming us every time a checkbox is rendered.
+                  borderLeftWidth: "2px",
+                  borderRightWidth: "2px",
+                  borderTopWidth: "2px",
+                  borderBottomWidth: "2px",
+                  borderLeftColor: borderColor,
+                  borderRightColor: borderColor,
+                  borderTopColor: borderColor,
+                  borderBottomColor: borderColor,
+                }
+              },
             },
             Label: {
               style: {


### PR DESCRIPTION
This slipped by when the design pass PR was merged as I guess I never
had a browser console open at the right time :cry:

I happened to notice a ton of warn logs being spammed to the browser
console whenever a checkbox was rendered. Unfortunately, this seems to
be due to the incompatibility of the short/long-hand versions of these
names and the fact that baseweb uses the long versions for some
components, so we don't have much of a choice other than to be very,
very verbose as well.
