### PR TITLE
Fix handling of svg image urls

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -358,7 +358,7 @@ def marshall_images(
         is_svg = False
         if isinstance(image, str):
             # Unpack local SVG image file to an SVG string
-            if image.endswith(".svg") and not image.startswith(('http://', 'https://')):
+            if image.endswith(".svg") and not image.startswith(("http://", "https://")):
                 with open(image) as textfile:
                     image = textfile.read()
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -358,7 +358,7 @@ def marshall_images(
         is_svg = False
         if isinstance(image, str):
             # Unpack local SVG image file to an SVG string
-            if image.endswith(".svg"):
+            if image.endswith(".svg") and not image.startswith(('http://', 'https://')):
                 with open(image) as textfile:
                     image = textfile.read()
 

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -199,10 +199,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
                 "https://streamlit.io/test.png",
                 "https://streamlit.io/test.png",
             ),
-            (
-                "https://streamlit.io/test.svg",
-                "https://streamlit.io/test.svg"
-            ),
+            ("https://streamlit.io/test.svg", "https://streamlit.io/test.svg"),
             (
                 "🦈",
                 "🦈",

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -200,6 +200,10 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
                 "https://streamlit.io/test.png",
             ),
             (
+                "https://streamlit.io/test.svg",
+                "https://streamlit.io/test.svg"
+            ),
+            (
                 "🦈",
                 "🦈",
             ),


### PR DESCRIPTION
**Issue:** #3537

**Description:** Add a check whether an SVG image string is a URL to avoid trying to read it from the local filesystem. The check could be made more sophisticated or more protocols besides `http` and `https` could be added, though I thought that this is very likely the most common scenario.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
