### PR TITLE
Finish Part 2 of the machine ID v3 work

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -89,6 +89,7 @@ describe("App", () => {
       installationId: "iid",
       installationIdV1: "iid1",
       installationIdV2: "iid2",
+      installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine: "command line",
@@ -267,6 +268,7 @@ describe("App.handleNewReport", () => {
         installationId: "installationId",
         installationIdV1: "installationIdV1",
         installationIdV2: "installationIdV2",
+        installationIdV3: "installationIdV3",
         email: "email",
       },
       environmentInfo: {

--- a/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
+++ b/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
@@ -31,6 +31,7 @@ function setSessionInfo(
     installationId: "iid",
     installationIdV1: "iid1",
     installationIdV2: "iid2",
+    installationIdV3: "iid3",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
     commandLine,

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
@@ -51,6 +51,7 @@ describe("withMapboxToken", () => {
       installationId: "iid",
       installationIdV1: "iid1",
       installationIdV2: "iid2",
+      installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine,

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -45,6 +45,7 @@ describe("FileUploadClient Upload", () => {
       installationId: "iid",
       installationIdV1: "iid1",
       installationIdV2: "iid2",
+      installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine: "command line",

--- a/frontend/src/lib/HttpClient.test.ts
+++ b/frontend/src/lib/HttpClient.test.ts
@@ -37,6 +37,7 @@ describe("HttpClient", () => {
       installationId: "iid",
       installationIdV1: "iid1",
       installationIdV2: "iid2",
+      installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
       commandLine: "command line",

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -32,6 +32,7 @@ const createSessionInfo = (): SessionInfo =>
     installationId: "iid",
     installationIdV1: "iid1",
     installationIdV2: "iid2",
+    installationIdV3: "iid3",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
     commandLine: "command line",
@@ -164,10 +165,12 @@ test("tracks installation data", () => {
   expect(mm.identify.mock.calls[0][1]).toMatchObject({
     machineIdV1: SessionInfo.current.installationIdV1,
     machineIdV2: SessionInfo.current.installationIdV2,
+    machineIdV3: SessionInfo.current.installationIdV3,
   })
   expect(mm.track.mock.calls[0][1]).toMatchObject({
     machineIdV1: SessionInfo.current.installationIdV1,
     machineIdV2: SessionInfo.current.installationIdV2,
+    machineIdV3: SessionInfo.current.installationIdV3,
   })
 })
 

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -227,6 +227,7 @@ export class MetricsManager {
     return {
       machineIdV1: SessionInfo.current.installationIdV1,
       machineIdV2: SessionInfo.current.installationIdV2,
+      machineIdV3: SessionInfo.current.installationIdV3,
     }
   }
 

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -30,6 +30,7 @@ test("Clears session info", () => {
     installationId: "iid",
     installationIdV1: "iid1",
     installationIdV2: "iid2",
+    installationIdV3: "iid3",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
     commandLine: "command line",
@@ -55,6 +56,7 @@ test("Can be initialized from a protobuf", () => {
         installationId: "installationId",
         installationIdV1: "installationIdV1",
         installationIdV2: "installationIdV2",
+        installationIdV3: "installationIdV3",
         email: "email",
       },
       environmentInfo: {
@@ -77,6 +79,7 @@ test("Can be initialized from a protobuf", () => {
   expect(si.installationId).toEqual("installationId")
   expect(si.installationIdV1).toEqual("installationIdV1")
   expect(si.installationIdV2).toEqual("installationIdV2")
+  expect(si.installationIdV3).toEqual("installationIdV3")
   expect(si.authorEmail).toEqual("email")
   expect(si.maxCachedMessageAge).toEqual(31)
   expect(si.commandLine).toEqual("commandLine")

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -30,6 +30,7 @@ export interface Args {
   installationId: string
   installationIdV1: string
   installationIdV2: string
+  installationIdV3: string
   authorEmail: string
   maxCachedMessageAge: number
   commandLine: string
@@ -49,6 +50,8 @@ export class SessionInfo {
   public readonly installationIdV1: string
 
   public readonly installationIdV2: string
+
+  public readonly installationIdV3: string
 
   public readonly authorEmail: string
 
@@ -110,6 +113,7 @@ export class SessionInfo {
       installationId: userInfo.installationId,
       installationIdV1: userInfo.installationIdV1,
       installationIdV2: userInfo.installationIdV2,
+      installationIdV3: userInfo.installationIdV3,
       authorEmail: userInfo.email,
       maxCachedMessageAge: config.maxCachedMessageAge,
       commandLine: initialize.commandLine,
@@ -124,6 +128,7 @@ export class SessionInfo {
     installationId,
     installationIdV1,
     installationIdV2,
+    installationIdV3,
     authorEmail,
     maxCachedMessageAge,
     commandLine,
@@ -136,6 +141,7 @@ export class SessionInfo {
       installationId == null ||
       installationIdV1 == null ||
       installationIdV2 == null ||
+      installationIdV3 == null ||
       authorEmail == null ||
       maxCachedMessageAge == null ||
       commandLine == null ||
@@ -150,6 +156,7 @@ export class SessionInfo {
     this.installationId = installationId
     this.installationIdV1 = installationIdV1
     this.installationIdV2 = installationIdV2
+    this.installationIdV3 = installationIdV3
     this.authorEmail = authorEmail
     this.maxCachedMessageAge = maxCachedMessageAge
     this.commandLine = commandLine

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -143,4 +143,4 @@ class Installation:
 
     @property
     def installation_id(self):
-        return self.installation_id_v1
+        return self.installation_id_v3


### PR DESCRIPTION
## History
- Part 2 of the machine ID v3 work was implemented in [this PR](https://github.com/streamlit/streamlit/pull/2605)
- The PR changed our Python code so we now calculate `machine_id_v3`
    **Great!** 😃

- **...but the PR did not touch the JS side!**  ☹️
    Meaning, we never send the new ID to Segment in any way.

    See [MetricsManager.ts](https://github.com/streamlit/streamlit/blob/96f17464a13969ecdfe31043ab8e875718eb0d10/frontend/src/lib/MetricsManager.ts#L226) and [SessionInfo.ts](https://github.com/streamlit/streamlit/blob/96f17464a13969ecdfe31043ab8e875718eb0d10/frontend/src/lib/SessionInfo.ts#L111). There are no mentions of `MachineIdV3` in those.

## This PR

This PR finishes piping MachineIdV3 to Segment. So what we send to Segment is this:
- `machine_id_v1`: this is the old MAC-address-based ID with annoying sudo step. This will go away in Part 3.
- `machine_id_v2`: this is the old random-number-based ID.  This will go away in Part 3.
- ADDED: `machine_id_v3`: the new MAC-address-based ID without sudo.  This will go away in Part 3.
- ADDED: `user_id`: the new MAC-address-based ID without sudo

## Double-checking...

To make sure I was sending out the right things to Segment, I _temporarily_ prepended "stidv1-", "stidv2-" and "stidv3-" to the three IDs and watched what MetricsManager.ts logged to the console:

<img width="1211" alt="Screen Shot 2021-05-04 at 4 34 57 PM" src="https://user-images.githubusercontent.com/690814/117082953-5d2c8e00-acf8-11eb-8ae8-9ae223e6b05e.png">

Looks right!