### PR TITLE
Check if widget value was changed before updating widget value

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -448,9 +448,13 @@ class SessionState(MutableMapping[str, Any]):
             # The initial_value of this widget has been changed (most likely by
             # the user live-editing their script), so we update its value in
             # widget_state and remember the new initial_value.
-            self._new_widget_state.set_from_value(widget_id, initial_value)
             self._initial_widget_values[widget_id] = initial_value
-            return True
+
+            # Only set the widget's return value to the new initial_value
+            # if there is not an incoming user set value from the frontend.
+            if not self._widget_changed(widget_id):
+                self._new_widget_state.set_from_value(widget_id, initial_value)
+                return True
 
         elif widget_id in self and widget_id not in self._new_widget_state:
             # This widget is being registered, but it had its value initially

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -560,7 +560,7 @@ class SessionStateMethodTests(unittest.TestCase):
         wstates = WStates()
         self.session_state._new_widget_state = wstates
 
-        self.session_state._initial_widget_values['widget_id_1'] = 0
+        self.session_state._initial_widget_values["widget_id_1"] = 0
         self.session_state._old_state["widget_id_1"] = 0
         self.session_state._new_widget_state.set_from_value("widget_id_1", 0)
         wstates.set_widget_metadata(


### PR DESCRIPTION
https://github.com/streamlit/streamlit/issues/3534

**Description:**
In `maybe_set_state_value`, the second part of the function handles the case where we've already got the widget in session state, but the initial value has been changed.

Allow the change to the initial value, but before changing the widgets value in `_new_widget_state` that is returned to the script, check to make sure it wasn't changed by the user using `_widget_changed` function.

Updated the tests to capture this behavior.

**Questions
- What does returning `True` to the caller mean if this function conditionally changes or doesn't change numerous value?
- Should `test_maybe_set_state_value` be broken into multiple tests, or is it fine to have one unit test for the various behaviors of this function?
