### PR TITLE
Force full garbage collection between script runs

### DIFF
--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -14,6 +14,7 @@
 
 import sys
 import threading
+import gc
 from contextlib import contextmanager
 from enum import Enum
 
@@ -347,6 +348,13 @@ class ScriptRunner(object):
 
         finally:
             self._on_script_finished(ctx)
+
+            # Force garbage collection to run, to help avoid memory use building up
+            # This is usually not an issue, but sometimes GC takes time to kick in and
+            # causes apps to go over resource limits, and forcing it to run between
+            # script runs is low cost, since we aren't doing much work anyway.
+            # Collecting gen 2 seems to cause test failures, so only collect 0 and 1.
+            gc.collect(1)
 
         # Use _log_if_error() to make sure we never ever ever stop running the
         # script without meaning to.

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -349,13 +349,6 @@ class ScriptRunner(object):
         finally:
             self._on_script_finished(ctx)
 
-            # Force garbage collection to run, to help avoid memory use building up
-            # This is usually not an issue, but sometimes GC takes time to kick in and
-            # causes apps to go over resource limits, and forcing it to run between
-            # script runs is low cost, since we aren't doing much work anyway.
-            # Collecting gen 2 seems to cause test failures, so only collect 0 and 1.
-            gc.collect(1)
-
         # Use _log_if_error() to make sure we never ever ever stop running the
         # script without meaning to.
         _log_if_error(_clean_problem_modules)
@@ -375,6 +368,12 @@ class ScriptRunner(object):
         # Delete expired files now that the script has run and files in use
         # are marked as active.
         media_file_manager.del_expired_files()
+
+        # Force garbage collection to run, to help avoid memory use building up
+        # This is usually not an issue, but sometimes GC takes time to kick in and
+        # causes apps to go over resource limits, and forcing it to run between
+        # script runs is low cost, since we aren't doing much work anyway.
+        gc.collect(2)
 
 
 class ScriptControlException(BaseException):

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -184,7 +184,14 @@ class ScriptRunnerTest(AsyncTestCase):
 
         time.sleep(0.1)
         scriptrunner.enqueue_rerun()
-        time.sleep(0.1)
+
+        # This test will fail if the script runner does not execute the infinite
+        # script's write call at least once during the final script run.
+        # The script runs forever, and when we enqueue a rerun it forcibly
+        # stops execution and runs some cleanup. If we do not wait for the
+        # forced GC to finish, the script won't start running before we stop
+        # the script runner, so the expected delta is never created.
+        time.sleep(0.3)
         scriptrunner.enqueue_stop()
         scriptrunner.join()
 


### PR DESCRIPTION
#3075, but GC for all generations, because I investigated and fixed the test failure that collecting the oldest gen was causing.

It had nothing to do with GC in itself. Rather, there was a race condition where a test would fail if a script rerun didn't happen fast enough, before a stop request was sent. Adding in full GC caused the cleanup phase to take just long enough to hit this (adding `time.wait()`to the cleanup was able to trigger it as well).

As a result of investigating this issue in depth, I am now confident that full collection is safe.