### PR TITLE
Fixes identation issue in `st.set_page_config` docstring

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -63,15 +63,16 @@ def set_page_config(
     menu_items: dict
         Configure the menu that appears on the top-right side of this app.
         The keys in this dict denote the menu item you'd like to configure:
-            - "Get help": str or None
-                The URL this menu item should point to.
-                If None, hides this menu item.
-            - "Report a Bug": str or None
-                The URL this menu item should point to.
-                If None, hides this menu item.
-            - "About": str or None
-                A markdown string to show in the About dialog.
-                If None, only shows Streamlit's default About text.
+
+        - "Get help": str or None
+            The URL this menu item should point to.
+            If None, hides this menu item.
+        - "Report a Bug": str or None
+            The URL this menu item should point to.
+            If None, hides this menu item.
+        - "About": str or None
+            A markdown string to show in the About dialog.
+            If None, only shows Streamlit's default About text.
 
 
     Example


### PR DESCRIPTION
Fixes incorrect indentation for bullet points in the `st.set_page_config` docstring. The incorrect indentation leads to a warning in Sphinx and breaks docstring generation for this function in the new docs repo.