### PR TITLE
ComponentInstance: cancel the componentReadyWarningTimer on unmount

### DIFF
--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -200,6 +200,14 @@ describe("ComponentInstance", () => {
     )
   })
 
+  it("cancels the componentReadyWarning timer on unmount", () => {
+    const mc = new MockComponent()
+    const unsafeInstance = mc.instance as any
+    expect(unsafeInstance.componentReadyWarningTimer.isRunning).toBe(true)
+    mc.wrapper.unmount()
+    expect(unsafeInstance.componentReadyWarningTimer.isRunning).toBe(false)
+  })
+
   it("re-registers its message listener when iframe.contentWindow changes", () => {
     const mc = new MockComponent()
     const originalContentWindow = mc.contentWindow

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -115,6 +115,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
 
   public componentWillUnmount = (): void => {
     this.deregisterIFrameListener()
+    this.componentReadyWarningTimer.cancel()
   }
 
   public componentDidUpdate = (): void => {


### PR DESCRIPTION
Currently, if a component gets unmounted while this timer is still running, we have a (small) memory leak.