### PR TITLE
Fix bug where apps crash on frontend reconnect and install serializers

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -145,8 +145,13 @@ class FileUploaderMixin:
         if help is not None:
             file_uploader_proto.help = help
 
+        # TODO: Fix this (de)serializer so that st.session_state[key] can be
+        #       used to access an uploaded file.
         def deserialize_file_uploader(ui_value):
             return ui_value
+
+        def serialize_file_uploader(v):
+            return v.data
 
         # FileUploader's widget value is a list of file IDs
         # representing the current set of files that this uploader should
@@ -159,6 +164,7 @@ class FileUploaderMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_file_uploader,
+            serializer=serialize_file_uploader,
         )
 
         file_recs = self._get_file_recs(file_uploader_proto.id, widget_value)

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -134,6 +134,9 @@ class MultiSelectMixin:
             current_value = ui_value.data if ui_value is not None else default_value
             return [options[i] for i in current_value]
 
+        def serialize_multiselect(value):
+            return _check_and_convert_to_indices(options, value)
+
         current_value, set_frontend_value = register_widget(
             "multiselect",
             multiselect_proto,
@@ -142,6 +145,7 @@ class MultiSelectMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_multiselect,
+            serializer=serialize_multiselect,
         )
 
         if set_frontend_value:

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -113,6 +113,11 @@ class RadioMixin:
                 options[idx] if len(options) > 0 and options[idx] is not None else None
             )
 
+        def serialize_radio(value):
+            # TODO: Catch and rethrow ValueErrors with a more clear error
+            # message.
+            return options.index(value)
+
         current_value, set_frontend_value = register_widget(
             "radio",
             radio_proto,
@@ -121,12 +126,11 @@ class RadioMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_radio,
+            serializer=serialize_radio,
         )
 
         if set_frontend_value:
-            # TODO: Catch and rethrow ValueErrors with a more clear error
-            # message.
-            radio_proto.value = options.index(current_value)
+            radio_proto.value = serialize_radio(current_value)
             radio_proto.set_value = True
 
         self.dg._enqueue("radio", radio_proto)

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -154,6 +154,10 @@ class SelectSliderMixin:
             # If the original value was a list/tuple, so will be the output (and vice versa)
             return tuple(return_value) if is_range_value else return_value[0]
 
+        def serialize_select_slider(v):
+            to_serialize = v if is_range_value else [v]
+            return [index_(options, u) for u in to_serialize]
+
         current_value, set_frontend_value = register_widget(
             "slider",
             slider_proto,
@@ -162,10 +166,11 @@ class SelectSliderMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_select_slider,
+            serializer=serialize_select_slider,
         )
 
         if set_frontend_value:
-            slider_proto.value[:] = current_value if is_range_value else [current_value]
+            slider_proto.value[:] = serialize_select_slider(current_value)
             slider_proto.set_value = True
 
         self.dg._enqueue("slider", slider_proto)

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -108,6 +108,9 @@ class SelectboxMixin:
                 options[idx] if len(options) > 0 and options[idx] is not None else None
             )
 
+        def serialize_select_box(v):
+            return options.index(v)
+
         current_value, set_frontend_value = register_widget(
             "selectbox",
             selectbox_proto,
@@ -116,10 +119,11 @@ class SelectboxMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_select_box,
+            serializer=serialize_select_box,
         )
 
         if set_frontend_value:
-            selectbox_proto.value = options.index(current_value)
+            selectbox_proto.value = serialize_select_box(current_value)
             selectbox_proto.set_value = True
 
         self.dg._enqueue("selectbox", selectbox_proto)

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -413,6 +413,9 @@ class SliderMixin:
                 ]
             return val[0] if single_value else tuple(val)
 
+        def serialize_slider(v):
+            return [v] if single_value else list(v)
+
         current_value, set_frontend_value = register_widget(
             "slider",
             slider_proto,
@@ -421,12 +424,11 @@ class SliderMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_slider,
+            serializer=serialize_slider,
         )
 
         if set_frontend_value:
-            slider_proto.value[:] = (
-                [current_value] if single_value else list(current_value)
-            )
+            slider_proto.value[:] = serialize_slider(current_value)
             slider_proto.set_value = True
 
         self.dg._enqueue("slider", slider_proto)

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -102,6 +102,11 @@ class TimeWidgetsMixin:
                 else value
             )
 
