### PR TITLE
UI tweaks #6: tables and dataframes

### DIFF
--- a/frontend/src/components/elements/ArrowDataFrame/ArrowDataFrame.test.tsx
+++ b/frontend/src/components/elements/ArrowDataFrame/ArrowDataFrame.test.tsx
@@ -25,7 +25,7 @@ import { chunk, random, range, times } from "lodash"
 import { Quiver } from "src/lib/Quiver"
 import { UNICODE, EMPTY } from "src/lib/mocks/arrow"
 import { ArrowDataFrame, DataFrameProps } from "./ArrowDataFrame"
-import { MIN_CELL_WIDTH_PX } from "./DataFrameUtil"
+import { ROW_HEIGHT } from "./DataFrameUtil"
 
 const SCROLLBAR_SIZE = 10
 jest.mock("src/vendor/dom-helpers", () => ({
@@ -86,12 +86,11 @@ describe("DataFrame Element", () => {
     expect(multiGridProps.columnCount).toBe(11)
     expect(multiGridProps).toHaveProperty("enableFixedColumnScroll")
     expect(multiGridProps).toHaveProperty("enableFixedRowScroll")
-    // 275px for the dataframe itself + 10px for the horizontal scrollbar
-    expect(multiGridProps.height).toBe(285)
-    expect(multiGridProps.rowHeight).toBe(25)
+    expect(multiGridProps.rowHeight).toBe(ROW_HEIGHT)
     expect(multiGridProps.rowCount).toBe(11)
-    // 400px full container width - 12px for border and vertical scrollbar
-    expect(multiGridProps.width).toBe(388)
+    expect(multiGridProps.height).toBe(ROW_HEIGHT * 11)
+    // 2px is for borders
+    expect(multiGridProps.width).toBe(400 - SCROLLBAR_SIZE - 2)
   })
 
   it("should render as empty if there's no data", () => {
@@ -106,9 +105,9 @@ describe("DataFrame Element", () => {
     expect(multiGridProps.columnCount).toBe(1)
     expect(multiGridProps).toHaveProperty("enableFixedColumnScroll")
     expect(multiGridProps).toHaveProperty("enableFixedRowScroll")
-    expect(multiGridProps.height).toBe(MIN_CELL_WIDTH_PX)
-    expect(multiGridProps.rowHeight).toBe(MIN_CELL_WIDTH_PX)
+    expect(multiGridProps.rowHeight).toBe(ROW_HEIGHT)
     expect(multiGridProps.rowCount).toBe(1)
+    expect(multiGridProps.height).toBe(ROW_HEIGHT)
     expect(multiGridProps.width).toBe(60)
   })
 
@@ -122,7 +121,7 @@ describe("DataFrame Element", () => {
     const heightWithScrollbar = wrapper.find("MultiGrid").props()
       .height as number
 
-    expect(heightWithScrollbar).toBe(normalHeight + SCROLLBAR_SIZE)
+    expect(heightWithScrollbar).toBe(normalHeight)
   })
 
   it("adds extra width for vertical scrollbar when tall but not wide", () => {

--- a/frontend/src/components/elements/ArrowDataFrame/ArrowDataFrame.tsx
+++ b/frontend/src/components/elements/ArrowDataFrame/ArrowDataFrame.tsx
@@ -105,7 +105,7 @@ export function ArrowDataFrame({
       columnIndex,
       key,
       rowIndex,
-      style,
+      style: baseStyle,
     }: CellRendererInput): ReactElement => {
       const { Component, cssId, cssClass, contents } = cellContentsGetter(
         columnIndex,
@@ -118,6 +118,22 @@ export function ArrowDataFrame({
       const columnSortDirection =
         columnIndex === sortColumn ? sortDirection : undefined
 
+      const cellDataType =
+        element.types.data[columnIndex - headerColumns]?.pandas_type
+      const isNumeric = cellDataType === "int64" || cellDataType === "float64"
+
+      const hasData = dataRows !== 0
+      const isLastRow = rowIndex === dataRows
+      const isLastCol = columnIndex === columns - headerColumns
+
+      // Merge our base styles with any additional cell-specific
+      // styles returned by the cellContentsGetter
+      const style: React.CSSProperties = {
+        ...baseStyle,
+        borderBottom: isLastRow && hasData ? "none" : undefined,
+        borderRight: isLastCol ? "none" : undefined,
+      }
+
       return (
         <DataFrameCell
           key={key}
@@ -127,6 +143,7 @@ export function ArrowDataFrame({
           columnIndex={columnIndex}
           rowIndex={rowIndex}
           style={style}
+          isNumeric={isNumeric}
           contents={contents}
           sortedByUser={sortedByUser}
           columnSortDirection={columnSortDirection}
@@ -292,14 +309,15 @@ export function ArrowDataFrame({
         fixedRowCount={headerRows}
         columnWidth={columnWidth}
         columnCount={columns}
-        enableFixedColumnScroll
-        enableFixedRowScroll
+        enableFixedColumnScroll={false}
+        enableFixedRowScroll={false}
         height={height}
         rowHeight={rowHeight}
         rowCount={rows}
         width={elementWidth}
         classNameBottomLeftGrid="table-bottom-left"
         classNameTopRightGrid="table-top-right"
+        classNameBottomRightGrid="table-bottom-right"
         hideBottomLeftGridScrollbar
         hideTopRightGridScrollbar
         ref={multiGridRef}

--- a/frontend/src/components/elements/ArrowDataFrame/DataFrameCell.test.tsx
+++ b/frontend/src/components/elements/ArrowDataFrame/DataFrameCell.test.tsx
@@ -18,8 +18,10 @@
 import React from "react"
 import { shallow } from "enzyme"
 import { ChevronTop, ChevronBottom } from "@emotion-icons/open-iconic"
-import { SortDirection } from "./SortDirection"
+import Tooltip from "src/components/shared/Tooltip"
+import { mount } from "src/lib/test_util"
 
+import { SortDirection } from "./SortDirection"
 import { StyledDataFrameCornerCell } from "./styled-components"
 import DataFrameCell, { DataFrameCellProps } from "./DataFrameCell"
 
@@ -34,16 +36,44 @@ const getProps = (
   sortedByUser: false,
   columnSortDirection: SortDirection.ASCENDING,
   style: {},
+  isNumeric: false,
   ...props,
 })
 
 describe("DataFrameCell Element", () => {
   it("renders without crashing", () => {
     const props = getProps()
-    const wrapper = shallow(<DataFrameCell {...props} />)
+    const wrapper = mount(<DataFrameCell {...props} />)
 
     expect(wrapper.find(StyledDataFrameCornerCell).length).toBe(1)
-    expect(wrapper.prop("children")).toStrictEqual(["", ""])
+
+    const tooltipContents = wrapper.find(Tooltip).prop("content").props
+      .children
+    expect(tooltipContents).toStrictEqual("")
+  })
+
+  describe("the alignment of the contents", () => {
+    it("should be to the right when numeric", () => {
+      const props = getProps({
+        isNumeric: true,
+      })
+      const wrapper = mount(<DataFrameCell {...props} />)
+
+      expect(wrapper.find("StyledEllipsizedDiv").props().style.textAlign).toBe(
+        "right"
+      )
+    })
+
+    it("should be to the left when non-numeric", () => {
+      const props = getProps({
+        isNumeric: false,
+      })
+      const wrapper = mount(<DataFrameCell {...props} />)
+
+      expect(wrapper.find("StyledEllipsizedDiv").props().style.textAlign).toBe(
+        undefined
+      )
+    })
   })
 
   describe("render a sortIcon if it's sorted by the user", () => {
@@ -51,7 +81,7 @@ describe("DataFrameCell Element", () => {
       const props = getProps({
         sortedByUser: true,
       })
-      const wrapper = shallow(<DataFrameCell {...props} />)
+      const wrapper = mount(<DataFrameCell {...props} />)
 
       expect(wrapper.find("Icon").prop("content")).toBe(ChevronTop)
     })
@@ -61,7 +91,7 @@ describe("DataFrameCell Element", () => {
         sortedByUser: true,
         columnSortDirection: SortDirection.DESCENDING,
       })
-      const wrapper = shallow(<DataFrameCell {...props} />)
+      const wrapper = mount(<DataFrameCell {...props} />)
 
       expect(wrapper.find("Icon").prop("content")).toBe(ChevronBottom)
     })
@@ -101,16 +131,16 @@ describe("DataFrameCell Element", () => {
     expect(result).toBe(1)
   })
 
-  describe("title", () => {
+  describe("tooltip", () => {
     it("should show sort by ascending", () => {
       const props = getProps({
         headerClickedCallback: jest.fn().mockReturnValue(1),
       })
-      const wrapper = shallow(<DataFrameCell {...props} />)
+      const wrapper = mount(<DataFrameCell {...props} />)
 
-      expect(wrapper.find(StyledDataFrameCornerCell).prop("title")).toBe(
-        'Sorted by column "" (ascending)'
-      )
+      const tooltipContents = wrapper.find(Tooltip).prop("content").props
+        .children
+      expect(tooltipContents).toBe("Sorted by this index column (ascending)")
     })
 
     it("should show sort by descending", () => {
@@ -118,11 +148,11 @@ describe("DataFrameCell Element", () => {
         headerClickedCallback: jest.fn().mockReturnValue(1),
         columnSortDirection: SortDirection.DESCENDING,
       })
-      const wrapper = shallow(<DataFrameCell {...props} />)
+      const wrapper = mount(<DataFrameCell {...props} />)
 
-      expect(wrapper.find(StyledDataFrameCornerCell).prop("title")).toBe(
-        'Sorted by column "" (descending)'
-      )
+      const tooltipContents = wrapper.find(Tooltip).prop("content").props
+        .children
+      expect(tooltipContents).toBe("Sorted by this index column (descending)")
     })
 
     it("should show sort when sorting is not specified", () => {
@@ -131,11 +161,11 @@ describe("DataFrameCell Element", () => {
         columnSortDirection: undefined,
         contents: "contenido",
       })
-      const wrapper = shallow(<DataFrameCell {...props} />)
+      const wrapper = mount(<DataFrameCell {...props} />)
 
-      expect(wrapper.find(StyledDataFrameCornerCell).prop("title")).toBe(
-        'Sort by column "contenido"'
-      )
+      const tooltipContents = wrapper.find(Tooltip).prop("content").props
+        .children
+      expect(tooltipContents).toBe('Sort by "contenido"')
     })
   })
 })

--- a/frontend/src/components/elements/ArrowDataFrame/DataFrameUtil.tsx
+++ b/frontend/src/components/elements/ArrowDataFrame/DataFrameUtil.tsx
@@ -19,6 +19,7 @@ import { logWarning } from "src/lib/log"
 import { scrollbarSize } from "src/vendor/dom-helpers"
 import React, { ReactElement, ComponentType } from "react"
 import { Quiver, DataFrameCellType } from "src/lib/Quiver"
+import { fontSizes } from "src/theme/primitives/typography"
 import {
   StyledDataFrameRowHeaderCell,
   StyledDataFrameDataCell,
@@ -32,6 +33,11 @@ import {
 const SORT_ICON_WIDTH_PX = 10
 
 /**
+ * Height of dataframe row.
+ */
+export const ROW_HEIGHT = fontSizes.smPx * 2
+
+/*
  * Minimum size of a dataframe cell.
  */
 export const MIN_CELL_WIDTH_PX = 25
@@ -86,7 +92,6 @@ interface ComputedWidths {
   elementWidth: number
   columnWidth: ({ index }: { index: number }) => number
   headerWidth: number
-  needsHorizontalScrollbar: boolean
 }
 
 const DEFAULT_HEIGHT = 300
@@ -109,8 +114,7 @@ export const getDimensions = (
   } = element.dimensions
 
   // Rendering constants.
-  const rowHeight = 25
-  const headerHeight = rowHeight * headerRows
+  const headerHeight = ROW_HEIGHT * headerRows
   const border = 2
 
   // Reserve enough space to render the dataframe border as well as a vertical
@@ -126,7 +130,6 @@ export const getDimensions = (
   )
 
   let { elementWidth, columnWidth, headerWidth } = widths
-  const { needsHorizontalScrollbar } = widths
 
   // Add space for the "empty" text when the table is empty.
   const EMPTY_WIDTH = 60 // px
@@ -143,17 +146,16 @@ export const getDimensions = (
   }
 
   // Allocate extra space for horizontal and vertical scrollbars, if needed.
-  const totalHeight = rows * rowHeight
+  const totalHeight = rows * ROW_HEIGHT
   const maxHeight = height || DEFAULT_HEIGHT
 
-  const horizScrollbarHeight = needsHorizontalScrollbar ? scrollbarSize() : 0
-  height = Math.min(totalHeight + horizScrollbarHeight, maxHeight)
+  height = Math.min(totalHeight, maxHeight)
 
   const needsVerticalScrollbar = totalHeight > maxHeight
   elementWidth += needsVerticalScrollbar ? scrollbarSize() : 0
 
   return {
-    rowHeight,
+    rowHeight: ROW_HEIGHT,
     headerHeight,
     border,
     columnWidth,
@@ -322,7 +324,6 @@ export function getWidths(
   }
 
   const elementWidth = Math.min(distributedTableTotal, containerWidth)
-  const needsHorizontalScrollbar = distributedTableTotal > containerWidth
   const columnWidth = ({ index }: { index: number }): number =>
     distributedTable[index]
 
@@ -334,6 +335,5 @@ export function getWidths(
     elementWidth,
     columnWidth,
     headerWidth,
-    needsHorizontalScrollbar,
   }
 }

--- a/frontend/src/components/elements/ArrowDataFrame/styled-components.ts
+++ b/frontend/src/components/elements/ArrowDataFrame/styled-components.ts
@@ -16,7 +16,6 @@
  */
 
 import styled, { CSSObject } from "@emotion/styled"
-import { transparentize } from "color2k"
 import { Theme } from "src/theme"
 
 export interface StyledDataFrameContainerProps {
@@ -27,38 +26,64 @@ export const StyledDataFrameContainer = styled.div<
   StyledDataFrameContainerProps
 >(({ width, theme }) => ({
   width,
-  border: `1px solid ${theme.colors.secondaryBg}`,
+  border: `1px solid ${theme.colors.fadedText10}`,
   boxSizing: "content-box",
 
-  "& .table-top-right": {
-    overflowX: "hidden",
-    backgroundColor: theme.colors.secondaryBg,
-  },
+  // Make sure when we scroll up the left side has a little extra padding to acccount for scrollbar.
   "& .table-bottom-left": {
-    overflowY: "hidden",
-    backgroundColor: theme.colors.secondaryBg,
+    paddingBottom: "6px" /* Scrollbar size */,
+  },
+
+  // Only this area should ever show a scrollbar
+  // However, only show on hover.
+  "& .table-bottom-right": {
+    overflow: "hidden !important",
+
+    "&:hover": {
+      overflow: "auto !important",
+    },
+  },
+
+  // Remove visible outline from click, since there's no click target/action anyway.
+  "& .table-bottom-right:focus-visible": {
+    outline: "none",
+  },
+  "& .table-bottom-right:focus": {
+    outline: "none",
   },
 }))
 
 const StyledDataFrameCell = styled.div(({ theme }) => ({
-  padding: theme.spacing.sm,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
+  borderBottom: `1px solid ${theme.colors.fadedText10}`,
+  borderRight: `1px solid ${theme.colors.fadedText10}`,
   fontSize: theme.fontSizes.sm,
-  fontFamily: theme.fonts.monospace,
-  textAlign: "right",
-  lineHeight: theme.lineHeights.none,
+  fontFamily: theme.fonts.sansSerif,
+  lineHeight: theme.lineHeights.table,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+
+  "&focus-visible, &:focus": {
+    outline: "none",
+  },
 }))
 
 const headerCellFormatter = (theme: Theme): CSSObject => ({
-  backgroundColor: theme.colors.secondaryBg,
   color: theme.colors.fadedText60,
+  borderBottom: `1px solid ${theme.colors.fadedText10}`,
+  borderRight: `1px solid ${theme.colors.fadedText10}`,
   zIndex: 1,
+  "&:focus-visible, &:focus": {
+    outline: "none",
+  },
 })
 
 const cellTextFormatter = (theme: Theme): CSSObject => ({
   overflow: "hidden",
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
-  lineHeight: theme.lineHeights.dataframeCell,
+  lineHeight: theme.lineHeights.table,
 })
 
 export const StyledDataFrameCornerCell = styled(
@@ -110,13 +135,13 @@ export const StyledFixup = styled.div<StyledFixupProps>(
 
 export const StyledEmptyDataframe = styled.div(({ theme }) => ({
   fontFamily: theme.fonts.monospace,
-  color: theme.colors.darkGray,
+  color: theme.colors.fadedText60,
   fontStyle: "italic",
   fontSize: theme.fontSizes.sm,
   textAlign: "center",
 }))
 
 export const StyledSortIcon = styled.span(({ theme }) => ({
-  color: transparentize(theme.colors.darkGray, 0.7),
+  color: theme.colors.fadedText10,
   verticalAlign: "top",
 }))

--- a/frontend/src/components/elements/ArrowTable/ArrowTable.tsx
+++ b/frontend/src/components/elements/ArrowTable/ArrowTable.tsx
@@ -44,7 +44,11 @@ export function ArrowTable(props: TableProps): ReactElement {
     <StyledTableContainer data-testid="stTable">
       {cssStyles && <style>{cssStyles}</style>}
       <StyledTable id={cssId}>
-        {caption && <caption>{caption}</caption>}
+        {caption && (
+          <caption>
+            <small>{caption}</small>
+          </caption>
+        )}
         {columnHeaders.length > 0 && (
           <thead>
             {columnHeaders.map(rowIndex =>
@@ -101,6 +105,15 @@ function generateTableCell(
   const formattedContent =
     displayContent || Quiver.format(content, contentType)
 
+  const { headerColumns } = table.dimensions
+  const cellDataType =
+    table.types.data[columnIndex - headerColumns]?.pandas_type
+  const isNumeric = cellDataType === "int64" || cellDataType === "float64"
+
+  const style: React.CSSProperties = {
+    textAlign: isNumeric ? "right" : "left",
+  }
+
   switch (type) {
     case "blank": {
       return (
@@ -127,6 +140,7 @@ function generateTableCell(
           key={columnIndex}
           scope="col"
           className={cssClass}
+          style={style}
         >
           {formattedContent}
         </StyledTableCellHeader>
@@ -134,7 +148,7 @@ function generateTableCell(
     }
     case "data": {
       return (
-        <StyledTableCell key={columnIndex} id={cssId}>
+        <StyledTableCell key={columnIndex} id={cssId} style={style}>
           {formattedContent}
         </StyledTableCell>
       )

--- a/frontend/src/components/elements/ArrowTable/styled-components.ts
+++ b/frontend/src/components/elements/ArrowTable/styled-components.ts
@@ -20,9 +20,8 @@ import { Theme } from "src/theme"
 
 export const StyledTableContainer = styled.div(({ theme }) => ({
   fontSize: theme.fontSizes.sm,
-  fontFamily: theme.fonts.monospace,
-  textAlign: "right",
-  padding: theme.spacing.sm,
+  fontFamily: theme.fonts.sansSerif,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
   lineHeight: theme.lineHeights.table,
 }))
 
@@ -31,21 +30,25 @@ export const StyledTable = styled.table(({ theme }) => ({
   marginBottom: theme.spacing.lg,
   color: theme.colors.bodyText,
   borderCollapse: "collapse",
+  border: `1px solid ${theme.colors.fadedText10}`,
 }))
 
-const styleHeaderFunction = (theme: Theme): CSSObject => ({
-  borderTop: `1px solid ${theme.colors.fadedText10}`,
+const styleCellFunction = (theme: Theme): CSSObject => ({
   borderBottom: `1px solid ${theme.colors.fadedText10}`,
+  borderRight: `1px solid ${theme.colors.fadedText10}`,
   verticalAlign: "middle",
-  padding: theme.spacing.md,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
+  fontWeight: theme.fontWeights.normal,
 })
 
 export const StyledTableCell = styled.td(({ theme }) =>
-  styleHeaderFunction(theme)
+  styleCellFunction(theme)
 )
-
 export const StyledTableCellHeader = styled.th(({ theme }) => ({
-  ...styleHeaderFunction(theme),
+  ...styleCellFunction(theme),
+
+  color: theme.colors.fadedText60,
+
   "@media print": {
     // Firefox prints a double blurred table header. Normal font weight fixes it
     "@-moz-document url-prefix()": {

--- a/frontend/src/components/elements/DataFrame/DataFrame.test.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrame.test.tsx
@@ -22,7 +22,7 @@ import { random, times } from "lodash"
 
 import { mockDataFrame, mockStringDataFrame } from "./mock"
 import { DataFrame, DataFrameProps } from "./DataFrame"
-import { MIN_CELL_WIDTH_PX } from "./DataFrameUtil"
+import { ROW_HEIGHT } from "./DataFrameUtil"
 
 const SCROLLBAR_SIZE = 10
 jest.mock("src/vendor/dom-helpers", () => ({
@@ -90,12 +90,11 @@ describe("DataFrame Element", () => {
     expect(multiGridProps.columnCount).toBe(11)
     expect(multiGridProps).toHaveProperty("enableFixedColumnScroll")
     expect(multiGridProps).toHaveProperty("enableFixedRowScroll")
-    // 275px for the dataframe itself + 10px for the horizontal scrollbar
-    expect(multiGridProps.height).toBe(285)
-    expect(multiGridProps.rowHeight).toBe(25)
+    expect(multiGridProps.rowHeight).toBe(ROW_HEIGHT)
     expect(multiGridProps.rowCount).toBe(11)
-    // 400px full container width - 12px for border and vertical scrollbar
-    expect(multiGridProps.width).toBe(388)
+    expect(multiGridProps.height).toBe(ROW_HEIGHT * 11)
+    // 2px is for borders
+    expect(multiGridProps.width).toBe(400 - SCROLLBAR_SIZE - 2)
   })
 
   it("should render as empty if there's no data", () => {
@@ -112,8 +111,8 @@ describe("DataFrame Element", () => {
     expect(multiGridProps.columnCount).toBe(1)
     expect(multiGridProps).toHaveProperty("enableFixedColumnScroll")
     expect(multiGridProps).toHaveProperty("enableFixedRowScroll")
-    expect(multiGridProps.height).toBe(MIN_CELL_WIDTH_PX)
-    expect(multiGridProps.rowHeight).toBe(MIN_CELL_WIDTH_PX)
+    expect(multiGridProps.height).toBe(ROW_HEIGHT)
+    expect(multiGridProps.rowHeight).toBe(ROW_HEIGHT)
     expect(multiGridProps.rowCount).toBe(1)
     expect(multiGridProps.width).toBe(60)
   })
@@ -127,7 +126,7 @@ describe("DataFrame Element", () => {
     wrapper = shallow(<DataFrame {...props} />)
     const heightWithScrollbar = wrapper.find("MultiGrid").props().height
 
-    expect(heightWithScrollbar).toBe(normalHeight + SCROLLBAR_SIZE)
+    expect(heightWithScrollbar).toBe(normalHeight)
   })
 
   it("adds extra width for vertical scrollbar when tall but not wide", () => {

--- a/frontend/src/components/elements/DataFrame/DataFrame.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrame.tsx
@@ -123,9 +123,17 @@ export function DataFrame({
       const columnSortDirection =
         columnIndex === sortColumn ? sortDirection : undefined
 
+      const isLastRow = rowIndex === dataRows
+      const isLastCol = columnIndex === cols - headerCols
+
       // Merge our base styles with any additional cell-specific
       // styles returned by the cellContentsGetter
-      const styles = { ...baseStyle, ...additionalStyles }
+      const styles = {
+        ...baseStyle,
+        ...additionalStyles,
+        borderBottom: isLastRow ? "none" : undefined,
+        borderRight: isLastCol ? "none" : undefined,
+      }
 
       return (
         <DataFrameCell
@@ -232,6 +240,7 @@ export function DataFrame({
         rowCount={rows}
         width={elementWidth}
         classNameBottomLeftGrid="table-bottom-left"
+        classNameBottomRightGrid="table-bottom-right"
         classNameTopRightGrid="table-top-right"
         hideBottomLeftGridScrollbar
         hideTopRightGridScrollbar

--- a/frontend/src/components/elements/DataFrame/DataFrameCell.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrameCell.tsx
@@ -110,8 +110,8 @@ export default function DataFrameCell({
       title={title}
       data-testid={CellType.displayName}
     >
-      {sortedByUser ? sortIcon : ""}
       {contents}
+      {sortedByUser ? sortIcon : ""}
     </CellType>
   )
 }
@@ -123,14 +123,14 @@ function drawSortIcon(sortDirection?: SortDirection): React.ReactNode {
     case SortDirection.ASCENDING:
       return (
         <StyledSortIcon data-testid="sortIcon">
-          <Icon content={ChevronTop} size="xs" margin="0 twoXS 0 0" />
+          <Icon content={ChevronTop} size="xs" margin="0 0 0 twoXS" />
         </StyledSortIcon>
       )
 
     case SortDirection.DESCENDING:
       return (
         <StyledSortIcon data-testid="sortIcon">
-          <Icon content={ChevronBottom} size="xs" margin="0 twoXS 0 0" />
+          <Icon content={ChevronBottom} size="xs" margin="0 0 0 twoXS" />
         </StyledSortIcon>
       )
 

--- a/frontend/src/components/elements/DataFrame/DataFrameUtil.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrameUtil.tsx
@@ -25,6 +25,7 @@ import { logWarning } from "src/lib/log"
 import { scrollbarSize } from "src/vendor/dom-helpers"
 import React, { ReactElement, ComponentType } from "react"
 import { Map as ImmutableMap } from "immutable"
+import { fontSizes } from "src/theme/primitives/typography"
 import {
   StyledDataFrameRowHeaderCell,
   StyledDataFrameDataCell,
@@ -36,6 +37,11 @@ import {
  * Size of the optional sort icon displayed in column headers
  */
 const SORT_ICON_WIDTH_PX = 10
+
+/**
+ * Height of dataframe row.
+ */
+export const ROW_HEIGHT = fontSizes.smPx * 2
 
 /**
  * Minimum size of a dataframe cell.
@@ -91,7 +97,6 @@ interface ComputedWidths {
   elementWidth: number
   columnWidth: ({ index }: { index: number }) => number
   headerWidth: number
-  needsHorizontalScrollbar: boolean
 }
 
 const DEFAULT_HEIGHT = 300
@@ -114,8 +119,7 @@ export const getDimensions = (
   } = dataFrameGetDimensions(element)
 
   // Rendering constants.
-  const rowHeight = 25
-  const headerHeight = rowHeight * headerRows
+  const headerHeight = ROW_HEIGHT * headerRows
   const border = 2
 
   // Reserve enough space to render the dataframe border as well as a vertical
@@ -131,7 +135,6 @@ export const getDimensions = (
   )
 
   let { elementWidth, columnWidth, headerWidth } = widths
-  const { needsHorizontalScrollbar } = widths
 
   // Add space for the "empty" text when the table is empty.
   const EMPTY_WIDTH = 60 // px
@@ -148,17 +151,16 @@ export const getDimensions = (
   }
 
   // Allocate extra space for horizontal and vertical scrollbars, if needed.
-  const totalHeight = rows * rowHeight
+  const totalHeight = rows * ROW_HEIGHT
   const maxHeight = height || DEFAULT_HEIGHT
 
-  const horizScrollbarHeight = needsHorizontalScrollbar ? scrollbarSize() : 0
-  height = Math.min(totalHeight + horizScrollbarHeight, maxHeight)
+  height = Math.min(totalHeight, maxHeight)
 
   const needsVerticalScrollbar = totalHeight > maxHeight
   elementWidth += needsVerticalScrollbar ? scrollbarSize() : 0
 
   return {
-    rowHeight,
+    rowHeight: ROW_HEIGHT,
     headerHeight,
     border,
     columnWidth,
@@ -323,7 +325,6 @@ export function getWidths(
   }
 
   const elementWidth = Math.min(distributedTableTotal, containerWidth)
-  const needsHorizontalScrollbar = distributedTableTotal > containerWidth
   const columnWidth = ({ index }: { index: number }): number =>
     distributedTable[index]
 
@@ -335,6 +336,5 @@ export function getWidths(
     elementWidth,
     columnWidth,
     headerWidth,
-    needsHorizontalScrollbar,
   }
 }

--- a/frontend/src/components/elements/DataFrame/styled-components.ts
+++ b/frontend/src/components/elements/DataFrame/styled-components.ts
@@ -16,7 +16,6 @@
  */
 
 import styled, { CSSObject } from "@emotion/styled"
-import { transparentize } from "color2k"
 import { Theme } from "src/theme"
 
 export interface StyledDataFrameContainerProps {
@@ -27,30 +26,51 @@ export const StyledDataFrameContainer = styled.div<
   StyledDataFrameContainerProps
 >(({ width, theme }) => ({
   width,
-  border: `1px solid ${theme.colors.secondaryBg}`,
+  border: `1px solid ${theme.colors.fadedText10}`,
   boxSizing: "content-box",
 
   "& .table-top-right": {
-    overflowX: "hidden",
-    backgroundColor: theme.colors.secondaryBg,
+    overflow: "hidden !important",
   },
+
   "& .table-bottom-left": {
-    overflowY: "hidden",
-    backgroundColor: theme.colors.secondaryBg,
+    overflow: "hidden !important",
+    paddingBottom: "6px",
+  },
+
+  "& .table-bottom-right": {
+    overflow: "hidden !important",
+
+    "&:hover": {
+      overflow: "auto !important",
+    },
+  },
+
+  "& .table-bottom-right:focus-visible": {
+    outline: "none",
+  },
+
+  "& .table-bottom-right:focus": {
+    outline: "none",
   },
 }))
 
 const StyledDataFrameCell = styled.div(({ theme }) => ({
-  padding: theme.spacing.sm,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
+  borderBottom: `1px solid ${theme.colors.fadedText10}`,
+  borderRight: `1px solid ${theme.colors.fadedText10}`,
   fontSize: theme.fontSizes.sm,
-  fontFamily: theme.fonts.monospace,
-  textAlign: "right",
-  lineHeight: theme.lineHeights.none,
+  fontFamily: theme.fonts.sansSerif,
+  lineHeight: theme.lineHeights.table,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
 }))
 
 const headerCellFormatter = (theme: Theme): CSSObject => ({
-  backgroundColor: theme.colors.secondaryBg,
   color: theme.colors.fadedText60,
+  borderBottom: `1px solid ${theme.colors.fadedText10}`,
+  borderRight: `1px solid ${theme.colors.fadedText10}`,
   zIndex: 1,
 })
 
@@ -58,7 +78,7 @@ const cellTextFormatter = (theme: Theme): CSSObject => ({
   overflow: "hidden",
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
-  lineHeight: theme.lineHeights.dataframeCell,
+  lineHeight: theme.lineHeights.table,
 })
 
 export const StyledDataFrameCornerCell = styled(
@@ -110,13 +130,13 @@ export const StyledFixup = styled.div<StyledFixupProps>(
 
 export const StyledEmptyDataframe = styled.div(({ theme }) => ({
   fontFamily: theme.fonts.monospace,
-  color: theme.colors.darkGray,
+  color: theme.colors.fadedText60,
   fontStyle: "italic",
   fontSize: theme.fontSizes.sm,
   textAlign: "center",
 }))
 
 export const StyledSortIcon = styled.span(({ theme }) => ({
-  color: transparentize(theme.colors.darkGray, 0.7),
+  color: theme.colors.fadedText10,
   verticalAlign: "top",
 }))

--- a/frontend/src/components/elements/Table/styled-components.ts
+++ b/frontend/src/components/elements/Table/styled-components.ts
@@ -20,9 +20,8 @@ import { Theme } from "src/theme"
 
 export const StyledTableContainer = styled.div(({ theme }) => ({
   fontSize: theme.fontSizes.sm,
-  fontFamily: theme.fonts.monospace,
-  textAlign: "right",
-  padding: theme.spacing.sm,
+  fontFamily: theme.fonts.sansSerif,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.sm}`,
   lineHeight: theme.lineHeights.table,
 }))
 
@@ -31,20 +30,25 @@ export const StyledTable = styled.table(({ theme }) => ({
   marginBottom: theme.spacing.lg,
   color: theme.colors.bodyText,
   borderCollapse: "collapse",
+  border: `1px solid ${theme.colors.fadedText10}`,
 }))
 
-const styleHeaderFunction = (theme: Theme): CSSObject => ({
-  borderTop: `1px solid ${theme.colors.fadedText10}`,
+const styleCellFunction = (theme: Theme): CSSObject => ({
   borderBottom: `1px solid ${theme.colors.fadedText10}`,
+  borderRight: `1px solid ${theme.colors.fadedText10}`,
   verticalAlign: "middle",
-  padding: theme.spacing.md,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.sm}`,
+  fontWeight: theme.fontWeights.normal,
 })
 
 export const StyledTableCell = styled.td(({ theme }) =>
-  styleHeaderFunction(theme)
+  styleCellFunction(theme)
 )
 export const StyledTableCellHeader = styled.th(({ theme }) => ({
-  ...styleHeaderFunction(theme),
+  ...styleCellFunction(theme),
+
+  color: theme.colors.fadedText60,
+
   "@media print": {
     // Firefox prints a double blurred table header. Normal font weight fixes it
     "@-moz-document url-prefix()": {

--- a/frontend/src/components/shared/Tooltip/OverflowTooltip.test.tsx
+++ b/frontend/src/components/shared/Tooltip/OverflowTooltip.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { shallow } from "enzyme"
+
+import OverflowTooltip from "./OverflowTooltip"
+
+describe("Tooltip component", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("should render and match snapshots when it fits onscreen", () => {
+    const useRefSpy = jest.spyOn(React, "useRef").mockReturnValue({
+      current: {
+        // Pretend the body is greater than its onscreen area.
+        offsetWidth: 200,
+        scrollWidth: 100,
+      },
+    })
+
+    jest.spyOn(React, "useEffect").mockImplementation(f => f())
+
+    const wrapper = shallow(
+      <OverflowTooltip content="the content">the child</OverflowTooltip>
+    )
+
+    expect(wrapper.props().content).toBe("")
+
+    expect(useRefSpy).toBeCalledWith(null)
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it("should render and match snapshots when ellipsized", () => {
+    const useRefSpy = jest.spyOn(React, "useRef").mockReturnValue({
+      current: {
+        // Pretend the body is smaller than its onscreen area.
+        offsetWidth: 100,
+        scrollWidth: 200,
+      },
+    })
+
+    jest.spyOn(React, "useEffect").mockImplementation(f => f())
+
+    const wrapper = shallow(
+      <OverflowTooltip content="the content">the child</OverflowTooltip>
+    )
+
+    expect(wrapper.props().content).toBe("the content")
+
+    expect(useRefSpy).toBeCalledWith(null)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/frontend/src/components/shared/Tooltip/OverflowTooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/OverflowTooltip.tsx
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode, ReactElement, useState } from "react"
+
+import Tooltip, { Placement } from "./Tooltip"
+import { StyledWrapper, StyledEllipsizedDiv } from "./styled-components"
+
+export interface OverflowTooltipProps {
+  content: ReactNode
+  placement: Placement
+  children: ReactNode
+  inline?: boolean
+  style: React.CSSProperties
+}
+
+/**
+ * Tooltip that only shows when the children are overflowing (in which case,
+ * this also ellipsizes the children).
+ */
+function OverflowTooltip({
+  content,
+  placement,
+  children,
+  inline,
+  style,
+}: OverflowTooltipProps): ReactElement {
+  const childRef = React.useRef<HTMLDivElement>(null)
+  const [allowTooltip, setAllowTooltip] = useState(false)
+
+  React.useEffect(() => {
+    const newAllowTooltip = childRef?.current
+      ? childRef.current.offsetWidth < childRef.current.scrollWidth
+      : false
+    if (newAllowTooltip !== allowTooltip) {
+      setAllowTooltip(newAllowTooltip)
+    }
+  }, [children, allowTooltip])
+
+  return (
+    <Tooltip
+      content={allowTooltip ? content : ""}
+      placement={placement}
+      inline={inline}
+    >
+      <StyledWrapper>
+        <StyledEllipsizedDiv ref={childRef} style={style}>
+          {children}
+        </StyledEllipsizedDiv>
+      </StyledWrapper>
+    </Tooltip>
+  )
+}
+
+export default OverflowTooltip

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -41,6 +41,7 @@ export interface TooltipProps {
   placement: Placement
   children: ReactNode
   inline?: boolean
+  style?: React.CSSProperties
 }
 
 function Tooltip({
@@ -48,6 +49,7 @@ function Tooltip({
   placement,
   children,
   inline,
+  style,
 }: TooltipProps): ReactElement {
   const theme: Theme = useTheme()
   const { colors, fontSizes } = theme
@@ -109,6 +111,7 @@ function Tooltip({
           display: "flex",
           flexDirection: "row",
           justifyContent: inline ? "flex-end" : "",
+          ...style,
         }}
         data-testid="tooltipHoverTarget"
       >

--- a/frontend/src/components/shared/Tooltip/__snapshots__/OverflowTooltip.test.tsx.snap
+++ b/frontend/src/components/shared/Tooltip/__snapshots__/OverflowTooltip.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip component should render and match snapshots when ellipsized 1`] = `
+<Tooltip
+  content="the content"
+>
+  <StyledWrapper>
+    <StyledEllipsizedDiv>
+      the child
+    </StyledEllipsizedDiv>
+  </StyledWrapper>
+</Tooltip>
+`;
+
+exports[`Tooltip component should render and match snapshots when it fits onscreen 1`] = `
+<Tooltip
+  content=""
+>
+  <StyledWrapper>
+    <StyledEllipsizedDiv>
+      the child
+    </StyledEllipsizedDiv>
+  </StyledWrapper>
+</Tooltip>
+`;

--- a/frontend/src/components/shared/Tooltip/styled-components.tsx
+++ b/frontend/src/components/shared/Tooltip/styled-components.tsx
@@ -15,6 +15,17 @@
  * limitations under the License.
  */
 
-export { default, Placement } from "./Tooltip"
-export { default as OverflowTooltip } from "./OverflowTooltip"
-export { StyledEllipsizedDiv } from "./styled-components"
+import styled from "@emotion/styled"
+
+export const StyledWrapper = styled.div({
+  display: "table",
+  tableLayout: "fixed",
+  width: "100%",
+})
+
+export const StyledEllipsizedDiv = styled.div({
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  display: "table-cell",
+})

--- a/frontend/src/components/shared/TooltipIcon/index.tsx
+++ b/frontend/src/components/shared/TooltipIcon/index.tsx
@@ -1,2 +1,3 @@
 export * from "./TooltipIcon"
 export { default } from "./TooltipIcon"
+export { StyledTooltipContentWrapper } from "./styled-components"

--- a/frontend/src/components/shared/TooltipIcon/styled-components.ts
+++ b/frontend/src/components/shared/TooltipIcon/styled-components.ts
@@ -22,7 +22,7 @@ export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
   maxWidth: `calc(${theme.sizes.contentMaxWidth} - 4rem)`,
   maxHeight: "300px",
   overflow: "auto",
-  padding: "14px 16px", // make vertical padding slightly smaller to account for line height
+  padding: `${theme.spacing.xs} ${theme.spacing.md}`,
 
   [`@media (max-width: ${theme.breakpoints.sm})`]: {
     maxWidth: `calc(100% - 2rem)`,

--- a/frontend/src/theme/globalStyles.ts
+++ b/frontend/src/theme/globalStyles.ts
@@ -428,9 +428,9 @@ export const globalStyles = (theme: Theme): any => css`
     border-collapse: collapse;
   }
 
-  caption {
+  table caption {
     padding-top: ${theme.spacing.sm};
-    padding-bottom: ${theme.spacing.sm};
+    padding-bottom: 0;
     color: ${theme.colors.gray60};
     text-align: left;
   }

--- a/frontend/src/theme/primitives/typography.ts
+++ b/frontend/src/theme/primitives/typography.ts
@@ -52,11 +52,10 @@ export const fontWeights = {
 
 export const lineHeights = {
   normal: "normal",
-  none: "1",
-  dataframeCell: "0.75",
-  tight: "1.25",
-  table: "1.3",
-  base: "1.6",
+  none: 1,
+  tight: 1.25,
+  table: 1.5,
+  base: 1.5,
 }
 
 export const letterSpacings = {


### PR DESCRIPTION
(Breaking up #3642 into multiple PRs)

* Change how st.table and st.dataframe look (legacy and Arrow)
  * White background
  * Gray grid
  * Better padding
  * More readable font family and font size
* Make Arrow version only align cells to the right when they're numeric
* Make table captions small, like image captions
* Change scrollbar behavior: don't _always_ include scrollbar. Instead, only show on hover.
  * Potential follow-up: on platforms that have an "overlay scrollbar", don't use custom scrollbars anywhere! The platform handles it nicely. For example, with [Modernizr](https://modernizr.com/docs) `hiddenscroll` feature detection
* Only show tooltip for cell if it's actually overflowing


NOTE: Screenshot tests coming after first round of reviews. Don't want to generate and re-generate as more reviews come in 😅 

NOTE #2: Note the base branch for this PR. I'm basing it on the previous UI tweaks PR so the diff is easier to read. The idea is to merge in order.