### PR TITLE
Release 0.80.0

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,6 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,20 @@ This page lists highlights, bug fixes, and known issues for official Streamlit r
       $ pip install --upgrade streamlit
 ```
 
+## Version 0.80.0
+
+_Release date: Apr 8, 2021_
+
+- 🔐 Streamlit now support Secrets management for apps deployed to Streamlit Sharing! Check out our blog post (add link)
+- ⚓️ Titles and headers now come with automatically generated anchor links. Just hover over any title and click the 🔗 to get the link!
+
+**Other changes**
+
+- Added `allow-downloads` capability to custom components ([#3040](https://github.com/streamlit/streamlit/issues/3040))
+- Fixed a markdown tables in dark theme ([#3020](https://github.com/streamlit/streamlit/issues/3020))
+- Improved color picker widget in the Custom Theme dialog ([#2970](https://github.com/streamlit/streamlit/issues/2970))
+- Fixed bugs in horizontal layouts ([#2880](https://github.com/streamlit/streamlit/issues/2880))
+
 ## Version 0.79.0
 
 _Release date: Mar 18, 2021_

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,7 +20,9 @@ This page lists highlights, bug fixes, and known issues for official Streamlit r
 
 _Release date: Apr 8, 2021_
 
-- 🔐 Streamlit now support Secrets management for apps deployed to Streamlit Sharing! Check out our blog post (add link)
+**Highlights**
+
+- 🔐 Streamlit now support Secrets management for apps deployed to Streamlit Sharing!
 - ⚓️ Titles and headers now come with automatically generated anchor links. Just hover over any title and click the 🔗 to get the link!
 
 **Other changes**
@@ -28,7 +30,6 @@ _Release date: Apr 8, 2021_
 - Added `allow-downloads` capability to custom components ([#3040](https://github.com/streamlit/streamlit/issues/3040))
 - Fixed a markdown tables in dark theme ([#3020](https://github.com/streamlit/streamlit/issues/3020))
 - Improved color picker widget in the Custom Theme dialog ([#2970](https://github.com/streamlit/streamlit/issues/2970))
-- Fixed bugs in horizontal layouts ([#2880](https://github.com/streamlit/streamlit/issues/2880))
 
 ## Version 0.79.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,7 @@ _Release date: Apr 8, 2021_
 **Other changes**
 
 - Added `allow-downloads` capability to custom components ([#3040](https://github.com/streamlit/streamlit/issues/3040))
-- Fixed a markdown tables in dark theme ([#3020](https://github.com/streamlit/streamlit/issues/3020))
+- Fixed markdown tables in dark theme ([#3020](https://github.com/streamlit/streamlit/issues/3020))
 - Improved color picker widget in the Custom Theme dialog ([#2970](https://github.com/streamlit/streamlit/issues/2970))
 
 ## Version 0.79.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 mypy-protobuf==1.20
 pipenv==2018.11.26
 recommonmark==0.6.0
-Sphinx>=3.2
+Sphinx==3.0.3
 sphinx-rtd-theme==0.4.3
 sphinx_markdown_tables==0.0.12
+docutils==0.16

--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -35,7 +35,7 @@ pip install --upgrade streamlit
 streamlit version
 ```
 
-...and then verify that the version number printed is `0.79.0`.
+...and then verify that the version number printed is `0.80.0`.
 
 **Try reproducing the issue now.** If not fixed, keep reading on.
 

--- a/e2e/scripts/st_header.py
+++ b/e2e/scripts/st_header.py
@@ -15,3 +15,4 @@
 import streamlit as st
 
 st.header("This header is awesome!")
+st.header("This header is awesome too!", anchor="awesome-header")

--- a/e2e/scripts/st_markdown.py
+++ b/e2e/scripts/st_markdown.py
@@ -36,6 +36,10 @@ $$
 """
 )
 
+st.markdown("# Some header 1")
+st.markdown("## Some header 2")
+st.markdown("### Some header 3")
+
 st.markdown(
     """
 | Col1      | Col2        |

--- a/e2e/scripts/st_subheader.py
+++ b/e2e/scripts/st_subheader.py
@@ -15,3 +15,4 @@
 import streamlit as st
 
 st.subheader("This subheader is awesome!")
+st.subheader("This subheader is awesome too!", anchor="awesome-subheader")

--- a/e2e/scripts/st_title.py
+++ b/e2e/scripts/st_title.py
@@ -15,3 +15,4 @@
 import streamlit as st
 
 st.title("This title is awesome!")
+st.title("This title is awesome too!", anchor="awesome-title")

