### PR TITLE
Adds st.caption to API reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,6 +69,7 @@ also use [magic commands](api.html#magic-commands) in place of `st.write`.
 ```eval_rst
 .. autofunction:: streamlit.text
 .. autofunction:: streamlit.markdown
+.. autofunction:: streamlit.caption
 .. autofunction:: streamlit.latex
 .. autofunction:: streamlit.write
 .. autofunction:: streamlit.title


### PR DESCRIPTION
Adds `st.caption` to the API reference:

`st.caption` was released in Streamlit, version 0.81.1 but isn't documented in the API reference.