### PR TITLE
Revive the docker image used to take cypress snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,22 +346,28 @@ headers:
 		examples \
 		scripts
 
-.PHONY: build-circleci
+.PHONY: build-test-env
 # Build docker image that mirrors circleci
-build-circleci:
-	docker build -t streamlit_circleci -f e2e/Dockerfile .
+build-test-env:
+	docker build \
+		--build-arg UID=$$(id -u) \
+		--build-arg GID=$$(id -g) \
+		--build-arg OSTYPE=$$(uname) \
+		-t streamlit_e2e_tests \
+		-f e2e/Dockerfile \
+		.
 
-.PHONY: run-circleci
-# Run circleci image with volume mounts
-run-circleci:
+.PHONY: run-test-env
+# Run test env image with volume mounts
+run-test-env:
 	docker-compose \
 		-f e2e/docker-compose.yml \
 		run \
 		--rm \
-		--name streamlit_circleci \
-		streamlit
+		--name streamlit_e2e_tests \
+		streamlit_e2e_tests
 
-.PHONY: connect-circleci
-# Connect to running circleci container
-connect-circleci:
-	docker exec -it streamlit_circleci /bin/bash
+.PHONY: connect-test-env
+# Connect to an already-running test env container
+connect-test-env:
+	docker exec -it streamlit_e2e_tests /bin/bash

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -3,16 +3,35 @@ FROM circleci/python:3.7.4-stretch
 SHELL ["/bin/bash", "-c"]
 ENV PYTHONUNBUFFERED 1
 
+# For the container running cypress to be able to write snapshots to a
+# directory mounted from the host, the UID/GID of the user in the container
+# must be UIDs/GIDs with write permissions on the host. We default to the
+# user/group IDs for the first non-root user on most linux systems, but in
+# practice these should always be explicitly set by the make targets
+# conventionally used to work with this image.
+ARG UID=1000
+ARG GID=1000
+
+# MacOS handles GroupIDs differently than Linux, so we don't have to run
+# `groupadd` on non-Linux system (more precisely, on MacOS since we haven't
+# even tried building this image on Windows).
+ARG OSTYPE=Linux
+
 ARG USER=circleci
 ARG HOME=/home/$USER
 ARG APP=$HOME/repo
 
+USER root
+
+RUN usermod -u $UID $USER
+RUN bash -c 'if [ ${OSTYPE} == Linux ]; then groupmod -g ${GID} ${USER}; fi'
+
+USER $USER
+
 # create `yarn start` cache directory
-# run before setting the user (https://github.com/docker/compose/issues/3270)
 RUN mkdir -p $APP/frontend/node_modules/.cache/hard-source \
     && chown $USER:$USER $APP/frontend/node_modules/.cache/hard-source
 
-USER $USER
 WORKDIR $APP
 RUN sudo chown $USER $APP
 

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,26 +1,21 @@
 version: "3.7"
 services:
-  streamlit:
-    image: streamlit_circleci
-    build: .
-    ports:
-      - "3000:3000"
+  streamlit_e2e_tests:
+    image: streamlit_e2e_tests
+    ipc: host
+    build:
+      context: ..
+      dockerfile: ./e2e/Dockerfile
+
     volumes:
-      - type: bind
-        source: ../e2e
-        target: /home/circleci/repo/e2e
-      - type: bind
-        source: ../frontend/cypress
-        target: /home/circleci/repo/frontend/cypress
-      - type: bind
-        source: ../frontend/test_results
-        target: /home/circleci/repo/frontend/test_results
-      - type: bind
-        source: ../frontend/src
-        target: /home/circleci/repo/frontend/src
-      - type: bind
-        source: ../lib/streamlit
-        target: /home/circleci/repo/lib/streamlit
+      - .:/home/circleci/repo/e2e
+      - ../component-template:/home/circleci/repo/component-template
+      - ../frontend/cypress:/home/circleci/repo/frontend/cypress
+      - ../frontend/src:/home/circleci/repo/frontend/src
+      - ../frontend/test_results:/home/circleci/repo/frontend/test_results
+      - ../lib/streamlit:/home/circleci/repo/lib/streamlit
+      - ../scripts:/home/circleci/repo/scripts
+
       - type: volume
         source: hard_source_webpack_plugin_cache
         target: /home/circleci/repo/frontend/node_modules/.cache/hard-source


### PR DESCRIPTION
This should make it possible to generate and update snapshots without relying
on CI in some way (either by deleting snapshots to have CI regenerate them or
having CI generate diffs to be processed by the cropping script)

After this PR goes in, I'll spend some time reworking our wiki pages to include
instructions on how to use this image as well as an overview of all of the
available options for updating snapshots.

Unfortunately, this isn't a perfect cure for our snapshot woes for a few
reasons.

- it takes _forever_ to build image, mostly due to the length of time it
  takes to install Python dependencies. As far as I can tell, this is
  naturally quite slow, and there's not much we can do about it.
- for whatever reason I'm having trouble getting component-template
  tests to work, but this is just a minor annoyance for now as those
  don't change much. This does mean that you can't run all e2e tests
  easily since they'll fail midway through due to these tests blowing
  up, but doing this takes so long that it seems unlikely that it'll be
  done often anyway.

Closes #2682