### PR TITLE
Explicitly add attrs as a Python dependency

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -30,6 +30,7 @@ sphinx-rtd-theme = "*"
 # And if you do add one, make the required version as general as possible.
 altair = ">=3.2.0"
 astor = "*"
+attrs = "*"
 base58 = "*"
 blinker = "*"
 cachetools = ">=4.0"


### PR DESCRIPTION
We already have the package because it's a transitive dependency, but
now that we're using it, we should explicitly specify it.