### PR TITLE
fix indent in doc example

### DIFF
--- a/docs/session_state_api.md
+++ b/docs/session_state_api.md
@@ -124,7 +124,7 @@ Widgets inside a form can have their values be accessed and set via the Session 
 
 ```python
 def form_callback():
-	st.write(st.session_state.my_slider)
+  st.write(st.session_state.my_slider)
   st.write(st.session_state.my_checkbox)
 
 with st.form(key='my_form'):


### PR DESCRIPTION
tab->spaces

**Description:**
Fixes this broken indent:
![image](https://user-images.githubusercontent.com/15624271/124261684-0b737900-db6c-11eb-8a13-bddf0b956ca8.png)


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
