### PR TITLE
Pin docutils to 0.16

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ recommonmark==0.6.0
 Sphinx==3.0.3
 sphinx-rtd-theme==0.4.3
 sphinx_markdown_tables==0.0.12
+docutils==0.16

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mypy-protobuf==1.20
 pipenv==2018.11.26
 recommonmark==0.6.0
-Sphinx>=3.2
+Sphinx==3.0.3
 sphinx-rtd-theme==0.4.3
 sphinx_markdown_tables==0.0.12


### PR DESCRIPTION
Fixes `AttributeError: 'Values' object has no attribute 'tab_width` error, reported internally and incorrectly fixed by #3076. docutils released a new version (0.17), which we were not pinning due to it being so infrequently being updated. 

https://github.com/sphinx-doc/sphinx/issues/9049#issuecomment-812900558

Visual inspection of the Streamlit API page shows that the docstrings and inline Streamlit apps are now deployed. While it appears that the Sphinx version itself may not be the cause of the error, leaving for future PR to address updating dependencies wholesale.

Edit: additionally sets `fail_on_warning: true` to try and fail faster when warnings are being thrown.