### PR TITLE
Have ScriptRunner call callbacks if widget values have changed

### DIFF
--- a/e2e/scripts/st_button.py
+++ b/e2e/scripts/st_button.py
@@ -14,7 +14,26 @@
 
 import streamlit as st
 
-i1 = st.button("button 1")
-st.write("value:", i1)
+# st.session_state can only be used in streamlit
+if st._is_running_with_streamlit:
 
-i2 = st.checkbox("reset button")
+    def on_change(x, y):
+        if "click_count" not in st.session_state:
+            st.session_state.click_count = 0
+
+        st.session_state.click_count += 1
+        st.session_state.x = x
+        st.session_state.y = y
+
+    i1 = st.button("button 1", on_change=on_change, args=(1,), kwargs={"y": 2})
+    st.write("value:", i1)
+
+    button_was_clicked = "click_count" in st.session_state
+    st.write("Button was clicked:", button_was_clicked)
+
+    if button_was_clicked:
+        st.write("times clicked:", st.session_state.click_count)
+        st.write("arg value:", st.session_state.x)
+        st.write("kwarg value:", st.session_state.y)
+
+i2 = st.checkbox("reset button return value")

--- a/e2e/specs/st_button.spec.js
+++ b/e2e/specs/st_button.spec.js
@@ -30,13 +30,13 @@ describe("st.button", () => {
   });
 
   it("has correct default value", () => {
-    cy.get(".stMarkdown").should("have.text", "value: False");
+    cy.get(".stMarkdown").contains("value: False");
   });
 
   it("sets value correctly when user clicks", () => {
     cy.get(".stButton button").click();
 
-    cy.get(".stMarkdown").should("have.text", "value: True");
+    cy.get(".stMarkdown").contains("value: True");
   });
 
   it("doesn't reset the value when user clicks again", () => {
@@ -44,14 +44,31 @@ describe("st.button", () => {
       .click()
       .click();
 
-    cy.get(".stMarkdown").should("have.text", "value: True");
+    cy.get(".stMarkdown").contains("value: True");
+  });
+
+  it("calls callback when clicked", () => {
+    cy.get(".stMarkdown").contains("Button was clicked: False");
+
+    cy.get(".stButton button").click();
+
+    cy.get(".stMarkdown").contains("Button was clicked: True");
+    cy.get(".stMarkdown").contains("times clicked: 1");
+    cy.get(".stMarkdown").contains("arg value: 1");
+    cy.get(".stMarkdown").contains("kwarg value: 2");
+
+    cy.get(".stButton button").click();
+    cy.get(".stMarkdown").contains("times clicked: 2");
+
+    cy.get(".stButton button").click();
+    cy.get(".stMarkdown").contains("times clicked: 3");
   });
 
   it("is reset when user changes another widget", () => {
     cy.get(".stButton button").click();
-    cy.get(".stMarkdown").should("have.text", "value: True");
+    cy.get(".stMarkdown").contains("value: True");
     cy.get(".stCheckbox").click();
 
-    cy.get(".stMarkdown").should("have.text", "value: False");
+    cy.get(".stMarkdown").contains("value: False");
   });
 });

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -17,7 +17,13 @@ from typing import Optional, cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.state.widgets import register_widget
+from streamlit.state.widgets import (
+    register_widget,
+    WidgetArgs,
+    WidgetCallback,
+    WidgetDeserializer,
+    WidgetKwargs,
+)
 from .form import current_form_id, is_in_form
 
 
@@ -29,20 +35,34 @@ For more information, refer to the
 
 
 class ButtonMixin:
-    def button(self, label, key=None, help=None):
+    def button(
+        self,
+        label,
+        key: Optional[str] = None,
+        help: Optional[str] = None,
+        on_change: Optional[WidgetCallback] = None,
+        args: Optional[WidgetArgs] = None,
+        kwargs: Optional[WidgetKwargs] = None,
+    ) -> bool:
         """Display a button widget.
 
         Parameters
         ----------
         label : str
             A short label explaining to the user what this button is for.
-        key : str
+        key : Optional[str]
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
-        help : str
+        help : Optional[str]
             A tooltip that gets displayed when the button is hovered over.
+        on_change : Optional[Callable]
+            A callback invoked when the button is clicked.
+        args : Optional[Tuple]
+            A tuple of args to pass to the callback.
+        kwargs : Optional[Dict]
+            A dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -57,7 +77,15 @@ class ButtonMixin:
         ...     st.write('Goodbye')
 
         """
