### PR TITLE
Rewrite FormSubmitButton using hooks; test with react-testing-library

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -104,6 +104,9 @@
   "devDependencies": {
     "@craco/craco": "^6.0.0",
     "@deck.gl/json": "^8.2.5",
+    "@testing-library/dom": "^7.30.3",
+    "@testing-library/react": "^11.2.6",
+    "@testing-library/user-event": "^13.1.2",
     "@types/classnames": "^2.2.10",
     "@types/clipboard": "^2.0.1",
     "@types/d3": "^5.7.2",

--- a/frontend/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -15,13 +15,15 @@
  * limitations under the License.
  */
 
+import { screen } from "@testing-library/dom"
+import userEvent from "@testing-library/user-event"
 import { enableAllPlugins } from "immer"
 import React from "react"
 
 import { Button as ButtonProto } from "src/autogen/proto"
 
 import UIButton from "src/components/shared/Button"
-import { shallow } from "src/lib/test_util"
+import { render, shallow } from "src/lib/test_util"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import { createFormsData, FormsManager } from "./FormsManager"
 import { FormSubmitButton, Props } from "./FormSubmitButton"
@@ -64,10 +66,7 @@ describe("FormSubmitButton", () => {
   }
 
   it("renders without crashing", () => {
-    const props = getProps()
-    const wrapper = shallow(<FormSubmitButton {...props} />)
-
-    expect(wrapper).toBeDefined()
+    render(<FormSubmitButton {...getProps()} />)
   })
 
   it("has correct className and style", () => {
@@ -96,21 +95,18 @@ describe("FormSubmitButton", () => {
 
   it("calls submitForm when clicked", () => {
     const props = getProps()
-    const wrapper = shallow(<FormSubmitButton {...props} />)
+    render(<FormSubmitButton {...props} />)
 
-    const wrappedUIButton = wrapper.find(UIButton)
-
-    wrappedUIButton.simulate("click")
-
+    userEvent.click(screen.getByRole("button"))
     expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(props.element)
   })
 
   it("is disabled when form has pending upload", () => {
     const props = getProps({ hasInProgressUpload: true })
-    const wrapper = shallow(<FormSubmitButton {...props} />)
+    render(<FormSubmitButton {...props} />)
 
-    const wrappedUIButton = wrapper.find(UIButton)
-    expect(wrappedUIButton.props().disabled).toBe(true)
+    const button = screen.getByRole("button") as HTMLButtonElement
+    expect(button.disabled).toBe(true)
   })
 
   it("increments submitButtonCount on mount and decrements on unmount", () => {
@@ -118,10 +114,10 @@ describe("FormSubmitButton", () => {
 
     const props = getProps()
 
-    const wrapper1 = shallow(<FormSubmitButton {...props} />)
+    const wrapper1 = render(<FormSubmitButton {...props} />)
     expect(formsData.submitButtonCount.get("mockFormId")).toBe(1)
 
-    const wrapper2 = shallow(<FormSubmitButton {...props} />)
+    const wrapper2 = render(<FormSubmitButton {...props} />)
     expect(formsData.submitButtonCount.get("mockFormId")).toBe(2)
 
     wrapper1.unmount()

--- a/frontend/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/src/components/widgets/Form/FormSubmitButton.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { PureComponent, ReactNode } from "react"
+import React, { ReactElement, useEffect } from "react"
 import { Button as ButtonProto } from "src/autogen/proto"
 import UIButton, { Kind, Size } from "src/components/shared/Button"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
@@ -31,54 +31,42 @@ export interface Props {
   width: number
 }
 
-export class FormSubmitButton extends PureComponent<Props> {
-  public componentDidMount = (): void => {
-    this.props.formsMgr.incrementSubmitButtonCount(this.props.element.formId)
-  }
+export function FormSubmitButton(props: Props): ReactElement {
+  const {
+    disabled,
+    element,
+    widgetMgr,
+    hasPendingChanges,
+    hasInProgressUpload,
+    formsMgr,
+    width,
+  } = props
+  const { formId } = element
+  const style = { width }
 
-  public componentWillUnmount = (): void => {
-    this.props.formsMgr.decrementSubmitButtonCount(this.props.element.formId)
-  }
+  useEffect(() => {
+    formsMgr.incrementSubmitButtonCount(formId)
+    return () => formsMgr.decrementSubmitButtonCount(formId)
+  }, [formsMgr, formId])
 
-  public componentDidUpdate = (prevProps: Props): void => {
-    const prevFormId = prevProps.element.formId
-    const newFormId = this.props.element.formId
-    if (prevFormId !== newFormId) {
-      this.props.formsMgr.decrementSubmitButtonCount(prevFormId)
-      this.props.formsMgr.incrementSubmitButtonCount(newFormId)
-    }
-  }
-
-  public render = (): ReactNode => {
-    const {
-      disabled,
-      element,
-      widgetMgr,
-      hasPendingChanges,
-      hasInProgressUpload,
-    } = this.props
-
-    const style = { width: this.props.width }
-
-    return (
-      <div
-        className="row-widget stButton"
-        data-testid="stFormSubmitButton"
-        style={style}
+  return (
+    <div
+      className="row-widget stButton"
+      data-testid="stFormSubmitButton"
+      style={style}
+    >
+      <UIButton
+        kind={
+          hasPendingChanges
+            ? Kind.FORM_SUBMIT_HAS_PENDING_CHANGES
+            : Kind.FORM_SUBMIT_NO_PENDING_CHANGES
+        }
+        size={Size.SMALL}
+        disabled={disabled || hasInProgressUpload}
+        onClick={() => widgetMgr.submitForm(element)}
       >
-        <UIButton
-          kind={
-            hasPendingChanges
-              ? Kind.FORM_SUBMIT_HAS_PENDING_CHANGES
-              : Kind.FORM_SUBMIT_NO_PENDING_CHANGES
-          }
-          size={Size.SMALL}
-          disabled={disabled || hasInProgressUpload}
-          onClick={() => widgetMgr.submitForm(element)}
-        >
-          {element.label}
-        </UIButton>
-      </div>
-    )
-  }
+        {element.label}
+      </UIButton>
+    </div>
+  )
 }

--- a/frontend/src/lib/test_util.tsx
+++ b/frontend/src/lib/test_util.tsx
@@ -15,17 +15,22 @@
  * limitations under the License.
  */
 
-import { Component, ReactElement } from "react"
+import {
+  render as reactTestingLibraryRender,
+  RenderOptions,
+  RenderResult,
+} from "@testing-library/react" // eslint-disable-line import/no-extraneous-dependencies
 import {
   mount as enzymeMount,
+  MountRendererProps,
+  ReactWrapper,
   shallow as enzymeShallow,
   ShallowRendererProps,
-  MountRendererProps,
   ShallowWrapper,
-  ReactWrapper,
 } from "enzyme" // eslint-disable-line import/no-extraneous-dependencies
-import { lightTheme, Theme } from "src/theme"
+import React, { Component, FC, ReactElement } from "react"
 import ThemeProvider from "src/components/core/ThemeProvider"
+import { lightTheme, Theme } from "src/theme"
 
 export function mount<C extends Component, P = C["props"], S = C["state"]>(
   node: ReactElement<P>,
@@ -57,4 +62,22 @@ export function shallow<C extends Component, P = C["props"], S = C["state"]>(
   }
 
   return enzymeShallow(node, opts)
+}
+
+const RenderWrapper: FC = ({ children }) => {
+  return <ThemeProvider theme={lightTheme.emotion}>{children}</ThemeProvider>
+}
+
+/**
+ * Use react-testing-library to render a ReactElement. The element will be
+ * wrapped in our ThemeProvider.
+ */
+export function render(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "queries">
+): RenderResult {
+  return reactTestingLibraryRender(ui, {
+    wrapper: RenderWrapper,
+    ...options,
+  })
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1153,6 +1153,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -2448,6 +2455,35 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@testing-library/dom@^7.28.1", "@testing-library/dom@^7.30.3":
+  version "7.30.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.3.tgz#779ea9bbb92d63302461800a388a5a890ac22519"
+  integrity sha512-7JhIg2MW6WPwyikH2iL3o7z+FTVgSOd2jqCwTAHqK7Qal2gRRYiUQyURAxtbK9VXm/UTyG9bRihv8C5Tznr2zw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/react@^11.2.6":
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
+  integrity sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
+"@testing-library/user-event@^13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.1.2.tgz#2dff143155da093f0dc2485cf4717780d12a6235"
+  integrity sha512-89S/QELVCXbcHmgAfPrk0U8kCu9qESqV8/QQaUe5B4+7qi3kJlfQYCiB7Pfi2XInBtO0qm7vDmJb+/Oa+TFdyQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@turf/area@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.0.1.tgz#50ed63c70ef2bdb72952384f1594319d94f3b051"
@@ -2488,6 +2524,11 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
+  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
@@ -7113,6 +7154,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -12026,6 +12072,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.7"


### PR DESCRIPTION
- FormSubmitButton is hooks-based, which simplifies its "increment/decrement submitButton count" logic
- Enzyme isn't hooks-friendly, so this PR also introduces react-testing-library. Most of FormSubmitButton's tests are written using `render()` (roughly equivalent to Enzyme's `mount()`). There were a few existing tests that were more simply expressed in Enzyme, so they remain in Enzyme!