### PR TITLE
Fix bug with KeyErrors when accessing st.session_state on reconnect

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -249,13 +249,30 @@ class SessionState(MutableMapping[str, Any]):
         self._new_session_state.clear()
         self._new_widget_state.clear()
 
+    def _safe_widget_state(self) -> Dict[str, Any]:
+        """Returns widget states for all widgets with deserializers registered.
+
+        On a browser tab reconnect, it's possible for widgets in
+        self._new_widget_state to not have deserializers registered, which will
+        result in trying to access them raising a KeyError. This results in
+        things exploding if we try to naively use the splat operator on
+        self._new_widget_state in _merged_state below.
+        """
+        wstate = {}
+        for k in self._new_widget_state.keys():
+            try:
+                wstate[k] = self._new_widget_state[k]
+            except KeyError:
+                pass
+        return wstate
+
     @property
     def _merged_state(self) -> Dict[str, Any]:
         # NOTE: The order that the dicts are unpacked here is important as it
         #       is what ensures that the new values take priority
         return {
             **self._old_state,
-            **self._new_widget_state,
+            **self._safe_widget_state(),
             **self._new_session_state,
         }
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -368,6 +368,16 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state.clear_state()
         assert self.session_state._merged_state == {}
 
+    def test_safe_widget_state(self):
+        new_session_state = MagicMock()
+
+        wstate = {"foo": "bar"}
+        new_session_state.__getitem__.side_effect = wstate.__getitem__
+        new_session_state.keys = lambda: {"foo", "baz"}
+        self.session_state = SessionState({}, {}, new_session_state)
+
+        assert self.session_state._safe_widget_state() == wstate
+
     def test_merged_state(self):
         assert self.session_state._merged_state == {
             "foo": "bar2",


### PR DESCRIPTION
See the in-line comment in the code for more info on what was fixed.
