### PR TITLE
Fix the empty date_input  crush bug. Add isEmpty to state to handle empty inputs

### DIFF
--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -150,7 +150,7 @@ describe("st.date_input", () => {
     );
   });
 
-  it("reset to default value if calendar closed empty", () => {
+  it("reset to default single value if calendar closed empty", () => {
     // open date picker
     cy.get(".stDateInput")
       .first()
@@ -172,6 +172,7 @@ describe("st.date_input", () => {
         "Date Input Changed: False"
     );
 
+    // Remove input
     cy.get(".stDateInput")
       .first()
       .click()
@@ -180,7 +181,67 @@ describe("st.date_input", () => {
     //Click outside of date input
     cy.contains("Single date").click();
 
-    // First value reset to 1970-01-01
+    // Value should be reset to 1970-01-01
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
+        "Value 6: 1970-01-01" +
+        "Date Input Changed: False"
+    );
+  });
+
+  it("reset to default range value if calendar closed empty", () => {
+    // open date picker
+    cy.get(".stDateInput")
+      .eq(4)
+      .click();
+
+    // select start date '2019/07/10'
+    cy.get(
+      '[data-baseweb="calendar"] [aria-label^="Choose Wednesday, July 10th 2019."]'
+    ).click();
+
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 10),)" +
+        "Value 6: 1970-01-01" +
+        "Date Input Changed: False"
+    );
+
+    // select end date '2019/07/10'
+    cy.get(
+      '[data-baseweb="calendar"] [aria-label^="Choose Friday, July 12th 2019."]'
+    ).click();
+
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 10), datetime.date(2019, 7, 12))" +
+        "Value 6: 1970-01-01" +
+        "Date Input Changed: False"
+    );
+
+    // Remove input
+    cy.get(".stDateInput")
+      .eq(4)
+      .click()
+      .type("{del}{selectall}{backspace}");
+
+    //Click outside of date input
+    cy.contains("Range, two dates").click();
+
+    // Value should be reset to default (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))
     cy.get(".stMarkdown").should(
       "have.text",
       "Value 1: 1970-01-01" +

--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -74,7 +74,7 @@ describe("st.date_input", () => {
       .eq(3)
       .click();
 
-    // select end date '2019/07/08'
+    // select end date '2019/07/10'
     cy.get(
       '[data-baseweb="calendar"] [aria-label^="Choose Wednesday, July 10th 2019."]'
     ).click();
@@ -113,7 +113,7 @@ describe("st.date_input", () => {
         "Date Input Changed: False"
     );
 
-    // select end date '2019/07/10'
+    // select end date '2019/07/12'
     cy.get(
       '[data-baseweb="calendar"] [aria-label^="Choose Friday, July 12th 2019."]'
     ).click();
@@ -172,16 +172,16 @@ describe("st.date_input", () => {
         "Date Input Changed: False"
     );
 
-    // Remove input
+    // remove input
     cy.get(".stDateInput")
       .first()
       .click()
       .type("{del}{selectall}{backspace}");
 
-    //Click outside of date input
+    // click outside of date input
     cy.contains("Single date").click();
 
-    // Value should be reset to 1970-01-01
+    // value should be reset to 1970-01-01
     cy.get(".stMarkdown").should(
       "have.text",
       "Value 1: 1970-01-01" +
@@ -216,7 +216,7 @@ describe("st.date_input", () => {
         "Date Input Changed: False"
     );
 
-    // select end date '2019/07/10'
+    // select end date '2019/07/12'
     cy.get(
       '[data-baseweb="calendar"] [aria-label^="Choose Friday, July 12th 2019."]'
     ).click();
@@ -232,16 +232,16 @@ describe("st.date_input", () => {
         "Date Input Changed: False"
     );
 
-    // Remove input
+    // remove input
     cy.get(".stDateInput")
       .eq(4)
       .click()
       .type("{del}{selectall}{backspace}");
 
-    //Click outside of date input
+    // click outside of date input
     cy.contains("Range, two dates").click();
 
-    // Value should be reset to default (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))
+    // value should be reset to default (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))
     cy.get(".stMarkdown").should(
       "have.text",
       "Value 1: 1970-01-01" +

--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -149,4 +149,47 @@ describe("st.date_input", () => {
       "Value 6: 1970-01-02" + "Date Input Changed: True"
     );
   });
+
+  it("reset to default value if calendar closed empty", () => {
+    // open date picker
+    cy.get(".stDateInput")
+      .first()
+      .click();
+
+    // select '1970/01/02'
+    cy.get(
+      '[data-baseweb="calendar"] [aria-label^="Choose Friday, January 2nd 1970."]'
+    ).click();
+
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-02" +
+        "Value 2: 2019-07-06" +
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
+        "Value 6: 1970-01-01" +
+        "Date Input Changed: False"
+    );
+
+    cy.get(".stDateInput")
+      .first()
+      .click()
+      .type("{del}{selectall}{backspace}");
+
+    //Click outside of date input
+    cy.contains("Single date").click();
+
+    // First value reset to 1970-01-01
+    cy.get(".stMarkdown").should(
+      "have.text",
+      "Value 1: 1970-01-01" +
+        "Value 2: 2019-07-06" +
+        "Value 3: ()" +
+        "Value 4: (datetime.date(2019, 7, 6),)" +
+        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
+        "Value 6: 1970-01-01" +
+        "Date Input Changed: False"
+    );
+  });
 });

--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -194,7 +194,7 @@ describe("st.date_input", () => {
     );
   });
 
-  it("reset to default range value if calendar closed empty", () => {
+  it("not reset to default range value if calendar closed empty", () => {
     // open date picker
     cy.get(".stDateInput")
       .eq(4)
@@ -241,14 +241,14 @@ describe("st.date_input", () => {
     // click outside of date input
     cy.contains("Range, two dates").click();
 
-    // value should be reset to default (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))
+    // value should _not_ be reset to default (datetime.date(2019, 7, 6), and should have empty range value ()
     cy.get(".stMarkdown").should(
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
         "Value 3: ()" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
-        "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
+        "Value 5: ()" +
         "Value 6: 1970-01-01" +
         "Date Input Changed: False"
     );

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -128,7 +128,7 @@ describe("DateInput widget", () => {
     )
   })
 
-  it("reset the widget value to default when it clsed empty", () => {
+  it("reset it's value to default when it closed with empty input", () => {
     const props = getProps()
     jest.spyOn(props.widgetMgr, "setStringArrayValue")
 

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -128,6 +128,35 @@ describe("DateInput widget", () => {
     )
   })
 
+  it("reset the widget value to default when it clsed empty", () => {
+    const props = getProps()
+    jest.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    const wrapper = mount(<DateInput {...props} />)
+    const newDate = new Date("2020/02/06")
+
+    // @ts-ignore
+    wrapper.find(UIDatePicker).prop("onChange")({
+      date: newDate,
+    })
+    wrapper.update()
+
+    expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([newDate])
+
+    // @ts-ignore
+    wrapper.find(UIDatePicker).prop("onChange")({
+      // @ts-ignore
+      date: null,
+    })
+
+    // @ts-ignore
+    wrapper.find(UIDatePicker).prop("onClose")()
+    wrapper.update()
+    expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([
+      new Date("1970/1/1"),
+    ])
+  })
+
   it("has a minDate", () => {
     const props = getProps()
     const wrapper = mount(<DateInput {...props} />)

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -142,13 +142,11 @@ describe("DateInput widget", () => {
     wrapper.update()
 
     expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([newDate])
-
     // @ts-ignore
     wrapper.find(UIDatePicker).prop("onChange")({
       // @ts-ignore
       date: null,
     })
-
     // @ts-ignore
     wrapper.find(UIDatePicker).prop("onClose")()
     wrapper.update()

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -145,7 +145,7 @@ class DateInput extends React.PureComponent<Props, State> {
     this.setState(
       {
         values: Array.isArray(date) ? date : [date],
-        isEmpty: !date || (Array.isArray(date) && !date.length),
+        isEmpty: !date,
       },
       () => {
         if (!this.state.isEmpty) this.commitWidgetValue({ fromUi: true })

--- a/frontend/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.tsx
@@ -49,6 +49,7 @@ interface State {
    * Boolean to toggle between single-date picker and range date picker.
    */
   isRange: boolean
+  isEmpty: boolean
 }
 
 // Date format for communication (protobuf) support
@@ -70,6 +71,7 @@ class DateInput extends React.PureComponent<Props, State> {
   public state: State = {
     values: this.initialValue,
     isRange: this.props.element.isRange,
+    isEmpty: false,
   }
 
   get initialValue(): Date[] {
@@ -140,9 +142,27 @@ class DateInput extends React.PureComponent<Props, State> {
   }
 
   private handleChange = ({ date }: { date: Date | Date[] }): void => {
-    this.setState({ values: Array.isArray(date) ? date : [date] }, () =>
-      this.commitWidgetValue({ fromUi: true })
+    this.setState(
+      {
+        values: Array.isArray(date) ? date : [date],
+        isEmpty: !date || (Array.isArray(date) && !date.length),
+      },
+      () => {
+        if (!this.state.isEmpty) this.commitWidgetValue({ fromUi: true })
+      }
     )
+  }
+
+  private handleClose = (): void => {
+    const { isEmpty } = this.state
+    if (isEmpty) {
+      this.setState(
+        { values: stringsToDates(this.props.element.default) },
+        () => {
+          this.commitWidgetValue({ fromUi: true })
+        }
+      )
+    }
   }
 
   private getMaxDate = (): Date | undefined => {
@@ -187,6 +207,7 @@ class DateInput extends React.PureComponent<Props, State> {
           formatString="yyyy/MM/dd"
           disabled={disabled}
           onChange={this.handleChange}
+          onClose={this.handleClose}
           overrides={{
             Popover: {
               props: {


### PR DESCRIPTION
Issue: #3194 

Description: The problem happened when the "Invalid date" string sent to backend. 
These changes prevent sending invalid or empty date(s) to python code. Instead, DateInput value reset to default value `onClose` event when input field is empty. To handle that additional `isEmpty` field added to the DateInput component. 

In this case, I was "inspired" by the handling of an empty value in the NumberInput widget.
Another solution could be to simply reset the value in the `handleChange` function, but it would also lead to ugly behavior like #3419 .

The important note is that now in the case of range Input it would be not possible to have an empty tuple as a value for the python widget unless the widget default is not specified as an empty list or tuple

CC @asaini here, since the last paragraph restricts a previously possible empty range value logic. 
The more I think about it, the more it seems to me that it is a good idea to keep for users the ability to delete completely values in case of a range value. (but loose logic consistency with how it works in case of single value)
Since I assume that range date_input widget is used to filter the rows in dataframe/csv document. And empty values in this case will mean not filtering the document at all.