### PR TITLE
[Security] Upgrade trim-newlines to 3.0.1 or later

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -185,6 +185,7 @@
     "ssri": "^8.0.1",
     "static-eval": "^2.0.5",
     "trim": "^0.0.3",
+    "trim-newlines": "^3.0.1",
     "websocket-extensions": "^0.1.4",
     "ws": "^7.4.6",
     "xmldom": "^0.5.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17892,10 +17892,10 @@ triangulate-polyline@^1.0.0:
   dependencies:
     cdt2d "^1.0.0"
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-trailing-lines@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
Details: https://github.com/advisories/GHSA-7p7h-4mm5-852v