### PR TITLE
Force wait for rerun to complete before making assertion

### DIFF
--- a/e2e/specs/st_columns.spec.js
+++ b/e2e/specs/st_columns.spec.js
@@ -51,6 +51,12 @@ describe("st.column", () => {
     cy.get(".stButton button").click();
     cy.get(".stMarkdown").should("have.text", "Pressed!");
 
+    // This assertion ensures that the report rerun completes first
+    cy.get("[data-testid='stHorizontalBlock'] [data-testid='stBlock']").should(
+      "have.length",
+      7
+    );
+
     // When layout was shifting, there was an old "flex: 8" block here.
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='stBlock']")
       .eq(3)

--- a/e2e/specs/st_form.spec.js
+++ b/e2e/specs/st_form.spec.js
@@ -69,7 +69,7 @@ describe("st.form", () => {
   it("changes widget values after the form has been submitted", () => {
     changeWidgetValues();
     cy.get(".stButton [kind='formSubmit']").click();
-
+    cy.get("@markdown").should("have.length", 12);
     cy.get("@markdown")
       .eq(0)
       .should("have.text", "Checkbox: True");

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -29,11 +29,11 @@ message NewReport {
   // The report ID
   string report_id = 2;
 
-  // The basename of the script that launched this report. Example: "foo.py"
+  // The basename of the script that launched this report. Example: 'foo.py'
   string name = 3;
 
   // The full path of the script that launched this report. Example:
-  // "/foo/bar/foo.py"
+  // '/foo/bar/foo.py'
   string script_path = 4;
 
   // DEPRECATED.


### PR DESCRIPTION
The e2e is flaky because the script is still running, and not all of the elements are displayed. We add a check for the number of elements on the page. This ensures the report finishes running before making the final assertion.

See https://www.cypress.io/blog/2020/07/22/do-not-get-too-detached/ for reference