### PR TITLE
Caching: type annotations, dead code removal

### DIFF
--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -617,12 +617,6 @@ def _clear_mem_cache():
     _mem_caches.clear()
 
 
-def _get_frame_info(caller_frame):
-    frameinfo = inspect.getframeinfo(caller_frame)
-    filename, caller_lineno, _, code_context, _ = frameinfo
-    return filename, caller_lineno, code_context
-
-
 class CacheError(Exception):
     pass
 

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -26,7 +26,7 @@ import threading
 import time
 import types
 from collections import namedtuple
-from typing import Dict, Optional, List, Iterator
+from typing import Dict, Optional, List, Iterator, Any
 
 from cachetools import TTLCache
 
@@ -217,7 +217,7 @@ def _write_to_mem_cache(
     mem_cache[key] = _CacheEntry(value=value, hash=hash)
 
 
-def _get_output_hash(value, func_or_code, hash_funcs):
+def _get_output_hash(value, func_or_code, hash_funcs) -> bytes:
     hasher = hashlib.new("md5")
     update_hash(
         value,
@@ -229,7 +229,7 @@ def _get_output_hash(value, func_or_code, hash_funcs):
     return hasher.digest()
 
 
-def _read_from_disk_cache(key):
+def _read_from_disk_cache(key) -> Any:
     path = file_util.get_streamlit_file_path("cache", "%s.pickle" % key)
     try:
         with file_util.streamlit_read(path, binary=True) as input:

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -35,7 +35,7 @@ from streamlit import file_util
 from streamlit import util
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIWarning
-from streamlit.hashing import update_hash
+from streamlit.hashing import update_hash, HashFuncsDict
 from streamlit.hashing import HashReason
 from streamlit.logger import get_logger
 import streamlit as st
@@ -324,13 +324,13 @@ def _write_to_cache(
 
 def cache(
     func=None,
-    persist: bool = False,
-    allow_output_mutation: bool = False,
-    show_spinner: bool = True,
-    suppress_st_warning: bool = False,
+    persist=False,
+    allow_output_mutation=False,
+    show_spinner=True,
+    suppress_st_warning=False,
     hash_funcs=None,
-    max_entries: Optional[int] = None,
-    ttl: Optional[float] = None,
+    max_entries=None,
+    ttl=None,
 ):
     """Function decorator to memoize function executions.
 
@@ -552,7 +552,7 @@ def cache(
     return wrapped_func
 
 
-def _hash_func(func, hash_funcs) -> str:
+def _hash_func(func: types.FunctionType, hash_funcs: HashFuncsDict) -> str:
     # Create the unique key for a function's cache. The cache will be retrieved
     # from inside the wrapped function.
     #
@@ -603,7 +603,7 @@ def _hash_func(func, hash_funcs) -> str:
     return cache_key
 
 
-def clear_cache():
+def clear_cache() -> bool:
     """Clear the memoization cache.
 
     Returns
@@ -616,11 +616,11 @@ def clear_cache():
     return _clear_disk_cache()
 
 
-def get_cache_path():
+def get_cache_path() -> str:
     return file_util.get_streamlit_file_path("cache")
 
 
-def _clear_disk_cache():
+def _clear_disk_cache() -> bool:
     # TODO: Only delete disk cache for functions related to the user's current
     # script.
     cache_path = get_cache_path()
@@ -630,7 +630,7 @@ def _clear_disk_cache():
     return False
 
 
-def _clear_mem_cache():
+def _clear_mem_cache() -> None:
     _mem_caches.clear()
 
 

--- a/lib/streamlit/caching.py
+++ b/lib/streamlit/caching.py
@@ -189,7 +189,7 @@ def _read_from_mem_cache(
     key: str,
     allow_output_mutation: bool,
     func_or_code: Callable[..., Any],
-    hash_funcs,
+    hash_funcs: Optional[HashFuncsDict],
 ) -> Any:
     if key in mem_cache:
         entry = mem_cache[key]
@@ -218,7 +218,7 @@ def _write_to_mem_cache(
     value: Any,
     allow_output_mutation: bool,
     func_or_code: Callable[..., Any],
-    hash_funcs,
+    hash_funcs: Optional[HashFuncsDict],
 ) -> None:
     if allow_output_mutation:
         hash = None
@@ -228,7 +228,9 @@ def _write_to_mem_cache(
     mem_cache[key] = _CacheEntry(value=value, hash=hash)
 
 
-def _get_output_hash(value: Any, func_or_code: Callable[..., Any], hash_funcs) -> bytes:
+def _get_output_hash(
+    value: Any, func_or_code: Callable[..., Any], hash_funcs: Optional[HashFuncsDict]
+) -> bytes:
     hasher = hashlib.new("md5")
     update_hash(
         value,
@@ -279,7 +281,7 @@ def _read_from_cache(
     persist: bool,
     allow_output_mutation: bool,
     func_or_code: Callable[..., Any],
-    hash_funcs=None,
+    hash_funcs: Optional[HashFuncsDict] = None,
 ) -> Any:
     """Read a value from the cache.
 
@@ -313,7 +315,7 @@ def _write_to_cache(
     persist: bool,
     allow_output_mutation: bool,
     func_or_code: Callable[..., Any],
-    hash_funcs=None,
+    hash_funcs: Optional[HashFuncsDict] = None,
 ):
     _write_to_mem_cache(
         mem_cache, key, value, allow_output_mutation, func_or_code, hash_funcs

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -148,7 +148,7 @@ def get_project_streamlit_file_path(*filepath):
     return os.path.join(os.getcwd(), CONFIG_FOLDER_NAME, *filepath)
 
 
-def file_is_in_folder_glob(filepath, folderpath_glob):
+def file_is_in_folder_glob(filepath, folderpath_glob) -> bool:
     """Test whether a file is in some folder with globbing support.
 
     Parameters
@@ -171,7 +171,7 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
     return fnmatch.fnmatch(file_dir, folderpath_glob)
 
 
-def file_in_pythonpath(filepath):
+def file_in_pythonpath(filepath) -> bool:
     """Test whether a filepath is in the same folder of a path specified in the PYTHONPATH env variable.
 
 

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -127,7 +127,7 @@ def get_assets_dir():
     return os.path.normpath(os.path.join(dirname, "static/assets"))
 
 
-def get_streamlit_file_path(*filepath):
+def get_streamlit_file_path(*filepath) -> str:
     """Return the full path to a file in ~/.streamlit.
 
     This doesn't guarantee that the file (or its directory) exists.

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -28,8 +28,9 @@ import sys
 import tempfile
 import textwrap
 import threading
+import typing
 import weakref
-from typing import Any, List, Pattern, Optional, Dict, Callable
+from typing import Any, List, Pattern, Optional, Dict, Callable, Union
 import unittest.mock
 
 from streamlit import config
@@ -77,11 +78,16 @@ _KERAS_TYPE_NAMES = [
     "tensorflow.python.keras.engine.functional.Functional",
 ]
 
-# A hashed value's HashSource is the code that is
-HashSource = Callable[..., Any]
-
 
 Context = collections.namedtuple("Context", ["globals", "cells", "varnames"])
+
+
+# Mapping of types or fully qualified names to hash functions. This is used to
+# override the behavior of the hasher inside Streamlit's caching mechanism:
+# when the hasher encounters an object, it will first check to see if its type
+# matches a key in this dict and, if so, will use the provided function to
+# generate a hash for it.
+HashFuncsDict = Dict[Union[str, typing.Type[Any]], Callable[[Any], Any]]
 
 
 class HashReason(enum.Enum):
@@ -95,9 +101,9 @@ def update_hash(
     val: Any,
     hasher,
     hash_reason: HashReason,
-    hash_source: HashSource,
+    hash_source: Callable[..., Any],
     context: Optional[Context] = None,
-    hash_funcs=None,
+    hash_funcs: Optional[HashFuncsDict] = None,
 ) -> None:
     """Updates a hashlib hasher with the hash of val.
 
@@ -131,7 +137,7 @@ class _HashStack:
         # Either a function or a code block, depending on whether the reason is
         # due to hashing part of a function (i.e. body, args, output) or an
         # st.Cache codeblock.
-        self.hash_source: Optional[HashSource] = None
+        self.hash_source: Optional[Callable[..., Any]] = None
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -316,7 +322,7 @@ def _key(obj: Optional[Any]) -> Any:
 class _CodeHasher:
     """A hasher that can hash code objects including dependencies."""
 
-    def __init__(self, hash_funcs=None):
+    def __init__(self, hash_funcs: Optional[HashFuncsDict] = None):
         # Can't use types as the keys in the internal _hash_funcs because
         # we always remove user-written modules from memory when rerunning a
         # script in order to reload it and grab the latest code changes.
@@ -324,6 +330,7 @@ class _CodeHasher:
         # the type object to refer to different underlying class instances each run,
         # so type-based comparisons fail. To solve this, we use the types converted
         # to fully-qualified strings as keys in our internal dict.
+        self._hash_funcs: HashFuncsDict
         if hash_funcs:
             self._hash_funcs = {
                 k if isinstance(k, str) else type_util.get_fqn(k): v
@@ -340,7 +347,7 @@ class _CodeHasher:
     def __repr__(self) -> str:
         return util.repr_(self)
 
-    def to_bytes(self, obj, context: Optional[Context] = None) -> bytes:
+    def to_bytes(self, obj: Any, context: Optional[Context] = None) -> bytes:
         """Add memoization to _to_bytes and protect against cycles in data structures."""
         tname = type(obj).__qualname__.encode()
         key = (tname, _key(obj))
@@ -633,6 +640,8 @@ class _CodeHasher:
             return h.digest()
 
         elif inspect.iscode(obj):
+            if context is None:
+                raise RuntimeError("context must be defined when hashing code")
             return self._code_to_bytes(obj, context)
 
         elif inspect.ismodule(obj):
@@ -676,7 +685,7 @@ class _CodeHasher:
                 self.update(h, item, context)
             return h.digest()
 
-    def _code_to_bytes(self, code, context, func=None) -> bytes:
+    def _code_to_bytes(self, code, context: Context, func=None) -> bytes:
         h = hashlib.new("md5")
 
         # Hash the bytecode.
@@ -709,7 +718,7 @@ class _CodeHasher:
         return str(os.path.dirname(main_path))
 
 
-def get_referenced_objects(code, context) -> List[Any]:
+def get_referenced_objects(code, context: Context) -> List[Any]:
     # Top of the stack
     tos: Any = None
     lineno = None
@@ -868,7 +877,7 @@ If you think this is actually a Streamlit bug, please [file a bug report here.]
             % args
         ).strip("\n")
 
-    def _get_message_from_code(self, orig_exc, cached_code, lineno):
+    def _get_message_from_code(self, orig_exc: BaseException, cached_code, lineno: int):
         args = _get_error_message_args(orig_exc, cached_code)
 
         failing_lines = _get_failing_lines(cached_code, lineno)
@@ -904,12 +913,12 @@ here.] (https://github.com/streamlit/streamlit/issues/new/choose)
 class InternalHashError(MarkdownFormattedException):
     """Exception in Streamlit hashing code (i.e. not a user error)"""
 
-    def __init__(self, orig_exc, failed_obj):
+    def __init__(self, orig_exc: BaseException, failed_obj: Any):
         msg = self._get_message(orig_exc, failed_obj)
         super(InternalHashError, self).__init__(msg)
         self.with_traceback(orig_exc.__traceback__)
 
-    def _get_message(self, orig_exc, failed_obj):
+    def _get_message(self, orig_exc: BaseException, failed_obj: Any) -> str:
         args = _get_error_message_args(orig_exc, failed_obj)
 
         # This needs to have zero indentation otherwise %(hash_stack)s will
@@ -950,7 +959,7 @@ for more details.
         ).strip("\n")
 
 
-def _get_error_message_args(orig_exc, failed_obj):
+def _get_error_message_args(orig_exc: BaseException, failed_obj: Any) -> Dict[str, Any]:
     hash_reason = hash_stacks.current.hash_reason
     hash_source = hash_stacks.current.hash_source
 
@@ -990,7 +999,7 @@ def _get_error_message_args(orig_exc, failed_obj):
     }
 
 
-def _get_failing_lines(code, lineno) -> List[str]:
+def _get_failing_lines(code, lineno: int) -> List[str]:
     """Get list of strings (lines of code) from lineno to lineno+3.
 
     Ideally we'd return the exact line where the error took place, but there

--- a/lib/streamlit/hashing.py
+++ b/lib/streamlit/hashing.py
@@ -29,8 +29,7 @@ import tempfile
 import textwrap
 import threading
 import weakref
-import types
-from typing import Any, List, Pattern
+from typing import Any, List, Pattern, Optional, Dict, Callable
 import unittest.mock
 
 from streamlit import config
@@ -78,11 +77,28 @@ _KERAS_TYPE_NAMES = [
     "tensorflow.python.keras.engine.functional.Functional",
 ]
 
+# A hashed value's HashSource is the code that is
+HashSource = Callable[..., Any]
+
 
 Context = collections.namedtuple("Context", ["globals", "cells", "varnames"])
 
 
-def update_hash(val, hasher, hash_reason, hash_source, context=None, hash_funcs=None):
+class HashReason(enum.Enum):
+    CACHING_FUNC_ARGS = 0
+    CACHING_FUNC_BODY = 1
+    CACHING_FUNC_OUTPUT = 2
+    CACHING_BLOCK = 3
+
+
+def update_hash(
+    val: Any,
+    hasher,
+    hash_reason: HashReason,
+    hash_source: HashSource,
+    context: Optional[Context] = None,
+    hash_funcs=None,
+) -> None:
     """Updates a hashlib hasher with the hash of val.
 
     This is the main entrypoint to hashing.py.
@@ -94,14 +110,7 @@ def update_hash(val, hasher, hash_reason, hash_source, context=None, hash_funcs=
     ch.update(hasher, val, context)
 
 
-class HashReason(enum.Enum):
-    CACHING_FUNC_ARGS = 0
-    CACHING_FUNC_BODY = 1
-    CACHING_FUNC_OUTPUT = 2
-    CACHING_BLOCK = 3
-
-
-class _HashStack(object):
+class _HashStack:
     """Stack of what has been hashed, for debug and circular reference detection.
 
     This internally keeps 1 stack per thread.
@@ -114,17 +123,15 @@ class _HashStack(object):
     """
 
     def __init__(self):
-        self._stack = (
-            collections.OrderedDict()
-        )  # type: collections.OrderedDict[int, List[Any]]
+        self._stack: collections.OrderedDict[int, List[Any]] = collections.OrderedDict()
 
         # The reason why we're doing this hashing, for debug purposes.
-        self.hash_reason = None
+        self.hash_reason: Optional[HashReason] = None
 
         # Either a function or a code block, depending on whether the reason is
         # due to hashing part of a function (i.e. body, args, output) or an
         # st.Cache codeblock.
-        self.hash_source = None
+        self.hash_source: Optional[HashSource] = None
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -153,19 +160,19 @@ class _HashStack(object):
         return "\n".join(to_str(x) for x in reversed(self._stack.values()))
 
 
-class _HashStacks(object):
+class _HashStacks:
     """Stacks of what has been hashed, with at most 1 stack per thread."""
 
     def __init__(self):
-        self._stacks = (
-            weakref.WeakKeyDictionary()
-        )  # type: weakref.WeakKeyDictionary[threading.Thread, _HashStack]
+        self._stacks: weakref.WeakKeyDictionary[
+            threading.Thread, _HashStack
+        ] = weakref.WeakKeyDictionary()
 
     def __repr__(self) -> str:
         return util.repr_(self)
 
     @property
-    def current(self):
+    def current(self) -> _HashStack:
         current_thread = threading.current_thread()
 
         stack = self._stacks.get(current_thread, None)
@@ -261,12 +268,12 @@ def _get_context(func) -> Context:
     return Context(globals=func.__globals__, cells=_Cells(), varnames=varnames)
 
 
-def _int_to_bytes(i):
+def _int_to_bytes(i: int) -> bytes:
     num_bytes = (i.bit_length() + 8) // 8
     return i.to_bytes(num_bytes, "little", signed=True)
 
 
-def _key(obj):
+def _key(obj: Optional[Any]) -> Any:
     """Return key for memoization."""
 
     if obj is None:
@@ -325,7 +332,7 @@ class _CodeHasher:
         else:
             self._hash_funcs = {}
 
-        self._hashes = {}
+        self._hashes: Dict[Any, bytes] = {}
 
         # The number of the bytes in the hash.
         self.size = 0
@@ -333,7 +340,7 @@ class _CodeHasher:
     def __repr__(self) -> str:
         return util.repr_(self)
 
-    def to_bytes(self, obj, context=None):
+    def to_bytes(self, obj, context: Optional[Context] = None) -> bytes:
         """Add memoization to _to_bytes and protect against cycles in data structures."""
         tname = type(obj).__qualname__.encode()
         key = (tname, _key(obj))
@@ -374,12 +381,12 @@ class _CodeHasher:
 
         return b
 
-    def update(self, hasher, obj, context=None):
+    def update(self, hasher, obj: Any, context: Optional[Context] = None) -> None:
         """Update the provided hasher with the hash of an object."""
         b = self.to_bytes(obj, context)
         hasher.update(b)
 
-    def _file_should_be_hashed(self, filename):
+    def _file_should_be_hashed(self, filename: str) -> bool:
         global _FOLDER_BLACK_LIST
 
         if not _FOLDER_BLACK_LIST:
@@ -396,7 +403,7 @@ class _CodeHasher:
             filepath, self._get_main_script_directory()
         ) or file_util.file_in_pythonpath(filepath)
 
-    def _to_bytes(self, obj, context):
+    def _to_bytes(self, obj: Any, context: Optional[Context]) -> bytes:
         """Hash objects to bytes, including code with dependencies.
 
         Python's built in `hash` does not produce consistent results across
@@ -479,7 +486,7 @@ class _CodeHasher:
             return h.digest()
 
         elif inspect.isbuiltin(obj):
-            return obj.__name__.encode()
+            return bytes(obj.__name__.encode())
 
         elif any(type_util.is_type(obj, typename) for typename in _FFI_TYPE_NAMES):
             return self.to_bytes(None)
@@ -490,7 +497,7 @@ class _CodeHasher:
             return self.to_bytes(dict(obj))
 
         elif type_util.is_type(obj, "builtins.getset_descriptor"):
-            return obj.__qualname__.encode()
+            return bytes(obj.__qualname__.encode())
 
         elif isinstance(obj, UploadedFile):
             # UploadedFile is a BytesIO (thus IOBase) but has a name.
@@ -574,7 +581,7 @@ class _CodeHasher:
 
         elif type_util.is_type(obj, "numpy.ufunc"):
             # For numpy.remainder, this returns remainder.
-            return obj.__name__.encode()
+            return bytes(obj.__name__.encode())
 
         elif type_util.is_type(obj, "socket.socket"):
             return self.to_bytes(id(obj))
@@ -669,7 +676,7 @@ class _CodeHasher:
                 self.update(h, item, context)
             return h.digest()
 
-    def _code_to_bytes(self, code, context, func=None):
+    def _code_to_bytes(self, code, context, func=None) -> bytes:
         h = hashlib.new("md5")
 
         # Hash the bytecode.
@@ -691,7 +698,7 @@ class _CodeHasher:
         return h.digest()
 
     @staticmethod
-    def _get_main_script_directory():
+    def _get_main_script_directory() -> str:
         """Get the directory of the main script."""
         import __main__  # type: ignore[import]
         import os
@@ -699,14 +706,14 @@ class _CodeHasher:
         # This works because we set __main__.__file__ to the report
         # script path in ScriptRunner.
         main_path = __main__.__file__
-        return os.path.dirname(main_path)
+        return str(os.path.dirname(main_path))
 
 
-def get_referenced_objects(code, context):
+def get_referenced_objects(code, context) -> List[Any]:
     # Top of the stack
-    tos = None  # type: Any
+    tos: Any = None
     lineno = None
-    refs = []
+    refs: List[Any] = []
 
     def set_tos(t):
         nonlocal tos
@@ -768,7 +775,7 @@ def get_referenced_objects(code, context):
     return refs
 
 
-class NoResult(object):
+class NoResult:
     """Placeholder class for return values when None is meaningful."""
 
     pass
@@ -983,7 +990,7 @@ def _get_error_message_args(orig_exc, failed_obj):
     }
 
 
-def _get_failing_lines(code, lineno):
+def _get_failing_lines(code, lineno) -> List[str]:
     """Get list of strings (lines of code) from lineno to lineno+3.
 
     Ideally we'd return the exact line where the error took place, but there


### PR DESCRIPTION
Adds (non-comprehensive) type annotations to caching.py and hashing.py.

Also removes two chunks of unused code:
- `_AddCopy` class (presumably part of some unused experiment?)
- `Cache` class (probably a vestige of an old, pre-release version of caching)

hashlib "hasher" args are left conspicuously untyped, because they... don't have a good common type.