### PR TITLE
Include theme.base in the theme object sent to custom components

### DIFF
--- a/component-lib/src/streamlit.ts
+++ b/component-lib/src/streamlit.ts
@@ -21,6 +21,7 @@ import { ArrowDataframeProto, ArrowTable } from "./ArrowTable";
 
 /** Object defining the currently set theme. */
 export interface Theme {
+  base: string;
   primaryColor: string;
   backgroundColor: string;
   secondaryBackgroundColor: string;

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -340,6 +340,7 @@ describe("ComponentInstance", () => {
     expect(mc.receiveForwardMsg).toHaveBeenLastCalledWith(
       renderMsg(jsonArgs, [], false, {
         ...toThemeInput(darkTheme.emotion),
+        base: "dark",
         font: fonts.sansSerif,
       }),
       "*"
@@ -576,7 +577,11 @@ function renderMsg(
   args: { [name: string]: any },
   dataframes: any[],
   disabled = false,
-  theme = { ...toThemeInput(lightTheme.emotion), font: fonts.sansSerif }
+  theme = {
+    ...toThemeInput(lightTheme.emotion),
+    base: "light",
+    font: fonts.sansSerif,
+  }
 ): any {
   return forwardMsg(StreamlitMessageType.RENDER, {
     args,

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -34,7 +34,12 @@ import { Timer } from "src/lib/Timer"
 import { Source, WidgetStateManager } from "src/lib/WidgetStateManager"
 import queryString from "query-string"
 import React, { createRef, ReactNode } from "react"
-import { fontEnumToString, toThemeInput, Theme } from "src/theme"
+import {
+  bgColorToBaseString,
+  fontEnumToString,
+  toThemeInput,
+  Theme,
+} from "src/theme"
 import { COMMUNITY_URL, COMPONENT_DEVELOPER_URL } from "src/urls"
 import { ComponentRegistry } from "./ComponentRegistry"
 import { ComponentMessageType, StreamlitMessageType } from "./enums"
@@ -316,6 +321,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       disabled: this.props.disabled,
       theme: {
         ...themeInput,
+        base: bgColorToBaseString(themeInput.backgroundColor),
         font: fontEnumToString(themeInput.font),
       },
     })

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -22,6 +22,7 @@ import { fonts } from "src/theme/primitives/typography"
 
 import {
   AUTO_THEME_NAME,
+  bgColorToBaseString,
   CUSTOM_THEME_NAME,
   computeSpacingStyle,
   createEmotionTheme,
@@ -547,5 +548,19 @@ describe("converting font <> enum", () => {
       CustomThemeConfig.FontFamily.SANS_SERIF
     )
     expect(fontToEnum(fonts.serif)).toBe(CustomThemeConfig.FontFamily.SERIF)
+  })
+})
+
+describe("bgColorToBaseString", () => {
+  it("returns 'light' if passed undefined", () => {
+    expect(bgColorToBaseString(undefined)).toBe("light")
+  })
+
+  it("returns 'light' for a light background color", () => {
+    expect(bgColorToBaseString("#FFFFFF")).toBe("light")
+  })
+
+  it("returns 'dark' for a dark background color", () => {
+    expect(bgColorToBaseString("#000000")).toBe("dark")
   })
 })

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -77,6 +77,9 @@ export const fontEnumToString = (
       ]
     : undefined
 
+export const bgColorToBaseString = (bgColor?: string): string =>
+  bgColor === undefined || getLuminance(bgColor) > 0.5 ? "light" : "dark"
+
 // Theme primitives. See lightThemePrimitives for what's available. These are
 // used to create a large JSON-style structure with theme values for all
 // widgets.


### PR DESCRIPTION
This wasn't updated in the theming fast follow work when base themes
were added, most likely just because we missed it at the time.

Note that we'll need to release a new version of streamlit-component-lib
to update the exported types for the object.

Fixes #3337
