### PR TITLE
[Security] Upgrade trim to 0.0.3 or later

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -191,6 +191,7 @@
     "serialize-javascript": "^3.1.0",
     "ssri": "^8.0.1",
     "static-eval": "^2.0.5",
+    "trim": "^0.0.3",
     "websocket-extensions": "^0.1.4",
     "xmldom": "^0.5.0",
     "y18n": "^4.0.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17983,10 +17983,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Details: [CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq)