### PR TITLE
[Security] Upgrade ssri to 8.0.1 or later

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -183,6 +183,7 @@
     "node-notifier": "^8.0.1",
     "minimist": "^0.2.1",
     "serialize-javascript": "^3.1.0",
+    "ssri": "^8.0.1",
     "static-eval": "^2.0.5",
     "websocket-extensions": "^0.1.4",
     "xmldom": "^0.5.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16976,14 +16976,7 @@ ssim.js@^3.1.1:
   resolved "https://registry.yarnpkg.com/ssim.js/-/ssim.js-3.5.0.tgz#d7276b9ee99b57a5ff0db34035f02f35197e62df"
   integrity sha512-Aj6Jl2z6oDmgYFFbQqK7fght19bXdOxY7Tj03nF+03M9gCBAjeIiO8/PlEGMfKDwYpw4q6iBqVq2YuREorGg/g==
 
-ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
-  dependencies:
-    figgy-pudding "^3.5.1"
-
-ssri@^8.0.0:
+ssri@^6.0.1, ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==


### PR DESCRIPTION
Details: https://github.com/advisories/GHSA-vx3p-948g-6vhq