### PR TITLE
Added 1 missed step in docs of publishing component

### DIFF
--- a/docs/publish_streamlit_components.md
+++ b/docs/publish_streamlit_components.md
@@ -22,14 +22,15 @@ The [component-template](https://github.com/streamlit/component-template) GitHub
    - Pass your component's name as the the first argument to `declare_component()`
 2. Edit `MANIFEST.in`, change the path for recursive-include from `package/frontend/build *` to `<component name>/frontend/build *`
 3. Edit `setup.py`, adding your component's name and other relevant info
-4. Create a release build of your frontend code. This will add a new directory, `frontend/build/`, with your compiled frontend in it:
+4. Edit `package.json` in `frontend/`, and add `"homepage": "."`.
+5. Create a release build of your frontend code. This will add a new directory, `frontend/build/`, with your compiled frontend in it:
 
    ```shell
    $ cd frontend
    $ npm run build
    ```
 
-5. Pass the build folder's path as the `path` parameter to `declare_component`. (If you're using the template Python file, you can set `_RELEASE = True` at the top of the file):
+6. Pass the build folder's path as the `path` parameter to `declare_component`. (If you're using the template Python file, you can set `_RELEASE = True` at the top of the file):
 
    ```python
       import streamlit.components.v1 as components


### PR DESCRIPTION
I was creating a custom component in streamlit. And was following this [template](https://github.com/streamlit/component-template/tree/master/template/my_component) and this [documentation](https://docs.streamlit.io/en/stable/publish_streamlit_components.html). And during development every things was working fine but when I went to publish my component. Then things went wrong. I checked all my code and read all the documentation but in vain. This was the error streamlit was showing:
![image](https://user-images.githubusercontent.com/31237074/125843004-450ee267-0e51-42fe-976f-e1f5fe098dfc.png)

Then after a hard struggle of comparing my code line by line to mentioned template I found that it was just a little line that was neither mentioned in the docs nor in template repo. That [line](https://github.com/streamlit/component-template/blob/bc6e70905beb8f9a178fc811603cc65b637bc38d/template/my_component/frontend/package.json#L36) was (in `frontend/package.json`).
```json
"homepage": "."
```

And in this pull request I've added this missing line.