### PR TITLE
Rename WidgetStateManager -> WidgetManager and widgets.py -> state/widgets.py

### DIFF
--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -30,8 +30,8 @@ from streamlit.logger import get_logger
 from streamlit.proto.ArrowTable_pb2 import ArrowTable as ArrowTableProto
 from streamlit.proto.ComponentInstance_pb2 import SpecialArg
 from streamlit.proto.Element_pb2 import Element
+from streamlit.state.widgets import NoValue, register_widget
 from streamlit.type_util import to_bytes
-from streamlit.widgets import NoValue, register_widget
 
 LOGGER = get_logger(__name__)
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -65,7 +65,7 @@ from streamlit.elements.pyplot import PyplotMixin
 from streamlit.elements.write import WriteMixin
 from streamlit.elements.layouts import LayoutsMixin
 from streamlit.elements.form import FormMixin, FormData, current_form_id
-from streamlit.widgets import NoValue
+from streamlit.state.widgets import NoValue
 
 LOGGER = get_logger(__name__)
 

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -17,7 +17,7 @@ from typing import Optional, cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.widgets import register_widget
+from streamlit.state.widgets import register_widget
 from .form import current_form_id, is_in_form
 
 

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -16,7 +16,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
-from streamlit.widgets import register_widget
+from streamlit.state.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -18,7 +18,7 @@ from typing import cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
-from streamlit.widgets import register_widget
+from streamlit.state.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -19,10 +19,10 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
 from streamlit.report_thread import get_report_ctx
+from streamlit.state.widgets import register_widget, NoValue
 from .form import current_form_id
 from ..proto.Common_pb2 import SInt64Array
 from ..uploaded_file_manager import UploadedFile, UploadedFileRec
-from ..widgets import register_widget, NoValue
 
 LOGGER = get_logger(__name__)
 

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -17,8 +17,8 @@ from typing import cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
+from streamlit.state.widgets import register_widget
 from streamlit.type_util import is_type, ensure_iterable
-from streamlit.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -19,7 +19,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber, JSNumberBoundsException
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
-from streamlit.widgets import register_widget, NoValue
+from streamlit.state.widgets import register_widget, NoValue
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -17,8 +17,8 @@ from typing import cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
+from streamlit.state.widgets import register_widget, NoValue
 from streamlit.type_util import ensure_iterable
-from streamlit.widgets import register_widget, NoValue
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -17,9 +17,9 @@ from typing import cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
+from streamlit.state.widgets import register_widget
 from streamlit.type_util import ensure_iterable
 from streamlit.util import index_
-from streamlit.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -17,8 +17,8 @@ from typing import cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
+from streamlit.state.widgets import register_widget, NoValue
 from streamlit.type_util import ensure_iterable
-from streamlit.widgets import register_widget, NoValue
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -20,7 +20,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
-from streamlit.widgets import register_widget
+from streamlit.state.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -18,7 +18,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
-from streamlit.widgets import register_widget
+from streamlit.state.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -21,7 +21,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
-from streamlit.widgets import register_widget
+from streamlit.state.widgets import register_widget
 from .form import current_form_id
 
 

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -42,10 +42,10 @@ from streamlit.script_request_queue import ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner
 from streamlit.script_runner import ScriptRunnerEvent
 from streamlit.server.server_util import serialize_forward_msg
+from streamlit.state.widgets import WidgetManager
 from streamlit.storage.file_storage import FileStorage
 from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
-from streamlit.widgets import WidgetStateManager
 
 LOGGER = get_logger(__name__)
 if TYPE_CHECKING:
@@ -121,7 +121,7 @@ class ReportSession(object):
         from streamlit.state.session_state import SessionState
 
         self._session_state = SessionState()
-        self._widget_state_mgr = WidgetStateManager()
+        self._widget_mgr = WidgetManager()
 
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
 
@@ -244,8 +244,8 @@ class ReportSession(object):
         return self._session_state
 
     @property
-    def widget_state_mgr(self) -> WidgetStateManager:
-        return self._widget_state_mgr
+    def widget_mgr(self) -> WidgetManager:
+        return self._widget_mgr
 
     def _on_source_file_changed(self):
         """One of our source files changed. Schedule a rerun if appropriate."""