--- a/e2e/specs/st_header.spec.js
+++ b/e2e/specs/st_header.spec.js
@@ -20,10 +20,21 @@ describe("st.header", () => {
     cy.visit("http://localhost:3000/");
   });
 
+  it("displays correct number of elements", () => {
+    cy.get(".element-container .stMarkdown h2").should("have.length", 2);
+  });
+
   it("displays a header", () => {
-    cy.get(".element-container .stMarkdown h2").should(
-      "contain",
-      "This header is awesome!"
-    );
+    cy.get(".element-container .stMarkdown h2").then(els => {
+      expect(els[0].textContent).to.eq("This header is awesome!");
+      expect(els[1].textContent).to.eq("This header is awesome too!");
+    });
+  });
+
+  it("displays headers with anchors", () => {
+    cy.get(".element-container .stMarkdown h2").then(els => {
+      cy.wrap(els[0]).should("have.attr", "id", "this-header-is-awesome");
+      cy.wrap(els[1]).should("have.attr", "id", "awesome-header");
+    });
   });
 });

--- a/e2e/specs/st_markdown.spec.js
+++ b/e2e/specs/st_markdown.spec.js
@@ -18,10 +18,16 @@
 describe("st.markdown", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
+
+    // Make the ribbon decoration line disappear
+    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+  });
+
+  it("displays correct number of elements", () => {
+    cy.get(".element-container .stMarkdown").should("have.length", 12);
   });
 
   it("displays markdown", () => {
-    cy.get(".element-container .stMarkdown").should("have.length", 9);
     cy.get(".element-container .stMarkdown").then(els => {
       expect(els[0].textContent).to.eq("This markdown is awesome! 😎");
       expect(els[1].textContent).to.eq("This <b>HTML tag</b> is escaped!");
@@ -33,15 +39,31 @@ describe("st.markdown", () => {
       expect(els[7].textContent).to.eq(
         "ax2+bx+c=0ax^2 + bx + c = 0ax2+bx+c=0"
       );
-      expect(els[8].textContent).to.eq("Col1Col2SomeData");
+      expect(els[8].textContent).to.eq("Some header 1");
+      expect(els[9].textContent).to.eq("Some header 2");
+      expect(els[10].textContent).to.eq("Some header 3");
+      expect(els[11].textContent).to.eq("Col1Col2SomeData");
 
       cy.wrap(els[3])
         .find("a")
         .should("not.exist");
-
       cy.wrap(els[4])
         .find("a")
         .should("have.attr", "href");
+    });
+  });
+
+  it("displays headers with anchors", () => {
+    cy.get(".element-container .stMarkdown").then(els => {
+      cy.wrap(els[8])
+        .find("h1")
+        .should("have.attr", "id", "some-header-1");
+      cy.wrap(els[9])
+        .find("h2")
+        .should("have.attr", "id", "some-header-2");
+      cy.wrap(els[10])
+        .find("h3")
+        .should("have.attr", "id", "some-header-3");
     });
   });
 

--- a/e2e/specs/st_subheader.spec.js
+++ b/e2e/specs/st_subheader.spec.js
@@ -20,10 +20,21 @@ describe("st.subheader", () => {
     cy.visit("http://localhost:3000/");
   });
 
+  it("displays correct number of elements", () => {
+    cy.get(".element-container .stMarkdown h3").should("have.length", 2);
+  });
+
   it("displays a subheader", () => {
-    cy.get(".element-container .stMarkdown h3").should(
-      "contain",
-      "This subheader is awesome!"
-    );
+    cy.get(".element-container .stMarkdown h3").then(els => {
+      expect(els[0].textContent).to.eq("This subheader is awesome!");
+      expect(els[1].textContent).to.eq("This subheader is awesome too!");
+    });
+  });
+
+  it("displays subheaders with anchors", () => {
+    cy.get(".element-container .stMarkdown h3").then(els => {
+      cy.wrap(els[0]).should("have.attr", "id", "this-subheader-is-awesome");
+      cy.wrap(els[1]).should("have.attr", "id", "awesome-subheader");
+    });
   });
 });

--- a/e2e/specs/st_title.spec.js
+++ b/e2e/specs/st_title.spec.js
@@ -20,10 +20,21 @@ describe("st.title", () => {
     cy.visit("http://localhost:3000/");
   });
 
