### PR TITLE
Exclude rent tutorial until polished

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,6 @@
 
    getting_started
    tutorial/create_a_data_explorer_app
-   tutorial/visualize_rent_prices_with_Streamlit
    streamlit_components
    tutorial/databases
    Self-driving car image browser <https://github.com/streamlit/demo-self-driving>
@@ -45,6 +44,8 @@
   changelog
   Source code & issue tracker <https://github.com/streamlit/streamlit/>
 ```
+
+[comment]: # (tutorial/visualize_rent_prices_with_Streamlit)
 
 # Welcome to Streamlit
 


### PR DESCRIPTION
Temporarily removed `visualize_rent_prices_with_Streamlit.md` from `index.md` to avoid a tutorial with errors from being visible on the [latest docs](https://docs.streamlit.io/en/latest/). A polished version will be included in a future PR.