### PR TITLE
Convert widget options to indexable form

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, List
+from typing import Any, Collection, cast, List
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import is_type, ensure_iterable
+from streamlit.type_util import ensure_indexable, is_type
 
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class MultiSelectMixin:
     def multiselect(
         self,
         label,
-        options,
+        options: Collection[Any],
         default=None,
         format_func=str,
         key=None,
@@ -44,7 +44,7 @@ class MultiSelectMixin:
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
-        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+        options : collection
             Labels for the select options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         default: [str] or None
@@ -93,11 +93,11 @@ class MultiSelectMixin:
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=default, key=key)
 
-        options = ensure_iterable(options)
+        opt = ensure_indexable(options)
 
         # Perform validation checks and return indices base on the default values.
-        def _check_and_convert_to_indices(options, default_values):
-            if default_values is None and None not in options:
+        def _check_and_convert_to_indices(opt, default_values):
+            if default_values is None and None not in opt:
                 return None
 
             if not isinstance(default_values, list):
@@ -108,38 +108,35 @@ class MultiSelectMixin:
                     default_values, "pandas.core.series.Series"
                 ):
                     default_values = list(default_values)
-                elif not default_values or default_values in options:
+                elif not default_values or default_values in opt:
                     default_values = [default_values]
                 else:
                     default_values = list(default_values)
 
-            if not isinstance(options, list):
-                options = list(options)
-
             for value in default_values:
-                if value not in options:
+                if value not in opt:
                     raise StreamlitAPIException(
                         "Every Multiselect default value must exist in options"
                     )
 
-            return [options.index(value) for value in default_values]
+            return [opt.index(value) for value in default_values]
 
-        indices = _check_and_convert_to_indices(options, default)
+        indices = _check_and_convert_to_indices(opt, default)
         multiselect_proto = MultiSelectProto()
         multiselect_proto.label = label
         default_value = [] if indices is None else indices
         multiselect_proto.default[:] = default_value
-        multiselect_proto.options[:] = [str(format_func(option)) for option in options]
+        multiselect_proto.options[:] = [str(format_func(option)) for option in opt]
         multiselect_proto.form_id = current_form_id(self.dg)
         if help is not None:
             multiselect_proto.help = help
 
         def deserialize_multiselect(ui_value, widget_id="") -> List[str]:
             current_value = ui_value if ui_value is not None else default_value
-            return [options[i] for i in current_value]
+            return [opt[i] for i in current_value]
 
         def serialize_multiselect(value):
