### PR TITLE
Adds memo and singleton docstrings to API reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -329,6 +329,8 @@ and its limitations, see [Caching](caching.md).
 
 ```eval_rst
 .. autofunction:: streamlit.cache
+.. autofunction:: streamlit.experimental_memo
+.. autofunction:: streamlit.experimental_singleton
 ```
 
 ## Pre-release features

--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -174,7 +174,7 @@ def memo(
     >>> d3 = fetch_and_clean_data(DATA_URL_2)
     >>> # This is a different URL, so the function executes.
 
-    To set the `persist` parameter, use this command as follows:
+    To set the ``persist`` parameter, use this command as follows:
 
     >>> @st.experimental_memo(persist="disk")
     ... def fetch_and_clean_data(url):
@@ -182,7 +182,7 @@ def memo(
     ...     return data
 
     By default, all parameters to a memoized function must be hashable.
-    Any parameter whose name begins with "_" will not be hashed. You can use
+    Any parameter whose name begins with ``_`` will not be hashed. You can use
     this as an "escape hatch" for parameters that are not hashable:
 
     >>> @st.experimental_memo

--- a/lib/streamlit/caching/singleton_decorator.py
+++ b/lib/streamlit/caching/singleton_decorator.py
@@ -100,7 +100,7 @@ def singleton(
     Singleton objects *must* be thread-safe, because they can be accessed from
     multiple threads concurrently.
 
-    (If thread-safety is an issue, consider using `st.session_state` to
+    (If thread-safety is an issue, consider using ``st.session_state`` to
     store per-session singleton objects instead.)
 
     Parameters
@@ -136,7 +136,7 @@ def singleton(
     >>> # This is a different URL, so the function executes.
 
     By default, all parameters to a singleton function must be hashable.
-    Any parameter whose name begins with "_" will not be hashed. You can use
+    Any parameter whose name begins with ``_`` will not be hashed. You can use
     this as an "escape hatch" for parameters that are not hashable:
 
     >>> @st.experimental_singleton

--- a/lib/streamlit/legacy_caching/caching.py
+++ b/lib/streamlit/legacy_caching/caching.py
@@ -392,14 +392,14 @@ def cache(
     >>> d3 = fetch_and_clean_data(DATA_URL_2)
     >>> # This is a different URL, so the function executes.
 
-    To set the `persist` parameter, use this command as follows:
+    To set the ``persist`` parameter, use this command as follows:
 
     >>> @st.cache(persist=True)
     ... def fetch_and_clean_data(url):
     ...     # Fetch data from URL here, and then clean it up.
     ...     return data
 
-    To disable hashing return values, set the `allow_output_mutation` parameter to `True`:
+    To disable hashing return values, set the ``allow_output_mutation`` parameter to ``True``:
 
     >>> @st.cache(allow_output_mutation=True)
     ... def fetch_and_clean_data(url):
@@ -408,14 +408,14 @@ def cache(
 
 
     To override the default hashing behavior, pass a custom hash function.
-    You can do that by mapping a type (e.g. `MongoClient`) to a hash function (`id`) like this:
+    You can do that by mapping a type (e.g. ``MongoClient``) to a hash function (``id``) like this:
 
     >>> @st.cache(hash_funcs={MongoClient: id})
     ... def connect_to_database(url):
     ...     return MongoClient(url)
 
     Alternatively, you can map the type's fully-qualified name
-    (e.g. `"pymongo.mongo_client.MongoClient"`) to the hash function instead:
+    (e.g. ``"pymongo.mongo_client.MongoClient"``) to the hash function instead:
 
     >>> @st.cache(hash_funcs={"pymongo.mongo_client.MongoClient": id})
     ... def connect_to_database(url):


### PR DESCRIPTION
### Changes
- Adds docstrings for `st.experimental_memo` and `st.experimental_singleton` to the docs API reference
- Fixes reStructuredText code formatting in the docstrings for the above functions and `st.cache`

### Why?
Docstrings with the `experimental_` prefix have historically not been added to the API reference. @kmcgrady suggested that we can maybe consider adding them for caching. 