### PR TITLE
Remove attr dunder methods from internal SessionState

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -220,14 +220,6 @@ class WStates(MutableMapping[str, Any]):
         callback(*args, **kwargs)
 
 
-INTERNAL_STATE_ATTRS = [
-    "_new_session_state",
-    "_new_widget_state",
-    "_old_state",
-    "_key_id_mapping",
-]
-
-
 def _missing_key_error_message(key: str) -> str:
     return f'st.session_state has no key "{key}". Did you forget to initialize it?'
 
@@ -429,9 +421,6 @@ class SessionState(MutableMapping[str, Any]):
         self._new_session_state[user_key] = value
 
     def __delitem__(self, key: str) -> None:
-        if key in INTERNAL_STATE_ATTRS:
-            raise KeyError(f"The key {key} is reserved.")
-
         widget_id = self._get_widget_id(key)
 
         if not (key in self or widget_id in self):

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -633,8 +633,6 @@ class LazySessionStateAttributeTests(unittest.TestCase):
     patched to avoid issues with mutability.
     """
 
-    reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
-
     def setUp(self):
         self.lazy_session_state = LazySessionState()
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -524,31 +524,6 @@ class SessionStateMethodTests(unittest.TestCase):
         with pytest.raises(KeyError):
             del self.session_state["nonexistent"]
 
-    def test_getattr(self):
-        assert self.session_state.foo == "bar2"
-
-    def test_getattr_error(self):
-        with pytest.raises(AttributeError):
-            del self.session_state.nonexistent
-
-    def test_setattr(self):
-        assert not self.session_state.is_new_state_value("corge")
-        self.session_state.corge = "grault2"
-        assert self.session_state.corge == "grault2"
-        assert self.session_state.is_new_state_value("corge")
-
-    def test_delattr(self):
-        del self.session_state.foo
-        assert "foo" not in self.session_state
-
-    def test_delitem_attr_errors(self):
-        for key in ["_new_session_state", "_new_widget_state", "_old_state"]:
-            with pytest.raises(AttributeError):
-                delattr(st.session_state, key)
-
-        with pytest.raises(AttributeError):
-            del self.session_state.nonexistent
-
     def test_widget_changed(self):
         assert self.session_state._widget_changed("foo")
         self.session_state._new_widget_state.set_from_value("foo", "bar")
@@ -625,8 +600,7 @@ class LazySessionStateTests(unittest.TestCase):
         assert self.lazy_session_state.to_dict() == {"foo": "bar"}
 
     # NOTE: We only test the error cases of {get, set, del}{item, attr} below
-    # since otherwise the methods simply defer to the eager SessionState class'
-    # implementation, which have their own unit tests.
+    # since the others are tested in another test class.
     def test_getitem_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
             self.lazy_session_state[self.reserved_key]
@@ -650,6 +624,50 @@ class LazySessionStateTests(unittest.TestCase):
     def test_delattr_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
             delattr(self.lazy_session_state, self.reserved_key)
+
+
+class LazySessionStateAttributeTests(unittest.TestCase):
+    """Tests of LazySessionState attribute methods.
+
+    Separate from the others to change patching. Test methods are individually
+    patched to avoid issues with mutability.
+    """
+
+    reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
+
+    def setUp(self):
+        self.lazy_session_state = LazySessionState()
+
+    @patch(
+        "streamlit.state.session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_delattr(self, _):
+        del self.lazy_session_state.foo
+        assert "foo" not in self.lazy_session_state
+
+    @patch(
+        "streamlit.state.session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_getattr(self, _):
+        assert self.lazy_session_state.foo == "bar"
+
+    @patch(
+        "streamlit.state.session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_getattr_error(self, _):
+        with pytest.raises(AttributeError):
+            del self.lazy_session_state.nonexistent
+
+    @patch(
+        "streamlit.state.session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_setattr(self, _):
+        self.lazy_session_state.corge = "grault2"
+        assert self.lazy_session_state.corge == "grault2"
 
 
 @given(state=stst.session_state())


### PR DESCRIPTION
So editor tooling will know what methods actually exist. Some error
message generation moved to the attr methods of the lazy wrapper.
