### PR TITLE
Add SessionState class

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -1,0 +1,128 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Iterator,
+    MutableMapping,
+    Optional,
+    TYPE_CHECKING,
+    Union,
+)
+
+import attr
+
+from streamlit.errors import StreamlitAPIException
+from streamlit.report_thread import get_report_ctx, ReportContext
+from streamlit.server.server import Server
+
+if TYPE_CHECKING:
+    from streamlit.report_session import ReportSession
+
+
+@attr.s(auto_attribs=True)
+class SessionState(MutableMapping[str, Any]):
+    """SessionState allows users to store values that persist between app
+    reruns.
+
+    SessionState objects are created lazily when a script accesses
+    st.session_state.
+
+    Example
+    -------
+    >>> if "num_script_runs" not in st.session_state:
+    ...     st.session_state.num_script_runs = 0
+    >>> st.session_state.num_script_runs += 1
+    >>> st.write(st.session_state.num_script_runs)  # writes 1
+
+    The next time your script runs, the value of
+    st.session_state.num_script_runs will be preserved.
+    >>> st.session_state.num_script_runs += 1
+    >>> st.write(st.session_state.num_script_runs)  # writes 2
+    """
+
+    _old_state: Dict[str, Any] = attr.Factory(dict)
+    _new_state: Dict[str, Any] = attr.Factory(dict)
+
+    def make_state_old(self) -> None:
+        self._old_state.update(self._new_state)
+        self._new_state.clear()
+
+    @property
+    def _merged_state(self) -> Dict[str, Any]:
+        # NOTE: The order that the dicts are unpacked here is important as it
+        #       is what ensures that the values in _new_state overwrite those
+        #       of _old_state in the returned, merged dictionary.
+        return {
+            **self._old_state,
+            # TODO: Also include widget values in the dict returned here.
+            **self._new_state,
+        }
+
+    def is_new_value(self, key: str) -> bool:
+        return key in self._new_state
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._merged_state)
+
+    def __len__(self) -> int:
+        return len(self._merged_state)
+
+    def __str__(self):
+        return str(self._merged_state)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._merged_state[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        ctx = cast(ReportContext, get_report_ctx())
+        # TODO: This will need to be slightly changed once we refactor widget
+        #       state to be less fragmented.
+        if key in ctx.widget_ids_this_run.items():
+            raise StreamlitAPIException(
+                "Setting the value of a widget after its creation is disallowed."
+            )
+        self._new_state[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        if not (key in self._new_state or key in self._old_state):
+            raise KeyError(key)
+
+        if key in self._new_state:
+            del self._new_state[key]
+
+        if key in self._old_state:
+            del self._old_state[key]
+
+    def __getattr__(self, key: str) -> Optional[Any]:
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        # Setting the _old_state and _new_state attributes must be done using
+        # the base method to avoid recursion.
+        if key in ["_new_state", "_old_state"]:
+            super().__setattr__(key, value)
+        else:
+            self[key] = value
+
+    def __delattr__(self, key: str) -> None:
+        try:
+            del self[key]
+        except KeyError:
+            raise AttributeError(key)

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -31,6 +31,13 @@ class SessionStateTests(unittest.TestCase):
             new_state={"baz": "qux"},
         )
 
+    def test_mapping_invariants(self):
+        s = self.session_state
+
+        assert len(s.values()) == len(s.keys()) == len(s.items()) == len(s)
+        assert list(s.values()) == [s[k] for k in s.keys()]
+        assert list(s.items()) == [(k, s[k]) for k in s.keys()]
+
     def test_make_state_old(self):
         self.session_state.make_state_old()
         assert self.session_state._new_state == {}

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -1,0 +1,138 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from streamlit.errors import StreamlitAPIException
+from streamlit.report_thread import _StringSet
+from streamlit.state.session_state import SessionState
+
+
+# TODO: Mock widget values and modify the tests below to account for this once
+#       session_state and widget state are unified.
+class SessionStateTests(unittest.TestCase):
+    def setUp(self):
+        self.session_state = SessionState(
+            old_state={"foo": "bar"},
+            new_state={"baz": "qux"},
+        )
+
+    def test_make_state_old(self):
+        self.session_state.make_state_old()
+        self.assertEqual(self.session_state._new_state, {})
+        self.assertEqual(self.session_state._old_state, {"foo": "bar", "baz": "qux"})
+
+    def test_merged_state(self):
+        self.assertEqual(self.session_state._merged_state, {"foo": "bar", "baz": "qux"})
+
+    def test_merged_state_new_state_priority(self):
+        session_state = SessionState(
+            old_state={"foo": "bar"},
+            new_state={"foo": "baz"},
+        )
+        self.assertEqual(session_state._merged_state, {"foo": "baz"})
+
+    def test_is_new_value(self):
+        self.assertFalse(self.session_state.is_new_value("foo"))
+        self.assertTrue(self.session_state.is_new_value("baz"))
+
+    def test_contains(self):
+        # does not contain key
+        self.assertFalse("corge" in self.session_state)
+        # key in new state
+        self.assertTrue("foo" in self.session_state)
+        # key in old state
+        self.assertTrue("baz" in self.session_state)
+
+    def test_iter(self):
+        state_iter = iter(self.session_state)
+        self.assertEqual(next(state_iter), "foo")
+        self.assertEqual(next(state_iter), "baz")
+        with self.assertRaises(StopIteration):
+            next(state_iter)
+
+    def test_len(self):
+        self.assertEqual(len(self.session_state), 2)
+
+    def test_str(self):
+        self.assertEqual(str(self.session_state), "{'foo': 'bar', 'baz': 'qux'}")
+
+    def test_getitem(self):
+        self.assertEqual(self.session_state["foo"], "bar")
+
+    def test_getitem_error(self):
+        with self.assertRaisesRegex(KeyError, "nonexistent"):
+            self.session_state["nonexistent"]
+
+    @patch("streamlit.state.session_state.get_report_ctx")
+    def test_setitem(self, patched_get_report_ctx):
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = _StringSet()
+        patched_get_report_ctx.return_value = mock_ctx
+
+        self.session_state["corge"] = "grault"
+        self.assertEqual(self.session_state["corge"], "grault")
+
+    @patch("streamlit.state.session_state.get_report_ctx")
+    def test_setitem_error(self, patched_get_report_ctx):
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = _StringSet()
+        mock_ctx.widget_ids_this_run.add("corge")
+        patched_get_report_ctx.return_value = mock_ctx
+
+        with self.assertRaisesRegex(StreamlitAPIException, "Setting the value"):
+            self.session_state["corge"] = "grault"
+
+    def test_delitem(self):
+        del self.session_state["foo"]
+        self.assertEqual(self.session_state._merged_state, {"baz": "qux"})
+
+    def test_delitem_error(self):
+        with self.assertRaisesRegex(KeyError, "nonexistent"):
+            del self.session_state["nonexistent"]
+
+    def test_getattr(self):
+        self.assertEqual(self.session_state.foo, "bar")
+
+    def test_getattr_error(self):
+        with self.assertRaisesRegex(AttributeError, "nonexistent"):
+            self.session_state.nonexistent
+
+    @patch("streamlit.state.session_state.get_report_ctx")
+    def test_setattr(self, patched_get_report_ctx):
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = _StringSet()
+        patched_get_report_ctx.return_value = mock_ctx
+
+        self.session_state.corge = "grault"
+        self.assertEqual(self.session_state.corge, "grault")
+
+    @patch("streamlit.state.session_state.get_report_ctx")
+    def test_setattr_error(self, patched_get_report_ctx):
+        mock_ctx = MagicMock()
+        mock_ctx.widget_ids_this_run = _StringSet()
+        mock_ctx.widget_ids_this_run.add("corge")
+        patched_get_report_ctx.return_value = mock_ctx
+
+        with self.assertRaisesRegex(StreamlitAPIException, "Setting the value"):
+            self.session_state.corge = "grault"
+
+    def test_delattr(self):
+        del self.session_state.foo
+        self.assertEqual(self.session_state._merged_state, {"baz": "qux"})
+
+    def test_delattr_error(self):
+        with self.assertRaisesRegex(AttributeError, "nonexistent"):
+            del self.session_state.nonexistent


### PR DESCRIPTION
This commit reimplements the SessionState class that currently lives in
the SessionState prototype. For the most part, this implementation
matches that of the prototype, but we do make a few small changes to
further polish it:
  * we named the file containing the class state/session_state.py instead of
    session.py
  * the attrs package was used to decrease boilerplate by a bit
    (@AnOctopus discovered that the package is in our dependency tree as
     it is used by Altair. We probably want to pin the version to ensure
     that it doesn't change unexpectedly)
  * the class docstring was updated to reflect API changes
  * the class' \_\_*attr\_\_ methods were changed to all delegate their
    behavior to the corresponding \_\_*item\_\_ methods.
  * more extensive test coverage was added

The class currently isn't used anywhere -- exposing it from the Streamlit
module and attaching instances of it to ReportSessions will be done in a
followup PR.