### PR TITLE
Filter auto-generated widget keys from st.session_state

### DIFF
--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import json
-from streamlit.state.session_state import WidgetMetadata, WidgetSerializer
+from streamlit.state.session_state import (
+    GENERATED_WIDGET_KEY_PREFIX,
+    WidgetMetadata,
+    WidgetSerializer,
+)
 import textwrap
 from pprint import pprint
 from typing import Any, Callable, cast, Dict, Optional, Set, Tuple, Union
@@ -406,4 +410,5 @@ def _get_widget_id(
     if user_key is not None:
         return user_key
     else:
-        return str(hash((element_type, element_proto.SerializeToString())))
+        h = str(hash((element_type, element_proto.SerializeToString())))
+        return f"{GENERATED_WIDGET_KEY_PREFIX}-{h}"

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -20,6 +20,7 @@ from unittest.mock import call, MagicMock
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
+from streamlit.state.session_state import GENERATED_WIDGET_KEY_PREFIX
 from streamlit.state.widgets import (
     _get_widget_id,
     coalesce_widget_states,
@@ -288,6 +289,15 @@ class WidgetManagerTests(unittest.TestCase):
 
 
 class WidgetHelperTests(unittest.TestCase):
+    def test_get_widget_with_generated_key(self):
+        button_proto = ButtonProto()
+        button_proto.label = "the label"
+        self.assertTrue(
+            _get_widget_id("button", button_proto).startswith(
+                GENERATED_WIDGET_KEY_PREFIX
+            )
+        )
+
     def test_get_widget_id_with_user_key(self):
         button_proto = ButtonProto()
         button_proto.label = "the label"


### PR DESCRIPTION
Note that we omit unit tests from this PR (although the changes are covered by
some e2e tests) as we'll be improving unit test coverage for the unified
widget+session state implementation in general in a future change.