### PR TITLE
Bugfix/3580

### DIFF
--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -224,15 +224,16 @@ class TimeWidgetsMixin:
             else:
                 max_value = date.today() + relativedelta.relativedelta(years=10)
 
-        start_value = value[0]
-        end_value = value[-1]
+        if value:
+            start_value = value[0]
+            end_value = value[-1]
 
-        if (start_value < min_value) or (end_value > max_value):
-            raise StreamlitAPIException(
-                f"The default `value` of {value} "
-                f"must lie between the `min_value` of {min_value} "
-                f"and the `max_value` of {max_value}, inclusively."
-            )
+            if (start_value < min_value) or (end_value > max_value):
+                raise StreamlitAPIException(
+                    f"The default `value` of {value} "
+                    f"must lie between the `min_value` of {min_value} "
+                    f"and the `max_value` of {max_value}, inclusively."
+                )
 
         date_input_proto = DateInputProto()
         date_input_proto.is_range = range_value

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -204,6 +204,18 @@ class TimeWidgetsMixin:
                 "0 - 2 date/datetime values"
             )
 
+        start_value = value.date() if single_value else value[0].date()
+        end_value = value.date() if single_value else value[1].date()
+
+        if (min_value and start_value < min_value.date()) or (
+            max_value and end_value > max_value.date()
+        ):
+            raise StreamlitAPIException(
+                f"The default `value` of {value} "
+                f"must lie between the `min_value` of {min_value} "
+                f"and the `max_value` of {max_value}, inclusively."
+            )
+
         if single_value:
             value = [value]
 

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -203,32 +203,11 @@ class TimeWidgetsMixin:
                 "DateInput value should either be an date/datetime or a list/tuple of "
                 "0 - 2 date/datetime values"
             )
-
-        start_value = value.date() if single_value else value[0].date()
-        end_value = value.date() if single_value else value[1].date()
-
-        if (min_value and start_value < min_value.date()) or (
-            max_value and end_value > max_value.date()
-        ):
-            raise StreamlitAPIException(
-                f"The default `value` of {value} "
-                f"must lie between the `min_value` of {min_value} "
-                f"and the `max_value` of {max_value}, inclusively."
-            )
-
+        
         if single_value:
             value = [value]
-
-        date_input_proto = DateInputProto()
-        date_input_proto.is_range = range_value
-        if help is not None:
-            date_input_proto.help = dedent(help)
-
         value = [v.date() if isinstance(v, datetime) else v for v in value]
-
-        date_input_proto.label = label
-        date_input_proto.default[:] = [date.strftime(v, "%Y/%m/%d") for v in value]
-
+        
         if isinstance(min_value, datetime):
             min_value = min_value.date()
         elif min_value is None:
@@ -244,6 +223,24 @@ class TimeWidgetsMixin:
                 max_value = value[-1] + relativedelta.relativedelta(years=10)
             else:
                 max_value = date.today() + relativedelta.relativedelta(years=10)
+
+        start_value = value[0]
+        end_value = value[-1]
+
+        if (start_value < min_value) or (end_value > max_value):
+            raise StreamlitAPIException(
+                f"The default `value` of {value} "
+                f"must lie between the `min_value` of {min_value} "
+                f"and the `max_value` of {max_value}, inclusively."
+            )
+
+        date_input_proto = DateInputProto()
+        date_input_proto.is_range = range_value
+        if help is not None:
+            date_input_proto.help = dedent(help)
+
+        date_input_proto.label = label
+        date_input_proto.default[:] = [date.strftime(v, "%Y/%m/%d") for v in value]
 
         date_input_proto.min = date.strftime(min_value, "%Y/%m/%d")
         date_input_proto.max = date.strftime(max_value, "%Y/%m/%d")

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -203,11 +203,11 @@ class TimeWidgetsMixin:
                 "DateInput value should either be an date/datetime or a list/tuple of "
                 "0 - 2 date/datetime values"
             )
-        
+
         if single_value:
             value = [value]
         value = [v.date() if isinstance(v, datetime) else v for v in value]
-        
+
         if isinstance(min_value, datetime):
             min_value = min_value.date()
         elif min_value is None:

--- a/lib/tests/streamlit/date_input_test.py
+++ b/lib/tests/streamlit/date_input_test.py
@@ -112,9 +112,12 @@ class DateInputTest(testutil.DeltaGeneratorTestCase):
             st.date_input(
                 "the label", value=value, min_value=min_date, max_value=max_date
             )
