### PR TITLE
Also clear session_state when the cache is reset

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -503,6 +503,11 @@ class ReportSession(object):
         # terminal.
         caching.clear_cache()
 
+        # This needs to be lazily imported to avoid a dependency cycle.
+        from streamlit.state.session_state import SessionState
+
+        self._session_state = SessionState()
+
     def handle_set_run_on_save_request(self, new_value):
         """Change our run_on_save flag to the given value.
 

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -147,6 +147,14 @@ class ReportSessionTest(unittest.TestCase):
         rs = ReportSession(None, "", "", UploadedFileManager())
         self.assertTrue(isinstance(rs.widget_mgr, WidgetManager))
 
+    @patch("streamlit.report_session.caching.clear_cache")
+    @patch("streamlit.report_session.LocalSourcesWatcher")
+    def test_clear_cache_resets_session_state(self, _1, _2):
+        rs = ReportSession(None, "", "", UploadedFileManager())
+        original_session_state = rs._session_state
+        rs.handle_clear_cache_request()
+        self.assertIsNot(original_session_state, rs._session_state)
+
 
 def _create_mock_websocket():
     @tornado.gen.coroutine


### PR DESCRIPTION
Note that this doesn't rerun the app (since cache resets don't), so it
may not be apparent that session_state was cleared until the next app
rerun is triggered.
