### PR TITLE
Fix user_key and wid conflation bugs, rename arguments for clarity

### DIFF
--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -168,7 +168,7 @@ def register_widget(
         session_state.set_keyed_widget(metadata, widget_id, user_key)
     else:
         session_state.set_unkeyed_widget(metadata, widget_id)
-    value_changed = session_state.should_set_frontend_state_value(widget_id)
+    value_changed = session_state.should_set_frontend_state_value(widget_id, user_key)
 
     val = session_state.get_value_for_registration(widget_id)
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -498,6 +498,7 @@ class SessionStateMethodTests(unittest.TestCase):
 
         with patch("streamlit.report_thread.get_report_ctx", return_value=mock_ctx):
             with pytest.raises(StreamlitAPIException) as e:
+                self.session_state._key_id_mapping = {"widget_id": "widget_id"}
                 self.session_state["widget_id"] = "blah"
             assert "`st.session_state.widget_id` cannot be modified" in str(e.value)
 
@@ -588,7 +589,8 @@ class SessionStateMethodTests(unittest.TestCase):
         )
         assert (
             self.session_state.should_set_frontend_state_value(
-                f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1"
+                f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1",
+                "widget_id_1",
             )
             == False
         )


### PR DESCRIPTION
A chunk of the session state api had ambiguous argument names, from back when we were trying to make user keys and widget ids interchangeable rather than being clear and explicit. Renaming them revealed an issue with the checks in `__setitem__`, which is now fixed, and the prompting issue of not checking the right key for setting the frontend value is also fixed by adding a `user_key` argument.

I don't know how these two bugs were in there, because I thought we had tests for these cases, but maybe we do and those tests are just too narrow.