### PR TITLE
Fix tooltip dedent for all widgets with tooltips

### DIFF
--- a/e2e/scripts/st_text_input.py
+++ b/e2e/scripts/st_text_input.py
@@ -14,7 +14,9 @@
 
 import streamlit as st
 
-i1 = st.text_input("text input 1")
+i1 = st.text_input("text input 1", help="""
+    Hello world!
+    """)
 st.write('value 1: "', i1, '"')
 
 i2 = st.text_input("text input 2", "default text")

--- a/e2e/scripts/st_tooltips.py
+++ b/e2e/scripts/st_tooltips.py
@@ -26,17 +26,40 @@ sapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,
 malesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.
 """.strip()
 
+leading_indent_code_tooltip = """
+    This
+    is
+    a
+    code
+    block!"""
+
+leading_indent_regular_text_tooltip = """
+This is a regular text block!
+Test1
+Test2
+
+"""
+
+indented_code_tooltip = """
+
+     for i in range(10):
+        x = i * 10
+        print(x)
+    """
+
+no_indent_tooltip="thisisatooltipwithnoindents. It has some spaces but no idents."
+
 st.text_input("some input text", "default text", help=default_tooltip)
-st.number_input("number input", value=1, help=default_tooltip)
-st.checkbox("some checkbox", help=default_tooltip)
-st.radio("best animal", ("tiger", "giraffe", "bear"), 0, help=default_tooltip)
-st.button("some button", help=default_tooltip)
+st.number_input("number input", value=1, help=leading_indent_code_tooltip)
+st.checkbox("some checkbox", help=leading_indent_regular_text_tooltip)
+st.radio("best animal", ("tiger", "giraffe", "bear"), 0, help=indented_code_tooltip)
 st.selectbox("selectbox", ("a", "b", "c"), 0, help=default_tooltip)
-st.time_input("time", datetime(2019, 7, 6, 21, 15), help=default_tooltip)
-st.date_input("date", datetime(2019, 7, 6, 21, 15), help=default_tooltip)
-st.slider("slider", 0, 100, 50, help=default_tooltip)
-st.color_picker("color picker", help=default_tooltip)
+st.time_input("time", datetime(2019, 7, 6, 21, 15), help=leading_indent_code_tooltip)
+st.date_input("date", datetime(2019, 7, 6, 21, 15), help=leading_indent_regular_text_tooltip)
+st.slider("slider", 0, 100, 50, help=indented_code_tooltip)
+st.color_picker("color picker", help=no_indent_tooltip)
 st.file_uploader("file uploader", help=default_tooltip)
-st.multiselect("multiselect", ["a", "b", "c"], ["a", "b"], help=default_tooltip)
-st.text_area("textarea", help=default_tooltip)
-st.select_slider("selectslider", options=["a", "b", "c"], help=default_tooltip)
+st.multiselect("multiselect", ["a", "b", "c"], ["a", "b"], help=leading_indent_code_tooltip)
+st.text_area("textarea", help=leading_indent_regular_text_tooltip)
+st.select_slider("selectslider", options=["a", "b", "c"], help=indented_code_tooltip)
+st.button("some button", help=no_indent_tooltip)

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -79,4 +79,188 @@ describe("tooltips on widgets", () => {
     // two sliders, st.slider and st.select_slider
     cy.get(`.stSlider .stTooltipIcon`).should("have.length", 2);
   });
+
+  it("Display text properly on tooltips on text input", () => {
+    cy.get(`.stTextInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+    );
+  });
+
+  it("Display text properly on tooltips on numberinput", () => {
+    cy.get(`.stNumberInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "contains.text",
+      `This
+is
+a
+code
+block!`
+    );
+  });
+
+  it("Display text properly on tooltips on checkbox", () => {
+    cy.get(`.stCheckbox .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `This is a regular text block!\nTest1\nTest2`
+    );
+  });
+
+  it("Display text properly on tooltips on radio", () => {
+    cy.get(`.stRadio .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "contains.text",
+      `for i in range(10):
+    x = i * 10
+    print(x)`
+    );
+  });
+
+  it("Display text properly on tooltips on Selectbox", () => {
+    cy.get(`.stSelectbox .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+    );
+  });
+
+  it("Display text properly on tooltips on timeinput", () => {
+    cy.get(`.stTimeInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "contains.text",
+      `This
+is
+a
+code
+block!`
+    );
+  });
+
+  it("Display text properly on tooltips on dateinput", () => {
+    cy.get(`.stDateInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `This is a regular text block!\nTest1\nTest2`
+    );
+  });
+
+  //This one needs to be the first slider
+  it("Display text properly on tooltips on sliders", () => {
+    cy.get(`.stSlider .stTooltipIcon`)
+      .eq(0)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "contains.text",
+      `for i in range(10):
+    x = i * 10
+    print(x)`
+    );
+  });
+
+  it("Display text properly on tooltips on colorpicker", () => {
+    cy.get(`[data-testid="stColorPicker"]  .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `thisisatooltipwithnoindents. It has some spaces but no idents.`
+    );
+  });
+
+  it("Display text properly on tooltips on fileuploader", () => {
+    cy.get(`[data-testid="stFileUploader"] .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+    );
+  });
+
+  it("Display text properly on tooltips on multiselect", () => {
+    cy.get(`.stMultiSelect .stTooltipIcon`)
+      .invoke("show")
+      .click({ force: true })
+      .trigger("mouseover");
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "contains.text",
+      `This
+is
+a
+code
+block!`
+    );
+  });
+
+  it("Display text properly on tooltips on textarea", () => {
+    cy.get(`.stTextArea .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `This is a regular text block!\nTest1\nTest2`
+    );
+  });
+
+  it("Display text properly on tooltips on sliders", () => {
+    cy.get(`.stSlider .stTooltipIcon`)
+      .eq(1)
+      .invoke("show")
+      .click()
+      .trigger("mouseleave");
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "contains.text",
+      `for i in range(10):
+    x = i * 10
+    print(x)`
+    );
+  });
+
+  it("Display text properly on tooltips on button", () => {
+    cy.get(".stButton [data-testid=tooltip_hover_target]").trigger(
+      "mouseover"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "contains.text",
+      `thisisatooltipwithnoindents. It has some spaces but no idents.`
+    );
+  });
 });

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -110,6 +110,7 @@ function Tooltip({
           flexDirection: "row",
           justifyContent: inline ? "flex-end" : "",
         }}
+        data-testid="tooltip_hover_target"
       >
         {children}
       </div>

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast
+import textwrap
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -90,7 +91,7 @@ class TextWidgetsMixin:
         text_input_proto.default = str(value)
         text_input_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            text_input_proto.help = help
+            text_input_proto.help = textwrap.dedent(help)
 
         if max_chars is not None:
             text_input_proto.max_chars = max_chars
@@ -197,7 +198,7 @@ class TextWidgetsMixin:
         text_area_proto.default = str(value)
         text_area_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            text_area_proto.help = help
+            text_area_proto.help = textwrap.dedent(help)
 
         if height is not None:
             text_area_proto.height = height

--- a/lib/tests/streamlit/checkbox_test.py
+++ b/lib/tests/streamlit/checkbox_test.py
@@ -75,3 +75,14 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
         form_proto = self.get_delta_from_queue(0).add_block.form
         checkbox_proto = self.get_delta_from_queue(1).new_element.checkbox
         self.assertEqual(checkbox_proto.form_id, form_proto.form_id)
+
+    def test_checkbox_help_dedents(self):
+        """test that the checkbox help properly dedents in order to avoid code blocks"""
+        st.checkbox("Checkbox label", value=True, help='''\
+hello
+ world
+''')
+        c = self.get_delta_from_queue(0).new_element.checkbox
+        self.assertEqual(c.label, "Checkbox label")
+        self.assertEqual(c.default, True)
+        self.assertEqual(c.help, "hello\n world\n")

--- a/lib/tests/streamlit/text_area_test.py
+++ b/lib/tests/streamlit/text_area_test.py
@@ -90,6 +90,24 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(text_area_proto.label, "foo")
 
+    def test_help_dedents(self):
+        """Test that help properly dedents"""
+        st.text_area("the label", value="TESTING", help="""\
+        Hello World!
+        This is a test
+
+
+        """)
+
+        c = self.get_delta_from_queue().new_element.text_area
+        self.assertEqual(c.label, "the label")
+        self.assertEqual(c.default, "TESTING")
+        self.assertEqual(c.help, """Hello World!
+This is a test
+
+
+""")
+
 
 class SomeObj(object):
     pass


### PR DESCRIPTION
These code changes are to fix the widgets that were not dedenting the help tooltips. This will close #3300 . 

In addition to the code changes, there are e2e tests and 2 unit tests to make sure code blocks are appearing and the right text is appearing. 