-        return self.dg._button(label, key, help, is_form_submitter=False)
+        return self.dg._button(
+            label,
+            key,
+            help,
+            is_form_submitter=False,
+            on_change=on_change,
+            args=args,
+            kwargs=kwargs,
+        )
 
     def _button(
         self,
@@ -65,9 +93,10 @@ class ButtonMixin:
         key: Optional[str],
         help: Optional[str],
         is_form_submitter: bool,
-    ) -> "streamlit.delta_generator.DeltaGenerator":
-        button_proto = ButtonProto()
-
+        on_change: Optional[WidgetCallback] = None,
+        args: Optional[WidgetArgs] = None,
+        kwargs: Optional[WidgetKwargs] = None,
+    ) -> bool:
         # It doesn't make sense to create a button inside a form (except
         # for the "Form Submitter" button that's automatically created in
         # every form). We throw an error to warn the user about this.
@@ -83,6 +112,7 @@ class ButtonMixin:
                     f"`st.submit_button()` must be used inside an `st.form()`.{FORM_DOCS_INFO}"
                 )
 
+        button_proto = ButtonProto()
         button_proto.label = label
         button_proto.default = False
         button_proto.is_form_submitter = is_form_submitter
@@ -90,10 +120,18 @@ class ButtonMixin:
         if help is not None:
             button_proto.help = help
 
-        ui_value = register_widget("button", button_proto, user_key=key)
-        current_value = ui_value if ui_value is not None else False
-
-        return self.dg._enqueue("button", button_proto, current_value)  # type: ignore
+        deserialize_button: WidgetDeserializer = lambda ui_value: ui_value or False
+        current_value: bool = register_widget(
+            "button",
+            button_proto,
+            user_key=key,
+            on_change_handler=on_change,
+            args=args,
+            kwargs=kwargs,
+            deserializer=deserialize_button,
+        )
+        self.dg._enqueue("button", button_proto)
+        return current_value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -56,13 +56,14 @@ class ButtonMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : Optional[str]
-            A tooltip that gets displayed when the button is hovered over.
+            An optional tooltip that gets displayed when the button is
+            hovered over.
         on_change : Optional[Callable]
-            A callback invoked when the button is clicked.
+            An optional callback invoked when the button is clicked.
         args : Optional[Tuple]
-            A tuple of args to pass to the callback.
+            An optional tuple of args to pass to the callback.
         kwargs : Optional[Dict]
-            A dict of kwargs to pass to the callback.
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -98,7 +98,7 @@ class ScriptRunner(object):
 
         self._client_state = client_state
         self._widget_mgr = widget_mgr
