### PR TITLE
A bit of theme caching and theme toml generation polish

### DIFF
--- a/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.test.tsx
@@ -73,6 +73,16 @@ base="light"
 `)
   })
 
+  it("is not case sensitive with color hex codes", () => {
+    const themeInput = {
+      ...toThemeInput(lightTheme.emotion),
+      backgroundColor: "#fFfFff",
+    }
+    expect(toMinimalToml(themeInput)).toBe(`[theme]
+base="light"
+`)
+  })
+
   it("sets base = light when closer to lightTheme", () => {
     const themeInput = {
       ...toThemeInput(lightTheme.emotion),

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.tsx
@@ -1,7 +1,9 @@
 import React, { ReactElement } from "react"
+import { Check } from "@emotion-icons/material-outlined"
 import { toHex } from "color2k"
 import humanizeString from "humanize-string"
-import { Check } from "@emotion-icons/material-outlined"
+import mapValues from "lodash/mapValues"
+
 import { CustomThemeConfig } from "src/autogen/proto"
 import PageLayoutContext from "src/components/core/PageLayoutContext"
 import Button, { Kind } from "src/components/shared/Button"
@@ -18,6 +20,7 @@ import {
   ThemeConfig,
   toThemeInput,
 } from "src/theme"
+
 import {
   StyledDialogBody,
   StyledFullRow,
@@ -89,7 +92,18 @@ const changedColorConfig = (
   themeInput: Partial<CustomThemeConfig>,
   baseTheme: Theme
 ): Array<string> => {
-  const baseInput = toThemeInput(baseTheme)
+  const toLowerCaseIfString = (x: any): any => {
+    if (typeof x === "string") {
+      return x.toLowerCase()
+    }
+    return x
+  }
+
+  const baseInput: Partial<CustomThemeConfig> = mapValues(
+    toThemeInput(baseTheme),
+    toLowerCaseIfString
+  )
+  themeInput = mapValues(themeInput, toLowerCaseIfString)
   const configLines: Array<string> = []
 
   // This is tedious, but typescript won't let us define an array with the keys

--- a/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreatorDialog.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/__snapshots__/ThemeCreatorDialog.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Renders ThemeCreatorDialog renders theme creator dialog 1`] = `
       />
       <ThemeOption
         name="backgroundColor"
-        value="#FFFFFF"
+        value="#ffffff"
       />
       <ThemeOption
         name="textColor"

--- a/frontend/src/components/elements/PlotlyChart/__snapshots__/PlotlyChart.test.tsx.snap
+++ b/frontend/src/components/elements/PlotlyChart/__snapshots__/PlotlyChart.test.tsx.snap
@@ -4980,7 +4980,7 @@ Object {
     "legend": Object {
       "traceorder": "reversed",
     },
-    "paper_bgcolor": "#FFFFFF",
+    "paper_bgcolor": "#ffffff",
     "plot_bgcolor": "#f0f2f6",
     "template": Object {
       "data": Object {
@@ -10796,7 +10796,7 @@ Object {
     "legend": Object {
       "traceorder": "reversed",
     },
-    "paper_bgcolor": "#FFFFFF",
+    "paper_bgcolor": "#ffffff",
     "plot_bgcolor": "#f0f2f6",
     "template": Object {
       "data": Object {

--- a/frontend/src/theme/primitives/colors.ts
+++ b/frontend/src/theme/primitives/colors.ts
@@ -20,7 +20,7 @@ export const colors = {
   current: "currentColor",
   inherit: "inherit",
   black: "#000000",
-  white: "#FFFFFF",
+  white: "#ffffff",
   streamlitPink: "#f63366",
 
   gray10: "#fafafa",

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -221,13 +221,16 @@ describe("Cached theme helpers", () => {
     })
 
     it("deletes cached themes with older versions", () => {
+      window.localStorage.setItem("stActiveTheme", "I should get deleted :|")
+
       window.localStorage.setItem(
         LocalStore.CACHED_THEME_BASE_KEY,
-        "I should get deleted :|"
+        "I should get deleted too :|"
       )
 
       setCachedTheme(customTheme)
 
+      expect(window.localStorage.getItem("stActiveTheme")).toBe(null)
       expect(
         window.localStorage.getItem(LocalStore.CACHED_THEME_BASE_KEY)
       ).toBe(null)

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -507,6 +507,10 @@ const deleteOldCachedThemes = (): void => {
   const { CACHED_THEME_VERSION, CACHED_THEME_BASE_KEY } = LocalStore
   const { localStorage } = window
 
+  // Pre-release versions of theming stored cached themes under the key
+  // "stActiveTheme".
+  localStorage.removeItem("stActiveTheme")
+
   // The first version of cached themes had keys of the form
   // `stActiveTheme-${window.location.pathname}` with no version number.
   localStorage.removeItem(CACHED_THEME_BASE_KEY)


### PR DESCRIPTION
This does two small theming-related things:

1. Make the minimal theme toml generator case insensitive
    We would previously incorrectly add lines to the output toml snippets when a user's config
    specified base theme colors with hex colors in a different casing.
2. Also remove cached themes with key "stActiveTheme"
    This key was used for cached themes in pre-release versions of theming.