### PR TITLE
Always send client_state to the frontend on a rerun

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -213,7 +213,7 @@ class ReportSession(object):
 
         self.enqueue(msg)
 
-    def request_rerun(self, client_state=None):
+    def request_rerun(self, client_state):
         """Signal that we're interested in running the script.
 
         If the script is not already running, it will be started immediately.
@@ -243,7 +243,7 @@ class ReportSession(object):
     def _on_source_file_changed(self):
         """One of our source files changed. Schedule a rerun if appropriate."""
         if self._run_on_save:
-            self.request_rerun()
+            self.request_rerun(self._client_state)
         else:
             self._enqueue_file_change_message()
 

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -381,3 +381,12 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
             '"comic sans" is an invalid value for theme.font.'
             " Allowed values include ['sans serif', 'serif', 'monospace']. Setting theme.font to \"sans serif\"."
         )
+
+    @patch("streamlit.report_session.LocalSourcesWatcher")
+    def test_passes_client_state_on_run_on_save(self, _):
+        rs = ReportSession(None, "", "", UploadedFileManager())
+        rs._run_on_save = True
+        rs.request_rerun = MagicMock()
+        rs._on_source_file_changed()
+
+        rs.request_rerun.assert_called_once_with(rs._client_state)


### PR DESCRIPTION
While manually testing #3535, I noticed a bug described in [this comment](https://github.com/streamlit/streamlit/pull/3535#issuecomment-890288395).

The cause of this bug turned out to be changes to how we handle widget identity in
the post-session_state world. Since a keyed widget's identity is stable even if its args
change, we may need to update the widget value on the frontend if its default value is
changed in the script (previously, this "just worked" because the widget being updated
was actually it being totally replaced by a new widget with a different ID).

Updating the widget frontend value requires us to always send the client state we have
stored to the client on a rerun, which previously wasn't being done when a user clicked
the "always rerun" button.