### PR TITLE
Release resources on signal disconnect

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1227,8 +1227,15 @@ def on_config_parsed(
         A function that the caller can use to deregister func.
     """
 
+    # We need to use the same receiver when we connect or disconnect on the
+    # Signal. If we don't do this, then the registered receiver won't be released
+    # leading to a memory leak because the Signal will keep a reference of the
+    # callable argument. When the callable argument is an object method, then
+    # the reference to that object won't be released.
+    receiver = lambda _: func_with_lock()
+
     def disconnect():
-        return _on_config_parsed.disconnect(func_with_lock)
+        return _on_config_parsed.disconnect(receiver)
 
     def func_with_lock():
         if lock:
@@ -1240,7 +1247,7 @@ def on_config_parsed(
     if force_connect or not _config_options:
         # weak=False so that we have control of when the on_config_parsed
         # callback is deregistered.
-        _on_config_parsed.connect(lambda _: func_with_lock(), weak=False)
+        _on_config_parsed.connect(receiver, weak=False)
     else:
         func_with_lock()
 


### PR DESCRIPTION
**Issue:** https://github.com/streamlit/streamlit/issues/3880

**Description:** In order to watch a for file changes and to react to them we register a function which is updating the report session. The registered function was different from the deregistered one and therefore the reference of the object providing the function was never release. This leads to a memory leak.

The leak was identified by measuring the memory consumption of a streamlit application that was accessed multiple times (in this case 10K accesses  which resulted in 10K sessions). After this fix, the memory consumption stayed constant even after 10K accesses.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
