### PR TITLE
Have MetricsManager enqueue events when disconnected

### DIFF
--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -120,7 +120,7 @@ export class MetricsManager {
   }
 
   public enqueue(evName: string, evData: Record<string, unknown> = {}): void {
-    if (!this.initialized) {
+    if (!this.initialized || !SessionInfo.isSet()) {
       this.pendingEvents.push([evName, evData])
       return
     }
@@ -129,6 +129,9 @@ export class MetricsManager {
       return
     }
 
+    if (this.pendingEvents.length) {
+      this.sendPendingEvents()
+    }
     this.send(evName, evData)
   }
 


### PR DESCRIPTION
Currently, MetricsManager only enqueues events when we attempt to send
them before it has been initialized, so trying to send an event when
MetricsManager was initialized but the app is disconnected from the
server results in an error being thrown.

This generally doesn't happen very much in practice (you see it from
time to time when developing streamlit itself when the react dev server
reloads files, but I'm not aware of any other instances where we run into
this).

Some of the theme metrics that I want to add, however, will run into
this when trying to record that a user changed their app's theme while
the app is disconnected, so this needs to be fixed before those metrics
can be added.

Closes #2958
