### PR TITLE
Make tooltips and theming play nicely together

### DIFF
--- a/frontend/src/components/shared/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/src/components/shared/ColorPicker/ColorPicker.test.tsx
@@ -113,4 +113,10 @@ describe("ColorPicker widget with optional params", () => {
     const wrapper = shallow(<ColorPicker {...props} />)
     expect(wrapper.find("StyledColorValue").exists()).toBe(false)
   })
+
+  it("should render TooltipIcon if help text provided", () => {
+    const props = getProps({ help: "help text" })
+    const wrapper = shallow(<ColorPicker {...props} />)
+    expect(wrapper.find("TooltipIcon").prop("content")).toBe("help text")
+  })
 })

--- a/frontend/src/components/shared/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/shared/ColorPicker/ColorPicker.tsx
@@ -18,7 +18,12 @@
 import React from "react"
 import { StatefulPopover as UIPopover } from "baseui/popover"
 import { ChromePicker, ColorResult } from "react-color"
-import { StyledWidgetLabel } from "components/widgets/BaseWidget"
+import { Placement } from "components/shared/Tooltip"
+import TooltipIcon from "components/shared/TooltipIcon"
+import {
+  StyledWidgetLabel,
+  StyledWidgetLabelHelpInline,
+} from "components/widgets/BaseWidget"
 import {
   StyledColorPicker,
   StyledColorPreview,
@@ -33,6 +38,7 @@ export interface Props {
   showValue?: boolean
   label: string
   onChange: (value: string) => any
+  help?: string
 }
 
 interface State {
@@ -66,7 +72,7 @@ class ColorPicker extends React.PureComponent<Props, State> {
   }
 
   public render = (): React.ReactNode => {
-    const { width, showValue } = this.props
+    const { width, showValue, label, help } = this.props
     const { value } = this.state
     const style = { width }
     const previewStyle = {
@@ -74,7 +80,14 @@ class ColorPicker extends React.PureComponent<Props, State> {
     }
     return (
       <StyledColorPicker data-testid="stColorPicker" style={style}>
-        <StyledWidgetLabel>{this.props.label}</StyledWidgetLabel>
+        <StyledWidgetLabel>
+          {label}
+          {help && (
+            <StyledWidgetLabelHelpInline>
+              <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
+            </StyledWidgetLabelHelpInline>
+          )}
+        </StyledWidgetLabel>
         <UIPopover
           onClose={this.onColorClose}
           content={() => (

--- a/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -161,6 +161,12 @@ describe("Selectbox widget with optional props", () => {
     const props = getProps({ label: undefined })
     const wrapper = shallow(<Selectbox {...props} />)
 
-    expect(wrapper.contains("StyledWidgetLabel")).toBe(false)
+    expect(wrapper.find("StyledWidgetLabel").exists()).toBeFalsy()
+  })
+
+  it("should render TooltipIcon if help text provided", () => {
+    const props = getProps({ help: "help text" })
+    const wrapper = shallow(<Selectbox {...props} />)
+    expect(wrapper.find("TooltipIcon").prop("content")).toBe("help text")
   })
 })

--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -19,7 +19,12 @@ import React from "react"
 import { Select as UISelect, OnChangeParams, Option } from "baseui/select"
 import { logWarning } from "lib/log"
 import { VirtualDropdown } from "components/shared/Dropdown"
-import { StyledWidgetLabel } from "components/widgets/BaseWidget"
+import { Placement } from "components/shared/Tooltip"
+import TooltipIcon from "components/shared/TooltipIcon"
+import {
+  StyledWidgetLabel,
+  StyledWidgetLabelHelpInline,
+} from "components/widgets/BaseWidget"
 
 export interface Props {
   disabled: boolean
@@ -28,6 +33,7 @@ export interface Props {
   onChange: (value: number) => void
   options: any[]
   label?: string
+  help?: string
 }
 
 interface State {
@@ -84,6 +90,24 @@ class Selectbox extends React.PureComponent<Props, State> {
     )
   }
 
+  private renderLabel = (): React.ReactElement | null => {
+    const { label, help } = this.props
+    if (!label) {
+      return null
+    }
+
+    return (
+      <StyledWidgetLabel>
+        {label}
+        {help && (
+          <StyledWidgetLabelHelpInline>
+            <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
+          </StyledWidgetLabelHelpInline>
+        )}
+      </StyledWidgetLabel>
+    )
+  }
+
   public render = (): React.ReactNode => {
     const style = { width: this.props.width }
     let { disabled, options } = this.props
@@ -113,9 +137,7 @@ class Selectbox extends React.PureComponent<Props, State> {
 
     return (
       <div className="row-widget stSelectbox" style={style}>
-        {this.props.label && (
-          <StyledWidgetLabel>{this.props.label}</StyledWidgetLabel>
-        )}
+        {this.renderLabel()}
         <UISelect
           clearable={false}
           disabled={disabled}

--- a/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -16,8 +16,10 @@
  */
 
 import React from "react"
-import { shallow } from "enzyme"
+import { mount } from "enzyme"
 import { PLACEMENT } from "baseui/tooltip"
+import ThemeProvider from "components/core/ThemeProvider"
+import { lightTheme, lightBaseUITheme } from "theme"
 
 import Tooltip, { Placement, TooltipProps } from "./Tooltip"
 
@@ -32,24 +34,32 @@ const getProps = (
 
 describe("Tooltip element", () => {
   it("renders a Tooltip", () => {
-    const wrapper = shallow(<Tooltip {...getProps()}></Tooltip>)
+    const wrapper = mount(
+      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
+        <Tooltip {...getProps()}></Tooltip>
+      </ThemeProvider>
+    )
 
     expect(wrapper.find("StatefulTooltip").exists()).toBeTruthy()
   })
 
   it("renders its children", () => {
-    const wrapper = shallow(
-      <Tooltip {...getProps()}>
-        <div className="foo" />
-      </Tooltip>
+    const wrapper = mount(
+      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
+        <Tooltip {...getProps()}>
+          <div className="foo" />
+        </Tooltip>
+      </ThemeProvider>
     )
 
     expect(wrapper.find(".foo").exists()).toBeTruthy()
   })
 
   it("sets its placement", () => {
-    const wrapper = shallow(
-      <Tooltip {...getProps({ placement: Placement.BOTTOM })} />
+    const wrapper = mount(
+      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
+        <Tooltip {...getProps({ placement: Placement.BOTTOM })} />
+      </ThemeProvider>
     )
 
     expect(wrapper.find("StatefulTooltip").prop("placement")).toEqual(
@@ -59,7 +69,11 @@ describe("Tooltip element", () => {
 
   it("sets the same content", () => {
     const content = <span className="foo" />
-    const wrapper = shallow(<Tooltip {...getProps({ content })} />)
+    const wrapper = mount(
+      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
+        <Tooltip {...getProps({ content })} />
+      </ThemeProvider>
+    )
 
     expect(wrapper.find("StatefulTooltip").prop("content")).toEqual(content)
   })

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -16,6 +16,8 @@
  */
 
 import React, { ReactElement, ReactNode } from "react"
+import { useTheme } from "emotion-theming"
+import { Theme } from "theme"
 import { StatefulTooltip, ACCESSIBILITY_TYPE, PLACEMENT } from "baseui/tooltip"
 
 export enum Placement {
@@ -47,6 +49,9 @@ function Tooltip({
   children,
   inline,
 }: TooltipProps): ReactElement {
+  const theme: Theme = useTheme()
+  const { colors } = theme
+
   return (
     <StatefulTooltip
       content={content}
@@ -57,18 +62,28 @@ function Tooltip({
       overrides={{
         Arrow: {
           style: {
-            backgroundColor: "black",
+            backgroundColor: colors.secondaryBg,
+            border: `1px solid ${colors.fadedText10}`,
           },
         },
         Body: {
           style: {
-            borderRadius: "0.25rem",
+            // This is annoying, but a bunch of warnings get logged when the
+            // shorthand version `borderRadius` is used here since the long
+            // names are used by (I'm assuming) BaseWeb and mixing the two
+            // is apparently bad :(
+            borderTopLeftRadius: "0.25rem",
+            borderTopRightRadius: "0.25rem",
+            borderBottomLeftRadius: "0.25rem",
+            borderBottomRightRadius: "0.25rem",
+            border: `1px solid ${colors.fadedText10}`,
+            backgroundColor: colors.fadedText10,
           },
         },
         Inner: {
           style: {
-            backgroundColor: "black",
-            color: "white",
+            backgroundColor: colors.secondaryBg,
+            color: colors.bodyText,
             fontSize: "0.875rem",
             fontWeight: "normal",
           },

--- a/frontend/src/components/shared/TooltipIcon/styled-components.ts
+++ b/frontend/src/components/shared/TooltipIcon/styled-components.ts
@@ -2,12 +2,12 @@ import styled from "@emotion/styled"
 
 export const StyledTooltipIconWrapper = styled.div(({ theme }) => ({
   svg: {
-    stroke: theme.colors.gray60,
+    stroke: theme.colors.fadedText40,
     strokeWidth: 2.25,
   },
   ":hover": {
     svg: {
-      stroke: theme.colors.gray70,
+      stroke: theme.colors.fadedText60,
     },
   },
 }))

--- a/frontend/src/components/widgets/BaseWidget/index.tsx
+++ b/frontend/src/components/widgets/BaseWidget/index.tsx
@@ -18,4 +18,5 @@
 export {
   StyledWidgetInstructions,
   StyledWidgetLabel,
+  StyledWidgetLabelHelpInline,
 } from "./styled-components"

--- a/frontend/src/components/widgets/BaseWidget/styled-components.ts
+++ b/frontend/src/components/widgets/BaseWidget/styled-components.ts
@@ -32,3 +32,9 @@ export const StyledWidgetInstructions = styled.div(({ theme }) => ({
   bottom: 0,
   right: theme.fontSizes.halfSmDefault,
 }))
+
+export const StyledWidgetLabelHelpInline = styled.label(() => ({
+  marginLeft: "10px",
+  position: "relative",
+  top: "-1px",
+}))


### PR DESCRIPTION
The changes in this commit aren't used yet, but they will be very soon
as tooltips are needed for the theme creator dialog.

Aside from pulling in some code that lives in the tooltips feature
branch a bit early, in this commit we also tweak tooltip colors so that
they adjust along with the active theme.