### PR TITLE
Add theming docs for base and partial themes

### DIFF
--- a/docs/theme_options.md
+++ b/docs/theme_options.md
@@ -71,8 +71,10 @@ the font selected here.
 
 ## base
 
-A much shorter way to define a custom theme that recreates the Streamlit Light
-theme as we did above is to write the following:
+An easy way to define custom themes that make small changes to one of the
+preset Streamlit themes is to use the `base` option. Using `base`, the
+Streamlit Light theme can be recreated as a custom theme by writing the
+following:
 
 ```toml
 [theme]
@@ -80,12 +82,12 @@ base="light"
 ```
 
 The `base` option allows you to specify a preset Streamlit theme that your
-custom theme inherits from. Valid values for `base` are `"light"` and `"dark"`.
+custom theme inherits from. Any theme config options not defined in your theme
+settings have their values set to those of the base theme. Valid values for
+`base` are `"light"` and `"dark"`.
 
-Any theme config options not defined in your theme settings have their values
-set to those of the base theme. For example, the following theme config defines
-a custom theme nearly identical to the Streamlit Dark theme, but with a changed
-`primaryColor`.
+For example, the following theme config defines a custom theme nearly identical
+to the Streamlit Dark theme, but with a new `primaryColor`.
 
 ```toml
 [theme]

--- a/docs/theme_options.md
+++ b/docs/theme_options.md
@@ -7,12 +7,12 @@ Streamlit themes, see the Themes section of the
 
 Streamlit themes are defined using regular config options: a theme can be set
 via command line flag when starting your app using `streamlit run` or by
-defining it in the `[theme]` section of a `config.toml` file. For more
-information on setting config options, please refer to the
+defining it in the `[theme]` section of a `.streamlit/config.toml` file. For
+more information on setting config options, please refer to the
 [Streamlit configuration documentation](streamlit_configuration.html#set-configuration-options).
 
 The following config options show the default Streamlit Light theme recreated
-in the `[theme]` section of a `config.toml` file.
+in the `[theme]` section of a `.streamlit/config.toml` file.
 
 ```toml
 [theme]
@@ -62,9 +62,42 @@ This option controls the text color for most of your Streamlit app.
 
 ## font
 
-Selects the font used in your Streamlit app. Valid values are "sans serif",
-"serif", and "monospace". This option defaults to "sans serif" if unset or
-invalid.
+Selects the font used in your Streamlit app. Valid values are `"sans serif"`,
+`"serif"`, and `"monospace"`. This option defaults to `"sans serif"` if unset
+or invalid.
 
 Note that code blocks are always rendered using the monospace font regardless of
 the font selected here.
+
+## base
+
+A much shorter way to define a custom theme that recreates the Streamlit Light
+theme as we did above is to write the following:
+
+```toml
+[theme]
+base="light"
+```
+
+The `base` option allows you to specify a preset Streamlit theme that your
+custom theme inherits from. Valid values for `base` are `"light"` and `"dark"`.
+
+Any theme config options not defined in your theme settings have their values
+set to those of the base theme. For example, the following theme config defines
+a custom theme nearly identical to the Streamlit Dark theme, but with a changed
+`primaryColor`.
+
+```toml
+[theme]
+base="dark"
+primaryColor="purple"
+```
+
+If `base` itself is omitted, it defaults to `"light"`, so you can define a
+custom theme that changes the font of the Streamlit Light theme to serif with
+the following config
+
+```toml
+[theme]
+font="serif"
+```


### PR DESCRIPTION
This PR primarily adds a new section to `theme_options.md` for the new
features added by the theming fast-follow work (#3164).

Additionally, it makes two small tweaks:

1. Replaces references to `config.toml` with `.streamlit/config.toml`. This is
   because we saw a good number of people trying to add a `config.toml` file to
   the root directory of their repo, and making this tweak should make that
   less likely to happen.
2. Changes most references to font family strings like "sans serif" to
   be formatted as code when we're talking about them as string literals
   used as config values.
