### PR TITLE
Consolidated startup messages into bootstrap.py and made them pretty.

### DIFF
--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -158,9 +158,7 @@ def _on_server_start(server):
     _maybe_print_old_git_warning(server.script_path)
     _print_url(server.is_running_hello)
     report_watchdog_availability()
-
-    if version.should_show_new_version_notice():
-        click.echo(NEW_VERSION_TEXT)
+    _print_new_version_message()
 
     # Load secrets.toml if it exists. If the file doesn't exist, this
     # function will return without raising an exception. We catch any parse
@@ -203,6 +201,11 @@ def _fix_pydeck_mapbox_api_warning():
     """Sets MAPBOX_API_KEY environment variable needed for PyDeck otherwise it will throw an exception"""
 
     os.environ["MAPBOX_API_KEY"] = config.get_option("mapbox.token")
+
+
+def _print_new_version_message():
+    if version.should_show_new_version_notice():
+        click.secho(NEW_VERSION_TEXT)
 
 
 def _print_url(is_running_hello):

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -58,6 +58,7 @@ NEW_VERSION_TEXT = """
     "command": click.style("pip install streamlit --upgrade", bold=True),
 }
 
+
 def _set_up_signal_handler():
     LOGGER.debug("Setting up signal handler")
 
@@ -157,7 +158,7 @@ def _on_server_start(server):
     _maybe_print_old_git_warning(server.script_path)
     _print_url(server.is_running_hello)
     report_watchdog_availability()
-    
+
     if version.should_show_new_version_notice():
         click.echo(NEW_VERSION_TEXT)
 

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -29,8 +29,8 @@ from streamlit import env_util
 from streamlit import secrets
 from streamlit import util
 from streamlit.config import CONFIG_FILENAMES
-from streamlit.report import Report
 from streamlit.logger import get_logger
+from streamlit.report import Report
 from streamlit.secrets import SECRETS_FILE_LOC
 from streamlit.server.server import Server, server_address_is_unix_socket
 from streamlit.watcher.file_watcher import watch_file

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -31,6 +31,7 @@ ACCEPTED_FILE_EXTENSIONS = ("py", "py3")
 
 LOG_LEVELS = ("error", "warning", "info", "debug")
 
+
 def _convert_config_option_to_click_option(config_option):
     """Composes given config option options as options for click lib."""
     option = "--{}".format(config_option.key)

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -24,29 +24,12 @@ import click
 
 import streamlit
 from streamlit.credentials import Credentials, check_credentials
-from streamlit import version
 import streamlit.bootstrap as bootstrap
 from streamlit.case_converters import to_snake_case
 
 ACCEPTED_FILE_EXTENSIONS = ("py", "py3")
 
 LOG_LEVELS = ("error", "warning", "info", "debug")
-
-NEW_VERSION_TEXT = """
-  %(new_version)s
-
-  See what's new at https://discuss.streamlit.io/c/announcements
-
-  Enter the following command to upgrade:
-  %(prompt)s %(command)s
-""" % {
-    "new_version": click.style(
-        "A new version of Streamlit is available.", fg="blue", bold=True
-    ),
-    "prompt": click.style("$", fg="blue"),
-    "command": click.style("pip install streamlit --upgrade", bold=True),
-}
-
 
 def _convert_config_option_to_click_option(config_option):
     """Composes given config option options as options for click lib."""
@@ -231,9 +214,6 @@ def _main_run(file, args=None, flag_options=None):
     streamlit._is_running_with_streamlit = True
 
     check_credentials()
-
-    if version.should_show_new_version_notice():
-        click.echo(NEW_VERSION_TEXT)
 
     bootstrap.run(file, command_line, args, flag_options)
 

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, Type, Callable
+from typing import Callable, Optional, Type, Union
+
 import click
 
 import streamlit.watcher
@@ -40,7 +41,7 @@ FileWatcherType = Union[
 
 
 def report_watchdog_availability():
-    if watchdog_available == False:
+    if not watchdog_available:
         if not config.get_option("global.disableWatchdogWarning"):
             msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
 

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -38,17 +38,23 @@ FileWatcherType = Union[
     Type[PollingFileWatcher],
 ]
 
+
 def report_watchdog_availability():
     if watchdog_available == False:
         if not config.get_option("global.disableWatchdogWarning"):
             msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
 
-            click.secho("  %s" % "For better performance, install the Watchdog module:", fg="blue", bold=True)
+            click.secho(
+                "  %s" % "For better performance, install the Watchdog module:",
+                fg="blue",
+                bold=True,
+            )
             click.secho(
                 """%s
   $ pip install watchdog
             """
-                % msg)
+                % msg
+            )
 
 
 def watch_file(

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Optional, Union, Type, Callable
+import click
 
 import streamlit.watcher
 from streamlit import config
@@ -29,18 +30,6 @@ try:
     watchdog_available = True
 except ImportError:
     watchdog_available = False
-    if not config.get_option("global.disableWatchdogWarning"):
-        msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
-
-        LOGGER.warning(
-            """
-  For better performance, install the Watchdog module:
-  %s
-  $ pip install watchdog
-
-        """
-            % msg
-        )
 
 # EventBasedFileWatcher won't be available if its import failed (due to
 # missing watchdog module), so we can't reference it directly in this type.
@@ -48,6 +37,18 @@ FileWatcherType = Union[
     Type["streamlit.watcher.event_based_file_watcher.EventBasedFileWatcher"],
     Type[PollingFileWatcher],
 ]
+
+def report_watchdog_availability():
+    if watchdog_available == False:
+        if not config.get_option("global.disableWatchdogWarning"):
+            msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
+
+            click.secho("  %s" % "For better performance, install the Watchdog module:", fg="blue", bold=True)
+            click.secho(
+                """%s
+  $ pip install watchdog
+            """
+                % msg)
 
 
 def watch_file(

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -17,13 +17,13 @@ import unittest
 
 from io import StringIO
 from unittest import mock
-from unittest.mock import patch, Mock
-
+from unittest.mock import Mock, patch
 import matplotlib
+
 import click
 
 import streamlit
-from streamlit import version, bootstrap, SECRETS_FILE_LOC, cli
+from streamlit import bootstrap, cli, config, SECRETS_FILE_LOC, version
 from streamlit import config
 from streamlit.report import Report
 from tests import testutil
@@ -95,7 +95,6 @@ class BootstrapPrintTest(unittest.TestCase):
         self.assertTrue("URL: http://the-address" in out)
 
     def test_print_new_version_message(self):
-
         with patch(
             "streamlit.version.should_show_new_version_notice", return_value=True
         ), patch("click.secho") as mock_echo:

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -14,15 +14,20 @@
 
 import sys
 import unittest
+
 from io import StringIO
+from unittest import mock
 from unittest.mock import patch, Mock
 
 import matplotlib
+import click
 
-from streamlit import bootstrap, SECRETS_FILE_LOC
+import streamlit
+from streamlit import version, bootstrap, SECRETS_FILE_LOC, cli
 from streamlit import config
 from streamlit.report import Report
 from tests import testutil
+from streamlit.bootstrap import NEW_VERSION_TEXT
 
 report = Report("the/path", "test command line")
 
@@ -88,6 +93,14 @@ class BootstrapPrintTest(unittest.TestCase):
             "Welcome to Streamlit. Check out our demo in your browser." in out
         )
         self.assertTrue("URL: http://the-address" in out)
+
+    def test_print_new_version_message(self):
+
+        with patch(
+            "streamlit.version.should_show_new_version_notice", return_value=True
+        ), patch("click.secho") as mock_echo:
+            bootstrap._print_new_version_message()
+            mock_echo.assert_called_once_with(NEW_VERSION_TEXT)
 
     def test_print_urls_configured(self):
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -199,22 +199,6 @@ class CliTest(unittest.TestCase):
             cli._main_run("/not/a/file", None)
             self.assertTrue(streamlit._is_running_with_streamlit)
 
-    def test_running_in_streamlit_new_version(self):
-        """Test that streamlit echos information about the new version
-        available if needed
-        """
-        self.assertFalse(streamlit._is_running_with_streamlit)
-        with patch("streamlit.cli.bootstrap.run"), mock.patch(
-            "streamlit.credentials.Credentials._check_activated"
-        ), patch("streamlit.cli._get_command_line_as_string"), patch(
-            "streamlit.version.should_show_new_version_notice", return_value=True
-        ), patch(
-            "click.echo"
-        ) as mock_echo:
-            cli._main_run("/not/a/file", None)
-            mock_echo.assert_called_once_with(NEW_VERSION_TEXT)
-            self.assertTrue(streamlit._is_running_with_streamlit)
-
     def test_convert_config_option_to_click_option(self):
         """Test that configurator_options adds dynamic commands based on a
         config lists.

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -31,7 +31,6 @@ import streamlit
 from streamlit import cli
 from streamlit import config
 from streamlit.cli import _convert_config_option_to_click_option
