### PR TITLE
Don't unmount iframe after custom component timeout

### DIFF
--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -417,7 +417,7 @@ describe("ComponentInstance", () => {
       // Advance past our warning timeout, and force a re-render.
       jest.advanceTimersByTime(COMPONENT_READY_WARNING_TIME_MS)
       expect(mock.instance.state.readyTimeout).toBe(true)
-      mock.wrapper.setProps({}) // (re-render)
+      mock.wrapper.update()
 
       const child = mock.wrapper.childAt(0)
       expect(child.type()).toEqual(Alert)
@@ -533,7 +533,7 @@ describe("ComponentInstance", () => {
         expect(iframe.prop("height")).toEqual(0)
 
         // Force a re-render. NOW the iframe element's height should be updated.
-        mc.wrapper.setProps({})
+        mc.wrapper.update()
         expect(iframe.prop("height")).toEqual(0)
       })
 

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -165,6 +165,10 @@ class MockComponent {
     // event handler that responds to BackMessage events posted from
     // the iframe - but since we're mocking the iframe, we hack around that.
     const unsafeInstance = this.instance as any
+
+    // Verify the iframe exists
+    expect(unsafeInstance.iframeRef.current).not.toBeNull()
+
     unsafeInstance.onBackMsg(type, data)
 
     // Synchronize the enzyme wrapper's tree snapshot

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -429,6 +429,9 @@ describe("ComponentInstance", () => {
         "The app is attempting to load the component from"
       )
 
+      // Ensure our iframe is still mounted.
+      expect(mock.wrapper.find("iframe").length).toBe(1)
+
       // Belatedly send the COMPONENT_READY message
       mock.sendBackMsg(ComponentMessageType.COMPONENT_READY, { apiVersion: 1 })
 

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -109,7 +109,12 @@ class MockComponent {
         width={100}
         disabled={false}
         theme={lightTheme.emotion}
-        widgetMgr={new WidgetStateManager(jest.fn())}
+        widgetMgr={
+          new WidgetStateManager({
+            sendRerunBackMsg: jest.fn(),
+            formsDataChanged: jest.fn(),
+          })
+        }
       />,
       { attachTo: mountNode }
     )
@@ -175,7 +180,7 @@ class MockComponent {
 describe("ComponentInstance", () => {
   beforeEach(() => {
     // Clear our class mocks
-    const mockWidgetStateManager = WidgetStateManager as jest.Mock
+    const mockWidgetStateManager = (WidgetStateManager as unknown) as jest.Mock
     mockWidgetStateManager.mockClear()
 
     const mockLog = logWarning as jest.Mock

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -347,9 +347,9 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
 
     // If we've timed out waiting for the READY message from the component,
     // display a warning.
-    if (this.state.readyTimeout) {
-      return this.renderComponentReadyTimeoutWarning()
-    }
+    const warns = this.state.readyTimeout
+      ? this.renderComponentReadyTimeoutWarning()
+      : null
 
     // Parse the component's arguments and src URL.
     // Some of these steps may throw an exception, so we wrap them in a
@@ -454,16 +454,19 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
     //
     // TODO: make sure horizontal scrolling still works!
     return (
-      <iframe
-        allow={DEFAULT_IFRAME_FEATURE_POLICY}
-        ref={this.iframeRef}
-        src={src}
-        width={this.props.width}
-        height={this.frameHeight}
-        scrolling="no"
-        sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
-        title={componentName}
-      />
+      <>
+        {warns}
+        <iframe
+          allow={DEFAULT_IFRAME_FEATURE_POLICY}
+          ref={this.iframeRef}
+          src={src}
+          width={this.props.width}
+          height={this.frameHeight}
+          scrolling="no"
+          sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
+          title={componentName}
+        />
+      </>
     )
   }
 }


### PR DESCRIPTION
We currently remove a Custom Component's iframe from the render output when it times out, which means the component has no way of belatedly saying "hey I've finally mounted".

This was discovered and fixed by https://github.com/lekev in https://github.com/streamlit/streamlit/pull/3306. I've just added some additional cleanup.