### PR TITLE
Fix "'setIn' cannot be called on an ElementNode" error

### DIFF
--- a/lib/streamlit/report_queue.py
+++ b/lib/streamlit/report_queue.py
@@ -36,16 +36,14 @@ class ReportQueue:
     def __init__(self):
         """Constructor."""
         self._lock = threading.Lock()
+        self._queue: List[ForwardMsg] = []
 
-        with self._lock:
-            self._queue: List[ForwardMsg] = []
-
-            # A mapping of (delta_path -> _queue.indexof(msg)) for each
-            # Delta message in the queue. We use this for coalescing
-            # redundant outgoing Deltas (where a newer Delta supercedes
-            # an older Delta, with the same delta_path, that's still in the
-            # queue).
-            self._delta_index_map: Dict[Tuple[int, ...], int] = dict()
+        # A mapping of (delta_path -> _queue.indexof(msg)) for each
+        # Delta message in the queue. We use this for coalescing
+        # redundant outgoing Deltas (where a newer Delta supercedes
+        # an older Delta, with the same delta_path, that's still in the
+        # queue).
+        self._delta_index_map: Dict[Tuple[int, ...], int] = dict()
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/report_queue.py
+++ b/lib/streamlit/report_queue.py
@@ -96,15 +96,6 @@ class ReportQueue:
                     self._delta_index_map[delta_key] = len(self._queue)
                     self._queue.append(msg)
 
-    def clone(self) -> "ReportQueue":
-        r = ReportQueue()
-
-        with self._lock:
-            r._queue = list(self._queue)
-            r._delta_index_map = dict(self._delta_index_map)
-
-        return r
-
     def _clear(self) -> None:
         self._queue = []
         self._delta_index_map = dict()

--- a/lib/streamlit/report_queue.py
+++ b/lib/streamlit/report_queue.py
@@ -19,7 +19,7 @@ Whenever possible, message deltas are combined.
 
 import copy
 import threading
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, List, Dict, Any, Tuple, Iterator
 
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -55,7 +55,7 @@ class ReportQueue:
             "ids": list(self._delta_index_map.keys()),
         }
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[ForwardMsg]:
         return iter(self._queue)
 
     def is_empty(self) -> bool:

--- a/lib/streamlit/report_queue.py
+++ b/lib/streamlit/report_queue.py
@@ -34,7 +34,6 @@ class ReportQueue:
     """Thread-safe queue that smartly accumulates the report's messages."""
 
     def __init__(self):
-        """Constructor."""
         self._lock = threading.Lock()
         self._queue: List[ForwardMsg] = []
 
@@ -68,12 +67,7 @@ class ReportQueue:
         return None
 
     def enqueue(self, msg: ForwardMsg) -> None:
-        """Add message into queue, possibly composing it with another message.
-
-        Parameters
-        ----------
-        msg : ForwardMsg
-        """
+        """Add message into queue, possibly composing it with another message."""
         with self._lock:
             # Optimize only if it's a delta message
             if not msg.HasField("delta"):
@@ -103,7 +97,6 @@ class ReportQueue:
                     self._queue.append(msg)
 
     def clone(self) -> "ReportQueue":
-        """Return the elements of this ReportQueue as a collections.deque."""
         r = ReportQueue()
 
         with self._lock:

--- a/lib/streamlit/report_queue.py
+++ b/lib/streamlit/report_queue.py
@@ -73,9 +73,11 @@ class ReportQueue:
                 self._queue.append(msg)
                 return
 
-            # Deltas are identified by their delta_path. If there's a Delta
-            # with the same delta_path already in the queue, we combine
-            # this new Delta into the old one if they're compatible.
+            # If there's a Delta message with the same delta_path already in
+            # the queue - meaning that it refers to the same location in
+            # the report - we attempt to combine this new Delta into the old
+            # one. This is an optimization that prevents redundant Deltas
+            # from being sent to the frontend.
             delta_key = tuple(msg.metadata.delta_path)
             if delta_key in self._delta_index_map:
                 index = self._delta_index_map[delta_key]

--- a/lib/streamlit/report_queue.py
+++ b/lib/streamlit/report_queue.py
@@ -140,10 +140,10 @@ def compose_deltas(old_delta: Delta, new_delta: Delta) -> Delta:
     if new_delta_type == "new_element":
         return new_delta
 
-    elif new_delta_type == "add_block":
+    if new_delta_type == "add_block":
         return new_delta
 
-    elif new_delta_type == "add_rows":
+    if new_delta_type == "add_rows":
         import streamlit.elements.legacy_data_frame as data_frame
 
         # We should make data_frame.add_rows *not* mutate any of the


### PR DESCRIPTION
In the `ReportQueue.enqueue` "Delta composition" logic, we no longer replace `add_block` deltas.

Replacing `add_block` deltas is problematic, because blocks can have other dependent deltas later in the queue. For example:
```python
placeholder = st.empty()
placeholder.columns(1)
placeholder.empty()
```

The call to `placeholder.columns(1)` creates two blocks, a parent container with delta_path `(0, 0)`, and a column child with delta_path `(0, 0, 0)`. If the final `placeholder.empty()` Delta is composed with the parent container Delta, the frontend will throw an error when it tries to add that column child to what is now just an element, and not a block.

(This PR also has type annotations and cleanup for all of `report_queue.py`).

Fixes #3659