### PR TITLE
Fix remote database ambiguity in tutorials

### DIFF
--- a/docs/tutorial/mongodb.md
+++ b/docs/tutorial/mongodb.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This guide explains how to securely access a MongoDB database from Streamlit sharing or Streamlit for Teams. It uses the [PyMongo](https://github.com/mongodb/mongo-python-driver) library and Streamlit's [secrets management](../deploy_streamlit_app.html#secrets-management).
+This guide explains how to securely access a remote MongoDB database from Streamlit sharing or Streamlit for Teams. It uses the [PyMongo](https://github.com/mongodb/mongo-python-driver) library and Streamlit's [secrets management](../deploy_streamlit_app.html#secrets-management).
 
 ## Create a MongoDB Database
 
@@ -38,6 +38,8 @@ password = "xxx"
 ## Copy your app secrets to the cloud
 
 As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit sharing or Streamlit for Teams) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](../deploy_streamlit_app.html#secrets-management).
+
+Make sure to replace `localhost` with the resolvable hostname or IP address of your remote MongoDB instance.
 
 ![](../media/databases/edit-secrets.png)
 

--- a/docs/tutorial/mysql.md
+++ b/docs/tutorial/mysql.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This guide explains how to securely access a MySQL database from Streamlit sharing or Streamlit for Teams. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](../deploy_streamlit_app.html#secrets-management).
+This guide explains how to securely access a remote MySQL database from Streamlit sharing or Streamlit for Teams. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](../deploy_streamlit_app.html#secrets-management).
 
 ## Create a MySQL database
 
@@ -47,6 +47,8 @@ password = "xxx"
 ## Copy your app secrets to the cloud
 
 As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit sharing or Streamlit for Teams) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](../deploy_streamlit_app.html#secrets-management).
+
+Make sure to replace `localhost` with the resolvable hostname or IP address of your remote MySQL database server.
 
 ![](../media/databases/edit-secrets.png)
 

--- a/docs/tutorial/postgresql.md
+++ b/docs/tutorial/postgresql.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This guide explains how to securely access a PostgreSQL database from Streamlit sharing or Streamlit for Teams. It uses the [psycopg2](https://www.psycopg.org/) library and Streamlit's [secrets management](../deploy_streamlit_app.html#secrets-management).
+This guide explains how to securely access a remote PostgreSQL database from Streamlit sharing or Streamlit for Teams. It uses the [psycopg2](https://www.psycopg.org/) library and Streamlit's [secrets management](../deploy_streamlit_app.html#secrets-management).
 
 ## Create a PostgreSQL database
 
@@ -43,6 +43,8 @@ password = "xxx"
 ## Copy your app secrets to the cloud
 
 As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit sharing or Streamlit for Teams) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](../deploy_streamlit_app.html#secrets-management).
+
+Make sure to replace `localhost` with the resolvable hostname or IP address of your remote PostgreSQL database server.
 
 ![](../media/databases/edit-secrets.png)
 


### PR DESCRIPTION
Some database tutorials are ambiguous about where the database being connected to is hosted. During local development, the `.streamlit/secrets.toml` file specifies the host as `localhost`. However, when copying the app secrets to the cloud, `localhost` should be replaced by the resolvable hostname or IP address of the _remote_ database server.

This PR introduces minimal changes to the language in the **Introduction** and **Copy your app secrets to the cloud** sections to make explicit that the Streamlit app is connecting to a _remote_ database, rather than one on `localhost` or hosted locally on Streamlit Sharing.