### PR TITLE
Add flag to check_session_state_rules for button / file_uploader

### DIFF
--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -57,13 +57,22 @@ def check_callback_rules(
 
 
 def check_session_state_rules(
-    widget_label: str, widget_val: Any, key: Optional[str]
+    default_val: Any, key: Optional[str], writes_allowed: bool = True
 ) -> None:
-    if key is None or widget_val is None:
+    if key is None:
         return
 
     session_state = get_session_state()
-    if session_state.is_new_value(key):
+    if not session_state.is_new_value(key):
+        return
+
+    if not writes_allowed:
+        raise StreamlitAPIException(
+            "Values for the st.button and st.file_uploader widgets cannot be"
+            " set using st.session_state."
+        )
+
+    if default_val is not None:
         streamlit.warning(
             f'The widget with key "{key}" was created with a default value, but'
             " it also had its value set via the session_state api. The results"

--- a/lib/tests/streamlit/element_utils_test.py
+++ b/lib/tests/streamlit/element_utils_test.py
@@ -42,7 +42,7 @@ class ElementUtilsTest(unittest.TestCase):
 
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_key(self, patched_st_warning):
-        check_session_state_rules("the label", 5, key=None)
+        check_session_state_rules(5, key=None)
 
         patched_st_warning.assert_not_called()
 
@@ -55,7 +55,7 @@ class ElementUtilsTest(unittest.TestCase):
         mock_session_state.is_new_value.return_value = True
         patched_get_session_state.return_value = mock_session_state
 
-        check_session_state_rules("the label", None, key="the key")
+        check_session_state_rules(None, key="the key")
 
         patched_st_warning.assert_not_called()
 
@@ -68,7 +68,7 @@ class ElementUtilsTest(unittest.TestCase):
         mock_session_state.is_new_value.return_value = False
         patched_get_session_state.return_value = mock_session_state
 
-        check_session_state_rules("the label", 5, key="the key")
+        check_session_state_rules(5, key="the key")
 
         patched_st_warning.assert_not_called()
 
@@ -81,9 +81,22 @@ class ElementUtilsTest(unittest.TestCase):
         mock_session_state.is_new_value.return_value = True
         patched_get_session_state.return_value = mock_session_state
 
-        check_session_state_rules("the label", 5, key="the key")
+        check_session_state_rules(5, key="the key")
 
         patched_st_warning.assert_called_once()
         args, kwargs = patched_st_warning.call_args
         warning_msg = args[0]
         assert 'The widget with key "the key"' in warning_msg
+
+    @patch("streamlit.elements.utils.get_session_state")
+    def test_check_session_state_rules_writes_not_allowed(
+        self, patched_get_session_state
+    ):
+        mock_session_state = MagicMock()
+        mock_session_state.is_new_value.return_value = True
+        patched_get_session_state.return_value = mock_session_state
+
+        with pytest.raises(StreamlitAPIException) as e:
+            check_session_state_rules(5, key="the key", writes_allowed=False)
+
+        assert "cannot be set using st.session_state" in str(e.value)


### PR DESCRIPTION
We want to disallow developers from using st.session_state to be able to
set values for these widgets since doing so doesn't make semantic sense.

We also removed the widget_label arg from check_session_state_rules as
it's unused.