-        self._widget_mgr.set_state(client_state.widget_states)
+        self._widget_mgr.set_widget_states(client_state.widget_states)
 
         self.on_event = Signal(
             doc="""Emitted when a ScriptRunnerEvent occurs.
@@ -310,7 +310,7 @@ class ScriptRunner(object):
         # Update the Widget object with the new widget_states.
         # (The ReportContext has a reference to this object, so we just update it in-place)
         if rerun_data.widget_states is not None:
-            self._widget_mgr.set_state(rerun_data.widget_states)
+            self._widget_mgr.set_widget_states(rerun_data.widget_states)
 
         if config.get_option("runner.installTracer"):
             self._install_tracer()

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -307,11 +307,6 @@ class ScriptRunner(object):
         # is to run it. Errors thrown during execution will be shown to the
         # user as ExceptionElements.
 
-        # Update the Widget object with the new widget_states.
-        # (The ReportContext has a reference to this object, so we just update it in-place)
-        if rerun_data.widget_states is not None:
-            self._widget_mgr.set_widget_states(rerun_data.widget_states)
-
         if config.get_option("runner.installTracer"):
             self._install_tracer()
 
@@ -339,6 +334,20 @@ class ScriptRunner(object):
             module.__dict__["__file__"] = self._report.script_path
 
             with modified_sys_path(self._report), self._set_execing_flag():
+                # Run callbacks for widgets whose values have changed.
+                if rerun_data.widget_states is not None:
+                    # Update the WidgetManager with the new widget_states.
+                    # The old states, used to skip callbacks if values
+                    # haven't changed, are also preserved in the
+                    # WidgetManager.
+                    self._widget_mgr.mark_widgets_as_old()
+                    self._widget_mgr.set_widget_states(rerun_data.widget_states)
+
+                    # TODO: Mark state as old when unifying widget and
+                    #       session state.
+
+                    self._widget_mgr.call_callbacks()
+
                 exec(code, module.__dict__)
 
         except RerunException as e:

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -15,9 +15,9 @@
 import json
 import textwrap
 from pprint import pprint
-from typing import Any, Optional, Dict, Set, Union
+from typing import Any, Callable, cast, Dict, Optional, Set, Tuple, Union
 
-from attr import attrs
+import attr
 
 from streamlit import report_thread
 from streamlit import util
@@ -57,6 +57,11 @@ WidgetProto = Union[
     TimeInput,
 ]
 
+WidgetArgs = Tuple[Any, ...]
+WidgetCallback = Callable[..., None]
+WidgetDeserializer = Callable[[Any], Any]
+WidgetKwargs = Dict[str, Any]
+
 
 class NoValue:
     """Return this from DeltaGenerator.foo_widget() when you want the st.foo_widget()
@@ -67,22 +72,32 @@ class NoValue:
     pass
 
 
-@attrs(auto_attribs=True)
+@attr.s(auto_attribs=True)
 class Widget:
-    state: WidgetState
+    id: str
+    state: Optional[WidgetState] = None
+    callback: Optional[WidgetCallback] = None
+    deserializer: WidgetDeserializer = lambda x: x
+    callback_args: Optional[WidgetArgs] = None
+    callback_kwargs: Optional[WidgetKwargs] = None
 
-    def type(self) -> str:
+    @property
+    def type(self) -> Optional[str]:
+        if self.state is None:
+            return None
         return self.state.WhichOneof("value")
 
     @property
-    def id(self):
-        return self.state.id
-
     def value(self) -> Any:
-        if self.type() == "json_value":
-            return json.loads(getattr(self.state, self.type()))
+        if self.type is None:
+            return self.deserializer(None)
 
-        return getattr(self.state, self.type())
+        if self.type == "json_value":
+            raw_value = json.loads(getattr(self.state, self.type))
+        else:
+            raw_value = getattr(self.state, self.type)
+
+        return self.deserializer(raw_value)
 
 
 def register_widget(
@@ -90,7 +105,11 @@ def register_widget(
     element_proto: WidgetProto,
     user_key: Optional[str] = None,
     widget_func_name: Optional[str] = None,
-) -> Optional[Any]:
+    on_change_handler: Optional[WidgetCallback] = None,
+    deserializer: WidgetDeserializer = lambda x: x,
+    args: Optional[WidgetArgs] = None,
+    kwargs: Optional[WidgetKwargs] = None,
+) -> Any:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
 
@@ -103,15 +122,24 @@ def register_widget(
     user_key : str
         Optional user-specified string to use as the widget ID.
         If this is None, we'll generate an ID by hashing the element.
-    widget_func_name : str or None
+    widget_func_name : Optional[str]
         The widget's DeltaGenerator function name, if it's different from
         its element_type. Custom components are a special case: they all have
         the element_type "component_instance", but are instantiated with
         dynamically-named functions.
+    on_change_handler : Optional[WidgetCallback]
+        An optional callback invoked when the widget's value changes.
+    deserializer : Optional[WidgetDeserializer]
+        Called to convert a widget's protobuf value to the value returned by
+        its st.<widget_name> function.
+    args : Optional[WidgetArgs]
+        args to pass to on_change_handler when invoked
+    kwargs : Optional[WidgetKwargs]
+        kwargs to pass to on_change_handler when invoked
 
     Returns
     -------
-    ui_value : Any or None
+    ui_value : Any
         - If our ReportContext doesn't exist (meaning that we're running
         a "bare script" outside of streamlit), we'll return None.
         - Else if this is a new widget, it won't yet have a value and we'll
@@ -131,7 +159,7 @@ def register_widget(
         # Early-out if we're not running inside a ReportThread (which
         # probably means we're running as a "bare" Python script, and
         # not via `streamlit run`).
-        return None
+        return deserializer(None)
 
     # Register the widget, and ensure another widget with the same id hasn't
     # already been registered.
@@ -144,7 +172,14 @@ def register_widget(
             )
         )
 
-    # Return the widget's current value.
+    ctx.widget_mgr.set_widget_attrs(
+        widget_id,
+        callback=on_change_handler,
+        deserializer=deserializer,
+        args=args,
+        kwargs=kwargs,
+    )
+
     return ctx.widget_mgr.get_widget_value(widget_id)
 
 
@@ -160,9 +195,9 @@ def coalesce_widget_states(
     `old_states` will be set to True in the coalesced result, so that button
     presses don't go missing.
     """
-    states_by_id: Dict[str, WidgetState] = {}
-    for new_state in new_states.widgets:
-        states_by_id[new_state.id] = new_state
+    states_by_id: Dict[str, WidgetState] = {
+        wstate.id: wstate for wstate in new_states.widgets
+    }
 
     for old_state in old_states.widgets:
         if old_state.WhichOneof("value") == "trigger_value" and old_state.trigger_value:
@@ -188,30 +223,79 @@ class WidgetManager(object):
 
     def __init__(self):
         self._widgets: Dict[str, Widget] = {}
+        self._prev_widgets: Dict[str, Widget] = {}
 
     def __repr__(self) -> str:
         return util.repr_(self)
 
     def get_widget_value(self, widget_id: str) -> Optional[Any]:
         """Return the value of a widget, or None if no value has been set."""
-        wstate = self._widgets.get(widget_id, None)
-        if wstate is None:
+        widget = self._widgets.get(widget_id, None)
+        if widget is None:
             return None
 
-        return wstate.value()
+        return widget.value
+
+    def get_prev_widget_value(self, widget_id: str) -> Optional[Any]:
+        prev_widget = self._prev_widgets.get(widget_id, None)
+        if prev_widget is None:
+            return None
+
+        return prev_widget.value
+
+    def mark_widgets_as_old(self) -> None:
+        self._prev_widgets = self._widgets
+        self._widgets = {}
 
     def set_widget_states(self, widget_states: WidgetStates) -> None:
-        """Copy the state from a WidgetStates protobuf into our state dict."""
-        self._widgets = {}
+        """Copy the state from a WidgetStates protobuf into self._widgets."""
         for wstate in widget_states.widgets:
-            widget = Widget(wstate)
-            self._widgets[wstate.id] = widget
+            widget = self._widgets.get(wstate.id, None)
+
+            if widget is None:
+                self._widgets[wstate.id] = Widget(wstate.id, state=wstate)
+            else:
+                widget.state = wstate
+
+    def set_widget_attrs(
+        self,
+        widget_id: str,
+        callback: Optional[WidgetCallback],
+        deserializer: WidgetDeserializer,
+        args: Optional[WidgetArgs],
+        kwargs: Optional[WidgetKwargs],
+    ) -> None:
+        widget = self._widgets.get(widget_id, None)
+        if widget is None:
+            widget = Widget(widget_id)
+            self._widgets[widget_id] = widget
+
+        if callback is not None:
+            widget.callback = callback
+            widget.callback_args = args
+            widget.callback_kwargs = kwargs
+        widget.deserializer = deserializer
+
+    def call_callbacks(self) -> None:
+        # The callbacks to run are those installed on the *previous* script
+        # run -- the ones for this run have yet to be installed.
+        for widget in self._prev_widgets.values():
+            callback = widget.callback
+            if callback is None:
+                continue
+
+            curr_value = self.get_widget_value(widget.id)
+            prev_value = self.get_prev_widget_value(widget.id)
+            if curr_value != prev_value:
+                args = widget.callback_args or ()
+                kwargs = widget.callback_kwargs or {}
+                callback(*args, **kwargs)
 
     def marshall(self, client_state: ClientState) -> None:
         """Populate a ClientState proto with the widget values stored in this
         object.
         """
-        states = [widget.state for widget in self._widgets.values()]
+        states = [widget.state for widget in self._widgets.values() if widget.state]
         client_state.widget_states.widgets.extend(states)
 
     def cull_nonexistent(self, widget_ids: Set[str]) -> None:
@@ -221,17 +305,11 @@ class WidgetManager(object):
         self._widgets = {k: v for k, v in self._widgets.items() if k in widget_ids}
 
     def reset_triggers(self) -> None:
-        """Remove all trigger values in our state dictionary.
-
-        (All trigger values default to False, so removing them is equivalent
-        to resetting them from True to False.)
-
-        """
-        prev_widgets = self._widgets
-        self._widgets = {}
-        for widget in prev_widgets.values():
-            if widget.type() != "trigger_value":
-                self._widgets[widget.id] = widget
+        """Sets all trigger values in our state dictionary to False."""
+        for widget in self._widgets.values():
+            if widget.type == "trigger_value":
+                state = cast(WidgetState, widget.state)
+                state.trigger_value = False
 
     def dump(self) -> None:
         """Pretty-print widget state to the console, for debugging."""

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -199,7 +199,7 @@ class WidgetManager:
 
         return wstate.value()
 
-    def set_state(self, widget_states: WidgetStates) -> None:
+    def set_widget_states(self, widget_states: WidgetStates) -> None:
         """Copy the state from a WidgetStates protobuf into our state dict."""
         self._state = {}
         for wstate in widget_states.widgets:

--- a/lib/tests/streamlit/script_request_queue_test.py
+++ b/lib/tests/streamlit/script_request_queue_test.py
@@ -95,7 +95,7 @@ class ScriptRequestQueueTest(unittest.TestCase):
         self.assertEqual(event, ScriptRequest.RERUN)
 
         widget_mgr = WidgetManager()
-        widget_mgr.set_state(data.widget_states)
+        widget_mgr.set_widget_states(data.widget_states)
 
         # Coalesced triggers should be True if either the old or
         # new value was True
@@ -118,7 +118,7 @@ class ScriptRequestQueueTest(unittest.TestCase):
 
         event, data = queue.dequeue()
         widget_mgr = WidgetManager()
-        widget_mgr.set_state(data.widget_states)
+        widget_mgr.set_widget_states(data.widget_states)
 
         self.assertEqual(event, ScriptRequest.RERUN)
         self.assertEqual(789, widget_mgr.get_widget_value("int"))
@@ -136,7 +136,7 @@ class ScriptRequestQueueTest(unittest.TestCase):
 
         event, data = queue.dequeue()
         widget_mgr = WidgetManager()
-        widget_mgr.set_state(data.widget_states)
+        widget_mgr.set_widget_states(data.widget_states)
 
         self.assertEqual(event, ScriptRequest.RERUN)
         self.assertEqual(101112, widget_mgr.get_widget_value("int"))

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -18,6 +18,7 @@ import os
 import sys
 import time
 from typing import List
+from unittest.mock import patch
 
 from parameterized import parameterized
 from tornado.testing import AsyncTestCase
@@ -121,6 +122,107 @@ class ScriptRunnerTest(AsyncTestCase):
             ],
         )
         self._assert_text_deltas(scriptrunner, [])
+
+    @patch("streamlit.state.widgets.WidgetManager.call_callbacks")
+    def test_calls_widget_callbacks(self, patched_call_callbacks):
+        scriptrunner = TestScriptRunner("widgets_script.py")
+        scriptrunner.enqueue_rerun()
+        scriptrunner.start()
+
+        # Default widget values
+        require_widgets_deltas([scriptrunner])
+        self._assert_text_deltas(
+            scriptrunner, ["False", "ahoy!", "0", "False", "loop_forever"]
+        )
+
+        patched_call_callbacks.assert_not_called()
+
+        # Update widgets
+        states = WidgetStates()
+        w1_id = scriptrunner.get_widget_id("checkbox", "checkbox")
+        _create_widget(w1_id, states).bool_value = True
+        w2_id = scriptrunner.get_widget_id("text_area", "text_area")
+        _create_widget(w2_id, states).string_value = "matey!"
+        w3_id = scriptrunner.get_widget_id("radio", "radio")
+        _create_widget(w3_id, states).int_value = 2
+        w4_id = scriptrunner.get_widget_id("button", "button")
+        _create_widget(w4_id, states).trigger_value = True
+
+        # Explicitly clear deltas before re-running, to prevent a race
+        # condition. (The ScriptRunner will clear the deltas when it
+        # starts the re-run, but if that doesn't happen before
+        # require_widgets_deltas() starts polling the ScriptRunner's deltas,
+        # it will see stale deltas from the last run.)
+        scriptrunner.clear_deltas()
+        scriptrunner.enqueue_rerun(widget_states=states)
+
+        require_widgets_deltas([scriptrunner])
+        self._assert_text_deltas(
+            scriptrunner, ["True", "matey!", "2", "True", "loop_forever"]
+        )
+
+        patched_call_callbacks.assert_called_once()
+
+        scriptrunner.enqueue_shutdown()
+        scriptrunner.join()
+
+    @patch("streamlit.exception")
+    @patch("streamlit.state.widgets.WidgetManager.call_callbacks")
+    def test_calls_widget_callbacks_error(
+        self, patched_call_callbacks, patched_st_exception
+    ):
+        patched_call_callbacks.side_effect = RuntimeError("Random Error")
+        scriptrunner = TestScriptRunner("widgets_script.py")
+        scriptrunner.enqueue_rerun()
+        scriptrunner.start()
+
+        # Default widget values
+        require_widgets_deltas([scriptrunner])
+        self._assert_text_deltas(
+            scriptrunner, ["False", "ahoy!", "0", "False", "loop_forever"]
+        )
+
+        patched_call_callbacks.assert_not_called()
+
+        # Update widgets
+        states = WidgetStates()
+        w1_id = scriptrunner.get_widget_id("checkbox", "checkbox")
+        _create_widget(w1_id, states).bool_value = True
+        w2_id = scriptrunner.get_widget_id("text_area", "text_area")
+        _create_widget(w2_id, states).string_value = "matey!"
+        w3_id = scriptrunner.get_widget_id("radio", "radio")
+        _create_widget(w3_id, states).int_value = 2
+        w4_id = scriptrunner.get_widget_id("button", "button")
+        _create_widget(w4_id, states).trigger_value = True
+
+        # Explicitly clear deltas before re-running, to prevent a race
+        # condition. (The ScriptRunner will clear the deltas when it
+        # starts the re-run, but if that doesn't happen before
+        # require_widgets_deltas() starts polling the ScriptRunner's deltas,
+        # it will see stale deltas from the last run.)
+        scriptrunner.clear_deltas()
+        scriptrunner.enqueue_rerun(widget_states=states)
+
+        scriptrunner.join()
+
+        patched_call_callbacks.assert_called_once()
+
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                # We use the SCRIPT_STOPPED_WITH_SUCCESS event even if the
+                # script runs into an error during execution. The user is
+                # informed of the error by an `st.exception` box that we check
+                # for below.
+                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+
+        patched_st_exception.assert_called_once()
 
     def test_missing_script(self):
         """Tests that we get an exception event when a script doesn't exist."""

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -41,7 +41,7 @@ class WidgetTest(unittest.TestCase):
         _create_widget("string", states).string_value = "howdy!"
 
         widget_mgr = WidgetManager()
-        widget_mgr.set_state(states)
+        widget_mgr.set_widget_states(states)
 
         self.assertEqual(True, widget_mgr.get_widget_value("trigger"))
         self.assertEqual(True, widget_mgr.get_widget_value("bool"))
@@ -55,7 +55,7 @@ class WidgetTest(unittest.TestCase):
 
         _create_widget("trigger", states).trigger_value = True
         _create_widget("int", states).int_value = 123
-        widget_mgr.set_state(states)
+        widget_mgr.set_widget_states(states)
 
         self.assertEqual(True, widget_mgr.get_widget_value("trigger"))
         self.assertEqual(123, widget_mgr.get_widget_value("int"))
@@ -81,7 +81,7 @@ class WidgetTest(unittest.TestCase):
         _create_widget("shape_changing_trigger", new_states).int_value = 3
 
         widget_mgr = WidgetManager()
-        widget_mgr.set_state(coalesce_widget_states(old_states, new_states))
+        widget_mgr.set_widget_states(coalesce_widget_states(old_states, new_states))
 
         self.assertIsNone(widget_mgr.get_widget_value("old_unset_trigger"))
         self.assertIsNone(widget_mgr.get_widget_value("missing_in_new"))

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -136,6 +136,34 @@ class WidgetManagerTests(unittest.TestCase):
 
         self.assertTrue(isinstance(widget_mgr._widgets["fake_widget_id"], Widget))
 
+    def test_has_widget_changed(self):
+        prev_states = WidgetStates()
+        _create_widget("will_change", prev_states).trigger_value = True
+        _create_widget("wont_change", prev_states).bool_value = True
+
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_states(prev_states)
+
+        deserializer = lambda x: x
+        for widget_id in ["will_change", "wont_change"]:
+            widget_mgr.set_widget_attrs(
+                widget_id,
+                deserializer=deserializer,
+                callback=None,
+                args=None,
+                kwargs=None,
+            )
+
+        states = WidgetStates()
+        _create_widget("will_change", states).trigger_value = False
+        _create_widget("wont_change", states).bool_value = True
+
+        widget_mgr.mark_widgets_as_old()
+        widget_mgr.set_widget_states(states)
+
+        self.assertTrue(widget_mgr._has_widget_changed("will_change"))
+        self.assertFalse(widget_mgr._has_widget_changed("wont_change"))
+
     def test_call_callbacks(self):
         """Test the call_callbacks method in 6 possible cases:
 

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -15,12 +15,15 @@
 """Tests widget-related functionality"""
 
 import unittest
+from unittest.mock import call, MagicMock
 
 from streamlit.proto.Button_pb2 import Button as ButtonProto
+from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.state.widgets import (
     _get_widget_id,
     coalesce_widget_states,
+    Widget,
     WidgetManager,
 )
 
@@ -30,8 +33,8 @@ def _create_widget(id, states):
     return states.widgets[-1]
 
 
-class WidgetTest(unittest.TestCase):
-    def test_values(self):
+class WidgetManagerTests(unittest.TestCase):
+    def test_get_widget_value(self):
         states = WidgetStates()
 
         _create_widget("trigger", states).trigger_value = True
@@ -49,6 +52,162 @@ class WidgetTest(unittest.TestCase):
         self.assertEqual(123, widget_mgr.get_widget_value("int"))
         self.assertEqual("howdy!", widget_mgr.get_widget_value("string"))
 
+    def test_get_widget_value_nonexistent(self):
+        widget_mgr = WidgetManager()
+        self.assertIsNone(widget_mgr.get_widget_value("fake_widget_id"))
+
+    def test_get_prev_widget_value(self):
+        states = WidgetStates()
+
+        _create_widget("trigger", states).trigger_value = True
+
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_states(states)
+        widget_mgr.mark_widgets_as_old()
+
+        self.assertEqual(True, widget_mgr.get_prev_widget_value("trigger"))
+        # Check that looking for our widget keys in current widget state does
+        # not find anything.
+        self.assertIsNone(widget_mgr.get_widget_value("trigger"))
+
+    def test_get_prev_widget_value_nonexistent(self):
+        widget_mgr = WidgetManager()
+        self.assertIsNone(widget_mgr.get_widget_value("fake_widget_id"))
+
+    def test_set_widget_attrs_with_callback(self):
+        states = WidgetStates()
+        _create_widget("bool", states).bool_value = True
+
+        mock_callback = MagicMock()
+        deserializer = lambda x: x
+
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_states(states)
+        widget_mgr.set_widget_attrs(
+            "bool",
+            callback=mock_callback,
+            deserializer=deserializer,
+            args=(1, 2),
+            kwargs={"x": 3, "y": 4},
+        )
+
+        widget = widget_mgr._widgets["bool"]
+
+        self.assertIs(widget.callback, mock_callback)
+        self.assertIs(widget.deserializer, deserializer)
+        self.assertEqual(widget.callback_args, (1, 2))
+        self.assertEqual(widget.callback_kwargs, {"x": 3, "y": 4})
+
+    def test_set_widget_attrs_no_callback(self):
+        states = WidgetStates()
+        _create_widget("bool", states).bool_value = True
+
+        deserializer = lambda x: x
+
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_states(states)
+        widget_mgr.set_widget_attrs(
+            "bool",
+            callback=None,
+            deserializer=deserializer,
+            args=(1, 2),
+            kwargs={"x": 3, "y": 4},
+        )
+
+        widget = widget_mgr._widgets["bool"]
+
+        self.assertIs(widget.deserializer, deserializer)
+
+        self.assertIsNone(widget.callback)
+        # callback_args and callback_kwargs should be ignored without a
+        # callback.
+        self.assertIsNone(widget.callback_args)
+        self.assertIsNone(widget.callback_kwargs)
+
+    def test_set_widget_attrs_nonexistent(self):
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_attrs(
+            "fake_widget_id",
+            callback=lambda _: None,
+            deserializer=lambda x: x,
+            args=None,
+            kwargs=None,
+        )
+
+        self.assertTrue(isinstance(widget_mgr._widgets["fake_widget_id"], Widget))
+
+    def test_call_callbacks(self):
+        """Test the call_callbacks method in 6 possible cases:
+
+        1. A widget does not have a callback
+        2. A widget's old and new values are equal, so the callback is not
+           called.
+        3. A widget's callback has no args provided.
+        4. A widget's callback has just args provided.
+        5. A widget's callback has just kwargs provided.
+        6. A widget's callback has both args and kwargs provided.
+        """
+        prev_states = WidgetStates()
+        _create_widget("trigger", prev_states).trigger_value = True
+        _create_widget("bool", prev_states).bool_value = True
+        _create_widget("bool2", prev_states).bool_value = True
+        _create_widget("float", prev_states).double_value = 0.5
+        _create_widget("int", prev_states).int_value = 123
+        _create_widget("string", prev_states).string_value = "howdy!"
+
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_states(prev_states)
+
+        mock_callback = MagicMock()
+        deserializer = lambda x: x
+
+        callback_cases = [
+            ("trigger", None, None, None),
+            ("bool", mock_callback, None, None),
+            ("bool2", mock_callback, None, None),
+            ("float", mock_callback, (1,), None),
+            ("int", mock_callback, None, {"x": 2}),
+            ("string", mock_callback, (1,), {"x": 2}),
+        ]
+        for widget_id, callback, args, kwargs in callback_cases:
+            widget_mgr.set_widget_attrs(
+                widget_id,
+                callback=callback,
+                deserializer=deserializer,
+                args=args,
+                kwargs=kwargs,
+            )
+
+        states = WidgetStates()
+        _create_widget("trigger", states).trigger_value = True
+        _create_widget("bool", states).bool_value = True
+        _create_widget("bool2", states).bool_value = False
+        _create_widget("float", states).double_value = 1.5
+        _create_widget("int", states).int_value = 321
+        _create_widget("string", states).string_value = "!ydwoh"
+
+        widget_mgr.mark_widgets_as_old()
+        widget_mgr.set_widget_states(states)
+
+        widget_mgr.call_callbacks()
+
+        mock_callback.assert_has_calls([call(), call(1), call(x=2), call(1, x=2)])
+
+    def test_marshall_excludes_widgets_without_state(self):
+        widget_states = WidgetStates()
+        _create_widget("trigger", widget_states).trigger_value = True
+
+        widget_mgr = WidgetManager()
+        widget_mgr.set_widget_states(widget_states)
+        widget_mgr.set_widget_attrs("other_widget", None, lambda x: x, None, None)
+
+        client_state = ClientState()
+        widget_mgr.marshall(client_state)
+
+        marshalled_widgets = client_state.widget_states.widgets
+        self.assertEqual(len(marshalled_widgets), 1)
+        self.assertEqual(marshalled_widgets[0].id, "trigger")
+
     def test_reset_triggers(self):
         states = WidgetStates()
         widget_mgr = WidgetManager()
@@ -62,7 +221,7 @@ class WidgetTest(unittest.TestCase):
 
         widget_mgr.reset_triggers()
 
-        self.assertEqual(None, widget_mgr.get_widget_value("trigger"))
+        self.assertEqual(False, widget_mgr.get_widget_value("trigger"))
         self.assertEqual(123, widget_mgr.get_widget_value("int"))
 
     def test_coalesce_widget_states(self):


### PR DESCRIPTION
This PR augments the `register_widget` function so that a caller can now specify an `on_change_handler`, args for it, and a deserializer for the widget being registered. Defaults were chosen for these new parameters so that existing usage of `register_widget` remains unchanged.

We also now call callbacks on a script rerun for widgets whose values have changed and add the ability to define callbacks / `args` / `kwargs` for the `st.button` widget. 

The implementation here is in essence the same as that of the prototype, but we were able to clean up the code considerably by

* using the new `Widget` data container class to hold the state, callback, args, kwargs, and deserializer for a widget instead of  managing them in different maps
* having the `Widget.value` property call the deserializer on the value it returns so that we don't have to manually call it later
