### PR TITLE
[DO NOT MERGE] Coerce values for multiselect/slider/selectbox when they are invalidated

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -144,7 +144,10 @@ class MultiSelectMixin:
             return [opt[i] for i in current_value]
 
         def serialize_multiselect(value):
-            return _check_and_convert_to_indices(opt, value)
+            try:
+                return _check_and_convert_to_indices(opt, value), False
+            except StreamlitAPIException:
+                return [], True
 
         current_value, set_frontend_value = register_widget(
             "multiselect",
@@ -157,10 +160,9 @@ class MultiSelectMixin:
             serializer=serialize_multiselect,
         )
 
-        if set_frontend_value:
-            multiselect_proto.value[:] = _check_and_convert_to_indices(
-                opt, current_value
-            )
+        serialized, coerced_value = serialize_multiselect(current_value)
+        if set_frontend_value or coerced_value:
+            multiselect_proto.value[:] = serialized
             multiselect_proto.set_value = True
 
         self.dg._enqueue("multiselect", multiselect_proto)

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -114,9 +114,10 @@ class SelectboxMixin:
             return opt[idx] if len(opt) > 0 and opt[idx] is not None else None
 
         def serialize_select_box(v):
-            if len(opt) == 0:
-                return 0
-            return index_(opt, v)
+            try:
+                return index_(opt, v), False
+            except ValueError:
+                return 0, True
 
         current_value, set_frontend_value = register_widget(
             "selectbox",
@@ -129,8 +130,9 @@ class SelectboxMixin:
             serializer=serialize_select_box,
         )
 
-        if set_frontend_value:
-            selectbox_proto.value = serialize_select_box(current_value)
+        serialized, coerced_value = serialize_select_box(current_value)
+        if set_frontend_value or coerced_value:
+            selectbox_proto.value = serialized
             selectbox_proto.set_value = True
 
         self.dg._enqueue("selectbox", selectbox_proto)

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -256,7 +256,10 @@ def check_roundtrip(widget_id: str, value: Any) -> None:
     serializer = metadata.serializer
     deserializer = metadata.deserializer
 
-    assert deserializer(serializer(value), "") == value
+    serialized = serializer(value)
+    if isinstance(serialized, tuple):
+        serialized, _ = serialized
+    assert deserializer(serialized, "") == value
 
 
 @patch("streamlit._is_running_with_streamlit", new=True)


### PR DESCRIPTION
When the arguments to a keyed widget change, it's possible for the value
we have stored in `st.session_state.<widget_key>` to no longer be a
valid value for the widget.

This commit implements a prototype for one way of handling this, where
we

* coerce the value of the widget to something reasonable
* give the user an st.warning telling them what happened and suggesting
  that they `del` the widget's key from `st.session_state`.

Note that we only implement value coercion for the multiselect,
selectbox, and slider widgets since these three widgets are the three
that are most likely to run into the problem we're trying to fix.
