### PR TITLE
Add snippets about CSS vars and minimum streamlit-component-lib versions

### DIFF
--- a/docs/develop_streamlit_components.md
+++ b/docs/develop_streamlit_components.md
@@ -202,6 +202,12 @@ This template has much more code than its React sibling, in that all the mechani
 
 #### Working with Themes
 
+```eval_rst
+.. note::
+   Custom component theme support requires streamlit-component-lib version
+   1.2.0 or higher.
+```
+
 Along with sending an `args` object to your component, Streamlit also sends
 a `theme` object defining the active theme so that your component can adjust
 its styling in a compatible way. This object is sent in the same message as
@@ -233,6 +239,16 @@ automatically.
 --secondary-background-color
 --text-color
 --font
+```
+
+If you're not familiar with
+[CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties),
+the TLDR version is that you can use them like this:
+
+```css
+.mySelector {
+  color: var(--text-color);
+}
 ```
 
 These variables match the fields defined in the `theme` object above, and


### PR DESCRIPTION
The referenced GitHub issue points out that we don't have any examples
for how to actually use the CSS vars that we provide to custom
components. We actually have a snippet about this in our theming launch
blog post, so this commit just adds that bit here verbatim.

Additionally, this adds a note about the minimum supported
streamlit-component-lib version for theming compatibility. This feels a
bit weird to have to do since our docs are versioned, but I think it's
needed in this case since the streamlit-component-lib package version is
decoupled from the PyPI package version that the docs are tied to.

Fixes #2996
