### PR TITLE
Add all callback-related args to all widgets

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -25,7 +25,7 @@ from streamlit.state.widgets import (
     WidgetKwargs,
 )
 from .form import current_form_id, is_in_form
-from .utils import check_callback_rules
+from .utils import check_callback_rules, check_session_state_rules
 
 
 FORM_DOCS_INFO = """
@@ -39,11 +39,11 @@ class ButtonMixin:
     def button(
         self,
         label,
-        key: Optional[str] = None,
-        help: Optional[str] = None,
-        on_change: Optional[WidgetCallback] = None,
-        args: Optional[WidgetArgs] = None,
-        kwargs: Optional[WidgetKwargs] = None,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ) -> bool:
         """Display a button widget.
 
@@ -51,19 +51,19 @@ class ButtonMixin:
         ----------
         label : str
             A short label explaining to the user what this button is for.
-        key : Optional[str]
+        key : str
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
-        help : Optional[str]
+        help : str
             An optional tooltip that gets displayed when the button is
             hovered over.
-        on_change : Optional[Callable]
-            An optional callback invoked when the button is clicked.
-        args : Optional[Tuple]
+        on_change : callable
+            An optional callback invoked when this button is clicked.
+        args : tuple
             An optional tuple of args to pass to the callback.
-        kwargs : Optional[Dict]
+        kwargs : dict
             An optional dict of kwargs to pass to the callback.
 
         Returns
@@ -80,6 +80,7 @@ class ButtonMixin:
 
         """
         check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
         return self.dg._button(
             label,
             key,

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -18,10 +18,20 @@ import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.state.widgets import register_widget
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class CheckboxMixin:
-    def checkbox(self, label, value=False, key=None, help=None):
+    def checkbox(
+        self,
+        label,
+        value=False,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
+    ):
         """Display a checkbox widget.
 
         Parameters
@@ -37,7 +47,13 @@ class CheckboxMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the checkbox.
+            An optional tooltip that gets displayed next to the checkbox.
+        on_change : callable
+            An optional callback invoked when this checkbox's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -52,6 +68,9 @@ class CheckboxMixin:
         ...     st.write('Great!')
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
+
         checkbox_proto = CheckboxProto()
         checkbox_proto.label = label
         checkbox_proto.default = bool(value)

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -13,24 +13,34 @@
 # limitations under the License.
 
 import re
