### PR TITLE
(Hopefully) Fix CI, and also suppress some warnings

### DIFF
--- a/e2e/specs/st_main_menu.spec.js
+++ b/e2e/specs/st_main_menu.spec.js
@@ -16,7 +16,7 @@
  */
 
 describe("main menu", () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
@@ -24,7 +24,7 @@ describe("main menu", () => {
   });
 
   it("displays light main menu and about section properly", () => {
-    cy.get("[data-testid='stConnectionStatus']").should("not.exist");
+    cy.changeTheme("Light");
 
     // Main menu renders visually as we expect
     cy.get("#MainMenu > button").click();
@@ -53,8 +53,6 @@ describe("main menu", () => {
   });
 
   it("displays dark main menu and about section properly", () => {
-    // close the main menu from last test
-    cy.get("#MainMenu > button").click();
     cy.changeTheme("Dark");
 
     cy.get("#MainMenu > button").click();

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -54,9 +54,10 @@ addMatchImageSnapshotCommand({
 
 Cypress.Commands.add("openSettings", () => {
   cy.get("#MainMenu > button").click()
+  cy.get('[data-testid="main-menu-list"]').should("contain.text", "Settings")
   cy.get('[data-testid="main-menu-list"]')
     .contains("Settings")
-    .click()
+    .click({ force: true })
 })
 
 Cypress.Commands.add("changeTheme", theme => {

--- a/frontend/src/components/core/MainMenu/styled-components.ts
+++ b/frontend/src/components/core/MainMenu/styled-components.ts
@@ -70,7 +70,7 @@ export const StyledMenuItemShortcut = styled.span<ItemProps>(
   }
 )
 
-export const StyledMenuItem = styled.li<ItemProps>(
+export const StyledMenuItem = styled.ul<ItemProps>(
   ({ isDisabled, isRecording, theme }) => {
     const disabledStyles = isDisabled
       ? {


### PR DESCRIPTION
It remains unknown why CI is fine for new PRs but explodes for the `develop`
pipeline, but it seems like the root cause of the issue is a problem with
Cypress itself that remains unresolved (see https://github.com/cypress-io/cypress/issues/5743
and https://github.com/cypress-io/cypress/issues/7306 for more information).

One of the comments in the issues linked above suggested passing
`{ force: true }` as an argument to the `click` method to get this to
work, and this seems to be a fix on my local machine.

We seem to have run into similar issues before because I remember having
to do the same to get other e2e tests to pass.

I also changed one styled-component tag type from `li` to `ul` to
suppress a warning about invalid tag nestings.
