### PR TITLE
[Quiver] Better formatting function

### DIFF
--- a/frontend/src/lib/Quiver.test.ts
+++ b/frontend/src/lib/Quiver.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { util } from "apache-arrow"
+import { Utf8Vector, util } from "apache-arrow"
 import { Quiver } from "src/lib/Quiver"
 import {
   // Types
@@ -149,6 +149,69 @@ describe("Quiver", () => {
 
       it("throws an exception if column index is out of range", () => {
         expect(() => q.getCell(0, 5)).toThrow("Column index is out of range.")
+      })
+    })
+
+    describe("format", () => {
+      test("null", () => {
+        expect(Quiver.format(null)).toEqual("<NA>")
+      })
+
+      test("string", () => {
+        expect(Quiver.format("foo")).toEqual("foo")
+      })
+
+      test("boolean", () => {
+        expect(Quiver.format(true)).toEqual("true")
+      })
+
+      test("float64", () => {
+        expect(Quiver.format(1.25, "float64")).toEqual("1.2500")
+      })
+
+      test("int64", () => {
+        const mockElement = { data: INT64 }
+        const q = new Quiver(mockElement)
+        const { content } = q.getCell(1, 2)
+        expect(Quiver.format(content, "int64")).toEqual("1")
+      })
+
+      test("uint64", () => {
+        const mockElement = { data: UINT64 }
+        const q = new Quiver(mockElement)
+        const { content } = q.getCell(1, 2)
+        expect(Quiver.format(content, "uint64")).toEqual("2")
+      })
+
+      test("bytes", () => {
+        expect(Quiver.format(new Uint8Array([1, 2, 3]), "bytes")).toEqual(
+          "1,2,3"
+        )
+      })
+
+      test("date", () => {
+        expect(Quiver.format(new Date(1970, 0, 1), "date")).toEqual(
+          "1970-01-01"
+        )
+      })
+
+      test("datetime", () => {
+        expect(Quiver.format(0, "datetime")).toEqual("1970-01-01T00:00:00")
+      })
+
+      test("datetimetz", () => {
+        expect(Quiver.format(0, "datetimetz")).toEqual(
+          "1970-01-01T00:00:00+00:00"
+        )
+      })
+
+      test("list[unicode]", () => {
+        expect(
+          Quiver.format(
+            Utf8Vector.from(["foo", "bar", "baz"]),
+            "list[unicode]"
+          )
+        ).toEqual('["foo","bar","baz"]')
       })
     })
 

--- a/frontend/src/lib/Quiver.ts
+++ b/frontend/src/lib/Quiver.ts
@@ -21,6 +21,7 @@
 import { Table, Vector } from "apache-arrow"
 import { range, unzip, cloneDeep } from "lodash"
 import moment from "moment"
+import numbro from "numbro"
 
 import { IArrow, Styler as StylerProto } from "src/autogen/proto"
 
@@ -607,7 +608,7 @@ export class Quiver {
     }
 
     if (type === "float64" && Number.isFinite(x)) {
-      return (x as number).toFixed(4)
+      return numbro(x).format("0,0.0000")
     }
 
     return String(x)

--- a/frontend/src/lib/Quiver.ts
+++ b/frontend/src/lib/Quiver.ts
@@ -62,7 +62,7 @@ type Data = DataType[][]
 //   Number = "int64",
 //   Float = "float64",
 //   String = "unicode",
-//   Date = "date",
+//   Date = "date", // "datetime", "datetimetz"
 //   Bytes = "bytes",
 //   Object = "object",
 //   List = "list[int64]",
@@ -593,17 +593,20 @@ export class Quiver {
       return "<NA>"
     }
 
-    // datetime, datetimetz, datetime64, etc.
+    // date, datetime, datetimetz.
     const isDate = x instanceof Date || Number.isFinite(x)
-    if (type?.startsWith("datetime") && isDate) {
-      return moment(x as Date | number)
-        .utc()
-        .format("YYYY-MM-DD HH:mm:ss")
+    if (isDate && type === "date") {
+      return moment.utc(x as Date | number).format("YYYY-MM-DD")
+    }
+    if (isDate && type === "datetime") {
+      return moment.utc(x as Date | number).format("YYYY-MM-DDTHH:mm:ss")
+    }
+    if (isDate && type === "datetimetz") {
+      return moment.utc(x as Date | number).format("YYYY-MM-DDTHH:mm:ssZ")
     }
 
-    // list[unicode], list[list[unicode]], etc.
+    // Nested arrays and objects.
     if (type === "object" || type?.startsWith("list")) {
-      // Covers the case with nested arrays and objects in data.
       return JSON.stringify(x)
     }
 
@@ -614,18 +617,22 @@ export class Quiver {
     return String(x)
   }
 
+  /** DataFrame's index (matrix of row names). */
   public get index(): Index {
     return this._index
   }
 
+  /** DataFrame's column labels (matrix of column names). */
   public get columns(): Columns {
     return this._columns
   }
 
+  /** DataFrame's data. */
   public get data(): Data {
     return this._data
   }
 
+  /** Types for DataFrame's index and data. */
   public get types(): Types {
     return this._types
   }


### PR DESCRIPTION
- Use commas and 4 digits of precision when formatting floats, i.e. `1,000,000.0000`.
- Special formatting for `Date` objects.
- Unit tests.