### PR TITLE
Fix image os error

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -134,10 +134,8 @@ class ImageMixin:
         return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
-def _image_has_alpha_channel(image):
-    if image.mode in ("RGBA", "LA") or (
-        image.mode == "P" and "transparency" in image.info
-    ):
+def _image_may_have_alpha_channel(image):
+    if image.mode in ("RGBA", "LA", "P"):
         return True
     else:
         return False
@@ -152,7 +150,7 @@ def _format_from_image_type(image, output_format):
     if output_format == "JPG":
         return "JPEG"
 
-    if _image_has_alpha_channel(image):
+    if _image_may_have_alpha_channel(image):
         return "PNG"
 
     return "JPEG"
@@ -162,7 +160,7 @@ def _PIL_to_bytes(image, format="JPEG", quality=100):
     tmp = io.BytesIO()
 
     # User must have specified JPEG, so we must convert it
-    if format == "JPEG" and _image_has_alpha_channel(image):
+    if format == "JPEG" and _image_may_have_alpha_channel(image):
         image = image.convert("RGB")
 
     image.save(tmp, format=format, quality=quality)

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -281,17 +281,8 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         """
         pass
 
-    @parameterized.expand(
-        [
-            ("P", True),
-            ("RGBA", True),
-            ("LA", True),
-            ("RGB", False)
-        ]
-    )
+    @parameterized.expand([("P", True), ("RGBA", True), ("LA", True), ("RGB", False)])
     def test_image_may_have_alpha_channel(self, format: str, expected_alpha: bool):
-        img = Image.new(format,(1,1))
+        img = Image.new(format, (1, 1))
         self.assertTrue(img.mode == format)
         self.assertEqual(image._image_may_have_alpha_channel(img), expected_alpha)
-
-

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -280,3 +280,18 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         * int  with clipping
         """
         pass
+
+    @parameterized.expand(
+        [
+            ("P", True),
+            ("RGBA", True),
+            ("LA", True),
+            ("RGB", False)
+        ]
+    )
+    def test_image_may_have_alpha_channel(self, format: str, expected_alpha: bool):
+        img = Image.new(format,(1,1))
+        self.assertTrue(img.mode == format)
+        self.assertEqual(image._image_may_have_alpha_channel(img), expected_alpha)
+
+

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -284,5 +284,4 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
     @parameterized.expand([("P", True), ("RGBA", True), ("LA", True), ("RGB", False)])
     def test_image_may_have_alpha_channel(self, format: str, expected_alpha: bool):
         img = Image.new(format, (1, 1))
-        self.assertTrue(img.mode == format)
         self.assertEqual(image._image_may_have_alpha_channel(img), expected_alpha)


### PR DESCRIPTION
Close #3597 . Discussed this with Vincent to change the logic to see if the image may have an alpha channel. Sometimes, there is a png that does not have an alpha channel and it looks like it causes some breakage within our code as OS tries to convert P mode image to JPEG. 