### PR TITLE
Temporarily disable `black` in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,9 @@ jobs:
           name: Run linters
           command: |
             make jslint
-            make pylint
+            # 2021.08.30: temporarily disabling pylint while we sort
+            # out `black` installation issues in CircleCI.
+            # make pylint
 
       - store_test_results:
           path: frontend/test-reports


### PR DESCRIPTION
Our Python jobs are failing in CircleCI due to a `black` + `pip` installation issue. Temporarily disabling our `black` task while we fix.