### PR TITLE
[Arrow] Custom exception for `numpy.dtype` conversion error

### DIFF
--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -77,6 +77,10 @@ class DuplicateWidgetID(StreamlitAPIException):
     pass
 
 
+class NumpyDtypeException(StreamlitAPIException):
+    pass
+
+
 class StreamlitAPIWarning(StreamlitAPIException, Warning):
     """Used to display a warning.
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -374,7 +374,7 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
     except Exception as e:
         _NUMPY_DTYPE_ERROR_MESSAGE = "Could not convert dtype"
         if _NUMPY_DTYPE_ERROR_MESSAGE in str(e):
-            raise errors.StreamlitAPIException(
+            raise errors.NumpyDtypeException(
                 """
 Unable to convert `numpy.dtype` to `pyarrow.DataType`.  
 This is likely due to a bug in Arrow (see https://issues.apache.org/jira/browse/ARROW-14087).  

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -21,7 +21,7 @@ import plotly.graph_objs as go
 
 from streamlit import type_util
 from streamlit.type_util import data_frame_to_bytes, is_bytes_like, to_bytes
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import NumpyDtypeException
 
 
 class TypeUtilTest(unittest.TestCase):
@@ -95,5 +95,5 @@ class TypeUtilTest(unittest.TestCase):
         df1 = pd.DataFrame(["foo", "bar"])
         df2 = pd.DataFrame(df1.dtypes)
 
-        with self.assertRaises(StreamlitAPIException):
+        with self.assertRaises(NumpyDtypeException):
             data_frame_to_bytes(df2)


### PR DESCRIPTION
Throw a custom exception instead of a generic `StreamlitAPIException` when there is a `numpy.dtype` conversion error for better user experience.