### PR TITLE
Fix mypy errors by casting call to WhichOneOf

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -97,7 +97,7 @@ class WStates(MutableMapping[str, Any]):
                     # No deserializer, which should only happen if state is gotten from a reconnecting browser
                     # and the script is trying to access it. Pretend it doesn't exist.
                     raise KeyError(k)
-                value_type = item.value.WhichOneof("value")
+                value_type = cast(str, item.value.WhichOneof("value"))
                 value = item.value.__getattribute__(value_type)
 
                 # Array types are messages with data in a `data` field
@@ -107,8 +107,7 @@ class WStates(MutableMapping[str, Any]):
                     "string_array_value",
                 ]:
                     value = value.data
-
-                if value_type == "json_value":
+                elif value_type == "json_value":
                     value = json.loads(value)
 
                 deserialized = metadata.deserializer(value, metadata.id)


### PR DESCRIPTION
It looks like the errors that didn't appear in the PR CI builds but
started appearing in the nightly and on develop are due to version 2.6
of mypy-protobuf being a bit more strict/correct with types. In this case,
we're guaranteed for the return value of WhichOneOf to be not None, so
we just need to cast this value.