-from typing import cast
+from typing import cast, Optional
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
 from streamlit.state.widgets import register_widget
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class ColorPickerMixin:
-    def color_picker(self, label, value=None, key=None, help=None):
+    def color_picker(
+        self,
+        label,
+        value=None,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
+    ):
         """Display a color picker widget.
 
         Parameters
         ----------
         label : str
             A short label explaining to the user what this input is for.
-        value : str or None
+        value : str
             The hex value of this widget when it first renders. If None,
             defaults to black.
         key : str
@@ -39,7 +49,14 @@ class ColorPickerMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the color picker.
+            An optional tooltip that gets displayed next to the color picker.
+        on_change : callable
+            An optional callback invoked when this color picker's value
+            changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -52,6 +69,9 @@ class ColorPickerMixin:
         >>> st.write('The current color is', color)
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
+
         # set value default
         if value is None:
             value = "#000000"

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from typing import cast, Optional
+from typing import cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -51,7 +51,7 @@ class ColorPickerMixin:
         help : str
             An optional tooltip that gets displayed next to the color picker.
         on_change : callable
-            An optional callback invoked when this color picker's value
+            An optional callback invoked when this color_picker's value
             changes.
         args : tuple
             An optional tuple of args to pass to the callback.

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -23,13 +23,22 @@ from streamlit.state.widgets import register_widget, NoValue
 from .form import current_form_id
 from ..proto.Common_pb2 import SInt64Array
 from ..uploaded_file_manager import UploadedFile, UploadedFileRec
+from .utils import check_callback_rules, check_session_state_rules
 
 LOGGER = get_logger(__name__)
 
 
 class FileUploaderMixin:
     def file_uploader(
-        self, label, type=None, accept_multiple_files=False, key=None, help=None
+        self,
+        label,
+        type=None,
+        accept_multiple_files=False,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a file uploader widget.
         By default, uploaded files are limited to 200MB. You can configure
@@ -57,6 +66,16 @@ class FileUploaderMixin:
 
         help : str
             A tooltip that gets displayed next to the file uploader.
+
+        on_change : callable
+            An optional callback invoked when this file_uploader's value
+            changes.
+
+        args : tuple
+            An optional tuple of args to pass to the callback.
+
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -101,6 +120,8 @@ class FileUploaderMixin:
         ...     st.write("filename:", uploaded_file.name)
         ...     st.write(bytes_data)
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
 
         if type:
             if isinstance(type, str):

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -20,11 +20,21 @@ from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.state.widgets import register_widget
 from streamlit.type_util import is_type, ensure_iterable
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class MultiSelectMixin:
     def multiselect(
-        self, label, options, default=None, format_func=str, key=None, help=None
+        self,
+        label,
+        options,
+        default=None,
+        format_func=str,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a multiselect widget.
         The multiselect widget starts as empty.
@@ -49,7 +59,13 @@ class MultiSelectMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the multiselect.
+            An optional tooltip that gets displayed next to the multiselect.
+        on_change : callable
+            An optional callback invoked when this multiselect's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -73,6 +89,9 @@ class MultiSelectMixin:
            `GitHub issue #1059 <https://github.com/streamlit/streamlit/issues/1059>`_ for updates on the issue.
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=default, key=key)
+
         options = ensure_iterable(options)
 
         # Perform validation checks and return indices base on the default values.

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -21,6 +21,7 @@ from streamlit.js_number import JSNumber, JSNumberBoundsException
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
 from streamlit.state.widgets import register_widget, NoValue
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class NumberInputMixin:
@@ -34,6 +35,9 @@ class NumberInputMixin:
         format=None,
         key=None,
         help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a numeric input widget.
 
@@ -64,7 +68,13 @@ class NumberInputMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the input.
+            An optional tooltip that gets displayed next to the input.
+        on_change : callable
+            An optional callback invoked when this number_input's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -77,6 +87,8 @@ class NumberInputMixin:
         >>> number = st.number_input('Insert a number')
         >>> st.write('The current number is ', number)
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
 
         # Ensure that all arguments are of the same type.
         args = [min_value, max_value, value, step]

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -20,10 +20,22 @@ from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.state.widgets import register_widget, NoValue
 from streamlit.type_util import ensure_iterable
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class RadioMixin:
-    def radio(self, label, options, index=0, format_func=str, key=None, help=None):
+    def radio(
+        self,
+        label,
+        options,
+        index=0,
+        format_func=str,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
+    ):
         """Display a radio button widget.
 
         Parameters
@@ -46,7 +58,13 @@ class RadioMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the radio.
+            An optional tooltip that gets displayed next to the radio.
+        on_change : callable
+            An optional callback invoked when this radio's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -65,6 +83,9 @@ class RadioMixin:
         ...     st.write("You didn\'t select comedy.")
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None if index == 0 else index, key=key)
+
         options = ensure_iterable(options)
 
         if not isinstance(index, int):

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -21,6 +21,7 @@ from streamlit.state.widgets import register_widget
 from streamlit.type_util import ensure_iterable
 from streamlit.util import index_
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class SelectSliderMixin:
@@ -32,6 +33,9 @@ class SelectSliderMixin:
         format_func=str,
         key=None,
         help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """
         Display a slider widget to select items from a list.
@@ -68,7 +72,13 @@ class SelectSliderMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the select slider.
+            An optional tooltip that gets displayed next to the select slider.
+        on_change : callable
+            An optional callback invoked when this select_slider's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -91,6 +101,8 @@ class SelectSliderMixin:
         ...     value=('red', 'blue'))
         >>> st.write('You selected wavelengths between', start_color, 'and', end_color)
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
 
         options = ensure_iterable(options)
 

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -20,10 +20,22 @@ from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.state.widgets import register_widget, NoValue
 from streamlit.type_util import ensure_iterable
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class SelectboxMixin:
-    def selectbox(self, label, options, index=0, format_func=str, key=None, help=None):
+    def selectbox(
+        self,
+        label,
+        options,
+        index=0,
+        format_func=str,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
+    ):
         """Display a select widget.
 
         Parameters
@@ -44,7 +56,13 @@ class SelectboxMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the selectbox.
+            An optional tooltip that gets displayed next to the selectbox.
+        on_change : callable
+            An optional callback invoked when this selectbox's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -60,6 +78,9 @@ class SelectboxMixin:
         >>> st.write('You selected:', option)
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None if index == 0 else index, key=key)
+
         options = ensure_iterable(options)
 
         if not isinstance(index, int):

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -22,6 +22,7 @@ from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.state.widgets import register_widget
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class SliderMixin:
@@ -35,6 +36,9 @@ class SliderMixin:
         format=None,
         key=None,
         help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a slider widget.
 
