### PR TITLE
Pin Pandas to <1.3.0

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -38,7 +38,7 @@ cachetools = ">=4.0"
 click = ">=7.0, <8.0"
 numpy = "*"
 packaging = "*"
-pandas = ">=0.21.0"
+pandas = ">=0.21.0, <1.3.0"
 pillow = ">=6.2.0"
 # protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
 protobuf = ">=3.6.0, !=3.11"


### PR DESCRIPTION
Pandas released an update on July 2 that introduced some issues in our functionality. We're pinning the version down until the fix is deployed.