### PR TITLE
Session state unit tests

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -352,30 +352,6 @@ class SessionState(MutableMapping[str, Any]):
         return self._new_widget_state.as_widget_states()
 
 
-def _get_current_session() -> "ReportSession":
-    # Getting the session id easily comes from the report context, which is
-    # a little weird, but a precedent that has been set.
-    from streamlit.report_thread import get_report_ctx
-
-    ctx = get_report_ctx()
-    this_session: Optional["ReportSession"] = None
-
-    if ctx is not None:
-        # This needs to be imported lazily to avoid a dependency cycle.
-        from streamlit.server.server import Server
-
-        this_session = Server.get_current().get_session_by_id(ctx.session_id)
-
-    if this_session is None:
-        raise RuntimeError(
-            "We were unable to retrieve your Streamlit session."
-            " Is your application utilizing threads? It's possible that could"
-            " be conflicting with our system."
-        )
-
-    return this_session
-
-
 def get_session_state() -> SessionState:
     """Get the SessionState object for the current session.
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -383,7 +383,12 @@ def get_session_state() -> SessionState:
     directly. Instead, SessionState objects should be accessed via
     st.session_state.
     """
-    return _get_current_session().session_state
+    from streamlit.report_thread import get_report_ctx
+
+    ctx = get_report_ctx()
+
+    assert ctx is not None
+    return ctx.session_state
 
 
 class LazySessionState(MutableMapping[str, Any]):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -162,36 +162,32 @@ class DeltaGeneratorTest(testutil.DeltaGeneratorTestCase):
 
         # Create a widget with a user-defined key to test that attempting to
         # create a duplicate raises an exception below.
-        with patch(
-            "streamlit.state.session_state._get_current_session",
-            return_value=self.report_session,
-        ):
-            st.button("", key="key")
+        st.button("", key="key")
 
-            # Iterate each widget type
-            for widget_type, create_widget in widgets.items():
+        # Iterate each widget type
+        for widget_type, create_widget in widgets.items():
+            create_widget()
+            with self.assertRaises(DuplicateWidgetID) as ctx:
+                # Test creating a widget with a duplicate auto-generated key
+                # raises an exception.
                 create_widget()
-                with self.assertRaises(DuplicateWidgetID) as ctx:
-                    # Test creating a widget with a duplicate auto-generated key
-                    # raises an exception.
-                    create_widget()
-                self.assertEqual(
-                    _build_duplicate_widget_message(
-                        widget_func_name=widget_type, user_key=None
-                    ),
-                    str(ctx.exception),
-                )
+            self.assertEqual(
+                _build_duplicate_widget_message(
+                    widget_func_name=widget_type, user_key=None
+                ),
+                str(ctx.exception),
+            )
 
