### PR TITLE
Implement _get_session_state

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -116,7 +116,11 @@ class ReportSession(object):
 
         self._scriptrunner = None
 
-        self._session_state: Optional["SessionState"] = None
+        # This needs to be lazily imported to avoid a dependency cycle.
+        from streamlit.state.session_state import SessionState
+
+        self._session_state = SessionState()
+
         # TODO: Also initialize the yet-to-be-implemented WidgetStateManager.
 
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
@@ -235,13 +239,8 @@ class ReportSession(object):
         self._enqueue_script_request(ScriptRequest.RERUN, rerun_data)
         self._set_page_config_allowed = True
 
-    def initialize_session_state(self, initial_state: "SessionState") -> None:
-        if self._session_state is not None:
-            raise RuntimeError("SessionState has already been initialized.")
-
-        self._session_state = initial_state
-
-    def get_session_state(self) -> Optional["SessionState"]:
+    @property
+    def session_state(self) -> "SessionState":
         return self._session_state
 
     def _on_source_file_changed(self):

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -15,6 +15,7 @@
 import sys
 import uuid
 from enum import Enum
+from typing import Optional, TYPE_CHECKING
 
 import tornado.gen
 import tornado.ioloop
@@ -46,6 +47,8 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 
 LOGGER = get_logger(__name__)
+if TYPE_CHECKING:
+    from streamlit.state.session_state import SessionState
 
 
 class ReportSessionState(Enum):
@@ -112,6 +115,9 @@ class ReportSession(object):
         self._script_request_queue = ScriptRequestQueue()
 
         self._scriptrunner = None
+
+        self._session_state: Optional["SessionState"] = None
+        # TODO: Also initialize the yet-to-be-implemented WidgetStateManager.
 
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
 
@@ -229,6 +235,15 @@ class ReportSession(object):
         self._enqueue_script_request(ScriptRequest.RERUN, rerun_data)
         self._set_page_config_allowed = True
 
+    def initialize_session_state(self, initial_state: "SessionState") -> None:
+        if self._session_state is not None:
+            raise RuntimeError("SessionState has already been initialized.")
+
+        self._session_state = initial_state
+
+    def get_session_state(self) -> Optional["SessionState"]:
+        return self._session_state
+
     def _on_source_file_changed(self):
         """One of our source files changed. Schedule a rerun if appropriate."""
         if self._run_on_save:
@@ -304,11 +319,8 @@ class ReportSession(object):
                     self._local_sources_watcher.update_watched_modules
                 )
             else:
-                # When a script fails to compile, we send along the exception.
-                import streamlit.elements.exception as exception_utils
-
                 msg = ForwardMsg()
