### PR TITLE
Always open user-provided text files as utf8

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1078,7 +1078,7 @@ def get_config_options(
             if not os.path.exists(filename):
                 continue
 
-            with open(filename, "r") as input:
+            with open(filename, "r", encoding="utf-8") as input:
                 file_contents = input.read()
 
             _update_config_with_toml(file_contents, filename)

--- a/lib/streamlit/secrets.py
+++ b/lib/streamlit/secrets.py
@@ -86,7 +86,7 @@ class Secrets(Mapping[str, Any]):
                 return self._secrets
 
             try:
-                with open(self._file_path) as f:
+                with open(self._file_path, encoding="utf-8") as f:
                     secrets_file_str = f.read()
             except FileNotFoundError:
                 if print_exceptions:

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -28,4 +28,4 @@ def open_python_file(filename):
         # found, opens as utf-8.
         return tokenize.open(filename)
     else:
-        return open(filename, "r")
+        return open(filename, "r", encoding="utf-8")


### PR DESCRIPTION
This shouldn't matter at all for Mac and Linux users, but in Windows,
utf8 isn't the default encoding, so things may explode when the file
handler returned by a call to the Python builtin `open` stumbles upon a
Unicode character.

We chose to specify the encoding explicitly in calls to `open` rather
than other ways of doing this (such as via env var) since there are very
few calls to `open` that needed to be updated, anyway.

Fixes #3022