### PR TITLE
Add events to keep track of theme changes and other theme stats

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -448,6 +448,14 @@ export class App extends PureComponent<Props, State> {
           MetricsManager.current.getAndResetDeltaCounter()
         )
 
+        const { availableThemes, activeTheme } = this.props.theme
+        const customThemeDefined =
+          availableThemes.length > createPresetThemes().length
+        MetricsManager.current.enqueue("themeStats", {
+          activeThemeName: activeTheme.name,
+          customThemeDefined,
+        })
+
         const customComponentCounter = MetricsManager.current.getAndResetCustomComponentCounter()
         Object.entries(customComponentCounter).forEach(([name, count]) => {
           MetricsManager.current.enqueue("customComponentStats", {

--- a/frontend/src/components/core/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/SettingsDialog.tsx
@@ -24,8 +24,12 @@ import React, {
 import { ThemeConfig } from "theme"
 import Button, { Kind } from "components/shared/Button"
 import Modal, { ModalHeader, ModalBody } from "components/shared/Modal"
-import PageLayoutContext from "components/core/PageLayoutContext"
+import PageLayoutContext, {
+  Props as PageLayoutContextProps,
+} from "components/core/PageLayoutContext"
 import UISelectbox from "components/shared/Dropdown"
+import { MetricsManager } from "lib/MetricsManager"
+
 import {
   StyledCheckbox,
   StyledDialogBody,
@@ -169,7 +173,18 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
   }
 
   private handleThemeChange = (index: number): void => {
-    this.context.setTheme(this.context.availableThemes[index])
+    const {
+      activeTheme: oldTheme,
+      availableThemes,
+    }: PageLayoutContextProps = this.context
+    const newTheme = availableThemes[index]
+
+    MetricsManager.current.enqueue("themeChanged", {
+      oldThemeName: oldTheme.name,
+      newThemeName: newTheme.name,
+    })
+
+    this.context.setTheme(newTheme)
   }
 
   private handleCancelButtonClick = (): void => {


### PR DESCRIPTION
Note: This builds off #3011, so that PR should be reviewed first
(the changes are separate since they're logically distinct, but even the
two PRs combined are just a few lines of code).

With a few small issues with MetricsManager cleaned up, we can now
collect all the theme-related data points we wanted to.
