### PR TITLE
Make copies of returned reference types stored in widget state

### DIFF
--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -21,7 +21,7 @@ else:
     st.text(single_file.read())
 
 if st._is_running_with_streamlit:
-    st.write(st.session_state.single == single_file)
+    st.write(repr(st.session_state.single) == repr(single_file))
 
 multiple_files = st.file_uploader(
     "Drop multiple files:",
@@ -36,7 +36,7 @@ else:
     st.text("\n".join(files))
 
 if st._is_running_with_streamlit:
-    st.write(st.session_state.multiple == multiple_files)
+    st.write(repr(st.session_state.multiple) == repr(multiple_files))
 
 with st.form("foo"):
     form_file = st.file_uploader("Inside form:", type=["txt"])

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
 import json
 from typing import (
     Any,
@@ -432,7 +433,7 @@ class SessionState(MutableMapping[str, Any]):
         """
         widget_metadata = self._new_widget_state.widget_metadata[widget_id]
         deserializer = widget_metadata.deserializer
-        initial_value = deserializer(None, widget_metadata.id)
+        initial_value = deepcopy(deserializer(None, widget_metadata.id))
 
         if widget_id not in self:
             # This is the first time this widget is being registered, so we set
@@ -462,10 +463,10 @@ class SessionState(MutableMapping[str, Any]):
     def get_value_for_registration(self, widget_id: str) -> Any:
         try:
             value = self[widget_id]
-            return value
+            return deepcopy(value)
         except KeyError:
             metadata = self._new_widget_state.widget_metadata[widget_id]
-            return metadata.deserializer(None, metadata.id)
+            return deepcopy(metadata.deserializer(None, metadata.id))
 
     def as_widget_states(self) -> List[WidgetStateProto]:
         return self._new_widget_state.as_widget_states()

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -52,9 +52,6 @@ class UploadedFile(io.BytesIO):
     def __repr__(self) -> str:
         return util.repr_(self)
 
-    def __eq__(self, other) -> bool:
-        return repr(self) == repr(other)
-
 
 class UploadedFileManager(object):
     """Holds files uploaded by users of the running Streamlit app,

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -52,6 +52,9 @@ class UploadedFile(io.BytesIO):
     def __repr__(self) -> str:
         return util.repr_(self)
 
+    def __eq__(self, other) -> bool:
+        return repr(self) == repr(other)
+
 
 class UploadedFileManager(object):
     """Holds files uploaded by users of the running Streamlit app,

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -245,8 +245,6 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
             key="color",
         )
 
-        color.append("purple")
-
         ctx = get_report_ctx()
         assert ctx.session_state._initial_widget_values["color"] is not color
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -25,7 +25,7 @@ import tornado.testing
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
-from streamlit.report_thread import _StringSet
+from streamlit.report_thread import _StringSet, get_report_ctx
 from streamlit.state.session_state import (
     GENERATED_WIDGET_KEY_PREFIX,
     get_session_state,
@@ -232,6 +232,23 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
 
         assert "foo" in state
         assert state.foo == "foo"
+
+    def test_widget_outputs_dont_alias(self):
+        color = st.select_slider(
+            "Select a color of the rainbow",
+            options=[
+                ["red", "orange"],
+                ["yellow", "green"],
+                ["blue", "indigo"],
+                ["violet"],
+            ],
+            key="color",
+        )
+
+        color.append("purple")
+
+        ctx = get_report_ctx()
+        assert ctx.session_state._initial_widget_values["color"] is not color
 
 
 def check_roundtrip(widget_id: str, value: Any) -> None:


### PR DESCRIPTION
#3600  is caused by the initial value of a widget, which is stored and
compared to internally, being returned directly as the widget's return
value. This is not a problem for value types, but if we return a mutable
reference type and the user mutates it later in the script, it changes
our stored copy, so we incorrectly think the initial value has changed
on the next run.

This is also a potential issue for values that are passed in, in various
ways, but handling them systematically will require some careful
checking. The reference type sharing introduces a potential for bugs
akin to "shotgun parsing", and Python is not very well equiped for
dealing with this kind of issue.

The unit test for this might make more sense elsewhere, but I couldn't
decide where.