### PR TITLE
* Fix inaccurate definition of return value type for multiselect in d…

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -53,7 +53,7 @@ class MultiSelectMixin:
 
         Returns
         -------
-        [str]
+        list
             A list with the selected options
 
         Example


### PR DESCRIPTION
This pull request fixes a small inaccuracy in our documentation, where return value type was defined as a list of strings, although it can be a list of any types, based on options types.

[Issue 3424](https://github.com/streamlit/streamlit/issues/3424) 