### PR TITLE
`width` not necessary for SVGs to work on `image.py` docstring

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -68,7 +68,6 @@ class ImageMixin:
         width : int or None
             Image width. None means use the image width,
             but do not exceed the width of the column.
-            Should be set for SVG images, as they have no default image width.
         use_column_width : 'auto' or 'always' or 'never' or bool
             If 'auto', set the image's width to its natural size,
             but do not exceed the width of the column.


### PR DESCRIPTION
removed formerly lineno 71 on the docstring, since `width` is not necessary for SVGs to work