### PR TITLE
Update `typed-signals` to 2.2.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,7 @@
     "sprintf-js": "^1.1.2",
     "styletron-engine-atomic": "^1.4.6",
     "styletron-react": "^5.2.6",
-    "typed-signals": "^1.0.5",
+    "typed-signals": "^2.2.0",
     "vega": "^5.17.3",
     "vega-embed": "^6.10.0",
     "vega-lite": "^4.14.1",

--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -21,6 +21,7 @@ import { ConnectionState } from "src/lib/ConnectionState"
 import { ReportRunState } from "src/lib/ReportRunState"
 import { SessionEventDispatcher } from "src/lib/SessionEventDispatcher"
 import { SessionEvent } from "src/autogen/proto"
+import { lightTheme } from "src/theme"
 
 import StatusWidget, { StatusWidgetProps } from "./StatusWidget"
 
@@ -30,9 +31,10 @@ const getProps = (
   connectionState: ConnectionState.CONNECTED,
   sessionEventDispatcher: new SessionEventDispatcher(),
   reportRunState: ReportRunState.RUNNING,
-  rerunReport: (alwaysRerun: boolean) => {},
+  rerunReport: () => {},
   stopReport: () => {},
   allowRunOnSave: true,
+  theme: lightTheme.emotion,
   ...propOverrides,
 })
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -18140,10 +18140,10 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.3.0.tgz#ada7c045f07ead08abf9e2edd29be1a0c0661132"
   integrity sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg==
 
-typed-signals@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/typed-signals/-/typed-signals-1.0.5.tgz#cb909bca73433f215d9e053bc37b7d9cde77f272"
-  integrity sha512-kKrgAGzAGXco9xu6UsoM3NaKBPO6g6KNxfOoJk8wMJbOFDJlw9hkbgoB60bC23At8gsehF1c02bTtLRMrhzTsA==
+typed-signals@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/typed-signals/-/typed-signals-2.2.0.tgz#521adf534d779cfbba135208b512e09154d82d02"
+  integrity sha512-jnhtsz24pprrh/ZREVAdOMTgASEj1P3tCGVoJ5mtfPd++TOMn7cEx5j7ODah/9cD5Wske6CDjnTFdi7hbTtCsA==
 
 typedarray-pool@^1.0.0, typedarray-pool@^1.0.2, typedarray-pool@^1.1.0, typedarray-pool@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Updates the `typed-signals` library to its latest version (this is used by WidgetStateManager, for form stuff, and by the StatusWidget).

Also adds a missing "theme" prop to StatusWidget.test's `getProps`