### PR TITLE
Update JSON5 to 2.2.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "humanize-string": "^2.1.0",
     "immer": "^9.0.1",
     "immutable": "^4.0.0-rc.12",
-    "json5": "^2.1.3",
+    "json5": "^2.2.0",
     "katex": "^0.11.1",
     "lodash": "^4.17.21",
     "mapbox-gl": "^1.11.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11622,17 +11622,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
-json5@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
 


### PR DESCRIPTION
This has no changes from 2.1.3, but it includes TypeScript type definitions. Though, somehow, we weren't including @types/json5, so there's nothing to remove there.
