### PR TITLE
Annotate `st.stop` as a `NoReturn` function

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -53,6 +53,7 @@ _LOGGER = _logger.get_logger("root")
 # Give the package a version.
 import pkg_resources as _pkg_resources
 from typing import List
+from typing import NoReturn
 
 # This used to be pkg_resources.require('streamlit') but it would cause
 # pex files to fail. See #394 for more details.
@@ -525,7 +526,7 @@ def _maybe_print_use_warning():
             )
 
 
-def stop():
+def stop() -> NoReturn:
     """Stops execution immediately.
 
     Streamlit will not run any statements after `st.stop()`.


### PR DESCRIPTION
**Issue:** #3908

**Description:** This annotation signals to type checkers that this function will never return a value, and will always raise an exception.

---

**Contribution License Agreement**

By submitting this pull request I agree that all contributions to this project are made under the Apache 2.0 license.
