### PR TITLE
* Pin torch version to avoid build fails when pytorch version >=1.9

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -22,5 +22,5 @@ setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
 tensorflow>2.2.0,<2.5.0
-torch>=1.8.0,<1.9.0
+torch==1.8.1
 torchvision

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -22,5 +22,5 @@ setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
 tensorflow>2.2.0,<2.5.0
-torch==1.8.1
+torch>=1.8.1,<1.9.0
 torchvision

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -22,5 +22,5 @@ setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
 tensorflow>2.2.0,<2.5.0
-torch
+torch==1.8.1
 torchvision

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -22,5 +22,5 @@ setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
 tensorflow>2.2.0,<2.5.0
-torch==1.8.1
+torch>=1.8.0,<1.9.0
 torchvision


### PR DESCRIPTION
Fix CI fails on `test_torch_c_tensorbase` when `torch>=1.9.0`
Test should be completely rewritten to be compatible with `torch>=1.9.0`