### PR TITLE
Rename Streamlit Sharing with Streamlit Cloud and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once you deploy your app, you can embed this badge right into your GitHub readme
 [Streamlit Cloud](https://streamlit.io/cloud) is our deployment solution for managing, sharing, and collaborating on your Streamlit apps.
 
 - The Teams and Enterprise tiers provide secure single-click deploy, authentication, web editing, versioning, and much more for your Streamlit apps. They're both currently in closed beta, and you can join the wait-list [here](https://streamlit.io/cloud-sign-up).
-- The Community tier (formerly Streamlit sharing) is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it. It's completely free to use and you can request your invite [here.](https://streamlit.io/sharing-sign-up)
+- The Community tier (formerly Streamlit sharing) is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it. It's completely free to use and you can request your invite [here.](https://streamlit.io/community-sign-up)
 
 ## License
 

--- a/docs/deploy_streamlit_app.md
+++ b/docs/deploy_streamlit_app.md
@@ -2,7 +2,7 @@
 
 Now that you've created your app, you're ready to share it! You can use [Streamlit Cloud](https://streamlit.io/cloud) to deploy and share your app. Streamlit Cloud has multiple tiers:
 
-- The **free** [Community tier](https://streamlit.io/sharing-sign-up) (formerly Streamlit sharing) is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it.
+- The **free** [Community tier](https://streamlit.io/community-sign-up) (formerly Streamlit sharing) is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it.
 - The [Team and Enterprise tiers](https://streamlit.io/cloud-sign-up) offer access controls, the ability to securely deploy apps from private repos, customize resources, and much more.
 
 Of course, if you want to host your app using another hosting provider, go for it! Streamlit apps work anywhere a Python app works. You can find guides for other hosting providers on our [community-supported deployment wiki](https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099).
@@ -11,7 +11,7 @@ Alright, let’s get started. Below, we highlight how to deploy apps with the f
 
 ## Sign up for Streamlit Cloud
 
-To get started, first request an invite on the [Community tier page](https://streamlit.io/sharing-sign-up). Once you receive your invite email, you're ready to deploy! It's really straightforward, just follow the next few steps.
+To get started, first request an invite on the [Community tier page](https://streamlit.io/community-sign-up). Once you receive your invite email, you're ready to deploy! It's really straightforward, just follow the next few steps.
 
 ## Put your Streamlit app on GitHub
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -257,7 +257,7 @@ for i in range(100):
 
 ## Share your app
 
-After you’ve built a Streamlit app, it's time to share it! To show it off to the world you can use **Streamlit Cloud** to deploy, manage, and share your app. Streamlit Cloud is currently invitation only, so please [request an invite](https://streamlit.io/sharing-sign-up) and we'll get you one soon!
+After you’ve built a Streamlit app, it's time to share it! To show it off to the world you can use **Streamlit Cloud** to deploy, manage, and share your app. Streamlit Cloud is currently invitation only, so please [request an invite](https://streamlit.io/community-sign-up) and we'll get you one soon!
 
 <!-- [[we'll need to grab the gif after the video editors are done with it on Wednesday]] -->
 

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -51,7 +51,7 @@ import {
   COMMUNITY_URL,
   DEPLOY_URL,
   ONLINE_DOCS_URL,
-  STREAMLIT_SHARE_URL,
+  STREAMLIT_CLOUD_URL,
   TEAMS_URL,
 } from "src/urls"
 import {
@@ -136,7 +136,7 @@ const getDeployAppUrl = (gitInfo: IGitInfo | null): (() => void) => {
   }
 
   // Otherwise, just direct them to the Streamlit Share page.
-  return getOpenInWindowCallback(STREAMLIT_SHARE_URL)
+  return getOpenInWindowCallback(STREAMLIT_CLOUD_URL)
 }
 
 const isLocalhost = (): boolean => {

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -135,7 +135,7 @@ const getDeployAppUrl = (gitInfo: IGitInfo | null): (() => void) => {
     return getOpenInWindowCallback(deployUrl.toString())
   }
 
-  // Otherwise, just direct them to the Streamlit Share page.
+  // Otherwise, just direct them to the Streamlit Cloud page.
   return getOpenInWindowCallback(STREAMLIT_CLOUD_URL)
 }
 

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
@@ -11,7 +11,7 @@ function NoRepositoryDetected(): IDeployErrorDialog {
           Could not find a remote repository hosted on GitHub. Are you sure you
           are on a branch that is tracking a remote GitHub branch?
         </p>
-        <p>How Streamlit sharing works:</p>
+        <p>How Streamlit Cloud works:</p>
         <ul>
           <li>
             To deploy a public app, you must first put it in a public GitHub

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/__snapshots__/NoRepositoryDetected.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/__snapshots__/NoRepositoryDetected.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
       Could not find a remote repository hosted on GitHub. Are you sure you are on a branch that is tracking a remote GitHub branch?
     </p>
     <p>
-      How Streamlit sharing works:
+      How Streamlit Cloud works:
     </p>
     <ul>
       <li>

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -17,7 +17,7 @@
 
 export const STREAMLIT_HOME_URL = "https://streamlit.io"
 export const DEPLOY_URL = "https://share.streamlit.io/deploy"
-export const STREAMLIT_SHARE_URL = "https://streamlit.io/cloud"
+export const STREAMLIT_CLOUD_URL = "https://streamlit.io/cloud"
 export const ONLINE_DOCS_URL = "https://docs.streamlit.io"
 export const COMMUNITY_URL = "https://discuss.streamlit.io"
 export const TEAMS_URL = "https://streamlit.io/for-teams"

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -17,7 +17,7 @@
 
 export const STREAMLIT_HOME_URL = "https://streamlit.io"
 export const DEPLOY_URL = "https://share.streamlit.io/deploy"
-export const STREAMLIT_SHARE_URL = "https://streamlit.io/sharing"
+export const STREAMLIT_SHARE_URL = "https://streamlit.io/cloud"
 export const ONLINE_DOCS_URL = "https://docs.streamlit.io"
 export const COMMUNITY_URL = "https://discuss.streamlit.io"
 export const TEAMS_URL = "https://streamlit.io/for-teams"

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -286,7 +286,7 @@ def _maybe_print_old_git_warning(script_path: str) -> None:
             fg="yellow",
         )
         click.secho(
-            "  Git is used by Streamlit Cloud (https://streamlit.io/sharing).",
+            "  Git is used by Streamlit Cloud (https://streamlit.io/cloud).",
             fg="yellow",
         )
         click.secho("  To enable this feature, please update Git.", fg="yellow")

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -286,7 +286,7 @@ def _maybe_print_old_git_warning(script_path: str) -> None:
             fg="yellow",
         )
         click.secho(
-            "  Git is used by Streamlit Sharing (https://streamlit.io/sharing).",
+            "  Git is used by Streamlit Cloud (https://streamlit.io/sharing).",
             fg="yellow",
         )
         click.secho("  To enable this feature, please update Git.", fg="yellow")

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -122,7 +122,7 @@ PyArrow. To do so locally:
 
 `pip install pyarrow`
 
-And if you're using Streamlit Sharing, add "pyarrow" to your requirements.txt."""
+And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
             )
 
         # In addition to the custom kwargs passed to the component, we also

--- a/lib/streamlit/secrets.py
+++ b/lib/streamlit/secrets.py
@@ -129,7 +129,7 @@ class Secrets(Mapping[str, Any]):
             if self._file_watcher_installed:
                 return
 
-            # We force our watcher_type to 'poll' because Streamlit Sharing
+            # We force our watcher_type to 'poll' because Streamlit Cloud
             # stores `secrets.toml` in a virtual filesystem that is
             # incompatible with watchdog.
             streamlit.watcher.file_watcher.watch_file(

--- a/lib/tests/streamlit/secrets_test.py
+++ b/lib/tests/streamlit/secrets_test.py
@@ -108,7 +108,7 @@ class SecretsTest(unittest.TestCase):
 
         # watch_file should have been called on the "secrets.toml" file with
         # the "poll" watcher_type. ("poll" is used here - rather than whatever
-        # is set in config - because Streamlit Sharing loads secrets.toml from
+        # is set in config - because Streamlit Cloud loads secrets.toml from
         # a virtual filesystem that watchdog is unable to fire events for.)
         mock_watch_file.assert_called_once_with(
             MOCK_SECRETS_FILE_LOC,


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit-issues/issues/235

**Description:** 
- Update Streamlit *Sharing* to Streamlit *Cloud*
- Update links that are just redirects:
  - Update https://streamlit.io/sharing-sign-up to https://streamlit.io/community-sign-up
  - Update https://streamlit.io/sharing to https://streamlit.io/cloud

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
