### PR TITLE
[Security] Upgrade `immer` to 9.0.6 or later

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -179,6 +179,7 @@
     "esm": "^3.1.0",
     "handlebars": "^4.4.5",
     "https-proxy-agent": "^2.2.4",
+    "immer": "^9.0.6",
     "ini": "^1.3.6",
     "is-svg": "^4.2.2",
     "jquery": "^3.5.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10262,12 +10262,7 @@ image-size@^0.7.5:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.7.5.tgz#269f357cf5797cb44683dfa99790e54c705ead04"
   integrity sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==
 
-immer@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
-
-immer@^9.0.6:
+immer@8.0.1, immer@^9.0.6:
   version "9.0.6"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
   integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==


### PR DESCRIPTION
Details: [GHSA-33f9-j839-rf8h](https://github.com/advisories/GHSA-33f9-j839-rf8h), [GHSA-c36v-fmgq-m8hx](https://github.com/advisories/GHSA-c36v-fmgq-m8hx)