### PR TITLE
[Arrow] Fix add rows on ArrowVegaLiteChart

### DIFF
--- a/frontend/src/lib/Quiver.ts
+++ b/frontend/src/lib/Quiver.ts
@@ -19,7 +19,7 @@
 /* eslint-disable no-underscore-dangle */
 
 import { Table, Vector } from "apache-arrow"
-import { range, unzip, cloneDeep } from "lodash"
+import { cloneDeep, range, unzip } from "lodash"
 import moment from "moment"
 
 import { IArrow, Styler as StylerProto } from "src/autogen/proto"

--- a/frontend/src/lib/ReportNode.test.ts
+++ b/frontend/src/lib/ReportNode.test.ts
@@ -294,7 +294,7 @@ describe("ElementNode.arrowAddRows", () => {
   } as ArrowNamedDataSet
 
   describe("arrowTable", () => {
-    test("addRows is called with an unnamed dataset", () => {
+    test("addRows can be called with an unnamed dataset", () => {
       const node = arrowTable()
       const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
       const q = newNode.quiverElement
@@ -313,7 +313,7 @@ describe("ElementNode.arrowAddRows", () => {
       })
     })
 
-    test("addRows is called with a named dataset", () => {
+    test("addRows throws an error when called with a named dataset", () => {
       const node = arrowTable()
       expect(() =>
         node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
@@ -324,7 +324,7 @@ describe("ElementNode.arrowAddRows", () => {
   })
 
   describe("arrowDataFrame", () => {
-    test("addRows is called with an unnamed dataset", () => {
+    test("addRows can be called with an unnamed dataset", () => {
       const node = arrowDataFrame()
       const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
       const q = newNode.quiverElement
@@ -343,7 +343,7 @@ describe("ElementNode.arrowAddRows", () => {
       })
     })
 
-    test("addRows is called with a named dataset", () => {
+    test("addRows throws an error when called with a named dataset", () => {
       const node = arrowDataFrame()
       expect(() =>
         node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)

--- a/frontend/src/lib/ReportNode.test.ts
+++ b/frontend/src/lib/ReportNode.test.ts
@@ -358,7 +358,7 @@ describe("ElementNode.arrowAddRows", () => {
       datasets?: ArrowNamedDataSet[],
       data?: Uint8Array
     ): IArrowVegaLiteChart => ({
-      datasets: datasets ? datasets : [],
+      datasets: datasets || [],
       data: data ? { data } : null,
       spec: JSON.stringify({
         mark: "circle",

--- a/frontend/src/lib/ReportNode.test.ts
+++ b/frontend/src/lib/ReportNode.test.ts
@@ -16,10 +16,12 @@
  */
 
 import {
+  ArrowNamedDataSet,
   Block as BlockProto,
   Delta as DeltaProto,
   Element,
   ForwardMsgMetadata,
+  IArrowVegaLiteChart,
   NamedDataSet,
 } from "src/autogen/proto"
 import mockDataFrameData from "src/components/elements/DataFrame/mock"
@@ -27,6 +29,7 @@ import { Writer } from "protobufjs"
 import { addRows } from "./dataFrameProto"
 import { toImmutableProto } from "./immutableProto"
 import { BlockNode, ElementNode, ReportNode, ReportRoot } from "./ReportNode"
+import { UNICODE } from "./mocks/arrow"
 
 const NO_REPORT_ID = "NO_REPORT_ID"
 
@@ -98,6 +101,457 @@ describe("ElementNode.immutableElement", () => {
     // accessing `immutableElement` twice should return the same instance.
     const node = text("ahoy!")
     expect(node.immutableElement).toStrictEqual(node.immutableElement)
+  })
+})
+
+describe("ElementNode.quiverElement", () => {
+  it("returns a quiverElement (arrowTable)", () => {
+    const node = arrowTable()
+    const q = node.quiverElement
+
+    expect(q.index).toEqual([["i1"], ["i2"]])
+    expect(q.columns).toEqual([["c1", "c2"]])
+    expect(q.data).toEqual([
+      ["foo", "1"],
+      ["bar", "2"],
+    ])
+    expect(q.types).toEqual({
+      index: [{ name: "unicode", meta: null }],
+      data: ["unicode", "unicode"],
+    })
+  })
+
+  it("returns a quiverElement (arrowDataFrame)", () => {
+    const node = arrowDataFrame()
+    const q = node.quiverElement
+
+    expect(q.index).toEqual([["i1"], ["i2"]])
+    expect(q.columns).toEqual([["c1", "c2"]])
+    expect(q.data).toEqual([
+      ["foo", "1"],
+      ["bar", "2"],
+    ])
+    expect(q.types).toEqual({
+      index: [{ name: "unicode", meta: null }],
+      data: ["unicode", "unicode"],
+    })
+  })
+
+  it("does not recompute its value (arrowTable)", () => {
+    // accessing `quiverElement` twice should return the same instance.
+    const node = arrowTable()
+    expect(node.quiverElement).toStrictEqual(node.quiverElement)
+  })
+
+  it("does not recompute its value (arrowDataframe)", () => {
+    // accessing `quiverElement` twice should return the same instance.
+    const node = arrowDataFrame()
+    expect(node.quiverElement).toStrictEqual(node.quiverElement)
+  })
+
+  it("throws an error for other element types", () => {
+    const node = text("foo")
+    expect(() => node.quiverElement).toThrow(
+      "elementType 'text' is not a valid Quiver element!"
+    )
+  })
+})
+
+describe("ElementNode.vegaLiteChartElement", () => {
+  it("returns a vegaLiteChartElement (data)", () => {
+    const MOCK_VEGA_LITE_CHART = {
+      spec: JSON.stringify({
+        mark: "circle",
+        encoding: {
+          x: { field: "a", type: "quantitative" },
+          y: { field: "b", type: "quantitative" },
+          size: { field: "c", type: "quantitative" },
+          color: { field: "c", type: "quantitative" },
+        },
+      }),
+      data: { data: UNICODE },
+      datasets: [],
+      useContainerWidth: true,
+    }
+    const node = arrowVegaLiteChart(MOCK_VEGA_LITE_CHART)
+    const element = node.vegaLiteChartElement
+
+    // spec
+    expect(element.spec).toEqual(MOCK_VEGA_LITE_CHART.spec)
+
+    // data
+    expect(element.data!.index).toEqual([["i1"], ["i2"]])
+    expect(element.data!.columns).toEqual([["c1", "c2"]])
+    expect(element.data!.data).toEqual([
+      ["foo", "1"],
+      ["bar", "2"],
+    ])
+    expect(element.data!.types).toEqual({
+      index: [{ name: "unicode", meta: null }],
+      data: ["unicode", "unicode"],
+    })
+
+    // datasets
+    expect(element.datasets.length).toEqual(0)
+
+    // use container width
+    expect(element.useContainerWidth).toEqual(
+      MOCK_VEGA_LITE_CHART.useContainerWidth
+    )
+  })
+
+  it("returns a vegaLiteChartElement (datasets)", () => {
+    const MOCK_VEGA_LITE_CHART = {
+      spec: JSON.stringify({
+        mark: "circle",
+        encoding: {
+          x: { field: "a", type: "quantitative" },
+          y: { field: "b", type: "quantitative" },
+          size: { field: "c", type: "quantitative" },
+          color: { field: "c", type: "quantitative" },
+        },
+      }),
+      data: null,
+      datasets: [{ hasName: true, name: "foo", data: { data: UNICODE } }],
+      useContainerWidth: true,
+    }
+    const node = arrowVegaLiteChart(MOCK_VEGA_LITE_CHART)
+    const element = node.vegaLiteChartElement
+
+    // spec
+    expect(element.spec).toEqual(MOCK_VEGA_LITE_CHART.spec)
+
+    // data
+    expect(element.data).toEqual(null)
+
+    // datasets
+    expect(element.datasets[0].hasName).toEqual(
+      MOCK_VEGA_LITE_CHART.datasets[0].hasName
+    )
+    expect(element.datasets[0].name).toEqual(
+      MOCK_VEGA_LITE_CHART.datasets[0].name
+    )
+    expect(element.datasets[0].data.index).toEqual([["i1"], ["i2"]])
+    expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
+    expect(element.datasets[0].data.data).toEqual([
+      ["foo", "1"],
+      ["bar", "2"],
+    ])
+    expect(element.datasets[0].data.types).toEqual({
+      index: [{ name: "unicode", meta: null }],
+      data: ["unicode", "unicode"],
+    })
+
+    // use container width
+    expect(element.useContainerWidth).toEqual(
+      MOCK_VEGA_LITE_CHART.useContainerWidth
+    )
+  })
+
+  it("does not recompute its value", () => {
+    const MOCK_VEGA_LITE_CHART = {
+      spec: JSON.stringify({
+        mark: "circle",
+        encoding: {
+          x: { field: "a", type: "quantitative" },
+          y: { field: "b", type: "quantitative" },
+          size: { field: "c", type: "quantitative" },
+          color: { field: "c", type: "quantitative" },
+        },
+      }),
+      data: { data: UNICODE },
+      datasets: [],
+      useContainerWidth: true,
+    }
+    // accessing `vegaLiteChartElement` twice should return the same instance.
+    const node = arrowVegaLiteChart(MOCK_VEGA_LITE_CHART)
+    expect(node.vegaLiteChartElement).toStrictEqual(node.vegaLiteChartElement)
+  })
+
+  it("throws an error for other element types", () => {
+    const node = text("foo")
+    expect(() => node.vegaLiteChartElement).toThrow(
+      "elementType 'text' is not a valid VegaLiteChartElement!"
+    )
+  })
+})
+
+describe("ElementNode.arrowAddRows", () => {
+  const MOCK_UNNAMED_DATASET = {
+    hasName: false,
+    name: "",
+    data: { data: UNICODE },
+  } as ArrowNamedDataSet
+  const MOCK_NAMED_DATASET = {
+    hasName: true,
+    name: "foo",
+    data: { data: UNICODE },
+  } as ArrowNamedDataSet
+  const MOCK_ANOTHER_NAMED_DATASET = {
+    hasName: true,
+    name: "bar",
+    data: { data: UNICODE },
+  } as ArrowNamedDataSet
+
+  describe("arrowTable", () => {
+    test("addRows is called with an unnamed dataset", () => {
+      const node = arrowTable()
+      const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
+      const q = newNode.quiverElement
+
+      expect(q.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
+      expect(q.columns).toEqual([["c1", "c2"]])
+      expect(q.data).toEqual([
+        ["foo", "1"],
+        ["bar", "2"],
+        ["foo", "1"],
+        ["bar", "2"],
+      ])
+      expect(q.types).toEqual({
+        index: [{ name: "unicode", meta: null }],
+        data: ["unicode", "unicode"],
+      })
+    })
+
+    test("addRows is called with a named dataset", () => {
+      const node = arrowTable()
+      expect(() =>
+        node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+      ).toThrow(
+        "Add rows cannot be used with a named dataset for this element."
+      )
+    })
+  })
+
+  describe("arrowDataFrame", () => {
+    test("addRows is called with an unnamed dataset", () => {
+      const node = arrowDataFrame()
+      const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
+      const q = newNode.quiverElement
+
+      expect(q.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
+      expect(q.columns).toEqual([["c1", "c2"]])
+      expect(q.data).toEqual([
+        ["foo", "1"],
+        ["bar", "2"],
+        ["foo", "1"],
+        ["bar", "2"],
+      ])
+      expect(q.types).toEqual({
+        index: [{ name: "unicode", meta: null }],
+        data: ["unicode", "unicode"],
+      })
+    })
+
+    test("addRows is called with a named dataset", () => {
+      const node = arrowDataFrame()
+      expect(() =>
+        node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+      ).toThrow(
+        "Add rows cannot be used with a named dataset for this element."
+      )
+    })
+  })
+
+  describe("arrowVegaLiteChart", () => {
+    const getVegaLiteChart = (
+      datasets?: ArrowNamedDataSet[],
+      data?: Uint8Array
+    ): IArrowVegaLiteChart => ({
+      datasets: datasets ? datasets : [],
+      data: data ? { data } : null,
+      spec: JSON.stringify({
+        mark: "circle",
+        encoding: {
+          x: { field: "a", type: "quantitative" },
+          y: { field: "b", type: "quantitative" },
+          size: { field: "c", type: "quantitative" },
+          color: { field: "c", type: "quantitative" },
+        },
+      }),
+      useContainerWidth: true,
+    })
+
+    describe("addRows is called with a named dataset", () => {
+      test("element has one dataset -> append new rows to that dataset", () => {
+        const node = arrowVegaLiteChart(
+          getVegaLiteChart([MOCK_ANOTHER_NAMED_DATASET])
+        )
+        const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.datasets[0].data.index).toEqual([
+          ["i1"],
+          ["i2"],
+          ["i1"],
+          ["i2"],
+        ])
+        expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
+        expect(element.datasets[0].data.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.datasets[0].data.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+
+      test("element has a dataset with the given name -> append new rows to that dataset", () => {
+        const node = arrowVegaLiteChart(
+          getVegaLiteChart([MOCK_NAMED_DATASET, MOCK_ANOTHER_NAMED_DATASET])
+        )
+        const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.datasets[0].data.index).toEqual([
+          ["i1"],
+          ["i2"],
+          ["i1"],
+          ["i2"],
+        ])
+        expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
+        expect(element.datasets[0].data.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.datasets[0].data.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+
+      test("element doesn't have a matched dataset, but has data -> append new rows to data", () => {
+        const node = arrowVegaLiteChart(getVegaLiteChart(undefined, UNICODE))
+        const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.data!.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
+        expect(element.data!.columns).toEqual([["c1", "c2"]])
+        expect(element.data!.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.data!.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+
+      test("element doesn't have a matched dataset or data -> use new rows as data", () => {
+        const node = arrowVegaLiteChart(
+          getVegaLiteChart([
+            MOCK_ANOTHER_NAMED_DATASET,
+            MOCK_ANOTHER_NAMED_DATASET,
+          ])
+        )
+        const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.data!.index).toEqual([["i1"], ["i2"]])
+        expect(element.data!.columns).toEqual([["c1", "c2"]])
+        expect(element.data!.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.data!.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+
+      test("element doesn't have any datasets or data -> use new rows as data", () => {
+        const node = arrowVegaLiteChart(getVegaLiteChart())
+        const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.data!.index).toEqual([["i1"], ["i2"]])
+        expect(element.data!.columns).toEqual([["c1", "c2"]])
+        expect(element.data!.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.data!.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+    })
+
+    describe("addRows is called with an unnamed dataset", () => {
+      test("element has one dataset -> append new rows to that dataset", () => {
+        const node = arrowVegaLiteChart(getVegaLiteChart([MOCK_NAMED_DATASET]))
+        const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.datasets[0].data.index).toEqual([
+          ["i1"],
+          ["i2"],
+          ["i1"],
+          ["i2"],
+        ])
+        expect(element.datasets[0].data.columns).toEqual([["c1", "c2"]])
+        expect(element.datasets[0].data.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.datasets[0].data.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+
+      test("element has data -> append new rows to data", () => {
+        const node = arrowVegaLiteChart(getVegaLiteChart(undefined, UNICODE))
+        const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.data!.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
+        expect(element.data!.columns).toEqual([["c1", "c2"]])
+        expect(element.data!.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.data!.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+
+      test("element doesn't have any datasets or data -> use new rows as data", () => {
+        const node = arrowVegaLiteChart(getVegaLiteChart())
+        const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
+        const element = newNode.vegaLiteChartElement
+
+        expect(element.data!.index).toEqual([["i1"], ["i2"]])
+        expect(element.data!.columns).toEqual([["c1", "c2"]])
+        expect(element.data!.data).toEqual([
+          ["foo", "1"],
+          ["bar", "2"],
+        ])
+        expect(element.data!.types).toEqual({
+          index: [{ name: "unicode", meta: null }],
+          data: ["unicode", "unicode"],
+        })
+      })
+    })
+  })
+
+  it("throws an error for other element types", () => {
+    const node = text("foo")
+    expect(() =>
+      node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
+    ).toThrow("elementType 'text' is not a valid arrowAddRows target!")
   })
 })
 
@@ -265,6 +719,27 @@ function block(
   reportId = NO_REPORT_ID
 ): BlockNode {
   return new BlockNode(children, makeProto(BlockProto, {}), reportId)
+}
+
+/** Create an arrowTable element node with the given properties. */
+function arrowTable(reportId = NO_REPORT_ID): ElementNode {
+  const element = makeProto(Element, { arrowTable: { data: UNICODE } })
+  return new ElementNode(element, ForwardMsgMetadata.create(), reportId)
+}
+
+/** Create an arrowDataFrame element node with the given properties. */
+function arrowDataFrame(reportId = NO_REPORT_ID): ElementNode {
+  const element = makeProto(Element, { arrowDataFrame: { data: UNICODE } })
+  return new ElementNode(element, ForwardMsgMetadata.create(), reportId)
+}
+
+/** Create an arrowVegaLiteChart element node with the given properties. */
+function arrowVegaLiteChart(
+  data: IArrowVegaLiteChart,
+  reportId = NO_REPORT_ID
+): ElementNode {
+  const element = makeProto(Element, { arrowVegaLiteChart: data })
+  return new ElementNode(element, ForwardMsgMetadata.create(), reportId)
 }
 
 /** Create a ForwardMsgMetadata with the given container and path */

--- a/frontend/src/lib/ReportNode.test.ts
+++ b/frontend/src/lib/ReportNode.test.ts
@@ -180,13 +180,13 @@ describe("ElementNode.vegaLiteChartElement", () => {
     expect(element.spec).toEqual(MOCK_VEGA_LITE_CHART.spec)
 
     // data
-    expect(element.data!.index).toEqual([["i1"], ["i2"]])
-    expect(element.data!.columns).toEqual([["c1", "c2"]])
-    expect(element.data!.data).toEqual([
+    expect(element.data?.index).toEqual([["i1"], ["i2"]])
+    expect(element.data?.columns).toEqual([["c1", "c2"]])
+    expect(element.data?.data).toEqual([
       ["foo", "1"],
       ["bar", "2"],
     ])
-    expect(element.data!.types).toEqual({
+    expect(element.data?.types).toEqual({
       index: [{ name: "unicode", meta: null }],
       data: ["unicode", "unicode"],
     })
@@ -430,15 +430,15 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data!.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
-        expect(element.data!.columns).toEqual([["c1", "c2"]])
-        expect(element.data!.data).toEqual([
+        expect(element.data?.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
+        expect(element.data?.columns).toEqual([["c1", "c2"]])
+        expect(element.data?.data).toEqual([
           ["foo", "1"],
           ["bar", "2"],
           ["foo", "1"],
           ["bar", "2"],
         ])
-        expect(element.data!.types).toEqual({
+        expect(element.data?.types).toEqual({
           index: [{ name: "unicode", meta: null }],
           data: ["unicode", "unicode"],
         })
@@ -454,13 +454,13 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data!.index).toEqual([["i1"], ["i2"]])
-        expect(element.data!.columns).toEqual([["c1", "c2"]])
-        expect(element.data!.data).toEqual([
+        expect(element.data?.index).toEqual([["i1"], ["i2"]])
+        expect(element.data?.columns).toEqual([["c1", "c2"]])
+        expect(element.data?.data).toEqual([
           ["foo", "1"],
           ["bar", "2"],
         ])
-        expect(element.data!.types).toEqual({
+        expect(element.data?.types).toEqual({
           index: [{ name: "unicode", meta: null }],
           data: ["unicode", "unicode"],
         })
@@ -471,13 +471,13 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_NAMED_DATASET, NO_REPORT_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data!.index).toEqual([["i1"], ["i2"]])
-        expect(element.data!.columns).toEqual([["c1", "c2"]])
-        expect(element.data!.data).toEqual([
+        expect(element.data?.index).toEqual([["i1"], ["i2"]])
+        expect(element.data?.columns).toEqual([["c1", "c2"]])
+        expect(element.data?.data).toEqual([
           ["foo", "1"],
           ["bar", "2"],
         ])
-        expect(element.data!.types).toEqual({
+        expect(element.data?.types).toEqual({
           index: [{ name: "unicode", meta: null }],
           data: ["unicode", "unicode"],
         })
@@ -514,15 +514,15 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data!.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
-        expect(element.data!.columns).toEqual([["c1", "c2"]])
-        expect(element.data!.data).toEqual([
+        expect(element.data?.index).toEqual([["i1"], ["i2"], ["i1"], ["i2"]])
+        expect(element.data?.columns).toEqual([["c1", "c2"]])
+        expect(element.data?.data).toEqual([
           ["foo", "1"],
           ["bar", "2"],
           ["foo", "1"],
           ["bar", "2"],
         ])
-        expect(element.data!.types).toEqual({
+        expect(element.data?.types).toEqual({
           index: [{ name: "unicode", meta: null }],
           data: ["unicode", "unicode"],
         })
@@ -533,13 +533,13 @@ describe("ElementNode.arrowAddRows", () => {
         const newNode = node.arrowAddRows(MOCK_UNNAMED_DATASET, NO_REPORT_ID)
         const element = newNode.vegaLiteChartElement
 
-        expect(element.data!.index).toEqual([["i1"], ["i2"]])
-        expect(element.data!.columns).toEqual([["c1", "c2"]])
-        expect(element.data!.data).toEqual([
+        expect(element.data?.index).toEqual([["i1"], ["i2"]])
+        expect(element.data?.columns).toEqual([["c1", "c2"]])
+        expect(element.data?.data).toEqual([
           ["foo", "1"],
           ["bar", "2"],
         ])
-        expect(element.data!.types).toEqual({
+        expect(element.data?.types).toEqual({
           index: [{ name: "unicode", meta: null }],
           data: ["unicode", "unicode"],
         })

--- a/frontend/src/lib/ReportNode.ts
+++ b/frontend/src/lib/ReportNode.ts
@@ -291,7 +291,7 @@ export class ElementNode implements ReportNode {
     const newQuiver = new Quiver(namedDataSet.data as IArrow)
     element.addRows(newQuiver)
 
-    // Clone deep is needed to update the React component.
+    // Cloning is needed here to force React component to update.
     return cloneDeep(element)
   }
 
@@ -317,7 +317,7 @@ export class ElementNode implements ReportNode {
       element.data = newDataSetQuiver
     }
 
-    // Clone deep is needed to update the React component.
+    // Cloning is needed here to force React component to update.
     return cloneDeep(element)
   }
 }

--- a/frontend/src/lib/ReportNode.ts
+++ b/frontend/src/lib/ReportNode.ts
@@ -16,6 +16,7 @@
  */
 
 import { Map as ImmutableMap } from "immutable"
+import { cloneDeep } from "lodash"
 import Protobuf, {
   Arrow as ArrowProto,
   ArrowNamedDataSet,
@@ -281,10 +282,17 @@ export class ElementNode implements ReportNode {
     element: Quiver,
     namedDataSet: ArrowNamedDataSet
   ): Quiver {
+    if (namedDataSet.hasName) {
+      throw new Error(
+        "Add rows cannot be used with a named dataset for this element."
+      )
+    }
+
     const newQuiver = new Quiver(namedDataSet.data as IArrow)
     element.addRows(newQuiver)
 
-    return element
+    // Clone deep is needed to update the React component.
+    return cloneDeep(element)
   }
 
   private static vegaLiteChartAddRowsHelper(
@@ -293,63 +301,43 @@ export class ElementNode implements ReportNode {
   ): VegaLiteChartElement {
     const newDataSetName = namedDataSet.hasName ? namedDataSet.name : null
     const newDataSetQuiver = new Quiver(namedDataSet.data as IArrow)
+    const existingDataSet = getNamedDataSet(element.datasets, newDataSetName)
 
-    const existingDataFrame = element.data
-    const [existingDataSetIndex, existingDataSet] = getNamedDataSet(
-      element.datasets,
-      newDataSetName
-    )
-
-    // 1. add_rows has a named dataset
-    //   a) element has a named dataset with that name -> use that one
-    //   b) element doesn't have a named dataset with that name -> put the new dataset into the element
-    //   c) element has an unnamed dataset -> use that one
-    // 2. add_rows has an unnamed dataset
-    //   a) element has an unnamed dataset -> use that one
-    //   b) element has only named datasets -> use the first named dataset
-    //   c) element has no dataset -> put the new dataset into the element
-    let dataframeToModify = existingDataSet
+    // If there is only one dataset, use that one.
+    // Otherwise, try to find a dataset with the given name.
+    // If unsuccessful, use `element.data`.
+    const dataframeToModify = existingDataSet
       ? existingDataSet.data
-      : existingDataFrame
+      : element.data
 
     if (dataframeToModify) {
       dataframeToModify.addRows(newDataSetQuiver)
     } else {
-      dataframeToModify = newDataSetQuiver
-      element.data = dataframeToModify
+      // If there is nothing to modify, just use new rows as data.
+      element.data = newDataSetQuiver
     }
 
-    if (existingDataSet) {
-      element.datasets[existingDataSetIndex].data = dataframeToModify
-    }
-
-    return element
+    // Clone deep is needed to update the React component.
+    return cloneDeep(element)
   }
 }
 
 /**
- * If there is only one NamedDataSet, return [0, NamedDataSet] with the 0th
- * NamedDataSet.
- * Otherwise, return the [index, NamedDataSet] with the NamedDataSet
- * matching the given name.
+ * If there is only one NamedDataSet, return it.
+ * If there is a NamedDataset that matches the given name, return it.
+ * Otherwise, return `undefined`.
  */
 function getNamedDataSet(
   namedDataSets: WrappedNamedDataset[],
   name: string | null
-): [number, WrappedNamedDataset | null] {
+): WrappedNamedDataset | undefined {
   if (namedDataSets.length === 1) {
-    return [0, namedDataSets[0]]
+    return namedDataSets[0]
   }
 
-  const namedDataSetEntry = namedDataSets.find(
+  return namedDataSets.find(
     (dataset: WrappedNamedDataset) => dataset.hasName && dataset.name === name
   )
-
-  if (namedDataSetEntry) {
-    return [namedDataSets.indexOf(namedDataSetEntry), namedDataSetEntry]
-  }
-
-  return [-1, null]
 }
 
 /**
@@ -558,7 +546,7 @@ export class ReportRoot {
       }
 
       case "arrowAddRows": {
-        // MetricsManager.current.incrementDeltaCounter("beta add rows")
+        MetricsManager.current.incrementDeltaCounter("arrow add rows")
         return this.arrowAddRows(
           deltaPath,
           delta.arrowAddRows as ArrowNamedDataSet,
@@ -566,8 +554,9 @@ export class ReportRoot {
         )
       }
 
-      default:
+      default: {
         throw new Error(`Unrecognized deltaType: '${delta.type}'`)
+      }
     }
   }
 


### PR DESCRIPTION

- Fix an issue where `ArrowVegaLiteChart` React component wasn't being updated after add rows, which caused an unexpected behavior.
- Fix a couple of "index out of bounds" issues in `ArrowVegaLiteChart` component.
- Additional `ReportNode` unit tests.
- Activate metrics for `arrow add rows`. (Totally unrelated, and should have been sent as a separate PR)