### PR TITLE
[3028] Add config option for the health endpoint

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -598,6 +598,16 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "server.healthEndpoint",
+    description="""
+        Endpoint where the application health is checked. On success, it returns
+        200 HTTP status code. On failure, it returns 503 HTTP status code.
+    """,
+    default_val="healthz",
+    type_=str,
+)
+
 
 # TODO: Rename to server.enableCorsProtection.
 @_create_option("server.enableCORS", type_=bool)

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -325,6 +325,8 @@ class Server(object):
 
         """
         base = config.get_option("server.baseUrlPath")
+        health_endpoint = config.get_option("server.healthEndpoint")
+
         routes = [
             (
                 make_url_path_regex(base, "stream"),
@@ -332,7 +334,7 @@ class Server(object):
                 dict(server=self),
             ),
             (
-                make_url_path_regex(base, "healthz"),
+                make_url_path_regex(base, health_endpoint),
                 HealthHandler,
                 dict(callback=lambda: self.is_ready_for_browser_connection),
             ),

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -329,6 +329,7 @@ class ConfigTest(unittest.TestCase):
                 "server.baseUrlPath",
                 "server.enableCORS",
                 "server.cookieSecret",
+                "server.healthEndpoint",
                 "server.enableWebsocketCompression",
                 "server.enableXsrfProtection",
                 "server.fileWatcherType",


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/3028

**Description:** `/healthz` is sometimes reserved and users need a way to change the health endpoint. This diff introduces a config option for changing the endpoint.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
