### PR TITLE
Install test requirements with pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ setup:
 	pip install pip-tools pipenv black ;
 
 .PHONY: pipenv-install
-pipenv-install: pipenv-dev-install pipenv-test-install
+pipenv-install: pipenv-dev-install py-test-install
 
 .PHONY: pipenv-dev-install
 pipenv-dev-install: lib/Pipfile
@@ -70,6 +70,11 @@ pipenv-test-install: lib/test-requirements.txt
 		cp Pipfile Pipfile.bkp ; \
 		pipenv install --dev --skip-lock --sequential -r test-requirements.txt ; \
 		mv Pipfile.bkp Pipfile
+
+.PHONY: py-test-install
+py-test-install: lib/test-requirements.txt
+	cd lib ; \
+		pip install -r test-requirements.txt
 
 .PHONY: pylint
 # Verify that our Python files are properly formatted.

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -22,5 +22,5 @@ setuptools<50.0.0
 sqlalchemy
 # The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
 tensorflow>2.2.0,<2.5.0
-torch
+torch<1.9.0
 torchvision


### PR DESCRIPTION
Pipenv appears to not correctly handle the version constraints from a
requirements file, possibly only when another dependency depends on the
first one but does not constrain it.

This issue notably is not sensitive to the order of the dependencies,
and appears no matter which comes first.