### PR TITLE
Downgrade decamelize to version 4.0.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "cypress-circleci-reporter": "^0.1.2",
     "d3": "^5.16.0",
     "d3-graphviz": "^2.6.1",
-    "decamelize": "^5.0.0",
+    "decamelize": "^4.0.0",
     "deck.gl": "^8.2.5",
     "dompurify": "^2.1.1",
     "emotion-theming": "^10.0.27",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6843,10 +6843,10 @@ decamelize@^2.0.0:
   dependencies:
     xregexp "4.0.0"
 
-decamelize@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.0.tgz#88358157b010ef133febfd27c18994bd80c6215b"
-  integrity sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decimal.js@^10.2.0:
   version "10.2.1"


### PR DESCRIPTION
Apparently version 5.0.0 breaks in Safari (and the author has no plans of
fixing this as it breaks other features), but the humanize-string
package that relies on it only needs a version more recent than 2.0.0,
so we can downgrade this here.

Ideally, we may want to just get rid of the need for humanize-string
entirely in the near-ish future since its usage is pretty minimal.