### PR TITLE
Ignore attr-defined for git Repo

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -22,11 +22,13 @@ twine = "*"
 wheel = "*"
 # mypy types
 types-click = "*"
+types-protobuf = "*"
 types-python-dateutil = "*"
 types-pytz = "*"
 types-requests = "*"
 types-setuptools = "*"
 types-toml = "*"
+types-typed-ast
 # Doc builder packages:
 Sphinx = ">=3.0"
 recommonmark = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -28,7 +28,7 @@ types-pytz = "*"
 types-requests = "*"
 types-setuptools = "*"
 types-toml = "*"
-types-typed-ast
+types-typed-ast = "*"
 # Doc builder packages:
 Sphinx = ">=3.0"
 recommonmark = "*"

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -36,6 +36,9 @@ class GitRepo:
         try:
             import git
 
+            # GitPython imports the Repo and doesn't specifically re-export it
+            # which causes mypy to fail. We ignore the type hint because
+            # GitPython recommends this in its examples.
             self.repo = git.Repo(path, search_parent_directories=True)  # type: ignore[attr-defined]
             self.git_version = self.repo.git.version_info
 

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -34,9 +34,9 @@ class GitRepo:
         self.git_version = None  # type: Optional[Tuple[int, ...]]
 
         try:
-            import git  # type: ignore[import]
+            import git
 
-            self.repo = git.Repo(path, search_parent_directories=True)
+            self.repo = git.Repo(path, search_parent_directories=True)  # type: ignore[attr-defined]
             self.git_version = self.repo.git.version_info
 
             if self.git_version >= MIN_GIT_VERSION:


### PR DESCRIPTION
Aimed to fix build issues with mypy.

Note: I had some other issues exist with regard to types and it looked like there were some type files missing. I ran `mypy --install-types` and the two packages were installed and resolved the issues.