### PR TITLE
Fix tooltip dedent for all widgets with tooltips

### DIFF
--- a/e2e/scripts/st_text_input.py
+++ b/e2e/scripts/st_text_input.py
@@ -14,7 +14,12 @@
 
 import streamlit as st
 
-i1 = st.text_input("text input 1")
+i1 = st.text_input(
+    "text input 1",
+    help="""
+    Hello world!
+    """,
+)
 st.write('value 1: "', i1, '"')
 
 i2 = st.text_input("text input 2", "default text")

--- a/e2e/scripts/st_text_input.py
+++ b/e2e/scripts/st_text_input.py
@@ -14,12 +14,7 @@
 
 import streamlit as st
 
-i1 = st.text_input(
-    "text input 1",
-    help="""
-    Hello world!
-    """,
-)
+i1 = st.text_input("text input 1")
 st.write('value 1: "', i1, '"')
 
 i2 = st.text_input("text input 2", "default text")

--- a/e2e/scripts/st_tooltips.py
+++ b/e2e/scripts/st_tooltips.py
@@ -26,17 +26,47 @@ sapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,
 malesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.
 """.strip()
 
+leading_indent_code_tooltip = """
+Code:
+
+    This
+    is
+    a
+    code
+    block!"""
+
+leading_indent_regular_text_tooltip = """
+This is a regular text block!
+Test1
+Test2
+
+"""
+
+indented_code_tooltip = """
+Code:
+
+     for i in range(10):
+        x = i * 10
+        print(x)
+    """
+
+no_indent_tooltip = "thisisatooltipwithnoindents. It has some spaces but no idents."
+
 st.text_input("some input text", "default text", help=default_tooltip)
-st.number_input("number input", value=1, help=default_tooltip)
-st.checkbox("some checkbox", help=default_tooltip)
-st.radio("best animal", ("tiger", "giraffe", "bear"), 0, help=default_tooltip)
-st.button("some button", help=default_tooltip)
+st.number_input("number input", value=1, help=leading_indent_code_tooltip)
+st.checkbox("some checkbox", help=leading_indent_regular_text_tooltip)
+st.radio("best animal", ("tiger", "giraffe", "bear"), 0, help=indented_code_tooltip)
 st.selectbox("selectbox", ("a", "b", "c"), 0, help=default_tooltip)
-st.time_input("time", datetime(2019, 7, 6, 21, 15), help=default_tooltip)
-st.date_input("date", datetime(2019, 7, 6, 21, 15), help=default_tooltip)
-st.slider("slider", 0, 100, 50, help=default_tooltip)
-st.color_picker("color picker", help=default_tooltip)
+st.time_input("time", datetime(2019, 7, 6, 21, 15), help=leading_indent_code_tooltip)
+st.date_input(
+    "date", datetime(2019, 7, 6, 21, 15), help=leading_indent_regular_text_tooltip
+)
+st.slider("slider", 0, 100, 50, help=indented_code_tooltip)
+st.color_picker("color picker", help=no_indent_tooltip)
 st.file_uploader("file uploader", help=default_tooltip)
-st.multiselect("multiselect", ["a", "b", "c"], ["a", "b"], help=default_tooltip)
-st.text_area("textarea", help=default_tooltip)
-st.select_slider("selectslider", options=["a", "b", "c"], help=default_tooltip)
+st.multiselect(
+    "multiselect", ["a", "b", "c"], ["a", "b"], help=leading_indent_code_tooltip
+)
+st.text_area("textarea", help=leading_indent_regular_text_tooltip)
+st.select_slider("selectslider", options=["a", "b", "c"], help=indented_code_tooltip)
+st.button("some button", help=no_indent_tooltip)

--- a/e2e/scripts/st_tooltips.py
+++ b/e2e/scripts/st_tooltips.py
@@ -45,7 +45,7 @@ Test2
 indented_code_tooltip = """
 Code:
 
