### PR TITLE
Don't allow config.get_option to be called on file import

### DIFF
--- a/lib/streamlit/folder_black_list.py
+++ b/lib/streamlit/folder_black_list.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 
 from streamlit import util
 from streamlit import file_util
@@ -34,15 +35,6 @@ DEFAULT_FOLDER_BLACKLIST = [
 ]
 
 
-# Add the Streamlit lib folder when in dev mode, since otherwise we end up with
-# weird situations where the ID of a class in one run is not the same as in another
-# run.
-if config.get_option("global.developmentMode"):
-    import os
-
-    DEFAULT_FOLDER_BLACKLIST.append(os.path.dirname(__file__))
-
-
 class FolderBlackList(object):
     """Implement a black list object with globbing.
 
@@ -63,6 +55,12 @@ class FolderBlackList(object):
         """
         self._folder_blacklist = list(folder_blacklist)
         self._folder_blacklist.extend(DEFAULT_FOLDER_BLACKLIST)
+
+        # Add the Streamlit lib folder when in dev mode, since otherwise we end
+        # up with weird situations where the ID of a class in one run is not
+        # the same as in another run.
+        if config.get_option("global.developmentMode"):
+            self._folder_blacklist.append(os.path.dirname(__file__))
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -60,7 +60,9 @@ _NP_SAMPLE_SIZE = 100000
 _CYCLE_PLACEHOLDER = b"streamlit-57R34ML17-hesamagicalponyflyingthroughthesky-CYCLE"
 
 
-_FOLDER_BLACK_LIST = FolderBlackList(config.get_option("server.folderWatchBlacklist"))
+# This needs to be initialized lazily to avoid calling config.get_option() and
+# thus initializing config options when this file is first imported.
+_FOLDER_BLACK_LIST = None
 
 
 # FFI objects (objects that interface with C libraries) can be any of these types:
@@ -378,6 +380,13 @@ class _CodeHasher:
         hasher.update(b)
 
     def _file_should_be_hashed(self, filename):
+        global _FOLDER_BLACK_LIST
+
+        if not _FOLDER_BLACK_LIST:
+            _FOLDER_BLACK_LIST = FolderBlackList(
+                config.get_option("server.folderWatchBlacklist")
+            )
+
         filepath = os.path.abspath(filename)
         file_is_blacklisted = _FOLDER_BLACK_LIST.is_blacklisted(filepath)
         # Short circuiting for performance.

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -37,12 +37,29 @@ except ImportError:
         pass
 
 
-# EventBasedFileWatcher will be a stub, and have no functional
+# local_sources_watcher.py caches the return value of
+# get_default_file_watcher_class(), so it needs to differentiate between the
+# cases where it:
+#   1. has yet to call get_default_file_watcher_class()
+#   2. has called get_default_file_watcher_class(), which returned that no
+#      file watcher should be installed.
+# This forces us to define this stub class since the cached value equaling
+# None corresponds to case 1 above.
+class NoOpFileWatcher:
+    def __init__(self, _file_path, _on_file_changed):
+        pass
+
+    def watch_file(self, _file_path, _callback):
+        pass
+
+
+# EventBasedFileWatcher will be a stub and have no functional
 # implementation if its import failed (due to missing watchdog module),
 # so we can't reference it directly in this type.
 FileWatcherType = Union[
     Type["streamlit.watcher.event_based_file_watcher.EventBasedFileWatcher"],
     Type[PollingFileWatcher],
+    Type[NoOpFileWatcher],
 ]
 
 
