### PR TITLE
Drop size of cached themes and recompute full themes from them

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -229,11 +229,11 @@ describe("App.handleNewReport", () => {
     window.localStorage.clear()
   })
 
-  it("adds the custom theme from the server to the list of available themes", () => {
+  it("respects the user's theme preferencece if set, but adds custom theme as an option", () => {
     const props = getProps()
     window.localStorage.setItem(
       LocalStore.ACTIVE_THEME,
-      JSON.stringify(lightTheme)
+      JSON.stringify({ name: lightTheme.name })
     )
     const wrapper = shallow(<App {...props} />)
 
@@ -269,7 +269,7 @@ describe("App.handleNewReport", () => {
   it("sets the custom theme again if a custom theme is already active", () => {
     window.localStorage.setItem(
       LocalStore.ACTIVE_THEME,
-      JSON.stringify({ ...lightTheme, name: CUSTOM_THEME_NAME })
+      JSON.stringify({ name: CUSTOM_THEME_NAME, themeInput: {} })
     )
     const props = getProps()
     props.theme.activeTheme = {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,8 +78,9 @@ import {
   createAutoTheme,
   createPresetThemes,
   createTheme,
-  ThemeConfig,
   getCachedTheme,
+  isPresetTheme,
+  ThemeConfig,
 } from "src/theme"
 
 import { StyledApp } from "./styled-components"
@@ -614,12 +615,7 @@ export class App extends PureComponent<Props, State> {
     }
     this.setState({ themeHash })
 
-    const presetThemeNames = createPresetThemes().map(
-      (t: ThemeConfig) => t.name
-    )
-    const usingCustomTheme = !presetThemeNames.includes(
-      this.props.theme.activeTheme.name
-    )
+    const usingCustomTheme = !isPresetTheme(this.props.theme.activeTheme)
 
     if (themeInput) {
       const customTheme = createTheme(CUSTOM_THEME_NAME, themeInput)

--- a/frontend/src/lib/storageUtils.ts
+++ b/frontend/src/lib/storageUtils.ts
@@ -1,3 +1,11 @@
+// Note: Cached themes before version 1 were simply stored with key equal to
+// CACHED_THEME_BASE_KEY (with no version number).
+const CACHED_THEME_VERSION = 1
+const CACHED_THEME_BASE_KEY = `stActiveTheme-${window.location.pathname}`
+
 export const LocalStore = {
-  ACTIVE_THEME: `stActiveTheme-${window.location.pathname}`,
+  CACHED_THEME_VERSION,
+  CACHED_THEME_BASE_KEY,
+
+  ACTIVE_THEME: `${CACHED_THEME_BASE_KEY}-v${CACHED_THEME_VERSION}`,
 }

--- a/frontend/src/theme/types.ts
+++ b/frontend/src/theme/types.ts
@@ -16,10 +16,14 @@
  */
 
 import { LightTheme, lightThemePrimitives } from "baseui"
+
+import { CustomThemeConfig } from "src/autogen/proto"
+
 import base from "./baseTheme"
 import { lightBaseUITheme } from "./baseui"
 
 export type Theme = typeof base
+
 export type ThemeConfig = {
   name: string
   emotion: Theme
@@ -32,6 +36,13 @@ export type ThemeConfig = {
   basewebTheme: typeof lightBaseUITheme
   primitives: typeof lightThemePrimitives
 }
+
+export type CachedTheme = {
+  name: string
+
+  themeInput?: Partial<CustomThemeConfig>
+}
+
 type IconSizes = typeof base.iconSizes
 type ThemeSpacings = typeof base.spacing
 type ThemeColors = typeof base.colors


### PR DESCRIPTION
  This fixes two issues that currently exist with cached themes that don't
  currently manifest, but would eventually be problematic if left unfixed.

  1. We cache the full theme, which is huge (order of tens of kilobytes)
     compared to the minimal representation of the actually-configurable
     parts of a theme. This change only stores the configurable pieces
     and recomputes the rest, which shrinks the size of what we're
     storing to a few hundred bytes.
  2. Newly added derived theme colors may not exist in a cached theme,
     which causes weird visual bugs until the theme is changed and
     derived colors are recomputed. This is no longer an issue since
     we're storing a minimal representation of a cached theme and
     recomputing the rest.