### PR TITLE
Deserialize json widget values, use and store dynamic widget value types

### DIFF
--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -185,6 +185,7 @@ And if you're using Streamlit Sharing, add "pyarrow" to your requirements.txt.""
                 marshall_element_args()
 
             def deserialize_component(ui_value, widget_id=""):
+                # ui_value is an object from json, an ArrowTable proto, or a bytearray
                 return ui_value
 
             widget_value, _ = register_widget(

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from typing import (
     Any,
     ItemsView,
@@ -96,16 +97,25 @@ class WStates(MutableMapping[str, Any]):
                     # No deserializer, which should only happen if state is gotten from a reconnecting browser
                     # and the script is trying to access it. Pretend it doesn't exist.
                     raise KeyError(k)
-                value = item.value.__getattribute__(item.value.WhichOneof("value"))
+                value_type = item.value.WhichOneof("value")
+                value = item.value.__getattribute__(value_type)
 
                 # Array types are messages with data in a `data` field
-                if metadata.value_type in [
+                if value_type in [
                     "double_array_value",
                     "int_array_value",
                     "string_array_value",
                 ]:
                     value = value.data
+
+                if value_type == "json_value":
+                    value = json.loads(value)
+
                 deserialized = metadata.deserializer(value, metadata.id)
+
+                # Update metadata to reflect information from WidgetState proto
+                self.set_widget_metadata(attr.evolve(metadata, value_type=value_type))
+
                 self.states[k] = Value(deserialized)
                 return deserialized
         else:
@@ -174,6 +184,8 @@ class WStates(MutableMapping[str, Any]):
                     ):
                         arr = getattr(widget, field)
                         arr.data.extend(serialized)
+                    elif field == "json_value":
+                        setattr(widget, field, json.dumps(serialized))
                     else:
                         setattr(widget, field, serialized)
                     return widget


### PR DESCRIPTION
The primary change is just loading json values for custom components to fix #3507, but also switch to using the value field indicated by the WidgetState protobuf we have, so that if a custom component sends back an Arrow table or raw bytes data, we can just pass that on directly instead of incorrectly trying to parse it as json.

I tested this on our component template and on the demo app of https://github.com/domoritz/streamlit-vega-lite, and it seems to fix the issues reported.