### PR TITLE
Retain file_uploader state when an expander closes

### DIFF
--- a/frontend/src/components/widgets/FileUploader/UploadFileInfo.ts
+++ b/frontend/src/components/widgets/FileUploader/UploadFileInfo.ts
@@ -43,7 +43,9 @@ export type FileStatus = UploadingStatus | UploadedStatus | ErrorStatus
  * This class is immutable because it's used in within FileUploader.state.
  */
 export class UploadFileInfo {
-  public readonly file: File
+  public readonly name: string
+
+  public readonly size: number
 
   public readonly status: FileStatus
 
@@ -58,11 +60,17 @@ export class UploadFileInfo {
    * Create a clone of this UploadFileInfo with the given status.
    */
   public setStatus(status: FileStatus): UploadFileInfo {
-    return new UploadFileInfo(this.file, this.id, status)
+    return new UploadFileInfo(this.name, this.size, this.id, status)
   }
 
-  public constructor(file: File, id: number, status: FileStatus) {
-    this.file = file
+  public constructor(
+    name: string,
+    size: number,
+    id: number,
+    status: FileStatus
+  ) {
+    this.name = name
+    this.size = size
     this.id = id
     this.status = status
   }

--- a/frontend/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -26,19 +26,14 @@ import Button from "src/components/shared/Button"
 import UploadedFile, { Props, UploadedFileStatus } from "./UploadedFile"
 import { FileStatus, UploadFileInfo } from "./UploadFileInfo"
 
-const MOCK_FILE = new File(["Text in a file!"], "filename.txt", {
-  type: "text/plain",
-  lastModified: 0,
-})
-
 const getProps = (fileStatus: FileStatus): Props => ({
-  fileInfo: new UploadFileInfo(MOCK_FILE, 0, fileStatus),
+  fileInfo: new UploadFileInfo("filename.txt", 15, 1, fileStatus),
   onDelete: jest.fn(),
 })
 
 describe("FileStatus widget", () => {
   it("renders without crashing", () => {
-    const props = getProps({ type: "uploaded" })
+    const props = getProps({ type: "uploaded", serverFileId: 1 })
     const wrapper = shallow(<UploadedFileStatus {...props} />)
 
     expect(wrapper).toBeDefined()
@@ -67,7 +62,7 @@ describe("FileStatus widget", () => {
   })
 
   it("show file size when uploaded", () => {
-    const props = getProps({ type: "uploaded" })
+    const props = getProps({ type: "uploaded", serverFileId: 1 })
 
     const wrapper = shallow(<UploadedFileStatus {...props} />)
     const statusWrapper = wrapper.find(Small)
@@ -77,14 +72,15 @@ describe("FileStatus widget", () => {
 
 describe("UploadedFile widget", () => {
   it("renders without crashing", () => {
-    const props = getProps({ type: "uploaded" })
+    const props = getProps({ type: "uploaded", serverFileId: 1 })
     const wrapper = shallow(<UploadedFile {...props} />)
 
     expect(wrapper).toBeDefined()
+    expect(wrapper.text()).toContain("filename.txt")
   })
 
   it("calls delete callback", () => {
-    const props = getProps({ type: "uploaded" })
+    const props = getProps({ type: "uploaded", serverFileId: 1 })
     const wrapper = mount(<UploadedFile {...props} />)
     const deleteBtn = wrapper.find(Button)
     deleteBtn.simulate("click")

--- a/frontend/src/components/widgets/FileUploader/UploadedFile.tsx
+++ b/frontend/src/components/widgets/FileUploader/UploadedFile.tsx
@@ -80,7 +80,7 @@ export const UploadedFileStatus = ({
   }
 
   if (fileInfo.status.type === "uploaded") {
-    return <Small>{getSizeDisplay(fileInfo.file.size, FileSize.Byte)}</Small>
+    return <Small>{getSizeDisplay(fileInfo.size, FileSize.Byte)}</Small>
   }
 
   return null
@@ -95,9 +95,9 @@ const UploadedFile = ({ fileInfo, onDelete }: Props): React.ReactElement => {
       <StyledUploadedFileData className="uploadedFileData">
         <StyledUploadedFileName
           className="uploadedFileName"
-          title={fileInfo.file.name}
+          title={fileInfo.name}
         >
-          {fileInfo.file.name}
+          {fileInfo.name}
         </StyledUploadedFileName>
         <UploadedFileStatus fileInfo={fileInfo} />
       </StyledUploadedFileData>

--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -16,7 +16,11 @@
  */
 
 import { enableAllPlugins } from "immer"
-import { ArrowTable } from "src/autogen/proto"
+import {
+  ArrowTable as ArrowTableProto,
+  FileUploaderState as FileUploaderStateProto,
+  UploadedFileInfo as UploadedFileInfoProto,
+} from "src/autogen/proto"
 import {
   createFormsData,
   FormsData,
@@ -25,7 +29,7 @@ import {
   WidgetStateManager,
 } from "src/lib/WidgetStateManager"
 
-const MOCK_ARROW_TABLE = new ArrowTable({
+const MOCK_ARROW_TABLE = new ArrowTableProto({
   data: new Uint8Array(),
   index: new Uint8Array(),
   columns: new Uint8Array(),
@@ -44,6 +48,23 @@ const MOCK_FORM_WIDGET = {
   id: "mockFormWidgetId",
   formId: "mockFormId",
 }
+
+const MOCK_FILE_UPLOADER_STATE = new FileUploaderStateProto({
+  maxFileId: 42,
+  uploadedFileInfo: [
+    new UploadedFileInfoProto({
+      id: 4,
+      name: "bob",
+      size: 5,
+    }),
+
+    new UploadedFileInfoProto({
+      id: 42,
+      name: "linus",
+      size: 9001,
+    }),
+  ],
+})
 
 // Required by ImmerJS
 enableAllPlugins()
@@ -198,6 +219,20 @@ describe("Widget State Manager", () => {
       const widget = getWidget({ insideForm })
       widgetMgr.setBytesValue(widget, MOCK_BYTES, { fromUi: true })
       expect(widgetMgr.getBytesValue(widget)).toEqual(MOCK_BYTES)
+      assertCallbacks({ insideForm })
+    }
+  )
+
+  it.each([false, true])(
+    "sets FileUploaderState value correctly (insideForm=%p)",
+    insideForm => {
+      const widget = getWidget({ insideForm })
+      widgetMgr.setFileUploaderStateValue(widget, MOCK_FILE_UPLOADER_STATE, {
+        fromUi: true,
+      })
+      expect(widgetMgr.getFileUploaderStateValue(widget)).toEqual(
+        MOCK_FILE_UPLOADER_STATE
+      )
       assertCallbacks({ insideForm })
     }
   )

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -21,6 +21,7 @@ import { Long, util } from "protobufjs"
 import {
   DoubleArray,
   IArrowTable,
+  IFileUploaderState,
   SInt64Array,
   StringArray,
   WidgetState,
@@ -443,6 +444,26 @@ export class WidgetStateManager {
     const state = this.getWidgetState(widget)
     if (state != null && state.value === "bytesValue") {
       return state.bytesValue as Uint8Array
+    }
+
+    return undefined
+  }
+
+  public setFileUploaderStateValue(
+    widget: WidgetInfo,
+    value: IFileUploaderState,
+    source: Source
+  ): void {
+    this.createWidgetState(widget, source).fileUploaderStateValue = value
+    this.onWidgetValueChanged(widget.formId, source)
+  }
+
+  public getFileUploaderStateValue(
+    widget: WidgetInfo
+  ): IFileUploaderState | undefined {
+    const state = this.getWidgetState(widget)
+    if (state != null && state.value === "fileUploaderStateValue") {
+      return state.fileUploaderStateValue as IFileUploaderState
     }
 
     return undefined

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -27,7 +27,10 @@ from streamlit.state.session_state import (
     WidgetKwargs,
 )
 from .form import current_form_id
-from ..proto.Common_pb2 import SInt64Array
+from ..proto.Common_pb2 import (
+    FileUploaderState as FileUploaderStateProto,
+    UploadedFileInfo as UploadedFileInfoProto,
+)
 from ..uploaded_file_manager import UploadedFile, UploadedFileRec
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -154,7 +157,7 @@ class FileUploaderMixin:
             file_uploader_proto.help = dedent(help)
 
         def deserialize_file_uploader(
-            ui_value: List[int], widget_id: str
+            ui_value: Optional[FileUploaderStateProto], widget_id: str
         ) -> SomeUploadedFiles:
             file_recs = self._get_file_recs(widget_id, ui_value)
             if len(file_recs) == 0:
@@ -166,23 +169,30 @@ class FileUploaderMixin:
                 return_value = files if accept_multiple_files else files[0]
             return return_value
 
-        def serialize_file_uploader(files: SomeUploadedFiles) -> List[int]:
-            if not files:
-                return []
-            if isinstance(files, list):
-                ids = [f.id for f in files]
-            else:
-                ids = [files.id]
+        def serialize_file_uploader(files: SomeUploadedFiles) -> FileUploaderStateProto:
+            state_proto = FileUploaderStateProto()
 
             ctx = get_report_ctx()
             if ctx is None:
-                return []
+                return state_proto
 
             # ctx.uploaded_file_mgr._file_id_counter stores the id to use for
-            # the next uploaded file, so the current highest file id is the
+            # the *next* uploaded file, so the current highest file id is the
             # counter minus 1.
-            max_id = ctx.uploaded_file_mgr._file_id_counter - 1
-            return [max_id] + ids
+            state_proto.max_file_id = ctx.uploaded_file_mgr._file_id_counter - 1
+
+            if not files:
+                return state_proto
+            elif not isinstance(files, list):
+                files = [files]
+
+            for f in files:
+                file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
+                file_info.id = f.id
+                file_info.name = f.name
+                file_info.size = f.size
+
+            return state_proto
 
         # FileUploader's widget value is a list of file IDs
         # representing the current set of files that this uploader should
@@ -199,12 +209,11 @@ class FileUploaderMixin:
         )
 
         ctx = get_report_ctx()
-        serialized = serialize_file_uploader(widget_value)
-        if ctx is not None and len(serialized) != 0:
-            # The first number in the serialized widget_value list is the id
-            # of the most recently uploaded file.
-            newest_file_id = serialized[0]
-            active_file_ids = list(serialized[1:])
+        file_uploader_state = serialize_file_uploader(widget_value)
+        uploaded_file_info = file_uploader_state.uploaded_file_info
+        if ctx is not None and len(uploaded_file_info) != 0:
+            newest_file_id = file_uploader_state.max_file_id
+            active_file_ids = [f.id for f in uploaded_file_info]
 
             ctx.uploaded_file_mgr.remove_orphaned_files(
                 session_id=ctx.session_id,
@@ -218,7 +227,7 @@ class FileUploaderMixin:
 
     @staticmethod
     def _get_file_recs(
-        widget_id: str, widget_value: Optional[List[int]]
+        widget_id: str, widget_value: Optional[FileUploaderStateProto]
     ) -> List[UploadedFileRec]:
         if widget_value is None:
             return []
@@ -227,10 +236,11 @@ class FileUploaderMixin:
         if ctx is None:
             return []
 
-        if len(widget_value) == 0:
+        uploaded_file_info = widget_value.uploaded_file_info
+        if len(uploaded_file_info) == 0:
             return []
 
-        active_file_ids = list(widget_value[1:])
+        active_file_ids = [f.id for f in uploaded_file_info]
 
         # Grab the files that correspond to our active file IDs.
         return ctx.uploaded_file_mgr.get_files(

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -186,6 +186,8 @@ class WStates(MutableMapping[str, Any]):
                         arr.data.extend(serialized)
                     elif field == "json_value":
                         setattr(widget, field, json.dumps(serialized))
+                    elif field == "file_uploader_state_value":
+                        widget.file_uploader_state_value.CopyFrom(serialized)
                     else:
                         setattr(widget, field, serialized)
                     return widget

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -181,7 +181,7 @@ element_type_to_value_type = {
     "checkbox": "bool_value",
     "color_picker": "string_value",
     "date_input": "string_array_value",
-    "file_uploader": "int_array_value",
+    "file_uploader": "file_uploader_state_value",
     "multiselect": "int_array_value",
     "number_input": "double_value",
     "radio": "int_value",

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -36,6 +36,7 @@ from streamlit.state.session_state import (
     WidgetMetadata,
     WStates,
 )
+from streamlit.uploaded_file_manager import UploadedFileRec
 from tests import testutil
 
 
@@ -278,6 +279,31 @@ class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
             key="date_interval",
         )
         check_roundtrip("date_interval", date_interval)
+
+    @patch("streamlit.elements.file_uploader.FileUploaderMixin._get_file_recs")
+    def test_file_uploader_serde(self, get_file_recs_patch):
+        file_recs = [
+            UploadedFileRec(1, "file1", "type", b"123"),
+        ]
+        get_file_recs_patch.return_value = file_recs
+
+        uploaded_file = st.file_uploader("file_uploader", key="file_uploader")
+
+        # We can't use check_roundtrip here as the return_value of a
+        # file_uploader widget isn't a primitive value, so comparing them
+        # using == checks for reference equality.
+        session_state = get_session_state()
+        metadata = session_state._new_widget_state.widget_metadata["file_uploader"]
+        serializer = metadata.serializer
+        deserializer = metadata.deserializer
+
+        file_after_serde = deserializer(serializer(uploaded_file), "")
+
+        assert uploaded_file.id == file_after_serde.id
+        assert uploaded_file.name == file_after_serde.name
+        assert uploaded_file.type == file_after_serde.type
+        assert uploaded_file.size == file_after_serde.size
+        assert uploaded_file.read() == file_after_serde.read()
 
     def test_multiselect_serde(self):
         multiselect = st.multiselect(

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -41,3 +41,18 @@ message SInt64Array {
 message UInt32Array {
   repeated uint32 data = 1;
 }
+
+// Information on a file uploaded via the file_uploader widget.
+message UploadedFileInfo {
+  sint64 id = 1;
+
+  string name = 2;
+
+  // The size of this file in bytes.
+  uint32 size = 3;
+}
+
+message FileUploaderState {
+  sint64 max_file_id = 1;
+  repeated UploadedFileInfo uploaded_file_info = 2;
+}

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -47,5 +47,6 @@ message WidgetState {
     string json_value = 10;
     ArrowTable arrow_value = 11;
     bytes bytes_value = 12;
+    FileUploaderState file_uploader_state_value = 13;
   }
 }


### PR DESCRIPTION
Currently, st.file_uploader and st.expander don't work well together as
the file_uploader widget loses its state (only on the frontend) when an
expander is closed and reopened. The reason for this is that we aren't
populating the initial value of a file_uploader widget if there's state
for the widget in the WidgetStateManager.

To fix this, we had to do a decent amount of extra work to send more
info about the file_uploader widget's state back to the server.
Previously, we somewhat hackily encoded all of the information in an
array of ints, where the first element in the array is the ID of the
most recently uploaded file, and the others are the IDs of the active
files. We now send a more descriptive proto back and forth, which
includes the max file ID in one field and a list of protos containing
the id/name/size of the uploaded files in another.

Closes #3557