@@ -83,7 +87,13 @@ class SliderMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the slider.
+            An optional tooltip that gets displayed next to the slider.
+        on_change : callable
+            An optional callback invoked when this slider's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -121,6 +131,8 @@ class SliderMixin:
         >>> st.write("Start time:", start_time)
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
 
         # Set value default.
         if value is None:

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -20,11 +20,21 @@ from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
 from streamlit.state.widgets import register_widget
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class TextWidgetsMixin:
     def text_input(
-        self, label, value="", max_chars=None, key=None, type="default", help=None
+        self,
+        label,
+        value="",
+        max_chars=None,
+        key=None,
+        type="default",
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a single-line text input widget.
 
@@ -47,7 +57,13 @@ class TextWidgetsMixin:
             a regular text input), or "password" (for a text input that
             masks the user's typed value). Defaults to "default".
         help : str
-            A tooltip that gets displayed next to the input.
+            An optional tooltip that gets displayed next to the input.
+        on_change : callable
+            An optional callback invoked when this text_input's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -60,6 +76,9 @@ class TextWidgetsMixin:
         >>> st.write('The current movie title is', title)
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None if value == "" else value, key=key)
+
         text_input_proto = TextInputProto()
         text_input_proto.label = label
         text_input_proto.default = str(value)
@@ -85,7 +104,16 @@ class TextWidgetsMixin:
         return self.dg._enqueue("text_input", text_input_proto, str(current_value))
 
     def text_area(
-        self, label, value="", height=None, max_chars=None, key=None, help=None
+        self,
+        label,
+        value="",
+        height=None,
+        max_chars=None,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a multi-line text input widget.
 
@@ -107,7 +135,13 @@ class TextWidgetsMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the textarea.
+            An optional tooltip that gets displayed next to the textarea.
+        on_change : callable
+            An optional callback invoked when this text_area's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -126,6 +160,9 @@ class TextWidgetsMixin:
         >>> st.write('Sentiment:', run_sentiment_analysis(txt))
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None if value == "" else value, key=key)
+
         text_area_proto = TextAreaProto()
         text_area_proto.label = label
         text_area_proto.default = str(value)

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime, date, time
-from typing import cast
+from typing import cast, Optional, Union
 
 from dateutil import relativedelta
 
@@ -23,10 +23,20 @@ from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
 from streamlit.state.widgets import register_widget
 from .form import current_form_id
+from .utils import check_callback_rules, check_session_state_rules
 
 
 class TimeWidgetsMixin:
-    def time_input(self, label, value=None, key=None, help=None):
+    def time_input(
+        self,
+        label,
+        value=None,
+        key=None,
+        help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
+    ):
         """Display a time input widget.
 
         Parameters
@@ -42,7 +52,13 @@ class TimeWidgetsMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the input.
+            An optional tooltip that gets displayed next to the input.
+        on_change : callable
+            An optional callback invoked when this time_input's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -55,6 +71,9 @@ class TimeWidgetsMixin:
         >>> st.write('Alarm is set for', t)
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
+
         # Set value default.
         if value is None:
             value = datetime.now().time()
@@ -92,6 +111,9 @@ class TimeWidgetsMixin:
         max_value=None,
         key=None,
         help=None,
+        on_change=None,
+        args=None,
+        kwargs=None,
     ):
         """Display a date input widget.
 
@@ -115,7 +137,13 @@ class TimeWidgetsMixin:
             based on its content. Multiple widgets of the same type may
             not share the same key.
         help : str
-            A tooltip that gets displayed next to the input.
+            An optional tooltip that gets displayed next to the input.
+        on_change : callable
+            An optional callback invoked when this date_input's value changes.
+        args : tuple
+            An optional tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         Returns
         -------
