### PR TITLE
Fix uploading multiple files to file_uploader

### DIFF
--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -158,7 +158,7 @@ describe("st.file_uploader", () => {
     });
   });
 
-  it("uploads and deletes multiple files", () => {
+  it("uploads and deletes multiple files quickly", () => {
     const fileName1 = "file1.txt";
     const fileName2 = "file2.txt";
     const uploaderIndex = 1;
@@ -216,6 +216,83 @@ describe("st.file_uploader", () => {
         cy.get("[data-testid='stFileUploader']")
           .eq(uploaderIndex)
           .matchThemedSnapshots("multi_file_uploader-uploaded");
+
+        // Delete the second file. The second file is on top because it was
+        // most recently uploaded. The first file should still exist.
+        cy.get("[data-testid='fileDeleteBtn'] button")
+          .first()
+          .click();
+        cy.get("[data-testid='stText']")
+          .eq(uploaderIndex)
+          .should("contain.text", file1);
+        cy.get("[data-testid='stMarkdownContainer']")
+          .eq(uploaderIndex)
+          .should("contain.text", "True");
+      });
+    });
+  });
+
+  // NOTE: This test is essentially identical to the one above. The only
+  // difference is that we add a short delay to uploading the two files to
+  // ensure that two script runs happen separately (sufficiently rapid widget
+  // changes will often be batched into a single script run) to test for the
+  // failure mode in https://github.com/streamlit/streamlit/issues/3531.
+  it("uploads and deletes multiple files slowly", () => {
+    const fileName1 = "file1.txt";
+    const fileName2 = "file2.txt";
+    const uploaderIndex = 1;
+
+    // Yes, this is the recommended way to load multiple fixtures
+    // in Cypress (!!) using Cypress.Promise.all is buggy. See:
+    // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/fundamentals__fixtures/cypress/integration/multiple-fixtures-spec.js
+    // Why can’t I use async / await?
+    // https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous
+    cy.fixture(fileName1).then(file1 => {
+      cy.fixture(fileName2).then(file2 => {
+        const files = [
+          { fileContent: file1, fileName: fileName1, mimeType: "text/plain" },
+          { fileContent: file2, fileName: fileName2, mimeType: "text/plain" }
+        ];
+
+        cy.get("[data-testid='stFileUploadDropzone']")
+          .eq(uploaderIndex)
+          .attachFile(files[0], {
+            force: true,
+            subjectType: "drag-n-drop",
+            events: ["dragenter", "drop"]
+          });
+
+        cy.get(".uploadedFileName").each(uploadedFileName => {
+          cy.get(uploadedFileName).should("have.text", fileName1);
+        });
+
+        cy.wait(1000);
+
+        cy.get("[data-testid='stFileUploadDropzone']")
+          .eq(uploaderIndex)
+          .attachFile(files[1], {
+            force: true,
+            subjectType: "drag-n-drop",
+            events: ["dragenter", "drop"]
+          });
+
+        // Wait for the HTTP request to complete
+        cy.wait("@uploadFile");
+
+        // The widget should show the names of the uploaded files in reverse
+        // order
+        const filenames = [fileName2, fileName1];
+        cy.get(".uploadedFileName").each((uploadedFileName, index) => {
+          cy.get(uploadedFileName).should("have.text", filenames[index]);
+        });
+
+        // The script should have printed the contents of the two files
+        // into an st.text. (This tests that the upload actually went
+        // through.)
+        const content = [file1, file2].join("\n");
+        cy.get("[data-testid='stText']")
+          .eq(uploaderIndex)
+          .should("have.text", content);
 
         // Delete the second file. The second file is on top because it was
         // most recently uploaded. The first file should still exist.

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -167,10 +167,15 @@ class FileUploaderMixin:
                 ids = [f.id for f in files]
             else:
                 ids = [files.id]
+
             ctx = get_report_ctx()
             if ctx is None:
                 return []
-            max_id = ctx.uploaded_file_mgr._file_id_counter
+
+            # ctx.uploaded_file_mgr._file_id_counter stores the id to use for
+            # the next uploaded file, so the current highest file id is the
+            # counter minus 1.
+            max_id = ctx.uploaded_file_mgr._file_id_counter - 1
             return [max_id] + ids
 
         # FileUploader's widget value is a list of file IDs
@@ -186,6 +191,22 @@ class FileUploaderMixin:
             deserializer=deserialize_file_uploader,
             serializer=serialize_file_uploader,
         )
+
+        ctx = get_report_ctx()
+        if ctx is not None and widget_value:
+            serialized = serialize_file_uploader(widget_value)
+
+            # The first number in the serialized widget_value list is the id
+            # of the most recently uploaded file.
+            newest_file_id = serialized[0]
+            active_file_ids = list(serialized[1:])
+
+            ctx.uploaded_file_mgr.remove_orphaned_files(
+                session_id=ctx.session_id,
+                widget_id=file_uploader_proto.id,
+                newest_file_id=newest_file_id,
+                active_file_ids=active_file_ids,
+            )
 
         self.dg._enqueue("file_uploader", file_uploader_proto)
         return widget_value
@@ -208,26 +229,14 @@ class FileUploaderMixin:
             )
             return []
 
-        # The first number in the widget_value list is 'newestServerFileId'
-        newest_file_id = widget_value[0]
         active_file_ids = list(widget_value[1:])
 
         # Grab the files that correspond to our active file IDs.
-        file_recs = ctx.uploaded_file_mgr.get_files(
+        return ctx.uploaded_file_mgr.get_files(
             session_id=ctx.session_id,
             widget_id=widget_id,
             file_ids=active_file_ids,
         )
-
-        # Garbage collect "orphaned" files.
-        ctx.uploaded_file_mgr.remove_orphaned_files(
-            session_id=ctx.session_id,
-            widget_id=widget_id,
-            newest_file_id=newest_file_id,
-            active_file_ids=active_file_ids,
-        )
-
-        return file_recs
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":


### PR DESCRIPTION
The issue was essentially caused by the file_uploader deserializer
having side effects, which resulted in "orphaned" files (that aren't
actually orphaned) being pruned at somewhat unexpected times since the
deserializer may be run during state compactions, before callbacks are
called, etc. We fixed this issue by getting rid of the side effects in
the deserializer by moving the orphaned file pruning stage out of it and
into the main file_uploader function.

Fixes #3531 
