### PR TITLE
[Security] Upgrade y18n to 4.0.1 or later

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -188,7 +188,8 @@
     "ssri": "^8.0.1",
     "static-eval": "^2.0.5",
     "websocket-extensions": "^0.1.4",
-    "xmldom": "^0.5.0"
+    "xmldom": "^0.5.0",
+    "y18n": "^4.0.1"
   },
   "browserslist": [
     ">0.2%",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -19595,15 +19595,10 @@ xxhashjs@^0.2.2:
   dependencies:
     cuint "^0.2.2"
 
-y18n@^4.0.0:
+y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.1, y18n@^5.0.5:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
-
-y18n@^5.0.1, y18n@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
-  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Details: https://github.com/advisories/GHSA-c4w7-xm78-47vh