### PR TITLE
Have theme hashes differentiate between being unset and the hash for null

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -386,10 +386,10 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
-  it("does nothing if no theme received from server with no previous theme", () => {
+  it("does nothing if no custom theme is received and themeHash is 'hash_for_undefined_custom_theme'", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
-    wrapper.setState({ themeHash: "no_theme_input" })
+    wrapper.setState({ themeHash: "hash_for_undefined_custom_theme" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -224,7 +224,7 @@ describe("App.handleNewReport", () => {
     window.localStorage.clear()
   })
 
-  it("adds custom theme to list of available themes", () => {
+  it("adds the custom theme from the server to the list of available themes", () => {
     const props = getProps()
     window.localStorage.setItem(
       LocalStore.ACTIVE_THEME,
@@ -242,7 +242,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
-  it("sets custom theme as default if no user preference", () => {
+  it("sets the custom theme as the default if no user preference is set", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
@@ -261,7 +261,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe(CUSTOM_THEME_NAME)
   })
 
-  it("sets custom theme again if custom theme active", () => {
+  it("sets the custom theme again if a custom theme is already active", () => {
     window.localStorage.setItem(
       LocalStore.ACTIVE_THEME,
       JSON.stringify({ ...lightTheme, name: CUSTOM_THEME_NAME })
@@ -288,7 +288,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe(CUSTOM_THEME_NAME)
   })
 
-  it("removes custom theme from options if none is received from the server", () => {
+  it("removes the custom theme from theme options if one is not received from the server", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
@@ -306,7 +306,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.addThemes.mock.calls[0][0]).toEqual([])
   })
 
-  it("Does not change dark/light/auto preference when removing custom theme", () => {
+  it("Does not change dark/light/auto user preferences when removing a custom theme", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
@@ -328,7 +328,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
-  it("Changes to auto when user has custom theme selected and it is removed", () => {
+  it("Changes theme to auto when user has a custom theme selected and it is removed", () => {
     const props = getProps()
     props.theme.activeTheme = {
       ...lightTheme,
@@ -352,7 +352,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme.mock.calls[0][0]).toEqual(createAutoTheme())
   })
 
-  it("changes theme if custom theme received from server has different hash", () => {
+  it("updates the custom theme if the one received from server has different hash", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
@@ -368,7 +368,7 @@ describe("App.handleNewReport", () => {
     expect(props.theme.setTheme).toHaveBeenCalled()
   })
 
-  it("does nothing if custom theme received from server has matching hash", () => {
+  it("does nothing if the custom theme received from server has a matching hash", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -291,7 +291,6 @@ describe("App.handleNewReport", () => {
   it("removes custom theme from options if none is received from the server", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
-    wrapper.setState({ themeHash: "someHash" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
@@ -310,7 +309,6 @@ describe("App.handleNewReport", () => {
   it("Does not change dark/light/auto preference when removing custom theme", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
-    wrapper.setState({ themeHash: "someHash" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
 
@@ -337,7 +335,6 @@ describe("App.handleNewReport", () => {
       name: CUSTOM_THEME_NAME,
     }
     const wrapper = shallow(<App {...props} />)
-    wrapper.setState({ themeHash: "someHash" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore
@@ -392,6 +389,7 @@ describe("App.handleNewReport", () => {
   it("does nothing if no theme received from server with no previous theme", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "no_theme_input" })
 
     const newReportJson = cloneDeep(NEW_REPORT_JSON)
     // @ts-ignore

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,7 +79,6 @@ import {
   createTheme,
   ThemeConfig,
   getCachedTheme,
-  setCachedTheme,
 } from "theme"
 
 import { StyledApp } from "./styled-components"
@@ -603,29 +602,28 @@ export class App extends PureComponent<Props, State> {
     const presetThemeNames = createPresetThemes().map(
       (t: ThemeConfig) => t.name
     )
-    const isPresetThemeActive = presetThemeNames.includes(
+    const usingCustomTheme = !presetThemeNames.includes(
       this.props.theme.activeTheme.name
     )
 
     if (themeInput) {
       const customTheme = createTheme(CUSTOM_THEME_NAME, themeInput)
-      if (!isPresetThemeActive) {
-        // If the active theme is a custom theme, update the local store since
-        // it has changed.
-        setCachedTheme(customTheme)
-      }
-      // For now users can only add one custom theme.
+      // For now, users can only add one custom theme.
       this.props.theme.addThemes([customTheme])
 
       const userPreference = getCachedTheme()
-      if (userPreference === null || !isPresetThemeActive) {
+      if (userPreference === null || usingCustomTheme) {
+        // Update the theme to be customTheme either if the user hasn't set a
+        // preference (developer-provided custom themes should be the default
+        // for an app) or if a custom theme is currently active (to ensure that
+        // we pick up any new changes to it).
         this.props.theme.setTheme(customTheme)
       }
     } else if (!themeInput) {
       // Remove the custom theme menu option.
       this.props.theme.addThemes([])
 
-      if (!isPresetThemeActive) {
+      if (usingCustomTheme) {
         this.props.theme.setTheme(createAutoTheme())
       }
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -121,7 +121,7 @@ interface State {
   allowRunOnSave: boolean
   deployParams?: IDeployParams | null
   developerMode: boolean
-  themeHash: string | null
+  themeHash?: string
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -181,7 +181,6 @@ export class App extends PureComponent<Props, State> {
       // A hack for now to get theming through. Product to think through how
       // developer mode should be designed in the long term.
       developerMode: window.location.host.includes("localhost"),
-      themeHash: null,
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -578,12 +577,12 @@ export class App extends PureComponent<Props, State> {
     this.handleSessionStateChanged(initialize.sessionState)
   }
 
-  createThemeHash = (themeInput: CustomThemeConfig): string | null => {
+  createThemeHash = (themeInput: CustomThemeConfig): string => {
     if (!themeInput) {
-      // Differentiate between the case where this.state.themeHash has yet to
-      // be computed (so this.state.themeHash === null)  and the case where we
-      // received no custom theme from the server.
-      return "no_theme_input"
+      // If themeInput is null, then we didn't receive a custom theme for this
+      // app from the server. We use a hardcoded string literal for the
+      // themeHash in this case.
+      return "hash_for_undefined_custom_theme"
     }
 
     const themeInputEntries = Object.entries(themeInput)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -580,7 +580,10 @@ export class App extends PureComponent<Props, State> {
 
   createThemeHash = (themeInput: CustomThemeConfig): string | null => {
     if (!themeInput) {
-      return null
+      // Differentiate between the case where this.state.themeHash has yet to
+      // be computed (so this.state.themeHash === null)  and the case where we
+      // received no custom theme from the server.
+      return "no_theme_input"
     }
 
     const themeInputEntries = Object.entries(themeInput)


### PR DESCRIPTION
There's a bug that I introduced when adding the theme hashing code that can be
reproduced in two ways.

Way 1 (which is really easy to run into.. not sure how this slipped by :disappointed:):

1. Use the theme picker to pick some new theme colors.
2. Refresh the page.
3. Wonder why the theme didn't revert back to what it was previously and notice that
   the theme name in the theme selector is empty.

Way 2:

1. Define a custom theme in a config file.
2. Point your browser at an app and have it load the custom theme by default.
3. Close the browser tab.
4. Remove the theme section from the config file.
5. Load the app again and notice that the custom theme is still applied and the
   theme name in the theme selector is empty.

The root cause of both of these bugs is that we're currently not differentiating
between the theme hash being unset because the app just loaded and it being
a theme hash corresponding to a null theme input. This means when a browser
first loads the app and any custom theme should be removed (because we don't
get one from the server), we don't actually do so.