@@ -563,7 +563,7 @@ class ReportSession(object):
             enqueue_forward_msg=self.enqueue,
             client_state=self._client_state,
             request_queue=self._script_request_queue,
-            widget_state_mgr=self._widget_state_mgr,
+            widget_mgr=self._widget_mgr,
             uploaded_file_mgr=self._uploaded_file_mgr,
         )
         self._scriptrunner.on_event.connect(self._on_scriptrunner_event)

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -19,8 +19,8 @@ from streamlit import util
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.state.widgets import WidgetManager
 from streamlit.uploaded_file_manager import UploadedFileManager
-from streamlit.widgets import WidgetStateManager
 
 LOGGER = get_logger(__name__)
 
@@ -43,7 +43,7 @@ class ReportContext:
         session_id: str,
         enqueue: Callable[[ForwardMsg], None],
         query_string: str,
-        widgets: WidgetStateManager,
+        widget_mgr: WidgetManager,
         uploaded_file_mgr: UploadedFileManager,
     ):
         """Construct a ReportContext.
@@ -56,8 +56,8 @@ class ReportContext:
             Function that enqueues ForwardMsg protos in the websocket.
         query_string : str
             The URL query string for this run.
-        widgets : WidgetStateManager
-            The WidgetStateManager for the report.
+        widget_mgr : WidgetManager
+            The WidgetManager for the report.
         uploaded_file_mgr : UploadedFileManager
             The manager for files uploaded by all users.
 
@@ -66,7 +66,7 @@ class ReportContext:
         self.session_id = session_id
         self._enqueue = enqueue
         self.query_string = query_string
-        self.widgets = widgets
+        self.widget_mgr = widget_mgr
         # The ID of each widget that's been registered this run
         self.widget_ids_this_run = _StringSet()
         self.form_ids_this_run = _StringSet()
@@ -159,7 +159,7 @@ class ReportThread(threading.Thread):
         session_id: str,
         enqueue: Callable[[ForwardMsg], None],
         query_string: str,
-        widgets: WidgetStateManager,
+        widget_mgr: WidgetManager,
         uploaded_file_mgr: UploadedFileManager,
         target: Optional[Callable[[], None]] = None,
         name: Optional[str] = None,
@@ -174,8 +174,8 @@ class ReportThread(threading.Thread):
             Function that enqueues ForwardMsg protos in the websocket.
         query_string : str
             The URL query string for this run.
-        widgets : WidgetStateManager
-            The Widgets state object for the report.
+        widget_mgr : WidgetManager
+            The WidgetManager object for the report.
         uploaded_file_mgr : UploadedFileManager
             The manager for files uploaded by all users.
         target : callable
@@ -191,7 +191,7 @@ class ReportThread(threading.Thread):
             session_id=session_id,
             enqueue=enqueue,
             query_string=query_string,
-            widgets=widgets,
+            widget_mgr=widget_mgr,
             uploaded_file_mgr=uploaded_file_mgr,
         )
 

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -19,7 +19,7 @@ from typing import Any, Tuple, Deque
 
 from streamlit import util
 from streamlit.proto.ClientState_pb2 import ClientState
-from streamlit.widgets import coalesce_widget_states
+from streamlit.state.widgets import coalesce_widget_states
 
 
 class ScriptRequest(Enum):

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -89,8 +89,6 @@ class SessionState(MutableMapping[str, Any]):
 
     def __setitem__(self, key: str, value: Any) -> None:
         ctx = cast(ReportContext, get_report_ctx())
-        # TODO: This will need to be slightly changed once we refactor widget
-        #       state to be less fragmented.
         if key in ctx.widget_ids_this_run.items():
             raise StreamlitAPIException(
                 "Setting the value of a widget after its creation is disallowed."

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -144,7 +144,7 @@ def register_widget(
         )
 
     # Return the widget's current value.
-    return ctx.widgets.get_widget_value(widget_id)
+    return ctx.widget_mgr.get_widget_value(widget_id)
 
 
 def coalesce_widget_states(
@@ -182,7 +182,7 @@ def coalesce_widget_states(
     return coalesced
 
 
-class WidgetStateManager:
+class WidgetManager:
     """Stores widget values for a single connected session."""
 
     def __init__(self):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -25,8 +25,8 @@ from parameterized import parameterized
 
 import pandas as pd
 
+import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
-from streamlit.widgets import _build_duplicate_widget_message, register_widget
 from streamlit.cursor import LockedCursor, make_delta_path
 from streamlit.errors import DuplicateWidgetID
 from streamlit.errors import StreamlitAPIException
@@ -37,8 +37,8 @@ from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.Text_pb2 import Text as TextProto
+from streamlit.state.widgets import _build_duplicate_widget_message, register_widget
 from tests import testutil
-import streamlit as st
 
 
 class FakeDeltaGenerator(object):

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -17,8 +17,8 @@ import unittest
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.report_thread import ReportContext
+from streamlit.state.widgets import WidgetManager
 from streamlit.uploaded_file_manager import UploadedFileManager
-from streamlit.widgets import WidgetStateManager
 
 
 class ReportContextTest(unittest.TestCase):
@@ -30,7 +30,7 @@ class ReportContextTest(unittest.TestCase):
             "TestSessionID",
             fake_enqueue,
             "",
-            WidgetStateManager(),
+            WidgetManager(),
             UploadedFileManager(),
         )
 
@@ -49,7 +49,7 @@ class ReportContextTest(unittest.TestCase):
             "TestSessionID",
             fake_enqueue,
             "",
-            WidgetStateManager(),
+            WidgetManager(),
             UploadedFileManager(),
         )
 
@@ -71,7 +71,7 @@ class ReportContextTest(unittest.TestCase):
             "TestSessionID",
             fake_enqueue,
             "",
-            WidgetStateManager(),
+            WidgetManager(),
             UploadedFileManager(),
         )
 

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -29,8 +29,8 @@ from streamlit.report_session import ReportSession, ReportSessionState
 from streamlit.report_thread import add_report_ctx, get_report_ctx, ReportContext
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
 from streamlit.state.session_state import SessionState
+from streamlit.state.widgets import WidgetManager
 from streamlit.uploaded_file_manager import UploadedFileManager
-from streamlit.widgets import WidgetStateManager
 from tests.mock_storage import MockStorage
 
 
@@ -143,9 +143,9 @@ class ReportSessionTest(unittest.TestCase):
         self.assertTrue(isinstance(rs.session_state, SessionState))
 
     @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_creates_widget_state_mgr_on_init(self, _):
+    def test_creates_widget_mgr_on_init(self, _):
         rs = ReportSession(None, "", "", UploadedFileManager())
-        self.assertTrue(isinstance(rs.widget_state_mgr, WidgetStateManager))
+        self.assertTrue(isinstance(rs.widget_mgr, WidgetManager))
 
 
 def _create_mock_websocket():
@@ -172,7 +172,7 @@ class ReportSessionSerializationTest(tornado.testing.AsyncTestCase):
             "TestSessionID",
             rs._report.enqueue,
             "",
-            WidgetStateManager(),
+            WidgetManager(),
             UploadedFileManager(),
         )
         add_report_ctx(ctx=ctx)

--- a/lib/tests/streamlit/script_request_queue_test.py
+++ b/lib/tests/streamlit/script_request_queue_test.py
@@ -21,8 +21,8 @@ from threading import Thread, Lock
 from streamlit.script_request_queue import RerunData
 from streamlit.script_request_queue import ScriptRequestQueue
 from streamlit.script_runner import ScriptRequest
+from streamlit.state.widgets import WidgetManager
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
-from streamlit.widgets import WidgetStateManager
 
 
 def _create_widget(id, states):
@@ -94,15 +94,15 @@ class ScriptRequestQueueTest(unittest.TestCase):
         event, data = queue.dequeue()
         self.assertEqual(event, ScriptRequest.RERUN)
 
-        widgets = WidgetStateManager()
-        widgets.set_state(data.widget_states)
+        widget_mgr = WidgetManager()
+        widget_mgr.set_state(data.widget_states)
 
         # Coalesced triggers should be True if either the old or
         # new value was True
-        self.assertEqual(True, widgets.get_widget_value("trigger"))
+        self.assertEqual(True, widget_mgr.get_widget_value("trigger"))
 
         # Other widgets should have their newest value
-        self.assertEqual(456, widgets.get_widget_value("int"))
+        self.assertEqual(456, widget_mgr.get_widget_value("int"))
 
         # We should have no more events
         self.assertEqual((None, None), queue.dequeue(), "Expected empty event queue")
@@ -117,11 +117,11 @@ class ScriptRequestQueueTest(unittest.TestCase):
         queue.enqueue(ScriptRequest.RERUN, RerunData(widget_states=states))
 
         event, data = queue.dequeue()
-        widgets = WidgetStateManager()
-        widgets.set_state(data.widget_states)
+        widget_mgr = WidgetManager()
+        widget_mgr.set_state(data.widget_states)
 
         self.assertEqual(event, ScriptRequest.RERUN)
-        self.assertEqual(789, widgets.get_widget_value("int"))
+        self.assertEqual(789, widget_mgr.get_widget_value("int"))
 
         # We should have no more events
         self.assertEqual((None, None), queue.dequeue(), "Expected empty event queue")
@@ -135,11 +135,11 @@ class ScriptRequestQueueTest(unittest.TestCase):
         queue.enqueue(ScriptRequest.RERUN, RerunData(widget_states=None))
 
         event, data = queue.dequeue()
-        widgets = WidgetStateManager()
-        widgets.set_state(data.widget_states)
+        widget_mgr = WidgetManager()
+        widget_mgr.set_state(data.widget_states)
 
         self.assertEqual(event, ScriptRequest.RERUN)
-        self.assertEqual(101112, widgets.get_widget_value("int"))
+        self.assertEqual(101112, widget_mgr.get_widget_value("int"))
 
         # We should have no more events
         self.assertEqual((None, None), queue.dequeue(), "Expected empty event queue")

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -33,7 +33,7 @@ from streamlit.report import Report
 from streamlit.report_queue import ReportQueue
 from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
-from streamlit.widgets import WidgetStateManager
+from streamlit.state.widgets import WidgetManager
 from tests import testutil
 
 text_utf = "complete! 👨‍🎤"
@@ -312,7 +312,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # At this point, scriptrunner should have finished running, detected
         # that our widget_id wasn't in the list of widgets found this run, and
         # culled it. Ensure widget cache no longer holds our widget ID.
-        self.assertIsNone(scriptrunner._widget_state_mgr.get_widget_value(widget_id))
+        self.assertIsNone(scriptrunner._widget_mgr.get_widget_value(widget_id))
 
     # TODO re-enable after flakyness is fixed
     def off_test_multiple_scriptrunners(self):
@@ -511,7 +511,7 @@ class TestScriptRunner(ScriptRunner):
             report=Report(script_path, "test command line"),
             enqueue_forward_msg=enqueue_fn,
             client_state=ClientState(),
-            widget_state_mgr=WidgetStateManager(),
+            widget_mgr=WidgetManager(),
             request_queue=self.script_request_queue,
         )
 

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -18,8 +18,11 @@ import unittest
 
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
-from streamlit.widgets import _get_widget_id, WidgetStateManager
-from streamlit.widgets import coalesce_widget_states
+from streamlit.state.widgets import (
+    _get_widget_id,
+    coalesce_widget_states,
+    WidgetManager,
+)
 
 
 def _create_widget(id, states):
@@ -37,30 +40,30 @@ class WidgetTest(unittest.TestCase):
         _create_widget("int", states).int_value = 123
         _create_widget("string", states).string_value = "howdy!"
 
-        widgets = WidgetStateManager()
-        widgets.set_state(states)
+        widget_mgr = WidgetManager()
+        widget_mgr.set_state(states)
 
-        self.assertEqual(True, widgets.get_widget_value("trigger"))
-        self.assertEqual(True, widgets.get_widget_value("bool"))
-        self.assertAlmostEqual(0.5, widgets.get_widget_value("float"))
-        self.assertEqual(123, widgets.get_widget_value("int"))
-        self.assertEqual("howdy!", widgets.get_widget_value("string"))
+        self.assertEqual(True, widget_mgr.get_widget_value("trigger"))
+        self.assertEqual(True, widget_mgr.get_widget_value("bool"))
+        self.assertAlmostEqual(0.5, widget_mgr.get_widget_value("float"))
+        self.assertEqual(123, widget_mgr.get_widget_value("int"))
+        self.assertEqual("howdy!", widget_mgr.get_widget_value("string"))
 
     def test_reset_triggers(self):
         states = WidgetStates()
-        widgets = WidgetStateManager()
+        widget_mgr = WidgetManager()
 
         _create_widget("trigger", states).trigger_value = True
         _create_widget("int", states).int_value = 123
-        widgets.set_state(states)
+        widget_mgr.set_state(states)
 
-        self.assertEqual(True, widgets.get_widget_value("trigger"))
-        self.assertEqual(123, widgets.get_widget_value("int"))
+        self.assertEqual(True, widget_mgr.get_widget_value("trigger"))
+        self.assertEqual(123, widget_mgr.get_widget_value("int"))
 
-        widgets.reset_triggers()
+        widget_mgr.reset_triggers()
 
-        self.assertEqual(None, widgets.get_widget_value("trigger"))
-        self.assertEqual(123, widgets.get_widget_value("int"))
+        self.assertEqual(None, widget_mgr.get_widget_value("trigger"))
+        self.assertEqual(123, widget_mgr.get_widget_value("int"))
 
     def test_coalesce_widget_states(self):
         old_states = WidgetStates()
@@ -77,19 +80,19 @@ class WidgetTest(unittest.TestCase):
         _create_widget("added_in_new", new_states).int_value = 456
         _create_widget("shape_changing_trigger", new_states).int_value = 3
 
-        widgets = WidgetStateManager()
-        widgets.set_state(coalesce_widget_states(old_states, new_states))
+        widget_mgr = WidgetManager()
+        widget_mgr.set_state(coalesce_widget_states(old_states, new_states))
 
-        self.assertIsNone(widgets.get_widget_value("old_unset_trigger"))
-        self.assertIsNone(widgets.get_widget_value("missing_in_new"))
+        self.assertIsNone(widget_mgr.get_widget_value("old_unset_trigger"))
+        self.assertIsNone(widget_mgr.get_widget_value("missing_in_new"))
 
-        self.assertEqual(True, widgets.get_widget_value("old_set_trigger"))
-        self.assertEqual(True, widgets.get_widget_value("new_set_trigger"))
-        self.assertEqual(456, widgets.get_widget_value("added_in_new"))
+        self.assertEqual(True, widget_mgr.get_widget_value("old_set_trigger"))
+        self.assertEqual(True, widget_mgr.get_widget_value("new_set_trigger"))
+        self.assertEqual(456, widget_mgr.get_widget_value("added_in_new"))
 
         # Widgets that were triggers before, but no longer are, will *not*
         # be coalesced
-        self.assertEqual(3, widgets.get_widget_value("shape_changing_trigger"))
+        self.assertEqual(3, widget_mgr.get_widget_value("shape_changing_trigger"))
 
 
 class WidgetHelperTests(unittest.TestCase):

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -24,7 +24,7 @@ from streamlit.report_queue import ReportQueue
 from streamlit.report_thread import ReportContext
 from streamlit.report_thread import add_report_ctx
 from streamlit.report_thread import get_report_ctx
-from streamlit.widgets import WidgetStateManager
+from streamlit.state.widgets import WidgetManager
 from streamlit.uploaded_file_manager import UploadedFileManager
 
 
@@ -83,7 +83,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                     session_id="test session id",
                     enqueue=self.report_queue.enqueue,
                     query_string="",
-                    widgets=WidgetStateManager(),
+                    widget_mgr=WidgetManager(),
                     uploaded_file_mgr=UploadedFileManager(),
                 ),
             )


### PR DESCRIPTION
WidgetStateManager will manage more than just states soon since it'll
also need to keep track of widget callbacks, deserializers, etc.

We also moved widgets.py to the new state submodule given how closely
tied widget and session_state behavior are.
