### PR TITLE
Collect GC between script runs

### DIFF
--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -14,6 +14,7 @@
 
 import sys
 import threading
+import gc
 from contextlib import contextmanager
 from enum import Enum
 
@@ -352,6 +353,13 @@ class ScriptRunner(object):
             # delete expired files now that the script has run and files in use
             # are marked as active
             media_file_manager.del_expired_files()
+
+            # Force garbage collection to run, to help avoid memory use building up
+            # This is usually not an issue, but sometimes GC takes time to kick in and
+            # causes apps to go over resource limits, and forcing it to run between
+            # script runs is low cost, since we aren't doing much work anyway.
+            # Collecting gen 2 seems to cause test failures, so only collect 0 and 1.
+            gc.collect(1)
 
         # Use _log_if_error() to make sure we never ever ever stop running the
         # script without meaning to.


### PR DESCRIPTION
@jrieke brought up a problem with apps exceeding their resource limits, and that this is more or less fixed by running GC. This PR calls GC after each script run, to save users from having to do this.

Running the GC for all gens causes one of the script runner tests to fail, which doesn't make any sense, so there is probably a bug lurking in the code, probably related to threading. The issue doesn't appear when only collecting gens 0 and 1, so hopefully doing that is safe in practice while still providing benefits.