### PR TITLE
Add st.form_submit_button to API refence in Docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -177,6 +177,7 @@ In addition to the sidebar, you have a few other options for controlling how you
 
 ```eval_rst
 .. autofunction:: streamlit.form
+.. autofunction:: streamlit.form_submit_button
 ```
 
 ```eval_rst


### PR DESCRIPTION
- Added missing st.form_submit_button to Streamlit's API reference below [st.form](https://docs.streamlit.io/en/latest/api.html#streamlit.form). 
- [#3203](https://github.com/streamlit/streamlit/pull/3203) should have included this change but didn't.