### PR TITLE
Hide type signatures in generated docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -219,6 +219,7 @@ epub_exclude_files = ["search.html"]
 # -- Extension configuration -------------------------------------------------
 
 autodoc_default_flags = ["members"]
+autodoc_typehints = "none"
 autosummary_generate = True
 html_copy_source = False
 github_doc_root = "https://github.com/streamlit/streamlit/tree/develop/docs"


### PR DESCRIPTION
They are very messy in RTD, so they are a net negative to have for
documentation, but by hiding them we will be able to add annotations on
public api functions, which will improve type safety for us and users.
