### PR TITLE
Decrease Tornado WebSocket ping_interval to 1s

### DIFF
--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -70,7 +70,7 @@ LOGGER = get_logger(__name__)
 
 TORNADO_SETTINGS = {
     "compress_response": True,  # Gzip HTTP responses.
-    "websocket_ping_interval": 20,  # Ping every 20s to keep WS alive.
+    "websocket_ping_interval": 1,  # Ping every 1s to keep WS alive.
     "websocket_ping_timeout": 30,  # Pings should be responded to within 30s.
     "websocket_max_message_size": MESSAGE_SIZE_LIMIT,  # Up the WS size limit.
 }

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -69,10 +69,19 @@ LOGGER = get_logger(__name__)
 
 
 TORNADO_SETTINGS = {
-    "compress_response": True,  # Gzip HTTP responses.
-    "websocket_ping_interval": 1,  # Ping every 1s to keep WS alive.
-    "websocket_ping_timeout": 30,  # Pings should be responded to within 30s.
-    "websocket_max_message_size": MESSAGE_SIZE_LIMIT,  # Up the WS size limit.
+    # Gzip HTTP responses.
+    "compress_response": True,
+    # Ping every 1s to keep WS alive.
+    # 2021.06.22: this value was previously 20s, and was causing
+    # connection instability for a small number of users. This smaller
+    # ping_interval fixes that instability.
+    # https://github.com/streamlit/streamlit/issues/3196
+    "websocket_ping_interval": 1,
+    # If we don't get a ping response within 30s, the connection
+    # is timed out.
+    "websocket_ping_timeout": 30,
+    # Set the websocket message size. The default value is too low.
+    "websocket_max_message_size": MESSAGE_SIZE_LIMIT,
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/streamlit/streamlit/issues/3196

I ran some tests with a simulated super-high-latency/low-bandwidth connection, and didn't run into any issues.