### PR TITLE
Add tests for widget serialization roundtrip

### DIFF
--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -205,6 +205,8 @@ And if you're using Streamlit Sharing, add "pyarrow" to your requirements.txt.""
                 element_proto=element.component_instance,
                 user_key=key,
                 widget_func_name=self.name,
+                deserializer=lambda x: x,
+                serializer=lambda x: x,
             )
 
             if key is not None:

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -135,6 +135,7 @@ class ButtonMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_button,
+            serializer=bool,
         )
         self.dg._enqueue("button", button_proto)
         return cast(bool, current_value)

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -16,7 +16,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
-from streamlit.state.widgets import register_widget
+from streamlit.state.widgets import WidgetProto, register_widget
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -91,6 +91,7 @@ class CheckboxMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_checkbox,
+            serializer=bool,
         )
 
         if set_frontend_value:

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -116,6 +116,7 @@ class ColorPickerMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_color_picker,
+            serializer=str,
         )
 
         if set_frontend_value:

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -151,7 +151,7 @@ class FileUploaderMixin:
             return ui_value
 
         def serialize_file_uploader(v):
-            return v.data
+            return v
 
         # FileUploader's widget value is a list of file IDs
         # representing the current set of files that this uploader should
@@ -180,7 +180,7 @@ class FileUploaderMixin:
 
     @staticmethod
     def _get_file_recs(
-        widget_id: str, widget_value: Optional[SInt64Array]
+        widget_id: str, widget_value: Optional[List[int]]
     ) -> List[UploadedFileRec]:
         if widget_value is None:
             return []
@@ -189,7 +189,7 @@ class FileUploaderMixin:
         if ctx is None:
             return []
 
-        if len(widget_value.data) == 0:
+        if len(widget_value) == 0:
             # Sanity check
             LOGGER.warning(
                 "Got an empty FileUploader widget_value. (We expect a list with at least one value in it.)"

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -197,8 +197,8 @@ class FileUploaderMixin:
             return []
 
         # The first number in the widget_value list is 'newestServerFileId'
-        newest_file_id = widget_value.data[0]
-        active_file_ids = list(widget_value.data[1:])
+        newest_file_id = widget_value[0]
+        active_file_ids = list(widget_value[1:])
 
         # Grab the files that correspond to our active file IDs.
         file_recs = ctx.uploaded_file_mgr.get_files(

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -131,7 +131,7 @@ class MultiSelectMixin:
             multiselect_proto.help = help
 
         def deserialize_multiselect(ui_value) -> List[str]:
-            current_value = ui_value.data if ui_value is not None else default_value
+            current_value = ui_value if ui_value is not None else default_value
             return [options[i] for i in current_value]
 
         def serialize_multiselect(value):

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -227,6 +227,7 @@ class NumberInputMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_number_input,
+            serializer=lambda x: x,
         )
 
         if set_frontend_value:

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -142,9 +142,7 @@ class SelectSliderMixin:
             slider_proto.help = help
 
         def deserialize_select_slider(ui_value):
-            if ui_value:
-                ui_value = getattr(ui_value, "data")
-            else:
+            if not ui_value:
                 # Widget has not been used; fallback to the original value,
                 ui_value = slider_value
 

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -394,7 +394,7 @@ class SliderMixin:
 
         def deserialize_slider(ui_value):
             if ui_value:
-                val = getattr(ui_value, "data")
+                val = ui_value
             else:
                 # Widget has not been used; fallback to the original value,
                 val = value

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -415,7 +415,14 @@ class SliderMixin:
             return val[0] if single_value else tuple(val)
 
         def serialize_slider(v: Any) -> List[Any]:
-            return [v] if single_value else list(v)
+            value = [v] if single_value else list(v)
+            if data_type == SliderProto.DATE:
+                value = [_datetime_to_micros(_date_to_datetime(v)) for v in value]
+            if data_type == SliderProto.TIME:
+                value = [_datetime_to_micros(_time_to_datetime(v)) for v in value]
+            if data_type == SliderProto.DATETIME:
+                value = [_datetime_to_micros(v) for v in value]
+            return value
 
         current_value, set_frontend_value = register_widget(
             "slider",

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 from datetime import date, time, datetime, timedelta, timezone
-from typing import cast
+from typing import Any, List, cast, Optional
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
+from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.state.widgets import register_widget
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -392,16 +393,16 @@ class SliderMixin:
         if help is not None:
             slider_proto.help = help
 
-        def deserialize_slider(ui_value):
-            if ui_value:
+        def deserialize_slider(ui_value: Optional[List[float]]):
+            if ui_value is not None:
                 val = ui_value
             else:
                 # Widget has not been used; fallback to the original value,
-                val = value
+                val = cast(List[float], value)
 
             # The widget always returns a float array, so fix the return type if necessary
             if data_type == SliderProto.INT:
-                val = list(map(int, val))
+                val = [int(v) for v in val]
             if data_type == SliderProto.DATETIME:
                 val = [_micros_to_datetime(int(v)) for v in val]
             if data_type == SliderProto.DATE:
@@ -413,7 +414,7 @@ class SliderMixin:
                 ]
             return val[0] if single_value else tuple(val)
 
-        def serialize_slider(v):
+        def serialize_slider(v: Any) -> List[Any]:
             return [v] if single_value else list(v)
 
         current_value, set_frontend_value = register_widget(

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -110,6 +110,7 @@ class TextWidgetsMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_text_input,
+            serializer=lambda x: x,
         )
 
         if set_frontend_value:
@@ -203,6 +204,7 @@ class TextWidgetsMixin:
             args=args,
             kwargs=kwargs,
             deserializer=deserialize_text_area,
+            serializer=lambda x: x,
         )
 
         if set_frontend_value:

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -86,7 +86,7 @@ class TimeWidgetsMixin:
 
         # Convert datetime to time
         if isinstance(value, datetime):
