### PR TITLE
streamlit.secrets is no longer beta

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -45,6 +45,7 @@ For more detailed info, see https://docs.streamlit.io.
 # Must be at the top, to avoid circular dependency.
 from streamlit import logger as _logger
 from streamlit import config as _config
+from streamlit.beta_util import object_beta_warning
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.secrets import Secrets, SECRETS_FILE_LOC
 
@@ -106,6 +107,8 @@ _config.on_config_parsed(_update_logger, True)
 _main = _DeltaGenerator(root_container=RootContainer.MAIN)
 sidebar = _DeltaGenerator(root_container=RootContainer.SIDEBAR, parent=_main)
 
+secrets = Secrets(SECRETS_FILE_LOC)
+
 # DeltaGenerator methods:
 
 altair_chart = _main.altair_chart
@@ -162,44 +165,12 @@ color_picker = _main.color_picker
 get_option = _config.get_option
 from streamlit.commands.page_config import set_page_config
 
-
-def _beta_warning(func, date):
-    """Wrapper for functions that are no longer in beta.
-
-    Wrapped functions will run as normal, but then proceed to show an st.warning
-    saying that the beta_ version will be removed in ~3 months.
-
-    Parameters
-    ----------
-    func: function
-        The `st.` function that used to be in beta.
-
-    date: str
-        A date like "2020-01-01", indicating the last day we'll guarantee
-        support for the beta_ prefix.
-    """
-
-    def wrapped(*args, **kwargs):
-        # Note: Since we use a wrapper, beta_ functions will not autocomplete
-        # correctly on VSCode.
-        result = func(*args, **kwargs)
-        warning(
-            f"`st.{func.__name__}` has graduated out of beta. "
-            + f"On {date}, the beta_ version will be removed.\n\n"
-            + f"Before then, update your code from `st.beta_{func.__name__}` to `st.{func.__name__}`."
-        )
-        return result
-
-    # Update the wrapped func's name & docstring so st.help does the right thing
-    wrapped.__name__ = "beta_" + func.__name__
-    wrapped.__doc__ = func.__doc__
-    return wrapped
-
+# Beta APIs
 
 beta_container = _main.beta_container
 beta_expander = _main.beta_expander
 beta_columns = _main.beta_columns
-beta_secrets = Secrets(SECRETS_FILE_LOC)
+beta_secrets = object_beta_warning(secrets, "secrets", "2021-06-30")
 
 
 def set_option(key, value):

--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -94,6 +94,10 @@ def object_beta_warning(obj, obj_name, date):
                 )
 
         def __getattr__(self, attr):
+            # We handle __getattr__ separately from our other magic
+            # functions. The wrapped class may not actually implement it,
+            # but we still need to implement it to call all its normal
+            # functions.
             if attr in self.__dict__:
                 return getattr(self, attr)
 
@@ -104,7 +108,7 @@ def object_beta_warning(obj, obj_name, date):
         def _get_magic_functions(cls) -> List[str]:
             # ignore the handful of magic functions we cannot override without
             # breaking the Wrapper.
