### PR TITLE
Revive dropped commits

### DIFF
--- a/e2e/scripts/linked_sliders.py
+++ b/e2e/scripts/linked_sliders.py
@@ -1,0 +1,55 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+if st._is_running_with_streamlit:
+
+    to_celsius = lambda fahrenheit: (fahrenheit - 32) * 5.0 / 9.0
+    to_fahrenheit = lambda celsius: 9.0 / 5.0 * celsius + 32
+
+    MIN_CELSIUS, MAX_CELSIUS = -100.0, 100.0
+
+    state = st.session_state
+
+    if "celsius" not in st.session_state:
+        state.celsius = MIN_CELSIUS
+        state.fahrenheit = to_fahrenheit(MIN_CELSIUS)
+
+    # Callbacks if something changes
+    def celsius_changed():
+        state.fahrenheit = to_fahrenheit(state.celsius)
+
+    def fahrenheit_changed():
+        state.celsius = to_celsius(state.fahrenheit)
+
+    # Display the sliders.
+    st.slider(
+        "Celsius",
+        min_value=MIN_CELSIUS,
+        max_value=MAX_CELSIUS,
+        on_change=celsius_changed,
+        key="celsius",
+    )
+
+    st.slider(
+        "Fahrenheit",
+        min_value=to_fahrenheit(MIN_CELSIUS),
+        max_value=to_fahrenheit(MAX_CELSIUS),
+        on_change=fahrenheit_changed,
+        key="fahrenheit",
+    )
+
+    st.write("Celsius", state.celsius)
+    st.write("Fahrenheit", state.fahrenheit)

--- a/e2e/specs/linked_sliders.spec.js
+++ b/e2e/specs/linked_sliders.spec.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("st.slider", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/");
+  });
+
+  it("has correct initial values", () => {
+    cy.get(".stMarkdown", { timeout: 10000 }).should(
+      "have.text",
+      "Celsius -100.0" + "Fahrenheit -148.0"
+    );
+  });
+
+  it("updates both sliders when the first is changed", () => {
+    // trigger click in the center of the slider
+    cy.get('.stSlider [role="slider"]')
+      .eq(0)
+      .parent()
+      .click();
+    // Without the wait, the next part fails because the page updating causes
+    // the element to detatch.
+    cy.wait(1000);
+
+    cy.get(".stMarkdown")
+      .eq(0)
+      .should("have.text", "Celsius 0.0");
+
+    cy.get(".stMarkdown")
+      .eq(1)
+      .should("have.text", "Fahrenheit 32.0");
+  });
+
+  it("updates both sliders when the second is changed", () => {
+    // 698 is the width of the slider. Asking cypress to click on the "right"
+    // side ends up just short of the actual end, so the numbers aren't quite right.
+    cy.get('.stSlider [role="slider"]')
+      .eq(1)
+      .parent()
+      .click(698, 0, { force: true });
+    cy.wait(1000);
+
+    cy.get(".stMarkdown")
+      .eq(0)
+      .should("have.text", "Celsius 100.0");
+
+    cy.get(".stMarkdown")
+      .eq(1)
+      .should("have.text", "Fahrenheit 212.0");
+  });
+
+  it("updates when a slider is changed repeatedly", () => {
+    cy.get('.stSlider [role="slider"]')
+      .eq(0)
+      .parent()
+      .click();
+    cy.wait(1000);
+
+    cy.get(".stMarkdown")
+      .eq(0)
+      .should("have.text", "Celsius 0.0");
+    cy.get(".stMarkdown")
+      .eq(1)
+      .should("have.text", "Fahrenheit 32.0");
+
+    cy.get('.stSlider [role="slider"]')
+      .eq(0)
+      .parent()
+      .click(698, 0, { force: true });
+
+    cy.get(".stMarkdown")
+      .eq(0)
+      .should("have.text", "Celsius 100.0");
+
+    cy.get(".stMarkdown")
+      .eq(1)
+      .should("have.text", "Fahrenheit 212.0");
+  });
+});

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -115,6 +115,8 @@ class RadioMixin:
             )
 
         def serialize_radio(v):
+            if len(options) == 0:
+                return 0
             return index_(options, v)
 
         current_value, set_frontend_value = register_widget(

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -110,6 +110,8 @@ class SelectboxMixin:
             )
 
         def serialize_select_box(v):
