### PR TITLE
Move WidgetStateManager from ScriptRunner -> ReportSession

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -45,6 +45,7 @@ from streamlit.server.server_util import serialize_forward_msg
 from streamlit.storage.file_storage import FileStorage
 from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
+from streamlit.widgets import WidgetStateManager
 
 LOGGER = get_logger(__name__)
 if TYPE_CHECKING:
@@ -120,8 +121,7 @@ class ReportSession(object):
         from streamlit.state.session_state import SessionState
 
         self._session_state = SessionState()
-
-        # TODO: Also initialize the yet-to-be-implemented WidgetStateManager.
+        self._widget_state_mgr = WidgetStateManager()
 
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
 
@@ -242,6 +242,10 @@ class ReportSession(object):
     @property
     def session_state(self) -> "SessionState":
         return self._session_state
+
+    @property
+    def widget_state_mgr(self) -> WidgetStateManager:
+        return self._widget_state_mgr
 
     def _on_source_file_changed(self):
         """One of our source files changed. Schedule a rerun if appropriate."""
@@ -559,6 +563,7 @@ class ReportSession(object):
             enqueue_forward_msg=self.enqueue,
             client_state=self._client_state,
             request_queue=self._script_request_queue,
+            widget_state_mgr=self._widget_state_mgr,
             uploaded_file_mgr=self._uploaded_file_mgr,
         )
         self._scriptrunner.on_event.connect(self._on_scriptrunner_event)

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -142,6 +142,11 @@ class ReportSessionTest(unittest.TestCase):
         rs = ReportSession(None, "", "", UploadedFileManager())
         self.assertTrue(isinstance(rs.session_state, SessionState))
 
+    @patch("streamlit.report_session.LocalSourcesWatcher")
+    def test_creates_widget_state_mgr_on_init(self, _):
+        rs = ReportSession(None, "", "", UploadedFileManager())
+        self.assertTrue(isinstance(rs.widget_state_mgr, WidgetStateManager))
+
 
 def _create_mock_websocket():
     @tornado.gen.coroutine

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -31,11 +31,9 @@ from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.report import Report
 from streamlit.report_queue import ReportQueue
-from streamlit.script_request_queue import RerunData
-from streamlit.script_request_queue import ScriptRequest
-from streamlit.script_request_queue import ScriptRequestQueue
-from streamlit.script_runner import ScriptRunner
-from streamlit.script_runner import ScriptRunnerEvent
+from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
+from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
+from streamlit.widgets import WidgetStateManager
 from tests import testutil
 
 text_utf = "complete! 👨‍🎤"
@@ -314,7 +312,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # At this point, scriptrunner should have finished running, detected
         # that our widget_id wasn't in the list of widgets found this run, and
         # culled it. Ensure widget cache no longer holds our widget ID.
-        self.assertIsNone(scriptrunner._widgets.get_widget_value(widget_id))
+        self.assertIsNone(scriptrunner._widget_state_mgr.get_widget_value(widget_id))
 
     # TODO re-enable after flakyness is fixed
     def off_test_multiple_scriptrunners(self):
@@ -513,6 +511,7 @@ class TestScriptRunner(ScriptRunner):
             report=Report(script_path, "test command line"),
             enqueue_forward_msg=enqueue_fn,
             client_state=ClientState(),
+            widget_state_mgr=WidgetStateManager(),
             request_queue=self.script_request_queue,
         )
 


### PR DESCRIPTION
In the pre-session-state world, we were able to simply create a new
WidgetStateManager for each script run since widget state was only
stored on the client. In this world, WidgetStateManager could have
probably been replaced by some stateless helper functions as a new one
would be created for each script run.

Now that we're unifying widget state and session state, we need to
use WidgetStateManager to actually preserve state, so it can no longer
live in the very transient ScriptRunner class. Naturally, we move it to
the ReportSession class since we need it to interact with SessionState.