### PR TITLE
UI tweaks #10: Tweak <code> syntax highlighting

### DIFF
--- a/frontend/src/components/core/StatusWidget/StatusWidget.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.tsx
@@ -285,10 +285,7 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
     }
 
     return (
-      <Tooltip
-        content={() => <div>{ui.tooltip}</div>}
-        placement={Placement.BOTTOM}
-      >
+      <Tooltip content={ui.tooltip} placement={Placement.BOTTOM}>
         <StyledConnectionStatus data-testid="stConnectionStatus">
           <Icon size="sm" content={ui.icon} />
           <StyledConnectionStatusLabel
@@ -322,7 +319,7 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
         {minimized ? (
           <Tooltip
             placement={Placement.BOTTOM}
-            content={() => <div>This script is currently running</div>}
+            content="This script is currently running"
           >
             {runningIcon}
           </Tooltip>

--- a/frontend/src/components/core/StatusWidget/styled-components.ts
+++ b/frontend/src/components/core/StatusWidget/styled-components.ts
@@ -51,6 +51,7 @@ export const StyledConnectionStatusLabel = styled.label<
     "opacity 500ms 0ms, clip 500ms 0ms, max-width 500ms 0ms, margin 500ms 0ms, visibility 0ms 500ms",
   opacity: isMinimized ? 0 : 1,
   visibility: isMinimized ? "hidden" : "visible",
+  lineHeight: 1,
 }))
 
 /*

--- a/frontend/src/components/elements/ArrowDataFrame/DataFrameCell.test.tsx
+++ b/frontend/src/components/elements/ArrowDataFrame/DataFrameCell.test.tsx
@@ -47,8 +47,7 @@ describe("DataFrameCell Element", () => {
 
     expect(wrapper.find(StyledDataFrameCornerCell).length).toBe(1)
 
-    const tooltipContents = wrapper.find(Tooltip).prop("content").props
-      .children
+    const tooltipContents = wrapper.find(Tooltip).prop("content")
     expect(tooltipContents).toStrictEqual("")
   })
 
@@ -138,8 +137,7 @@ describe("DataFrameCell Element", () => {
       })
       const wrapper = mount(<DataFrameCell {...props} />)
 
-      const tooltipContents = wrapper.find(Tooltip).prop("content").props
-        .children
+      const tooltipContents = wrapper.find(Tooltip).prop("content")
       expect(tooltipContents).toBe("Sorted by this index column (ascending)")
     })
 
@@ -150,8 +148,7 @@ describe("DataFrameCell Element", () => {
       })
       const wrapper = mount(<DataFrameCell {...props} />)
 
-      const tooltipContents = wrapper.find(Tooltip).prop("content").props
-        .children
+      const tooltipContents = wrapper.find(Tooltip).prop("content")
       expect(tooltipContents).toBe("Sorted by this index column (descending)")
     })
 
@@ -163,8 +160,7 @@ describe("DataFrameCell Element", () => {
       })
       const wrapper = mount(<DataFrameCell {...props} />)
 
-      const tooltipContents = wrapper.find(Tooltip).prop("content").props
-        .children
+      const tooltipContents = wrapper.find(Tooltip).prop("content")
       expect(tooltipContents).toBe('Sort by "contenido"')
     })
   })

--- a/frontend/src/components/elements/ArrowDataFrame/DataFrameCell.tsx
+++ b/frontend/src/components/elements/ArrowDataFrame/DataFrameCell.tsx
@@ -23,7 +23,6 @@ import Tooltip, {
   OverflowTooltip,
   StyledEllipsizedDiv,
 } from "src/components/shared/Tooltip"
-import { StyledTooltipContentWrapper } from "src/components/shared/TooltipIcon"
 import { SortDirection } from "./SortDirection"
 import { StyledSortIcon } from "./styled-components"
 
@@ -197,11 +196,7 @@ function HeaderContentsWithTooltip({
 
   return (
     <Tooltip
-      content={
-        <StyledTooltipContentWrapper>
-          {tooltipContents}
-        </StyledTooltipContentWrapper>
-      }
+      content={tooltipContents}
       placement={Placement.BOTTOM_LEFT}
       style={{ width: "100%" }}
     >
@@ -230,9 +225,7 @@ function CellContentsWithTooltip({
 }: CellContentsProps): ReactElement {
   return (
     <OverflowTooltip
-      content={
-        <StyledTooltipContentWrapper>{contents}</StyledTooltipContentWrapper>
-      }
+      content={contents}
       placement={Placement.AUTO}
       style={{
         textAlign: isNumeric ? "right" : undefined,

--- a/frontend/src/components/elements/CodeBlock/styled-components.ts
+++ b/frontend/src/components/elements/CodeBlock/styled-components.ts
@@ -26,6 +26,7 @@ import styled from "@emotion/styled"
 export const StyledPre = styled.pre(({ theme }) => ({
   margin: 0,
   paddingRight: "2.75rem",
+  color: theme.colors.bodyText,
 
   ".token.comment, .token.prolog, .token.doctype, .token.cdata": {
     color: "slategray",
@@ -39,32 +40,51 @@ export const StyledPre = styled.pre(({ theme }) => ({
     opacity: 0.7,
   },
 
-  ".token.property, .token.tag, .token.boolean, .token.number, .token.constant, .token.symbol, .token.deleted": {
-    color: "#905",
+  ".token.attr-name, .token.property, .token.variable": {
+    color: theme.colors.lightBlue80,
   },
 
-  ".token.selector, .token.attr-name, .token.string, .token.char, .token.builtin, .token.inserted": {
-    color: "#690",
+  ".token.boolean, .token.constant, .token.symbol": {
+    color: theme.colors.green70,
   },
 
-  ".token.operator, .token.entity, .token.url, .language-css .token.string, .style .token.string": {
-    color: "#9a6e3a",
+  ".token.number, .token.regex": {
+    color: theme.colors.blueGreen80,
   },
 
-  ".token.atrule, .token.attr-value, .token.keyword": {
-    color: "#07a",
+  ".token.string, .token.char, .token.attr-value": {
+    color: theme.colors.green80,
   },
 
-  ".token.function, .token.class-name": {
-    color: "#dd4a68",
+  ".token.operator, .token.entity": {
+    color: theme.colors.orange90,
   },
 
-  ".token.regex, .token.important, .token.variable": {
-    color: "#e90",
+  ".token.url": {
+    color: theme.colors.purple80,
   },
 
-  ".token.important, .token.bold": {
+  ".token.decorator, .token.atrule": {
+    color: theme.colors.orange90,
+  },
+
+  ".token.keyword, .token.tag": {
+    color: theme.colors.blue70,
+  },
+
+  ".token.function, .token.class-name, .token.selector": {
+    color: theme.colors.blue70,
     fontWeight: "bold",
+  },
+
+  ".token.important": {
+    color: theme.colors.red70,
+    fontWeight: "bold",
+  },
+
+  ".token.comment": {
+    color: theme.colors.gray70,
+    fontStyle: "italic",
   },
 
   ".token.italic": {

--- a/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -16,10 +16,8 @@
  */
 
 import React from "react"
