### PR TITLE
Allow classes with _repr_html_ in st.write

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -14,6 +14,7 @@
 
 import json as json
 import types
+import inspect
 from typing import cast, Any, List, Tuple, Type
 
 import numpy as np
@@ -219,7 +220,9 @@ class WriteMixin:
             elif type_util.is_pydeck(arg):
                 flush_buffer()
                 self.dg.pydeck_chart(arg)
-            elif hasattr(arg, "_repr_html_"):
+            elif hasattr(arg, "_repr_html_") and not inspect.isclass(arg):
+                # Classes may have a _repr_html_ method, but we don't want to
+                # use it because it's defined for instances
                 self.dg.markdown(
                     arg._repr_html_(),
                     unsafe_allow_html=True,

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -54,6 +54,21 @@ class StreamlitWriteTest(unittest.TestCase):
                 "<strong>hello world</strong>", unsafe_allow_html=True
             )
 
+    def test_class_repr_html(self):
+        """Test st.write with an class that defines _repr_html_."""
+
+        class FakeHTMLable(object):
+            def _repr_html_(self):
+                return "<strong>hello world</strong>"
+
+        with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:
+            st.write(type(FakeHTMLable()))
+
+            p.assert_called_once_with(
+                "`<class 'write_test.StreamlitWriteTest.test_class_repr_html.<locals>.FakeHTMLable'>`",
+                unsafe_allow_html=False,
+            )
+
     def test_string(self):
         """Test st.write with a string."""
         with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:


### PR DESCRIPTION
fixes #3336 

`st.write` throws an error when writing the type of a dataframe. When calling `type` on instances with `_repr_html_` the same method exists on the class type. When calling the method, an exception is thrown requiring the `self` argument. This fix checks to see if the instance also is not a class in order to use it.

It's possible a class may define it properly, but `st.write` is expecting a `_repr_html_` instance method and not a `_repr_html_` static method.