### PR TITLE
Remove path from 404 response

### DIFF
--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -314,7 +314,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         component_name = parts[0]
         component_root = self._registry.get_component_path(component_name)
         if component_root is None:
-            self.write(f"{path} not found")
+            self.write(f"not found")
             self.set_status(404)
             return
 
@@ -327,7 +327,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             with open(abspath, "r", encoding="utf-8") as file:
                 contents = file.read()
         except (OSError, UnicodeDecodeError) as e:
-            self.write(f"{path} read error: {e}")
+            self.write(f"read error: {e}")
             self.set_status(404)
             return
 

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -314,7 +314,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         component_name = parts[0]
         component_root = self._registry.get_component_path(component_name)
         if component_root is None:
-            self.write(f"not found")
+            self.write("not found")
             self.set_status(404)
             return
 
@@ -327,7 +327,8 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             with open(abspath, "r", encoding="utf-8") as file:
                 contents = file.read()
         except (OSError, UnicodeDecodeError) as e:
-            self.write(f"read error: {e}")
+            LOGGER.error(f"ComponentRequestHandler: GET {path} read error", exc_info=e)
+            self.write("read error")
             self.set_status(404)
             return
 

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -84,7 +84,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
             media_file_manager.get(absolute_path)
         except KeyError:
             LOGGER.error("MediaFileManager: Missing file %s" % absolute_path)
-            raise tornado.web.HTTPError(404, "%s not found", absolute_path)
+            raise tornado.web.HTTPError(404, "not found")
 
         return absolute_path
 

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -411,7 +411,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         response = self._request_component("invalid_component")
         self.assertEqual(404, response.code)
-        self.assertEqual(b"invalid_component not found", response.body)
+        self.assertEqual(b"not found", response.body)
 
     def test_invalid_content_request(self):
         """Test request failure when invalid content (file) is provided."""
@@ -425,7 +425,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(404, response.code)
         self.assertEqual(
-            b"components_test.test read error: Invalid content",
+            b"read error: Invalid content",
             response.body,
         )
 
@@ -443,7 +443,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(404, response.code)
         self.assertEqual(
-            b"components_test.test read error: 'utf-8' codec can't decode bytes in position 9-10: unexpected end of data",
+            b"read error: 'utf-8' codec can't decode bytes in position 9-10: unexpected end of data",
             response.body,
         )
 

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -425,7 +425,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(404, response.code)
         self.assertEqual(
-            b"read error: Invalid content",
+            b"read error",
             response.body,
         )
 
@@ -443,7 +443,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(404, response.code)
         self.assertEqual(
-            b"read error: 'utf-8' codec can't decode bytes in position 9-10: unexpected end of data",
+            b"read error",
             response.body,
         )
 


### PR DESCRIPTION
Browsers attempt to render the path, which doesn't make any sense. It's best to just remove it.