### PR TITLE
Force file_watcher_type to "poll" for secrets.toml

### DIFF
--- a/lib/streamlit/secrets.py
+++ b/lib/streamlit/secrets.py
@@ -129,7 +129,14 @@ class Secrets(Mapping[str, Any]):
             if self._file_watcher_installed:
                 return
 
-            watch_file(self._file_path, self._on_secrets_file_changed)
+            # We force our watcher_type to 'poll' because Streamlit Sharing
+            # stores `secrets.toml` in a virtual filesystem that is
+            # incompatible with watchdog.
+            watch_file(
+                self._file_path,
+                self._on_secrets_file_changed,
+                watcher_type="poll",
+            )
 
             # We set file_watcher_installed to True even if watch_file
             # returns False to avoid repeatedly trying to install it.

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -14,6 +14,7 @@
 
 from typing import Optional, Union, Type, Callable
 
+import streamlit.watcher
 from streamlit import config
 from streamlit import env_util
 from streamlit.logger import get_logger

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -14,7 +14,6 @@
 
 from typing import Optional, Union, Type, Callable
 
-import streamlit.watcher
 from streamlit import config
 from streamlit import env_util
 from streamlit.logger import get_logger
@@ -50,7 +49,11 @@ FileWatcherType = Union[
 ]
 
 
-def watch_file(path: str, on_file_changed: Callable[[str], None]) -> bool:
+def watch_file(
+    path: str,
+    on_file_changed: Callable[[str], None],
+    watcher_type: Optional[str] = None,
+) -> bool:
     """Create a FileWatcher for the given file if we have a viable
     FileWatcher class.
 
@@ -60,6 +63,9 @@ def watch_file(path: str, on_file_changed: Callable[[str], None]) -> bool:
         Path of the file to watch.
     on_file_changed
         Function that's called when the file changes.
+    watcher_type
+        Optional watcher_type string. If None, it will default to the
+        'server.fileWatcherType` config option.
 
     Returns
     -------
@@ -67,7 +73,11 @@ def watch_file(path: str, on_file_changed: Callable[[str], None]) -> bool:
         True if the file is being watched, or False if we have no
         FileWatcher class.
     """
-    watcher_class = get_file_watcher_class()
+
+    if watcher_type is None:
+        watcher_type = config.get_option("server.fileWatcherType")
+
+    watcher_class = get_file_watcher_class(watcher_type)
     if watcher_class is None:
         return False
 
@@ -75,12 +85,17 @@ def watch_file(path: str, on_file_changed: Callable[[str], None]) -> bool:
     return True
 
 
-def get_file_watcher_class() -> Optional[FileWatcherType]:
-    """Return the class to use for being notified of file changes, based on the
+def get_default_file_watcher_class() -> Optional[FileWatcherType]:
+    """Return the class to use for file changes notifications, based on the
     server.fileWatcherType config option.
     """
-    watcher_type = config.get_option("server.fileWatcherType")
+    return get_file_watcher_class(config.get_option("server.fileWatcherType"))
 
+
+def get_file_watcher_class(watcher_type: str) -> Optional[FileWatcherType]:
+    """Return the FileWatcher class that corresponds to the given watcher_type
+    string. Acceptable values are 'auto', 'watchdog', 'poll' and 'none'.
+    """
     if watcher_type == "auto":
         if watchdog_available:
             return EventBasedFileWatcher

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -21,12 +21,12 @@ from streamlit import file_util
 from streamlit.folder_black_list import FolderBlackList
 
 from streamlit.logger import get_logger
-from streamlit.watcher.file_watcher import get_file_watcher_class
+from streamlit.watcher.file_watcher import get_default_file_watcher_class
 
 LOGGER = get_logger(__name__)
 
 
-FileWatcher = get_file_watcher_class()
+FileWatcher = get_default_file_watcher_class()
 
 WatchedModule = collections.namedtuple("WatchedModule", ["watcher", "module_name"])
 

--- a/lib/tests/streamlit/secrets_test.py
+++ b/lib/tests/streamlit/secrets_test.py
@@ -21,7 +21,6 @@ from toml import TomlDecodeError
 
 import streamlit as st
 from streamlit.secrets import Secrets, SECRETS_FILE_LOC
-from tests.testutil import patch_config_options
 
 MOCK_TOML = """
 # Everything in this section will be available as an environment variable
@@ -49,9 +48,9 @@ class SecretsTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self._prev_environ)
 
