### PR TITLE
Add metric docs and fix urls

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,7 @@ raw form. These are the Streamlit commands you can use to display raw data.
 .. autofunction:: streamlit.dataframe
 .. autofunction:: streamlit.table
 .. autofunction:: streamlit.json
+.. autofunction:: streamlit.metric
 ```
 
 ## Display charts

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -34,8 +34,8 @@ class MetricMixin:
         """Display a metric in big bold font, with an optional indicator of how the metric changed.
 
         Tip: If you want to display a large number, it may be a good idea to
-        shorten it using packages like [millify](https://github.com/azaitsev/millify)
-        or [numerize](https://github.com/davidsa03/numerize). E.g. `1234` can be
+        shorten it using packages like `millify <https://github.com/azaitsev/millify>`_
+        or `numerize <https://github.com/davidsa03/numerize>`_. E.g. `1234` can be
         displayed as `1.2k` using `st.metric("Short number", millify(1234))`.
 
         Parameters


### PR DESCRIPTION
The docs for metrics were missing, so we added them. In testing, I realized that Sphinx is Markdown-like, but not Markdown. I had to update the links to the correct syntax.