### PR TITLE
Don't accidentally mutate the light/dark theme when creating a new one

### DIFF
--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -203,6 +203,7 @@ describe("createTheme", () => {
       darkTheme.emotion.colors.bgColor
     )
     expect(customTheme.emotion.inSidebar).toBe(true)
+    expect(darkTheme.emotion.inSidebar).toBe(false)
   })
 
   it("handles hex values without #", () => {

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -22,6 +22,7 @@ import { ThemePrimitives, Theme as BaseTheme } from "baseui/theme"
 import { getLuminance, darken, lighten, mix, transparentize } from "color2k"
 import camelcase from "camelcase"
 import decamelize from "decamelize"
+import cloneDeep from "lodash/cloneDeep"
 import merge from "lodash/merge"
 
 import { CustomThemeConfig, ICustomThemeConfig } from "src/autogen/proto"
@@ -434,9 +435,7 @@ export const createTheme = (
   // themeInput.base === LIGHT and themeInput.backgroundColor === "black".
   const bgColor = themeInput.backgroundColor as string
   const startingTheme = merge(
-    {
-      ...(getLuminance(bgColor) > 0.5 ? lightTheme : darkTheme),
-    },
+    cloneDeep(getLuminance(bgColor) > 0.5 ? lightTheme : darkTheme),
     { emotion: { inSidebar } }
   )
 


### PR DESCRIPTION
It turns out that we were accidentally mutating the "starterTheme"'s
`emotion.inSidebar` field since the spread operator only does a shallow
copy, and `lodash/merge` mutates the target object. This resulted in a
spacing bug where, when a custom theme is set, the base theme for it
(which depends on the background color of the custom theme) has weird
spacing since it has `emotion.inSidebar` set to true for it, even in the
main content area.