### PR TITLE
st.beta_submit_form_button

### DIFF
--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -29,7 +29,7 @@ else:
     files = [file.read().decode() for file in multiple_files]
     st.text("\n".join(files))
 
-with st.beta_form():
+with st.beta_form("foo"):
     form_file = st.file_uploader("Inside form:", type=["txt"])
     if form_file is None:
         st.text("No upload")

--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -31,6 +31,7 @@ else:
 
 with st.beta_form("foo"):
     form_file = st.file_uploader("Inside form:", type=["txt"])
+    st.beta_form_submit_button("Submit")
     if form_file is None:
         st.text("No upload")
     else:

--- a/e2e/scripts/st_form.py
+++ b/e2e/scripts/st_form.py
@@ -4,7 +4,7 @@ from datetime import date, time
 # Tests all widgets, sans file_uploader, inside a form.
 # st.file_uploader is omitted because it's so different; its form-related
 # test lives inside the `st_file_uploader.py` spec instead.
-with st.beta_form():
+with st.beta_form("form"):
     checkbox = st.checkbox("Checkbox", False)
     color_picker = st.color_picker("Color Picker")
     date_input = st.date_input("Date Input", date(2019, 7, 6))

--- a/e2e/scripts/st_form.py
+++ b/e2e/scripts/st_form.py
@@ -17,6 +17,7 @@ with st.beta_form("form"):
     text_area = st.text_area("Text Area", value="foo")
     text_input = st.text_input("Text Input", value="foo")
     time_input = st.time_input("Time Input", time(8, 45))
+    st.beta_form_submit_button("Submit")
 
 "Checkbox:", checkbox
 "Color Picker:", color_picker

