### PR TITLE
Keys can also be ints

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from streamlit.type_util import Key, to_key
 from typing import Optional, cast
 from textwrap import dedent
 
@@ -40,7 +41,7 @@ class ButtonMixin:
     def button(
         self,
         label: str,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_click: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -52,7 +53,7 @@ class ButtonMixin:
         ----------
         label : str
             A short label explaining to the user what this button is for.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -80,6 +81,7 @@ class ButtonMixin:
         ...     st.write('Goodbye')
 
         """
+        key = to_key(key)
         return self.dg._button(
             label,
             key,

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -54,7 +54,7 @@ class ButtonMixin:
         label : str
             A short label explaining to the user what this button is for.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -49,7 +49,7 @@ class CheckboxMixin:
             Preselect the checkbox when it first renders. This will be
             cast to bool internally.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from streamlit.type_util import Key, to_key
 from textwrap import dedent
 from typing import cast, Optional
 
@@ -32,7 +33,7 @@ class CheckboxMixin:
         self,
         label: str,
         value: bool = False,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -47,7 +48,7 @@ class CheckboxMixin:
         value : bool
             Preselect the checkbox when it first renders. This will be
             cast to bool internally.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -74,6 +75,7 @@ class CheckboxMixin:
         ...     st.write('Great!')
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(
             default_value=None if value is False else value, key=key

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from streamlit.type_util import Key, to_key
 from textwrap import dedent
 from typing import Optional, cast
 
@@ -34,7 +35,7 @@ class ColorPickerMixin:
         self,
         label: str,
         value: Optional[str] = None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -49,7 +50,7 @@ class ColorPickerMixin:
         value : str
             The hex value of this widget when it first renders. If None,
             defaults to black.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -75,6 +76,7 @@ class ColorPickerMixin:
         >>> st.write('The current color is', color)
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -51,7 +51,7 @@ class ColorPickerMixin:
             The hex value of this widget when it first renders. If None,
             defaults to black.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from streamlit.type_util import Key, to_key
 from typing import cast, List, Optional, Union
 from textwrap import dedent
 
@@ -45,7 +46,7 @@ class FileUploaderMixin:
         label: str,
         type: Optional[Union[str, List[str]]] = None,
         accept_multiple_files: bool = False,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -69,7 +70,7 @@ class FileUploaderMixin:
             in which case the return value will be a list of files.
             Default: False
 
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -131,6 +132,7 @@ class FileUploaderMixin:
         ...     st.write("filename:", uploaded_file.name)
         ...     st.write(bytes_data)
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)
 

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -71,7 +71,7 @@ class FileUploaderMixin:
             Default: False
 
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -61,7 +61,7 @@ class MultiSelectMixin:
             shown for that option. This has no impact on the return value of
             the selectbox.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -19,7 +19,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import OptionSequence, ensure_indexable, is_type
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, is_type, to_key
 
 from streamlit.state.session_state import (
     WidgetArgs,
@@ -37,7 +37,7 @@ class MultiSelectMixin:
         options: OptionSequence,
         default: Optional[List[str]] = None,
         format_func=str,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -60,7 +60,7 @@ class MultiSelectMixin:
             the raw option as an argument and should output the label to be
             shown for that option. This has no impact on the return value of
             the selectbox.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -96,6 +96,7 @@ class MultiSelectMixin:
            `GitHub issue #1059 <https://github.com/streamlit/streamlit/issues/1059>`_ for updates on the issue.
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=default, key=key)
 

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -72,7 +72,7 @@ class NumberInputMixin:
             display numbers. Output must be purely numeric. This does not impact
             the return value. Valid formatters: %d %e %f %g %i %u
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numbers
+from streamlit.type_util import Key, to_key
 from textwrap import dedent
 from typing import Optional, Union, cast
 
@@ -41,7 +42,7 @@ class NumberInputMixin:
         value=NoValue(),
         step: Optional[Number] = None,
         format=None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -70,7 +71,7 @@ class NumberInputMixin:
             A printf-style format string controlling how the interface should
             display numbers. Output must be purely numeric. This does not impact
             the return value. Valid formatters: %d %e %f %g %i %u
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -95,6 +96,7 @@ class NumberInputMixin:
         >>> number = st.number_input('Insert a number')
         >>> st.write('The current number is ', number)
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -24,7 +24,7 @@ from streamlit.state.session_state import (
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.type_util import OptionSequence, ensure_indexable
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -37,7 +37,7 @@ class RadioMixin:
         options: OptionSequence,
         index: int = 0,
         format_func=str,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -59,7 +59,7 @@ class RadioMixin:
             the raw option as an argument and should output the label to be
             shown for that option. This has no impact on the return value of
             the radio.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -90,6 +90,7 @@ class RadioMixin:
         ...     st.write("You didn\'t select comedy.")
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
 

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -60,7 +60,7 @@ class RadioMixin:
             shown for that option. This has no impact on the return value of
             the radio.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -24,7 +24,7 @@ from streamlit.state.session_state import (
     WidgetKwargs,
 )
 from streamlit.state.widgets import register_widget
-from streamlit.type_util import OptionSequence, ensure_indexable
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -37,7 +37,7 @@ class SelectSliderMixin:
         options: OptionSequence = [],
         value=None,
         format_func=str,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -72,7 +72,7 @@ class SelectSliderMixin:
             Function to modify the display of the labels from the options.
             argument. It receives the option as an argument and its output
             will be cast to str.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -107,6 +107,7 @@ class SelectSliderMixin:
         ...     value=('red', 'blue'))
         >>> st.write('You selected wavelengths between', start_color, 'and', end_color)
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 
@@ -178,7 +179,7 @@ class SelectSliderMixin:
             slider_proto.set_value = True
 
         self.dg._enqueue("slider", slider_proto)
-        return cast(str, current_value)
+        return current_value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -73,7 +73,7 @@ class SelectSliderMixin:
             argument. It receives the option as an argument and its output
             will be cast to str.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -24,7 +24,7 @@ from streamlit.state.session_state import (
     WidgetKwargs,
 )
 from streamlit.state.widgets import register_widget, NoValue
-from streamlit.type_util import OptionSequence, ensure_indexable
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -37,7 +37,7 @@ class SelectboxMixin:
         options: OptionSequence,
         index: int = 0,
         format_func=str,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -57,7 +57,7 @@ class SelectboxMixin:
         format_func : function
             Function to modify the display of the labels. It receives the option
             as an argument and its output will be cast to str.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -85,6 +85,7 @@ class SelectboxMixin:
         >>> st.write('You selected:', option)
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
 

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -58,7 +58,7 @@ class SelectboxMixin:
             Function to modify the display of the labels. It receives the option
             as an argument and its output will be cast to str.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -90,7 +90,7 @@ class SliderMixin:
             Formatter for date/time/datetime uses Moment.js notation:
             https://momentjs.com/docs/#/displaying/format/
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import date, time, datetime, timedelta, timezone
+from streamlit.type_util import Key, to_key
 from typing import Any, List, cast, Optional
 from textwrap import dedent
 
@@ -41,7 +42,7 @@ class SliderMixin:
         value=None,
         step=None,
         format=None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -88,7 +89,7 @@ class SliderMixin:
             Formatter for int/float supports: %d %e %f %g %i
             Formatter for date/time/datetime uses Moment.js notation:
             https://momentjs.com/docs/#/displaying/format/
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -138,6 +139,7 @@ class SliderMixin:
         >>> st.write("Start time:", start_time)
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -57,7 +57,7 @@ class TextWidgetsMixin:
         max_chars : int or None
             Max number of characters allowed in text input.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
@@ -168,7 +168,7 @@ class TextWidgetsMixin:
         max_chars : int or None
             Maximum number of characters allowed in text area.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from streamlit.type_util import Key, to_key
 from textwrap import dedent
 from typing import Optional, cast
 
@@ -36,7 +37,7 @@ class TextWidgetsMixin:
         label: str,
         value: str = "",
         max_chars: Optional[int] = None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         type: str = "default",
         help: Optional[str] = None,
         autocomplete: Optional[str] = None,
@@ -55,7 +56,7 @@ class TextWidgetsMixin:
             cast to str internally.
         max_chars : int or None
             Max number of characters allowed in text input.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -89,6 +90,7 @@ class TextWidgetsMixin:
         >>> st.write('The current movie title is', title)
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if value == "" else value, key=key)
 
@@ -145,7 +147,7 @@ class TextWidgetsMixin:
         value: str = "",
         height: Optional[int] = None,
         max_chars: Optional[int] = None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -165,7 +167,7 @@ class TextWidgetsMixin:
             default height is used.
         max_chars : int or None
             Maximum number of characters allowed in text area.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -196,6 +198,7 @@ class TextWidgetsMixin:
         >>> st.write('Sentiment:', run_sentiment_analysis(txt))
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if value == "" else value, key=key)
 

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -54,7 +54,7 @@ class TimeWidgetsMixin:
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to the current time.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
@@ -162,7 +162,7 @@ class TimeWidgetsMixin:
             The maximum selectable date. If value is a date, defaults to value + 10 years.
             If value is the interval [start, end], defaults to end + 10 years.
         key : str or int
-            An optional string to use as the unique key for the widget.
+            An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime, date, time
+from streamlit.type_util import Key, to_key
 from typing import cast, Optional, Union
 from textwrap import dedent
 
@@ -37,7 +38,7 @@ class TimeWidgetsMixin:
         self,
         label: str,
         value=None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -52,7 +53,7 @@ class TimeWidgetsMixin:
         value : datetime.time/datetime.datetime
             The value of this widget when it first renders. This will be
             cast to str internally. Defaults to the current time.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -77,6 +78,7 @@ class TimeWidgetsMixin:
         >>> st.write('Alarm is set for', t)
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 
@@ -137,7 +139,7 @@ class TimeWidgetsMixin:
         value=None,
         min_value=None,
         max_value=None,
-        key: Optional[str] = None,
+        key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
@@ -159,7 +161,7 @@ class TimeWidgetsMixin:
         max_value : datetime.date or datetime.datetime
             The maximum selectable date. If value is a date, defaults to value + 10 years.
             If value is the interval [start, end], defaults to end + 10 years.
-        key : str
+        key : str or int
             An optional string to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
@@ -186,6 +188,7 @@ class TimeWidgetsMixin:
         >>> st.write('Your birthday is:', d)
 
         """
+        key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -14,6 +14,7 @@
 
 from copy import deepcopy
 import json
+from streamlit.type_util import Key
 from typing import (
     Any,
     ItemsView,
@@ -534,17 +535,20 @@ class LazySessionState(MutableMapping[str, Any]):
         state = get_session_state()
         return str(state.filtered_state)
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: Key) -> Any:
+        key = str(key)
         self._validate_key(key)
         state = get_session_state()
         return state[key]
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    def __setitem__(self, key: Key, value: Any) -> None:
+        key = str(key)
         self._validate_key(key)
         state = get_session_state()
         state[key] = value
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: Key) -> None:
+        key = str(key)
         self._validate_key(key)
         state = get_session_state()
         del state[key]

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -15,7 +15,7 @@
 """A bunch of useful utilities for dealing with types."""
 
 import re
-from typing import Any, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Sequence, Tuple, Union, cast
 
 from pandas import DataFrame, Series, Index
 import numpy as np
@@ -24,6 +24,7 @@ import pyarrow as pa
 from streamlit import errors
 
 OptionSequence = Union[Sequence[Any], DataFrame, Series, Index, np.ndarray]
+Key = Union[str, int]
 
 
 def is_type(obj, fqn_type_pattern):
@@ -384,3 +385,10 @@ def bytes_to_data_frame(source: bytes) -> DataFrame:
 
     reader = pa.RecordBatchStreamReader(source)
     return reader.read_pandas()
+
+
+def to_key(key: Optional[Key]) -> Optional[str]:
+    if key is None:
+        return None
+    else:
+        return str(key)


### PR DESCRIPTION
Some people use ints for keys, and it is easy enough to support, so this updates the type annotations and docs to allow it, and ensures int keys are converted to strings so we can still rely on that internally