### PR TITLE
Random cleanup: docstrings + type-safety

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -340,9 +340,11 @@ class DeltaGenerator(
 
         Returns
         -------
-        DeltaGenerator
-            A DeltaGenerator that can be used to modify the newly-created
-            element.
+        DeltaGenerator or any
+            If this element is NOT an interactive widget, return a
+            DeltaGenerator that can be used to modify the newly-created
+            element. Otherwise, if the element IS a widget, return the
+            `return_value` parameter.
 
         """
         # Operate on the active DeltaGenerator, in case we're in a `with` block.

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -26,6 +26,18 @@ LOGGER = get_logger(__name__)
 
 
 class ReportContext:
+    """A context object that contains data for a "report run" - that is,
+    data that's scoped to a single ScriptRunner execution (and therefore also
+    scoped to a single connected "session").
+
+    ReportContext is used internally by virtually every `st.foo()` function.
+    It should be accessed only from the script thread that's created by
+    ScriptRunner; it is not safe to use from other threads.
+
+    Streamlit code typically retrieves the active ReportContext via the
+    `get_report_ctx` function.
+    """
+
     def __init__(
         self,
         session_id: str,
@@ -55,6 +67,7 @@ class ReportContext:
         self._enqueue = enqueue
         self.query_string = query_string
         self.widgets = widgets
+        # The ID of each widget that's been registered this run
         self.widget_ids_this_run = _StringSet()
         self.form_ids_this_run = _StringSet()
         self.uploaded_file_mgr = uploaded_file_mgr


### PR DESCRIPTION
- Better docstrings for `ReportContext` and `delta_generator._enqueue`
- `register_widget` is properly type annotated