### PR TITLE
`xmldom` is no longer needed in resolutions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -192,7 +192,6 @@
     "trim-newlines": "^3.0.1",
     "websocket-extensions": "^0.1.4",
     "ws": "^7.4.6",
-    "xmldom": "^0.5.0",
     "y18n": "^4.0.1"
   },
   "browserslist": [


### PR DESCRIPTION
Looks like our dependencies are not using `xmldom` anymore. Thus, that resolution is currently useless.