### PR TITLE
Fix to image captions extending beyond image width

### DIFF
--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -29,7 +29,9 @@ describe("st.image", () => {
   it("displays a caption", () => {
     cy.get(
       ".element-container [data-testid='stImage'] [data-testid='caption']"
-    ).should("contain", "Black Square");
+    )
+      .should("contain", "Black Square")
+      .should("have.css", "width", "100px");
   });
 
   it("displays a JPEG image when specified", () => {

--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -34,6 +34,12 @@ describe("st.image", () => {
       .should("have.css", "width", "100px");
   });
 
+  it("displays the image and caption together", () => {
+    cy.get(".element-container [data-testid='stImage']")
+      .eq(0)
+      .matchImageSnapshot("image-with-caption");
+  });
+
   it("displays a JPEG image when specified", () => {
     cy.get(".element-container [data-testid='stImage'] img")
       .eq(0)

--- a/frontend/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.test.tsx
@@ -53,13 +53,9 @@ describe("ImageList Element", () => {
   })
 
   it("should render explicit width for each image", () => {
-    const props = {
-      ...getProps({
-        width: 300,
-      }),
-      width: 1,
-    }
+    const props = getProps({ width: 300 })
     const wrapper = shallow(<ImageList {...props} />)
+
     expect(wrapper.find("StyledImageContainer").length).toEqual(2)
   })
 
@@ -93,14 +89,10 @@ describe("ImageList Element", () => {
   })
 
   it("should render explicit width for each caption", () => {
-    const props = {
-      ...getProps({
-        width: 300,
-      }),
-      width: 1,
-    }
+    const props = getProps({ width: 300 })
     const captionWidth = { width: 300 }
     const wrapper = shallow(<ImageList {...props} />)
+
     wrapper.find("StyledCaption").forEach(captionWrapper => {
       expect(captionWrapper.prop("style")).toStrictEqual(captionWidth)
     })

--- a/frontend/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.test.tsx
@@ -92,6 +92,20 @@ describe("ImageList Element", () => {
     })
   })
 
+  it("should render explicit width for each caption", () => {
+    const props = {
+      ...getProps({
+        width: 300,
+      }),
+      width: 1,
+    }
+    const captionWidth = { width: 300 }
+    const wrapper = shallow(<ImageList {...props} />)
+    wrapper.find("StyledCaption").forEach(captionWrapper => {
+      expect(captionWrapper.prop("style")).toStrictEqual(captionWidth)
+    })
+  })
+
   it("should render absolute src", () => {
     const props = getProps({
       imgs: [

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -93,25 +93,19 @@ export function ImageList({
         (iimage: IImage, idx: number): ReactElement => {
           const image = iimage as ImageProto
           return (
-            // <StyledImageContainer key={idx} data-testid="stImage">
-            <StyledImageContainer
-              key={idx}
-              data-testid="stImage"
-              style={imgStyle}
-            >
+            <StyledImageContainer key={idx} data-testid="stImage">
               {image.markup ? (
                 // SVGs are received unsanitized
                 ReactHtmlParser(xssSanitizeSvg(image.markup))
               ) : (
                 <img
-                  // style={imgStyle}
+                  style={imgStyle}
                   src={buildMediaUri(image.url)}
                   alt={idx.toString()}
                 />
               )}
               {image.caption && (
-                <StyledCaption data-testid="caption">
-                  {/* <StyledCaption data-testid="caption" style={imgStyle}> */}
+                <StyledCaption data-testid="caption" style={imgStyle}>
                   {` ${image.caption} `}
                 </StyledCaption>
               )}

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -93,19 +93,25 @@ export function ImageList({
         (iimage: IImage, idx: number): ReactElement => {
           const image = iimage as ImageProto
           return (
-            <StyledImageContainer key={idx} data-testid="stImage">
+            // <StyledImageContainer key={idx} data-testid="stImage">
+            <StyledImageContainer
+              key={idx}
+              data-testid="stImage"
+              style={imgStyle}
+            >
               {image.markup ? (
                 // SVGs are received unsanitized
                 ReactHtmlParser(xssSanitizeSvg(image.markup))
               ) : (
                 <img
-                  style={imgStyle}
+                  // style={imgStyle}
                   src={buildMediaUri(image.url)}
                   alt={idx.toString()}
                 />
               )}
               {image.caption && (
                 <StyledCaption data-testid="caption">
+                  {/* <StyledCaption data-testid="caption" style={imgStyle}> */}
                   {` ${image.caption} `}
                 </StyledCaption>
               )}

--- a/frontend/src/components/elements/ImageList/styled-components.ts
+++ b/frontend/src/components/elements/ImageList/styled-components.ts
@@ -31,6 +31,7 @@ export const StyledImageContainer = styled.div(({ theme }) => ({
   alignItems: "stretch",
   width: "auto",
   flexGrow: 0,
+  // margin: "0.125rem",
 }))
 
 export const StyledCaption = styled.div(({ theme }) => ({
@@ -39,4 +40,6 @@ export const StyledCaption = styled.div(({ theme }) => ({
   color: theme.colors.fadedText60,
   textAlign: "center",
   marginTop: theme.spacing.xs,
+  wordWrap: "break-word",
+  // padding: "0.125rem",
 }))

--- a/frontend/src/components/elements/ImageList/styled-components.ts
+++ b/frontend/src/components/elements/ImageList/styled-components.ts
@@ -31,8 +31,6 @@ export const StyledImageContainer = styled.div(({ theme }) => ({
   alignItems: "stretch",
   width: "auto",
   flexGrow: 0,
-  // spacing between columns
-  // margin: "0.125rem",
 }))
 
 export const StyledCaption = styled.div(({ theme }) => ({
@@ -42,6 +40,5 @@ export const StyledCaption = styled.div(({ theme }) => ({
   textAlign: "center",
   marginTop: theme.spacing.xs,
   wordWrap: "break-word",
-  // versus spacing around the caption div
-  // padding: "0.125rem",
+  padding: "0.125rem",
 }))

--- a/frontend/src/components/elements/ImageList/styled-components.ts
+++ b/frontend/src/components/elements/ImageList/styled-components.ts
@@ -31,6 +31,7 @@ export const StyledImageContainer = styled.div(({ theme }) => ({
   alignItems: "stretch",
   width: "auto",
   flexGrow: 0,
+  // spacing between columns
   // margin: "0.125rem",
 }))
 
@@ -41,5 +42,6 @@ export const StyledCaption = styled.div(({ theme }) => ({
   textAlign: "center",
   marginTop: theme.spacing.xs,
   wordWrap: "break-word",
+  // versus spacing around the caption div
   // padding: "0.125rem",
 }))


### PR DESCRIPTION
**Problem:**
    The StyledImageContainer is adjusting to the caption length, extending past the width of the image

**Fix:**
 * Added styling to StyledCaption (width, wordWrap, & padding) to ensure captions stay within image width and are readable (even at smaller dimensions)
 * Added test to validate caption width is the same as the image width
 

**Before:**
![image](https://user-images.githubusercontent.com/63436329/134090650-551ec4ed-e7ea-4a65-a0f1-8498cfde71f7.png)

**After:**
<img width="580" alt="Screen Shot 2021-09-20 at 4 46 13 PM" src="https://user-images.githubusercontent.com/63436329/134091340-01920c40-cdc6-48d0-a500-2565a393528b.png">

close #3530