-     for i in range(10):
+    for i in range(10):
         x = i * 10
         print(x)
     """

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -15,6 +15,21 @@
  * limitations under the License.
  */
 
+const defaultTooltip = `This is a really long tooltip.Lorem ipsum dolor sit am\
+et, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a \
+vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec ero\
+s risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel \
+ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod e\
+leifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In no\
+n arcu et risus maximus fermentum eget nec ante.`;
+
+const tooltipCodeBlock1 = `This\nis\na\ncode\nblock!`;
+const tooltipCodeBlock2 = `for i in range(10):\n    x = i * 10\n    print(x)`;
+
+const tooltipTextBlock1 = `This is a regular text block!\nTest1\nTest2`;
+const tooltipTextBlock2 = `thisisatooltipwithnoindents. It has some spaces but\
+ no idents.`;
+
 describe("tooltips on widgets", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -79,6 +94,12 @@ describe("tooltips on widgets", () => {
     // two sliders, st.slider and st.select_slider
     cy.get(`.stSlider .stTooltipIcon`).should("have.length", 2);
   });
+});
+
+describe("tooltip text with dedent on widgets", () => {
+  before(() => {
+    cy.visit("http://localhost:3000/");
+  });
 
   it("Display text properly on tooltips on text input", () => {
     cy.get(`.stTextInput .stTooltipIcon`)
@@ -89,7 +110,7 @@ describe("tooltips on widgets", () => {
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+      defaultTooltip
     );
   });
 
@@ -99,11 +120,7 @@ describe("tooltips on widgets", () => {
       .click();
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
-      `This
-is
-a
-code
-block!`
+      tooltipCodeBlock1
     );
   });
 
@@ -116,7 +133,7 @@ block!`
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `This is a regular text block!\nTest1\nTest2`
+      tooltipTextBlock1
     );
   });
 
@@ -126,9 +143,7 @@ block!`
       .click();
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
-      `for i in range(10):
-    x = i * 10
-    print(x)`
+      tooltipCodeBlock2
     );
   });
 
@@ -141,7 +156,7 @@ block!`
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+      defaultTooltip
     );
   });
 
@@ -151,11 +166,7 @@ block!`
       .click();
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
-      `This
-is
-a
-code
-block!`
+      tooltipCodeBlock1
     );
   });
 
@@ -168,7 +179,7 @@ block!`
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `This is a regular text block!\nTest1\nTest2`
+      tooltipTextBlock1
     );
   });
 
@@ -180,9 +191,7 @@ block!`
       .click();
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
-      `for i in range(10):
-    x = i * 10
-    print(x)`
+      tooltipCodeBlock2
     );
   });
 
@@ -195,7 +204,7 @@ block!`
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `thisisatooltipwithnoindents. It has some spaces but no idents.`
+      tooltipTextBlock2
     );
   });
 
@@ -208,7 +217,7 @@ block!`
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+      defaultTooltip
     );
   });
 
@@ -219,11 +228,7 @@ block!`
       .trigger("mouseover");
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
-      `This
-is
-a
-code
-block!`
+      tooltipCodeBlock1
     );
   });
 
@@ -237,7 +242,7 @@ block!`
     );
     cy.get("[data-testid=stMarkdownContainer]").should(
       "have.text",
-      `This is a regular text block!\nTest1\nTest2`
+      tooltipTextBlock1
     );
   });
 
@@ -249,9 +254,7 @@ block!`
       .trigger("mouseover");
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
-      `for i in range(10):
-    x = i * 10
-    print(x)`
+      tooltipCodeBlock2
     );
   });
 
@@ -259,7 +262,7 @@ block!`
     cy.get(".stButton [data-testid=tooltipHoverTarget]").trigger("mouseover");
     cy.get("[data-testid=stMarkdownContainer]").should(
       "contain.text",
-      `thisisatooltipwithnoindents. It has some spaces but no idents.`
+      tooltipTextBlock2
     );
   });
 });

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -79,4 +79,186 @@ describe("tooltips on widgets", () => {
     // two sliders, st.slider and st.select_slider
     cy.get(`.stSlider .stTooltipIcon`).should("have.length", 2);
   });
+
+  it("Display text properly on tooltips on text input", () => {
+    cy.get(`.stTextInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+    );
+  });
+
+  it("Display text properly on tooltips on numberinput", () => {
+    cy.get(`.stNumberInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "have.text",
+      `This
+is
+a
+code
+block!`
+    );
+  });
+
+  it("Display text properly on tooltips on checkbox", () => {
+    cy.get(`.stCheckbox .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `This is a regular text block!\nTest1\nTest2`
+    );
+  });
+
+  it("Display text properly on tooltips on radio", () => {
+    cy.get(`.stRadio .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "have.text",
+      `for i in range(10):
+    x = i * 10
+    print(x)`
+    );
+  });
+
+  it("Display text properly on tooltips on Selectbox", () => {
+    cy.get(`.stSelectbox .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+    );
+  });
+
+  it("Display text properly on tooltips on timeinput", () => {
+    cy.get(`.stTimeInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "have.text",
+      `This
+is
+a
+code
+block!`
+    );
+  });
+
+  it("Display text properly on tooltips on dateinput", () => {
+    cy.get(`.stDateInput .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `This is a regular text block!\nTest1\nTest2`
+    );
+  });
+
+  //This one needs to be the first slider
+  it("Display text properly on tooltips on sliders", () => {
+    cy.get(`.stSlider .stTooltipIcon`)
+      .eq(0)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "have.text",
+      `for i in range(10):
+    x = i * 10
+    print(x)`
+    );
+  });
+
+  it("Display text properly on tooltips on colorpicker", () => {
+    cy.get(`[data-testid="stColorPicker"]  .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `thisisatooltipwithnoindents. It has some spaces but no idents.`
+    );
+  });
+
+  it("Display text properly on tooltips on fileuploader", () => {
+    cy.get(`[data-testid="stFileUploader"] .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `This is a really long tooltip.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec eros risus, ultrices ut eleifend vel, auctor eu turpis.\nIn consectetur erat vel ante accumsan, a egestas urna aliquet. Nullam eget\nsapien eget diam euismod eleifend. Nulla purus enim, finibus ut velit eu,\nmalesuada dictum nulla. In non arcu et risus maximus fermentum eget nec ante.`
+    );
+  });
+
+  it("Display text properly on tooltips on multiselect", () => {
+    cy.get(`.stMultiSelect .stTooltipIcon`)
+      .invoke("show")
+      .click({ force: true })
+      .trigger("mouseover");
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "have.text",
+      `This
+is
+a
+code
+block!`
+    );
+  });
+
+  it("Display text properly on tooltips on textarea", () => {
+    cy.get(`.stTextArea .stTooltipIcon`)
+      .invoke("show")
+      .click();
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "not.exist"
+    );
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `This is a regular text block!\nTest1\nTest2`
+    );
+  });
+
+  it("Display text properly on tooltips on sliders", () => {
+    cy.get(`.stSlider .stTooltipIcon`)
+      .eq(1)
+      .invoke("show")
+      .click()
+      .trigger("mouseleave");
+    cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
+      "have.text",
+      `for i in range(10):
+    x = i * 10
+    print(x)`
+    );
+  });
+
+  it("Display text properly on tooltips on button", () => {
+    cy.get(".stButton [data-testid=tooltipHoverTarget]").trigger("mouseover");
+    cy.get("[data-testid=stMarkdownContainer]").should(
+      "have.text",
+      `thisisatooltipwithnoindents. It has some spaces but no idents.`
+    );
+  });
 });

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -230,7 +230,8 @@ block!`
   it("Display text properly on tooltips on textarea", () => {
     cy.get(`.stTextArea .stTooltipIcon`)
       .invoke("show")
-      .click();
+      .click({ force: true })
+      .trigger("mouseover");
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "not.exist"
     );
@@ -244,8 +245,8 @@ block!`
     cy.get(`.stSlider .stTooltipIcon`)
       .eq(1)
       .invoke("show")
-      .click()
-      .trigger("mouseleave");
+      .trigger("mouseenter")
+      .trigger("mouseover");
     cy.get("[data-testid=stMarkdownContainer] .stCodeBlock").should(
       "have.text",
       `for i in range(10):
@@ -257,7 +258,7 @@ block!`
   it("Display text properly on tooltips on button", () => {
     cy.get(".stButton [data-testid=tooltipHoverTarget]").trigger("mouseover");
     cy.get("[data-testid=stMarkdownContainer]").should(
-      "have.text",
+      "contain.text",
       `thisisatooltipwithnoindents. It has some spaces but no idents.`
     );
   });

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -110,6 +110,7 @@ function Tooltip({
           flexDirection: "row",
           justifyContent: inline ? "flex-end" : "",
         }}
+        data-testid="tooltipHoverTarget"
       >
         {children}
       </div>

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Optional, cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -124,7 +125,7 @@ class ButtonMixin:
         button_proto.is_form_submitter = is_form_submitter
         button_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            button_proto.help = help
+            button_proto.help = dedent(help)
 
         def deserialize_button(ui_value, widget_id=""):
             return ui_value or False

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
@@ -78,7 +79,7 @@ class CheckboxMixin:
         checkbox_proto.default = bool(value)
         checkbox_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            checkbox_proto.help = help
+            checkbox_proto.help = dedent(help)
 
         def deserialize_checkbox(ui_value, widget_id="") -> bool:
             return bool(ui_value if ui_value is not None else value)

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -14,6 +14,7 @@
 
 import re
 from typing import cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -103,7 +104,7 @@ class ColorPickerMixin:
         color_picker_proto.default = str(value)
         color_picker_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            color_picker_proto.help = help
+            color_picker_proto.help = dedent(help)
 
         def deserialize_color_picker(ui_value, widget_id="") -> str:
             return str(ui_value if ui_value is not None else value)

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast, List, Optional, Union
+from textwrap import dedent
 
 import streamlit
 from streamlit import config
@@ -143,7 +144,7 @@ class FileUploaderMixin:
         file_uploader_proto.multiple_files = accept_multiple_files
         file_uploader_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            file_uploader_proto.help = help
+            file_uploader_proto.help = dedent(help)
 
         def deserialize_file_uploader(
             ui_value: List[int], widget_id: str

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast, List
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -129,7 +130,7 @@ class MultiSelectMixin:
         multiselect_proto.options[:] = [str(format_func(option)) for option in opt]
         multiselect_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            multiselect_proto.help = help
+            multiselect_proto.help = dedent(help)
 
         def deserialize_multiselect(ui_value, widget_id="") -> List[str]:
             current_value = ui_value if ui_value is not None else default_value

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -14,6 +14,7 @@
 
 import numbers
 from typing import cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -200,7 +201,7 @@ class NumberInputMixin:
         number_input_proto.default = value
         number_input_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            number_input_proto.help = help
+            number_input_proto.help = dedent(help)
 
         if min_value is not None:
             number_input_proto.min = min_value

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -105,7 +106,7 @@ class RadioMixin:
         radio_proto.options[:] = [str(format_func(option)) for option in opt]
         radio_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            radio_proto.help = help
+            radio_proto.help = dedent(help)
 
         def deserialize_radio(ui_value, widget_id=""):
             idx = ui_value if ui_value is not None else index

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -139,7 +140,7 @@ class SelectSliderMixin:
         slider_proto.options[:] = [str(format_func(option)) for option in opt]
         slider_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            slider_proto.help = help
+            slider_proto.help = dedent(help)
 
         def deserialize_select_slider(ui_value, widget_id=""):
             if not ui_value:

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -100,7 +101,7 @@ class SelectboxMixin:
         selectbox_proto.options[:] = [str(format_func(option)) for option in opt]
         selectbox_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            selectbox_proto.help = help
+            selectbox_proto.help = dedent(help)
 
         def deserialize_select_box(ui_value, widget_id=""):
             idx = ui_value if ui_value is not None else index

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -14,6 +14,7 @@
 
 from datetime import date, time, datetime, timedelta, timezone
 from typing import Any, List, cast, Optional
+from textwrap import dedent
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
@@ -391,7 +392,7 @@ class SliderMixin:
         slider_proto.options[:] = []
         slider_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            slider_proto.help = help
+            slider_proto.help = dedent(help)
 
         def deserialize_slider(ui_value: Optional[List[float]], widget_id=""):
             if ui_value is not None:

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from textwrap import dedent
 from typing import cast
 
 import streamlit
@@ -19,6 +20,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
 from streamlit.state.widgets import register_widget
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -90,7 +92,7 @@ class TextWidgetsMixin:
         text_input_proto.default = str(value)
         text_input_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            text_input_proto.help = help
+            text_input_proto.help = dedent(help)
 
         if max_chars is not None:
             text_input_proto.max_chars = max_chars
@@ -197,7 +199,7 @@ class TextWidgetsMixin:
         text_area_proto.default = str(value)
         text_area_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            text_area_proto.help = help
+            text_area_proto.help = dedent(help)
 
         if height is not None:
             text_area_proto.height = height

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -14,6 +14,7 @@
 
 from datetime import datetime, date, time
 from typing import cast, Optional, Union
+from textwrap import dedent
 
 from dateutil import relativedelta
 
@@ -93,7 +94,7 @@ class TimeWidgetsMixin:
         time_input_proto.default = time.strftime(value, "%H:%M")
         time_input_proto.form_id = current_form_id(self.dg)
         if help is not None:
-            time_input_proto.help = help
+            time_input_proto.help = dedent(help)
 
         def deserialize_time_input(ui_value, widget_id=""):
             return (
@@ -201,7 +202,7 @@ class TimeWidgetsMixin:
         date_input_proto = DateInputProto()
         date_input_proto.is_range = range_value
         if help is not None:
-            date_input_proto.help = help
+            date_input_proto.help = dedent(help)
 
         value = [v.date() if isinstance(v, datetime) else v for v in value]
 

--- a/lib/tests/streamlit/checkbox_test.py
+++ b/lib/tests/streamlit/checkbox_test.py
@@ -75,3 +75,18 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
         form_proto = self.get_delta_from_queue(0).add_block.form
         checkbox_proto = self.get_delta_from_queue(1).new_element.checkbox
         self.assertEqual(checkbox_proto.form_id, form_proto.form_id)
+
+    def test_checkbox_help_dedents(self):
+        """Test that the checkbox help properly dedents in order to avoid code blocks"""
+        st.checkbox(
+            "Checkbox label",
+            value=True,
+            help="""\
+hello
+ world
+""",
+        )
+        c = self.get_delta_from_queue(0).new_element.checkbox
+        self.assertEqual(c.label, "Checkbox label")
+        self.assertEqual(c.default, True)
+        self.assertEqual(c.help, "hello\n world\n")

--- a/lib/tests/streamlit/text_area_test.py
+++ b/lib/tests/streamlit/text_area_test.py
@@ -90,6 +90,31 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(text_area_proto.label, "foo")
 
+    def test_help_dedents(self):
+        """Test that help properly dedents"""
+        st.text_area(
+            "the label",
+            value="TESTING",
+            help="""\
+        Hello World!
+        This is a test
+
+
+        """,
+        )
+
+        c = self.get_delta_from_queue().new_element.text_area
+        self.assertEqual(c.label, "the label")
+        self.assertEqual(c.default, "TESTING")
+        self.assertEqual(
+            c.help,
+            """Hello World!
+This is a test
+
+
+""",
+        )
+
 
 class SomeObj(object):
     pass


### PR DESCRIPTION
These code changes are to fix the widgets that were not dedenting the help tooltips. This will close #3300 .

In addition to the code changes, there are e2e tests and 2 unit tests to make sure code blocks are appearing and the right text is appearing.