### PR TITLE
Move docs.streamlit.io to Segment

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -14,16 +14,14 @@
 
 <head>
 
-  <!-- Google Tag Manager -->
-  <script>(function (w, d, s, l, i) {
-      w[l] = w[l] || []; w[l].push({
-        'gtm.start':
-          new Date().getTime(), event: 'gtm.js'
-      }); var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', 'GTM-52GRQSL');</script>
-  <!-- End Google Tag Manager -->
+  <!-- Segment snippet start -->
+  <script>
+    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="pUoB6ihRTAFLDtLp2NWEuJvBNtiooQwE";analytics.SNIPPET_VERSION="4.13.2";
+    analytics.load("pUoB6ihRTAFLDtLp2NWEuJvBNtiooQwE");
+    analytics.page();
+    }}();
+  </script>
+  <!-- End of Segment -->
 
   <meta charset="utf-8">
   {{ metatags }}


### PR DESCRIPTION
The docs.streamlit.io currently uses Google Tag Manager for metrics. This PR moves our docs page to Segment instead, where we can reroute events to Google Tag Manager, BigQuery, and Heap.

From Tag Manager's point-of-view, this change should be a no-op since we're routing these events to the same exact project as we were before. See config below and compare to the ID in the old source file (i.e. "GTM-52GRQSL"):

![image](https://user-images.githubusercontent.com/690814/112066786-389f9c80-8b24-11eb-89f7-975887a7e312.png)
