### PR TITLE
solve #3604

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -362,8 +362,15 @@ def marshall_images(
             if image.endswith(".svg"):
                 with open(image) as textfile:
                     image = textfile.read()
+
+            if image.strip().startswith("<svg"):
                 proto_img.markup = f"data:image/svg+xml,{image}"
                 is_svg = True
+
+            else:
+                proto_img.markup = f"data:image/svg+xml,{image}"
+                is_svg = True
+
         if not is_svg:
             proto_img.url = image_to_url(
                 image, width, clamp, channels, output_format, image_id

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -362,7 +362,6 @@ def marshall_images(
             if image.endswith(".svg"):
                 with open(image) as textfile:
                     image = textfile.read()
-            # if image.strip().startswith("<svg"):
                 proto_img.markup = f"data:image/svg+xml,{image}"
                 is_svg = True
         if not is_svg:

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -362,7 +362,7 @@ def marshall_images(
             if image.endswith(".svg"):
                 with open(image) as textfile:
                     image = textfile.read()
-            if image.strip().startswith("<svg"):
+            # if image.strip().startswith("<svg"):
                 proto_img.markup = f"data:image/svg+xml,{image}"
                 is_svg = True
         if not is_svg:


### PR DESCRIPTION
There's an issue with formerly lineno 365, where streamlit *checks* if the SVG code starts with a `<svg`. This is obviously not the case with most SVG files, and hence it spits out a `FileNotFoundError` when the file starts with anything other than `<svg`. This is solved when the `if` statement that checks for `startswith()` is removed, so the SVG file is rendered regardless of  the starting tag(s)/strings.