+            if len(options) == 0:
+                return 0
             return index_(options, v)
 
         current_value, set_frontend_value = register_widget(

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -288,8 +288,8 @@ class SessionState(MutableMapping[str, Any]):
     def __setitem__(self, key: str, value: Any) -> None:
         from streamlit.report_thread import get_report_ctx, ReportContext
 
-        ctx = cast(ReportContext, get_report_ctx())
-        if key in ctx.widget_ids_this_run.items():
+        ctx = get_report_ctx()
+        if ctx is not None and key in ctx.widget_ids_this_run.items():
             raise StreamlitAPIException(
                 f"`st.session_state.{key}` cannot be modified after the widget"
                 f" with key `{key}` is instantiated."

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -203,6 +203,14 @@ class WStates(MutableMapping[str, Any]):
         callback(*args, **kwargs)
 
 
+INTERNAL_STATE_ATTRS = [
+    "_initial_widget_values",
+    "_new_session_state",
+    "_new_widget_state",
+    "_old_state",
+]
+
+
 def _missing_key_error_message(key: str) -> str:
     return f'st.session_state has no key "{key}". Did you forget to initialize it?'
 
@@ -235,6 +243,7 @@ class SessionState(MutableMapping[str, Any]):
     _old_state: Dict[str, Any] = attr.Factory(dict)
     _new_session_state: Dict[str, Any] = attr.Factory(dict)
     _new_widget_state: WStates = attr.Factory(WStates)
+    _initial_widget_values: Dict[str, Any] = attr.Factory(dict)
 
     # is it possible for a value to get through this without being deserialized?
     def compact_state(self) -> None:
@@ -297,7 +306,7 @@ class SessionState(MutableMapping[str, Any]):
         self._new_session_state[key] = value
 
     def __delitem__(self, key: str) -> None:
-        if key in ["_new_session_state", "_new_widget_state", "_old_state"]:
+        if key in INTERNAL_STATE_ATTRS:
             raise KeyError(f"The key {key} is reserved.")
 
         if not (
@@ -323,9 +332,9 @@ class SessionState(MutableMapping[str, Any]):
             raise AttributeError(_missing_attr_error_message(key))
 
     def __setattr__(self, key: str, value: Any) -> None:
-        # Setting the _old_state and _new_state attributes must be done using
-        # the base method to avoid recursion.
-        if key in ["_new_session_state", "_new_widget_state", "_old_state"]:
+        # Setting internal attributes must be done using the base method to
+        # avoid recursion.
+        if key in INTERNAL_STATE_ATTRS:
             super().__setattr__(key, value)
         else:
             self[key] = value
@@ -374,11 +383,23 @@ class SessionState(MutableMapping[str, Any]):
         widget_id = widget_metadata.id
         self._new_widget_state.widget_metadata[widget_id] = widget_metadata
 
-    def maybe_set_state_value(self, widget_id: str) -> None:
+    def maybe_set_state_value(self, widget_id: str) -> bool:
         widget_metadata = self._new_widget_state.widget_metadata[widget_id]
+        deserializer = widget_metadata.deserializer
+        initial_value = deserializer(None)
+
         if widget_id not in self:
-            deserializer = widget_metadata.deserializer
-            self._old_state[widget_id] = deserializer(None)
+            self._old_state[widget_id] = initial_value
+            self._initial_widget_values[widget_id] = initial_value
+        elif (
+            widget_id in self._initial_widget_values
+            and initial_value != self._initial_widget_values[widget_id]
+        ):
+            self._new_widget_state.set_from_value(widget_id, initial_value)
+            self._initial_widget_values[widget_id] = initial_value
+            return True
+
+        return False
 
     def get_value_for_registration(self, widget_id: str) -> Any:
         try:

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -161,10 +161,10 @@ def register_widget(
         callback_kwargs=kwargs,
     )
     session_state.set_metadata(metadata)
-    session_state.maybe_set_state_value(widget_id)
+    value_changed = session_state.maybe_set_state_value(widget_id)
 
     val = session_state.get_value_for_registration(widget_id)
-    set_val_in_frontend = session_state.is_new_state_value(widget_id)
+    set_val_in_frontend = value_changed or session_state.is_new_state_value(widget_id)
 
     return (val, set_val_in_frontend)
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -452,6 +452,32 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state._new_widget_state["foo"] = "bar"
         assert not self.session_state._widget_changed("foo")
 
+    def test_maybe_set_state_value(self):
+        wstates = WStates()
+        self.session_state._new_widget_state = wstates
+
+        wstates.set_widget_metadata(
+            WidgetMetadata(
+                id="widget_id_1",
+                deserializer=lambda _: 0,
+                serializer=identity,
+                value_type="int_value",
+            )
+        )
+        assert self.session_state.maybe_set_state_value("widget_id_1") == False
+        assert self.session_state["widget_id_1"] == 0
+
+        wstates.set_widget_metadata(
+            WidgetMetadata(
+                id="widget_id_1",
+                deserializer=lambda _: 1,
+                serializer=identity,
+                value_type="int_value",
+            )
+        )
+        assert self.session_state.maybe_set_state_value("widget_id_1") == True
+        assert self.session_state["widget_id_1"] == 1
+
 
 @patch(
     "streamlit.state.session_state.get_session_state",


### PR DESCRIPTION
I'm not exactly sure what happened (it was most likely a rebase of the `feature/session-state` branch
onto `develop` gone wrong), but it seems like #3466 and #3477 are nowhere to be found in the commits
merged into `develop` when we merged the `feature/session-state` branch.

This PR revives the two, which brings in some important bugfixes and e2e tests. I also
double-checked all the session_state-related commits from the past month or so to ensure that this
didn't happen elsewhere :grimacing: 