@@ -130,6 +158,9 @@ class TimeWidgetsMixin:
         >>> st.write('Your birthday is:', d)
 
         """
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=value, key=key)
+
         # Set value default.
         if value is None:
             value = datetime.now().date()

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -57,7 +57,7 @@ def check_callback_rules(
 
 
 def check_session_state_rules(
-    default_val: Any, key: Optional[str], writes_allowed: bool = True
+    default_value: Any, key: Optional[str], writes_allowed: bool = True
 ) -> None:
     if key is None:
         return
@@ -72,7 +72,7 @@ def check_session_state_rules(
             " set using st.session_state."
         )
 
-    if default_val is not None:
+    if default_value is not None:
         streamlit.warning(
             f'The widget with key "{key}" was created with a default value, but'
             " it also had its value set via the session_state api. The results"

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -63,7 +63,7 @@ def check_session_state_rules(
         return
 
     session_state = get_session_state()
-    if not session_state.is_new_value(key):
+    if not session_state.is_new_state_value(key):
         return
 
     if not writes_allowed:

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -222,6 +222,9 @@ class SessionState(MutableMapping[str, Any]):
             **self._new_session_state,
         }
 
+    def is_new_state_value(self, key: str) -> bool:
+        return key in self._new_session_state
+
     def __iter__(self) -> Iterator[Any]:
         return iter(self._merged_state)
 

--- a/lib/tests/streamlit/element_utils_test.py
+++ b/lib/tests/streamlit/element_utils_test.py
@@ -52,7 +52,7 @@ class ElementUtilsTest(unittest.TestCase):
         self, patched_st_warning, patched_get_session_state
     ):
         mock_session_state = MagicMock()
-        mock_session_state.is_new_value.return_value = True
+        mock_session_state.is_new_state_value.return_value = True
         patched_get_session_state.return_value = mock_session_state
 
         check_session_state_rules(None, key="the key")
@@ -65,7 +65,7 @@ class ElementUtilsTest(unittest.TestCase):
         self, patched_st_warning, patched_get_session_state
     ):
         mock_session_state = MagicMock()
-        mock_session_state.is_new_value.return_value = False
+        mock_session_state.is_new_state_value.return_value = False
         patched_get_session_state.return_value = mock_session_state
 
         check_session_state_rules(5, key="the key")
@@ -78,7 +78,7 @@ class ElementUtilsTest(unittest.TestCase):
         self, patched_st_warning, patched_get_session_state
     ):
         mock_session_state = MagicMock()
-        mock_session_state.is_new_value.return_value = True
+        mock_session_state.is_new_state_value.return_value = True
         patched_get_session_state.return_value = mock_session_state
 
         check_session_state_rules(5, key="the key")
@@ -93,7 +93,7 @@ class ElementUtilsTest(unittest.TestCase):
         self, patched_get_session_state
     ):
         mock_session_state = MagicMock()
-        mock_session_state.is_new_value.return_value = True
+        mock_session_state.is_new_state_value.return_value = True
         patched_get_session_state.return_value = mock_session_state
 
         with pytest.raises(StreamlitAPIException) as e:

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -21,9 +21,8 @@ from unittest.mock import patch
 
 from streamlit import config
 from streamlit.report_queue import ReportQueue
-from streamlit.report_thread import ReportContext
-from streamlit.report_thread import add_report_ctx
-from streamlit.report_thread import get_report_ctx
+from streamlit.report_session import ReportSession
+from streamlit.report_thread import add_report_ctx, get_report_ctx, ReportContext
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
 
@@ -69,6 +68,11 @@ def build_mock_config_is_manually_set(overrides_dict):
     return mock_config_is_manually_set
 
 
+class FakeReportSession(ReportSession):
+    def __init__(self):
+        self._session_state = SessionState()
+
+
 class DeltaGeneratorTestCase(unittest.TestCase):
     def setUp(self, override_root=True):
         self.report_queue = ReportQueue()
@@ -87,6 +91,8 @@ class DeltaGeneratorTestCase(unittest.TestCase):
                     uploaded_file_mgr=UploadedFileManager(),
                 ),
             )
+
+        self.report_session = FakeReportSession()
 
     def tearDown(self):
         self.clear_queue()


### PR DESCRIPTION
Note that we don't actually do anything with these args aside from
verify that the widget is well-behaved and follows some rules we have
around callbacks. Actually hooking them in can happen once session and
widget state are more properly unified, and we might as well get this
routine work out of the way now.

I hesitantly but intentionally omitted a good amount of type info from
both the docstrings and function signatures. This feels a bit weird, but
I think it's necessary because

  * when sphinx/RTD renders documentation, it uses the function
    signature to do so, and unfortunately things look pretty awful for
    long function signatures with complex types. See the screenshot
    below.

<img width="699" alt="Screen Shot 2021-06-04 at 4 29 16 PM" src="https://user-images.githubusercontent.com/3144420/120871946-0bbf2b00-c552-11eb-94c5-8eef4e08f1c4.png">

  * existing documentation in the API Reference does not state that some
    args are optional in the type but does do so in the following
    explanatory text, and I didn't want to take the time to also rewrite
    parts of the docstrings for every widget.

We can probably look to resolve these issues later, but I think doing so
is outside of the scope of this work on session state.
