### PR TITLE
Remove `pyarrow` warning for Python 3.9

### DIFF
--- a/docs/troubleshooting/sanity-checks.md
+++ b/docs/troubleshooting/sanity-checks.md
@@ -10,8 +10,7 @@ guaranteeing compatibility with _at least_ the last three minor versions of Pyth
 As new versions of Python are released, we will try to be compatible with the new version as soon
 as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
 
-Streamlit currently supports versions 3.6, 3.7 and 3.8 of Python. Python 3.9 support is currently on-hold as we
-wait for [pyarrow to support Python 3.9](https://arrow.apache.org/docs/python/install.html#python-compatibility).
+Streamlit currently supports versions 3.6, 3.7, 3.8, and 3.9 of Python.
 
 ## Check #1: Is Streamlit running?
 

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -42,11 +42,7 @@ pandas = ">=0.21.0"
 pillow = ">=6.2.0"
 # protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
 protobuf = ">=3.6.0, !=3.11"
-# pyarrow does not yet support Python 3.9. Since pyarrow is only needed for
-# Custom Components, make it an extra dependency for Python <3.9.
-# We'll show an error if the user then tries to add a Custom Component.
-# See: https://discuss.streamlit.io/t/note-installation-issues-with-python-3-9-and-streamlit/6946
-pyarrow = {version = "*", markers = "python_version < '3.9'"}
+pyarrow = "*"
 pydeck = ">=0.1.dev5"
 python-dateutil = "*"
 requests = "*"

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -116,29 +116,14 @@ class CustomComponent:
             import pyarrow
             from streamlit.components.v1 import component_arrow
         except ImportError:
-            import sys
-
-            if sys.version_info >= (3, 9):
-                raise StreamlitAPIException(
-                    """To use Custom Components in Streamlit, you need to install
-PyArrow. Unfortunately, PyArrow does not yet support Python 3.9.
-
-You can either switch to Python 3.8 with an environment manager like PyEnv, or stay on 3.9 by
-[installing Streamlit with conda](https://discuss.streamlit.io/t/note-installation-issues-with-python-3-9-and-streamlit/6946):
-
-`conda install -c conda-forge streamlit`
-
-"""
-                )
-            else:
-                raise StreamlitAPIException(
-                    """To use Custom Components in Streamlit, you need to install
+            raise StreamlitAPIException(
+                """To use Custom Components in Streamlit, you need to install
 PyArrow. To do so locally:
 
 `pip install pyarrow`
 
 And if you're using Streamlit Sharing, add "pyarrow" to your requirements.txt."""
-                )
+            )
 
         # In addition to the custom kwargs passed to the component, we also
         # send the special 'default' and 'key' params to the component


### PR DESCRIPTION
Close #2668.