### PR TITLE
Allow setting meta description tag

### DIFF
--- a/e2e/scripts/st_set_page_config.py
+++ b/e2e/scripts/st_set_page_config.py
@@ -19,6 +19,7 @@ st.set_page_config(
     page_icon=":shark:",
     layout="wide",
     initial_sidebar_state="collapsed",
+    page_description="Stream Lit description",
 )
 st.sidebar.button("Sidebar!")
 st.markdown("Main!")

--- a/e2e/specs/st_set_page_config.spec.js
+++ b/e2e/specs/st_set_page_config.spec.js
@@ -51,4 +51,12 @@ describe("st.set_page_config", () => {
       "wide-mode"
     );
   });
+
+  it("sets the page description", () => {
+    cy.get("meta[name='description']").should(
+      "have.attr",
+      "content",
+      "Stream Lit description"
+    );
+  });
 });

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -22,6 +22,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <meta name="description" content="" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png" />
 
     <title>Streamlit</title>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,7 +368,16 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePageConfigChanged = (pageConfig: PageConfig): void => {
-    const { title, favicon, layout, initialSidebarState } = pageConfig
+    const {
+      title,
+      favicon,
+      layout,
+      initialSidebarState,
+      description,
+    } = pageConfig
+    const descriptionElement = document.querySelector(
+      `meta[name="description"]`
+    ) as HTMLElement
 
     if (title) {
       this.props.s4aCommunication.sendMessage({
@@ -381,6 +390,15 @@ export class App extends PureComponent<Props, State> {
 
     if (favicon) {
       handleFavicon(favicon)
+    }
+
+    if (description) {
+      this.props.s4aCommunication.sendMessage({
+        type: "SET_PAGE_DESCRIPTION",
+        description,
+      })
+
+      descriptionElement.setAttribute("content", description)
     }
 
     // Only change layout/sidebar when the page config has changed.

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -82,6 +82,10 @@ export type IGuestToHostMessage =
       type: "UPDATE_HASH"
       hash: string
     }
+  | {
+      type: "SET_PAGE_DESCRIPTION"
+      description: string
+    }
 
 export type VersionedMessage<Message> = {
   stCommVersion: number

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -20,7 +20,11 @@ from streamlit.errors import StreamlitAPIException
 
 
 def set_page_config(
-    page_title=None, page_icon=None, layout="centered", initial_sidebar_state="auto"
+    page_title=None,
+    page_icon=None,
+    layout="centered",
+    initial_sidebar_state="auto",
+    page_description=None,
 ):
     """
     Configures the default settings of the page.
@@ -48,6 +52,9 @@ def set_page_config(
         How the sidebar should start out. Defaults to "auto",
         which hides the sidebar on mobile-sized devices, and shows it otherwise.
         "expanded" shows the sidebar initially; "collapsed" hides it.
+    page_description: str or None
+        The page description in the form of a meta tag. If None, defaults to
+        an empty description.
 
     Example
     -------
@@ -56,6 +63,7 @@ def set_page_config(
     ...     page_icon="🧊",
     ...     layout="wide",
     ...     initial_sidebar_state="expanded",
+    ...     page_description="LIT description"
     ... )
     """
 
@@ -63,6 +71,9 @@ def set_page_config(
 
     if page_title:
         msg.page_config_changed.title = page_title
+
+    if page_description:
+        msg.page_config_changed.description = page_description
 
     if page_icon:
         if page_icon == "random":

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -42,4 +42,6 @@ message PageConfig {
     COLLAPSED = 2;
   }
   SidebarState initial_sidebar_state = 4;
+
+  string description = 5;
 }


### PR DESCRIPTION
**Issue:** #2469 

**Description:** Allow users to set a value for a meta description tag.

This PR allows users to set a description meta tag in the same manner that a title is set, i.e. using `st.set_page_config()`

* A default value for the description was set to `""`.
* Test sets a value for `"Stream Lit description"`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