-            return _check_and_convert_to_indices(options, value)
+            return _check_and_convert_to_indices(opt, value)
 
         current_value, set_frontend_value = register_widget(
             "multiselect",
@@ -154,7 +151,7 @@ class MultiSelectMixin:
 
         if set_frontend_value:
             multiselect_proto.value[:] = _check_and_convert_to_indices(
-                options, current_value
+                opt, current_value
             )
             multiselect_proto.set_value = True
 

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Collection, cast, List
+from typing import cast, List
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import ensure_indexable, is_type
+from streamlit.type_util import OptionSequence, ensure_indexable, is_type
 
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class MultiSelectMixin:
     def multiselect(
         self,
         label,
-        options: Collection[Any],
+        options: OptionSequence,
         default=None,
         format_func=str,
         key=None,
@@ -44,7 +44,7 @@ class MultiSelectMixin:
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
-        options : collection
+        options : Sequence, numpy.ndarray, pandas.Series, pandas.DataFrame, or pandas.Index
             Labels for the select options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         default: [str] or None

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
+from typing import Any, Collection, cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import ensure_iterable
+from streamlit.type_util import ensure_indexable
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class RadioMixin:
     def radio(
         self,
         label,
-        options,
+        options: Collection[Any],
         index=0,
         format_func=str,
         key=None,
@@ -43,7 +43,7 @@ class RadioMixin:
         ----------
         label : str
             A short label explaining to the user what this radio group is for.
-        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+        options : collection
             Labels for the radio options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         index : int
@@ -87,14 +87,14 @@ class RadioMixin:
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
 
-        options = ensure_iterable(options)
+        opt = ensure_indexable(options)
 
         if not isinstance(index, int):
             raise StreamlitAPIException(
                 "Radio Value has invalid type: %s" % type(index).__name__
             )
 
-        if len(options) > 0 and not 0 <= index < len(options):
+        if len(opt) > 0 and not 0 <= index < len(opt):
             raise StreamlitAPIException(
                 "Radio index must be between 0 and length of options"
             )
@@ -102,7 +102,7 @@ class RadioMixin:
         radio_proto = RadioProto()
         radio_proto.label = label
         radio_proto.default = index
-        radio_proto.options[:] = [str(format_func(option)) for option in options]
+        radio_proto.options[:] = [str(format_func(option)) for option in opt]
         radio_proto.form_id = current_form_id(self.dg)
         if help is not None:
             radio_proto.help = help
@@ -110,9 +110,7 @@ class RadioMixin:
         def deserialize_radio(ui_value, widget_id=""):
             idx = ui_value if ui_value is not None else index
 
-            return (
-                options[idx] if len(options) > 0 and options[idx] is not None else None
-            )
+            return opt[idx] if len(opt) > 0 and opt[idx] is not None else None
 
         def serialize_radio(v):
             if len(options) == 0:

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Collection, cast
+from typing import cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import ensure_indexable
+from streamlit.type_util import OptionSequence, ensure_indexable
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class RadioMixin:
     def radio(
         self,
         label,
-        options: Collection[Any],
+        options: OptionSequence,
         index=0,
         format_func=str,
         key=None,
@@ -43,7 +43,7 @@ class RadioMixin:
         ----------
         label : str
             A short label explaining to the user what this radio group is for.
-        options : collection
+        options : Sequence, numpy.ndarray, pandas.Series, pandas.DataFrame, or pandas.Index
             Labels for the radio options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         index : int

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
+from typing import Any, Collection, cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import ensure_iterable
+from streamlit.type_util import ensure_indexable
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class SelectSliderMixin:
     def select_slider(
         self,
         label,
-        options=[],
+        options: Collection[Any] = [],
         value=None,
         format_func=str,
         key=None,
@@ -52,7 +52,7 @@ class SelectSliderMixin:
         ----------
         label : str
             A short label explaining to the user what this slider is for.
-        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+        options : collection
             Labels for the slider options. All options will be cast to str
             internally by default. For pandas.DataFrame, the first column is
             selected.
@@ -104,9 +104,9 @@ class SelectSliderMixin:
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 
-        options = ensure_iterable(options)
+        opt = ensure_indexable(options)
 
-        if len(options) == 0:
+        if len(opt) == 0:
             raise StreamlitAPIException("The `options` argument needs to be non-empty")
 
         is_range_value = isinstance(value, (list, tuple))
@@ -114,14 +114,14 @@ class SelectSliderMixin:
 
         # Convert element to index of the elements
         if is_range_value:
-            slider_value = list(map(lambda v: index_(options, v), value))
+            slider_value = list(map(lambda v: index_(opt, v), value))
             start, end = slider_value
             if start > end:
                 slider_value = [end, start]
         else:
             # Simplify future logic by always making value a list
             try:
-                slider_value = [index_(options, value)]
+                slider_value = [index_(opt, value)]
             except ValueError:
                 if value is not None:
                     raise
@@ -133,10 +133,10 @@ class SelectSliderMixin:
         slider_proto.format = "%s"
         slider_proto.default[:] = slider_value
         slider_proto.min = 0
-        slider_proto.max = len(options) - 1
+        slider_proto.max = len(opt) - 1
         slider_proto.step = 1  # default for index changes
         slider_proto.data_type = SliderProto.INT
-        slider_proto.options[:] = [str(format_func(option)) for option in options]
+        slider_proto.options[:] = [str(format_func(option)) for option in opt]
         slider_proto.form_id = current_form_id(self.dg)
         if help is not None:
             slider_proto.help = help
@@ -147,14 +147,14 @@ class SelectSliderMixin:
                 ui_value = slider_value
 
             # The widget always returns floats, so convert to ints before indexing
-            return_value = list(map(lambda x: options[int(x)], ui_value))  # type: ignore[no-any-return]
+            return_value = list(map(lambda x: opt[int(x)], ui_value))  # type: ignore[no-any-return]
 
             # If the original value was a list/tuple, so will be the output (and vice versa)
             return tuple(return_value) if is_range_value else return_value[0]
 
         def serialize_select_slider(v):
             to_serialize = v if is_range_value else [v]
-            return [index_(options, u) for u in to_serialize]
+            return [index_(opt, u) for u in to_serialize]
 
         current_value, set_frontend_value = register_widget(
             "slider",

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Collection, cast
+from typing import cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import ensure_indexable
+from streamlit.type_util import OptionSequence, ensure_indexable
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class SelectSliderMixin:
     def select_slider(
         self,
         label,
-        options: Collection[Any] = [],
+        options: OptionSequence = [],
         value=None,
         format_func=str,
         key=None,
@@ -52,7 +52,7 @@ class SelectSliderMixin:
         ----------
         label : str
             A short label explaining to the user what this slider is for.
-        options : collection
+        options : Sequence, numpy.ndarray, pandas.Series, pandas.DataFrame, or pandas.Index
             Labels for the slider options. All options will be cast to str
             internally by default. For pandas.DataFrame, the first column is
             selected.

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
+from typing import Any, Collection, cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.state.widgets import register_widget, NoValue
-from streamlit.type_util import ensure_iterable
+from streamlit.type_util import ensure_indexable
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class SelectboxMixin:
     def selectbox(
         self,
         label,
-        options,
+        options: Collection[Any],
         index=0,
         format_func=str,
         key=None,
@@ -43,7 +43,7 @@ class SelectboxMixin:
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
-        options : list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame
+        options : collection
             Labels for the select options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         index : int
@@ -82,14 +82,14 @@ class SelectboxMixin:
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
 
-        options = ensure_iterable(options)
+        opt = ensure_indexable(options)
 
         if not isinstance(index, int):
             raise StreamlitAPIException(
                 "Selectbox Value has invalid type: %s" % type(index).__name__
             )
 
-        if len(options) > 0 and not 0 <= index < len(options):
+        if len(opt) > 0 and not 0 <= index < len(opt):
             raise StreamlitAPIException(
                 "Selectbox index must be between 0 and length of options"
             )
@@ -97,7 +97,7 @@ class SelectboxMixin:
         selectbox_proto = SelectboxProto()
         selectbox_proto.label = label
         selectbox_proto.default = index
-        selectbox_proto.options[:] = [str(format_func(option)) for option in options]
+        selectbox_proto.options[:] = [str(format_func(option)) for option in opt]
         selectbox_proto.form_id = current_form_id(self.dg)
         if help is not None:
             selectbox_proto.help = help
@@ -105,14 +105,12 @@ class SelectboxMixin:
         def deserialize_select_box(ui_value, widget_id=""):
             idx = ui_value if ui_value is not None else index
 
-            return (
-                options[idx] if len(options) > 0 and options[idx] is not None else None
-            )
+            return opt[idx] if len(opt) > 0 and opt[idx] is not None else None
 
         def serialize_select_box(v):
-            if len(options) == 0:
+            if len(opt) == 0:
                 return 0
-            return index_(options, v)
+            return index_(opt, v)
 
         current_value, set_frontend_value = register_widget(
             "selectbox",

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Collection, cast
+from typing import cast
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.state.widgets import register_widget, NoValue
-from streamlit.type_util import ensure_indexable
+from streamlit.type_util import OptionSequence, ensure_indexable
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -28,7 +28,7 @@ class SelectboxMixin:
     def selectbox(
         self,
         label,
-        options: Collection[Any],
+        options: OptionSequence,
         index=0,
         format_func=str,
         key=None,
@@ -43,7 +43,7 @@ class SelectboxMixin:
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
-        options : collection
+        options : Sequence, numpy.ndarray, pandas.Series, pandas.DataFrame, or pandas.Index
             Labels for the select options. This will be cast to str internally
             by default. For pandas.DataFrame, the first column is selected.
         index : int

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -15,7 +15,7 @@
 """A bunch of useful utilities for dealing with types."""
 
 import re
-from typing import Any, Tuple, cast
+from typing import Any, Collection, Sequence, Tuple, cast
 
 from pandas import DataFrame
 
@@ -297,6 +297,21 @@ def ensure_iterable(obj):
         return obj
     except:
         raise
+
+
+def ensure_indexable(obj: Collection[Any]) -> Sequence[Any]:
+    """Try to ensure a Collection is an indexable Sequence. If the collection already
+    is one, it has the index method that we need. Otherwise, since it is Iterable,
+    we can turn it into a list and use that.
+    """
+    it = ensure_iterable(obj)
+    # This is an imperfect check because there is no guarantee that an `index`
+    # function actually does the thing we want.
+    index_fn = getattr(it, "index", None)
+    if callable(index_fn):
+        return it  # type: ignore
+    else:
+        return list(it)
 
 
 def is_old_pandas_version():

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -15,11 +15,14 @@
 """A bunch of useful utilities for dealing with types."""
 
 import re
-from typing import Any, Collection, Sequence, Tuple, cast
+from typing import Any, Sequence, Tuple, Union, cast
 
-from pandas import DataFrame
+from pandas import DataFrame, Series, Index
+import numpy as np
 
 from streamlit import errors
+
+OptionSequence = Union[Sequence[Any], DataFrame, Series, Index, np.ndarray]
 
 
 def is_type(obj, fqn_type_pattern):
@@ -299,10 +302,9 @@ def ensure_iterable(obj):
         raise
 
 
-def ensure_indexable(obj: Collection[Any]) -> Sequence[Any]:
-    """Try to ensure a Collection is an indexable Sequence. If the collection already
-    is one, it has the index method that we need. Otherwise, since it is Iterable,
-    we can turn it into a list and use that.
+def ensure_indexable(obj: OptionSequence) -> Sequence[Any]:
+    """Try to ensure a value is an indexable Sequence. If the collection already
+    is one, it has the index method that we need. Otherwise, convert it to a list.
     """
     it = ensure_iterable(obj)
     # This is an imperfect check because there is no guarantee that an `index`

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -42,6 +42,12 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
             (pd.DataFrame({"options": ["male", "female"]}), ["male", "female"]),
+            (
+                pd.DataFrame(
+                    data=[[1, 4, 7], [2, 5, 8], [3, 6, 9]], columns=["a", "b", "c"]
+                ).columns,
+                ["a", "b", "c"],
+            ),
         ]
     )
     def test_option_types(self, options, proto_options):

--- a/lib/tests/streamlit/radio_test.py
+++ b/lib/tests/streamlit/radio_test.py
@@ -57,6 +57,12 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
             (pd.DataFrame({"options": ["male", "female"]}), ["male", "female"]),
+            (
+                pd.DataFrame(
+                    data=[[1, 4, 7], [2, 5, 8], [3, 6, 9]], columns=["a", "b", "c"]
+                ).columns,
+                ["a", "b", "c"],
+            ),
         ]
     )
     def test_option_types(self, options, proto_options):

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -56,6 +56,12 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
             (np.array(["m", "f"]), ["m", "f"]),
             (pd.Series(np.array(["male", "female"])), ["male", "female"]),
             (pd.DataFrame({"options": ["male", "female"]}), ["male", "female"]),
+            (
+                pd.DataFrame(
+                    data=[[1, 4, 7], [2, 5, 8], [3, 6, 9]], columns=["a", "b", "c"]
+                ).columns,
+                ["a", "b", "c"],
+            ),
         ]
     )
     def test_option_types(self, options, proto_options):


### PR DESCRIPTION
Fixes #3505. Technically that issue is resolved by #3501, but the same
problem can happen for several other widgets that take options, so it is
worth applying a fix more broadly.

We already ensure the options are iterable, but this is not sufficient
for all of our needs, because we sometimes need to look up an index of a
value, which requires a `Sequence`. Additionally, users sometimes pass
in types that were not included in the existing list of supported types,
and we would like to more precisely define the requirements we have on
types and ensure our code can handle them.

Widgets now accept any `Collection` for an options parameter, because
the required iterability means we can fall back to turning it into a
list if it does not support the desired `index` operation. This should
work for nearly all types, though it is possible that some will require
special handling like Pandas DataFrames. (Do dataframes actually count
as `Collection`s? If not, the type annotation added here should be
extended to union with them)

To make mypy cooperate with some added type annotations, one of the
locals in the widgets has been renamed.