@@ -93,21 +110,21 @@ def watch_file(
         watcher_type = config.get_option("server.fileWatcherType")
 
     watcher_class = get_file_watcher_class(watcher_type)
-    if watcher_class is None:
+    if watcher_class is NoOpFileWatcher:
         return False
 
     watcher_class(path, on_file_changed)
     return True
 
 
-def get_default_file_watcher_class() -> Optional[FileWatcherType]:
+def get_default_file_watcher_class() -> FileWatcherType:
     """Return the class to use for file changes notifications, based on the
     server.fileWatcherType config option.
     """
     return get_file_watcher_class(config.get_option("server.fileWatcherType"))
 
 
-def get_file_watcher_class(watcher_type: str) -> Optional[FileWatcherType]:
+def get_file_watcher_class(watcher_type: str) -> FileWatcherType:
     """Return the FileWatcher class that corresponds to the given watcher_type
     string. Acceptable values are 'auto', 'watchdog', 'poll' and 'none'.
     """
@@ -121,4 +138,4 @@ def get_file_watcher_class(watcher_type: str) -> Optional[FileWatcherType]:
     elif watcher_type == "poll":
         return PollingFileWatcher
     else:
-        return None
+        return NoOpFileWatcher

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -36,12 +36,18 @@ gatherUsageStats = false
 with patch(
     "streamlit.config.open", mock_open(read_data=CONFIG_FILE_CONTENTS), create=True
 ), patch("streamlit.config.os.path.exists") as path_exists:
-    # It is important that no streamlit imports happen outside of this patch
-    # context. Some Streamlit modules read config values at import time, which
-    # will cause config.toml to be read. We need to ensure that the mock config
-    # is read instead of the user's actual config.
+    # Import streamlit even if we don't do anything with it below as we want to
+    # be sure to catch any instances of calling config.get_option() when
+    # first importing a file. We disallow this because doing so means that we
+    # miss config options set via flag or environment variable.
+    import streamlit as st
+
     from streamlit import file_util
     from streamlit import config
+
+    assert (
+        not config._config_options
+    ), "config.get_option() should not be called on file import!"
 
     config_path = file_util.get_streamlit_file_path("config.toml")
     path_exists.side_effect = lambda path: path == config_path

--- a/lib/tests/streamlit/watcher/file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/file_watcher_test.py
@@ -21,7 +21,11 @@ import click
 
 from streamlit import env_util
 import streamlit.watcher.file_watcher
-from streamlit.watcher.file_watcher import get_default_file_watcher_class, watch_file
+from streamlit.watcher.file_watcher import (
+    get_default_file_watcher_class,
+    NoOpFileWatcher,
+    watch_file,
+)
 from tests.testutil import patch_config_options
 
 
@@ -82,11 +86,11 @@ class FileWatcherTest(unittest.TestCase):
         `watchdog_available` is true.
         """
         subtest_params = [
-            (None, False, None),
-            (None, True, None),
+            (None, False, NoOpFileWatcher),
+            (None, True, NoOpFileWatcher),
             ("poll", False, mock_polling_watcher),
             ("poll", True, mock_polling_watcher),
-            ("watchdog", False, None),
+            ("watchdog", False, NoOpFileWatcher),
             ("watchdog", True, mock_event_watcher),
             ("auto", False, mock_polling_watcher),
             ("auto", True, mock_event_watcher),
@@ -105,12 +109,16 @@ class FileWatcherTest(unittest.TestCase):
                         file_watcher_class, get_default_file_watcher_class()
                     )
 
-                    # Test watch_file(). If file_watcher_class is None,
-                    # nothing should happen. Otherwise, file_watcher_class
-                    # should be called with the watch_file params.
+                    # Test watch_file(). If file_watcher_class is
+                    # NoOpFileWatcher, nothing should happen. Otherwise,
+                    # file_watcher_class should be called with the watch_file
+                    # params.
                     on_file_changed = Mock()
-                    watch_file("some/file/path", on_file_changed)
-                    if file_watcher_class is not None:
+                    watching_file = watch_file("some/file/path", on_file_changed)
+                    if file_watcher_class is not NoOpFileWatcher:
                         file_watcher_class.assert_called_with(
                             "some/file/path", on_file_changed
                         )
+                        self.assertTrue(watching_file)
+                    else:
+                        self.assertFalse(watching_file)


### PR DESCRIPTION
This makes some things harder to write, but it's necessary because
otherwise, config options that are accessed on file import may ignore
options set via flag or environment variable (as those haven't been parsed
yet). Thankfully, there are only two places where code had to be reworked,
and both of these changes were relatively straightforward.

To prevent this from accidentally happening in the future, we added an
assertion in conftest.py that explodes if config options have been
populated after importing streamlit.

Closes #2257
Closes #2989 
Closes #2990