### PR TITLE
[Arrow] Better error message for `numpy.dtype` → `pyarrow.DataType` conversion exception

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -15,7 +15,6 @@
 """A bunch of useful utilities for dealing with types."""
 
 import re
-import sys
 from typing import Any, Optional, Sequence, Tuple, Union, cast
 
 from pandas import DataFrame, Series, Index

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -372,12 +372,13 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
         table = pa.Table.from_pandas(df)
         return pyarrow_table_to_bytes(table)
     except Exception as e:
-        NUMPY_DTYPE_ERROR_MESSAGE = "Could not convert dtype"
-        if NUMPY_DTYPE_ERROR_MESSAGE in str(e):
+        _NUMPY_DTYPE_ERROR_MESSAGE = "Could not convert dtype"
+        if _NUMPY_DTYPE_ERROR_MESSAGE in str(e):
             raise errors.StreamlitAPIException(
                 """
-Unable to convert `numpy.dtype` to `pyarrow.DataType`. This is likely due to a bug in Arrow.
-A possible workaround is to convert the DataFrame cells to strings with `df.astype(str)`.
+Unable to convert `numpy.dtype` to `pyarrow.DataType`.  
+This is likely due to a bug in Arrow (see https://issues.apache.org/jira/browse/ARROW-14087).  
+As a temporary workaround, you can convert the DataFrame cells to strings with `df.astype(str)`.
 """
             )
         else:

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -16,10 +16,12 @@ import unittest
 from collections import namedtuple
 from unittest.mock import patch
 
+import pandas as pd
 import plotly.graph_objs as go
 
 from streamlit import type_util
-from streamlit.type_util import is_bytes_like, to_bytes
+from streamlit.type_util import data_frame_to_bytes, is_bytes_like, to_bytes
+from streamlit.errors import StreamlitAPIException
 
 
 class TypeUtilTest(unittest.TestCase):
@@ -88,3 +90,10 @@ class TypeUtilTest(unittest.TestCase):
         self.assertFalse(is_bytes_like(string_obj))
         with self.assertRaises(RuntimeError):
             to_bytes(string_obj)
+
+    def test_data_frame_to_bytes_numpy_dtype_exception(self):
+        df1 = pd.DataFrame(["foo", "bar"])
+        df2 = pd.DataFrame(df1.dtypes)
+
+        with self.assertRaises(StreamlitAPIException):
+            data_frame_to_bytes(df2)


### PR DESCRIPTION
Closes #3709.

`df.dtypes` returns a `pandas.Series` of `numpy.dtype`s. There is a bug in Arrow which causes a conversion from `numpy.dtype` to `pyarrow.DataType` to fail. Thus, an error is thrown when trying to display `df.dtypes`.

The current workaround is to convert all cells to strings with `df.dtypes.astype(str)` until the issue is resolved.
This PR just makes the error message more readable.

Filed issue: https://issues.apache.org/jira/browse/ARROW-14087
PR Preview: https://share.streamlit.io/streamlit/core-previews/pr-3836.