### PR TITLE
mypy: ignore `git` package entirely

### DIFF
--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -31,6 +31,10 @@ ignore_errors = True
 [mypy-streamlit.proto.*]
 ignore_errors = True
 
+[mypy-git]
+# The GitPython package is untyped and causes spurious mypy errors.
+ignore_errors = True
+ignore_missing_imports = True
 
 [mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,matplotlib,matplotlib.pyplot,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers]
 ignore_missing_imports = true

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -14,7 +14,7 @@
 
 import os
 import re
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 from streamlit import util
 
 # Github has two URLs, one that is https and one that is ssh
@@ -36,10 +36,11 @@ class GitRepo:
         try:
             import git
 
-            # GitPython imports the Repo and doesn't specifically re-export it
-            # which causes mypy to fail. We ignore the type hint because
-            # GitPython recommends this in its examples.
-            self.repo = git.Repo(path, search_parent_directories=True)  # type: ignore[attr-defined]
+            # GitPython is not fully typed, and mypy is outputting inconsistent
+            # type errors on Mac and Linux. We bypass type checking entirely
+            # by re-declaring the `git` import as an "Any".
+            git_package: Any = git
+            self.repo = git_package.Repo(path, search_parent_directories=True)
             self.git_version = self.repo.git.version_info
 
             if self.git_version >= MIN_GIT_VERSION:


### PR DESCRIPTION
The recent mypy fix for the `git` import (https://github.com/streamlit/streamlit/pull/3819) is causing mypy to fail locally:

```
$ make mypy
./scripts/mypy
lib/streamlit/git_util.py:37:1: error: Skipping analyzing "git": found module but no type hints or library stubs  [import]
                import git
    ^
lib/streamlit/git_util.py:37:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
lib/streamlit/git_util.py:42: error: unused "type: ignore" comment
                self.repo = git.Repo(path, search_parent_directories=True)  # type: ignore[attr-defined]
```

Instead, let's just have mypy ignore the git package altogether. This should work in both CircleCI and local.