### PR TITLE
Fix `SessionState.keys()` to handle new widget edgecase

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -384,19 +384,22 @@ class SessionState(MutableMapping[str, Any]):
             except KeyError:
                 pass
 
-        # Since session state entries used for writing widget values are
-        # converted to use widget ids when they are put into _old_state,
-        # it is not possible for a user key and a matching widget id to both
-        # appear in _old_state, so we can check them in any order.
-        if user_key:
-            try:
-                return self._old_state[user_key]
-            except KeyError:
-                pass
-
+        # Typically, there won't be both a widget id and an associated state key in
+        # old state at the same time, so the order we check is arbitrary.
+        # The exception is if session state is set and then a later run has
+        # a widget created, so the widget id entry should be newer.
+        # The opposite case shouldn't happen, because setting the value of a widget
+        # through session state will result in the next widget state reflecting that
+        # value.
         if widget_id:
             try:
                 return self._old_state[widget_id]
+            except KeyError:
+                pass
+
+        if user_key:
+            try:
+                return self._old_state[user_key]
             except KeyError:
                 pass
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -330,7 +330,7 @@ class SessionState(MutableMapping[str, Any]):
     def keys(self) -> Set[str]:
         """All keys active in Session State, with widget keys converted
         to widget ids when one is known."""
-        old_keys = set(self._old_state.keys())
+        old_keys = {self._get_widget_id(k) for k in self._old_state.keys()}
         new_widget_keys = set(self._new_widget_state.keys())
         new_session_state_keys = {
             self._get_widget_id(k) for k in self._new_session_state.keys()

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -370,15 +370,15 @@ class SessionState(MutableMapping[str, Any]):
         being accessed.
 
         At least one of the arguments must have a value."""
-        assert user_key or widget_id
+        assert user_key is not None or widget_id is not None
 
-        if user_key:
+        if user_key is not None:
             try:
                 return self._new_session_state[user_key]
             except KeyError:
                 pass
 
-        if widget_id:
+        if widget_id is not None:
             try:
                 return self._new_widget_state[widget_id]
             except KeyError:
@@ -391,13 +391,13 @@ class SessionState(MutableMapping[str, Any]):
         # The opposite case shouldn't happen, because setting the value of a widget
         # through session state will result in the next widget state reflecting that
         # value.
-        if widget_id:
+        if widget_id is not None:
             try:
                 return self._old_state[widget_id]
             except KeyError:
                 pass
 
-        if user_key:
+        if user_key is not None:
             try:
                 return self._old_state[user_key]
             except KeyError:

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -718,3 +718,33 @@ def test_key_wid_lookup_equiv(state):
     k_wid_map = state._key_id_mapping
     for k, wid in k_wid_map.items():
         assert state[k] == state[wid]
+
+
+def test_map_set_del_3837_regression():
+    """A regression test for `test_map_set_del` that involves too much setup
+    to conveniently use the hypothesis `example` decorator."""
+
+    meta1 = stst.mock_metadata(
+        "$$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None", 0
+    )
+    meta2 = stst.mock_metadata(
+        "$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", 0
+    )
+    m = SessionState()
+    m["0"] = 0
+    m.set_unkeyed_widget(
+        meta1, "$$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None"
+    )
+    m.compact_state()
+
+    m.set_keyed_widget(
+        meta2, "$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", "0"
+    )
+    key = "0"
+    value1 = 0
+
+    m[key] = value1
+    l1 = len(m)
+    del m[key]
+    assert key not in m
+    assert len(m) == l1 - 1


### PR DESCRIPTION
It didn't properly combine an old session state key with the widget id
of a new widget that uses that key.
