### PR TITLE
Add tests to improve coverage around config options set via flag

### DIFF
--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -330,8 +330,24 @@ class BootstrapPrintTest(unittest.TestCase):
             exc_info=mock_exception,
         )
 
+    @patch("streamlit.config.get_config_options")
     @patch("streamlit.bootstrap.watch_file")
-    def test_install_config_watcher(self, patched_watch_file):
+    def test_install_config_watcher(
+        self, patched_watch_file, patched_get_config_options
+    ):
         with patch("os.path.exists", return_value=True):
-            bootstrap._install_config_watchers(flag_options={})
+            bootstrap._install_config_watchers(flag_options={"server_port": 8502})
         self.assertEqual(patched_watch_file.call_count, 2)
+
+        args, _kwargs = patched_watch_file.call_args_list[0]
+        on_config_changed = args[1]
+
+        # Simulate a config file change being detected.
+        on_config_changed("/unused/nonexistent/file/path")
+
+        patched_get_config_options.assert_called_once_with(
+            force_reparse=True,
+            options_from_flags={
+                "server.port": 8502,
+            },
+        )

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -152,6 +152,20 @@ class CliTest(unittest.TestCase):
         )
         self.assertEqual(0, result.exit_code)
 
+    def test_run_command_with_flag_config_options(self):
+        with patch("validators.url", return_value=False), patch(
+            "streamlit.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+
+            result = self.runner.invoke(
+                cli, ["run", "file_name.py", "--server.port=8502"]
+            )
+
+        cli.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = cli.bootstrap.load_config_options.call_args
+        self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
+        self.assertEqual(0, result.exit_code)
+
     def test_get_command_line(self):
         """Test that _get_command_line_as_string correctly concatenates values
         from click.
@@ -318,6 +332,18 @@ class CliTest(unittest.TestCase):
             self.runner.invoke(cli, ["--log_level", "error", "hello"])
             mock_set_log_level.assert_called_with("ERROR")
 
+    def test_hello_command_with_flag_config_options(self):
+        with patch("validators.url", return_value=False), patch(
+            "streamlit.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+
+            result = self.runner.invoke(cli, ["hello", "--server.port=8502"])
+
+        cli.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = cli.bootstrap.load_config_options.call_args
+        self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
+        self.assertEqual(0, result.exit_code)
+
     def test_config_show_command(self):
         """Tests the config show command calls the corresponding method in
         config
@@ -325,6 +351,18 @@ class CliTest(unittest.TestCase):
         with patch("streamlit.config.show_config") as mock_config:
             self.runner.invoke(cli, ["config", "show"])
             mock_config.assert_called()
+
+    def test_config_show_command_with_flag_config_options(self):
+        with patch("validators.url", return_value=False), patch(
+            "streamlit.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+
+            result = self.runner.invoke(cli, ["config", "show", "--server.port=8502"])
+
+        cli.bootstrap.load_config_options.assert_called_once()
+        _args, kwargs = cli.bootstrap.load_config_options.call_args
+        self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
+        self.assertEqual(0, result.exit_code)
 
     @patch("builtins.print")
     def test_cache_clear_command_with_cache(self, mock_print):


### PR DESCRIPTION
@kantuni pointed out in a previous PR that our test coverage around config
options set via CLI flag was lacking, and now that 0.79/theming has
landed I had a bit of time to improve this.
