### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
   python-min-version:
     <<: *job-template
     docker:
-      - image: circleci/python:3.6.5
+      - image: circleci/python:3.7.9
 
   create-tag:
     docker:


### PR DESCRIPTION
python-min-version is now 3.7