### PR TITLE
Update widget values when the default changes in a script

### DIFF
--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -115,6 +115,8 @@ class RadioMixin:
             )
 
         def serialize_radio(v):
+            if len(options) == 0:
+                return 0
             return index_(options, v)
 
         current_value, set_frontend_value = register_widget(

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -110,6 +110,8 @@ class SelectboxMixin:
             )
 
         def serialize_select_box(v):
+            if len(options) == 0:
+                return 0
             return index_(options, v)
 
         current_value, set_frontend_value = register_widget(

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -203,6 +203,14 @@ class WStates(MutableMapping[str, Any]):
         callback(*args, **kwargs)
 
 
+INTERNAL_STATE_ATTRS = [
+    "_initial_widget_values",
+    "_new_session_state",
+    "_new_widget_state",
+    "_old_state",
+]
+
+
 def _missing_key_error_message(key: str) -> str:
     return f'st.session_state has no key "{key}". Did you forget to initialize it?'
 
@@ -235,6 +243,7 @@ class SessionState(MutableMapping[str, Any]):
     _old_state: Dict[str, Any] = attr.Factory(dict)
     _new_session_state: Dict[str, Any] = attr.Factory(dict)
     _new_widget_state: WStates = attr.Factory(WStates)
+    _initial_widget_values: Dict[str, Any] = attr.Factory(dict)
 
     # is it possible for a value to get through this without being deserialized?
     def compact_state(self) -> None:
@@ -297,7 +306,7 @@ class SessionState(MutableMapping[str, Any]):
         self._new_session_state[key] = value
 
     def __delitem__(self, key: str) -> None:
-        if key in ["_new_session_state", "_new_widget_state", "_old_state"]:
+        if key in INTERNAL_STATE_ATTRS:
             raise KeyError(f"The key {key} is reserved.")
 
         if not (
@@ -323,9 +332,9 @@ class SessionState(MutableMapping[str, Any]):
             raise AttributeError(_missing_attr_error_message(key))
 
     def __setattr__(self, key: str, value: Any) -> None:
-        # Setting the _old_state and _new_state attributes must be done using
-        # the base method to avoid recursion.
-        if key in ["_new_session_state", "_new_widget_state", "_old_state"]:
+        # Setting internal attributes must be done using the base method to
+        # avoid recursion.
+        if key in INTERNAL_STATE_ATTRS:
             super().__setattr__(key, value)
         else:
             self[key] = value
@@ -374,11 +383,23 @@ class SessionState(MutableMapping[str, Any]):
         widget_id = widget_metadata.id
         self._new_widget_state.widget_metadata[widget_id] = widget_metadata
 
-    def maybe_set_state_value(self, widget_id: str) -> None:
+    def maybe_set_state_value(self, widget_id: str) -> bool:
         widget_metadata = self._new_widget_state.widget_metadata[widget_id]
+        deserializer = widget_metadata.deserializer
+        initial_value = deserializer(None)
+
         if widget_id not in self:
-            deserializer = widget_metadata.deserializer
-            self._old_state[widget_id] = deserializer(None)
+            self._old_state[widget_id] = initial_value
+            self._initial_widget_values[widget_id] = initial_value
+        elif (
+            widget_id in self._initial_widget_values
+            and initial_value != self._initial_widget_values[widget_id]
+        ):
+            self._new_widget_state.set_from_value(widget_id, initial_value)
+            self._initial_widget_values[widget_id] = initial_value
+            return True
+
+        return False
 
     def get_value_for_registration(self, widget_id: str) -> Any:
         try:

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -161,10 +161,10 @@ def register_widget(
         callback_kwargs=kwargs,
     )
     session_state.set_metadata(metadata)
-    session_state.maybe_set_state_value(widget_id)
+    value_changed = session_state.maybe_set_state_value(widget_id)
 
     val = session_state.get_value_for_registration(widget_id)
-    set_val_in_frontend = session_state.is_new_state_value(widget_id)
+    set_val_in_frontend = value_changed or session_state.is_new_state_value(widget_id)
 
     return (val, set_val_in_frontend)
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -452,6 +452,32 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state._new_widget_state["foo"] = "bar"
         assert not self.session_state._widget_changed("foo")
 
+    def test_maybe_set_state_value(self):
+        wstates = WStates()
+        self.session_state._new_widget_state = wstates
+
+        wstates.set_widget_metadata(
+            WidgetMetadata(
+                id="widget_id_1",
+                deserializer=lambda _: 0,
+                serializer=identity,
+                value_type="int_value",
+            )
+        )
+        assert self.session_state.maybe_set_state_value("widget_id_1") == False
+        assert self.session_state["widget_id_1"] == 0
+
+        wstates.set_widget_metadata(
+            WidgetMetadata(
+                id="widget_id_1",
+                deserializer=lambda _: 1,
+                serializer=identity,
+                value_type="int_value",
+            )
+        )
+        assert self.session_state.maybe_set_state_value("widget_id_1") == True
+        assert self.session_state["widget_id_1"] == 1
+
 
 @patch(
     "streamlit.state.session_state.get_session_state",


### PR DESCRIPTION
@jrieke found a bug where updating the initial value of a keyed widget would not be reflected on script rerun.
This was happening because keyed widgets have their values stored in session state, and since the key is stable
(as opposed to the case where it's auto-generated, where updating the widget default value changes the key), the
old value stored in session state would be used.

This PR fixes this issue by explicitly checking for the case that the default has changed when registering a widget. 