### PR TITLE
Maintain state priority ordering when compacting

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -226,9 +226,9 @@ class SessionState(MutableMapping[str, Any]):
 
     # is it possible for a value to get through this without being deserialized?
     def compact_state(self) -> None:
-        self._old_state.update(self._new_session_state)
         for wid in self._new_widget_state:
             self._old_state[wid] = self._new_widget_state[wid]
+        self._old_state.update(self._new_session_state)
         self._new_session_state.clear()
         self._new_widget_state.clear()
 


### PR DESCRIPTION
Previously, there was an issue with widget updates from the frontend
being lost sometimes, which was mitigated by compacting in multiple
places. One of the (seemingly redundant) compaction calls was removed,
which caused the bug to resurface. This is a proper fix for the bug,
which was the result of incorrectly preferring widget state over values
from session state set during callbacks.