### PR TITLE
Expose st.session_state to users and add e2e tests

### DIFF
--- a/e2e/scripts/st_session_state.py
+++ b/e2e/scripts/st_session_state.py
@@ -1,0 +1,43 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+# st.session_state can only be accessed while running with streamlit
+if st._is_running_with_streamlit:
+    if "initialized" not in st.session_state:
+        st.session_state["item_counter"] = 0
+        st.session_state.attr_counter = 0
+
+        st.session_state.initialized = True
+
+    if st.button("inc_item_counter"):
+        st.session_state["item_counter"] += 1
+
+    if st.button("inc_attr_counter"):
+        st.session_state.attr_counter += 1
+
+    if st.button("del_item_counter"):
+        del st.session_state["item_counter"]
+
+    if st.button("del_attr_counter"):
+        del st.session_state.attr_counter
+
+    if "item_counter" in st.session_state:
+        st.write(f"item_counter: {st.session_state['item_counter']}")
+
+    if "attr_counter" in st.session_state:
+        st.write(f"attr_counter: {st.session_state.attr_counter}")
+
+    st.write(f"len(st.session_state): {len(st.session_state)}")

--- a/e2e/specs/st_session_state.spec.js
+++ b/e2e/specs/st_session_state.spec.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("st.beta_session_state", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/");
+
+    // Make the ribbon decoration line disappear
+    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+  });
+
+  it("has correct starting values", () => {
+    cy.get(".stMarkdown").contains("item_counter: 0");
+    cy.get(".stMarkdown").contains("attr_counter: 0");
+    // item_counter + attr_counter + initialized flag
+    cy.get(".stMarkdown").contains("len(st.session_state): 3");
+  });
+
+  it("can get/set/delete session_state items", () => {
+    cy.get(".stMarkdown").contains("item_counter: 0");
+    cy.get(".stMarkdown").contains("attr_counter: 0");
+
+    cy.get(".stButton button")
+      .contains("inc_item_counter")
+      .click();
+    cy.get(".stMarkdown").contains("item_counter: 1");
+    cy.get(".stMarkdown").contains("attr_counter: 0");
+
+    cy.get(".stButton button")
+      .contains("inc_item_counter")
+      .click();
+    cy.get(".stMarkdown").contains("item_counter: 2");
+    cy.get(".stMarkdown").contains("attr_counter: 0");
+
+    cy.get(".stButton button")
+      .contains("del_item_counter")
+      .click();
+    cy.get(".stMarkdown")
+      .contains("item_counter:")
+      .should("not.exist");
+    cy.get(".stMarkdown").contains("attr_counter: 0");
+    cy.get(".stMarkdown").contains("len(st.session_state): 2");
+  });
+
+  it("can get/set/delete session_state attrs", () => {
+    cy.get(".stMarkdown").contains("item_counter: 0");
+    cy.get(".stMarkdown").contains("attr_counter: 0");
+
+    cy.get(".stButton button")
+      .contains("inc_attr_counter")
+      .click();
+    cy.get(".stMarkdown").contains("item_counter: 0");
+    cy.get(".stMarkdown").contains("attr_counter: 1");
+
+    cy.get(".stButton button")
+      .contains("inc_attr_counter")
+      .click();
+    cy.get(".stMarkdown").contains("item_counter: 0");
+    cy.get(".stMarkdown").contains("attr_counter: 2");
+
+    cy.get(".stButton button")
+      .contains("del_attr_counter")
+      .click();
+    cy.get(".stMarkdown").contains("item_counter: 0");
+    cy.get(".stMarkdown")
+      .contains("attr_counter:")
+      .should("not.exist");
+    cy.get(".stMarkdown").contains("len(st.session_state): 2");
+  });
+});

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -168,6 +168,13 @@ color_picker = _main.color_picker
 get_option = _config.get_option
 from streamlit.commands.page_config import set_page_config
 
+# Session State
+
+from streamlit.state.session_state import LazySessionState
+
+session_state = LazySessionState()
+
+
 # Beta APIs
 
 beta_container = _main.beta_container

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -107,7 +107,7 @@ class SessionState(MutableMapping[str, Any]):
         if key in self._old_state:
             del self._old_state[key]
 
-    def __getattr__(self, key: str) -> Optional[Any]:
+    def __getattr__(self, key: str) -> Any:
         try:
             return self[key]
         except KeyError:
@@ -151,3 +151,50 @@ def _get_session_state() -> SessionState:
         )
 
     return this_session.session_state
+
+
+class LazySessionState(MutableMapping[str, Any]):
+    """A lazy wrapper around SessionState.
+
+    SessionState can't be instantiated normally in lib/streamlit/__init__.py
+    because there may not be a ReportSession yet. Instead we have this wrapper,
+    which delegates to the SessionState for the active ReportSession. This will
+    only be interacted within an app script, that is, when a ReportSession is
+    guaranteed to exist.
+    """
+
+    def __iter__(self) -> Iterator[Any]:
+        state = _get_session_state()
+        return iter(state)
+
+    def __len__(self) -> int:
+        state = _get_session_state()
+        return len(state)
+
+    def __str__(self):
+        state = _get_session_state()
+        return str(state)
+
+    def __getitem__(self, key: str) -> Any:
+        state = _get_session_state()
+        return state[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        state = _get_session_state()
+        state[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        state = _get_session_state()
+        del state[key]
+
+    def __getattr__(self, key: str) -> Any:
+        state = _get_session_state()
+        return state.__getattr__(key)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        state = _get_session_state()
+        state.__setattr__(key, value)
+
+    def __delattr__(self, key: str) -> None:
+        state = _get_session_state()
+        state.__delattr__(key)

--- a/scripts/test_data/print_command_line.py
+++ b/scripts/test_data/print_command_line.py
@@ -14,7 +14,7 @@
 
 import streamlit as st
 
-server = st.server.server.Server.get_current()  # type: ignore
+server = st.server.server.Server.get_current()
 print(
     f'{{"server._command_line": "{server._command_line}"}}'  # pylint: disable = protected-access
 )


### PR DESCRIPTION
NOTE: This PR builds on top of #3267, so this diff will shrink considerably
once that PR is merged.

As with the past couple PRs, we were able to essentially just use the
prototype implementation here and improve its test coverage.
    
The only notable change is that we defined the LazySessionState class in
state/session_state.py so that the only thing done in
lib/streamlit/\_\_init\_\_.py is importing LazySessionState and creating an
instance of the class to be exposed to the user.