-import { mount } from "enzyme"
 import { PLACEMENT } from "baseui/tooltip"
-import ThemeProvider from "src/components/core/ThemeProvider"
-import { lightTheme, lightBaseUITheme } from "src/theme"
+import { mount } from "src/lib/test_util"
 
 import Tooltip, { Placement, TooltipProps } from "./Tooltip"
 
@@ -34,22 +32,16 @@ const getProps = (
 
 describe("Tooltip element", () => {
   it("renders a Tooltip", () => {
-    const wrapper = mount(
-      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
-        <Tooltip {...getProps()}></Tooltip>
-      </ThemeProvider>
-    )
+    const wrapper = mount(<Tooltip {...getProps()}></Tooltip>)
 
     expect(wrapper.find("StatefulTooltip").exists()).toBeTruthy()
   })
 
   it("renders its children", () => {
     const wrapper = mount(
-      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
-        <Tooltip {...getProps()}>
-          <div className="foo" />
-        </Tooltip>
-      </ThemeProvider>
+      <Tooltip {...getProps()}>
+        <div className="foo" />
+      </Tooltip>
     )
 
     expect(wrapper.find(".foo").exists()).toBeTruthy()
@@ -57,9 +49,7 @@ describe("Tooltip element", () => {
 
   it("sets its placement", () => {
     const wrapper = mount(
-      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
-        <Tooltip {...getProps({ placement: Placement.BOTTOM })} />
-      </ThemeProvider>
+      <Tooltip {...getProps({ placement: Placement.BOTTOM })} />
     )
 
     expect(wrapper.find("StatefulTooltip").prop("placement")).toEqual(
@@ -69,12 +59,10 @@ describe("Tooltip element", () => {
 
   it("sets the same content", () => {
     const content = <span className="foo" />
-    const wrapper = mount(
-      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={lightBaseUITheme}>
-        <Tooltip {...getProps({ content })} />
-      </ThemeProvider>
-    )
+    const wrapper = mount(<Tooltip {...getProps({ content })} />)
 
-    expect(wrapper.find("StatefulTooltip").prop("content")).toEqual(content)
+    expect(
+      wrapper.find("StatefulTooltip").props().content.props.children
+    ).toEqual(content)
   })
 })

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -19,6 +19,7 @@ import React, { ReactElement, ReactNode } from "react"
 import { useTheme } from "emotion-theming"
 import { Theme } from "src/theme"
 import { StatefulTooltip, ACCESSIBILITY_TYPE, PLACEMENT } from "baseui/tooltip"
+import { StyledTooltipContentWrapper } from "./styled-components"
 
 export enum Placement {
   AUTO = "auto",
@@ -56,7 +57,11 @@ function Tooltip({
 
   return (
     <StatefulTooltip
-      content={content}
+      content={
+        content ? (
+          <StyledTooltipContentWrapper>{content}</StyledTooltipContentWrapper>
+        ) : null
+      }
       placement={PLACEMENT[placement]}
       accessibilityType={ACCESSIBILITY_TYPE.tooltip}
       showArrow

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -69,7 +69,7 @@ function Tooltip({
       overrides={{
         Arrow: {
           style: {
-            backgroundColor: colors.secondaryBg,
+            backgroundColor: colors.bgColor,
             border: `1px solid ${colors.fadedText10}`,
           },
         },
@@ -95,7 +95,7 @@ function Tooltip({
         },
         Inner: {
           style: {
-            backgroundColor: colors.secondaryBg,
+            backgroundColor: colors.bgColor,
             color: colors.bodyText,
             fontSize: fontSizes.sm,
             fontWeight: "normal",

--- a/frontend/src/components/shared/Tooltip/styled-components.tsx
+++ b/frontend/src/components/shared/Tooltip/styled-components.tsx
@@ -33,7 +33,7 @@ export const StyledEllipsizedDiv = styled.div({
 
 export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
   boxSizing: "border-box",
-  fontSize: `${theme.fontSizes.sm} !important`,
+  fontSize: `${theme.fontSizes.sm}`,
   maxWidth: `calc(${theme.sizes.contentMaxWidth} - 4rem)`,
   maxHeight: "300px",
   overflow: "auto",
@@ -47,5 +47,8 @@ export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
   },
   code: {
     background: transparentize(theme.colors.darkenedBgMix60, 0.8),
+  },
+  "*": {
+    fontSize: theme.fontSizes.sm,
   },
 }))

--- a/frontend/src/components/shared/Tooltip/styled-components.tsx
+++ b/frontend/src/components/shared/Tooltip/styled-components.tsx
@@ -16,6 +16,7 @@
  */
 
 import styled from "@emotion/styled"
+import { transparentize } from "color2k"
 
 export const StyledWrapper = styled.div({
   display: "table",
@@ -29,3 +30,22 @@ export const StyledEllipsizedDiv = styled.div({
   whiteSpace: "nowrap",
   display: "table-cell",
 })
+
+export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
+  boxSizing: "border-box",
+  fontSize: `${theme.fontSizes.sm} !important`,
+  maxWidth: `calc(${theme.sizes.contentMaxWidth} - 4rem)`,
+  maxHeight: "300px",
+  overflow: "auto",
+  padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+
+  [`@media (max-width: ${theme.breakpoints.sm})`]: {
+    maxWidth: `calc(100% - 2rem)`,
+  },
+  img: {
+    maxWidth: "100%",
+  },
+  code: {
+    background: transparentize(theme.colors.darkenedBgMix60, 0.8),
+  },
+}))

--- a/frontend/src/components/shared/TooltipIcon/TooltipIcon.tsx
+++ b/frontend/src/components/shared/TooltipIcon/TooltipIcon.tsx
@@ -6,10 +6,7 @@ import StreamlitMarkdown, {
 } from "src/components/shared/StreamlitMarkdown"
 import { useTheme } from "emotion-theming"
 import { Theme } from "src/theme"
-import {
-  StyledTooltipIconWrapper,
-  StyledTooltipContentWrapper,
-} from "./styled-components"
+import { StyledTooltipIconWrapper } from "./styled-components"
 
 export interface TooltipIconProps {
   placement?: Placement
@@ -31,14 +28,12 @@ function TooltipIcon({
     <StyledTooltipIconWrapper className="stTooltipIcon">
       <Tooltip
         content={
-          <StyledTooltipContentWrapper>
-            <StreamlitMarkdown
-              style={{ fontSize: theme.fontSizes.sm }}
-              source={content}
-              allowHTML={false}
-              {...(markdownProps || {})}
-            />
-          </StyledTooltipContentWrapper>
+          <StreamlitMarkdown
+            style={{ fontSize: theme.fontSizes.sm }}
+            source={content}
+            allowHTML={false}
+            {...(markdownProps || {})}
+          />
         }
         placement={placement}
         inline

--- a/frontend/src/components/shared/TooltipIcon/index.tsx
+++ b/frontend/src/components/shared/TooltipIcon/index.tsx
@@ -1,3 +1,2 @@
 export * from "./TooltipIcon"
 export { default } from "./TooltipIcon"
-export { StyledTooltipContentWrapper } from "./styled-components"

--- a/frontend/src/components/shared/TooltipIcon/styled-components.ts
+++ b/frontend/src/components/shared/TooltipIcon/styled-components.ts
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled"
-import { transparentize } from "color2k"
 
 export const StyledTooltipIconWrapper = styled.div(({ theme }) => ({
   display: "flex",
@@ -13,24 +12,5 @@ export const StyledTooltipIconWrapper = styled.div(({ theme }) => ({
     svg: {
       stroke: theme.colors.fadedText60,
     },
-  },
-}))
-
-export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
-  boxSizing: "border-box",
-  fontSize: `${theme.fontSizes.sm} !important`,
-  maxWidth: `calc(${theme.sizes.contentMaxWidth} - 4rem)`,
-  maxHeight: "300px",
-  overflow: "auto",
-  padding: `${theme.spacing.xs} ${theme.spacing.md}`,
-
-  [`@media (max-width: ${theme.breakpoints.sm})`]: {
-    maxWidth: `calc(100% - 2rem)`,
-  },
-  img: {
-    maxWidth: "100%",
-  },
-  code: {
-    background: transparentize(theme.colors.darkenedBgMix60, 0.8),
   },
 }))


### PR DESCRIPTION
(Breaking up #3642 into multiple PRs)

* Make `<code>` syntax highlighting use colors from the Streamlit palette.

NOTE: Screenshot tests coming after first round of reviews. Don't want to generate and re-generate as more reviews come in 😅

NOTE #2: Note the base branch for this PR. I'm basing it on the previous UI tweaks PR so the diff is easier to read. The idea is to merge in order.