### PR TITLE
Updates Components API docs with `theme.base` support

### DIFF
--- a/docs/develop_streamlit_components.md
+++ b/docs/develop_streamlit_components.md
@@ -218,6 +218,7 @@ The `theme` object has the following shape:
 
 ```json
 {
+  "base": "lightORdark",
   "primaryColor": "someColor1",
   "backgroundColor": "someColor2",
   "secondaryBackgroundColor": "someColor3",
@@ -225,6 +226,8 @@ The `theme` object has the following shape:
   "font": "someFont"
 }
 ```
+
+The `base` option allows you to specify a preset Streamlit theme that your custom theme inherits from. Any theme config options not defined in your theme settings have their values set to those of the base theme. Valid values for `base` are `"light"` and `"dark"`.
 
 Note that the theme object has fields with the same names and semantics as the
 options in the "theme" section of the config options printed with the command
@@ -234,6 +237,7 @@ When using the React template, the following CSS variables are also set
 automatically.
 
 ```css
+--base
 --primary-color
 --background-color
 --secondary-background-color

--- a/docs/streamlit_configuration.md
+++ b/docs/streamlit_configuration.md
@@ -84,7 +84,7 @@ Shows all config options available for Streamlit, including their current
 values:
 
 ```toml
-# last updated 2021-07-22
+# last updated 2021-09-21
 
 [global]
 
@@ -286,6 +286,9 @@ keyPrefix = ""
 
 
 [theme]
+
+# The preset Streamlit theme that your custom theme inherits from. One of "light" or "dark".
+#base =
 
 # Primary accent color for interactive elements.
 #primaryColor =


### PR DESCRIPTION
With v0.89, we now support `theme.base` in the theme object when it's sent to custom components.
- This PR adds the `base` option to the `theme` object in the Components API.
- Updates the output of `streamlit config show` in [View all configuration options](https://docs.streamlit.io/en/latest/streamlit_configuration.html#view-all-configuration-options) to include the `base` field.