### PR TITLE
yarn start only tracks our code

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -23,6 +23,9 @@ module.exports = {
       // This allows static files request other static files in development mode.
       "Access-Control-Allow-Origin": "*",
     },
+    watchOptions: {
+      ignored: [/node_modules/, "*.test.{ts,tsx}", /cypress/],
+    },
   },
   jest: {
     configure: jestConfig => {


### PR DESCRIPTION
When running yarn start, we set up a file watch on files that don't make
sense to check for live reload:

- third party packages in node_modules
- test files
- etc

This affects our ability to build in environments with a limited number
of file watches available.

## Testing done

I ran this in my limited-file-watch environment before and after this
change.

- Before, I got error messages for >1000 files, including node_modules, etc.
- After, I only got error messages for <500 files, with no node_modules, etc.