### PR TITLE
Rerun script on `secrets.toml` file change

### DIFF
--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -257,7 +257,13 @@ class ReportSession(object):
             self._enqueue_file_change_message()
 
     def _on_secrets_file_changed(self, _):
-        """Is called when secrets._file_change_listener emits a Signal."""
+        """Called when `secrets._file_change_listener` emits a Signal."""
+
+        # NOTE: At the time of writing, this function only calls `_on_source_file_changed`.
+        # The reason behind creating this function instead of just passing `_on_source_file_changed`
+        # to `connect` / `disconnect` directly is that every function that is passed to `connect` / `disconnect`
+        # must have at least one argument for `sender` (in this case we don't really care about it, thus `_`),
+        # and introducing an unnecessary argument to `_on_source_file_changed` just for this purpose sounded finicky.
         self._on_source_file_changed()
 
     def _clear_queue(self):

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -104,7 +104,7 @@ class ReportSession(object):
         self._client_state = ClientState()
 
         # The script should rerun when the `secrets.toml` file has been changed.
-        secrets._file_change_listener.connect(self.request_rerun)
+        secrets._file_change_listener.connect(self._on_secrets_file_changed)
 
         self._local_sources_watcher = LocalSourcesWatcher(
             self._report, self._on_source_file_changed
@@ -167,7 +167,7 @@ class ReportSession(object):
             self._state = ReportSessionState.SHUTDOWN_REQUESTED
             self._local_sources_watcher.close()
             self._stop_config_listener()
-            secrets._file_change_listener.disconnect(self.request_rerun)
+            secrets._file_change_listener.disconnect(self._on_secrets_file_changed)
 
     def enqueue(self, msg):
         """Enqueue a new ForwardMsg to our browser queue.
@@ -255,6 +255,10 @@ class ReportSession(object):
             self.request_rerun(self._client_state)
         else:
             self._enqueue_file_change_message()
+
+    def _on_secrets_file_changed(self, _):
+        """Is called when secrets._file_change_listener emits a Signal."""
+        self._on_source_file_changed()
 
     def _clear_queue(self):
         self._report.clear()


### PR DESCRIPTION
Until now users had to manually rerun their scripts to see the changes made in `secrets.toml`. Not anymore!