-from streamlit.cli import NEW_VERSION_TEXT
 from streamlit.config_option import ConfigOption
 
 

--- a/lib/tests/streamlit/watcher/file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/file_watcher_test.py
@@ -15,13 +15,39 @@
 """Tests the public utility funtions in file_watcher.py"""
 
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import call, Mock, patch
 
+import click
+
+from streamlit import env_util
+import streamlit.watcher.file_watcher
 from streamlit.watcher.file_watcher import get_default_file_watcher_class, watch_file
 from tests.testutil import patch_config_options
 
 
 class FileWatcherTest(unittest.TestCase):
+    def test_report_watchdog_availability(self):
+        with patch(
+            "streamlit.watcher.file_watcher.watchdog_available", new=False
+        ), patch("click.secho") as mock_echo:
+            streamlit.watcher.file_watcher.report_watchdog_availability()
+
+        msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
+        calls = [
+            call(
+                "  %s" % "For better performance, install the Watchdog module:",
+                fg="blue",
+                bold=True,
+            ),
+            call(
+                """%s
+  $ pip install watchdog
+            """
+                % msg
+            ),
+        ]
+        mock_echo.assert_has_calls(calls)
+
     @patch("streamlit.watcher.file_watcher.PollingFileWatcher")
     @patch("streamlit.watcher.file_watcher.EventBasedFileWatcher")
     def test_watch_file(self, mock_event_watcher, mock_polling_watcher):

