### PR TITLE
Fix a (dev-mode-only) theming bug with cached themes

### DIFF
--- a/frontend/src/ThemedApp.test.tsx
+++ b/frontend/src/ThemedApp.test.tsx
@@ -16,11 +16,20 @@
  */
 
 import React from "react"
-import { shallow, mount } from "src/lib/test_util"
-import { AUTO_THEME_NAME, darkTheme, ThemeConfig } from "src/theme"
+
 import { LocalStore } from "src/lib/storageUtils"
-import ThemedApp from "./ThemedApp"
+import { shallow, mount } from "src/lib/test_util"
+import {
+  AUTO_THEME_NAME,
+  CUSTOM_THEME_NAME,
+  createPresetThemes,
+  darkTheme,
+  setCachedTheme,
+  ThemeConfig,
+} from "src/theme"
+
 import AppWithScreencast from "./App"
+import ThemedApp from "./ThemedApp"
 
 describe("ThemedApp", () => {
   beforeEach(() => {
@@ -102,5 +111,30 @@ describe("ThemedApp", () => {
 
     // Should only have added one theme despite multiple calls adding themes.
     expect(newThemes.length).toBe(initialThemes.length + 1)
+  })
+
+  it("sets the cached theme as the default theme if one is set", () => {
+    setCachedTheme(darkTheme)
+
+    const wrapper = shallow(<ThemedApp />)
+    const app = wrapper.find(AppWithScreencast)
+    const { activeTheme, availableThemes } = app.props().theme
+
+    expect(activeTheme.name).toBe(darkTheme.name)
+    expect(availableThemes.length).toBe(createPresetThemes().length)
+  })
+
+  it("includes a custom theme as an available theme if one is cached", () => {
+    setCachedTheme({
+      ...darkTheme,
+      name: CUSTOM_THEME_NAME,
+    })
+
+    const wrapper = shallow(<ThemedApp />)
+    const app = wrapper.find(AppWithScreencast)
+    const { activeTheme, availableThemes } = app.props().theme
+
+    expect(activeTheme.name).toBe(CUSTOM_THEME_NAME)
+    expect(availableThemes.length).toBe(createPresetThemes().length + 1)
   })
 })

--- a/frontend/src/ThemedApp.tsx
+++ b/frontend/src/ThemedApp.tsx
@@ -4,21 +4,25 @@ import { Global } from "@emotion/core"
 import ThemeProvider from "src/components/core/ThemeProvider"
 import {
   AUTO_THEME_NAME,
-  ThemeConfig,
-  getDefaultTheme,
-  globalStyles,
   createAutoTheme,
   createPresetThemes,
+  getDefaultTheme,
+  globalStyles,
+  isPresetTheme,
   removeCachedTheme,
   setCachedTheme,
+  ThemeConfig,
 } from "src/theme"
 import AppWithScreencast from "./App"
 
 const ThemedApp = (): JSX.Element => {
-  const [theme, setTheme] = React.useState<ThemeConfig>(getDefaultTheme())
-  const [availableThemes, setAvailableThemes] = React.useState<ThemeConfig[]>(
-    createPresetThemes()
-  )
+  const defaultTheme = getDefaultTheme()
+
+  const [theme, setTheme] = React.useState<ThemeConfig>(defaultTheme)
+  const [availableThemes, setAvailableThemes] = React.useState<ThemeConfig[]>([
+    ...createPresetThemes(),
+    ...(isPresetTheme(defaultTheme) ? [] : [defaultTheme]),
+  ])
 
   const addThemes = (themeConfigs: ThemeConfig[]): void => {
     setAvailableThemes([...createPresetThemes(), ...themeConfigs])


### PR DESCRIPTION
There's a cached theme bug that should only be possible to run into in dev
mode that frustrated me enough that I still want to fix it. It's also
probably possible to run into in between the react app loading and the script
run starting, but in practice the delay between that happening is short
enough to make that really hard.

The issue is that if you're connected to the react dev server, but the
streamlit server isn't running, a cached custom theme may be loaded as
the active theme of the app, but it won't appear as an available theme
in the selector menu.

This is just because the default value for that piece of react state
doesn't consider that there may be a custom theme option, so we just
need to add it on the ThemedApp component's first render.