### PR TITLE
UI tweaks #11: teeny tiny scrollbar and button improvements 

### DIFF
--- a/frontend/public/assets/streamlit.css
+++ b/frontend/public/assets/streamlit.css
@@ -932,7 +932,7 @@ pre code {
   width: 6px;
 }
 
-::-webkit-scrollbar:hover {
+::-webkit-scrollbar:active {
   background-color: rgba(0, 0, 0, 0.09);
 }
 

--- a/frontend/src/components/shared/Button/styled-components.ts
+++ b/frontend/src/components/shared/Button/styled-components.ts
@@ -82,6 +82,7 @@ export const StyledBaseButton = styled.button<RequiredButtonProps>(
     lineHeight: theme.lineHeights.base,
     color: "inherit",
     width: fluidWidth ? "100%" : "auto",
+    userSelect: "none",
     "&:focus": {
       boxShadow: `0 0 0 0.2rem ${transparentize(theme.colors.primary, 0.5)}`,
       outline: "none",

--- a/frontend/src/theme/globalStyles.ts
+++ b/frontend/src/theme/globalStyles.ts
@@ -678,7 +678,7 @@ export const globalStyles = (theme: Theme): any => css`
     width: 6px;
   }
 
-  ::-webkit-scrollbar:hover {
+  ::-webkit-scrollbar:active {
     background: ${theme.colors.fadedText10};
   }
 


### PR DESCRIPTION
(Breaking up #3642 into multiple PRs)

* Make `st.button` text unselectable. Otherwise sometimes when you click on it the text inside it actually gets selected.
* Make the background of webkit scrollbars only "light up" when clicked  

NOTE: Screenshot tests coming after first round of reviews. Don't want to generate and re-generate as more reviews come in 😅

NOTE #2: Note the base branch for this PR. I'm basing it on the previous UI tweaks PR so the diff is easier to read. The idea is to merge in order.