### PR TITLE
Minor refactor: "setWidgetValue" -> "commitWidgetValue"

### DIFF
--- a/frontend/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.tsx
@@ -60,10 +60,11 @@ class Checkbox extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setBoolValue(
       this.props.element,
       this.state.value,
@@ -73,7 +74,7 @@ class Checkbox extends React.PureComponent<Props, State> {
 
   private onChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const value = e.target.checked
-    this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
+    this.setState({ value }, () => this.commitWidgetValue({ fromUi: true }))
   }
 
   public render = (): React.ReactNode => {

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -48,10 +48,11 @@ class ColorPicker extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setStringValue(
       this.props.element,
       this.state.value,
@@ -61,7 +62,7 @@ class ColorPicker extends React.PureComponent<Props, State> {
 
   private onColorClose = (color: string): void => {
     this.setState({ value: color }, () =>
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     )
   }
 

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -71,10 +71,11 @@ class DateInput extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setStringArrayValue(
       this.props.element,
       this.state.values.map((value: Date) =>
@@ -86,7 +87,7 @@ class DateInput extends React.PureComponent<Props, State> {
 
   private handleChange = ({ date }: { date: Date | Date[] }): void => {
     this.setState({ values: Array.isArray(date) ? date : [date] }, () =>
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     )
   }
 

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -65,10 +65,11 @@ class Multiselect extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setIntArrayValue(
       this.props.element,
       this.state.value,
@@ -107,7 +108,7 @@ class Multiselect extends React.PureComponent<Props, State> {
 
   private onChange = (params: OnChangeParams): void => {
     const newState = this.generateNewState(params)
-    this.setState(newState, () => this.setWidgetValue({ fromUi: true }))
+    this.setState(newState, () => this.commitWidgetValue({ fromUi: true }))
   }
 
   public render(): React.ReactNode {

--- a/frontend/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.tsx
@@ -84,7 +84,7 @@ class NumberInput extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
   private formatValue = (value: number): string => {
@@ -126,7 +126,8 @@ class NumberInput extends React.PureComponent<Props, State> {
     return 0.01
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     const { value } = this.state
     const { element, widgetMgr } = this.props
     const data = this.props.element
@@ -158,7 +159,7 @@ class NumberInput extends React.PureComponent<Props, State> {
 
   private onBlur = (): void => {
     if (this.state.dirty) {
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     }
   }
 
@@ -200,7 +201,7 @@ class NumberInput extends React.PureComponent<Props, State> {
 
   private onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter" && this.state.dirty) {
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     }
   }
 
@@ -221,7 +222,7 @@ class NumberInput extends React.PureComponent<Props, State> {
               value: value + step,
             },
             () => {
-              this.setWidgetValue({ fromUi: true })
+              this.commitWidgetValue({ fromUi: true })
             }
           )
         }
@@ -234,7 +235,7 @@ class NumberInput extends React.PureComponent<Props, State> {
               value: value - step,
             },
             () => {
-              this.setWidgetValue({ fromUi: true })
+              this.commitWidgetValue({ fromUi: true })
             }
           )
         }

--- a/frontend/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.tsx
@@ -48,10 +48,11 @@ class Radio extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setIntValue(
       this.props.element,
       this.state.value,
@@ -61,7 +62,7 @@ class Radio extends React.PureComponent<Props, State> {
 
   private onChange = (selectedIndex: number): void => {
     this.setState({ value: selectedIndex }, () =>
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     )
   }
 

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -48,10 +48,11 @@ class Selectbox extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setIntValue(
       this.props.element,
       this.state.value,
@@ -60,7 +61,7 @@ class Selectbox extends React.PureComponent<Props, State> {
   }
 
   private onChange = (value: number): void => {
-    this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
+    this.setState({ value }, () => this.commitWidgetValue({ fromUi: true }))
   }
 
   public render = (): React.ReactNode => {

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -61,13 +61,13 @@ class Slider extends React.PureComponent<Props, State> {
 
   private sliderRef = React.createRef<HTMLDivElement>()
 
-  private readonly setWidgetValueDebounced: (source: Source) => void
+  private readonly commitWidgetValueDebounced: (source: Source) => void
 
   public constructor(props: Props) {
     super(props)
-    this.setWidgetValueDebounced = debounce(
+    this.commitWidgetValueDebounced = debounce(
       DEBOUNCE_TIME_MS,
-      this.setWidgetValueImmediately.bind(this)
+      this.commitWidgetValue.bind(this)
     )
     this.state = { value: this.initialValue }
   }
@@ -80,10 +80,11 @@ class Slider extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount = (): void => {
-    this.setWidgetValueImmediately({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValueImmediately = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setDoubleArrayValue(
       this.props.element,
       this.state.value,
@@ -93,7 +94,7 @@ class Slider extends React.PureComponent<Props, State> {
 
   private handleChange = ({ value }: { value: number[] }): void => {
     this.setState({ value }, () =>
-      this.setWidgetValueDebounced({ fromUi: true })
+      this.commitWidgetValueDebounced({ fromUi: true })
     )
   }
 

--- a/frontend/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.tsx
@@ -63,10 +63,11 @@ class TextArea extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setStringValue(
       this.props.element,
       this.state.value,
@@ -77,7 +78,7 @@ class TextArea extends React.PureComponent<Props, State> {
 
   private onBlur = (): void => {
     if (this.state.dirty) {
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     }
   }
 
@@ -104,7 +105,7 @@ class TextArea extends React.PureComponent<Props, State> {
     // to re-run. (This also means that we won't show the "Press Enter
     // to Apply" prompt because the TextArea will never be "dirty").
     this.setState({ dirty: false, value }, () =>
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     )
   }
 
@@ -125,7 +126,7 @@ class TextArea extends React.PureComponent<Props, State> {
     if (this.isEnterKeyPressed(e) && (ctrlKey || metaKey) && dirty) {
       e.preventDefault()
 
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     }
   }
 

--- a/frontend/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.tsx
@@ -63,10 +63,11 @@ class TextInput extends React.PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setStringValue(
       this.props.element,
       this.state.value,
@@ -77,7 +78,7 @@ class TextInput extends React.PureComponent<Props, State> {
 
   private onBlur = (): void => {
     if (this.state.dirty) {
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     }
   }
 
@@ -104,13 +105,13 @@ class TextInput extends React.PureComponent<Props, State> {
     // to re-run. (This also means that we won't show the "Press Enter
     // to Apply" prompt because the TextInput will never be "dirty").
     this.setState({ dirty: false, value }, () =>
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     )
   }
 
   private onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter" && this.state.dirty) {
-      this.setWidgetValue({ fromUi: true })
+      this.commitWidgetValue({ fromUi: true })
     }
   }
 

--- a/frontend/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/src/components/widgets/TimeInput/TimeInput.tsx
@@ -54,10 +54,11 @@ class TimeInput extends PureComponent<Props, State> {
   }
 
   public componentDidMount(): void {
-    this.setWidgetValue({ fromUi: false })
+    this.commitWidgetValue({ fromUi: false })
   }
 
-  private setWidgetValue = (source: Source): void => {
+  /** Commit state.value to the WidgetStateManager. */
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setStringValue(
       this.props.element,
       this.state.value,
@@ -67,7 +68,7 @@ class TimeInput extends PureComponent<Props, State> {
 
   private handleChange = (newDate: Date): void => {
     const value = this.dateToString(newDate)
-    this.setState({ value }, () => this.setWidgetValue({ fromUi: true }))
+    this.setState({ value }, () => this.commitWidgetValue({ fromUi: true }))
   }
 
   private stringToDate = (value: string): Date => {


### PR DESCRIPTION
Most of our widgets have a confusingly-named "setWidgetValue" function. These functions do not actually change the values of the widgets themselves, but rather _commit_ the widgets' currently-stored values to the WidgetStateManager. 

This is just a trivial refactor that renames these functions to "commitWidgetValue", for clarity.