### PR TITLE
Cleanup: remove obsolete "CachingObjectTest"

### DIFF
--- a/lib/tests/streamlit/caching_test.py
+++ b/lib/tests/streamlit/caching_test.py
@@ -15,7 +15,6 @@
 """st.caching unit tests."""
 import threading
 import types
-import unittest
 from unittest.mock import patch, Mock
 
 from parameterized import parameterized
@@ -410,51 +409,6 @@ class CacheTest(testutil.DeltaGeneratorTestCase):
         # the value_key). It should only be used to compute the value_key!
         foo("ahoy")
         str_hash_func.assert_called_once_with("ahoy")
-
-
-# Temporarily turn off these tests since there's no Cache object in __init__
-# right now.
-class CachingObjectTest(unittest.TestCase):
-    def off_test_simple(self):
-        val = 42
-
-        for _ in range(2):
-            c = st.Cache()
-            if c:
-                c.value = val
-
-            self.assertEqual(c.value, val)
-
-    def off_test_allow_output_mutation(self):
-        val = 42
-
-        for _ in range(2):
-            c = st.Cache(allow_output_mutation=True)
-            if c:
-                c.value = val
-
-            self.assertEqual(c.value, val)
-
-    def off_test_has_changes(self):
-        val = 42
-
-        for _ in range(2):
-            c = st.Cache()
-            if c.has_changes():
-                c.value = val
-
-            self.assertEqual(c.value, val)
-
-    @patch.object(st, "exception")
-    def off_test_mutate(self, exception):
-        for _ in range(2):
-            c = st.Cache()
-            if c:
-                c.value = [0, 1]
-
-            c.value[0] = 1
-
-        exception.assert_called()
 
 
 class CacheErrorsTest(testutil.DeltaGeneratorTestCase):


### PR DESCRIPTION
This test is disabled, and refers to a long-gone `Cache` class that predated `@st.cache` and never shipped (and no longer exists).