### PR TITLE
Fix docs URL in submit button error message

### DIFF
--- a/frontend/src/components/widgets/Form/Form.tsx
+++ b/frontend/src/components/widgets/Form/Form.tsx
@@ -38,7 +38,7 @@ export const MISSING_SUBMIT_BUTTON_WARNING =
   "never be sent to your Streamlit app." +
   "\n\nTo create a submit button, use the `st.form_submit_button()` function." +
   "\n\nFor more information, refer to the " +
-  "[documentation for forms](https://docs.streamlit.io/api.html#form)."
+  "[documentation for forms](https://docs.streamlit.io/api.html#streamlit.form)."
 
 export function Form(props: Props): ReactElement {
   const {

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -31,7 +31,7 @@ from .utils import check_callback_rules, check_session_state_rules
 FORM_DOCS_INFO = """
 
 For more information, refer to the
-[documentation for forms](https://docs.streamlit.io/api.html#form).
+[documentation for forms](https://docs.streamlit.io/api.html#streamlit.form).
 """
 
 


### PR DESCRIPTION
The warning displayed when a form is missing a submit button contains an incorrect link to the relevant section of our API reference. 

**What it says:**
https://docs.streamlit.io/api.html#form

**What it should say:**
https://docs.streamlit.io/api.html#streamlit.form