-                exception_utils.marshall(
+                exception.marshall(
                     msg.session_event.script_compilation_exception, exception
                 )
                 self.enqueue(msg)

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -93,7 +93,7 @@ class SessionInfo(object):
     the ForwardMsgCache.
     """
 
-    def __init__(self, ws, session):
+    def __init__(self, ws, session: ReportSession):
         """Initialize a SessionInfo instance.
 
         Parameters
@@ -251,6 +251,15 @@ class Server(object):
     @property
     def script_path(self) -> str:
         return self._script_path
+
+    def get_session_by_id(self, session_id: str) -> Optional[ReportSession]:
+        """Return the ReportSession corresponding to the given id, or None if
+        no such session exists."""
+        session_info = self._get_session_info(session_id)
+        if session_info is None:
+            return None
+
+        return session_info.session
 
     def on_files_updated(self, session_id: str) -> None:
         """Event handler for UploadedFileManager.on_file_added.

--- a/lib/streamlit/state/__init__.py
+++ b/lib/streamlit/state/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -128,7 +128,13 @@ class SessionState(MutableMapping[str, Any]):
             raise AttributeError(key)
 
 
-def _get_current_session() -> "ReportSession":
+def _get_session_state() -> SessionState:
+    """Get the SessionState object for the current session.
+
+    Note that in streamlit scripts, this function should not be called
+    directly. Instead, SessionState objects should be accessed via
+    st.session_state.
+    """
     # Getting the session id easily comes from the report context, which is
     # a little weird, but a precedent that has been set.
     ctx = get_report_ctx()
@@ -144,22 +150,4 @@ def _get_current_session() -> "ReportSession":
             " be conflicting with our system."
         )
 
-    return this_session
-
-
-def get_session_state() -> SessionState:
-    """Get the SessionState object for the current session, creating it if it
-    does not yet exist.
-
-    Note that in streamlit scripts, this function should not be called
-    directly. Instead, SessionState objects should be accessed via
-    st.session_state.
-    """
-    session = _get_current_session()
-    session_state = session.get_session_state()
-
-    if session_state is None:
-        session_state = SessionState()
-        session.initialize_session_state(session_state)
-
-    return session_state
+    return this_session.session_state

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -138,26 +138,9 @@ class ReportSessionTest(unittest.TestCase):
         self.assertNotEqual(rs1.id, rs2.id)
 
     @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_init_session_state(self, _):
+    def test_creates_session_state_on_init(self, _):
         rs = ReportSession(None, "", "", UploadedFileManager())
-
-        self.assertEqual(rs.get_session_state(), None)
-
-        state = SessionState()
-
-        rs.initialize_session_state(state)
-        self.assertEqual(rs.get_session_state(), state)
-
-    @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_init_session_state_twice_explodes(self, _):
-        rs = ReportSession(None, "", "", UploadedFileManager())
-
-        state = SessionState()
-        rs.initialize_session_state(state)
-
-        with pytest.raises(RuntimeError) as e:
-            rs.initialize_session_state(state)
-        self.assertEqual(str(e.value), "SessionState has already been initialized.")
+        self.assertTrue(isinstance(rs.session_state, SessionState))
 
 
 def _create_mock_websocket():

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -19,21 +19,19 @@ import pytest
 import tornado.gen
 import tornado.testing
 
+import streamlit as st
 import streamlit.report_session as report_session
 from streamlit import config
-from streamlit.report_session import ReportSession, ReportSessionState
-from streamlit.report_thread import ReportContext
-from streamlit.report_thread import add_report_ctx
-from streamlit.report_thread import get_report_ctx
-from streamlit.script_runner import ScriptRunner
-from streamlit.script_runner import ScriptRunnerEvent
-from streamlit.uploaded_file_manager import UploadedFileManager
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.StaticManifest_pb2 import StaticManifest
-from streamlit.errors import StreamlitAPIException
+from streamlit.report_session import ReportSession, ReportSessionState
+from streamlit.report_thread import add_report_ctx, get_report_ctx, ReportContext
+from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
+from streamlit.state.session_state import SessionState
+from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.widgets import WidgetStateManager
 from tests.mock_storage import MockStorage
-import streamlit as st
 
 
 @pytest.fixture
@@ -138,6 +136,28 @@ class ReportSessionTest(unittest.TestCase):
         rs1 = ReportSession(None, "", "", file_mgr)
         rs2 = ReportSession(None, "", "", file_mgr)
         self.assertNotEqual(rs1.id, rs2.id)
+
+    @patch("streamlit.report_session.LocalSourcesWatcher")
+    def test_init_session_state(self, _):
+        rs = ReportSession(None, "", "", UploadedFileManager())
+
+        self.assertEqual(rs.get_session_state(), None)
+
+        state = SessionState()
+
+        rs.initialize_session_state(state)
+        self.assertEqual(rs.get_session_state(), state)
+
+    @patch("streamlit.report_session.LocalSourcesWatcher")
+    def test_init_session_state_twice_explodes(self, _):
+        rs = ReportSession(None, "", "", UploadedFileManager())
+
+        state = SessionState()
+        rs.initialize_session_state(state)
+
+        with pytest.raises(RuntimeError) as e:
+            rs.initialize_session_state(state)
+        self.assertEqual(str(e.value), "SessionState has already been initialized.")
 
 
 def _create_mock_websocket():

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -197,6 +197,23 @@ class ServerTest(ServerTestCase):
             self.assertEqual(populate_hash_if_needed(msg), received.hash)
 
     @tornado.testing.gen_test
+    def test_get_session_by_id_nonexistent_session(self):
+        """Test getting a nonexistent session returns None."""
+        with self._patch_report_session():
+            yield self.start_server_loop()
+            self.assertEqual(self.server.get_session_by_id("abc123"), None)
+
+    @tornado.testing.gen_test
+    def test_get_session_by_id(self):
+        """Test getting sessions by id produces the correct ReportSession."""
+        with self._patch_report_session():
+            yield self.start_server_loop()
+            ws_client = yield self.ws_connect()
+
+            session = list(self.server._session_info_by_id.values())[0].session
+            self.assertEqual(self.server.get_session_by_id(session.id), session)
+
+    @tornado.testing.gen_test
     def test_forwardmsg_cacheable_flag(self):
         """Test that the metadata.cacheable flag is set properly on outgoing
         ForwardMsgs."""
@@ -334,31 +351,6 @@ class ServerTest(ServerTestCase):
                 ),
                 [],
             )
-
-    @staticmethod
-    def _create_mock_report_session(*args, **kwargs):
-        """Create a mock ReportSession. Each mocked instance will have
-        its own unique ID."""
-        mock_id = mock.PropertyMock(
-            return_value="mock_id:%s" % ServerTest._next_report_id
-        )
-        ServerTest._next_report_id += 1
-
-        mock_session = mock.MagicMock(ReportSession, autospec=True, *args, **kwargs)
-        type(mock_session).id = mock_id
-        return mock_session
-
-    def _patch_report_session(self):
-        """Mock the Server's ReportSession import. We don't want
-        actual sessions to be instantiated, or scripts to be run.
-        """
-
-        return mock.patch(
-            "streamlit.server.server.ReportSession",
-            # new_callable must return a function, not an object, or else
-            # there will only be a single ReportSession mock. Hence the lambda.
-            new_callable=lambda: self._create_mock_report_session,
-        )
 
 
 class ServerUtilsTest(unittest.TestCase):

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -182,8 +182,15 @@ class GetSessionStateTests(ServerTestCase):
 
         assert isinstance(_get_session_state(), SessionState)
 
+    def test_get_session_state_error_if_no_ctx(self, patched_get_report_ctx, _):
+        patched_get_report_ctx.return_value = None
+
+        with pytest.raises(RuntimeError) as e:
+            _get_session_state()
+        assert "We were unable to retrieve your Streamlit session." in str(e.value)
+
     @tornado.testing.gen_test
-    def test_get_session_state_error(self, patched_get_report_ctx, _):
+    def test_get_session_state_error_if_no_session(self, patched_get_report_ctx, _):
         yield self.start_server_loop()
 
         mock_ctx = MagicMock()


### PR DESCRIPTION
_get_session_state fetches the SessionState object for the session it is called
from.

We're once again mostly able to copy the implementation in the prototype for
this PR. The only notable change was to account for the fact that the
st.session_state API no longer allows users to initialize default values
for SessionState objects on creation (more precisely, users can no
longer directly call the SessionState constructor), so we can create a
`SessionState` object when we initialize a `ReportSession`.

We also had to
* Create an \_\_init\_\_.py file in the new `state` directory. We didn't
  notice that this hadn't been done before because mypy didn't start
  complaining until we started importing `streamlit.state.session_state`
  in other files.
* Move some test util code out of `server_test.py` and into
  `server_test_case.py`.
