### PR TITLE
widgets.py organization + cleanup

### DIFF
--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -24,13 +24,13 @@ import tornado.web
 import streamlit.server.routes
 from streamlit import type_util
 from streamlit import util
-from streamlit.elements.utils import register_widget, NoValue
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ArrowTable_pb2 import ArrowTable as ArrowTableProto
 from streamlit.proto.ComponentInstance_pb2 import SpecialArg
 from streamlit.proto.Element_pb2 import Element
 from streamlit.type_util import to_bytes
+from streamlit.widgets import NoValue, register_widget
 
 LOGGER = get_logger(__name__)
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Allows us to create and absorb changes (aka Deltas) to elements."""
-from typing import Optional, Iterable, List
+from typing import Optional, Iterable
 
 import streamlit as st
 from streamlit import caching
@@ -29,7 +29,6 @@ from streamlit.proto import ForwardMsg_pb2
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.logger import get_logger
 
-from streamlit.elements.utils import NoValue
 from streamlit.elements.balloons import BalloonsMixin
 from streamlit.elements.button import ButtonMixin
 from streamlit.elements.markdown import MarkdownMixin
@@ -65,6 +64,7 @@ from streamlit.elements.image import ImageMixin
 from streamlit.elements.pyplot import PyplotMixin
 from streamlit.elements.write import WriteMixin
 from streamlit.elements.layouts import LayoutsMixin
+from streamlit.widgets import NoValue
 
 LOGGER = get_logger(__name__)
 

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -16,7 +16,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class ButtonMixin:

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -16,7 +16,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class CheckboxMixin:

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -18,7 +18,7 @@ from typing import cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class ColorPickerMixin:

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -19,9 +19,9 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
 from streamlit.report_thread import get_report_ctx
-from .utils import NoValue, register_widget
 from ..proto.Common_pb2 import SInt64Array
 from ..uploaded_file_manager import UploadedFile, UploadedFileRec
+from ..widgets import register_widget, NoValue
 
 LOGGER = get_logger(__name__)
 

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -18,7 +18,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.type_util import is_type, ensure_iterable
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class MultiSelectMixin:

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -19,7 +19,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber, JSNumberBoundsException
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
-from .utils import register_widget, NoValue
+from streamlit.widgets import register_widget, NoValue
 
 
 class NumberInputMixin:

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -18,7 +18,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.type_util import ensure_iterable
-from .utils import register_widget, NoValue
+from streamlit.widgets import register_widget, NoValue
 
 
 class RadioMixin:

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -18,7 +18,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.type_util import ensure_iterable
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class SelectSliderMixin:

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -18,7 +18,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.type_util import ensure_iterable
-from .utils import register_widget, NoValue
+from streamlit.widgets import register_widget, NoValue
 
 
 class SelectboxMixin:

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -20,7 +20,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class SliderMixin:

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -18,7 +18,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class TextWidgetsMixin:

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -19,7 +19,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
-from .utils import register_widget
+from streamlit.widgets import register_widget
 
 
 class TimeWidgetsMixin:

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -13,130 +13,14 @@
 # limitations under the License.
 
 import textwrap
+from typing import Any
 
 from streamlit import type_util
-from streamlit.report_thread import get_report_ctx
-from streamlit.errors import DuplicateWidgetID
-from typing import Optional, Any
-
-
-class NoValue:
-    """Return this from DeltaGenerator.foo_widget() when you want the st.foo_widget()
-    call to return None. This is needed because `DeltaGenerator._enqueue`
-    replaces `None` with a `DeltaGenerator` (for use in non-widget elements).
-    """
-
-    pass
 
 
 def clean_text(text: Any) -> str:
     """Convert an object to text, dedent it, and strip whitespace."""
     return textwrap.dedent(str(text)).strip()
-
-
-def _build_duplicate_widget_message(
-    widget_func_name: str, user_key: Optional[str] = None
-) -> str:
-    if user_key is not None:
-        message = textwrap.dedent(
-            """
-            There are multiple identical `st.{widget_type}` widgets with
-            `key='{user_key}'`.
-
-            To fix this, please make sure that the `key` argument is unique for
-            each `st.{widget_type}` you create.
-            """
-        )
-    else:
-        message = textwrap.dedent(
-            """
-            There are multiple identical `st.{widget_type}` widgets with the
-            same generated key.
-
-            When a widget is created, it's assigned an internal key based on
-            its structure. Multiple widgets with an identical structure will
-            result in the same internal key, which causes this error.
-
-            To fix this error, please pass a unique `key` argument to
-            `st.{widget_type}`.
-            """
-        )
-
-    return message.strip("\n").format(widget_type=widget_func_name, user_key=user_key)
-
-
-def _get_widget_id(
-    element_type: str, element_proto: Any, user_key: Optional[str] = None
-) -> str:
-    """Generate the widget id for the given widget.
-
-    Does not mutate the element_proto object.
-    """
-    # Identify the widget with a hash of type + contents
-    element_hash = hash((element_type, element_proto.SerializeToString()))
-    if user_key is not None:
-        widget_id = "%s-%s" % (user_key, element_hash)
-    else:
-        widget_id = "%s" % element_hash
-
-    return widget_id
-
-
-def register_widget(
-    element_type: str,
-    element_proto: Any,
-    user_key: Optional[str] = None,
-    widget_func_name: Optional[str] = None,
-) -> Optional[Any]:
-    """Register a widget with Streamlit, and return its current ui_value.
-    NOTE: This function should be called after the proto has been filled.
-
-    Parameters
-    ----------
-    element_type : str
-        The type of the element as stored in proto.
-    element_proto : proto
-        The proto of the specified type (e.g. Button/Multiselect/Slider proto)
-    user_key : str
-        Optional user-specified string to use as the widget ID.
-        If this is None, we'll generate an ID by hashing the element.
-    widget_func_name : str or None
-        The widget's DeltaGenerator function name, if it's different from
-        its element_type. Custom components are a special case: they all have
-        the element_type "component_instance", but are instantiated with
-        dynamically-named functions.
-
-    Returns
-    -------
-    ui_value : Any or None
-        The value of the widget set by the client or
-        the default value passed. If the report context
-        doesn't exist, None will be returned.
-
-    """
-    widget_id = _get_widget_id(element_type, element_proto, user_key)
-    element_proto.id = widget_id
-
-    ctx = get_report_ctx()
-    if ctx is None:
-        # Early-out if we're not running inside a ReportThread (which
-        # probably means we're running as a "bare" Python script, and
-        # not via `streamlit run`).
-        return None
-
-    # Register the widget, and ensure another widget with the same id hasn't
-    # already been registered.
-    added = ctx.widget_ids_this_run.add(widget_id)
-    if not added:
-        raise DuplicateWidgetID(
-            _build_duplicate_widget_message(
-                widget_func_name if widget_func_name is not None else element_type,
-                user_key,
-            )
-        )
-
-    # Return the widget's current value.
-    return ctx.widgets.get_widget_value(widget_id)
 
 
 def last_index_for_melted_dataframes(data):

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -20,7 +20,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.uploaded_file_manager import UploadedFileManager
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 
 LOGGER = get_logger(__name__)
 
@@ -31,7 +31,7 @@ class ReportContext:
         session_id: str,
         enqueue: Callable[[ForwardMsg], None],
         query_string: str,
-        widgets: Widgets,
+        widgets: WidgetStateManager,
         uploaded_file_mgr: UploadedFileManager,
     ):
         """Construct a ReportContext.
