### PR TITLE
Call _repr_html_ when available

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -43,7 +43,7 @@ class WriteMixin:
 
         1. You can pass in multiple arguments, all of which will be written.
         2. Its behavior depends on the input types as follows.
-        3. It returns None, so it's "slot" in the App cannot be reused.
+        3. It returns None, so its "slot" in the App cannot be reused.
 
         Parameters
         ----------
@@ -60,7 +60,6 @@ class WriteMixin:
             - write(func)       : Displays information about a function.
             - write(module)     : Displays information about the module.
             - write(dict)       : Displays dict in an interactive widget.
-            - write(obj)        : The default is to print str(obj).
             - write(mpl_fig)    : Displays a Matplotlib figure.
             - write(altair)     : Displays an Altair chart.
             - write(keras)      : Displays a Keras model.
@@ -68,6 +67,8 @@ class WriteMixin:
             - write(plotly_fig) : Displays a Plotly figure.
             - write(bokeh_fig)  : Displays a Bokeh figure.
             - write(sympy_expr) : Prints SymPy expression using LaTeX.
+            - write(htmlable)   : Prints _repr_html_() for the object if available.
+            - write(obj)        : Prints str(obj) if otherwise unknown.
 
         unsafe_allow_html : bool
             This is a keyword-only argument that defaults to False.
@@ -217,6 +218,11 @@ class WriteMixin:
             elif type_util.is_pydeck(arg):
                 flush_buffer()
                 self.dg.pydeck_chart(arg)
+            elif hasattr(arg, '_repr_html_'):
+                self.dg.markdown(
+                    arg._repr_html_(),
+                    unsafe_allow_html=True,
+                )
             else:
                 string_buffer.append("`%s`" % str(arg).replace("`", "\\`"))
 

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -218,7 +218,7 @@ class WriteMixin:
             elif type_util.is_pydeck(arg):
                 flush_buffer()
                 self.dg.pydeck_chart(arg)
-            elif hasattr(arg, '_repr_html_'):
+            elif hasattr(arg, "_repr_html_"):
                 self.dg.markdown(
                     arg._repr_html_(),
                     unsafe_allow_html=True,

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -41,6 +41,7 @@ class StreamlitWriteTest(unittest.TestCase):
 
     def test_repr_html(self):
         """Test st.write with an object that defines _repr_html_."""
+
         class FakeHTMLable(object):
             def _repr_html_(self):
                 return "<strong>hello world</strong>"
@@ -48,7 +49,9 @@ class StreamlitWriteTest(unittest.TestCase):
         with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:
             st.write(FakeHTMLable())
 
-            p.assert_called_once_with("<strong>hello world</strong>", unsafe_allow_html=True)
+            p.assert_called_once_with(
+                "<strong>hello world</strong>", unsafe_allow_html=True
+            )
 
     def test_string(self):
         """Test st.write with a string."""

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -39,6 +39,17 @@ class StreamlitWriteTest(unittest.TestCase):
     trying to check is that the right st.* method gets called
     """
 
+    def test_repr_html(self):
+        """Test st.write with an object that defines _repr_html_."""
+        class FakeHTMLable(object):
+            def _repr_html_(self):
+                return "<strong>hello world</strong>"
+
+        with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:
+            st.write(FakeHTMLable())
+
+            p.assert_called_once_with("<strong>hello world</strong>", unsafe_allow_html=True)
+
     def test_string(self):
         """Test st.write with a string."""
         with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:


### PR DESCRIPTION
**Issue:** Closes #1117.

**Description:**

If an object passed to `st.write()` has a function `_repr_html_`, write its output as unsafe HTML.