### PR TITLE
WIP Tabs UI - Looking for feedback

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -80,7 +80,8 @@ import {
 import Maybe from "src/components/core/Maybe/"
 import withExpandable from "src/hocs/withExpandable"
 import { Form, FormSubmitContent } from "src/components/widgets/Form"
-import { Tabs, Tab } from "baseui/tabs-motion"
+import { TabsContainer, TabContent } from "src/components/widgets/Tabs"
+import { Tab } from "baseui/tabs"
 import {
   StyledBlock,
   StyledColumn,
@@ -269,31 +270,11 @@ class Block extends PureComponent<Props> {
       )
     }
 
-    if (node.deltaBlock.tabs) {
-      return (
-        <StyledBlock
-          key={index}
-          data-testid="stBlock"
-          width={width}
-          isEmpty={node.isEmpty}
-        >
-          <Tabs>
-            <Tab title="text">gadsg</Tab>
-          </Tabs>
-        </StyledBlock>
-      )
-    }
-
     if (node.deltaBlock.tab) {
       return (
-        <StyledBlock
-          key={index}
-          data-testid="stBlock"
-          width={width}
-          isEmpty={node.isEmpty}
-        >
-          <Tab title={node.deltaBlock.tab.title}>Content</Tab>
-        </StyledBlock>
+        <TabContent key={index} title={node.deltaBlock.tab.title}>
+          {child}
+        </TabContent>
       )
     }
 
@@ -741,9 +722,10 @@ class Block extends PureComponent<Props> {
       )
     }
 
-    // if (this.props.node.deltaBlock.tabs) {
-    //   return <Tabs activateOnFocus><Tab title="test">content</Tab></Tabs>
-    // }
+    // Create a tabs container for child tabs
+    if (this.props.node.deltaBlock.tabs) {
+      return <TabsContainer>{this.renderElements(0)}</TabsContainer>
+    }
 
     // Create a vertical block. Widths of children autosizes to window width.
     return (

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -80,7 +80,7 @@ import {
 import Maybe from "src/components/core/Maybe/"
 import withExpandable from "src/hocs/withExpandable"
 import { Form, FormSubmitContent } from "src/components/widgets/Form"
-
+import { Tabs, Tab } from "baseui/tabs-motion"
 import {
   StyledBlock,
   StyledColumn,
@@ -266,6 +266,34 @@ class Block extends PureComponent<Props> {
         >
           {child}
         </StyledColumn>
+      )
+    }
+
+    if (node.deltaBlock.tabs) {
+      return (
+        <StyledBlock
+          key={index}
+          data-testid="stBlock"
+          width={width}
+          isEmpty={node.isEmpty}
+        >
+          <Tabs>
+            <Tab title="text">gadsg</Tab>
+          </Tabs>
+        </StyledBlock>
+      )
+    }
+
+    if (node.deltaBlock.tab) {
+      return (
+        <StyledBlock
+          key={index}
+          data-testid="stBlock"
+          width={width}
+          isEmpty={node.isEmpty}
+        >
+          <Tab title={node.deltaBlock.tab.title}>Content</Tab>
+        </StyledBlock>
       )
     }
 
@@ -712,6 +740,10 @@ class Block extends PureComponent<Props> {
         </StyledHorizontalBlock>
       )
     }
+
+    // if (this.props.node.deltaBlock.tabs) {
+    //   return <Tabs activateOnFocus><Tab title="test">content</Tab></Tabs>
+    // }
 
     // Create a vertical block. Widths of children autosizes to window width.
     return (

--- a/frontend/src/components/widgets/Tabs/TabContent.tsx
+++ b/frontend/src/components/widgets/Tabs/TabContent.tsx
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, ReactNode } from "react"
+import { Tab, TabProps } from "baseui/tabs-motion"
+
+export function TabContent(props: TabProps): ReactElement {
+  const { key, title, children } = props
+  return (
+    <Tab title={title} key={key}>
+      {children}
+    </Tab>
+  )
+}

--- a/frontend/src/components/widgets/Tabs/TabsContainer.tsx
+++ b/frontend/src/components/widgets/Tabs/TabsContainer.tsx
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, ReactNode, useState } from "react"
+import { Tabs } from "baseui/tabs-motion"
+
+export interface Props {
+  children?: ReactNode
+}
+
+export function TabsContainer(props: Props): ReactElement {
+  const [activeKey, setActiveKey] = useState<string | number>("0")
+  const { children } = props
+
+  return (
+    <Tabs
+      onChange={({ activeKey }) => setActiveKey(activeKey)}
+      activeKey={activeKey}
+    >
+      {children}
+    </Tabs>
+  )
+}

