### PR TITLE
Only use localStorage when it is available

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,7 +67,6 @@ import { MetricsManager } from "lib/MetricsManager"
 import { FileUploadClient } from "lib/FileUploadClient"
 import { logError, logMessage } from "lib/log"
 import { ReportRoot } from "lib/ReportNode"
-import { LocalStore } from "lib/storageUtils"
 
 import { UserSettings } from "components/core/StreamlitDialog/UserSettings"
 import { ComponentRegistry } from "components/widgets/CustomComponent"
@@ -79,6 +78,8 @@ import {
   createPresetThemes,
   createTheme,
   ThemeConfig,
+  getCachedTheme,
+  setCachedTheme,
 } from "theme"
 
 import { StyledApp } from "./styled-components"
@@ -611,17 +612,12 @@ export class App extends PureComponent<Props, State> {
       if (!isPresetThemeActive) {
         // If the active theme is a custom theme, update the local store since
         // it has changed.
-        window.localStorage.setItem(
-          LocalStore.ACTIVE_THEME,
-          JSON.stringify(customTheme)
-        )
+        setCachedTheme(customTheme)
       }
       // For now users can only add one custom theme.
       this.props.theme.addThemes([customTheme])
 
-      const userPreference = window.localStorage.getItem(
-        LocalStore.ACTIVE_THEME
-      )
+      const userPreference = getCachedTheme()
       if (userPreference === null || !isPresetThemeActive) {
         this.props.theme.setTheme(customTheme)
       }

--- a/frontend/src/ThemedApp.tsx
+++ b/frontend/src/ThemedApp.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { BaseProvider } from "baseui"
 import { Global } from "@emotion/core"
 import ThemeProvider from "components/core/ThemeProvider"
-import { LocalStore } from "lib/storageUtils"
 import {
   AUTO_THEME_NAME,
   ThemeConfig,
@@ -10,6 +9,8 @@ import {
   globalStyles,
   createAutoTheme,
   createPresetThemes,
+  removeCachedTheme,
+  setCachedTheme,
 } from "theme"
 import AppWithScreencast from "./App"
 
@@ -30,12 +31,9 @@ const ThemedApp = (): JSX.Element => {
       // Only save to localStorage if it is not Auto since auto is the default.
       // Important to not save since it can change depending on time of day.
       if (newTheme.name === AUTO_THEME_NAME) {
-        window.localStorage.removeItem(LocalStore.ACTIVE_THEME)
+        removeCachedTheme()
       } else {
-        window.localStorage.setItem(
-          LocalStore.ACTIVE_THEME,
-          JSON.stringify(newTheme)
-        )
+        setCachedTheme(newTheme)
       }
     }
   }

--- a/frontend/src/lib/storageUtils.ts
+++ b/frontend/src/lib/storageUtils.ts
@@ -1,3 +1,3 @@
-export enum LocalStore {
-  ACTIVE_THEME = "stActiveTheme",
+export const LocalStore = {
+  ACTIVE_THEME: `stActiveTheme-${window.location.pathname}`,
 }

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -58,7 +58,7 @@ describe("Styling utils", () => {
   })
 })
 
-describe.only("Cached theme helpers", () => {
+describe("Cached theme helpers", () => {
   // NOTE: localStorage is weird, and calling .spyOn(window.localStorage, "setItem")
   // doesn't work. Accessing .__proto__ here isn't too bad of a crime since
   // it's test code.

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -430,9 +430,10 @@ export const getSystemTheme = (): ThemeConfig => {
 // Method taken from
 // https://stackoverflow.com/questions/16427636/check-if-localstorage-is-available
 export const localStorageAvailable = (): boolean => {
-  const { localStorage } = window
   const testData = "testData"
+
   try {
+    const { localStorage } = window
     localStorage.setItem(testData, testData)
     localStorage.getItem(testData)
     localStorage.removeItem(testData)

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -427,20 +427,59 @@ export const getSystemTheme = (): ThemeConfig => {
     : lightTheme
 }
 
+// Method taken from
+// https://stackoverflow.com/questions/16427636/check-if-localstorage-is-available
+export const localStorageAvailable = (): boolean => {
+  const { localStorage } = window
+  const testData = "testData"
+  try {
+    localStorage.setItem(testData, testData)
+    localStorage.getItem(testData)
+    localStorage.removeItem(testData)
+  } catch (e) {
+    return false
+  }
+  return true
+}
+
+export const getCachedTheme = (): ThemeConfig | null => {
+  if (!localStorageAvailable()) {
+    return null
+  }
+
+  const storedTheme = window.localStorage.getItem(LocalStore.ACTIVE_THEME)
+  return storedTheme ? (JSON.parse(storedTheme) as ThemeConfig) : null
+}
+
+export const setCachedTheme = (themeConfig: ThemeConfig): void => {
+  if (!localStorageAvailable()) {
+    return
+  }
+
+  window.localStorage.setItem(
+    LocalStore.ACTIVE_THEME,
+    JSON.stringify(themeConfig)
+  )
+}
+
+export const removeCachedTheme = (): void => {
+  if (!localStorageAvailable()) {
+    return
+  }
+
+  window.localStorage.removeItem(LocalStore.ACTIVE_THEME)
+}
+
 export const getDefaultTheme = (): ThemeConfig => {
   // Priority for default theme
   // 1. Previous user preference
   // 2. OS preference
-  const storedTheme = window.localStorage.getItem(LocalStore.ACTIVE_THEME)
-  const parsedTheme = storedTheme
-    ? (JSON.parse(storedTheme) as ThemeConfig)
-    : null
-
   // If local storage has Auto, refetch system theme as it may have changed
   // based on time of day. We shouldn't ever have this saved in our storage
   // but checking in case!
-  return parsedTheme && parsedTheme.name !== AUTO_THEME_NAME
-    ? parsedTheme
+  const cachedTheme = getCachedTheme()
+  return cachedTheme && cachedTheme.name !== AUTO_THEME_NAME
+    ? cachedTheme
     : createAutoTheme()
 }
 


### PR DESCRIPTION
We ran into an issue with theming on Streamlit Sharing on Chrome
Incognito mode because streamlit apps are run in an iframe so are
considered third party code.

Chrome Incognito disallows third party cookies/data by default, which
was causing the app to fail to load in this case. A (temporary) solution
is to simply avoid trying using `localStorage` when it's unavailable to
us.
