### PR TITLE
Remove a throwing of Exception in order to deal with sticky error page.

### DIFF
--- a/frontend/src/components/elements/Json/Json.test.tsx
+++ b/frontend/src/components/elements/Json/Json.test.tsx
@@ -40,11 +40,10 @@ describe("JSON element", () => {
     expect(wrapper).toBeDefined()
   })
 
-  it("should raise an exception with invalid JSON", () => {
+  it("should show an error with invalid JSON", () => {
     const props = getProps({ body: "invalid JSON" })
-    expect(() => {
-      mount(<Json {...props} />)
-    }).toThrow(SyntaxError)
+    const wrapper = mount(<Json {...props} />)
+    expect(wrapper.find("Alert")).toBeDefined()
   })
 
   it("renders json with NaN and infinity values", () => {

--- a/frontend/src/components/elements/Json/Json.tsx
+++ b/frontend/src/components/elements/Json/Json.tsx
@@ -21,7 +21,6 @@ import { useTheme } from "emotion-theming"
 import JSON5 from "json5"
 import ReactJson from "react-json-view"
 import ErrorElement from "src/components/shared/ErrorElement"
-import { Kind } from "src/components/shared/AlertContainer"
 
 import { Json as JsonProto } from "src/autogen/proto"
 import { Theme } from "src/theme"

--- a/frontend/src/components/elements/Json/Json.tsx
+++ b/frontend/src/components/elements/Json/Json.tsx
@@ -20,6 +20,8 @@ import { getLuminance } from "color2k"
 import { useTheme } from "emotion-theming"
 import JSON5 from "json5"
 import ReactJson from "react-json-view"
+import ErrorElement from "src/components/shared/ErrorElement"
+import { Kind } from "src/components/shared/AlertContainer"
 
 import { Json as JsonProto } from "src/autogen/proto"
 import { Theme } from "src/theme"
@@ -47,7 +49,7 @@ export default function Json({ width, element }: JsonProps): ReactElement {
       // to show where the problem occurred.
       const pos = parseInt(e.message.replace(/[^0-9]/g, ""), 10)
       e.message += `\n${element.body.substr(0, pos + 1)} ← here`
-      throw e
+      return <ErrorElement name={"Json Parse Error"} message={e.message} />
     }
   }
 


### PR DESCRIPTION
This will close #2324 . This change removes throwing an error and instead displays an error. I have tested it manually with 2 json objects and it looks like it works. I changed the other test that tests for invalid json. 