### PR TITLE
Add st.form to API reference in Docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -176,6 +176,10 @@ add_selectbox = st.sidebar.selectbox(
 In addition to the sidebar, you have a few other options for controlling how your app is laid out.
 
 ```eval_rst
+.. autofunction:: streamlit.form
+```
+
+```eval_rst
 .. note:: These are beta features. See
   https://docs.streamlit.io/en/latest/api.html#pre-release-features for more information.
 ```


### PR DESCRIPTION
Description: Added st.form to Streamlit's API reference under the [Lay out your app](https://docs.streamlit.io/en/stable/api.html#lay-out-your-app) sub-section. [#3187](https://github.com/streamlit/streamlit/pull/3187) containing st.form API examples should be merged before this PR.
