### PR TITLE
Fix issue with svg images starting not with a <svg> tag

### DIFF
--- a/e2e/scripts/st_image.py
+++ b/e2e/scripts/st_image.py
@@ -57,3 +57,13 @@ st.image(
 </svg>
 """
 )
+
+st.image(
+    """<?xml version="1.0" encoding="utf-8"?>
+    <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500" height="100">
+    <text x="0" y="50">"I am prefixed with some meta tags</text>
+    </svg>
+"""
+)

--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -87,4 +87,10 @@ describe("st.image", () => {
       .eq(1)
       .should("contain", "avatars.githubusercontent");
   });
+
+  it("displays SVG tags prefixed with meta xml tags", () => {
+    cy.get("[data-testid='stImage'] svg")
+      .eq(2)
+      .should("contain", "I am prefixed with some meta tags");
+  });
 });

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -19,6 +19,7 @@ import io
 import mimetypes
 from typing import cast
 from urllib.parse import urlparse
+import re
 
 import numpy as np
 from PIL import Image, ImageFile
@@ -360,7 +361,9 @@ def marshall_images(
             if image.endswith(".svg"):
                 with open(image) as textfile:
                     image = textfile.read()
-            if image.strip().startswith("<svg"):
+
+            # Following regex allows svg image files to start either via a "<?xml...>" tag eventually followed by a "<svg...>" tag or directly starting with a "<svg>" tag
+            if re.search(r"(^\s?(<\?xml[\s\S]*<svg )|^\s?<svg )", image):
                 proto_img.markup = f"data:image/svg+xml,{image}"
                 is_svg = True
         if not is_svg:

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -232,6 +232,14 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
                 "\n<svg fake></svg>",
                 "data:image/svg+xml,\n<svg fake></svg>",
             ),
+            (
+                '<?xml version="1.0" encoding="utf-8"?><!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg fake></svg>',
+                'data:image/svg+xml,<?xml version="1.0" encoding="utf-8"?><!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg fake></svg>',
+            ),
+            (
+                '\n<?xml version="1.0" encoding="utf-8"?>\n<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg fake></svg>',
+                'data:image/svg+xml,\n<?xml version="1.0" encoding="utf-8"?>\n<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg fake></svg>',
+            ),
         ]
     )
     def test_marshall_svg(self, image_markup: str, expected_prefix: str):


### PR DESCRIPTION
**Issue:** #3655

**Description:** The current check whether an svg file starts with `<svg...>` is replaced with a regex. The regex also the svg file to start also with a `<xml...>` tag and other optional tags (e.g. `<!DOCTYPE...`>) before the `<svg...>` appears which fixes the linked issue. This is not a fully-fledged svg-validation, though.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
