### PR TITLE
Pin keras to <2.5.0 in testing

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -5,7 +5,7 @@ chart-studio
 # 8.0.0 causes test_sqlalchemy_engine_2_oracle to fail.
 cx-Oracle<8.0.0
 graphviz
-keras
+keras<2.5.0
 matplotlib
 mysqlclient
 opencv-python
@@ -20,6 +20,6 @@ scipy>=1.4.1
 seaborn
 setuptools<50.0.0
 sqlalchemy
-tensorflow>2.2.0
+tensorflow>2.2.0,<2.5.0
 torch<1.9.0
 torchvision

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -20,7 +20,6 @@ scipy>=1.4.1
 seaborn
 setuptools<50.0.0
 sqlalchemy
-# The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
-tensorflow>2.2.0,<2.5.0
+tensorflow>2.2.0
 torch<1.9.0
 torchvision

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -20,6 +20,7 @@ scipy>=1.4.1
 seaborn
 setuptools<50.0.0
 sqlalchemy
+# The > sign will skip rc versions. TF 2.5 pulls in keras-nightly, which is backwards incompatible and breaks tests
 tensorflow>2.2.0,<2.5.0
 torch<1.9.0
 torchvision


### PR DESCRIPTION
We originally kept tensorflow downgraded in #3266 because of failed tests with keras-nightly. Keras has now been upgraded. We tested the waters, and errors still occur. We will, for now, restrict keras to 2.5.0 or less for the tests.

Likely, the long term solution is to remove the keras import in favor for the tensorflow.keras test, but this test was intentional to test the keras library and needs some investigation. The goal here is to fix the build.