--- a/frontend/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -83,7 +83,7 @@ describe("FormSubmitButton", () => {
 
     wrappedUIButton.simulate("click")
 
-    expect(props.widgetMgr.submitForm).toHaveBeenCalledWith("mockFormId")
+    expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(props.element)
   })
 
   it("is disabled when form has pending upload", () => {

--- a/frontend/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/src/components/widgets/Form/FormSubmitButton.tsx
@@ -46,7 +46,7 @@ export default function FormSubmitButton(props: Props): ReactElement {
         }
         size={Size.SMALL}
         disabled={props.disabled || props.hasInProgressUpload}
-        onClick={() => props.widgetMgr.submitForm(props.element.formId)}
+        onClick={() => props.widgetMgr.submitForm(props.element)}
       >
         {props.element.label}
       </UIButton>

--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -256,6 +256,45 @@ describe("Widget State Manager", () => {
       })
 
       expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
+      expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
+    })
+  })
+
+  describe("submitForm", () => {
+    it("calls sendBackMsg with expected data", () => {
+      // Populate a form
+      const formId = "mockFormId"
+      widgetMgr.setStringValue({ id: "widget1", formId }, "foo", {
+        fromUi: true,
+      })
+      widgetMgr.setStringValue({ id: "widget2", formId }, "bar", {
+        fromUi: true,
+      })
+
+      // We have a single pending form.
+      expect(pendingFormsChanged).toHaveBeenLastCalledWith(new Set([formId]))
+
+      // Submit the form
+      widgetMgr.submitForm({ id: "submitButton", formId })
+
+      // Our backMsg should be populated with our two widget values,
+      // plus the submitButton's triggerValue.
+      expect(sendBackMsg).toHaveBeenCalledWith({
+        widgets: [
+          { id: "widget1", stringValue: "foo" },
+          { id: "widget2", stringValue: "bar" },
+          { id: "submitButton", triggerValue: true },
+        ],
+      })
+
+      // We have no more pending form.
+      expect(pendingFormsChanged).toHaveBeenLastCalledWith(new Set<string>())
+    })
+
+    it("throws on invalid formId", () => {
+      expect(() => widgetMgr.submitForm(MOCK_WIDGET)).toThrowError(
+        `invalid formID ${MOCK_WIDGET.formId}`
+      )
     })
   })
 })

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -156,25 +156,35 @@ export class WidgetStateManager {
   /**
    * Commit pending changes for widgets that belong to the given form,
    * and send a rerunBackMsg to the server.
-   *
-   * If the given form has no pending changes, this is a no-op.
    */
-  public submitForm(formId: string): void {
-    if (!isValidFormId(formId)) {
-      return
+  public submitForm(submitButton: WidgetInfo): void {
+    if (!isValidFormId(submitButton.formId)) {
+      // This should never get thrown - only FormSubmitButton calls this
+      // function.
+      throw new Error(`submitForm: invalid formID '${submitButton.formId}'`)
     }
 
-    const form = this.pendingForms.get(formId)
-    if (form == null || form.isEmpty) {
-      return
+    // Create the button's triggerValue. Just like with a regular button,
+    // `st.form_submit_button()` returns True during a rerun after
+    // it's clicked.
+    this.createWidgetState(submitButton, { fromUi: true }).triggerValue = true
+
+    const form = this.pendingForms.get(submitButton.formId)
+    if (form == null) {
+      // Sanity check. This should never be possible: the call to
+      // `createWidgetState` will have created our form.
+      throw new Error(`submitForm: FormData is unexpectedly null`)
     }
 
     // Copy the form's values into widgetStates, delete the form's pending
     // changes, and send our widgetStates back to the server.
     this.widgetStates.copyFrom(form)
-    this.pendingForms.delete(formId)
+    this.pendingForms.delete(submitButton.formId)
     this.sendUpdateWidgetsMessage()
     this.maybeCallPendingFormsChanged()
+
+    // Reset the button's triggerValue.
+    this.deleteWidgetState(submitButton.id)
   }
 
   /**

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -161,7 +161,7 @@ export class WidgetStateManager {
     if (!isValidFormId(submitButton.formId)) {
       // This should never get thrown - only FormSubmitButton calls this
       // function.
-      throw new Error(`submitForm: invalid formID '${submitButton.formId}'`)
+      throw new Error(`invalid formID '${submitButton.formId}'`)
     }
 
     // Create the button's triggerValue. Just like with a regular button,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -204,6 +204,7 @@ beta_container = _main.beta_container  # noqa: E221
 beta_expander = _main.beta_expander  # noqa: E221
 beta_columns = _main.beta_columns  # noqa: E221
 beta_form = _main.beta_form  # noqa: E221
+beta_form_submit_button = _main.beta_form_submit_button
 beta_secrets = Secrets(SECRETS_FILE_LOC)
 
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -209,18 +209,8 @@ class DeltaGenerator(
     def __exit__(self, type, value, traceback):
         # with block ended
         ctx = get_report_ctx()
-        if ctx:
+        if ctx is not None:
             ctx.dg_stack.pop()
-
-        if self._form_data is not None:
-            # We're exiting an `st.form` block. Create the form's Submit
-            # button.
-            self._button(
-                label=self._form_data.submit_button_label,
-                key=self._form_data.submit_button_key,
-                help=None,
-                is_form_submitter=True,
-            )
 
         # Re-raise any exceptions
         return False

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -66,6 +66,8 @@ class ButtonMixin:
         # every form). We throw an error to warn the user about this.
         if is_in_form(self.dg) and not is_form_submitter:
             raise StreamlitAPIException("Button can't be used in a form.")
+        elif not is_in_form(self.dg) and is_form_submitter:
+            raise StreamlitAPIException("submit_button must be used inside a form.")
 
         button_proto.label = label
         button_proto.default = False

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -16,9 +16,8 @@ import textwrap
 from typing import cast, Optional, NamedTuple
 
 import streamlit
-from streamlit.elements.utils import _get_widget_id
 from streamlit.errors import StreamlitAPIException
-from streamlit.proto import Block_pb2, Button_pb2
+from streamlit.proto import Block_pb2
 from streamlit.report_thread import get_report_ctx
 
 
@@ -27,10 +26,6 @@ class FormData(NamedTuple):
 
     # The form's unique ID.
     form_id: str
-    # The label for the submit button that's automatically created for a form.
-    submit_button_label: str
-    # The optional key for the submit button.
-    submit_button_key: Optional[str]
 
 
 def _current_form(
@@ -57,27 +52,6 @@ def _current_form(
             return dg._form_data
 
     return this_dg._form_data
-
-
-def _create_form_id(submit_label: str, key: Optional[str]) -> str:
-    """Create an ID for a form.
-
-    A form's ID is equal to its Submit button's widget ID. To make it,
-    we fake up our Submit button - which need not have been created yet.
-    We know that this ID will be unique across all forms, because widget IDs
-    are unique across widgets, and this widget ID will be registered when the
-    form's Submit button is created.
-    """
-    # To generate an ID for the form, we fake up our Submit button -
-    # which is not yet created - and use its ID. (We know that this ID
-    # will be unique among all forms, because widget IDs are among all
-    # widgets, and this widget ID will be registered when the form's
-    # Submit button is created.)
-    button_proto = Button_pb2.Button()
-    button_proto.label = submit_label
-    button_proto.default = False
-    button_proto.is_form_submitter = True
-    return _get_widget_id("button", button_proto, user_key=key)
 
 
 def current_form_id(dg: "streamlit.delta_generator.DeltaGenerator") -> str:
@@ -126,12 +100,11 @@ def _build_duplicate_form_message(user_key: Optional[str] = None) -> str:
 
 
 class FormMixin:
-    def beta_form(self, submit_label="Submit", key=None):
+    def beta_form(self, key: str):
         """TODO
 
         Parameters
         ----------
-        submit_label
         key
 
         Returns
@@ -142,7 +115,9 @@ class FormMixin:
         if is_in_form(self.dg):
             raise StreamlitAPIException("Forms cannot be nested in other forms.")
 
-        form_id = _create_form_id(submit_label, key)
+        # A form is uniquely identified by its key.
+        form_id = key
+
         ctx = get_report_ctx()
         if ctx is not None:
             added_form_id = ctx.form_ids_this_run.add(form_id)
@@ -154,10 +129,30 @@ class FormMixin:
         block_dg = self.dg._block(block_proto)
 
         # Attach the form's button info to the newly-created block's
-        # DeltaGenerator. The block will create its submit button when it
-        # exits.
-        block_dg._form_data = FormData(form_id, submit_label, key)
+        # DeltaGenerator.
+        block_dg._form_data = FormData(form_id)
         return block_dg
+
+    def beta_form_submit_button(self, label="Submit"):
+        """TODO
+
+        Parameters
+        ----------
+        label
+
+        Returns
+        -------
+        bool
+            True if the submit button was clicked.
+        """
+        # _button() will raise an Exception if this is called from outside
+        # a form.
+        return self.dg._button(
+            label=label,
+            key=f"FormSubmitter:{current_form_id(self.dg)}",
+            help=None,
+            is_form_submitter=True,
+        )
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/tests/streamlit/checkbox_test.py
+++ b/lib/tests/streamlit/checkbox_test.py
@@ -64,8 +64,6 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.checkbox("foo")
 

--- a/lib/tests/streamlit/checkbox_test.py
+++ b/lib/tests/streamlit/checkbox_test.py
@@ -66,11 +66,11 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.checkbox("foo")
 
-        # 3 elements will be created: a block, a checkbox, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: a block and a checkbox
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         checkbox_proto = self.get_delta_from_queue(1).new_element.checkbox

--- a/lib/tests/streamlit/color_picker_test.py
+++ b/lib/tests/streamlit/color_picker_test.py
@@ -61,11 +61,11 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.color_picker("foo")
 
-        # 3 elements will be created: a block, a color picker, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         color_picker_proto = self.get_delta_from_queue(1).new_element.color_picker

--- a/lib/tests/streamlit/color_picker_test.py
+++ b/lib/tests/streamlit/color_picker_test.py
@@ -59,8 +59,6 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.color_picker("foo")
 

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -382,11 +382,11 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("foo"):
             self.test_component()
 
-        # 3 elements will be created: a block, a component instance, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         component_instance_proto = self.get_delta_from_queue(

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -380,8 +380,6 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("foo"):
             self.test_component()
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -14,8 +14,6 @@
 
 """Form unit tests."""
 
-import textwrap
-
 from tests import testutil
 
 import streamlit as st
@@ -25,42 +23,8 @@ from streamlit.errors import StreamlitAPIException
 class FormTest(testutil.DeltaGeneratorTestCase):
     """Test ability to marshall form protos."""
 
-    def test_multiple_forms_no_labels_no_keys(self):
-        """Test that multiple forms without labels and keys are not allowed."""
-
-        with self.assertRaises(StreamlitAPIException) as ctx:
-            st.beta_form()
-            st.beta_form()
-
-        self.assertIn(
-            "There are multiple identical forms with the same generated key.",
-            str(ctx.exception),
-        )
-
-    def test_multiple_forms_same_labels_no_keys(self):
-        """Test that multiple forms with same labels and no keys are not allowed."""
-
-        with self.assertRaises(StreamlitAPIException) as ctx:
-            st.beta_form(submit_label="foo")
-            st.beta_form(submit_label="foo")
-
-        self.assertIn(
-            "There are multiple identical forms with the same generated key.",
-            str(ctx.exception),
-        )
-
-    def test_multiple_forms_different_labels_no_keys(self):
-        """Test that multiple forms with different labels and no keys are allowed."""
-
-        try:
-            st.beta_form(submit_label="foo")
-            st.beta_form(submit_label="bar")
-
-        except Exception:
-            self.fail("Forms with different labels and no keys failed to create.")
-
-    def test_multiple_forms_no_labels_same_keys(self):
-        """Test that multiple forms with no labels and same keys are not allowed."""
+    def test_multiple_forms_same_key(self):
+        """Multiple forms with the same key are not allowed."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
             st.beta_form(key="foo")
@@ -71,7 +35,7 @@ class FormTest(testutil.DeltaGeneratorTestCase):
         )
 
     def test_multiple_forms_same_labels_different_keys(self):
-        """Test that multiple forms with same labels and no keys are allowed."""
+        """Multiple forms with different keys are allowed."""
 
         try:
             st.beta_form(key="foo")
@@ -84,8 +48,8 @@ class FormTest(testutil.DeltaGeneratorTestCase):
         """Test that forms cannot be nested in other forms."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
-            with st.beta_form():
-                with st.beta_form():
+            with st.beta_form("foo"):
+                with st.beta_form("bar"):
                     pass
 
         self.assertEqual(str(ctx.exception), "Forms cannot be nested in other forms.")
@@ -94,7 +58,7 @@ class FormTest(testutil.DeltaGeneratorTestCase):
         """Test that buttons are not allowed in forms."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
-            with st.beta_form():
+            with st.beta_form("foo"):
                 st.button("foo")
 
         self.assertEqual(str(ctx.exception), "Button can't be used in a form.")
@@ -103,56 +67,19 @@ class FormTest(testutil.DeltaGeneratorTestCase):
         """Test that a form creates a block element with a correct id."""
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form(key="foo"):
             pass
 
-        # 2 elements will be created: a block, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
-
+        # Check that we create a form block element
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 1)
         form_proto = self.get_delta_from_queue(0).add_block
         self.assertIn("foo", form_proto.form_id)
 
     def test_form_block_data(self):
         """Test that a form creates a block element with correct data."""
 
-        form_data = st.beta_form(submit_label="foo", key="bar")._form_data
-
-        self.assertEqual(form_data.submit_button_label, "foo")
-        self.assertEqual(form_data.submit_button_key, "bar")
+        form_data = st.beta_form(key="bar")._form_data
         self.assertIn("bar", form_data.form_id)
-
-    def test_form_submit_button_with_default_label(self):
-        """Test that form creates a submit button with default label."""
-
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
-        with st.beta_form(key="foo"):
-            pass
-
-        # 2 elements will be created: a block, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
-
-        submit_button_proto = self.get_delta_from_queue(1).new_element.button
-        self.assertIn("foo", submit_button_proto.id)
-        self.assertEqual(submit_button_proto.label, "Submit")
-        self.assertEqual(submit_button_proto.is_form_submitter, True)
-
-    def test_form_submit_button_with_custom_label(self):
-        """Test that form creates a submit button with custom label."""
-
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
-        with st.beta_form(submit_label="foo", key="bar"):
-            pass
-
-        # 2 elements will be created: a block, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
-
-        submit_button_proto = self.get_delta_from_queue(1).new_element.button
-        self.assertIn("bar", submit_button_proto.id)
-        self.assertEqual(submit_button_proto.label, "foo")
-        self.assertEqual(submit_button_proto.is_form_submitter, True)
 
     # (HK) TODOs:
     # - columns inside a form

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -148,8 +148,6 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.multiselect("foo", ["bar", "baz"])
 

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -150,11 +150,11 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.multiselect("foo", ["bar", "baz"])
 
-        # 3 elements will be created: a block, a multiselect, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         multiselect_proto = self.get_delta_from_queue(1).new_element.multiselect

--- a/lib/tests/streamlit/number_input_test.py
+++ b/lib/tests/streamlit/number_input_test.py
@@ -208,11 +208,11 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.number_input("foo")
 
-        # 3 elements will be created: a block, a number input, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         number_input_proto = self.get_delta_from_queue(1).new_element.number_input

--- a/lib/tests/streamlit/number_input_test.py
+++ b/lib/tests/streamlit/number_input_test.py
@@ -206,8 +206,6 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.number_input("foo")
 

--- a/lib/tests/streamlit/radio_test.py
+++ b/lib/tests/streamlit/radio_test.py
@@ -123,11 +123,11 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.radio("foo", ["bar", "baz"])
 
-        # 3 elements will be created: a block, a radio button, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         radio_proto = self.get_delta_from_queue(1).new_element.radio

--- a/lib/tests/streamlit/radio_test.py
+++ b/lib/tests/streamlit/radio_test.py
@@ -121,8 +121,6 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.radio("foo", ["bar", "baz"])
 

--- a/lib/tests/streamlit/select_slider_test.py
+++ b/lib/tests/streamlit/select_slider_test.py
@@ -104,8 +104,6 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.select_slider("foo", ["bar", "baz"])
 

--- a/lib/tests/streamlit/select_slider_test.py
+++ b/lib/tests/streamlit/select_slider_test.py
@@ -106,11 +106,11 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.select_slider("foo", ["bar", "baz"])
 
-        # 3 elements will be created: a block, a select slider, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         select_slider_proto = self.get_delta_from_queue(1).new_element.slider

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -128,11 +128,11 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.selectbox("foo", ("bar", "baz"))
 
-        # 3 elements will be created: a block, a selectbox, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         selectbox_proto = self.get_delta_from_queue(1).new_element.selectbox

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -126,8 +126,6 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.selectbox("foo", ("bar", "baz"))
 

--- a/lib/tests/streamlit/slider_test.py
+++ b/lib/tests/streamlit/slider_test.py
@@ -195,8 +195,6 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.slider("foo")
 

--- a/lib/tests/streamlit/slider_test.py
+++ b/lib/tests/streamlit/slider_test.py
@@ -197,11 +197,11 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.slider("foo")
 
-        # 3 elements will be created: a block, a slider, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         slider_proto = self.get_delta_from_queue(1).new_element.slider

--- a/lib/tests/streamlit/text_area_test.py
+++ b/lib/tests/streamlit/text_area_test.py
@@ -63,8 +63,6 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.text_area("foo")
 

--- a/lib/tests/streamlit/text_area_test.py
+++ b/lib/tests/streamlit/text_area_test.py
@@ -65,11 +65,11 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.text_area("foo")
 
-        # 3 elements will be created: a block, a text area, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         text_area_proto = self.get_delta_from_queue(1).new_element.text_area

--- a/lib/tests/streamlit/text_input_test.py
+++ b/lib/tests/streamlit/text_input_test.py
@@ -79,11 +79,11 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
 
         # Calling `with` will invoke `__exit__` on `DeltaGenerator`
         # which in turn will create the submit button.
-        with st.beta_form():
+        with st.beta_form("form"):
             st.text_input("foo")
 
-        # 3 elements will be created: a block, a text input, and a submit button.
-        self.assertEqual(len(self.get_all_deltas_from_queue()), 3)
+        # 2 elements will be created: form block, widget
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
 
         form_proto = self.get_delta_from_queue(0).add_block
         text_input_proto = self.get_delta_from_queue(1).new_element.text_input

--- a/lib/tests/streamlit/text_input_test.py
+++ b/lib/tests/streamlit/text_input_test.py
@@ -77,8 +77,6 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
-        # Calling `with` will invoke `__exit__` on `DeltaGenerator`
-        # which in turn will create the submit button.
         with st.beta_form("form"):
             st.text_input("foo")
 


### PR DESCRIPTION
We no longer automatically create a form's submit button when exiting its decorator. Instead, there's a new function, `st.beta_submit_form_button` that you call to explicitly create the button.

- It's an error to call `st.beta_submit_form_button` outside of a form.
- It's _not_ an error to call `st.beta_submit_form_button` multiple times in a single form (though there probably isn't much point).
- Just like a regular button, `st.beta_submit_form_button` returns True on the rerun immediately after it's clicked, so you can check to see if your form was just submitted.
- The `st.beta_form` "key" param is now required, rather than optional. This key uniquely identifies the form. (Previously, we generated the form ID from the submit button's label, but that's no longer possible.)

(This includes changes from https://github.com/streamlit/streamlit/pull/3006, so that should be reviewed first.)