### PR TITLE
Have st.write(st.session_state) format the output as JSON

### DIFF
--- a/e2e/scripts/st_session_state.py
+++ b/e2e/scripts/st_session_state.py
@@ -41,3 +41,4 @@ if st._is_running_with_streamlit:
         st.write(f"attr_counter: {st.session_state.attr_counter}")
 
     st.write(f"len(st.session_state): {len(st.session_state)}")
+    st.write(st.session_state)

--- a/e2e/specs/st_session_state.spec.js
+++ b/e2e/specs/st_session_state.spec.js
@@ -28,6 +28,7 @@ describe("st.beta_session_state", () => {
     cy.get(".stMarkdown").contains("attr_counter: 0");
     // item_counter + attr_counter + initialized flag
     cy.get(".stMarkdown").contains("len(st.session_state): 3");
+    cy.get("[data-testid='stJson']").should("be.visible");
   });
 
   it("can get/set/delete session_state items", () => {

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -17,6 +17,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Json_pb2 import Json as JsonProto
+from streamlit.state.session_state import LazySessionState
 
 
 class JsonMixin:
@@ -49,6 +50,9 @@ class JsonMixin:
 
         """
         import streamlit as st
+
+        if isinstance(body, LazySessionState):
+            body = body.to_dict()
 
         if not isinstance(body, str):
             try:

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -21,6 +21,7 @@ import numpy as np
 import streamlit
 from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
+from streamlit.state.session_state import LazySessionState
 
 # Special methods:
 
@@ -209,7 +210,7 @@ class WriteMixin:
                 flush_buffer()
                 dot = vis_utils.model_to_dot(arg)
                 self.dg.graphviz_chart(dot.to_string())
-            elif isinstance(arg, (dict, list)):
+            elif isinstance(arg, (dict, list, LazySessionState)):
                 flush_buffer()
                 self.dg.json(arg)
             elif type_util.is_namedtuple(arg):

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -222,6 +222,9 @@ class SessionState(MutableMapping[str, Any]):
             **self._new_session_state,
         }
 
+    def to_dict(self) -> Dict:
+        return self._merged_state
+
     def is_new_state_value(self, key: str) -> bool:
         return key in self._new_session_state
 
@@ -405,3 +408,7 @@ class LazySessionState(MutableMapping[str, Any]):
     def __delattr__(self, key: str) -> None:
         state = get_session_state()
         state.__delattr__(key)
+
+    def to_dict(self) -> Dict:
+        state = get_session_state()
+        return state.to_dict()

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -27,6 +27,7 @@ import streamlit as st
 from streamlit import type_util
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIException
+from streamlit.state.session_state import LazySessionState
 
 
 class StreamlitWriteTest(unittest.TestCase):
@@ -164,6 +165,13 @@ class StreamlitWriteTest(unittest.TestCase):
             Boy = namedtuple("Boy", ("name", "age"))
             John = Boy("John", 29)
             st.write(John)
+
+            p.assert_called_once()
+
+    def test_session_state(self):
+        """Test st.write with st.session_state."""
+        with patch("streamlit.delta_generator.DeltaGenerator.json") as p:
+            st.write(LazySessionState())
 
             p.assert_called_once()
 


### PR DESCRIPTION
Note that the cypress test failures are due to issues that get fixed in #3399, so they
should disappear once that PR is merged and this branch is rebased.