### PR TITLE
Fix: re-render iframe after custom component timeout

### DIFF
--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -165,6 +165,10 @@ class MockComponent {
     // event handler that responds to BackMessage events posted from
     // the iframe - but since we're mocking the iframe, we hack around that.
     const unsafeInstance = this.instance as any
+
+    // Verify the iframe exists
+    expect(unsafeInstance.iframeRef.current).not.toBeNull()
+
     unsafeInstance.onBackMsg(type, data)
 
     // Synchronize the enzyme wrapper's tree snapshot

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -347,9 +347,9 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
 
     // If we've timed out waiting for the READY message from the component,
     // display a warning.
-    if (this.state.readyTimeout) {
-      return this.renderComponentReadyTimeoutWarning()
-    }
+    const warns = this.state.readyTimeout
+      ? this.renderComponentReadyTimeoutWarning()
+      : null
 
     // Parse the component's arguments and src URL.
     // Some of these steps may throw an exception, so we wrap them in a
@@ -454,16 +454,19 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
     //
     // TODO: make sure horizontal scrolling still works!
     return (
-      <iframe
-        allow={DEFAULT_IFRAME_FEATURE_POLICY}
-        ref={this.iframeRef}
-        src={src}
-        width={this.props.width}
-        height={this.frameHeight}
-        scrolling="no"
-        sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
-        title={componentName}
-      />
+      <>
+        {warns}
+        <iframe
+          allow={DEFAULT_IFRAME_FEATURE_POLICY}
+          ref={this.iframeRef}
+          src={src}
+          width={this.props.width}
+          height={this.frameHeight}
+          scrolling="no"
+          sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
+          title={componentName}
+        />
+      </>
     )
   }
 }


### PR DESCRIPTION
Issue: #2888
![image](https://user-images.githubusercontent.com/436002/119265750-71292880-bbf0-11eb-9e77-b841e3f9ff7c.png)

Description: If belatedly a customBelatedly send the COMPONENT_READY message after the hardcoded timeout, the warning  ```Your app is having trouble loading the ** (The app is attempting to load the component from **...```  is not remove and the error ```ComponentInstance iframe does not have a contentWindow, and will not receive messages!``` appears in the console