### PR TITLE
Replace PR Preview Email with our streamlit bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
       - run:
           name: Setup preview repo
           command: |
-            git config --global user.email "austin@streamlit.io"
+            git config --global user.email "core+streamlitbot-github@streamlit.io"
             git config --global user.name "CircleCI"
             git clone git@github.com:streamlit/core-previews.git
 


### PR DESCRIPTION
Use our dedicated streamlit bot email. Should verify the commit on the PR preview app worked successfully and points to the correct user