@@ -44,8 +44,8 @@ class ReportContext:
             Function that enqueues ForwardMsg protos in the websocket.
         query_string : str
             The URL query string for this run.
-        widgets : Widgets
-            The Widgets state object for the report.
+        widgets : WidgetStateManager
+            The WidgetStateManager for the report.
         uploaded_file_mgr : UploadedFileManager
             The manager for files uploaded by all users.
 
@@ -144,7 +144,7 @@ class ReportThread(threading.Thread):
         session_id: str,
         enqueue: Callable[[ForwardMsg], None],
         query_string: str,
-        widgets: Widgets,
+        widgets: WidgetStateManager,
         uploaded_file_mgr: UploadedFileManager,
         target: Optional[Callable[[], None]] = None,
         name: Optional[str] = None,
@@ -159,7 +159,7 @@ class ReportThread(threading.Thread):
             Function that enqueues ForwardMsg protos in the websocket.
         query_string : str
             The URL query string for this run.
-        widgets : Widgets
+        widgets : WidgetStateManager
             The Widgets state object for the report.
         uploaded_file_mgr : UploadedFileManager
             The manager for files uploaded by all users.

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -30,7 +30,7 @@ from streamlit.report_thread import get_report_ctx
 from streamlit.script_request_queue import ScriptRequest
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 
 LOGGER = get_logger(__name__)
 
