### PR TITLE
Bump handlebars minimum version to 4.7.7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -180,7 +180,7 @@
     "dot-prop": "^4.2.1",
     "elliptic": "^6.5.4",
     "esm": "^3.1.0",
-    "handlebars": "^4.4.5",
+    "handlebars": "^4.7.7",
     "https-proxy-agent": "^2.2.4",
     "ini": "^1.3.6",
     "is-svg": "^4.2.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9735,10 +9735,10 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.4.5:
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
-  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"


### PR DESCRIPTION
For whatever reason we didn't get an automated dependabot PR for this
:thinking:
