### PR TITLE
"Missing submit button" iteration

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -238,7 +238,12 @@ class Block extends PureComponent<Props> {
       const hasSubmitButton =
         submitButtonCount !== undefined && submitButtonCount > 0
       return (
-        <Form formId={formId} width={width} hasSubmitButton={hasSubmitButton}>
+        <Form
+          formId={formId}
+          width={width}
+          hasSubmitButton={hasSubmitButton}
+          reportRunState={this.props.reportRunState}
+        >
           {child}
         </Form>
       )

--- a/frontend/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/src/components/widgets/Form/Form.test.tsx
@@ -16,6 +16,7 @@
  */
 
 import React from "react"
+import { Kind } from "src/components/shared/AlertContainer"
 import { shallow } from "src/lib/test_util"
 import { Form, Props, SUBMIT_BUTTON_WARNING_TIME_MS } from "./Form"
 
@@ -42,12 +43,13 @@ describe("Form", () => {
     expect(wrapper.state("submitButtonTimeout")).toBe(true)
   })
 
-  it("shows warning if !hasSubmitButton && submitButtonTimeout", () => {
+  it("shows error if !hasSubmitButton && submitButtonTimeout", () => {
     const props = getProps({ hasSubmitButton: false })
     const wrapper = shallow(<Form {...props} />)
     wrapper.setState({ submitButtonTimeout: true })
 
     expect(wrapper.find("Alert").exists()).toBeTruthy()
+    expect(wrapper.find("Alert").prop("kind")).toBe(Kind.ERROR)
     expect(wrapper.find("Alert").prop("body")).toContain(
       "Missing Submit Button"
     )

--- a/frontend/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/src/components/widgets/Form/Form.test.tsx
@@ -17,11 +17,9 @@
 
 import React from "react"
 import { Kind } from "src/components/shared/AlertContainer"
+import { ReportRunState } from "src/lib/ReportRunState"
 import { shallow } from "src/lib/test_util"
-import { Form, Props, SUBMIT_BUTTON_WARNING_TIME_MS } from "./Form"
-
-// We have some timeouts that we want to use fake timers for.
-jest.useFakeTimers()
+import { Form, Props } from "./Form"
 
 describe("Form", () => {
   function getProps(props: Partial<Props> = {}): Props {
@@ -29,24 +27,24 @@ describe("Form", () => {
       formId: "mockFormId",
       width: 100,
       hasSubmitButton: false,
+      reportRunState: ReportRunState.RUNNING,
       ...props,
     }
   }
 
-  it("sets submitButtonTimeout after a timeout", () => {
-    const props = getProps()
+  it("shows error if !hasSubmitButton && reportRunState==NOT_RUNNING", () => {
+    const props = getProps({
+      hasSubmitButton: false,
+      reportRunState: ReportRunState.RUNNING,
+    })
     const wrapper = shallow(<Form {...props} />)
-    expect(wrapper.state("submitButtonTimeout")).toBe(false)
 
-    // Advance our timer and force a rerender
-    jest.advanceTimersByTime(SUBMIT_BUTTON_WARNING_TIME_MS)
-    expect(wrapper.state("submitButtonTimeout")).toBe(true)
-  })
+    // We have no Submit Button, but the app is still running
+    expect(wrapper.find("Alert").exists()).toBeFalsy()
 
-  it("shows error if !hasSubmitButton && submitButtonTimeout", () => {
-    const props = getProps({ hasSubmitButton: false })
-    const wrapper = shallow(<Form {...props} />)
-    wrapper.setState({ submitButtonTimeout: true })
+    // When the app stops running, we show an error if the submit button
+    // is still missing.
+    wrapper.setProps({ reportRunState: ReportRunState.NOT_RUNNING })
 
     expect(wrapper.find("Alert").exists()).toBeTruthy()
     expect(wrapper.find("Alert").prop("kind")).toBe(Kind.ERROR)
@@ -54,7 +52,12 @@ describe("Form", () => {
       "Missing Submit Button"
     )
 
-    // If we later get a submit button, our alert should go away.
+    // If the app restarts, we continue to show the error...
+    wrapper.setProps({ reportRunState: ReportRunState.RUNNING })
+    expect(wrapper.find("Alert").exists()).toBeTruthy()
+
+    // Until we get a submit button, and the error is removed immediately,
+    // regardless of ReportRunState.
     wrapper.setProps({ hasSubmitButton: true })
     expect(wrapper.find("Alert").exists()).toBeFalsy()
   })

--- a/frontend/src/components/widgets/Form/Form.tsx
+++ b/frontend/src/components/widgets/Form/Form.tsx
@@ -29,8 +29,7 @@ export interface Props {
 }
 
 interface State {
-  // Set to true when our 'submitButtonWarningTimer' expires and we
-  // don't have a submit button.
+  // Set to true if we're missing a submit button when the report stops running.
   showMissingSubmitButtonWarning: boolean
 }
 

--- a/frontend/src/components/widgets/Form/Form.tsx
+++ b/frontend/src/components/widgets/Form/Form.tsx
@@ -74,7 +74,7 @@ export class Form extends PureComponent<Props, State> {
       submitWarning = (
         <Alert
           body={MISSING_SUBMIT_BUTTON_WARNING}
-          kind={Kind.WARNING}
+          kind={Kind.ERROR}
           width={this.props.width}
         />
       )

--- a/frontend/src/components/widgets/Form/Form.tsx
+++ b/frontend/src/components/widgets/Form/Form.tsx
@@ -18,27 +18,21 @@
 import React, { PureComponent, ReactElement, ReactNode } from "react"
 import Alert from "src/components/elements/Alert"
 import { Kind } from "src/components/shared/AlertContainer"
-import { Timer } from "src/lib/Timer"
+import { ReportRunState } from "src/lib/ReportRunState"
 import { StyledForm } from "./styled-components"
 
 export interface Props {
   formId: string
   width: number
   hasSubmitButton: boolean
+  reportRunState: ReportRunState
 }
 
 interface State {
   // Set to true when our 'submitButtonWarningTimer' expires and we
   // don't have a submit button.
-  submitButtonTimeout: boolean
+  showMissingSubmitButtonWarning: boolean
 }
-
-/**
- * If the form doesn't have a submit button after this many milliseconds
- * have elapsed, we show a warning that tells them they probably want to
- * create one.
- */
-export const SUBMIT_BUTTON_WARNING_TIME_MS = 1500
 
 export const MISSING_SUBMIT_BUTTON_WARNING =
   "**Missing Submit Button**" +
@@ -47,30 +41,38 @@ export const MISSING_SUBMIT_BUTTON_WARNING =
   "\n\nTo create a submit button, use the `st.beta_submit_button()` function."
 
 export class Form extends PureComponent<Props, State> {
-  private readonly submitButtonWarningTimer = new Timer()
-
-  private submitButtonWarningFormId?: string
-
   public constructor(props: Props) {
     super(props)
-    this.state = { submitButtonTimeout: false }
+    this.state = { showMissingSubmitButtonWarning: false }
   }
 
-  public componentDidMount = (): void => {
-    this.updateSubmitButtonWarningTimer()
-  }
+  public static getDerivedStateFromProps(
+    props: Readonly<Props>
+  ): Partial<State> | null {
+    // Determine if we need to show the "missing submit button" warning.
+    // If we have a submit button, we don't show the warning, of course.
+    // If we *don't* have a submit button, then we only mutate the showWarning
+    // flag when our reportRunState is NOT_RUNNING. (If the report is still
+    // running, there might be an incoming SubmitButton delta that we just
+    // haven't seen yet.)
 
-  public componentDidUpdate = (): void => {
-    this.updateSubmitButtonWarningTimer()
-  }
+    if (props.hasSubmitButton) {
+      return { showMissingSubmitButtonWarning: false }
+    }
 
-  public componentWillUnmount = (): void => {
-    this.submitButtonWarningTimer.cancel()
+    if (props.reportRunState === ReportRunState.NOT_RUNNING) {
+      return { showMissingSubmitButtonWarning: true }
+    }
+
+    return null
   }
 
   public render = (): ReactNode => {
     let submitWarning: ReactElement | undefined
-    if (!this.props.hasSubmitButton && this.state.submitButtonTimeout) {
+    if (
+      !this.props.hasSubmitButton &&
+      this.state.showMissingSubmitButtonWarning
+    ) {
       submitWarning = (
         <Alert
           body={MISSING_SUBMIT_BUTTON_WARNING}
@@ -86,28 +88,5 @@ export class Form extends PureComponent<Props, State> {
         {submitWarning}
       </StyledForm>
     )
-  }
-
-  private updateSubmitButtonWarningTimer = (): void => {
-    if (this.props.hasSubmitButton) {
-      // The submit button was created. Cancel the timer if it's running.
-      this.submitButtonWarningTimer.cancel()
-      this.submitButtonWarningFormId = undefined
-      return
-    }
-
-    if (this.submitButtonWarningFormId === this.props.formId) {
-      // The timer is already running, so no need to do anything.
-      return
-    }
-
-    // Start a timer. If it expires and the form doesn't yet have a submit
-    // button, we'll warn the user that they probably want to create one.
-    this.setState({ submitButtonTimeout: false })
-    this.submitButtonWarningTimer.setTimeout(
-      () => this.setState({ submitButtonTimeout: true }),
-      SUBMIT_BUTTON_WARNING_TIME_MS
-    )
-    this.submitButtonWarningFormId = this.props.formId
   }
 }


### PR DESCRIPTION
Addresses two bits of product feedback on the "form is missing a submit button" warning:

- The warning is shown in red (as an error), rather than yellow
- We show the warning when the app has finished running, rather than on a timeout

Fixes https://github.com/streamlit/streamlit-issues/issues/71