-                with self.assertRaises(DuplicateWidgetID) as ctx:
-                    # Test creating a widget with a duplicate user-defined key
-                    # raises an exception.
-                    create_widget("key")
-                self.assertEqual(
-                    _build_duplicate_widget_message(
-                        widget_func_name=widget_type, user_key="key"
-                    ),
-                    str(ctx.exception),
-                )
+            with self.assertRaises(DuplicateWidgetID) as ctx:
+                # Test creating a widget with a duplicate user-defined key
+                # raises an exception.
+                create_widget("key")
+            self.assertEqual(
+                _build_duplicate_widget_message(
+                    widget_func_name=widget_type, user_key="key"
+                ),
+                str(ctx.exception),
+            )
 
 
 class DeltaGeneratorClassTest(testutil.DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -287,8 +287,6 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
 
 @patch("streamlit._is_running_with_streamlit", new=True)
 class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
-    ...
-
     def test_exception_for_callbacks_on_widgets(self):
         with self.assertRaises(StreamlitAPIException):
             with st.form("form"):
@@ -299,14 +297,3 @@ class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
         with st.form("form"):
             st.radio("radio", ["a", "b", "c"], 0)
             st.form_submit_button(on_change=lambda x: x)
-
-    def test_allow_keyed_widgets(self):
-        with patch(
-            "streamlit.state.session_state._get_current_session",
-            return_value=self.report_session,
-        ):
-            with st.form("form"):
-                st.radio("radio", ["a", "b", "c"], 0, key="radio")
-                st.form_submit_button()
-
-            assert st.session_state.radio == "a"

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -15,6 +15,7 @@
 """Form unit tests."""
 
 from unittest.mock import patch
+import pytest
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
@@ -246,59 +247,66 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
     def test_submit_button_outside_form(self):
         """Test that a submit button is not allowed outside a form."""
 
-        with patch(
-            "streamlit.state.session_state._get_current_session",
-            return_value=self.report_session,
-        ):
-            with self.assertRaises(StreamlitAPIException) as ctx:
-                st.form_submit_button()
+        with self.assertRaises(StreamlitAPIException) as ctx:
+            st.form_submit_button()
 
-            self.assertIn(
-                "`st.form_submit_button()` must be used inside an `st.form()`",
-                str(ctx.exception),
-            )
+        self.assertIn(
+            "`st.form_submit_button()` must be used inside an `st.form()`",
+            str(ctx.exception),
+        )
 
     def test_submit_button_inside_form(self):
         """Test that a submit button is allowed inside a form."""
 
-        with patch(
-            "streamlit.state.session_state._get_current_session",
-            return_value=self.report_session,
-        ):
-            with st.form("foo"):
-                st.form_submit_button()
+        with st.form("foo"):
+            st.form_submit_button()
 
-            last_delta = self.get_delta_from_queue()
-            self.assertEqual("foo", last_delta.new_element.button.form_id)
+        last_delta = self.get_delta_from_queue()
+        self.assertEqual("foo", last_delta.new_element.button.form_id)
 
     def test_submit_button_called_directly_on_form_block(self):
         """Test that a submit button can be called directly on a form block."""
 
-        with patch(
-            "streamlit.state.session_state._get_current_session",
-            return_value=self.report_session,
-        ):
-            form = st.form("foo")
-            form.form_submit_button()
+        form = st.form("foo")
+        form.form_submit_button()
 
-            last_delta = self.get_delta_from_queue()
-            self.assertEqual("foo", last_delta.new_element.button.form_id)
+        last_delta = self.get_delta_from_queue()
+        self.assertEqual("foo", last_delta.new_element.button.form_id)
 
     def test_return_false_when_not_submitted(self):
-        with patch(
-            "streamlit.state.session_state._get_current_session",
-            return_value=self.report_session,
-        ):
-            with st.form("form1"):
-                submitted = st.form_submit_button("Submit")
-                self.assertEqual(submitted, False)
+        with st.form("form1"):
+            submitted = st.form_submit_button("Submit")
+            self.assertEqual(submitted, False)
 
     @patch("streamlit.elements.button.register_widget", return_value=(True, False))
     def test_return_true_when_submitted(self, _):
+        with st.form("form"):
+            submitted = st.form_submit_button("Submit")
+            self.assertEqual(submitted, True)
+
+
+@patch("streamlit._is_running_with_streamlit", new=True)
+class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
+    ...
+
+    def test_exception_for_callbacks_on_widgets(self):
+        with self.assertRaises(StreamlitAPIException):
+            with st.form("form"):
+                st.radio("radio", ["a", "b", "c"], 0, on_change=lambda x: x)
+                st.form_submit_button()
+
+    def test_no_exception_for_callbacks_on_submit_button(self):
+        with st.form("form"):
+            st.radio("radio", ["a", "b", "c"], 0)
+            st.form_submit_button(on_change=lambda x: x)
+
+    def test_allow_keyed_widgets(self):
         with patch(
             "streamlit.state.session_state._get_current_session",
             return_value=self.report_session,
         ):
             with st.form("form"):
-                submitted = st.form_submit_button("Submit")
-                self.assertEqual(submitted, True)
+                st.radio("radio", ["a", "b", "c"], 0, key="radio")
+                st.form_submit_button()
+
+            assert st.session_state.radio == "a"

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -1,0 +1,41 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Session state unit tests."""
+
+from unittest.mock import patch
+import pytest
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+from tests import testutil
+
+
+@patch("streamlit._is_running_with_streamlit", new=True)
+class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
+    def test_widget_creation_updates_state(self):
+        state = st.session_state
+        assert "c" not in state
+
+        st.checkbox("checkbox", value=True, key="c")
+
+        assert state.c == True
+
+    def test_setting_before_widget_creation(self):
+        state = st.session_state
+        state.c = True
+        assert state.c == True
+
+        c = st.checkbox("checkbox", key="c")
+        assert c == True

--- a/scripts/test_data/print_command_line.py
+++ b/scripts/test_data/print_command_line.py
@@ -14,7 +14,7 @@
 
 import streamlit as st
 
-server = st.server.server.Server.get_current()
+server = st.server.server.Server.get_current()  # type: ignore
 print(
     f'{{"server._command_line": "{server._command_line}"}}'  # pylint: disable = protected-access
 )


### PR DESCRIPTION
`get_session_state` now accesses the context directly, because that's
what `register_widget` uses. During normal execution they are references
to the same dict so it doesn't matter, but this helps with unit testing.
