### PR TITLE
Fix "Install graphviz dependencies" step in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt-get update --allow-releaseinfo-change
+              apt-get --allow-releaseinfo-change update
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -106,7 +106,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt-get update --allow-releaseinfo-change
+              ${SUDO} apt-get --allow-releaseinfo-change update
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -140,7 +140,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt-get update --allow-releaseinfo-change
+            ${SUDO} apt-get --allow-releaseinfo-change update
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -168,11 +168,11 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt-get update --allow-releaseinfo-change
+            ${SUDO} apt-get --allow-releaseinfo-change update
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt-get update --allow-releaseinfo-change
+            ${SUDO} apt-get --allow-releaseinfo-change update
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt-get update
-              apt-get upgrade
+              apt-get update --fix-missing
+              apt-get install -f
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -107,8 +107,8 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt-get update
-              ${SUDO} apt-get upgrade
+              ${SUDO} apt-get update --fix-missing
+              ${SUDO} apt-get install -f
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -142,8 +142,8 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt-get update
-            ${SUDO} apt-get upgrade
+            ${SUDO} apt-get update --fix-missing
+            ${SUDO} apt-get install -f
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -171,13 +171,13 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt-get update
-            ${SUDO} apt-get upgrade
+            ${SUDO} apt-get update --fix-missing
+            ${SUDO} apt-get install -f
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt-get update
-            ${SUDO} apt-get upgrade
+            ${SUDO} apt-get update --fix-missing
+            ${SUDO} apt-get install -f
             
             ${SUDO} apt-get install -y protobuf-compiler
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt update --allow-releaseinfo-change
+              apt-get dist-upgrade
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -106,7 +106,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt update --allow-releaseinfo-change
+              ${SUDO} apt-get dist-upgrade
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -140,7 +140,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt update --allow-releaseinfo-change
+            ${SUDO} apt-get dist-upgrade
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -168,11 +168,11 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt update --allow-releaseinfo-change
+            ${SUDO} apt-get dist-upgrade
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt update --allow-releaseinfo-change
+            ${SUDO} apt-get dist-upgrade
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
+              apt-get update
               apt-get dist-upgrade
               apt-get install -y make
               cp -f /usr/bin/make make.bin
@@ -106,6 +107,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
+              ${SUDO} apt-get update
               ${SUDO} apt-get dist-upgrade
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
@@ -140,6 +142,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
+            ${SUDO} apt-get update
             ${SUDO} apt-get dist-upgrade
             ${SUDO} apt-get install -y libgvc6
 
@@ -168,10 +171,12 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
+            ${SUDO} apt-get update
             ${SUDO} apt-get dist-upgrade
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
+            ${SUDO} apt-get update
             ${SUDO} apt-get dist-upgrade
             ${SUDO} apt-get install -y protobuf-compiler
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt-get update --fix-missing
-              apt-get install -f
+              apt update -y
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -107,8 +106,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt-get update --fix-missing
-              ${SUDO} apt-get install -f
+              ${SUDO} apt update -y
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -142,8 +140,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt-get update --fix-missing
-            ${SUDO} apt-get install -f
+            ${SUDO} apt update -y
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -171,13 +168,11 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt-get update --fix-missing
-            ${SUDO} apt-get install -f
+            ${SUDO} apt update -y
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt-get update --fix-missing
-            ${SUDO} apt-get install -f
+            ${SUDO} apt update -y
             
             ${SUDO} apt-get install -y protobuf-compiler
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt-get --allow-releaseinfo-change update
+              apt-get clean
+              apt-get update
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -106,7 +107,8 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt-get --allow-releaseinfo-change update
+              ${SUDO} apt-get clean
+              ${SUDO} apt-get update
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -140,7 +142,8 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt-get --allow-releaseinfo-change update
+            ${SUDO} apt-get clean
+            ${SUDO} apt-get update
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -168,11 +171,13 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt-get --allow-releaseinfo-change update
+            ${SUDO} apt-get clean
+            ${SUDO} apt-get update
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt-get --allow-releaseinfo-change update
+            ${SUDO} apt-get clean
+            ${SUDO} apt-get update
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt-get update -y
+              apt-get update --allow-releaseinfo-change
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -106,7 +106,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt-get update -y
+              ${SUDO} apt-get update --allow-releaseinfo-change
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -140,7 +140,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt-get update -y
+            ${SUDO} apt-get update --allow-releaseinfo-change
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -168,11 +168,11 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt-get update -y
+            ${SUDO} apt-get update --allow-releaseinfo-change
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt-get update -y
+            ${SUDO} apt-get update --allow-releaseinfo-change
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt update -y
+              apt update
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -106,7 +106,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt update -y
+              ${SUDO} apt update
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -140,7 +140,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt update -y
+            ${SUDO} apt update
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -168,11 +168,11 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt update -y
+            ${SUDO} apt update
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt update -y
+            ${SUDO} apt update
             
             ${SUDO} apt-get install -y protobuf-compiler
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,6 @@ commands:
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
             ${SUDO} apt update
