### PR TITLE
Add value and set_value fields to all widget protos

### DIFF
--- a/proto/streamlit/proto/ColorPicker.proto
+++ b/proto/streamlit/proto/ColorPicker.proto
@@ -21,4 +21,6 @@ message ColorPicker {
   string default = 3;
   string help = 4;
   string form_id = 5;
+  string value = 6;
+  bool set_value = 7;
 }

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -25,4 +25,6 @@ message DateInput {
   bool is_range = 6;
   string help = 7;
   string form_id = 8;
+  repeated string value = 9;
+  bool set_value = 10;
 }

--- a/proto/streamlit/proto/MultiSelect.proto
+++ b/proto/streamlit/proto/MultiSelect.proto
@@ -23,4 +23,6 @@ message MultiSelect {
   repeated string options = 4;
   string help = 5;
   string form_id = 6;
+  repeated int32 value = 7;
+  bool set_value = 8;
 }

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -38,6 +38,8 @@ message NumberInput {
   double min = 16;
   double max = 17;
   string help = 18;
+  double value = 19;
+  bool set_value = 20;
 
   reserved 4, 5, 6, 7, 9, 10;
 }

--- a/proto/streamlit/proto/Radio.proto
+++ b/proto/streamlit/proto/Radio.proto
@@ -23,4 +23,6 @@ message Radio {
   repeated string options = 4;
   string help = 5;
   string form_id = 6;
+  int32 value = 7;
+  bool set_value = 8;
 }

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -23,4 +23,6 @@ message Selectbox {
   repeated string options = 4;
   string help = 5;
   string form_id = 6;
+  int32 value = 7;
+  bool set_value = 8;
 }

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -38,6 +38,8 @@ message Slider {
   double min = 7;
   double max = 8;
   double step = 9;
+  repeated double value = 10;
+  bool set_value = 11;
 
   repeated string options = 13;
   string help = 14;

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -24,4 +24,6 @@ message TextArea {
   uint32 max_chars = 5;
   string help = 6;
   string form_id = 7;
+  string value = 8;
+  bool set_value = 9;
 }

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -32,4 +32,6 @@ message TextInput {
   uint32 max_chars = 5;
   string help = 6;
   string form_id = 7;
+  string value = 8;
+  bool set_value = 9;
 }

--- a/proto/streamlit/proto/TimeInput.proto
+++ b/proto/streamlit/proto/TimeInput.proto
@@ -22,4 +22,6 @@ message TimeInput {
   string default = 3;
   string help = 4;
   string form_id = 5;
+  string value = 6;
+  bool set_value = 7;
 }


### PR DESCRIPTION
Getting this out of the way just because it's low hanging fruit. This commit
was cherry-picked off the hackathon session state branch.