### PR TITLE
Longer sleep in scriptrunner stopping test

### DIFF
--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -191,7 +191,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # stops execution and runs some cleanup. If we do not wait for the
         # forced GC to finish, the script won't start running before we stop
         # the script runner, so the expected delta is never created.
-        time.sleep(0.3)
+        time.sleep(1)
         scriptrunner.enqueue_stop()
         scriptrunner.join()
 


### PR DESCRIPTION
The test can fail if the script does not run long enough before the test
moves to the next stage, and it appears to be flaky in CI, so we'll give
it more time to complete.

I confirmed that when the sleep in the test is too short, it fails in the way that it does in CI, so I feel fairly confident that this is the cause, but since I can't directly reproduce it locally I don't know for sure how long is needed.