+        if isinstance(value, (date, datetime)):
+            value = [value]
+        value = [v.date() if isinstance(v, datetime) else v for v in value]
         assert (
-            f"The default `value` of {value} must lie between the `min_value` of {min_date} "
-            f"and the `max_value` of {max_date}, inclusively." == str(exc_message.value)
+            f"The default `value` of {value} must lie between the `min_value` of {min_date.date()} "
+            f"and the `max_value` of {max_date.date()}, inclusively." == str(exc_message.value)
         )
 
     @parameterized.expand(

--- a/lib/tests/streamlit/date_input_test.py
+++ b/lib/tests/streamlit/date_input_test.py
@@ -16,10 +16,13 @@
 
 from datetime import date
 from datetime import datetime
+from datetime import timedelta
 
+from pytest import raises
 from parameterized import parameterized
 
 import streamlit as st
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 
 
@@ -74,6 +77,73 @@ class DateInputTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(c.label, "the label")
         self.assertEqual(c.min, min_date_value)
         self.assertEqual(c.max, max_date_value)
+
+    @parameterized.expand(
+        [
+            (
+                datetime.today(),
+                datetime.today() + timedelta(days=7),
+                datetime.today() + timedelta(days=14),
+            ),
+            (
+                datetime.today() + timedelta(days=8),
+                datetime.today(),
+                datetime.today() + timedelta(days=7),
+            ),
+            (
+                [datetime.today(), datetime.today() + timedelta(2)],
+                datetime.today() + timedelta(days=7),
+                datetime.today() + timedelta(days=14),
+            ),
+            (
+                [datetime.today(), datetime.today() + timedelta(8)],
+                datetime.today() + timedelta(days=7),
+                datetime.today() + timedelta(days=14),
+            ),
+            (
+                [datetime.today(), datetime.today() + timedelta(8)],
+                datetime.today(),
+                datetime.today() + timedelta(days=7),
+            ),
+        ]
+    )
+    def test_value_out_of_range(self, value, min_date, max_date):
+        with raises(StreamlitAPIException) as exc_message:
+            st.date_input(
+                "the label", value=value, min_value=min_date, max_value=max_date
+            )
+        assert (
+            f"The default `value` of {value} must lie between the `min_value` of {min_date} "
+            f"and the `max_value` of {max_date}, inclusively." == str(exc_message.value)
+        )
+
+    @parameterized.expand(
+        [
+            (datetime.today(), datetime.today(), datetime.today() + timedelta(days=14)),
+            (
+                datetime.today() + timedelta(days=14),
+                datetime.today(),
+                datetime.today() + timedelta(days=14),
+            ),
+            (
+                datetime.today() + timedelta(days=10),
+                datetime.today(),
+                datetime.today() + timedelta(days=14),
+            ),
+            (
+                [datetime.today() + timedelta(1), datetime.today() + timedelta(2)],
+                datetime.today(),
+                datetime.today() + timedelta(days=14),
+            ),
+            (
+                [datetime.today(), datetime.today() + timedelta(14)],
+                datetime.today(),
+                datetime.today() + timedelta(days=14),
+            ),
+        ]
+    )
+    def test_value_in_range(self, value, min_date, max_date):
+        st.date_input("the label", value=value, min_value=min_date, max_value=max_date)
 
     def test_inside_column(self):
         """Test that it works correctly inside of a column."""

--- a/lib/tests/streamlit/date_input_test.py
+++ b/lib/tests/streamlit/date_input_test.py
@@ -117,7 +117,8 @@ class DateInputTest(testutil.DeltaGeneratorTestCase):
         value = [v.date() if isinstance(v, datetime) else v for v in value]
         assert (
             f"The default `value` of {value} must lie between the `min_value` of {min_date.date()} "
-            f"and the `max_value` of {max_date.date()}, inclusively." == str(exc_message.value)
+            f"and the `max_value` of {max_date.date()}, inclusively."
+            == str(exc_message.value)
         )
 
     @parameterized.expand(


### PR DESCRIPTION

**Issue:** [date_input widget should thrown an exception if value not in (min_value, max_value) range](https://app.zenhub.com/workspaces/streamlit-5e86ef71136dd5db5f2ba10b/issues/streamlit/streamlit/3580)

**Description:** Adds a check to date_input to ensure the default value provided falls within the range. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
