### PR TITLE
return type for date_input may be tuple

### DIFF
--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -144,7 +144,7 @@ class TimeWidgetsMixin:
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
         kwargs: Optional[WidgetKwargs] = None,
-    ) -> date:
+    ) -> Union[date,tuple]:
         """Display a date input widget.
 
         Parameters

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -177,7 +177,7 @@ class TimeWidgetsMixin:
 
         Returns
         -------
-        datetime.date
+        datetime.date or a tuple with 0-2 dates
             The current value of the date input widget.
 
         Example

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -144,7 +144,7 @@ class TimeWidgetsMixin:
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
         kwargs: Optional[WidgetKwargs] = None,
-    ) -> Union[date,tuple]:
+    ) -> Union[date, tuple]:
         """Display a date input widget.
 
         Parameters

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -14,7 +14,7 @@
 
 from datetime import datetime, date, time
 from streamlit.type_util import Key, to_key
-from typing import cast, Optional, Union
+from typing import cast, Optional, Union, Tuple
 from textwrap import dedent
 
 from dateutil import relativedelta
@@ -144,7 +144,7 @@ class TimeWidgetsMixin:
         on_change: Optional[WidgetCallback] = None,
         args: Optional[WidgetArgs] = None,
         kwargs: Optional[WidgetKwargs] = None,
-    ) -> Union[date, tuple]:
+    ) -> Union[date, Tuple[date, ...]]:
         """Display a date input widget.
 
         Parameters


### PR DESCRIPTION
**Issue:** https://app.zenhub.com/workspaces/streamlit-5e86ef71136dd5db5f2ba10b/issues/streamlit/streamlit/3494

**Description:** 

- Use Union of date and tuple types to include tuple return type for date_input

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