+        def serialize_time_input(v):
+            if isinstance(v, datetime):
+                v = v.time()
+            return time.strftime(v, "%H:%M")
+
         current_value, set_frontend_value = register_widget(
             "time_input",
             time_input_proto,
@@ -110,12 +115,11 @@ class TimeWidgetsMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_time_input,
+            serializer=serialize_time_input,
         )
 
         if set_frontend_value:
-            if isinstance(current_value, datetime):
-                current_value = current_value.time()
-            time_input_proto.value = time.strftime(current_value, "%H:%M")
+            time_input_proto.value = serialize_time_input(current_value)
             time_input_proto.set_value = True
 
         self.dg._enqueue("time_input", time_input_proto)
@@ -236,6 +240,10 @@ class TimeWidgetsMixin:
 
             return return_value[0] if single_value else tuple(return_value)
 
+        def serialize_date_input(v):
+            to_serialize = [v] if single_value else list(v)
+            return [date.strftime(v, "%Y/%m/%d") for v in to_serialize]
+
         current_value, set_frontend_value = register_widget(
             "date_input",
             date_input_proto,
@@ -244,13 +252,11 @@ class TimeWidgetsMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_date_input,
+            serializer=serialize_date_input,
         )
 
         if set_frontend_value:
-            to_serialize = [current_value] if single_value else list(current_value)
-            date_input_proto.value[:] = [
-                date.strftime(v, "%Y/%m/%d") for v in to_serialize
-            ]
+            date_input_proto.value[:] = serialize_date_input(current_value)
             date_input_proto.set_value = True
 
         self.dg._enqueue("date_input", date_input_proto)

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -496,10 +496,7 @@ class ReportSession(object):
         # terminal.
         caching.clear_cache()
 
-        # This needs to be lazily imported to avoid a dependency cycle.
-        from streamlit.state.session_state import SessionState
-
-        self._session_state = SessionState()
+        self._session_state.clear_state()
 
     def handle_set_run_on_save_request(self, new_value):
         """Change our run_on_save flag to the given value.

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -305,7 +305,6 @@ class SessionState(MutableMapping[str, Any]):
         changed_widget_ids = [
             wid for wid in self._new_widget_state if self._widget_changed(wid)
         ]
-        self.compact_state()
         for wid in changed_widget_ids:
             self._new_widget_state.call_callback(wid)
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -153,7 +153,16 @@ class WStates(MutableMapping[str, Any]):
                     return default
                 else:
                     field = metadata.value_type
-                    widget.__setattr__(field, metadata.serializer(item.value))
+                    serialized = metadata.serializer(item.value)
+                    if field in (
+                        "double_array_value",
+                        "int_array_value",
+                        "string_array_value",
+                    ):
+                        arr = getattr(widget, field)
+                        arr.data.extend(serialized)
+                    else:
+                        setattr(widget, field, serialized)
                     return widget
             else:
                 return item.value

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -189,6 +189,9 @@ class WStates(MutableMapping[str, Any]):
         kwargs = metadata.callback_kwargs or {}
         callback(*args, **kwargs)
 
+    def clear_state(self) -> None:
+        self.states = {}
+
 
 @attr.s(auto_attribs=True, slots=True)
 class SessionState(MutableMapping[str, Any]):
@@ -222,6 +225,11 @@ class SessionState(MutableMapping[str, Any]):
             self._old_state[wid] = self._new_widget_state[wid]
         self._new_session_state.clear()
         self._new_widget_state.clear()
+
+    def clear_state(self) -> None:
+        self._old_state = {}
+        self._new_session_state = {}
+        self._new_widget_state.clear_state()
 
     @property
     def _merged_state(self) -> Dict[str, Any]:

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -145,9 +145,9 @@ class ReportSessionTest(unittest.TestCase):
     @patch("streamlit.report_session.LocalSourcesWatcher")
     def test_clear_cache_resets_session_state(self, _1, _2):
         rs = ReportSession(None, "", "", UploadedFileManager())
-        original_session_state = rs._session_state
+        rs._session_state["foo"] = "bar"
         rs.handle_clear_cache_request()
-        self.assertIsNot(original_session_state, rs._session_state)
+        self.assertTrue("foo" not in rs._session_state)
 
 
 def _create_mock_websocket():


### PR DESCRIPTION
This ended up being due to an extra/unneeded state compaction that was
done while calling callbacks.

We also added serializers where in this PR as it was necessary to get things
working e2e after fixing the bug.