### PR TITLE
Update links to `hash_funcs` docs

### DIFF
--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -802,7 +802,7 @@ then pass that to `hash_funcs` instead:
 ```
 
 Please see the `hash_funcs` [documentation]
-(https://streamlit.io/docs/caching.html)
+(https://docs.streamlit.io/en/stable/caching.html#the-hash-funcs-parameter)
 for more details.
             """
             % args
@@ -927,7 +927,7 @@ then pass that to `hash_funcs` instead:
 ```
 
 Please see the `hash_funcs` [documentation]
-(https://streamlit.io/docs/caching.html)
+(https://docs.streamlit.io/en/stable/caching.html#the-hash-funcs-parameter)
 for more details.
             """
             % args


### PR DESCRIPTION
**Description:** Link to `hash_funcs` docs in the error message was broken, I changed it to the correct URL. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
