### PR TITLE
Small fix for `make pylint` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ pipenv-test-install: lib/test-requirements.txt
 # "linting"; we're not checking anything but code style.)
 pylint:
 	if command -v "black" > /dev/null; then \
-		$(BLACK) --check docs/ ; \
-		$(BLACK) --check examples/ ; \
-		$(BLACK) --check lib/streamlit/ --exclude=/*_pb2.py$/ ; \
-		$(BLACK) --check lib/tests/ ; \
+		$(BLACK) --check docs/ && \
+		$(BLACK) --check examples/ && \
+		$(BLACK) --check lib/streamlit/ --exclude=/*_pb2.py$/ && \
+		$(BLACK) --check lib/tests/ && \
 		$(BLACK) --check e2e/scripts/ ; \
 	fi
 

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -142,7 +142,7 @@ class RunningCursor(Cursor):
             root_container=self._root_container,
             parent_path=self._parent_path,
             index=self._index,
-            **props
+            **props,
         )
 
         self._index += 1
@@ -156,7 +156,7 @@ class LockedCursor(Cursor):
         root_container: int,
         parent_path: Tuple[int, ...] = (),
         index: int = 0,
-        **props
+        **props,
     ):
         """A locked pointer to a location in the app.
 

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -431,9 +431,12 @@ class ScriptRunnerTest(AsyncTestCase):
 
         # The cached functions should not have been called on this second run,
         # except for the one that has actually changed.
-        self._assert_text_deltas(runner, [
-            "cached_depending_on_not_yet_defined called",
-        ])
+        self._assert_text_deltas(
+            runner,
+            [
+                "cached_depending_on_not_yet_defined called",
+            ],
+        )
 
     def _assert_no_exceptions(self, scriptrunner):
         """Asserts that no uncaught exceptions were thrown in the


### PR DESCRIPTION
Hi @kmcgrady,

This is a small drive-by fix for an issue where the `pylint` command would previously fail internally but still give a 0 exit status, and therefore not raise an issue within the CI.