### PR TITLE
Cast `max_message_size` to `int` before passing to `tornado`

### DIFF
--- a/lib/streamlit/server/server_util.py
+++ b/lib/streamlit/server/server_util.py
@@ -25,7 +25,7 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 # Largest message that can be sent via the WebSocket connection.
 # (Limit was picked arbitrarily)
 # TODO: Break message in several chunks if too large.
-MESSAGE_SIZE_LIMIT = 50 * 1e6  # 50MB
+MESSAGE_SIZE_LIMIT = 50 * int(1e6)  # 50MB
 
 
 def is_cacheable_msg(msg: ForwardMsg) -> bool:


### PR DESCRIPTION
**Issue:** #3782 (`https://github.com/streamlit/streamlit/issues/3782`)

**Description:** Fixes `DeprecationWarning` that interrupts `tornado` event loop (`tornado` web socket handler expects an `int` for `max_message_size`, but `streamlit` currently passes a `float`).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
