### PR TITLE
Update caching.md

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -80,7 +80,7 @@ Now when you rerun the app the text "Cache miss" appears on the first run, but n
 
 ```eval_rst
 .. note::
-   You may have noticed that we've added the `suppress_st_warning` keyword to the `@st.cache` decorators. That's because the cached function above uses a Streamlit command itself (`st.write` in this case), and when Streamlit sees that, it shows a warning that your command will only execute when you get a cache hit. More often than not, when you see that warning it's because there's a bug in your code. However, in our case we're using the `st.write` command to demonstrate when the cache is being hit, so the behavior Streamlit is warning us about is exactly what we want. As a result, we are passing in `suppress_st_warning=True` to turn that warning off.
+   You may have noticed that we've added the `suppress_st_warning` keyword to the `@st.cache` decorators. That's because the cached function above uses a Streamlit command itself (`st.write` in this case), and when Streamlit sees that, it shows a warning that your command will only execute when you get a cache miss. More often than not, when you see that warning it's because there's a bug in your code. However, in our case we're using the `st.write` command to demonstrate when the cache is being missed, so the behavior Streamlit is warning us about is exactly what we want. As a result, we are passing in `suppress_st_warning=True` to turn that warning off.
 ```
 
 ## Example 2: When the function arguments change


### PR DESCRIPTION
fix typo in [https://docs.streamlit.io/en/stable/caching.html](https://docs.streamlit.io/en/stable/caching.html): _cache hit_ ⟶ _cache miss_