### PR TITLE
Add support for toml syntax highlighting in code blocks

### DIFF
--- a/frontend/src/components/elements/CodeBlock/CodeBlock.tsx
+++ b/frontend/src/components/elements/CodeBlock/CodeBlock.tsx
@@ -17,19 +17,22 @@
 
 import Prism, { Grammar } from "prismjs"
 import React, { ReactElement } from "react"
-import { logWarning } from "src/lib/log"
 
 // Prism language definition files.
 // These must come after the prismjs import because they modify Prism.languages
+import "prismjs/components/prism-bash"
+import "prismjs/components/prism-c"
+import "prismjs/components/prism-css"
+import "prismjs/components/prism-json"
 import "prismjs/components/prism-jsx"
 import "prismjs/components/prism-python"
-import "prismjs/components/prism-typescript"
 import "prismjs/components/prism-sql"
-import "prismjs/components/prism-bash"
-import "prismjs/components/prism-json"
+import "prismjs/components/prism-toml"
+import "prismjs/components/prism-typescript"
 import "prismjs/components/prism-yaml"
-import "prismjs/components/prism-css"
-import "prismjs/components/prism-c"
+
+import { logWarning } from "src/lib/log"
+
 import CopyButton from "./CopyButton"
 import {
   StyledPre,


### PR DESCRIPTION
We changed the behavior of auto-syntax highlighting in code blocks in #2814 to
_not_ attempt to highlight code as if it were python if the language
specified isn't a supported one, which had the side effect of removing
syntax highlighting from toml code blocks (toml was being highlighted as if it
were python). This change adds toml highlighting back using prismjs' native
support.

We also re-order and re-group the imports in the file.

Note that it's possible for syntax highlighting in general to not look great in alert
boxes because there are 4 possible background colors that they can be, and
I filed #3156 to address this. Since we still highlight syntax for other supported
languages, I think we should still re-add toml syntax highlighting as its strictly
better than not having it, and code blocks for other languages in alert boxes still
have potential display issues.