### PR TITLE
Downgrade st.warning in local_sources_watcher to a log

### DIFF
--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -20,7 +20,6 @@ import types
 
 from streamlit import config
 from streamlit import file_util
-from streamlit import warning
 from streamlit.folder_black_list import FolderBlackList
 
 from streamlit.logger import get_logger
@@ -173,7 +172,7 @@ def get_module_paths(module: types.ModuleType) -> t.Set[str]:
         except AttributeError:
             pass
         except Exception as e:
-            warning(f"Examining the path of {module.__name__} raised {e}")
+            LOGGER.warning(f"Examining the path of {module.__name__} raised: {e}")
 
         all_paths.update([str(p) for p in potential_paths if _is_valid_path(p)])
     return all_paths

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -155,8 +155,9 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         fob.assert_called_once()
 
+    @patch("streamlit.watcher.local_sources_watcher.LOGGER")
     @patch("streamlit.watcher.local_sources_watcher.FileWatcher")
-    def test_misbehaved_module(self, fob, _):
+    def test_misbehaved_module(self, fob, patched_logger, _):
         lso = local_sources_watcher.LocalSourcesWatcher(REPORT, NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -166,6 +167,10 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         lso.update_watched_modules()
 
         fob.assert_called_once()  # Just __init__.py
+
+        patched_logger.warning.assert_called_once_with(
+            "Examining the path of MisbehavedModule raised: Oh noes!"
+        )
 
     @patch("streamlit.watcher.local_sources_watcher.FileWatcher")
     def test_nested_module_parent_unloaded(self, fob, _):


### PR DESCRIPTION
I ran into some trouble trying to call st.warning outside of code run by
the ScriptRunner, which made me remember that some code changed in a
recent PR (#3001) did just that.

I double-checked that this code indeed doesn't work as calls that
end up sending Delta protos rely on a ReportContext, which isn't
available in the LocalSourcesWatcher.

Since we can't present the warning in Streamlit itself (which would be
ideal), I just downgraded this to be a warning log for now.