-    @patch_config_options({"server.fileWatcherType": "none"})
+    @patch("streamlit.secrets.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
-    def test_access_secrets(self, _):
+    def test_access_secrets(self, *mocks):
         self.assertEqual(self.secrets["db_username"], "Jane")
         self.assertEqual(self.secrets["subsection"]["email"], "eng@streamlit.io")
 
@@ -59,7 +58,6 @@ class SecretsTest(unittest.TestCase):
         """Verify that we're looking for secrets.toml in the right place."""
         self.assertEqual(os.path.abspath("./.streamlit/secrets.toml"), SECRETS_FILE_LOC)
 
-    @patch_config_options({"server.fileWatcherType": "none"})
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_os_environ(self, _):
         """os.environ gets patched when we load our secrets.toml"""
@@ -73,7 +71,6 @@ class SecretsTest(unittest.TestCase):
         # Subsections do not get loaded into os.environ
         self.assertEqual(os.environ.get("subsection"), None)
 
-    @patch_config_options({"server.fileWatcherType": "none"})
     @patch("streamlit.error")
     def test_missing_toml_error(self, mock_st_error):
         """Secrets access raises an error, and calls st.error, if
@@ -89,7 +86,6 @@ class SecretsTest(unittest.TestCase):
             f"Secrets file not found. Expected at: {MOCK_SECRETS_FILE_LOC}"
         )
 
-    @patch_config_options({"server.fileWatcherType": "none"})
     @patch("builtins.open", new_callable=mock_open, read_data="invalid_toml")
     @patch("streamlit.error")
     def test_malformed_toml_error(self, mock_st_error, _):
@@ -110,9 +106,14 @@ class SecretsTest(unittest.TestCase):
             self.assertEqual("Jane", os.environ["db_username"])
             self.assertEqual("12345qwerty", os.environ["db_password"])
 
-        # watch_file should have been called on the secrets.toml file
+        # watch_file should have been called on the "secrets.toml" file with
+        # the "poll" watcher_type. ("poll" is used here - rather than whatever
+        # is set in config - because Streamlit Sharing loads secrets.toml from
+        # a virtual filesystem that watchdog is unable to fire events for.)
         mock_watch_file.assert_called_once_with(
-            MOCK_SECRETS_FILE_LOC, self.secrets._on_secrets_file_changed
+            MOCK_SECRETS_FILE_LOC,
+            self.secrets._on_secrets_file_changed,
+            watcher_type="poll",
         )
 
         # Change the text that will be loaded on the next call to `open`

--- a/lib/tests/streamlit/watcher/file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/file_watcher_test.py
@@ -17,7 +17,7 @@
 import unittest
 from unittest.mock import patch, Mock
 
-from streamlit.watcher.file_watcher import get_file_watcher_class, watch_file
+from streamlit.watcher.file_watcher import get_default_file_watcher_class, watch_file
 from tests.testutil import patch_config_options
 
 
@@ -25,7 +25,7 @@ class FileWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.file_watcher.PollingFileWatcher")
     @patch("streamlit.watcher.file_watcher.EventBasedFileWatcher")
     def test_watch_file(self, mock_event_watcher, mock_polling_watcher):
-        """Test all possible outcomes of both `get_file_watcher_class` and
+        """Test all possible outcomes of both `get_default_file_watcher_class` and
         `watch_file`, based on config.fileWatcherType and whether
         `watchdog_available` is true.
         """
@@ -48,8 +48,10 @@ class FileWatcherTest(unittest.TestCase):
                     "streamlit.watcher.file_watcher.watchdog_available",
                     watchdog_available,
                 ):
-                    # Test get_file_watcher_class() result
-                    self.assertEqual(file_watcher_class, get_file_watcher_class())
+                    # Test get_default_file_watcher_class() result
+                    self.assertEqual(
+                        file_watcher_class, get_default_file_watcher_class()
+                    )
 
                     # Test watch_file(). If file_watcher_class is None,
                     # nothing should happen. Otherwise, file_watcher_class

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -217,33 +217,33 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         """Test server.fileWatcherType"""
 
         config.set_option("server.fileWatcherType", "none")
-        self.assertIsNone(local_sources_watcher.get_file_watcher_class())
+        self.assertIsNone(local_sources_watcher.get_default_file_watcher_class())
 
         config.set_option("server.fileWatcherType", "poll")
-        if local_sources_watcher.get_file_watcher_class() is not None:
+        if local_sources_watcher.get_default_file_watcher_class() is not None:
             self.assertEqual(
-                local_sources_watcher.get_file_watcher_class().__name__,
+                local_sources_watcher.get_default_file_watcher_class().__name__,
                 "PollingFileWatcher",
             )
 
         config.set_option("server.fileWatcherType", "watchdog")
-        if local_sources_watcher.get_file_watcher_class() is not None:
+        if local_sources_watcher.get_default_file_watcher_class() is not None:
             self.assertEqual(
-                local_sources_watcher.get_file_watcher_class().__name__,
+                local_sources_watcher.get_default_file_watcher_class().__name__,
                 "EventBasedFileWatcher",
             )
 
         config.set_option("server.fileWatcherType", "auto")
-        self.assertIsNotNone(local_sources_watcher.get_file_watcher_class())
+        self.assertIsNotNone(local_sources_watcher.get_default_file_watcher_class())
 
         if sys.modules["streamlit.watcher.event_based_file_watcher"] is not None:
             self.assertEqual(
-                local_sources_watcher.get_file_watcher_class().__name__,
+                local_sources_watcher.get_default_file_watcher_class().__name__,
                 "EventBasedFileWatcher",
             )
         else:
             self.assertEqual(
-                local_sources_watcher.get_file_watcher_class().__name__,
+                local_sources_watcher.get_default_file_watcher_class().__name__,
                 "PollingFileWatcher",
             )
 


### PR DESCRIPTION
Streamlit Sharing makes an app's 'secrets.toml' file available from a special file system that is incompatible with watchdog. So by default, in Sharing, changes to secrets.toml won't be detected at runtime.

With this change, we force the use of PollingFileWatcher (for secrets.toml only) instead of using whatever file_watcher method is set in config.