+  it("displays correct number of elements", () => {
+    cy.get(".element-container .stMarkdown h1").should("have.length", 2);
+  });
+
   it("displays a title", () => {
-    cy.get(".element-container .stMarkdown h1").should(
-      "contain",
-      "This title is awesome!"
-    );
+    cy.get(".element-container .stMarkdown h1").then(els => {
+      expect(els[0].textContent).to.eq("This title is awesome!");
+      expect(els[1].textContent).to.eq("This title is awesome too!");
+    });
+  });
+
+  it("displays title with anchors", () => {
+    cy.get(".element-container .stMarkdown h1").then(els => {
+      cy.wrap(els[0]).should("have.attr", "id", "this-title-is-awesome");
+      cy.wrap(els[1]).should("have.attr", "id", "awesome-title");
+    });
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-browser",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,6 +60,7 @@ import {
   SessionState,
   Config,
 } from "src/autogen/proto"
+import { without, concat } from "lodash"
 
 import { RERUN_PROMPT_MODAL_DIALOG } from "src/lib/baseconsts"
 import { SessionInfo } from "src/lib/SessionInfo"
@@ -120,6 +121,7 @@ interface State {
   initialSidebarState: PageConfig.SidebarState
   allowRunOnSave: boolean
   deployParams?: IDeployParams | null
+  reportFinishedHandlers: (() => void)[]
   developerMode: boolean
   themeHash?: string
 }
@@ -178,6 +180,7 @@ export class App extends PureComponent<Props, State> {
       initialSidebarState: PageConfig.SidebarState.AUTO,
       allowRunOnSave: true,
       deployParams: null,
+      reportFinishedHandlers: [],
       // A hack for now to get theming through. Product to think through how
       // developer mode should be designed in the long term.
       developerMode: window.location.host.includes("localhost"),
@@ -647,6 +650,12 @@ export class App extends PureComponent<Props, State> {
    */
   handleReportFinished(status: ForwardMsg.ReportFinishedStatus): void {
     if (status === ForwardMsg.ReportFinishedStatus.FINISHED_SUCCESSFULLY) {
+      // Notify any subscribers of this event (and do it on the next cycle of
+      // the event loop)
+      window.setTimeout(() => {
+        this.state.reportFinishedHandlers.map(handler => handler())
+      }, 0)
+
       // Clear any stale elements left over from the previous run.
       // (We don't do this if our script had a compilation error and didn't
       // finish successfully.)
@@ -1000,6 +1009,18 @@ export class App extends PureComponent<Props, State> {
     this.setState({ isFullScreen })
   }
 
+  addReportFinishedHandler = (func: () => void): void => {
+    this.setState({
+      reportFinishedHandlers: concat(this.state.reportFinishedHandlers, func),
+    })
+  }
+
+  removeReportFinishedHandler = (func: () => void): void => {
+    this.setState({
+      reportFinishedHandlers: without(this.state.reportFinishedHandlers, func),
+    })
+  }
+
   render(): JSX.Element {
     const {
       allowRunOnSave,
@@ -1040,6 +1061,8 @@ export class App extends PureComponent<Props, State> {
           embedded: isEmbeddedInIFrame(),
           isFullScreen,
           setFullScreen: this.handleFullScreen,
+          addReportFinishedHandler: this.addReportFinishedHandler,
+          removeReportFinishedHandler: this.removeReportFinishedHandler,
           activeTheme: this.props.theme.activeTheme,
           availableThemes: this.props.theme.availableThemes,
           setTheme: this.props.theme.setTheme,

--- a/frontend/src/components/core/PageLayoutContext/index.tsx
+++ b/frontend/src/components/core/PageLayoutContext/index.tsx
@@ -26,6 +26,8 @@ export interface Props {
   embedded: boolean
   isFullScreen: boolean
   setFullScreen: (value: boolean) => void
+  addReportFinishedHandler: (func: () => void) => void
+  removeReportFinishedHandler: (func: () => void) => void
   activeTheme: ThemeConfig
   setTheme: (theme: ThemeConfig) => void
   availableThemes: ThemeConfig[]
@@ -39,6 +41,8 @@ export default React.createContext<Props>({
   embedded: false,
   isFullScreen: false,
   setFullScreen: (value: boolean) => {},
+  addReportFinishedHandler: (func: () => void) => {},
+  removeReportFinishedHandler: (func: () => void) => {},
   activeTheme: baseTheme,
   setTheme: (theme: ThemeConfig) => {},
   availableThemes: [],

--- a/frontend/src/components/core/ReportView/ReportView.tsx
+++ b/frontend/src/components/core/ReportView/ReportView.tsx
@@ -22,6 +22,7 @@ import { ReportRunState } from "src/lib/ReportRunState"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import { FileUploadClient } from "src/lib/FileUploadClient"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent"
+import { sendS4AMessage } from "src/hocs/withS4ACommunication/withS4ACommunication"
 
 import PageLayoutContext from "src/components/core/PageLayoutContext"
 import { BlockNode, ReportRoot } from "src/lib/ReportNode"
@@ -74,6 +75,17 @@ function ReportView(props: ReportViewProps): ReactElement {
     uploadClient,
     componentRegistry,
   } = props
+
+  React.useEffect(() => {
+    const listener = (): void => {
+      sendS4AMessage({
+        type: "UPDATE_HASH",
+        hash: window.location.hash,
+      })
+    }
+    window.addEventListener("hashchange", listener, false)
+    return () => window.removeEventListener("hashchange", listener, false)
+  }, [])
 
   const { wideMode, initialSidebarState, embedded } = React.useContext(
     PageLayoutContext

--- a/frontend/src/components/core/Sidebar/IsSidebarContext.ts
+++ b/frontend/src/components/core/Sidebar/IsSidebarContext.ts
@@ -1,0 +1,3 @@
+import React from "react"
+
+export default React.createContext(false)

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -16,17 +16,14 @@
  */
 
 import React from "react"
-import { ShallowWrapper } from "enzyme"
-import { shallow } from "src/lib/test_util"
+import { ReactWrapper } from "enzyme"
+import { mount } from "src/lib/test_util"
 import { PageConfig } from "src/autogen/proto"
 
 import Sidebar, { SidebarProps } from "./Sidebar"
 
-function renderSideBar(props: Partial<SidebarProps>): ShallowWrapper {
-  // Diving twice to render the WithTheme
-  return shallow(<Sidebar {...props} />)
-    .dive()
-    .dive()
+function renderSideBar(props: Partial<SidebarProps>): ReactWrapper {
+  return mount(<Sidebar {...props} />)
 }
 
 describe("Sidebar Component", () => {

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   StyledSidebarCollapsedControl,
   StyledSidebarContent,
 } from "./styled-components"
+import IsSidebarContext from "./IsSidebarContext"
 
 export interface SidebarProps {
   children?: ReactElement
@@ -171,4 +172,12 @@ class Sidebar extends PureComponent<SidebarProps, State> {
   }
 }
 
-export default withTheme(Sidebar)
+function SidebarWithProvider(props: SidebarProps): ReactElement {
+  return (
+    <IsSidebarContext.Provider value={true}>
+      <Sidebar {...props} />
+    </IsSidebarContext.Provider>
+  )
+}
+
+export default withTheme(SidebarWithProvider)

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -17,12 +17,16 @@
 
 import React, { ReactElement } from "react"
 import ReactMarkdown from "react-markdown"
-import { mount } from "enzyme"
+import { mount } from "src/lib/test_util"
+import IsSidebarContext from "src/components/core/Sidebar/IsSidebarContext"
 
-import {
+import StreamlitMarkdown, {
   linkWithTargetBlank,
   linkReferenceHasParens,
+  createAnchorFromText,
 } from "./StreamlitMarkdown"
+
+import { StyledLinkIconContainer } from "./styled-components"
 
 // Fixture Generator
 const getMarkdownElement = (body: string): ReactElement => {
@@ -32,6 +36,20 @@ const getMarkdownElement = (body: string): ReactElement => {
   }
   return <ReactMarkdown source={body} renderers={renderers} />
 }
+
+describe("createAnchorFromText", () => {
+  it("generates slugs correctly", () => {
+    const cases = [
+      ["some header", "some-header"],
+      ["some -24$35-9824  header", "some-24-35-9824-header"],
+      ["blah___blah___blah", "blah-blah-blah"],
+    ]
+
+    cases.forEach(([s, want]) => {
+      expect(createAnchorFromText(s)).toEqual(want)
+    })
+  })
+})
 
 describe("linkReference", () => {
   it("renders a link with _blank target", () => {
@@ -81,5 +99,27 @@ describe("linkReference", () => {
       "Don't convert to a link if only [text] and missing (href)"
     )
     expect(wrapper.find("a").exists()).toBe(false)
+  })
+})
+
+describe("StreamlitMarkdown", () => {
+  it("renders header anchors when isSidebar is false", () => {
+    const source = "# header"
+    const wrapper = mount(
+      <IsSidebarContext.Provider value={false}>
+        <StreamlitMarkdown source={source} allowHTML={false} />
+      </IsSidebarContext.Provider>
+    )
+    expect(wrapper.find(StyledLinkIconContainer).exists()).toBeTruthy()
+  })
+
+  it("doesn't render header anchors when isSidebar is true", () => {
+    const source = "# header"
+    const wrapper = mount(
+      <IsSidebarContext.Provider value={true}>
+        <StreamlitMarkdown source={source} allowHTML={false} />
+      </IsSidebarContext.Provider>
+    )
+    expect(wrapper.find(StyledLinkIconContainer).exists()).toBeFalsy()
   })
 })

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -23,16 +23,25 @@ import React, {
   CSSProperties,
 } from "react"
 import ReactMarkdown from "react-markdown"
+import { once } from "lodash"
 // @ts-ignore
 import htmlParser from "react-markdown/plugins/html-parser"
 // @ts-ignore
 import Tex from "@matejmazur/react-katex"
 // @ts-ignore
 import RemarkMathPlugin from "remark-math"
+import { Link as LinkIcon } from "react-feather"
 // @ts-ignore
 import RemarkEmoji from "remark-emoji"
+import PageLayoutContext from "src/components/core/PageLayoutContext"
 import CodeBlock from "src/components/elements/CodeBlock/"
-import { StyledStreamlitMarkdown } from "./styled-components"
+import IsSidebarContext from "src/components/core/Sidebar/IsSidebarContext"
+import {
+  StyledStreamlitMarkdown,
+  StyledLinkIconContainer,
+  StyledLinkIcon,
+  StyledHeaderContent,
+} from "./styled-components"
 
 import "katex/dist/katex.min.css"
 
@@ -48,6 +57,135 @@ export interface Props {
    */
   allowHTML: boolean
   style?: CSSProperties
+}
+
+/**
+ * Creates a slug suitable for use as an anchor given a string.
+ * Splits the string on non-alphanumeric characters, and joins with a dash.
+ */
+export function createAnchorFromText(text: string | null): string {
+  const newAnchor = text
+    ?.toLowerCase()
+    .split(/[^A-Za-z0-9]/)
+    .filter(Boolean)
+    .join("-")
+  return newAnchor || ""
+}
+
+// wrapping in `once` ensures we only scroll once
+const scrollNodeIntoView = once((node: HTMLElement): void => {
+  node.scrollIntoView(true)
+})
+
+interface HeadingWithAnchorProps {
+  tag: string
+  anchor?: string
+  children: [ReactElement]
+}
+
+interface CustomHeadingProps {
+  level: string | number
+  children: [ReactElement]
+}
+
+interface CustomParsedHtmlProps {
+  type: ReactElement
+  element: {
+    type: string
+    props: {
+      "data-anchor": string
+      children: [ReactElement]
+    }
+  }
+}
+
+function HeadingWithAnchor({
+  tag,
+  anchor: propsAnchor,
+  children,
+}: HeadingWithAnchorProps): ReactElement {
+  const isSidebar = React.useContext(IsSidebarContext)
+  const [elementId, setElementId] = React.useState(propsAnchor)
+  const [target, setTarget] = React.useState<HTMLElement | null>(null)
+
+  const {
+    addReportFinishedHandler,
+    removeReportFinishedHandler,
+  } = React.useContext(PageLayoutContext)
+
+  if (isSidebar) {
+    return React.createElement(tag, {}, children)
+  }
+
+  const onReportFinished = React.useCallback(() => {
+    if (target !== null) {
+      // wait a bit for everything on page to finish loading
+      window.setTimeout(() => {
+        scrollNodeIntoView(target)
+      }, 300)
+    }
+  }, [target])
+
+  React.useEffect(() => {
+    addReportFinishedHandler(onReportFinished)
+    return () => {
+      removeReportFinishedHandler(onReportFinished)
+    }
+  }, [addReportFinishedHandler, removeReportFinishedHandler, onReportFinished])
+
+  const ref = React.useCallback(
+    node => {
+      if (node === null) {
+        return
+      }
+
+      const anchor = propsAnchor || createAnchorFromText(node.textContent)
+      setElementId(anchor)
+      if (window.location.hash.slice(1) === anchor) {
+        setTarget(node)
+      }
+    },
+    [propsAnchor]
+  )
+
+  return React.createElement(
+    tag,
+    { ref, id: elementId },
+    <StyledLinkIconContainer>
+      {elementId && (
+        <StyledLinkIcon href={`#${elementId}`}>
+          <LinkIcon size="18" />
+        </StyledLinkIcon>
+      )}
+      <StyledHeaderContent>{children}</StyledHeaderContent>
+    </StyledLinkIconContainer>
+  )
+}
+
+function CustomHeading({ level, children }: CustomHeadingProps): ReactElement {
+  return <HeadingWithAnchor tag={`h${level}`}>{children}</HeadingWithAnchor>
+}
+
+function CustomParsedHtml(props: CustomParsedHtmlProps): ReactElement {
+  const {
+    element: { type, props: elementProps },
+  } = props
+
+  const isSidebar = React.useContext(IsSidebarContext)
+
+  const headingElements = ["h1", "h2", "h3", "h4", "h5", "h6"]
+  if (isSidebar || !headingElements.includes(type)) {
+    // casting to any because ReactMarkdown's types are funky
+    // but this just means "call the original renderer provided by ReactMarkdown"
+    return (ReactMarkdown.renderers.parsedHtml as any)(props)
+  }
+
+  const { "data-anchor": anchor, children } = elementProps
+  return (
+    <HeadingWithAnchor tag={type} anchor={anchor}>
+      {children}
+    </HeadingWithAnchor>
+  )
 }
 
 /**
@@ -78,6 +216,8 @@ class StreamlitMarkdown extends PureComponent<Props> {
       math: (props: { value: string }): ReactElement => (
         <Tex block>{props.value}</Tex>
       ),
+      heading: CustomHeading,
+      parsedHtml: CustomParsedHtml,
     }
 
     const plugins = [RemarkMathPlugin, RemarkEmoji]
@@ -112,8 +252,13 @@ interface LinkReferenceProps {
 // Using target="_blank" without rel="noopener noreferrer" is a security risk:
 // see https://mathiasbynens.github.io/rel-noopener
 export function linkWithTargetBlank(props: LinkProps): ReactElement {
-  const { href, title, children } = props
+  // if it's a #hash link, don't open in new tab
+  if (props.href.startsWith("#")) {
+    const { children, ...rest } = props
+    return <a {...rest}>{children}</a>
+  }
 
+  const { href, title, children } = props
   return (
     <a href={href} title={title} target="_blank" rel="noopener noreferrer">
       {children}

--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -39,3 +39,49 @@ export const StyledStreamlitMarkdown = styled.div(({ theme }) => ({
     border: `1px solid ${theme.colors.fadedText10}`,
   },
 }))
+
+export const StyledLinkIconContainer = styled.div(() => ({
+  position: "relative",
+  left: "calc(-2.5rem - 0.5rem)",
+  width: "calc(100% + 2.5rem + 0.5rem)",
+  display: "flex",
+  alignItems: "flex-start",
+  height: "1em",
+  overflow: "visible",
+  ":hover": {
+    a: {
+      opacity: 0.75,
+    },
+  },
+}))
+
+export const StyledLinkIcon = styled.a(({ theme }) => ({
+  position: "relative",
+  top: "calc(-1.25rem + 0.5em)",
+  left: 0,
+  marginRight: "0.5rem",
+
+  // center icon
+  lineHeight: 0,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+
+  // copied from full screen button
+  transition: "opacity 300ms",
+  opacity: 0,
+  height: "2.5rem",
+  width: "2.5rem",
+  zIndex: theme.zIndices.sidebar + 1,
+  border: "none",
+  backgroundColor: theme.colors.bgColor,
+  borderRadius: theme.radii.xl,
+
+  svg: {
+    stroke: theme.colors.bodyText,
+  },
+}))
+
+export const StyledHeaderContent = styled.span(() => ({
+  position: "relative",
+}))

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -49,6 +49,10 @@ export type IHostToGuestMessage = {
       type: "SET_METADATA"
       metadata: StreamlitShareMetadata
     }
+  | {
+      type: "UPDATE_HASH"
+      hash: string
+    }
 )
 
 export type IGuestToHostMessage =
@@ -70,6 +74,10 @@ export type IGuestToHostMessage =
   | {
       type: "SET_QUERY_PARAM"
       queryParams: string
+    }
+  | {
+      type: "UPDATE_HASH"
+      hash: string
     }
 
 export type VersionedMessage<Message> = {

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -16,13 +16,14 @@
  */
 
 import React, { ReactElement } from "react"
-import { shallow } from "src/lib/test_util"
+import { shallow, mount } from "src/lib/test_util"
 
 import withS4ACommunication, {
   S4ACommunicationHOC,
+  S4A_COMM_VERSION,
 } from "./withS4ACommunication"
 
-const testComponent = (props: {
+const TestComponentNaked = (props: {
   s4aCommunication: S4ACommunicationHOC
 }): ReactElement => {
   props.s4aCommunication.connect()
@@ -30,29 +31,41 @@ const testComponent = (props: {
   return <div>test</div>
 }
 
+const TestComponent = withS4ACommunication(TestComponentNaked)
+
+function mockEventListeners(): (type: string, event: any) => void {
+  const listeners: { [name: string]: ((event: Event) => void)[] } = {}
+
+  window.addEventListener = jest.fn((event: string, cb: any) => {
+    listeners[event] = listeners[event] || []
+    listeners[event].push(cb)
+  })
+
+  const dispatchEvent = (type: string, event: Event): void =>
+    listeners[type].forEach(cb => cb(event))
+  return dispatchEvent
+}
+
 describe("withS4ACommunication HOC", () => {
   it("renders without crashing", () => {
-    const WithHoc = withS4ACommunication(testComponent)
-    const wrapper = shallow(<WithHoc />)
+    const wrapper = shallow(<TestComponent />)
 
     expect(wrapper.html()).not.toBeNull()
   })
 
   it("wrapped component should have s4aCommunication prop", () => {
-    const WithHoc = withS4ACommunication(testComponent)
-    const wrapper = shallow(<WithHoc />)
-
-    expect(wrapper.find(testComponent).prop("s4aCommunication")).toBeDefined()
+    const wrapper = shallow(<TestComponent />)
+    expect(
+      wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    ).toBeDefined()
   })
 
   it("s4a should receive a GUEST_READY message", done => {
-    const WithHoc = withS4ACommunication(testComponent)
-
-    shallow(<WithHoc />)
+    shallow(<TestComponent />)
 
     const listener = (event: MessageEvent): void => {
       expect(event.data).toStrictEqual({
-        stCommVersion: 1,
+        stCommVersion: S4A_COMM_VERSION,
         type: "GUEST_READY",
       })
 
@@ -61,5 +74,25 @@ describe("withS4ACommunication HOC", () => {
     }
 
     window.addEventListener("message", listener)
+  })
+
+  it("should respond to UPDATE_HASH message", () => {
+    const dispatchEvent = mockEventListeners()
+
+    mount(<TestComponent />)
+
+    dispatchEvent(
+      "message",
+      new MessageEvent("message", {
+        data: {
+          stCommVersion: S4A_COMM_VERSION,
+          type: "UPDATE_HASH",
+          hash: "#somehash",
+        },
+        origin: "http://devel.streamlit.test",
+      })
+    )
+
+    expect(window.location.hash).toEqual("#somehash")
   })
 })

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -40,7 +40,7 @@ export interface S4ACommunicationHOC {
   sendMessage: (message: IGuestToHostMessage) => void
 }
 
-const S4A_COMM_VERSION = 1
+export const S4A_COMM_VERSION = 1
 
 export function sendS4AMessage(message: IGuestToHostMessage): void {
   window.parent.postMessage(
@@ -90,6 +90,9 @@ function withS4ACommunication(
         }
         if (message.type === "SET_METADATA") {
           setStreamlitShareMetadata(message.metadata)
+        }
+        if (message.type === "UPDATE_HASH") {
+          window.location.hash = message.hash
         }
       }
 

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -27,7 +27,7 @@ except:
     )
     sys.exit(exit_msg)
 
-VERSION = "0.79.0"  # PEP-440
+VERSION = "0.80.0"  # PEP-440
 
 NAME = "streamlit"
 

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -78,13 +78,17 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
-    def header(self, body):
+    def header(self, body, anchor=None):
         """Display text in header formatting.
 
         Parameters
         ----------
         body : str
             The text to display.
+
+        anchor : str
+            The anchor name of the header that can be accessed with #anchor
+            in the URL. If omitted, it generates an anchor using the body.
 
         Example
         -------
@@ -96,16 +100,24 @@ class MarkdownMixin:
 
         """
         header_proto = MarkdownProto()
-        header_proto.body = "## %s" % clean_text(body)
+        if anchor is None:
+            header_proto.body = f"## {clean_text(body)}"
+        else:
+            header_proto.body = f'<h2 data-anchor="{anchor}">{clean_text(body)}</h2>'
+            header_proto.allow_html = True
         return self.dg._enqueue("markdown", header_proto)
 
-    def subheader(self, body):
+    def subheader(self, body, anchor=None):
         """Display text in subheader formatting.
 
         Parameters
         ----------
         body : str
             The text to display.
+
+        anchor : str
+            The anchor name of the header that can be accessed with #anchor
+            in the URL. If omitted, it generates an anchor using the body.
 
         Example
         -------
@@ -117,7 +129,12 @@ class MarkdownMixin:
 
         """
         subheader_proto = MarkdownProto()
-        subheader_proto.body = "### %s" % clean_text(body)
+        if anchor is None:
+            subheader_proto.body = f"### {clean_text(body)}"
+        else:
+            subheader_proto.body = f'<h3 data-anchor="{anchor}">{clean_text(body)}</h3>'
+            subheader_proto.allow_html = True
+
         return self.dg._enqueue("markdown", subheader_proto)
 
     def code(self, body, language="python"):
@@ -153,7 +170,7 @@ class MarkdownMixin:
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
-    def title(self, body):
+    def title(self, body, anchor=None):
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not
@@ -163,6 +180,10 @@ class MarkdownMixin:
         ----------
         body : str
             The text to display.
+
+        anchor : str
+            The anchor name of the header that can be accessed with #anchor
+            in the URL. If omitted, it generates an anchor using the body.
 
         Example
         -------
@@ -174,7 +195,11 @@ class MarkdownMixin:
 
         """
         title_proto = MarkdownProto()
-        title_proto.body = "# %s" % clean_text(body)
+        if anchor is None:
+            title_proto.body = f"# {clean_text(body)}"
+        else:
+            title_proto.body = f'<h1 data-anchor="{anchor}">{clean_text(body)}</h1>'
+            title_proto.allow_html = True
         return self.dg._enqueue("markdown", title_proto)
 
     def latex(self, body):

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -43,7 +43,7 @@ class WriteMixin:
 
         1. You can pass in multiple arguments, all of which will be written.
         2. Its behavior depends on the input types as follows.
-        3. It returns None, so its "slot" in the App cannot be reused.
+        3. It returns None, so it's "slot" in the App cannot be reused.
 
         Parameters
         ----------
@@ -60,6 +60,7 @@ class WriteMixin:
             - write(func)       : Displays information about a function.
             - write(module)     : Displays information about the module.
             - write(dict)       : Displays dict in an interactive widget.
+            - write(obj)        : The default is to print str(obj).
             - write(mpl_fig)    : Displays a Matplotlib figure.
             - write(altair)     : Displays an Altair chart.
             - write(keras)      : Displays a Keras model.
@@ -67,8 +68,6 @@ class WriteMixin:
             - write(plotly_fig) : Displays a Plotly figure.
             - write(bokeh_fig)  : Displays a Bokeh figure.
             - write(sympy_expr) : Prints SymPy expression using LaTeX.
-            - write(htmlable)   : Prints _repr_html_() for the object if available.
-            - write(obj)        : Prints str(obj) if otherwise unknown.
 
         unsafe_allow_html : bool
             This is a keyword-only argument that defaults to False.
@@ -218,11 +217,6 @@ class WriteMixin:
             elif type_util.is_pydeck(arg):
                 flush_buffer()
                 self.dg.pydeck_chart(arg)
-            elif hasattr(arg, "_repr_html_"):
-                self.dg.markdown(
-                    arg._repr_html_(),
-                    unsafe_allow_html=True,
-                )
             else:
                 string_buffer.append("`%s`" % str(arg).replace("`", "\\`"))
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -319,6 +319,15 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.markdown.body, "## some header")
 
+    def test_st_header_with_anchor(self):
+        """Test st.header with anchor."""
+        st.header("some header", anchor="some-anchor")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(
+            el.markdown.body, '<h2 data-anchor="some-anchor">some header</h2>'
+        )
+
     def test_st_help(self):
         """Test st.help."""
         st.help(st.header)
@@ -330,7 +339,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        self.assertEqual(el.doc_string.signature, "(body)")
+        self.assertEqual(el.doc_string.signature, "(body, anchor=None)")
 
     def test_st_image_PIL_image(self):
         """Test st.image with PIL image."""
@@ -609,6 +618,15 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.markdown.body, "### some subheader")
 
+    def test_st_subheader_with_anchor(self):
+        """Test st.subheader with anchor."""
+        st.subheader("some subheader", anchor="some-anchor")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(
+            el.markdown.body, '<h3 data-anchor="some-anchor">some subheader</h3>'
+        )
+
     def test_st_success(self):
         """Test st.success."""
         st.success("some success")
@@ -643,6 +661,15 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.markdown.body, "# some title")
+
+    def test_st_title_with_anchor(self):
+        """Test st.title with anchor."""
+        st.title("some title", anchor="some-anchor")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(
+            el.markdown.body, '<h1 data-anchor="some-anchor">some title</h1>'
+        )
 
     def test_st_vega_lite_chart(self):
         """Test st.vega_lite_chart."""

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -39,20 +39,6 @@ class StreamlitWriteTest(unittest.TestCase):
     trying to check is that the right st.* method gets called
     """
 
-    def test_repr_html(self):
-        """Test st.write with an object that defines _repr_html_."""
-
-        class FakeHTMLable(object):
-            def _repr_html_(self):
-                return "<strong>hello world</strong>"
-
-        with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:
-            st.write(FakeHTMLable())
-
-            p.assert_called_once_with(
-                "<strong>hello world</strong>", unsafe_allow_html=True
-            )
-
     def test_string(self):
         """Test st.write with a string."""
         with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:


### PR DESCRIPTION
* Reverts a change for `repr_html` based on product feedback
* Includes the anchors, which should already exist in `develop`