### PR TITLE
Widget test cleanup

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -566,7 +566,7 @@ class Block extends PureComponent<Props> {
             key={fileUploaderProto.id}
             element={fileUploaderProto}
             width={width}
-            widgetStateManager={widgetProps.widgetMgr}
+            widgetMgr={widgetProps.widgetMgr}
             uploadClient={this.props.uploadClient}
             disabled={widgetProps.disabled}
           />

--- a/frontend/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/src/components/shared/Radio/Radio.test.tsx
@@ -19,38 +19,39 @@ import React from "react"
 import { mount } from "src/lib/test_util"
 
 import { Radio as UIRadio, RadioGroup } from "baseui/radio"
-import { Radio as RadioProto } from "src/autogen/proto"
+import { lightTheme } from "src/theme"
 import Radio, { Props } from "./Radio"
 
-jest.mock("src/lib/WidgetStateManager")
-
-const getProps = (props: Partial<RadioProto> = {}): Props => ({
+const getProps = (props: Partial<Props> = {}): Props => ({
   width: 0,
   disabled: false,
   value: 0,
-  onChange: (selectedIndex: number) => {},
+  onChange: () => {},
   options: ["a", "b", "c"],
   label: "Label",
+  theme: lightTheme.emotion,
   ...props,
 })
 
 describe("Radio widget", () => {
-  const props = getProps()
-  const wrapper = mount(<Radio {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
+
     expect(wrapper.find(RadioGroup).length).toBe(1)
     expect(wrapper.find(UIRadio).length).toBe(3)
   })
 
-  it("renders without crashing if no label is provided(optional)", () => {
+  it("renders without crashing if no label is provided", () => {
     const props = getProps({ label: undefined })
-    const optionalLabelWrapper = mount(<Radio {...props} />)
-    expect(optionalLabelWrapper.find(RadioGroup).length).toBe(1)
-    expect(optionalLabelWrapper.find(UIRadio).length).toBe(3)
+    const wrapper = mount(<Radio {...props} />)
+    expect(wrapper.find(RadioGroup).length).toBe(1)
+    expect(wrapper.find(UIRadio).length).toBe(3)
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -64,19 +65,27 @@ describe("Radio widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a label", () => {
+  it("renders a label", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.label)
   })
 
-  it("should have a default value", () => {
+  it("has a default value", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     expect(wrapper.find(RadioGroup).prop("value")).toBe(props.value.toString())
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     expect(wrapper.find(RadioGroup).prop("disabled")).toBe(props.disabled)
   })
 
-  it("should have the correct options", () => {
+  it("has the correct options", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     const options = wrapper.find(UIRadio)
 
     options.forEach((option, index) => {
@@ -85,10 +94,8 @@ describe("Radio widget", () => {
     })
   })
 
-  it("should show a message when there are no options to be shown", () => {
-    const props = getProps({
-      options: [],
-    })
+  it("shows a message when there are no options to be shown", () => {
+    const props = getProps({ options: [] })
     const wrapper = mount(<Radio {...props} />)
 
     expect(wrapper.find(UIRadio).length).toBe(1)
@@ -97,7 +104,10 @@ describe("Radio widget", () => {
     )
   })
 
-  it("should select just one option and set the value", () => {
+  it("handles value changes", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
+
     // @ts-ignore
     wrapper.find(RadioGroup).prop("onChange")({
       target: {

--- a/frontend/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -23,10 +23,6 @@ import { Checkbox as UICheckbox } from "baseui/checkbox"
 import { Checkbox as CheckboxProto } from "src/autogen/proto"
 import Checkbox, { OwnProps } from "./Checkbox"
 
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
-
 const getProps = (elementProps: Partial<CheckboxProto> = {}): OwnProps => ({
   element: CheckboxProto.create({
     id: "1",
@@ -36,18 +32,26 @@ const getProps = (elementProps: Partial<CheckboxProto> = {}): OwnProps => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    pendingFormsChanged: jest.fn(),
+  }),
 })
 
 describe("Checkbox widget", () => {
-  const props = getProps()
-  const wrapper = mount(<Checkbox {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = mount(<Checkbox {...props} />)
+
     expect(wrapper.find(UICheckbox).length).toBe(1)
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setBoolValue")
+
+    mount(<Checkbox {...props} />)
+
     expect(props.widgetMgr.setBoolValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -55,7 +59,10 @@ describe("Checkbox widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = mount(<Checkbox {...props} />)
+
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -69,7 +76,10 @@ describe("Checkbox widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a label", () => {
+  it("renders a label", () => {
+    const props = getProps()
+    const wrapper = mount(<Checkbox {...props} />)
+
     const children = wrapper.find(UICheckbox).prop("children")
     if (Array.isArray(children)) {
       expect(children).toContain(props.element.label)
@@ -78,22 +88,31 @@ describe("Checkbox widget", () => {
     }
   })
 
-  it("should be unchecked by default", () => {
+  it("is unchecked by default", () => {
+    const props = getProps()
+    const wrapper = mount(<Checkbox {...props} />)
+
     expect(wrapper.find(UICheckbox).prop("checked")).toBe(
       props.element.default
     )
   })
 
-  it("should be unchecked by default", () => {
+  it("is not disabled by default", () => {
+    const props = getProps()
+    const wrapper = mount(<Checkbox {...props} />)
+
     expect(wrapper.find(UICheckbox).prop("disabled")).toBe(props.disabled)
   })
 
-  it("onChange should work", () => {
+  it("handles the onChange event", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setBoolValue")
+
+    const wrapper = mount(<Checkbox {...props} />)
+
     // @ts-ignore
     wrapper.find(UICheckbox).prop("onChange")({
-      target: {
-        checked: true,
-      },
+      target: { checked: true },
     } as EventTarget)
     wrapper.update()
 
@@ -102,6 +121,6 @@ describe("Checkbox widget", () => {
       true,
       { fromUi: true }
     )
-    expect(wrapper.find(UICheckbox).prop("checked")).toBeTruthy()
+    expect(wrapper.find(UICheckbox).prop("checked")).toBe(true)
   })
 })

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { ReactWrapper } from "enzyme"
 import React from "react"
 import { mount } from "src/lib/test_util"
 import { StatefulPopover as UIPopover } from "baseui/popover"
@@ -23,10 +24,6 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import { ChromePicker } from "react-color"
 
 import ColorPicker, { Props } from "./ColorPicker"
-
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
 
 const getProps = (elementProps: Partial<ColorPickerProto> = {}): Props => ({
   element: ColorPickerProto.create({
@@ -37,19 +34,50 @@ const getProps = (elementProps: Partial<ColorPickerProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    pendingFormsChanged: jest.fn(),
+  }),
 })
-const props = getProps()
-const wrapper = mount(<ColorPicker {...props} />)
-const colorPickerWrapper = wrapper.find(UIPopover).renderProp("content")()
+
+/** Return the ColorPicker's popover (where the color picking happens). */
+function getPopoverWrapper(wrapper: ReactWrapper<ColorPicker>): any {
+  // @ts-ignore
+  return wrapper.find(UIPopover).renderProp("content")()
+}
+
+/** Return the ColorPicker's currently-selected color as a hex string. */
+function getPickedColor(wrapper: ReactWrapper<ColorPicker>): string {
+  return getPopoverWrapper(wrapper).prop("children").props.color
+}
+
+/** Simulate selecting a new color with the ColorPicker's UI. */
+function selectColor(wrapper: ReactWrapper<ColorPicker>, color: string): void {
+  // Open the popover, select the new color, close the popover.
+  wrapper.find(UIPopover).simulate("click")
+  getPopoverWrapper(wrapper)
+    .find(ChromePicker)
+    .prop("onChange")({
+    hex: color,
+  })
+  wrapper.find(UIPopover).simulate("click")
+}
 
 describe("ColorPicker widget", () => {
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = mount(<ColorPicker {...props} />)
+
     expect(wrapper.find(UIPopover).length).toBe(1)
-    expect(colorPickerWrapper.find(ChromePicker).length).toBe(1)
+    expect(getPopoverWrapper(wrapper).find(ChromePicker).length).toBe(1)
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
+
+    mount(<ColorPicker {...props} />)
+
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -57,30 +85,34 @@ describe("ColorPicker widget", () => {
     )
   })
 
-  it("should render a default color in the preview and the color picker", () => {
+  it("renders a default color in the preview and the color picker", () => {
+    const props = getProps()
+    const wrapper = mount(<ColorPicker {...props} />)
+
     wrapper.find(UIPopover).simulate("click")
 
     expect(wrapper.find("StyledColorBlock").prop("style")).toEqual({
       backgroundColor: "#000000",
     })
 
-    expect(colorPickerWrapper.prop("children").props.color).toEqual("#000000")
+    expect(getPickedColor(wrapper)).toEqual("#000000")
   })
 
-  it("should update the widget value when it's changed", () => {
+  it("updates its widget value when it's changed", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
+
+    const wrapper = mount(<ColorPicker {...props} />)
+
     const newColor = "#E91E63"
-    wrapper.find(UIPopover).simulate("click")
-    colorPickerWrapper.find(ChromePicker).prop("onChange")({
-      hex: newColor,
-    })
+    selectColor(wrapper, newColor)
 
-    wrapper.find(UIPopover).simulate("click")
+    // Our widget should be updated.
+    expect(getPickedColor(wrapper)).toEqual(newColor)
 
+    // And the WidgetMgr should also be updated.
     expect(
-      wrapper
-        .find(UIPopover)
-        .renderProp("content")()
-        .prop("children").props.color
-    ).toEqual(newColor)
+      props.widgetMgr.setStringValue
+    ).toHaveBeenLastCalledWith(props.element, newColor, { fromUi: true })
   })
 })

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -275,6 +275,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
     this.iframeRef.current.height = this.frameHeight.toString()
   }
 
+  /** Send a message to the component through its iframe. */
   private sendForwardMsg = (type: StreamlitMessageType, data: any): void => {
     if (this.iframeRef.current == null) {
       // This should never happen!

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -21,11 +21,8 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import { DateInput as DateInputProto } from "src/autogen/proto"
 
 import { Datepicker as UIDatePicker } from "baseui/datepicker"
+import { lightTheme } from "src/theme"
 import DateInput, { Props } from "./DateInput"
-
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
 
 const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
   element: DateInputProto.create({
@@ -37,22 +34,31 @@ const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  theme: lightTheme.emotion,
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    pendingFormsChanged: jest.fn(),
+  }),
 })
 
 describe("DateInput widget", () => {
-  const props = getProps()
-  const wrapper = mount(<DateInput {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
     expect(wrapper.find(UIDatePicker).length).toBe(1)
   })
 
-  it("should render a label", () => {
+  it("renders a label", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    mount(<DateInput {...props} />)
     expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -62,7 +68,10 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
+
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -75,21 +84,32 @@ describe("DateInput widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a default value", () => {
+  it("renders a default value", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
+
     expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([
       new Date(props.element.default[0]),
     ])
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
     expect(wrapper.find(UIDatePicker).prop("disabled")).toBe(props.disabled)
   })
 
-  it("should have the correct format", () => {
+  it("has the correct format", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
     expect(wrapper.find(UIDatePicker).prop("formatString")).toBe("yyyy/MM/dd")
   })
 
-  it("should update the widget value when it's changed", () => {
+  it("updates the widget value when it's changed", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    const wrapper = mount(<DateInput {...props} />)
     const newDate = new Date("2020/02/06")
 
     // @ts-ignore
@@ -108,17 +128,17 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("should have a minDate", () => {
+  it("has a minDate", () => {
+    const props = getProps()
+    const wrapper = mount(<DateInput {...props} />)
     expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
       new Date("1970/1/1")
     )
     expect(wrapper.find(UIDatePicker).prop("maxDate")).toBeUndefined()
   })
 
-  it("should have a maxDate if it is passed", () => {
-    const props = getProps({
-      max: "2030/02/06",
-    })
+  it("has a maxDate if it is passed", () => {
+    const props = getProps({ max: "2030/02/06" })
     const wrapper = mount(<DateInput {...props} />)
 
     expect(wrapper.find(UIDatePicker).prop("maxDate")).toStrictEqual(
@@ -126,10 +146,8 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("should handle min dates with years less than 100", () => {
-    const props = getProps({
-      min: "0001/01/01",
-    })
+  it("handles min dates with years less than 100", () => {
+    const props = getProps({ min: "0001/01/01" })
     const wrapper = mount(<DateInput {...props} />)
 
     expect(wrapper.find(UIDatePicker).prop("minDate")).toStrictEqual(
@@ -137,10 +155,8 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("should handle max dates with years less than 100", () => {
-    const props = getProps({
-      max: "0001/01/01",
-    })
+  it("handles max dates with years less than 100", () => {
+    const props = getProps({ max: "0001/01/01" })
     const wrapper = mount(<DateInput {...props} />)
 
     expect(wrapper.find(UIDatePicker).prop("maxDate")).toStrictEqual(

--- a/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -22,7 +22,7 @@ import { mount, shallow } from "src/lib/test_util"
 
 import { FileUploader as FileUploaderProto } from "src/autogen/proto"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
-import { notUndefined } from "../../../lib/utils"
+import { notUndefined } from "src/lib/utils"
 import FileDropzone from "./FileDropzone"
 import FileUploader, { Props } from "./FileUploader"
 import { ErrorStatus, UploadFileInfo, UploadingStatus } from "./UploadFileInfo"
@@ -62,7 +62,7 @@ const getProps = (elementProps: Partial<FileUploaderProto> = {}): Props => {
     }),
     width: 0,
     disabled: false,
-    widgetStateManager: new WidgetStateManager({
+    widgetMgr: new WidgetStateManager({
       sendRerunBackMsg: jest.fn(),
       pendingFormsChanged: jest.fn(),
     }),
@@ -131,7 +131,7 @@ describe("FileUploader widget", () => {
     expect(instance.status).toBe("updating")
 
     // WidgetStateManager should not have been called yet
-    expect(props.widgetStateManager.setIntArrayValue).not.toHaveBeenCalled()
+    expect(props.widgetMgr.setIntArrayValue).not.toHaveBeenCalled()
 
     await process.nextTick
 
@@ -149,7 +149,7 @@ describe("FileUploader widget", () => {
     expect(instance.status).toBe("ready")
 
     // And WidgetStateManager should have been called with the file's ID
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
       props.element,
       [newestServerFileId, serverFileId],
       {
@@ -198,7 +198,7 @@ describe("FileUploader widget", () => {
     const newestServerFileId = fileId
 
     // WidgetStateManager should have been called with the file's ID
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
       props.element,
       [newestServerFileId, fileId],
       {
@@ -282,7 +282,7 @@ describe("FileUploader widget", () => {
     const uploadedFileIds = getServerFileIds(uploadedFiles)
     const newestServerId = Math.max(...uploadedFileIds)
     const expectedWidgetValue = [newestServerId, ...uploadedFileIds]
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
       props.element,
       expectedWidgetValue,
       {
@@ -309,11 +309,11 @@ describe("FileUploader widget", () => {
     expect(instance.status).toBe("ready")
 
     // WidgetStateManager should have been called with our two file IDs
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenCalledTimes(1)
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(1)
 
     const initialFileIds = getServerFileIds(initialFiles)
     const initialWidgetValue = [Math.max(...initialFileIds), ...initialFileIds]
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenLastCalledWith(
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenLastCalledWith(
       props.element,
       initialWidgetValue,
       {
@@ -336,9 +336,9 @@ describe("FileUploader widget", () => {
     // WidgetStateManager should have been called with the file ID
     // of the remaining file. This should be the second time WidgetStateManager
     // has been updated.
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenCalledTimes(2)
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(2)
     const newWidgetValue = [Math.max(...initialFileIds), initialFileIds[1]]
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenLastCalledWith(
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenLastCalledWith(
       props.element,
       newWidgetValue,
       {
@@ -372,8 +372,8 @@ describe("FileUploader widget", () => {
     // WidgetStateManager will still have been called once, with a single
     // value - the id that was last returned from the server.
     const expectedWidgetValue = [INITIAL_SERVER_FILE_ID]
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenCalledTimes(1)
-    expect(props.widgetStateManager.setIntArrayValue).toHaveBeenLastCalledWith(
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledTimes(1)
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenLastCalledWith(
       props.element,
       expectedWidgetValue,
       {
@@ -403,7 +403,7 @@ describe("FileUploader widget", () => {
     expect(getFiles(wrapper).length).toBe(0)
 
     // WidgetStateManager should not have been called - no uploads happened.
-    expect(props.widgetStateManager.setIntArrayValue).not.toHaveBeenCalled()
+    expect(props.widgetMgr.setIntArrayValue).not.toHaveBeenCalled()
   })
 
   it("handles upload error", async () => {

--- a/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -27,8 +27,6 @@ import FileDropzone from "./FileDropzone"
 import FileUploader, { Props } from "./FileUploader"
 import { ErrorStatus, UploadFileInfo, UploadingStatus } from "./UploadFileInfo"
 
-jest.mock("src/lib/WidgetStateManager")
-
 const createFile = (): File => {
   return new File(["Text in a file!"], "filename.txt", {
     type: "text/plain",
@@ -120,13 +118,14 @@ describe("FileUploader widget", () => {
 
   it("uploads a single selected file", async () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
     const wrapper = shallow(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
     const fileDropzone = wrapper.find(FileDropzone)
     fileDropzone.props().onDrop([createFile()], [])
 
     // We should have 1 file in the uploading state
-    expect(props.uploadClient.uploadFile.mock.calls.length).toBe(1)
+    expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(1)
     expect(getFiles(wrapper).length).toBe(1)
     expect(getFiles(wrapper)[0].status.type).toBe("uploading")
     expect(instance.status).toBe("updating")
@@ -161,6 +160,7 @@ describe("FileUploader widget", () => {
 
   it("uploads a single file even if too many files are selected", async () => {
     const props = getProps({ multipleFiles: false })
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
     const wrapper = shallow(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
     const fileDropzone = wrapper.find(FileDropzone)
@@ -176,7 +176,7 @@ describe("FileUploader widget", () => {
       ]
     )
 
-    expect(props.uploadClient.uploadFile.mock.calls.length).toBe(1)
+    expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(1)
 
     // We should have 3 files. One will be uploading, the other two will
     // be in the error state.
@@ -245,6 +245,7 @@ describe("FileUploader widget", () => {
 
   it("uploads multiple files, even if some have errors", async () => {
     const props = getProps({ multipleFiles: true })
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
     const wrapper = shallow(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
     const fileDropzone = wrapper.find(FileDropzone)
@@ -259,7 +260,7 @@ describe("FileUploader widget", () => {
       ]
     )
 
-    expect(props.uploadClient.uploadFile.mock.calls.length).toBe(2)
+    expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(2)
 
     // We should have two files uploading, and 3 showing an error.
     expect(getFiles(wrapper).length).toBe(5)
@@ -292,6 +293,7 @@ describe("FileUploader widget", () => {
 
   it("can delete completed upload", async () => {
     const props = getProps({ multipleFiles: true })
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
     const wrapper = mount(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
 
@@ -347,6 +349,7 @@ describe("FileUploader widget", () => {
 
   it("can delete in-progress upload", async () => {
     const props = getProps({ multipleFiles: true })
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
     const wrapper = mount(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
 
@@ -381,6 +384,7 @@ describe("FileUploader widget", () => {
 
   it("can delete file with ErrorStatus", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
     const wrapper = shallow(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
     const fileDropzone = wrapper.find(FileDropzone)
@@ -484,6 +488,7 @@ describe("FileUploader widget", () => {
   it("resets on disconnect", () => {
     const props = getProps()
     const wrapper = shallow(<FileUploader {...props} />)
+    // @ts-ignore
     const resetSpy = jest.spyOn(wrapper.instance(), "reset")
     wrapper.setProps({ disabled: true })
     expect(resetSpy).toBeCalled()

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -38,7 +38,7 @@ import { UploadFileInfo } from "./UploadFileInfo"
 export interface Props {
   disabled: boolean
   element: FileUploaderProto
-  widgetStateManager: WidgetStateManager
+  widgetMgr: WidgetStateManager
   uploadClient: FileUploadClient
   width: number
 }
@@ -102,7 +102,7 @@ class FileUploader extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate = (prevProps: Props): void => {
-    const { element, widgetStateManager } = this.props
+    const { element, widgetMgr } = this.props
 
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users
@@ -111,7 +111,7 @@ class FileUploader extends React.PureComponent<Props, State> {
     // in sync with the new session.
     if (prevProps.disabled !== this.props.disabled && this.props.disabled) {
       this.reset()
-      widgetStateManager.setIntArrayValue(element, [], {
+      widgetMgr.setIntArrayValue(element, [], {
         fromUi: false,
       })
       return
@@ -132,9 +132,9 @@ class FileUploader extends React.PureComponent<Props, State> {
       return
     }
 
-    const prevWidgetValue = widgetStateManager.getIntArrayValue(element)
+    const prevWidgetValue = widgetMgr.getIntArrayValue(element)
     if (!_.isEqual(newWidgetValue, prevWidgetValue)) {
-      widgetStateManager.setIntArrayValue(element, newWidgetValue, {
+      widgetMgr.setIntArrayValue(element, newWidgetValue, {
         fromUi: true,
       })
     }

--- a/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -21,11 +21,8 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 
 import { Select as UISelect, TYPE } from "baseui/select"
 import { MultiSelect as MultiSelectProto } from "src/autogen/proto"
+import { lightTheme } from "src/theme"
 import Multiselect, { Props } from "./Multiselect"
-
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
 
 const getProps = (elementProps: Partial<MultiSelectProto> = {}): Props => ({
   element: MultiSelectProto.create({
@@ -37,18 +34,25 @@ const getProps = (elementProps: Partial<MultiSelectProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  theme: lightTheme.emotion,
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    pendingFormsChanged: jest.fn(),
+  }),
 })
 
 describe("Multiselect widget", () => {
-  const props = getProps()
-  const wrapper = mount(<Multiselect {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
     expect(wrapper.find(UISelect).length).toBeTruthy()
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
+
+    mount(<Multiselect {...props} />)
     expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -58,7 +62,9 @@ describe("Multiselect widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -72,21 +78,23 @@ describe("Multiselect widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a label", () => {
+  it("renders a label", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
   describe("placeholder", () => {
-    it("should render when it's not empty", () => {
+    it("renders when it's not empty", () => {
+      const props = getProps()
+      const wrapper = mount(<Multiselect {...props} />)
       expect(wrapper.find(UISelect).prop("placeholder")).toBe(
         "Choose an option"
       )
     })
 
-    it("should render with empty options", () => {
-      const props = getProps({
-        options: [],
-      })
+    it("renders with empty options", () => {
+      const props = getProps({ options: [] })
       const wrapper = mount(<Multiselect {...props} />)
 
       expect(wrapper.find(UISelect).prop("placeholder")).toBe(
@@ -95,8 +103,11 @@ describe("Multiselect widget", () => {
     })
   })
 
-  it("should render options", () => {
-    const options = wrapper.find(UISelect).prop("options") || []
+  it("renders options", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
+    // @ts-ignore
+    const options = (wrapper.find(UISelect).prop("options") as string[]) || []
 
     options.forEach(option => {
       expect(option).toHaveProperty("label")
@@ -108,19 +119,28 @@ describe("Multiselect widget", () => {
     expect(wrapper.find(UISelect).prop("valueKey")).toBe("value")
   })
 
-  it("should have multi attr", () => {
+  it("has multi attr", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
     expect(wrapper.find(UISelect).prop("multi")).toBeDefined()
   })
 
-  it("should have correct type", () => {
+  it("has correct type", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
     expect(wrapper.find(UISelect).prop("type")).toBe(TYPE.select)
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
     expect(wrapper.find(UISelect).prop("disabled")).toBe(props.disabled)
   })
 
-  it("should be able to select multiple options", () => {
+  it("can select multiple options", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
+
     // @ts-ignore
     wrapper.find(UISelect).prop("onChange")({
       type: "select",
@@ -136,7 +156,10 @@ describe("Multiselect widget", () => {
     ])
   })
 
-  it("should be able to remove an option", () => {
+  it("can remove options", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
+
     // @ts-ignore
     wrapper.find(UISelect).prop("onChange")({
       type: "remove",
@@ -151,11 +174,12 @@ describe("Multiselect widget", () => {
     ])
   })
 
-  it("should be able to clear it", () => {
+  it("can clear", () => {
+    const props = getProps()
+    const wrapper = mount(<Multiselect {...props} />)
+
     // @ts-ignore
-    wrapper.find(UISelect).prop("onChange")({
-      type: "clear",
-    })
+    wrapper.find(UISelect).prop("onChange")({ type: "clear" })
     wrapper.update()
 
     expect(wrapper.find(UISelect).prop("value")).toStrictEqual([])

--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -23,7 +23,6 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 
 import NumberInput, { Props } from "./NumberInput"
 
-const preventDefault = jest.fn()
 const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
   element: NumberInputProto.create({
     label: "Label",
@@ -124,6 +123,8 @@ describe("NumberInput widget", () => {
       const wrapper = shallow(<NumberInput {...props} />)
       const InputWrapper = wrapper.find(UIInput)
 
+      const preventDefault = jest.fn()
+
       // @ts-ignore
       InputWrapper.props().onKeyDown({
         key: "ArrowDown",
@@ -134,14 +135,63 @@ describe("NumberInput widget", () => {
       expect(wrapper.state("value")).toBe(10.9)
       expect(wrapper.state("dirty")).toBe(false)
     })
+
+    it("sets widget value on mount", () => {
+      const props = getFloatProps()
+      jest.spyOn(props.widgetMgr, "setDoubleValue")
+
+      shallow(<NumberInput {...props} />)
+
+      expect(props.widgetMgr.setDoubleValue).toHaveBeenCalledWith(
+        props.element,
+        props.element.default,
+        {
+          fromUi: false,
+        }
+      )
+    })
+
+    it("sets value on Enter", () => {
+      const props = getFloatProps({ default: 10 })
+      jest.spyOn(props.widgetMgr, "setDoubleValue")
+
+      const wrapper = shallow(<NumberInput {...props} />)
+
+      wrapper.setState({ dirty: true })
+
+      const InputWrapper = wrapper.find(UIInput)
+
+      // @ts-ignore
+      InputWrapper.props().onKeyPress({
+        key: "Enter",
+      })
+
+      expect(props.widgetMgr.setDoubleValue).toHaveBeenCalled()
+      expect(wrapper.state("dirty")).toBe(false)
+    })
   })
 
-  describe("Value", () => {
+  describe("IntData", () => {
     it("passes a default value", () => {
       const props = getIntProps({ default: 10 })
       const wrapper = shallow(<NumberInput {...props} />)
 
       expect(wrapper.find(UIInput).props().value).toBe("10")
+    })
+
+    it("sets widget value on mount", () => {
+      const props = getIntProps()
+      jest.spyOn(props.widgetMgr, "setIntValue")
+
+      shallow(<NumberInput {...props} />)
+
+      expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+        props.element,
+        props.element.default,
+        {
+          fromUi: false,
+        }
+      )
     })
 
     it("calls onChange", () => {
@@ -200,6 +250,8 @@ describe("NumberInput widget", () => {
       const wrapper = shallow(<NumberInput {...props} />)
       const InputWrapper = wrapper.find(UIInput)
 
+      const preventDefault = jest.fn()
+
       // @ts-ignore
       InputWrapper.props().onKeyDown({
         key: "ArrowUp",
@@ -219,6 +271,8 @@ describe("NumberInput widget", () => {
       })
       const wrapper = shallow(<NumberInput {...props} />)
       const InputWrapper = wrapper.find(UIInput)
+
+      const preventDefault = jest.fn()
 
       // @ts-ignore
       InputWrapper.props().onKeyDown({
@@ -244,7 +298,6 @@ describe("NumberInput widget", () => {
 
       expect(wrapper.state("dirty")).toBe(false)
       expect(wrapper.state("value")).toBe(9)
-      expect(preventDefault).toHaveBeenCalled()
     })
 
     it("handles stepUp button clicks", () => {
@@ -260,7 +313,6 @@ describe("NumberInput widget", () => {
 
       expect(wrapper.state("dirty")).toBe(false)
       expect(wrapper.state("value")).toBe(11)
-      expect(preventDefault).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -34,7 +34,7 @@ const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
 })
 

--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -23,9 +23,6 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 
 import NumberInput, { Props } from "./NumberInput"
 
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
 const preventDefault = jest.fn()
 const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
   element: NumberInputProto.create({
@@ -36,7 +33,10 @@ const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
 })
 
 const getIntProps = (elementProps: Partial<NumberInputProto> = {}): Props => {
@@ -81,14 +81,14 @@ describe("NumberInput widget", () => {
     expect(wrapper.state("value")).toBe(5.0)
   })
 
-  it("should show a label", () => {
+  it("shows a label", () => {
     const props = getIntProps()
     const wrapper = shallow(<NumberInput {...props} />)
 
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
-  it("should set min/max defaults", () => {
+  it("sets min/max defaults", () => {
     const props = getIntProps()
     const wrapper = shallow(<NumberInput {...props} />)
 
@@ -98,7 +98,7 @@ describe("NumberInput widget", () => {
     expect(wrapper.instance().getMax()).toBe(+Infinity)
   })
 
-  it("should set min/max", () => {
+  it("sets min/max values", () => {
     const props = getIntProps({
       hasMin: true,
       hasMax: true,
@@ -115,7 +115,7 @@ describe("NumberInput widget", () => {
   })
 
   describe("FloatData", () => {
-    it("should change the state when ArrowDown", () => {
+    it("changes state on ArrowDown", () => {
       const props = getFloatProps({
         format: "%0.2f",
         default: 11.0,
@@ -137,14 +137,14 @@ describe("NumberInput widget", () => {
   })
 
   describe("Value", () => {
-    it("should pass a default value", () => {
+    it("passes a default value", () => {
       const props = getIntProps({ default: 10 })
       const wrapper = shallow(<NumberInput {...props} />)
 
       expect(wrapper.find(UIInput).props().value).toBe("10")
     })
 
-    it("should call onChange", () => {
+    it("calls onChange", () => {
       const props = getIntProps({ default: 10 })
       const wrapper = shallow(<NumberInput {...props} />)
 
@@ -162,13 +162,13 @@ describe("NumberInput widget", () => {
       expect(wrapper.state("dirty")).toBe(true)
     })
 
-    it("should set value on Enter", () => {
+    it("sets value on Enter", () => {
       const props = getIntProps({ default: 10 })
+      jest.spyOn(props.widgetMgr, "setIntValue")
+
       const wrapper = shallow(<NumberInput {...props} />)
 
-      wrapper.setState({
-        dirty: true,
-      })
+      wrapper.setState({ dirty: true })
 
       const InputWrapper = wrapper.find(UIInput)
 
@@ -183,7 +183,7 @@ describe("NumberInput widget", () => {
   })
 
   describe("Step", () => {
-    it("should have an step", () => {
+    it("passes the step prop", () => {
       const props = getIntProps({ default: 10, step: 1 })
       const wrapper = shallow(<NumberInput {...props} />)
 
@@ -191,7 +191,7 @@ describe("NumberInput widget", () => {
       expect(wrapper.find(UIInput).props().overrides.Input.props.step).toBe(1)
     })
 
-    it("should change the state when ArrowUp", () => {
+    it("changes state on ArrowUp", () => {
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -211,7 +211,7 @@ describe("NumberInput widget", () => {
       expect(wrapper.state("dirty")).toBe(false)
     })
 
-    it("should change the state when ArrowDown", () => {
+    it("changes state on ArrowDown", () => {
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -231,7 +231,7 @@ describe("NumberInput widget", () => {
       expect(wrapper.state("dirty")).toBe(false)
     })
 
-    it("stepDown button onClick", () => {
+    it("handles stepDown button clicks", () => {
       const props = getIntProps({
         format: "%d",
         default: 10,
@@ -247,7 +247,7 @@ describe("NumberInput widget", () => {
       expect(preventDefault).toHaveBeenCalled()
     })
 
-    it("stepUp button onClick", () => {
+    it("handles stepUp button clicks", () => {
       const props = getIntProps({
         format: "%d",
         default: 10,

--- a/frontend/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.test.tsx
@@ -23,10 +23,6 @@ import { Radio as UIRadio, RadioGroup } from "baseui/radio"
 import { Radio as RadioProto } from "src/autogen/proto"
 import Radio, { Props } from "./Radio"
 
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
-
 const getProps = (elementProps: Partial<RadioProto> = {}): Props => ({
   element: RadioProto.create({
     id: "1",
@@ -37,19 +33,26 @@ const getProps = (elementProps: Partial<RadioProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
 })
 
 describe("Radio widget", () => {
-  const props = getProps()
-  const wrapper = mount(<Radio {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
+
     expect(wrapper.find(RadioGroup).length).toBe(1)
     expect(wrapper.find(UIRadio).length).toBe(3)
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setIntValue")
+    mount(<Radio {...props} />)
+
     expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -57,7 +60,9 @@ describe("Radio widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -71,21 +76,29 @@ describe("Radio widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a label", () => {
+  it("renders a label", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
-  it("should have a default value", () => {
+  it("has a default value", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     expect(wrapper.find(RadioGroup).prop("value")).toBe(
       props.element.default.toString()
     )
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     expect(wrapper.find(RadioGroup).prop("disabled")).toBe(props.disabled)
   })
 
-  it("should have the correct options", () => {
+  it("has the correct options", () => {
+    const props = getProps()
+    const wrapper = mount(<Radio {...props} />)
     const options = wrapper.find(UIRadio)
 
     options.forEach((option, index) => {
@@ -94,10 +107,8 @@ describe("Radio widget", () => {
     })
   })
 
-  it("should show a message when there are no options to be shown", () => {
-    const props = getProps({
-      options: [],
-    })
+  it("shows a message when there are no options to be shown", () => {
+    const props = getProps({ options: [] })
     const wrapper = mount(<Radio {...props} />)
 
     expect(wrapper.find(UIRadio).length).toBe(1)
@@ -106,7 +117,11 @@ describe("Radio widget", () => {
     )
   })
 
-  it("should select just one option and set the widget value", () => {
+  it("sets the widget value when an option is selected", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setIntValue")
+    const wrapper = mount(<Radio {...props} />)
+
     // @ts-ignore
     wrapper.find(RadioGroup).prop("onChange")({
       target: {

--- a/frontend/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.test.tsx
@@ -35,7 +35,7 @@ const getProps = (elementProps: Partial<RadioProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
 })
 
@@ -124,14 +124,12 @@ describe("Radio widget", () => {
 
     // @ts-ignore
     wrapper.find(RadioGroup).prop("onChange")({
-      target: {
-        value: "1",
-      },
+      target: { value: "1" },
     } as React.ChangeEvent<HTMLInputElement>)
     wrapper.update()
 
     expect(wrapper.find(RadioGroup).prop("value")).toBe("1")
-    expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
       props.element,
       1,
       { fromUi: true }

--- a/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -35,7 +35,7 @@ const getProps = (elementProps: Partial<SelectboxProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
 })
 

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -25,9 +25,6 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import { lightTheme } from "src/theme"
 import Slider, { Props } from "./Slider"
 
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
 const getProps = (elementProps: Partial<SliderProto> = {}): Props => ({
   element: SliderProto.create({
     id: "1",
@@ -42,7 +39,10 @@ const getProps = (elementProps: Partial<SliderProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
   theme: lightTheme.emotion,
 })
 
@@ -54,15 +54,16 @@ describe("Slider widget", () => {
     jest.clearAllTimers()
   })
 
-  it("should show a label", () => {
+  it("shows a label", () => {
     const props = getProps()
     const wrapper = mount(<Slider {...props} />)
 
     expect(wrapper.find("StyledWidgetLabel").text()).toBe("Label")
   })
 
-  it("should send the value to the backend when did mount", async () => {
+  it("sets widget value on mount", async () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setDoubleArrayValue")
 
     const wrapper = mount(<Slider {...props} />)
 
@@ -81,7 +82,7 @@ describe("Slider widget", () => {
     const props = getProps()
     const wrapper = mount(<Slider {...props} />)
 
-    it("should render tick bar with min and max", () => {
+    it("renders tick bar with min and max", () => {
       expect(
         wrapper.find("StyledTickBarItem[data-testid='stTickBarMin']").text()
       ).toBe("0")
@@ -106,7 +107,7 @@ describe("Slider widget", () => {
       expect(wrapper.find("StyledThumbValue")).toHaveLength(1)
     })
 
-    it("should have a correct value", () => {
+    it("has the correct value", () => {
       const props = getProps()
       const wrapper = mount(<Slider {...props} />)
       const UISliderWrapper = wrapper.find(UISlider)
@@ -117,13 +118,13 @@ describe("Slider widget", () => {
       expect(propValue[0]).toBeLessThan(props.element.max)
     })
 
-    it("should handle value changes", async () => {
+    it("handles value changes", async () => {
       const props = getProps()
+      jest.spyOn(props.widgetMgr, "setDoubleArrayValue")
+
       const wrapper = mount(<Slider {...props} />)
       // @ts-ignore
-      wrapper.find(UISlider).prop("onChange")({
-        value: [10],
-      })
+      wrapper.find(UISlider).prop("onChange")({ value: [10] })
 
       // We need to do this as we are using a debounce when the widget value is set
       jest.runAllTimers()
@@ -139,27 +140,21 @@ describe("Slider widget", () => {
 
   describe("Range value", () => {
     it("renders without crashing", () => {
-      const props = getProps({
-        default: [1, 9],
-      })
+      const props = getProps({ default: [1, 9] })
       const wrapper = mount(<Slider {...props} />)
 
       expect(wrapper).toBeDefined()
     })
 
     it("displays 2 thumb values", () => {
-      const props = getProps({
-        default: [1, 9],
-      })
+      const props = getProps({ default: [1, 9] })
       const wrapper = mount(<Slider {...props} />)
 
       expect(wrapper.find("StyledThumbValue")).toHaveLength(2)
     })
 
-    it("should have a correct value", () => {
-      const props = getProps({
-        default: [1, 9],
-      })
+    it("has the correct value", () => {
+      const props = getProps({ default: [1, 9] })
       const wrapper = mount(<Slider {...props} />)
       const UISliderWrapper = wrapper.find(UISlider)
       const propValue = UISliderWrapper.prop("value")
@@ -173,9 +168,7 @@ describe("Slider widget", () => {
     })
 
     describe("value should be within bounds", () => {
-      const props = getProps({
-        default: [1, 9],
-      })
+      const props = getProps({ default: [1, 9] })
       const wrapper = mount(<Slider {...props} />)
 
       it("start > end", () => {
@@ -229,10 +222,10 @@ describe("Slider widget", () => {
       })
     })
 
-    it("should handle value changes", async () => {
-      const props = getProps({
-        default: [1, 9],
-      })
+    it("handles value changes", async () => {
+      const props = getProps({ default: [1, 9] })
+      jest.spyOn(props.widgetMgr, "setDoubleArrayValue")
+
       const wrapper = mount(<Slider {...props} />)
 
       // @ts-ignore
@@ -279,7 +272,7 @@ describe("Slider widget", () => {
     })
     const wrapper = mount(<Slider {...props} />)
 
-    it("should format min and max as dates", () => {
+    it("formats min and max as dates", () => {
       expect(
         wrapper.find("StyledTickBarItem[data-testid='stTickBarMin']").text()
       ).toBe("1970-01-01")

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -41,7 +41,7 @@ const getProps = (elementProps: Partial<SliderProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
   theme: lightTheme.emotion,
 })

--- a/frontend/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.test.tsx
@@ -19,15 +19,9 @@ import React from "react"
 import { shallow } from "src/lib/test_util"
 import { TextArea as TextAreaProto } from "src/autogen/proto"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
-import { isInForm } from "src/lib/utils"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 import TextArea, { Props } from "./TextArea"
-
-jest.mock("src/lib/WidgetStateManager")
-jest.mock("src/lib/utils")
-
-const sendBackMsg = jest.fn()
 
 const getProps = (elementProps: Partial<TextAreaProto> = {}): Props => ({
   element: TextAreaProto.create({
@@ -38,19 +32,25 @@ const getProps = (elementProps: Partial<TextAreaProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  // @ts-ignore
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
 })
 
 describe("TextArea widget", () => {
-  const props = getProps()
-  const wrapper = shallow(<TextArea {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextArea {...props} />)
+
     expect(wrapper.find(UITextArea).length).toBe(1)
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    shallow(<TextArea {...props} />)
+
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -58,7 +58,10 @@ describe("TextArea widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextArea {...props} />)
+
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -71,27 +74,35 @@ describe("TextArea widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a label", () => {
+  it("renders a label", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextArea {...props} />)
+
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
-  it("should have a default value", () => {
+  it("has a default value", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextArea {...props} />)
+
     expect(wrapper.find(UITextArea).prop("value")).toBe(props.element.default)
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextArea {...props} />)
+
     expect(wrapper.find(UITextArea).prop("disabled")).toBe(props.disabled)
   })
 
-  it("should set widget value on blur", () => {
+  it("sets widget value on blur", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
     // @ts-ignore
     wrapper.find(UITextArea).prop("onChange")({
-      target: {
-        value: "testing",
-      },
+      target: { value: "testing" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
 
     // @ts-ignore
@@ -106,15 +117,14 @@ describe("TextArea widget", () => {
     )
   })
 
-  it("should set widget value when ctrl+enter is pressed", () => {
+  it("sets widget value when ctrl+enter is pressed", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
     // @ts-ignore
     wrapper.find(UITextArea).prop("onChange")({
-      target: {
-        value: "testing",
-      },
+      target: { value: "testing" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
 
     // @ts-ignore
@@ -133,7 +143,7 @@ describe("TextArea widget", () => {
     )
   })
 
-  it("should set widget height if it is passed from props", () => {
+  it("sets widget height if it is passed from props", () => {
     const props = getProps({
       height: 500,
     })
@@ -147,7 +157,7 @@ describe("TextArea widget", () => {
     expect(resize).toBe("vertical")
   })
 
-  it("should limit the length if max_chars is passed", () => {
+  it("limits the length if max_chars is passed", () => {
     const props = getProps({
       height: 500,
       maxChars: 10,
@@ -156,39 +166,30 @@ describe("TextArea widget", () => {
 
     // @ts-ignore
     wrapper.find(UITextArea).prop("onChange")({
-      target: {
-        value: "0123456789",
-      },
+      target: { value: "0123456789" },
     } as EventTarget)
 
     expect(wrapper.find(UITextArea).prop("value")).toBe("0123456789")
 
     // @ts-ignore
     wrapper.find(UITextArea).prop("onChange")({
-      target: {
-        value: "0123456789a",
-      },
+      target: { value: "0123456789a" },
     } as EventTarget)
 
     expect(wrapper.find(UITextArea).prop("value")).toBe("0123456789")
   })
 
-  it("should update widget value and not be dirty on text changes when it's inside of a form", () => {
-    const props = getProps()
+  it("updates widget value on text changes when inside of a form", () => {
+    const props = getProps({ formId: "form" })
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
     // @ts-ignore
-    isInForm.mockImplementation(() => true)
-
-    // @ts-ignore
     wrapper.find(UITextArea).prop("onChange")({
-      target: {
-        value: "TEST",
-      },
+      target: { value: "TEST" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
 
-    // @ts-ignore
-    expect(wrapper.state().dirty).toBeFalsy()
+    expect(wrapper.state("dirty")).toBe(false)
 
     // Check that the last call used the TEST value.
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
@@ -200,22 +201,17 @@ describe("TextArea widget", () => {
     )
   })
 
-  it("should not update widget value and set dirty to true on text changes when it's outside of a form", () => {
+  it("does not update widget value on text changes when outside of a form", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
     // @ts-ignore
-    isInForm.mockImplementation(() => false)
-
-    // @ts-ignore
     wrapper.find(UITextArea).prop("onChange")({
-      target: {
-        value: "TEST",
-      },
+      target: { value: "TEST" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
 
-    // @ts-ignore
-    expect(wrapper.state().dirty).toBeTruthy()
+    expect(wrapper.state("dirty")).toBe(true)
 
     // Check that the last call was in componentDidMount.
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
@@ -227,21 +223,20 @@ describe("TextArea widget", () => {
     )
   })
 
-  describe("On mac it should", () => {
+  describe("on mac", () => {
     Object.defineProperty(navigator, "platform", {
       value: "MacIntel",
       writable: true,
     })
 
-    const props = getProps()
-    const wrapper = shallow(<TextArea {...props} />)
+    it("sets widget value when ⌘+enter is pressed", () => {
+      const props = getProps()
+      jest.spyOn(props.widgetMgr, "setStringValue")
+      const wrapper = shallow(<TextArea {...props} />)
 
-    it("should set widget value when ⌘+enter is pressed", () => {
       // @ts-ignore
       wrapper.find(UITextArea).prop("onChange")({
-        target: {
-          value: "testing",
-        },
+        target: { value: "testing" },
       } as React.ChangeEvent<HTMLTextAreaElement>)
 
       // @ts-ignore

--- a/frontend/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.test.tsx
@@ -34,7 +34,7 @@ const getProps = (elementProps: Partial<TextAreaProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
 })
 

--- a/frontend/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.test.tsx
@@ -21,13 +21,8 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 
 import { Input as UIInput } from "baseui/input"
 import { TextInput as TextInputProto } from "src/autogen/proto"
-import { isInForm } from "src/lib/utils"
 import TextInput, { Props } from "./TextInput"
 
-jest.mock("src/lib/WidgetStateManager")
-jest.mock("src/lib/utils")
-
-const sendBackMsg = jest.fn()
 const getProps = (elementProps: Partial<TextInputProto> = {}): Props => ({
   element: TextInputProto.create({
     label: "Label",
@@ -37,23 +32,26 @@ const getProps = (elementProps: Partial<TextInputProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  // @ts-ignore
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
 })
 
 describe("TextInput widget", () => {
-  const props = getProps()
-  const wrapper = shallow(<TextInput {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextInput {...props} />)
     expect(wrapper).toBeDefined()
   })
 
-  it("should show a label", () => {
+  it("shows a label", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextInput {...props} />)
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
-  it("should handle TextInputProto.Type properly", () => {
+  it("handles TextInputProto.Type properly", () => {
     const defaultProps = getProps({ type: TextInputProto.Type.DEFAULT })
     let textInput = shallow(<TextInput {...defaultProps} />)
     let uiInput = textInput.find(UIInput)
@@ -65,7 +63,10 @@ describe("TextInput widget", () => {
     expect(uiInput.props().type).toBe("password")
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    shallow(<TextInput {...props} />)
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -73,7 +74,9 @@ describe("TextInput widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextInput {...props} />)
     const wrappedDiv = wrapper.find("StyledTextInput").first()
 
     const { className, width } = wrappedDiv.props()
@@ -86,19 +89,20 @@ describe("TextInput widget", () => {
     expect(width).toBe(getProps().width)
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = shallow(<TextInput {...props} />)
     expect(wrapper.find(UIInput).prop("disabled")).toBe(props.disabled)
   })
 
-  it("should set widget value on blur", () => {
+  it("sets widget value on blur", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
     // @ts-ignore
     wrapper.find(UIInput).prop("onChange")({
-      target: {
-        value: "testing",
-      },
+      target: { value: "testing" },
     } as React.ChangeEvent<HTMLInputElement>)
 
     // @ts-ignore
@@ -113,15 +117,14 @@ describe("TextInput widget", () => {
     )
   })
 
-  it("should set widget value when enter is pressed", () => {
+  it("sets widget value when enter is pressed", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
     // @ts-ignore
     wrapper.find(UIInput).prop("onChange")({
-      target: {
-        value: "testing",
-      },
+      target: { value: "testing" },
     } as React.ChangeEvent<HTMLInputElement>)
 
     // @ts-ignore
@@ -139,8 +142,9 @@ describe("TextInput widget", () => {
     )
   })
 
-  it("don't do anything when the component is clean", () => {
+  it("doesn't set widget value when not dirty", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
     // @ts-ignore
@@ -148,53 +152,44 @@ describe("TextInput widget", () => {
       preventDefault: jest.fn(),
       key: "Enter",
     })
+
+    expect(props.widgetMgr.setStringValue).toHaveBeenCalledTimes(1)
+
     // @ts-ignore
     wrapper.find(UIInput).prop("onBlur")()
-
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledTimes(1)
   })
 
-  it("should limit the length if max_chars is passed", () => {
-    const props = getProps({
-      maxChars: 10,
-    })
+  it("limits input length if max_chars is passed", () => {
+    const props = getProps({ maxChars: 10 })
     const wrapper = shallow(<TextInput {...props} />)
 
     // @ts-ignore
     wrapper.find(UIInput).prop("onChange")({
-      target: {
-        value: "0123456789",
-      },
+      target: { value: "0123456789" },
     } as EventTarget)
 
     expect(wrapper.find(UIInput).prop("value")).toBe("0123456789")
 
     // @ts-ignore
     wrapper.find(UIInput).prop("onChange")({
-      target: {
-        value: "0123456789a",
-      },
+      target: { value: "0123456789a" },
     } as EventTarget)
 
     expect(wrapper.find(UIInput).prop("value")).toBe("0123456789")
   })
 
-  it("should update widget value and not be dirty on text changes when it's inside of a form", () => {
-    const props = getProps()
+  it("updates widget value on text changes when inside of a form", () => {
+    const props = getProps({ formId: "form" })
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
     // @ts-ignore
-    isInForm.mockImplementation(() => true)
-
-    // @ts-ignore
     wrapper.find(UIInput).prop("onChange")({
-      target: {
-        value: "TEST",
-      },
+      target: { value: "TEST" },
     } as React.ChangeEvent<HTMLInputElement>)
 
-    // @ts-ignore
-    expect(wrapper.state().dirty).toBeFalsy()
+    expect(wrapper.state("dirty")).toBe(false)
 
     // Check that the last call used the TEST value.
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
@@ -206,22 +201,17 @@ describe("TextInput widget", () => {
     )
   })
 
-  it("should not update widget value and set dirty to true on text changes when it's outside of a form", () => {
+  it("does not update widget value on text changes when outside of a form", () => {
     const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
     // @ts-ignore
-    isInForm.mockImplementation(() => false)
-
-    // @ts-ignore
     wrapper.find(UIInput).prop("onChange")({
-      target: {
-        value: "TEST",
-      },
+      target: { value: "TEST" },
     } as React.ChangeEvent<HTMLInputElement>)
 
-    // @ts-ignore
-    expect(wrapper.state().dirty).toBeTruthy()
+    expect(wrapper.state("dirty")).toBe(true)
 
     // Check that the last call was in componentDidMount.
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(

--- a/frontend/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.test.tsx
@@ -34,7 +34,7 @@ const getProps = (elementProps: Partial<TextInputProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
 })
 

--- a/frontend/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -35,7 +35,7 @@ const getProps = (elementProps: Partial<TimeInputProto> = {}): Props => ({
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
-    formsDataChanged: jest.fn(),
+    pendingFormsChanged: jest.fn(),
   }),
 })
 

--- a/frontend/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -24,9 +24,6 @@ import { TimeInput as TimeInputProto } from "src/autogen/proto"
 import { TimePicker as UITimePicker } from "baseui/timepicker"
 import TimeInput, { Props } from "./TimeInput"
 
-jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
 const getProps = (elementProps: Partial<TimeInputProto> = {}): Props => ({
   element: TimeInputProto.create({
     id: "123",
@@ -36,22 +33,29 @@ const getProps = (elementProps: Partial<TimeInputProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
 })
 
 describe("TimeInput widget", () => {
-  const props = getProps()
-  const wrapper = shallow(<TimeInput {...props} />)
-
   it("renders without crashing", () => {
+    const props = getProps()
+    const wrapper = shallow(<TimeInput {...props} />)
     expect(wrapper).toBeDefined()
   })
 
-  it("should show a label", () => {
+  it("shows a label", () => {
+    const props = getProps()
+    const wrapper = shallow(<TimeInput {...props} />)
     expect(wrapper.find("StyledWidgetLabel").text()).toBe(props.element.label)
   })
 
-  it("should set widget value on did mount", () => {
+  it("sets widget value on mount", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    shallow(<TimeInput {...props} />)
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
@@ -59,7 +63,9 @@ describe("TimeInput widget", () => {
     )
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
+    const props = getProps()
+    const wrapper = shallow(<TimeInput {...props} />)
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
@@ -72,7 +78,9 @@ describe("TimeInput widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("could be disabled", () => {
+  it("can be disabled", () => {
+    const props = getProps()
+    const wrapper = shallow(<TimeInput {...props} />)
     expect(wrapper.find(UITimePicker).prop("overrides")).toStrictEqual({
       Select: {
         props: {
@@ -82,18 +90,25 @@ describe("TimeInput widget", () => {
     })
   })
 
-  it("should have the correct default value", () => {
+  it("has the correct default value", () => {
+    const props = getProps()
+    const wrapper = shallow(<TimeInput {...props} />)
     const wrapperValue = wrapper.find(UITimePicker).prop("value")
 
     // @ts-ignore
     expect(moment(wrapperValue).format("hh:mm")).toBe("12:45")
   })
 
-  it("should have a 24 format", () => {
+  it("has a 24 format", () => {
+    const props = getProps()
+    const wrapper = shallow(<TimeInput {...props} />)
     expect(wrapper.find(UITimePicker).prop("format")).toBe("24")
   })
 
-  it("should set the widget value on change", () => {
+  it("sets the widget value on change", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    const wrapper = shallow(<TimeInput {...props} />)
     const date = new Date(1995, 10, 10, 12, 8)
 
     // @ts-ignore


### PR DESCRIPTION
Lots of drive-by cleanup on all our widget tests, in preparation for the incoming "clear-on-submit" forms PR.

- Remove redundant "should do X" from test descriptions (`it("renders a label")`, instead of `it("should render a label")`)
- Fix WidgetStateManager mocking
- Move `props` and `wrapper` instances outside of global scope, and into individual test scopes
- Don't mock all of WidgetStateManager. Instead, use `jest.spyOn` on the single WidgetStateManager function each widget uses
- Add a handful of tests for widgets with low coverage