### PR TITLE
Add missing Python dependency needed for testing

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -24,3 +24,4 @@ sqlalchemy
 tensorflow>2.2.0,<2.5.0
 torch<1.9.0
 torchvision
+watchdog==2.1.5


### PR DESCRIPTION
**Issue:** #3772

**Description:**
- Add watchdog as a dependency to the `test-requirements.txt` file to fix the issue.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
