### PR TITLE
Pin GitPython version not equal to 3.1.19 to avoid nightly builds crush.

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -54,4 +54,4 @@ validators = "*"
 # Don't require watchdog on MacOS, since it'll fail without xcode tools.
 # Without watchdog, we fallback to a polling file watcher to check for app changes.
 watchdog = {version = "*", markers = "platform_system != 'Darwin'"}
-gitpython = "*"
+gitpython = "!=3.1.19"


### PR DESCRIPTION
Pin GitPython version not equal to 3.1.19 to avoid nightly builds crush. 
This release includes the unfinished addition of types to the library.

For more information please see [this issue](https://github.com/gitpython-developers/GitPython/issues/1095)