### PR TITLE
Fix regex warnings

### DIFF
--- a/lib/streamlit/code_util.py
+++ b/lib/streamlit/code_util.py
@@ -60,7 +60,7 @@ def get_method_args_from_code(args, line):
     ----------
     args : list
         A list where it's size matches the expected number of parsed arguments
-    line : list
+    line : str
         Stringified line of code with method arguments inside parentheses
 
     Returns
@@ -80,7 +80,7 @@ def get_method_args_from_code(args, line):
 
     # Split arguments, https://stackoverflow.com/a/26634150
     if len(args) > 1:
-        inputs = re.split(",\\s*(?![^(){}[\]]*\\))", line_args)
+        inputs = re.split(r",\s*(?![^(){}[\]]*\))", line_args)
         assert len(inputs) == len(args), "Could not split arguments"
     else:
         inputs = [line_args]

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -144,17 +144,17 @@ class ConfigOption(object):
             # Matching text comprised of letters and numbers that begins
             # with a lowercase letter with an optional "_" preceeding it.
             # Examples: "_section", "section1"
-            "\_?[a-z][a-zA-Z0-9]*"
-            ")"
-            # Seperator between groups
-            "\."
+            r"\_?[a-z][a-zA-Z0-9]*"
+            r")"
+            # Separator between groups
+            r"\."
             # Capture a group called "name"
-            "(?P<name>"
+            r"(?P<name>"
             # Match text comprised of letters and numbers beginning with a
             # lowercase letter.
             # Examples: "name", "nameOfConfig", "config1"
-            "[a-z][a-zA-Z0-9]*"
-            ")$"
+            r"[a-z][a-zA-Z0-9]*"
+            r")$"
         )
         match = re.match(key_format, self.key)
         assert match, 'Key "%s" has invalid format.' % self.key


### PR DESCRIPTION
Fixes 3 regex-related warnings that were thrown when running pytest:

- DeprecationWarning: invalid escape sequence \_
- DeprecationWarning: invalid escape sequence \.
- DeprecationWarning: invalid escape sequence \]

The solve is to use raw strings - which don't process `\` as a Python escape character - instead of normal Python strings.

(Both functions already have test coverage, so this shouldn't break anything.)