### PR TITLE
Remove sourcemaps in final build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,6 @@ react-build:
 	cd frontend/ ; yarn run build
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/build/ lib/streamlit/static/
-	# If you're debugging sharing, you may want to comment this out so that
-	# sourcemaps exist.
-	find lib/streamlit/static -type 'f' -iname '*.map' | xargs rm -fv
 
 .PHONY: jslint
 # Lint the JS code. Saves results to test-reports/eslint/eslint.xml.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true craco start",
-    "build": "env NODE_OPTIONS=--max_old_space_size=8192 craco build",
+    "build": "env NODE_OPTIONS=--max_old_space_size=8192 GENERATE_SOURCEMAP=false craco build",
     "test": "env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=jsdom",
     "test:coverage": "env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=jsdom --coverage --watchAll false --watch false ./",
     "cy:open": "unset NODE_OPTIONS && cypress open --env devicePixelRatio=1",


### PR DESCRIPTION
closes #3421 

It looks like we were trying to remove the map files _post_ build, which is fine, but the sourcemap comment is still included in the JS file. This forces browsers to make erroneous requests :cough: safari :cough: that are 1) unnecessary and 2) polluting the console with errors.

Setting an ENV variable is much better.