--- a/lib/tests/streamlit/watcher/file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/file_watcher_test.py
@@ -76,7 +76,7 @@ class FileWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.file_watcher.PollingFileWatcher")
     @patch("streamlit.watcher.file_watcher.EventBasedFileWatcher")
-    def test_wath_file(self, mock_event_watcher, mock_polling_watcher):
+    def test_watch_file(self, mock_event_watcher, mock_polling_watcher):
         """Test all possible outcomes of both `get_default_file_watcher_class` and
         `watch_file`, based on config.fileWatcherType and whether
         `watchdog_available` is true.


### PR DESCRIPTION


## Before contributing (PLEASE READ!)

⚠️ **If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer and tag @nthmost, then wait for a positive response.** And if there is no issue for it yet, create it first.

This helps make sure (1) two people aren't working on the same thing, (2) this is something Streamlit's maintainers believe should be implemented/fixed, (3) any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers, and (4) your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing

---

**Issue:** Please include a link to the issue you're addressing. If no issue exists, create one first and then link it here.

https://github.com/streamlit/streamlit/issues/2673

**Description:** Describe the changes you made to the code, so it's easier for the reader to navigate your pull request. Usually this is a bullet list.

* Move startup message calls to a single location in bootstrap.py so their order can be consistent
* Reformatted messages as requested in the issue

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
