### PR TITLE
Remove trailing slash from in-memory file access endpoint

### DIFF
--- a/e2e/scripts/st_download_button.py
+++ b/e2e/scripts/st_download_button.py
@@ -19,3 +19,10 @@ st.download_button(
     data="Hello world!",
     file_name="hello.txt",
 )
+
+st.download_button(
+    "Download RAR archive file",
+    data=b"bytes",
+    file_name="archive.rar",
+    mime="application/vnd.rar",
+)

--- a/e2e/specs/st_download_button.spec.js
+++ b/e2e/specs/st_download_button.spec.js
@@ -25,16 +25,28 @@ describe("st.download_button", () => {
   });
 
   it("shows widget correctly", () => {
-    cy.get(".stDownloadButton").should("have.length", 1);
-    cy.get(".stDownloadButton").matchThemedSnapshots("download-button-widget");
+    cy.get(".stDownloadButton").should("have.length", 2);
+    cy.get(".stDownloadButton")
+      .first()
+      .matchThemedSnapshots("download-button-widget");
   });
 
-  it("downloads file when the button is clicked", () => {
-    cy.get(".stDownloadButton button").click();
+  it("downloads txt file when the button is clicked", () => {
+    cy.get(".stDownloadButton button")
+      .first()
+      .click();
     const downloadsFolder = Cypress.config("downloadsFolder");
     cy.readFile(path.join(downloadsFolder, "hello.txt")).should(
       "eq",
       "Hello world!"
     );
+  });
+
+  it("downloads RAR archive file when the button is clicked", () => {
+    cy.get(".stDownloadButton button")
+      .last()
+      .click();
+    const downloadsFolder = Cypress.config("downloadsFolder");
+    cy.readFile(path.join(downloadsFolder, "archive.rar")).should("exist");
   });
 });

--- a/frontend/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -41,7 +41,7 @@ function DownloadButton(props: Props): ReactElement {
     // for the user.
     widgetMgr.setTriggerValue(element, { fromUi: true })
     const link = document.createElement("a")
-    const uri = `${buildMediaUri(element.url)}/?title=${encodeURIComponent(
+    const uri = `${buildMediaUri(element.url)}?title=${encodeURIComponent(
       document.title
     )}`
     link.setAttribute("href", uri)


### PR DESCRIPTION
**Description:** The issue was found on the forum https://discuss.streamlit.io/t/download-zip-file/14753/6 

After the investigation, it turned out that the download button does not work if `mime` parameter is specified and it is impossible to guess the file extension based on it. In particular, an error occurred when specifying MIME to `application / vnd.rar` (for RAR archives)

The reason was the trailing slash, which was perceived as part of the file name, which led to an error.

I removed a slash in DownloadButton frontend code and added an e2e test for verification.
