### PR TITLE
Temporarily disable extremely flaky tests

### DIFF
--- a/e2e/specs/st_checkbox.spec.js
+++ b/e2e/specs/st_checkbox.spec.js
@@ -34,7 +34,7 @@ describe("st.checkbox", () => {
   // We have to manually use the changeTheme command in the next two tests
   // since changing the theme between snapshots using the matchThemedSnapshots
   // command will unfocus the widget we're trying to take a snapshot of.
-  it("shows focused widget correctly in dark mode", () => {
+  xit("shows focused widget correctly in dark mode", () => {
     cy.changeTheme("Dark");
 
     cy.get(".stCheckbox")
@@ -55,7 +55,7 @@ describe("st.checkbox", () => {
       });
   });
 
-  it("shows focused widget correctly in light mode", () => {
+  xit("shows focused widget correctly in light mode", () => {
     cy.changeTheme("Light");
 
     cy.get(".stCheckbox")

--- a/e2e/specs/st_radio.spec.js
+++ b/e2e/specs/st_radio.spec.js
@@ -34,7 +34,7 @@ describe("st.radio", () => {
   // We have to manually use the changeTheme command in the next two tests
   // since changing the theme between snapshots using the matchThemedSnapshots
   // command will unfocus the widget we're trying to take a snapshot of.
-  it("shows focused widget correctly in dark mode", () => {
+  xit("shows focused widget correctly in dark mode", () => {
     cy.changeTheme("Dark");
 
     cy.get(".stRadio")
@@ -56,7 +56,7 @@ describe("st.radio", () => {
       });
   });
 
-  it("shows focused widget correctly in light mode", () => {
+  xit("shows focused widget correctly in light mode", () => {
     cy.changeTheme("Light");
 
     cy.get(".stRadio")


### PR DESCRIPTION
I added some snapshot tests for things that previously didn't have any
test coverage in the theming fast follow feature branch. These tests
seemed okay in the branch but suddenly turned flaky to the point of
being unusable once it got merged into develop, so this commit disables
them for now to un-break the build until the tests can be de-flaked and
revived.