### PR TITLE
Extend docstring of `st.image` to include filepath option

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -59,6 +59,7 @@ class ImageMixin:
             OR a color image of shape (w,h,3)
             OR an RGBA image of shape (w,h,4)
             OR a URL to fetch the image from
+            OR a path of a local image file
             OR an SVG XML string like `<svg xmlns=...</svg>`
             OR a list of one of the above, to display multiple images.
         caption : str or list of str


### PR DESCRIPTION
## Before contributing (PLEASE READ!)

⚠️ **If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer and tag @nthmost, then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers, and (4) your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** One line change.

**Description:** `st.image` accepts the path to an image file, which is not documented in the docstring. I added it, feel free to change the wording. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
