### PR TITLE
Remove "Streamlit" from custom page title

### DIFF
--- a/e2e/specs/st_set_page_config.spec.js
+++ b/e2e/specs/st_set_page_config.spec.js
@@ -27,7 +27,7 @@ describe("st.set_page_config", () => {
   });
 
   it("sets the page title", () => {
-    cy.title().should("eq", "Heya, world? · Streamlit");
+    cy.title().should("eq", "Heya, world?");
   });
 
   it("collapses the sidebar", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -24,6 +24,7 @@ import {
   CustomThemeConfig,
   ForwardMsg,
   NewReport,
+  PageConfig,
   PageInfo,
 } from "src/autogen/proto"
 import { IMenuItem } from "src/hocs/withS4ACommunication/types"
@@ -540,6 +541,22 @@ describe("App.handleNewReport", () => {
 
     expect(oneTimeInitialization).toHaveBeenCalledTimes(2)
     expect(SessionInfo.isSet()).toBe(true)
+  })
+})
+
+describe("App.handlePageConfigChanged", () => {
+  it("sets document title when 'title' is non-null", () => {
+    expect(document.title).toBe("")
+
+    const wrapper = shallow(<App {...getProps()} />)
+    const app = wrapper.instance() as App
+    app.handlePageConfigChanged(new PageConfig({ title: "Jabberwocky" }))
+
+    expect(document.title).toBe("Jabberwocky")
+  })
+
+  afterEach(() => {
+    document.title = ""
   })
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -545,18 +545,22 @@ describe("App.handleNewReport", () => {
 })
 
 describe("App.handlePageConfigChanged", () => {
-  it("sets document title when 'title' is non-null", () => {
-    expect(document.title).toBe("")
+  let documentTitle: string
 
+  beforeEach(() => {
+    documentTitle = document.title
+  })
+
+  afterEach(() => {
+    document.title = documentTitle
+  })
+
+  it("sets document title when 'PageConfig.title' is set", () => {
     const wrapper = shallow(<App {...getProps()} />)
     const app = wrapper.instance() as App
     app.handlePageConfigChanged(new PageConfig({ title: "Jabberwocky" }))
 
     expect(document.title).toBe("Jabberwocky")
-  })
-
-  afterEach(() => {
-    document.title = ""
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -428,7 +428,7 @@ export class App extends PureComponent<Props, State> {
         title,
       })
 
-      document.title = `${title} · Streamlit`
+      document.title = title
     }
 
     if (favicon) {


### PR DESCRIPTION
Currently, if you write `st.set_page_config(page_title="Foo")`, the page title is actually set to "Foo · Streamlit". This change just removes the " · Streamlit" bit.

Fixes https://github.com/streamlit/streamlit/issues/1856