-            
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
             else
               echo "/usr/bin/make doesn't exist; installing"
               apt-get update
-              apt-get dist-upgrade
+              apt-get upgrade
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -108,7 +108,7 @@ commands:
             else
               echo "/usr/bin/dot doesn't exist, installing"
               ${SUDO} apt-get update
-              ${SUDO} apt-get dist-upgrade
+              ${SUDO} apt-get upgrade
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -143,7 +143,7 @@ commands:
           name: Install graphviz dependencies
           command: |
             ${SUDO} apt-get update
-            ${SUDO} apt-get dist-upgrade
+            ${SUDO} apt-get upgrade
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -172,12 +172,13 @@ commands:
           command: |
             # install protobuf v3
             ${SUDO} apt-get update
-            ${SUDO} apt-get dist-upgrade
+            ${SUDO} apt-get upgrade
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
             ${SUDO} apt-get update
-            ${SUDO} apt-get dist-upgrade
+            ${SUDO} apt-get upgrade
+            
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,7 @@ commands:
               echo "make.bin exists; not installing"
             else
               echo "/usr/bin/make doesn't exist; installing"
-              apt-get clean
-              apt-get update
+              apt update --allow-releaseinfo-change
               apt-get install -y make
               cp -f /usr/bin/make make.bin
             fi
@@ -107,8 +106,7 @@ commands:
               echo "dot.bin exists and is non zero"
             else
               echo "/usr/bin/dot doesn't exist, installing"
-              ${SUDO} apt-get clean
-              ${SUDO} apt-get update
+              ${SUDO} apt update --allow-releaseinfo-change
               ${SUDO} apt-get install -y graphviz
               cp -f /usr/bin/dot dot.bin
             fi
@@ -142,8 +140,7 @@ commands:
       - run:
           name: Install graphviz dependencies
           command: |
-            ${SUDO} apt-get clean
-            ${SUDO} apt-get update
+            ${SUDO} apt update --allow-releaseinfo-change
             ${SUDO} apt-get install -y libgvc6
 
       - run: &activate_virtualenv
@@ -171,13 +168,11 @@ commands:
           name: Generate protobufs
           command: |
             # install protobuf v3
-            ${SUDO} apt-get clean
-            ${SUDO} apt-get update
+            ${SUDO} apt update --allow-releaseinfo-change
             ${SUDO} apt-get install -y gnupg
             echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | ${SUDO} tee /etc/apt/sources.list.d/protobuf.list
             ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-            ${SUDO} apt-get clean
-            ${SUDO} apt-get update
+            ${SUDO} apt update --allow-releaseinfo-change
             ${SUDO} apt-get install -y protobuf-compiler
 
             # Generate protobufs


### PR DESCRIPTION
Nightly [failed](https://app.circleci.com/pipelines/github/streamlit/streamlit/9155/workflows/316e1728-e4e8-40a6-9abe-e097cf895d1d/jobs/28801) multiple times in the last couple of days.
After a bunch of unsuccessful tries, replacing `apt-get update -y` with `apt update` seems to fix the issue.