### PR TITLE
Make calling st.experimental_rerun() within a callback a no-op

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -455,11 +455,18 @@ class SessionState(MutableMapping[str, Any]):
             self._new_widget_state.set_widget_from_proto(state)
 
     def call_callbacks(self):
+        from streamlit.script_runner import RerunException
+
         changed_widget_ids = [
             wid for wid in self._new_widget_state if self._widget_changed(wid)
         ]
         for wid in changed_widget_ids:
-            self._new_widget_state.call_callback(wid)
+            try:
+                self._new_widget_state.call_callback(wid)
+            except RerunException:
+                st.warning(
+                    "Calling st.experimental_rerun() within a callback is a no-op."
+                )
 
     def _widget_changed(self, widget_id: str) -> bool:
         new_value = self._new_widget_state.get(widget_id)

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -251,6 +251,21 @@ class SessionStateTest(testutil.DeltaGeneratorTestCase):
         ctx = get_report_ctx()
         assert ctx.session_state["color"] is not color
 
+    @patch("streamlit.warning")
+    def test_callbacks_with_experimental_rerun(self, patched_warning):
+        def on_change():
+            st.experimental_rerun()
+
+        st.checkbox("the checkbox", on_change=on_change)
+
+        session_state = get_session_state()
+        widget_ids = list(session_state._new_widget_state.keys())
+        wid = widget_ids[0]
+        session_state._new_widget_state.set_from_value(wid, True)
+
+        session_state.call_callbacks()
+        patched_warning.assert_called_once()
+
 
 def check_roundtrip(widget_id: str, value: Any) -> None:
     session_state = get_session_state()


### PR DESCRIPTION
Since callbacks are hoisted to run before the actual script run, there's
generally no need to use the st.experimental_rerun() function within a
callback.

Currently, attempting to do so breaks the streamlit app. This PR fixes this so
that calling `st.experimental_rerun()` in a callback is a no-op, and a
warning gets printed to the user's streamlit app to warn the user of
this.

Closes #3854