-            ignore = ("__class__", "__dict__", "__getattribute__")
+            ignore = ("__class__", "__dict__", "__getattribute__", "__getattr__")
             return [
                 name
                 for name in dir(cls)

--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
+
 import streamlit
 
 
@@ -74,6 +76,10 @@ def object_beta_warning(obj, obj_name, date):
     class Wrapper:
         def __init__(self, obj):
             self._obj = obj
+
+        def __getitem__(self, key):
+            _show_beta_warning(obj_name, date)
+            return operator.getitem(self._obj, key)
 
         def __getattr__(self, attr):
             if attr in self.__dict__:

--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -31,7 +31,7 @@ def function_beta_warning(func, date):
 
     Parameters
     ----------
-    func: function
+    func: callable
         The `st.` function that used to be in beta.
 
     date: str

--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -73,6 +73,14 @@ def object_beta_warning(obj, obj_name, date):
         support for the beta_ prefix.
     """
 
+    has_shown_beta_warning = False
+
+    def show_wrapped_obj_warning():
+        nonlocal has_shown_beta_warning
+        if not has_shown_beta_warning:
+            has_shown_beta_warning = True
+            _show_beta_warning(obj_name, date)
+
     class Wrapper:
         def __init__(self, obj):
             self._obj = obj
@@ -89,13 +97,13 @@ def object_beta_warning(obj, obj_name, date):
             if attr in self.__dict__:
                 return getattr(self, attr)
 
-            _show_beta_warning(obj_name, date)
+            show_wrapped_obj_warning()
             return getattr(self._obj, attr)
 
         @staticmethod
         def _get_magic_functions(cls) -> List[str]:
-            # "ignore" contains the handful of magic functions we cannot
-            # override without breaking the Wrapper.
+            # ignore the handful of magic functions we cannot override without
+            # breaking the Wrapper.
             ignore = ("__class__", "__dict__", "__getattribute__")
             return [
                 name
@@ -106,7 +114,7 @@ def object_beta_warning(obj, obj_name, date):
         @staticmethod
         def _make_magic_function_proxy(name):
             def proxy(self, *args):
-                _show_beta_warning(obj_name, date)
+                show_wrapped_obj_warning()
                 return getattr(self._obj, name)
 
             return proxy

--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -1,0 +1,87 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit
+
+
+def _show_beta_warning(name: str, date: str) -> None:
+    streamlit.warning(
+        f"`st.{name}` has graduated out of beta. "
+        + f"On {date}, the beta_ version will be removed.\n\n"
+        + f"Before then, update your code from `st.beta_{name}` to `st.{name}`."
+    )
+
+
+def function_beta_warning(func, date):
+    """Wrapper for functions that are no longer in beta.
+
+    Wrapped functions will run as normal, but then proceed to show an st.warning
+    saying that the beta_ version will be removed in ~3 months.
+
+    Parameters
+    ----------
+    func: function
+        The `st.` function that used to be in beta.
+
+    date: str
+        A date like "2020-01-01", indicating the last day we'll guarantee
+        support for the beta_ prefix.
+    """
+
+    def wrapped_func(*args, **kwargs):
+        # Note: Since we use a wrapper, beta_ functions will not autocomplete
+        # correctly on VSCode.
+        result = func(*args, **kwargs)
+        _show_beta_warning(func.__name__, date)
+        return result
+
+    # Update the wrapped func's name & docstring so st.help does the right thing
+    wrapped_func.__name__ = "beta_" + func.__name__
+    wrapped_func.__doc__ = func.__doc__
+    return wrapped_func
+
+
+def object_beta_warning(obj, obj_name, date):
+    """Wrapper for objects that are no longer in beta.
+
+    Wrapped objects will run as normal, but then proceed to show an st.warning
+    saying that the beta_ version will be removed in ~3 months.
+
+    Parameters
+    ----------
+    obj: Any
+        The `st.` object that used to be in beta.
+
+    obj_name: str
+        The name of the object within __init__.py
+
+    date: str
+        A date like "2020-01-01", indicating the last day we'll guarantee
+        support for the beta_ prefix.
+    """
+
+    class Wrapper:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def __getattr__(self, attr):
+            if attr in self.__dict__:
+                return getattr(self, attr)
+
+            if not attr.startswith("_"):
+                _show_beta_warning(obj_name, date)
+
+            return getattr(self._obj, attr)
+
+    return Wrapper(obj)

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -25,7 +25,7 @@ from streamlit import config
 from streamlit import net_util
 from streamlit import url_util
 from streamlit import env_util
-from streamlit import beta_secrets
+from streamlit import secrets
 from streamlit import util
 from streamlit.config import CONFIG_FILENAMES
 from streamlit.report import Report
@@ -145,7 +145,7 @@ def _on_server_start(server):
     # function will return without raising an exception. We catch any parse
     # errors and display them here.
     try:
-        beta_secrets.load_if_toml_exists()
+        secrets.load_if_toml_exists()
     except BaseException as e:
         LOGGER.error(f"Failed to load {SECRETS_FILE_LOC}", exc_info=e)
 

--- a/lib/streamlit/secrets.py
+++ b/lib/streamlit/secrets.py
@@ -19,8 +19,8 @@ from typing import Any, Optional, Mapping
 import toml
 
 import streamlit as st
+import streamlit.watcher.file_watcher
 from streamlit.logger import get_logger
-from streamlit.watcher.file_watcher import watch_file
 
 LOGGER = get_logger(__name__)
 SECRETS_FILE_LOC = os.path.abspath(os.path.join(".", ".streamlit", "secrets.toml"))
@@ -132,7 +132,7 @@ class Secrets(Mapping[str, Any]):
             # We force our watcher_type to 'poll' because Streamlit Sharing
             # stores `secrets.toml` in a virtual filesystem that is
             # incompatible with watchdog.
-            watch_file(
+            streamlit.watcher.file_watcher.watch_file(
                 self._file_path,
                 self._on_secrets_file_changed,
                 watcher_type="poll",

--- a/lib/tests/streamlit/beta_util_test.py
+++ b/lib/tests/streamlit/beta_util_test.py
@@ -1,0 +1,47 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from streamlit.beta_util import function_beta_warning, object_beta_warning
+
+
+class BetaUtilTest(unittest.TestCase):
+    @patch("streamlit.warning")
+    def test_function_beta_warning(self, mock_warning):
+        def multiply(a, b):
+            return a * b
+
+        beta_multiply = function_beta_warning(multiply, "1980-01-01")
+
+        self.assertEqual(beta_multiply(3, 2), 6)
+        mock_warning.assert_called_once_with(
+            "`st.multiply` has graduated out of beta. On 1980-01-01, the beta_ version will be removed."
+            "\n\nBefore then, update your code from `st.beta_multiply` to `st.multiply`."
+        )
+
+    @patch("streamlit.warning")
+    def test_object_beta_warning(self, mock_warning):
+        class Multiplier:
+            def multiply(self, a, b):
+                return a * b
+
+        beta_multiplier = object_beta_warning(Multiplier(), "multiplier", "1980-01-01")
+
+        self.assertEqual(beta_multiplier.multiply(3, 2), 6)
+        mock_warning.assert_called_once_with(
+            "`st.multiplier` has graduated out of beta. On 1980-01-01, the beta_ version will be removed."
+            "\n\nBefore then, update your code from `st.beta_multiplier` to `st.multiplier`."
+        )

--- a/lib/tests/streamlit/beta_util_test.py
+++ b/lib/tests/streamlit/beta_util_test.py
@@ -38,10 +38,20 @@ class BetaUtilTest(unittest.TestCase):
             def multiply(self, a, b):
                 return a * b
 
+            def __getitem__(self, key):
+                return "item!"
+
         beta_multiplier = object_beta_warning(Multiplier(), "multiplier", "1980-01-01")
 
-        self.assertEqual(beta_multiplier.multiply(3, 2), 6)
-        mock_warning.assert_called_once_with(
+        expected_warning = (
             "`st.multiplier` has graduated out of beta. On 1980-01-01, the beta_ version will be removed."
             "\n\nBefore then, update your code from `st.beta_multiplier` to `st.multiplier`."
         )
+
+        self.assertEqual(beta_multiplier.multiply(3, 2), 6)
+        mock_warning.assert_called_once_with(expected_warning)
+
+        mock_warning.reset_mock()
+
+        self.assertEqual(beta_multiplier["asdf"], "item!")
+        mock_warning.assert_called_once_with(expected_warning)

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -311,14 +311,14 @@ class BootstrapPrintTest(unittest.TestCase):
             },
         )
 
-    @patch("streamlit.bootstrap.beta_secrets.load_if_toml_exists")
+    @patch("streamlit.bootstrap.secrets.load_if_toml_exists")
     def test_load_secrets(self, mock_load_secrets):
         """We should load secrets.toml on startup."""
         bootstrap._on_server_start(Mock())
         mock_load_secrets.assert_called_once()
 
     @patch("streamlit.bootstrap.LOGGER.error")
-    @patch("streamlit.bootstrap.beta_secrets.load_if_toml_exists")
+    @patch("streamlit.bootstrap.secrets.load_if_toml_exists")
     def test_log_secret_load_error(self, mock_load_secrets, mock_log_error):
         """If secrets throws an error on startup, we catch and log it."""
         mock_exception = Exception("Secrets exploded!")


### PR DESCRIPTION
`st.beta_secrets` is now `st.secrets`. Calling `st.beta_secrets` will show a deprecation warning.

This also moves the `_beta_warning` utility function into a new `beta_util.py` file, and adds a new function (`object_beta_warning`) for wrapping objects that have graduated from beta.