### PR TITLE
Updates docs with `st.download_button` related changes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,6 +135,7 @@ With widgets, Streamlit allows you to bake interactivity directly into your apps
 
 ```eval_rst
 .. autofunction:: streamlit.button
+.. autofunction:: streamlit.download_button
 .. autofunction:: streamlit.checkbox
 .. autofunction:: streamlit.radio
 .. autofunction:: streamlit.selectbox

--- a/docs/session_state_api.md
+++ b/docs/session_state_api.md
@@ -114,6 +114,7 @@ Widgets which support the `on_change` event:
 Widgets which support the `on_click` event:
 
 - `st.button`
+- `st.download_button`
 - `st.form_submit_button`
 
 To add a callback, define a callback function **above** the widget declaration and pass it to the widget via the `on_change` (or `on_click` ) parameter.
@@ -163,7 +164,7 @@ with st.form(key='my_form'):
 
   ![state-value-api-exception](_static/img/state_value_api_exception.png)
 
-- Setting the state of button-like widgets: `st.button` and `st.file_uploader` via the Session State API is not allowed. Such type of widgets are by default _False_ and have ephemeral _True_ states which are only valid for a single run. For example:
+- Setting the state of button-like widgets: `st.button`, `st.download_button`, and `st.file_uploader` via the Session State API is not allowed. Such type of widgets are by default _False_ and have ephemeral _True_ states which are only valid for a single run. For example:
 
   ```python
   if 'my_button' not in st.session_state:

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -123,8 +123,8 @@ class FormMixin:
 
         Forms have a few constraints:
 
-        * Every form must contain a `st.form_submit_button`.
-        * You cannot add a normal `st.button` to a form.
+        * Every form must contain a ``st.form_submit_button``.
+        * ``st.button`` and ``st.download_button`` cannot be added to a form.
         * Forms can appear anywhere in your app (sidebar, columns, etc),
           but they cannot be embedded inside other forms.
 


### PR DESCRIPTION
### Updates docs with `st.download_button` related changes:
- Adds download button to the [Display interactive widgets](https://docs.streamlit.io/en/stable/api.html#display-interactive-widgets) section of the API reference
- Updates `st.form` docstring to say download button cannot be added to a form
- Updates Session State API caveat to include download button as a button-like widget whose state cannot be set via the Session State API

### Important
PR #3579 should be merged before this PR. Until then, download button will not appear in the API reference as the implementation code is not included in this branch.
