### PR TITLE
Fix vertical alignment inconsistencies for unlabeled widgets

### DIFF
--- a/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -191,11 +191,11 @@ describe("Selectbox widget", () => {
 })
 
 describe("Selectbox widget with optional props", () => {
-  it("should not render label if none provided", () => {
+  it("should render label element even if no text provided", () => {
     const props = getProps({ label: undefined })
     const wrapper = shallow(<Selectbox {...props} />)
 
-    expect(wrapper.find("StyledWidgetLabel").exists()).toBeFalsy()
+    expect(wrapper.find("StyledWidgetLabel").exists()).toBeTruthy()
   })
 
   it("should render TooltipIcon if help text provided", () => {

--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -25,7 +25,7 @@ import { Placement } from "src/components/shared/Tooltip"
 import TooltipIcon from "src/components/shared/TooltipIcon"
 import {
   StyledWidgetLabel,
-  StyledWidgetLabelHelpInline,
+  StyledWidgetLabelHelp,
 } from "src/components/widgets/BaseWidget"
 
 export interface Props {
@@ -104,26 +104,9 @@ class Selectbox extends React.PureComponent<Props, State> {
   ): readonly Option[] =>
     fuzzyFilterSelectOptions(options as SelectOption[], filterValue)
 
-  private renderLabel = (): React.ReactElement | null => {
-    const { label, help } = this.props
-    if (!label) {
-      return null
-    }
-
-    return (
-      <StyledWidgetLabel>
-        {label}
-        {help && (
-          <StyledWidgetLabelHelpInline>
-            <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
-          </StyledWidgetLabelHelpInline>
-        )}
-      </StyledWidgetLabel>
-    )
-  }
-
   public render = (): React.ReactNode => {
     const style = { width: this.props.width }
+    const { label, help } = this.props
     let { disabled, options } = this.props
 
     const value = [
@@ -151,7 +134,12 @@ class Selectbox extends React.PureComponent<Props, State> {
 
     return (
       <div className="row-widget stSelectbox" style={style}>
-        {this.renderLabel()}
+        <StyledWidgetLabel>{label}</StyledWidgetLabel>
+        {help && (
+          <StyledWidgetLabelHelp>
+            <TooltipIcon content={help} placement={Placement.TOP_RIGHT} />
+          </StyledWidgetLabelHelp>
+        )}
         <UISelect
           clearable={false}
           disabled={disabled}

--- a/frontend/src/components/widgets/BaseWidget/styled-components.ts
+++ b/frontend/src/components/widgets/BaseWidget/styled-components.ts
@@ -21,6 +21,8 @@ export const StyledWidgetLabel = styled.label(({ theme }) => ({
   fontSize: theme.fontSizes.smDefault,
   color: theme.colors.bodyText,
   marginBottom: theme.fontSizes.halfSmDefault,
+  height: theme.fontSizes.xl,
+  verticalAlign: "middle",
 }))
 
 export const StyledWidgetLabelHelp = styled.div(() => ({


### PR DESCRIPTION
**Issue:** #3071

**Description:** This PR fixes visual inconsistencies that may occur when creating widgets in a `beta_columns` container without specifying a label.
* Updated `Selectbox` component's label+help element structure to make it vertically align properly with other widget types when all widgets in a `beta_columns` container are unlabeled
* Updated `Selectbox.test.tsx` to ensure that a label element always exists within a `Selectbox` component, even if a label is not specified, for accessibility purposes
* Added 2 more CSS properties to `StyledWidgetLabel` component to ensure that widgets in `beta_columns` container are vertically aligned when there is a combination of labeled & unlabeled widgets

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.