### PR TITLE
Allow empty string for DeckGL tooltip

### DIFF
--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -94,4 +94,24 @@ describe("DeckGlJsonChart element", () => {
 
     expect(createdTooltip.html).toBe("<b>Elevation Value:</b> 10")
   })
+
+  it("should render an empty tooltip", () => {
+    const props = getProps({
+      tooltip: "",
+    })
+    const wrapper = shallow(<DeckGlJsonChart {...props} />)
+    const DeckGL = wrapper.find("DeckGL")
+
+    expect(DeckGL.length).toBe(1)
+    expect(DeckGL.prop("getTooltip")).toBeDefined()
+
+    // @ts-ignore
+    const createdTooltip = DeckGL.prop("getTooltip")({
+      object: {
+        elevationValue: 10,
+      },
+    })
+
+    expect(createdTooltip).toBe(false)
+  })
 })

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -159,7 +159,7 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
   createTooltip = (info: PickingInfo): Record<string, unknown> | boolean => {
     const { element } = this.props
 
-    if (!info || !info.object || element.tooltip == null) {
+    if (!info || !info.object || !element.tooltip) {
       return false
     }
 


### PR DESCRIPTION
Closes #3395 

When serializing, an empty string can be produced for the tooltip. DeckGLChart should effectively ignore the tooltip in any condition. Checking for any falsy value includes empty string and many nonsensical inputs, `null`, and `undefined`.