-            value = value.time()
+            value = value.time().replace(second=0, microsecond=0)
 
         time_input_proto = TimeInputProto()
         time_input_proto.label = label

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -231,9 +231,8 @@ class TimeWidgetsMixin:
 
         def deserialize_date_input(ui_value):
             if ui_value is not None:
-                return_value = getattr(ui_value, "data")
                 return_value = [
-                    datetime.strptime(v, "%Y/%m/%d").date() for v in return_value
+                    datetime.strptime(v, "%Y/%m/%d").date() for v in ui_value
                 ]
             else:
                 return_value = value

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -76,7 +76,7 @@ class TimeWidgetsMixin:
 
         # Set value default.
         if value is None:
-            value = datetime.now().time()
+            value = datetime.now().time().replace(second=0, microsecond=0)
 
         # Ensure that the value is either datetime/time
         if not isinstance(value, datetime) and not isinstance(value, time):

--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import traceback
 
 import streamlit as st
 from streamlit import config
@@ -42,7 +43,7 @@ def handle_uncaught_app_exception(e: BaseException) -> None:
     warning in the frontend instead.
     """
     if config.get_option("client.showErrorDetails"):
-        LOGGER.debug(e)
+        LOGGER.warning(traceback.format_exc())
         st.exception(e)
         # TODO: Clean up the stack trace, so it doesn't include ScriptRunner.
     else:

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -94,13 +94,13 @@ class WStates(MutableMapping[str, Any]):
                     raise KeyError(k)
                 value = item.value.__getattribute__(item.value.WhichOneof("value"))
 
-                # Array types are messages with data in a `value` field
+                # Array types are messages with data in a `data` field
                 if metadata.value_type in [
                     "double_array_value",
                     "int_array_value",
                     "string_array_value",
                 ]:
-                    value = value.value
+                    value = value.data
                 deserialized = metadata.deserializer(value)
                 self.states[k] = Value(deserialized)
                 return deserialized

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -56,8 +56,8 @@ WState = Union[Serialized, Value]
 
 WidgetArgs = Tuple[Any, ...]
 WidgetCallback = Callable[..., None]
-WidgetDeserializer = Callable[[Any], Any]
-WidgetSerializer = Callable[[Any], WidgetStateProto]
+WidgetDeserializer = Callable[[Optional[WidgetStateProto]], Any]
+WidgetSerializer = Callable[[Any], Any]
 WidgetKwargs = Dict[str, Any]
 
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -56,7 +56,10 @@ WState = Union[Serialized, Value]
 
 WidgetArgs = Tuple[Any, ...]
 WidgetCallback = Callable[..., None]
-WidgetDeserializer = Callable[[Optional[WidgetStateProto]], Any]
+# A deserializer receives the value from whatever field is set on the WidgetState proto, and returns a regular python value.
+# A serializer receives a regular python value, and returns something suitable for a value field on WidgetState proto.
+# They should be inverses.
+WidgetDeserializer = Callable[[Any], Any]
 WidgetSerializer = Callable[[Any], Any]
 WidgetKwargs = Dict[str, Any]
 
@@ -79,19 +82,26 @@ class WStates(MutableMapping[str, Any]):
     widget_metadata: Dict[str, WidgetMetadata] = attr.Factory(dict)
 
     def __getitem__(self, k: str) -> Any:
-        item = self.states.get(k, None)
+        item = self.states.get(k)
         if item is not None:
             if isinstance(item, Value):
                 return item.value
             else:
-                metadata = self.widget_metadata.get(k, None)
+                metadata = self.widget_metadata.get(k)
                 if metadata is None:
                     # No deserializer, which should only happen if state is gotten from a reconnecting browser
                     # and the script is trying to access it. Pretend it doesn't exist.
                     raise KeyError(k)
-                deserialized = metadata.deserializer(
-                    item.value.__getattribute__(item.value.WhichOneof("value"))
-                )
+                value = item.value.__getattribute__(item.value.WhichOneof("value"))
+
+                # Array types are messages with data in a `value` field
+                if metadata.value_type in [
+                    "double_array_value",
+                    "int_array_value",
+                    "string_array_value",
+                ]:
+                    value = value.value
+                deserialized = metadata.deserializer(value)
                 self.states[k] = Value(deserialized)
                 return deserialized
         else:

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -79,8 +79,8 @@ class NoValue:
 def register_widget(
     element_type: str,
     element_proto: WidgetProto,
-    deserializer: WidgetDeserializer = lambda x: x,
-    serializer: WidgetSerializer = lambda x: x,  # type: ignore
+    deserializer: WidgetDeserializer,
+    serializer: WidgetSerializer,
     user_key: Optional[str] = None,
     widget_func_name: Optional[str] = None,
     on_change_handler: Optional[WidgetCallback] = None,

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -14,6 +14,7 @@
 
 """DeltaGenerator Unittest."""
 
+import functools
 from unittest.mock import patch, MagicMock
 import json
 
@@ -38,8 +39,18 @@ from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.Text_pb2 import Text as TextProto
-from streamlit.state.widgets import _build_duplicate_widget_message, register_widget
+from streamlit.state.widgets import _build_duplicate_widget_message
+import streamlit.state.widgets as w
 from tests import testutil
+
+
+def identity(x):
+    return x
+
+
+register_widget = functools.partial(
+    w.register_widget, deserializer=identity, serializer=identity
+)
 
 
 class FakeDeltaGenerator(object):

--- a/lib/tests/streamlit/file_uploader_test.py
+++ b/lib/tests/streamlit/file_uploader_test.py
@@ -58,8 +58,7 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
         get_files_patch.return_value = file_recs
 
         # Patch register_widget to return the IDs of our two files
-        file_ids = SInt64Array()
-        file_ids.data[:] = [rec.id for rec in file_recs]
+        file_ids = [rec.id for rec in file_recs]
         register_widget_patch.return_value = (file_ids, False)
 
         for accept_multiple in [True, False]:
@@ -118,8 +117,7 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
         get_files_patch.return_value = file_recs
 
         # Patch register_widget to return the IDs of our two files
-        file_ids = SInt64Array()
-        file_ids.data[:] = [rec.id for rec in file_recs]
+        file_ids = [rec.id for rec in file_recs]
         register_widget_patch.return_value = (file_ids, False)
 
         # These file_uploaders have different labels so that we don't cause
@@ -148,8 +146,7 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
 
         # Patch register_widget. The first value in the array is
         # "newest_file_id". It's followed by all the active file IDs
-        file_ids = SInt64Array()
-        file_ids.data[:] = [newest_file_id] + active_file_ids
+        file_ids = [newest_file_id] + active_file_ids
         register_widget_patch.return_value = (file_ids, False)
 
         st.file_uploader("foo")

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -17,7 +17,7 @@
 from typing import Any
 import unittest
 from unittest.mock import patch, MagicMock
-from datetime import datetime, timedelta, date, time
+from datetime import datetime, timedelta, date
 
 import pytest
 import tornado.testing
@@ -200,21 +200,27 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         assert "foo" in state
         assert state.foo == "foo"
 
-    def test_widget_serde_roundtrip(self):
-        def check_roundtrip(widget_id: str, value: Any):
-            session_state = get_session_state()
-            metadata = session_state._new_widget_state.widget_metadata[widget_id]
-            serializer = metadata.serializer
-            deserializer = metadata.deserializer
 
-            assert deserializer(serializer(value)) == value
+def check_roundtrip(widget_id: str, value: Any) -> None:
+    session_state = get_session_state()
+    metadata = session_state._new_widget_state.widget_metadata[widget_id]
+    serializer = metadata.serializer
+    deserializer = metadata.deserializer
 
+    assert deserializer(serializer(value)) == value
+
+
+@patch("streamlit._is_running_with_streamlit", new=True)
+class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
+    def test_checkbox_serde(self):
         cb = st.checkbox("cb", key="cb")
         check_roundtrip("cb", cb)
 
+    def test_color_picker_serde(self):
         cp = st.color_picker("cp", key="cp")
         check_roundtrip("cp", cp)
 
+    def test_date_input_serde(self):
         date = st.date_input("date", key="date")
         check_roundtrip("date", date)
 
@@ -225,6 +231,7 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("date_interval", date_interval)
 
+    def test_multiselect_serde(self):
         multiselect = st.multiselect(
             "multiselect", options=["a", "b", "c"], key="multiselect"
         )
@@ -238,12 +245,14 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("multiselect_multiple", multiselect_multiple)
 
+    def test_number_input_serde(self):
         number = st.number_input("number", key="number")
         check_roundtrip("number", number)
 
         number_int = st.number_input("number_int", value=16777217, key="number_int")
         check_roundtrip("number_int", number_int)
 
+    def test_radio_input_serde(self):
         radio = st.radio("radio", options=["a", "b", "c"], key="radio")
         check_roundtrip("radio", radio)
 
@@ -255,14 +264,17 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("radio_nondefault", radio_nondefault)
 
+    def test_selectbox_serde(self):
         selectbox = st.selectbox("selectbox", options=["a", "b", "c"], key="selectbox")
         check_roundtrip("selectbox", selectbox)
 
+    def test_select_slider_serde(self):
         select_slider = st.select_slider(
             "select_slider", options=["a", "b", "c"], key="select_slider"
         )
         check_roundtrip("select_slider", select_slider)
 
+    def test_slider_serde(self):
         slider = st.slider("slider", key="slider")
         check_roundtrip("slider", slider)
 
@@ -297,6 +309,7 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("slider_interval", slider_interval)
 
+    def test_text_area_serde(self):
         text_area = st.text_area("text_area", key="text_area")
         check_roundtrip("text_area", text_area)
 
@@ -307,6 +320,7 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("text_area_default", text_area_default)
 
+    def test_text_input_serde(self):
         text_input = st.text_input("text_input", key="text_input")
         check_roundtrip("text_input", text_input)
 
@@ -317,6 +331,7 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("text_input_default", text_input_default)
 
+    def test_time_input_serde(self):
         time = st.time_input("time", key="time")
         check_roundtrip("time", time)
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -17,7 +17,7 @@
 from typing import Any
 import unittest
 from unittest.mock import patch, MagicMock
-
+from datetime import datetime, timedelta, date, time
 
 import pytest
 import tornado.testing
@@ -201,9 +201,8 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         assert state.foo == "foo"
 
     def test_widget_serde_roundtrip(self):
-        session_state = get_session_state()
-
         def check_roundtrip(widget_id: str, value: Any):
+            session_state = get_session_state()
             metadata = session_state._new_widget_state.widget_metadata[widget_id]
             serializer = metadata.serializer
             deserializer = metadata.deserializer
@@ -219,16 +218,42 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         date = st.date_input("date", key="date")
         check_roundtrip("date", date)
 
+        date_interval = st.date_input(
+            "date_interval",
+            value=[datetime.now().date(), datetime.now().date() + timedelta(days=1)],
+            key="date_interval",
+        )
+        check_roundtrip("date_interval", date_interval)
+
         multiselect = st.multiselect(
             "multiselect", options=["a", "b", "c"], key="multiselect"
         )
         check_roundtrip("multiselect", multiselect)
 
+        multiselect_multiple = st.multiselect(
+            "multiselect_multiple",
+            options=["a", "b", "c"],
+            default=["b", "c"],
+            key="multiselect_multiple",
+        )
+        check_roundtrip("multiselect_multiple", multiselect_multiple)
+
         number = st.number_input("number", key="number")
         check_roundtrip("number", number)
 
+        number_int = st.number_input("number_int", value=16777217, key="number_int")
+        check_roundtrip("number_int", number_int)
+
         radio = st.radio("radio", options=["a", "b", "c"], key="radio")
         check_roundtrip("radio", radio)
+
+        radio_nondefault = st.radio(
+            "radio_nondefault",
+            options=["a", "b", "c"],
+            index=1,
+            key="radio_nondefault",
+        )
+        check_roundtrip("radio_nondefault", radio_nondefault)
 
         selectbox = st.selectbox("selectbox", options=["a", "b", "c"], key="selectbox")
         check_roundtrip("selectbox", selectbox)
@@ -241,11 +266,63 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         slider = st.slider("slider", key="slider")
         check_roundtrip("slider", slider)
 
+        slider_float = st.slider("slider_float", value=0.5, key="slider_float")
+        check_roundtrip("slider_float", slider_float)
+
+        slider_date = st.slider(
+            "slider_date",
+            value=date.today(),
+            key="slider_date",
+        )
+        check_roundtrip("slider_date", slider_date)
+
+        slider_time = st.slider(
+            "slider_time",
+            value=datetime.now().time(),
+            key="slider_time",
+        )
+        check_roundtrip("slider_time", slider_time)
+
+        slider_datetime = st.slider(
+            "slider_datetime",
+            value=datetime.now(),
+            key="slider_datetime",
+        )
+        check_roundtrip("slider_datetime", slider_datetime)
+
+        slider_interval = st.slider(
+            "slider_interval",
+            value=[-1.0, 1.0],
+            key="slider_interval",
+        )
+        check_roundtrip("slider_interval", slider_interval)
+
         text_area = st.text_area("text_area", key="text_area")
         check_roundtrip("text_area", text_area)
+
+        text_area_default = st.text_area(
+            "text_area_default",
+            value="default",
+            key="text_area_default",
+        )
+        check_roundtrip("text_area_default", text_area_default)
 
         text_input = st.text_input("text_input", key="text_input")
         check_roundtrip("text_input", text_input)
 
+        text_input_default = st.text_input(
+            "text_input_default",
+            value="default",
+            key="text_input_default",
+        )
+        check_roundtrip("text_input_default", text_input_default)
+
         time = st.time_input("time", key="time")
         check_roundtrip("time", time)
+
+        time_datetime = st.time_input(
+            "datetime",
+            value=datetime.now(),
+            key="time_datetime",
+        )
+        check_roundtrip("time_datetime", time_datetime)


### PR DESCRIPTION
Some tests for testing that serialization and deserialization are inverses for each widget. Currently not all passing.