### PR TITLE
Remove now-spurious warn log in _get_file_recs

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -223,10 +223,6 @@ class FileUploaderMixin:
             return []
 
         if len(widget_value) == 0:
-            # Sanity check
-            LOGGER.warning(
-                "Got an empty FileUploader widget_value. (We expect a list with at least one value in it.)"
-            )
             return []
 
         active_file_ids = list(widget_value[1:])


### PR DESCRIPTION
This warning is now incorrect as the case that it complains about can
now happen under normal usage. We may save an empty list in unified
widget/session_state so that users can access the value of a
file_uploader widget via st.session_state.<key>
