### PR TITLE
Set genericColors properly and make theme defs more consistent

### DIFF
--- a/frontend/src/theme/darkTheme/index.ts
+++ b/frontend/src/theme/darkTheme/index.ts
@@ -16,14 +16,16 @@
  */
 
 import baseTheme from "../baseTheme"
-// TODO: figure out colors for dark mode
 import genericColors from "./themeColors"
 import { createEmotionColors } from "../utils"
 
 export default {
   ...baseTheme,
   inSidebar: false,
-  genericColors,
+  genericColors: {
+    ...baseTheme.genericColors,
+    ...genericColors,
+  },
   colors: createEmotionColors({
     ...baseTheme.colors,
     ...genericColors,

--- a/frontend/src/theme/lightTheme/index.ts
+++ b/frontend/src/theme/lightTheme/index.ts
@@ -16,13 +16,16 @@
  */
 
 import baseTheme from "../baseTheme"
-// TODO: figure out what colors go in base vs light
 import genericColors from "./themeColors"
 import { createEmotionColors } from "../utils"
 
 export default {
   ...baseTheme,
   inSidebar: false,
+  genericColors: {
+    ...baseTheme.genericColors,
+    ...genericColors,
+  },
   colors: createEmotionColors({
     ...baseTheme.colors,
     ...genericColors,

--- a/frontend/src/theme/themeConfigs.ts
+++ b/frontend/src/theme/themeConfigs.ts
@@ -32,6 +32,7 @@ export const lightTheme: ThemeConfig = {
   emotion: light,
   baseweb: LightTheme,
   basewebTheme: lightBaseUITheme,
+  primitives: lightThemePrimitives,
 }
 
 export const createAutoTheme = (): ThemeConfig => ({

--- a/frontend/src/theme/types.ts
+++ b/frontend/src/theme/types.ts
@@ -30,7 +30,7 @@ export type ThemeConfig = {
   // create separate themes for in the children. Currently required to accomodate
   // sidebar theming.
   basewebTheme: typeof lightBaseUITheme
-  primitives?: typeof lightThemePrimitives
+  primitives: typeof lightThemePrimitives
 }
 type IconSizes = typeof base.iconSizes
 type ThemeSpacings = typeof base.spacing


### PR DESCRIPTION
We were previously incorrectly reexporting `baseTheme.genericColors` from
`lightTheme` instead of overwriting the colors that get changed in
`lightTheme`. Thankfully, this doesn't make a difference in the light
theme itself but can cause subtle differences in custom themes.
