### PR TITLE
fix-3509 - st.json() serialization output for custom classes

### DIFF
--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -56,13 +56,13 @@ class JsonMixin:
 
         if not isinstance(body, str):
             try:
-                body = json.dumps(body, default=lambda o: str(type(o)))
+                body = json.dumps(body, default=repr)
             except TypeError as err:
                 st.warning(
                     "Warning: this data structure was not fully serializable as "
                     "JSON due to one or more unexpected keys.  (Error was: %s)" % err
                 )
-                body = json.dumps(body, skipkeys=True, default=lambda o: str(type(o)))
+                body = json.dumps(body, skipkeys=True, default=repr)
 
         json_proto = JsonProto()
         json_proto.body = body

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -399,7 +399,7 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
         element = self.get_delta_from_queue().new_element
 
         # validate a substring since repr for a module may contain an installation-specific path
-        self.assertEqual(element.json.body[0:15], "\"<module 'json'")
+        self.assertTrue(element.json.body.startswith("\"<module 'json'"))
 
     def test_markdown(self):
         """Test Markdown element."""

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -397,7 +397,9 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
         st.json(obj)
 
         element = self.get_delta_from_queue().new_element
-        self.assertEqual("\"<class 'module'>\"", element.json.body)
+
+        # validate a substring since repr for a module may contain an installation-specific path
+        self.assertEqual(element.json.body[0:15], "\"<module 'json'")
 
     def test_markdown(self):
         """Test Markdown element."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -529,7 +529,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         st.json(data)
 
         el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.json.body, '{"array": "<class \'numpy.ndarray\'>"}')
+
+        self.assertEqual(el.json.body, '{"array": "array([1, 2, 3, 4, 5])"}')
+
 
     def test_st_legacy_line_chart(self):
         """Test st._legacy_line_chart."""


### PR DESCRIPTION
Issue [#3509](https://github.com/streamlit/streamlit/issues/3509)

* Replaced call to `lambda o: str(type(o))` with `repr`
* Updated unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