@@ -92,7 +92,7 @@ class ScriptRunner(object):
         self._uploaded_file_mgr = uploaded_file_mgr
 
         self._client_state = client_state
-        self._widgets = Widgets()
+        self._widgets = WidgetStateManager()
         self._widgets.set_state(client_state.widget_states)
 
         self.on_event = Signal(

--- a/lib/streamlit/widgets.py
+++ b/lib/streamlit/widgets.py
@@ -12,13 +12,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import textwrap
 from pprint import pprint
 from typing import Any, Optional, Dict, Set
 
 from streamlit import util
+from streamlit import report_thread
+from streamlit.errors import DuplicateWidgetID
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.WidgetStates_pb2 import WidgetStates, WidgetState
-import json
+
+
+class NoValue:
+    """Return this from DeltaGenerator.foo_widget() when you want the st.foo_widget()
+    call to return None. This is needed because `DeltaGenerator._enqueue`
+    replaces `None` with a `DeltaGenerator` (for use in non-widget elements).
+    """
+
+    pass
+
+
+def register_widget(
+    element_type: str,
+    element_proto: Any,
+    user_key: Optional[str] = None,
+    widget_func_name: Optional[str] = None,
+) -> Optional[Any]:
+    """Register a widget with Streamlit, and return its current ui_value.
+    NOTE: This function should be called after the proto has been filled.
+
+    Parameters
+    ----------
+    element_type : str
+        The type of the element as stored in proto.
+    element_proto : proto
+        The proto of the specified type (e.g. Button/Multiselect/Slider proto)
+    user_key : str
+        Optional user-specified string to use as the widget ID.
+        If this is None, we'll generate an ID by hashing the element.
+    widget_func_name : str or None
+        The widget's DeltaGenerator function name, if it's different from
+        its element_type. Custom components are a special case: they all have
+        the element_type "component_instance", but are instantiated with
+        dynamically-named functions.
+
+    Returns
+    -------
+    ui_value : Any or None
+        The value of the widget set by the client or
+        the default value passed. If the report context
+        doesn't exist, None will be returned.
+
+    """
+    widget_id = _get_widget_id(element_type, element_proto, user_key)
+    element_proto.id = widget_id
+
+    ctx = report_thread.get_report_ctx()
+    if ctx is None:
+        # Early-out if we're not running inside a ReportThread (which
+        # probably means we're running as a "bare" Python script, and
+        # not via `streamlit run`).
+        return None
+
+    # Register the widget, and ensure another widget with the same id hasn't
+    # already been registered.
+    added = ctx.widget_ids_this_run.add(widget_id)
+    if not added:
+        raise DuplicateWidgetID(
+            _build_duplicate_widget_message(
+                widget_func_name if widget_func_name is not None else element_type,
+                user_key,
+            )
+        )
+
+    # Return the widget's current value.
+    return ctx.widgets.get_widget_value(widget_id)
 
 
 def coalesce_widget_states(
@@ -111,3 +180,51 @@ class WidgetStateManager:
     def dump(self) -> None:
         """Pretty-print widget state to the console, for debugging."""
         pprint(self._state)
+
+
+def _build_duplicate_widget_message(
+    widget_func_name: str, user_key: Optional[str] = None
+) -> str:
+    if user_key is not None:
+        message = textwrap.dedent(
+            """
+            There are multiple identical `st.{widget_type}` widgets with
+            `key='{user_key}'`.
+
+            To fix this, please make sure that the `key` argument is unique for
+            each `st.{widget_type}` you create.
+            """
+        )
+    else:
+        message = textwrap.dedent(
+            """
+            There are multiple identical `st.{widget_type}` widgets with the
+            same generated key.
+
+            When a widget is created, it's assigned an internal key based on
+            its structure. Multiple widgets with an identical structure will
+            result in the same internal key, which causes this error.
+
+            To fix this error, please pass a unique `key` argument to
+            `st.{widget_type}`.
+            """
+        )
+
+    return message.strip("\n").format(widget_type=widget_func_name, user_key=user_key)
+
+
+def _get_widget_id(
+    element_type: str, element_proto: Any, user_key: Optional[str] = None
+) -> str:
+    """Generate the widget id for the given widget.
+
+    Does not mutate the element_proto object.
+    """
+    # Identify the widget with a hash of type + contents
+    element_hash = hash((element_type, element_proto.SerializeToString()))
+    if user_key is not None:
+        widget_id = "%s-%s" % (user_key, element_hash)
+    else:
+        widget_id = "%s" % element_hash
+
+    return widget_id

--- a/lib/streamlit/widgets.py
+++ b/lib/streamlit/widgets.py
@@ -56,9 +56,11 @@ def coalesce_widget_states(
     return coalesced
 
 
-class Widgets(object):
+class WidgetStateManager:
+    """Stores widget values for a single connected session."""
+
     def __init__(self):
-        self._state = {}  # type: Dict[str, WidgetState]
+        self._state: Dict[str, WidgetState] = {}
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -26,7 +26,7 @@ from parameterized import parameterized
 import pandas as pd
 
 from streamlit.delta_generator import DeltaGenerator
-from streamlit.elements.utils import _build_duplicate_widget_message, register_widget
+from streamlit.widgets import _build_duplicate_widget_message, register_widget
 from streamlit.cursor import LockedCursor, make_delta_path
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -18,7 +18,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.report_thread import ReportContext
 from streamlit.uploaded_file_manager import UploadedFileManager
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 
 
 class ReportContextTest(unittest.TestCase):
@@ -27,7 +27,11 @@ class ReportContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ReportContext(
-            "TestSessionID", fake_enqueue, "", Widgets(), UploadedFileManager()
+            "TestSessionID",
+            fake_enqueue,
+            "",
+            WidgetStateManager(),
+            UploadedFileManager(),
         )
 
         msg = ForwardMsg()
@@ -42,7 +46,11 @@ class ReportContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ReportContext(
-            "TestSessionID", fake_enqueue, "", Widgets(), UploadedFileManager()
+            "TestSessionID",
+            fake_enqueue,
+            "",
+            WidgetStateManager(),
+            UploadedFileManager(),
         )
 
         markdown_msg = ForwardMsg()
@@ -60,7 +68,11 @@ class ReportContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ReportContext(
-            "TestSessionID", fake_enqueue, "", Widgets(), UploadedFileManager()
+            "TestSessionID",
+            fake_enqueue,
+            "",
+            WidgetStateManager(),
+            UploadedFileManager(),
         )
 
         msg = ForwardMsg()

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -31,7 +31,7 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.StaticManifest_pb2 import StaticManifest
 from streamlit.errors import StreamlitAPIException
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 from tests.mock_storage import MockStorage
 import streamlit as st
 
@@ -169,7 +169,11 @@ class ReportSessionSerializationTest(tornado.testing.AsyncTestCase):
 
         orig_ctx = get_report_ctx()
         ctx = ReportContext(
-            "TestSessionID", rs._report.enqueue, "", Widgets(), UploadedFileManager()
+            "TestSessionID",
+            rs._report.enqueue,
+            "",
+            WidgetStateManager(),
+            UploadedFileManager(),
         )
         add_report_ctx(ctx=ctx)
 

--- a/lib/tests/streamlit/script_request_queue_test.py
+++ b/lib/tests/streamlit/script_request_queue_test.py
@@ -22,7 +22,7 @@ from streamlit.script_request_queue import RerunData
 from streamlit.script_request_queue import ScriptRequestQueue
 from streamlit.script_runner import ScriptRequest
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 
 
 def _create_widget(id, states):
@@ -94,7 +94,7 @@ class ScriptRequestQueueTest(unittest.TestCase):
         event, data = queue.dequeue()
         self.assertEqual(event, ScriptRequest.RERUN)
 
-        widgets = Widgets()
+        widgets = WidgetStateManager()
         widgets.set_state(data.widget_states)
 
         # Coalesced triggers should be True if either the old or
@@ -117,7 +117,7 @@ class ScriptRequestQueueTest(unittest.TestCase):
         queue.enqueue(ScriptRequest.RERUN, RerunData(widget_states=states))
 
         event, data = queue.dequeue()
-        widgets = Widgets()
+        widgets = WidgetStateManager()
         widgets.set_state(data.widget_states)
 
         self.assertEqual(event, ScriptRequest.RERUN)
@@ -135,7 +135,7 @@ class ScriptRequestQueueTest(unittest.TestCase):
         queue.enqueue(ScriptRequest.RERUN, RerunData(widget_states=None))
 
         event, data = queue.dequeue()
-        widgets = Widgets()
+        widgets = WidgetStateManager()
         widgets.set_state(data.widget_states)
 
         self.assertEqual(event, ScriptRequest.RERUN)

--- a/lib/tests/streamlit/widgets_test.py
+++ b/lib/tests/streamlit/widgets_test.py
@@ -17,7 +17,7 @@
 import unittest
 
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 from streamlit.widgets import coalesce_widget_states
 
 
@@ -36,7 +36,7 @@ class WidgetTest(unittest.TestCase):
         _create_widget("int", states).int_value = 123
         _create_widget("string", states).string_value = "howdy!"
 
-        widgets = Widgets()
+        widgets = WidgetStateManager()
         widgets.set_state(states)
 
         self.assertEqual(True, widgets.get_widget_value("trigger"))
@@ -47,7 +47,7 @@ class WidgetTest(unittest.TestCase):
 
     def test_reset_triggers(self):
         states = WidgetStates()
-        widgets = Widgets()
+        widgets = WidgetStateManager()
 
         _create_widget("trigger", states).trigger_value = True
         _create_widget("int", states).int_value = 123
@@ -76,7 +76,7 @@ class WidgetTest(unittest.TestCase):
         _create_widget("added_in_new", new_states).int_value = 456
         _create_widget("shape_changing_trigger", new_states).int_value = 3
 
-        widgets = Widgets()
+        widgets = WidgetStateManager()
         widgets.set_state(coalesce_widget_states(old_states, new_states))
 
         self.assertIsNone(widgets.get_widget_value("old_unset_trigger"))

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -24,7 +24,7 @@ from streamlit.report_queue import ReportQueue
 from streamlit.report_thread import ReportContext
 from streamlit.report_thread import add_report_ctx
 from streamlit.report_thread import get_report_ctx
-from streamlit.widgets import Widgets
+from streamlit.widgets import WidgetStateManager
 from streamlit.uploaded_file_manager import UploadedFileManager
 
 
@@ -83,7 +83,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                     session_id="test session id",
                     enqueue=self.report_queue.enqueue,
                     query_string="",
-                    widgets=Widgets(),
+                    widgets=WidgetStateManager(),
                     uploaded_file_mgr=UploadedFileManager(),
                 ),
             )


### PR DESCRIPTION
This is a renaming/reorganization change to widgets.py - no functionality is changed (and so there are no new tests included).

- `Widgets` is now `WidgetStateManager`
- `register_widget` and the `NoValue` type have been moved from `utils.py` into `widgets.py`