### PR TITLE
st.text_input autocomplete param

### DIFF
--- a/frontend/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.test.tsx
@@ -63,6 +63,18 @@ describe("TextInput widget", () => {
     expect(uiInput.props().type).toBe("password")
   })
 
+  it("handles TextInputProto.autocomplete", () => {
+    let props = getProps()
+    let textInput = shallow(<TextInput {...props} />)
+    let uiInput = textInput.find(UIInput)
+    expect(uiInput.props().autoComplete).toBe("")
+
+    props = getProps({ autocomplete: "one-time-password" })
+    textInput = shallow(<TextInput {...props} />)
+    uiInput = textInput.find(UIInput)
+    expect(uiInput.props().autoComplete).toBe("one-time-password")
+  })
+
   it("sets widget value on mount", () => {
     const props = getProps()
     jest.spyOn(props.widgetMgr, "setStringValue")

--- a/frontend/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.tsx
@@ -192,6 +192,7 @@ class TextInput extends React.PureComponent<Props, State> {
           onKeyPress={this.onKeyPress}
           disabled={disabled}
           type={this.getTypeString()}
+          autoComplete={element.autocomplete}
           overrides={{
             Input: {
               style: {

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -32,6 +32,7 @@ class TextWidgetsMixin:
         key=None,
         type="default",
         help=None,
+        autocomplete=None,
         on_change=None,
         args=None,
         kwargs=None,
@@ -58,6 +59,11 @@ class TextWidgetsMixin:
             masks the user's typed value). Defaults to "default".
         help : str
             An optional tooltip that gets displayed next to the input.
+        autocomplete : str
+            An optional value that will be passed to the <input> element's
+            autocomplete property. If unspecified, this value will be set to
+            "new-password" for "password" inputs, and the empty string for
+            "default" inputs. For more details, see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
         on_change : callable
             An optional callback invoked when this text_input's value changes.
         args : tuple
@@ -98,6 +104,12 @@ class TextWidgetsMixin:
                 "'%s' is not a valid text_input type. Valid types are 'default' and 'password'."
                 % type
             )
+
+        # Marshall the autocomplete param. If unspecified, this will be
+        # set to "new-password" for password inputs.
+        if autocomplete is None:
+            autocomplete = "new-password" if type == "password" else ""
+        text_input_proto.autocomplete = autocomplete
 
         def deserialize_text_input(ui_value) -> str:
             return str(ui_value if ui_value is not None else value)

--- a/lib/tests/streamlit/text_input_test.py
+++ b/lib/tests/streamlit/text_input_test.py
@@ -123,5 +123,5 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("you-complete-me", proto.autocomplete)
 
 
-class SomeObj(object):
+class SomeObj:
     pass

--- a/lib/tests/streamlit/text_input_test.py
+++ b/lib/tests/streamlit/text_input_test.py
@@ -104,6 +104,24 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(text_input_proto.label, "foo")
 
+    def test_autocomplete_defaults(self):
+        """If 'autocomplete' is unspecified, it defaults to the empty string
+        for default inputs, and "new-password" for password inputs.
+        """
+        st.text_input("foo")
+        proto = self.get_delta_from_queue().new_element.text_input
+        self.assertEqual("", proto.autocomplete)
+
+        st.text_input("password", type="password")
+        proto = self.get_delta_from_queue().new_element.text_input
+        self.assertEqual("new-password", proto.autocomplete)
+
+    def test_autcomplete(self):
+        """Autocomplete should be marshalled if specified."""
+        st.text_input("foo", autocomplete="you-complete-me")
+        proto = self.get_delta_from_queue().new_element.text_input
+        self.assertEqual("you-complete-me", proto.autocomplete)
+
 
 class SomeObj(object):
     pass

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -34,4 +34,5 @@ message TextInput {
   string form_id = 7;
   string value = 8;
   bool set_value = 9;
+  string autocomplete = 10;
 }


### PR DESCRIPTION
`st.text_input` now takes an optional `autocomplete` param, which is passed directly through to the `<input>` element's autocomplete property.

If autocomplete is unspecified, we default to "new-password" (for password inputs) and the empty string (for default inputs). This matches the current behavior.

Fixes #3080