### PR TITLE
Increase default timeout in Cypress so that all elements are rendered

### DIFF
--- a/e2e/specs/st_legacy_add_rows.spec.js
+++ b/e2e/specs/st_legacy_add_rows.spec.js
@@ -18,6 +18,10 @@
 describe("st._legacy_add_rows", () => {
   // Doesn't have to run before each, since these tests are stateless.
   before(() => {
+    // Increasing timeout since we're waiting for
+    // dataframes, tables, and charts to be rendered.
+    Cypress.config("defaultCommandTimeout", 30000);
+
     cy.visit("http://localhost:3000/");
 
     // Rerun the script because we want to test that JS-side coalescing works.

--- a/e2e_flaky/specs/st_legacy_add_rows.spec.ts
+++ b/e2e_flaky/specs/st_legacy_add_rows.spec.ts
@@ -20,6 +20,10 @@
 describe("st._legacy_add_rows", () => {
   // Doesn't have to run before each, since these tests are stateless.
   before(() => {
+    // Increasing timeout since we're waiting for
+    // dataframes, tables, and charts to be rendered.
+    Cypress.config("defaultCommandTimeout", 30000);
+
     cy.visit("http://localhost:3000/");
 
     // Rerun the script because we want to test that JS-side coalescing works.


### PR DESCRIPTION
Fixes the recent [issue](https://app.circleci.com/pipelines/github/streamlit/streamlit/9751/workflows/7d8874ba-5ac7-44cc-8f42-b1d35528d99e/jobs/31210) we were having with E2E tests.

> "before each" hook for "works for all elements that support it" - st._legacy_add_rows
>
> AssertionError: Timed out retrying after 4000ms: Not enough elements found. Found '8', expected '26' ...