### PR TITLE
Allow users to click and drag in the color picker

### DIFF
--- a/frontend/src/components/shared/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/src/components/shared/ColorPicker/ColorPicker.test.tsx
@@ -67,7 +67,7 @@ describe("ColorPicker widget", () => {
   it("supports hex shorthand", () => {
     wrapper.find(UIPopover).simulate("click")
 
-    colorPickerWrapper.prop("onChangeComplete")({
+    colorPickerWrapper.prop("onChange")({
       hex: "#333",
     })
 
@@ -83,7 +83,7 @@ describe("ColorPicker widget", () => {
     const newColor = "#E91E63"
     wrapper.find(UIPopover).simulate("click")
 
-    colorPickerWrapper.prop("onChangeComplete")({
+    colorPickerWrapper.prop("onChange")({
       hex: newColor,
     })
 

--- a/frontend/src/components/shared/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/shared/ColorPicker/ColorPicker.tsx
@@ -63,7 +63,10 @@ class ColorPicker extends React.PureComponent<Props, State> {
     }
   }
 
-  private onChangeComplete = (color: ColorResult): void => {
+  // Note: This is a "local" onChange handler used to update the color preview
+  // (allowing the user to click and drag). this.props.onChange is only called
+  // when the ColorPicker popover is closed.
+  private onColorChange = (color: ColorResult): void => {
     this.setState({ value: color.hex })
   }
 
@@ -93,7 +96,7 @@ class ColorPicker extends React.PureComponent<Props, State> {
           content={() => (
             <ChromePicker
               color={value}
-              onChangeComplete={this.onChangeComplete}
+              onChange={this.onColorChange}
               disableAlpha={true}
             />
           )}

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -70,7 +70,7 @@ describe("ColorPicker widget", () => {
   it("should update the widget value when it's changed", () => {
     const newColor = "#E91E63"
     wrapper.find(UIPopover).simulate("click")
-    colorPickerWrapper.find(ChromePicker).prop("onChangeComplete")({
+    colorPickerWrapper.find(ChromePicker).prop("onChange")({
       hex: newColor,
     })
 


### PR DESCRIPTION
It turns out that doing this was actually quite easy as we only need to
use `react-color`s `onChange` instead of `onChangeComplete`. Note that the
corresponding event fires a lot when clicking and dragging, but the
`onChange` handler passed to the ColorPicker component is only called
when the picker popover is closed.

Closes #2970