--- a/frontend/src/components/widgets/Tabs/index.tsx
+++ b/frontend/src/components/widgets/Tabs/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2018-2020 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { TabsContainer } from "./TabsContainer"
+export { TabContent } from "./TabContent"

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -200,6 +200,7 @@ beta_container = _main.beta_container
 beta_expander = _main.beta_expander
 beta_columns = _main.beta_columns
 
+beta_tabs = _main.beta_tabs
 
 def set_option(key, value):
     """Set config option.

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, Sequence, Union
+from typing import cast, List, Sequence, Union
 
 from streamlit.beta_util import function_beta_warning
 from streamlit.errors import StreamlitAPIException

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -220,6 +220,29 @@ class LayoutsMixin:
 
         return self.dg._block(block_proto=block_proto)
 
+    def beta_tabs(self, titles: List, index: int = 0):
+        """
+        Insert group of blocks rendered as tabs
+
+        The passed in list specifies the labels of the tabs
+        """
+
+        if len(titles) == 0 or any(type(title) != str for title in titles):
+            raise StreamlitAPIException(
+                "The input argument to st.beta_tabs must be a list of strings."
+            )
+
+        def tab_proto(title):
+            tab_proto = BlockProto()
+            tab_proto.tab.title = title
+            tab_proto.allow_empty = True
+            return tab_proto
+
+        tabs_proto = BlockProto()
+        tabs_proto.tabs.index = index
+        row = self.dg._block(tabs_proto)
+        return [row._block(tab_proto(t)) for t in titles]
+
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
         """Get our DeltaGenerator."""

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -23,9 +23,11 @@ message Block {
     Column column = 3;
     Expandable expandable = 4;
     Form form = 5;
+    Tabs tabs = 6;
+    Tab tab = 7;
   }
 
-  bool allow_empty = 6;
+  bool allow_empty = 8;
 
   message Vertical {
   }
@@ -46,5 +48,13 @@ message Block {
   message Form {
     string form_id = 1;
     bool clear_on_submit = 2;
+  }
+
+  message Tabs {
+    int32 index = 1;
+  }
+
+  message Tab {
+    string title = 1;
   }
 }


### PR DESCRIPTION
https://github.com/streamlit/streamlit/issues/233 Attempting to created tabbed UI as described in this issue.

This is a work in progress and I am looking to get some initial feedback about whether this would be accepted into streamlit.

I added a new method in `layouts.py` called `beta_tabs` which behaves similarly to `columns`. It takes an array of strings which it will use as Tab titles and then returns an array of block items which can be used to render any other streamlit elements into.

I added a change to `Block.tsx` which renders the main `<Tabs/>` container and then `<Tab>` content containers, also fairly similarly to how columns are implemented.

I looked at various other patterns - styledblock and family, withExpandable, etc - I don't quite see an exact pattern that I could adapt to this use case - so before I go off writing more code, is there any feedback about how this could be done, or any preferences to how it might be done?

Example code snippet:

```
import streamlit as st

st.set_page_config(layout="wide")
st.title("Testing Tabs!")

tab1, tab2 = st.beta_tabs(["Tab 1", "Tab 2"])

with tab1:
    tabbtn1 = st.button("Hello, world!")
    if tabbtn1:
        st.write("You clicked the button")

with tab2:
    tabbtn2 = st.button("Hello there!")
    if tabbtn2:
        st.write("You clicked the other button!")
```

Thanks!

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
