### PR TITLE
"Clear cache" clears memo + singleton

### DIFF
--- a/lib/streamlit/caching/__init__.py
+++ b/lib/streamlit/caching/__init__.py
@@ -14,8 +14,8 @@
 import contextlib
 from typing import Iterator
 
-from .memo_decorator import MEMO_CALL_STACK
-from .singleton_decorator import SINGLETON_CALL_STACK
+from .memo_decorator import MEMO_CALL_STACK, MemoCache
+from .singleton_decorator import SINGLETON_CALL_STACK, SingletonCache
 
 
 def maybe_show_cached_st_function_warning(dg, st_func_name: str) -> None:
@@ -27,6 +27,14 @@ def maybe_show_cached_st_function_warning(dg, st_func_name: str) -> None:
 def suppress_cached_st_function_warning() -> Iterator[None]:
     with MEMO_CALL_STACK.suppress_cached_st_function_warning(), SINGLETON_CALL_STACK.suppress_cached_st_function_warning():
         yield
+
+
+def clear_singleton_cache() -> None:
+    SingletonCache.clear_all()
+
+
+def clear_memo_cache() -> None:
+    MemoCache.clear_all()
 
 
 # Explicitly export `memo` and `singleton`

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -229,8 +229,9 @@ def cache():
 
 @cache.command("clear")
 def cache_clear():
-    """Clear the Streamlit on-disk cache."""
+    """Clear st.cache, st.memo, and st.singleton caches."""
     import streamlit.legacy_caching
+    import streamlit.caching
 
     result = streamlit.legacy_caching.clear_cache()
     cache_path = streamlit.legacy_caching.get_cache_path()
@@ -238,6 +239,9 @@ def cache_clear():
         print("Cleared directory %s." % cache_path)
     else:
         print("Nothing to clear at %s." % cache_path)
+
+    streamlit.caching.clear_memo_cache()
+    streamlit.caching.clear_singleton_cache()
 
 
 # SUBCOMMAND: config

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -22,7 +22,7 @@ import tornado.ioloop
 
 import streamlit.elements.exception as exception_utils
 import streamlit.server.server_util as server_util
-from streamlit import __version__, config, legacy_caching, secrets, url_util
+from streamlit import __version__, config, legacy_caching, secrets, url_util, caching
 from streamlit.case_converters import to_snake_case
 from streamlit.credentials import Credentials
 from streamlit.in_memory_file_manager import in_memory_file_manager
@@ -509,12 +509,9 @@ class ReportSession(object):
         Because this cache is global, it will be cleared for all users.
 
         """
-        # Setting verbose=True causes clear_cache to print to stdout.
-        # Since this command was initiated from the browser, the user
-        # doesn't need to see the results of the command in their
-        # terminal.
         legacy_caching.clear_cache()
-
+        caching.clear_memo_cache()
+        caching.clear_singleton_cache()
         self._session_state.clear_state()
 
     def handle_set_run_on_save_request(self, new_value):

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -267,7 +267,10 @@ class CommonCacheTest(unittest.TestCase):
             ("singleton", singleton, clear_singleton_cache),
         ]
     )
-    def test_clear_cache(self, _, cache_decorator, clear_cache_func):
+    def test_clear_all_caches(self, _, cache_decorator, clear_cache_func):
+        """Calling a cache's global `clear_all` function should remove all
+        items from all caches of the appropriate type.
+        """
         foo_vals = []
 
         @cache_decorator

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -22,7 +22,12 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit import report_thread
-from streamlit.caching import MEMO_CALL_STACK, SINGLETON_CALL_STACK
+from streamlit.caching import (
+    MEMO_CALL_STACK,
+    SINGLETON_CALL_STACK,
+    clear_memo_cache,
+    clear_singleton_cache,
+)
 
 memo = st.experimental_memo
 singleton = st.experimental_singleton
@@ -255,3 +260,38 @@ class CommonCacheTest(unittest.TestCase):
 
         # The other thread should not have modified the main thread
         self.assertEqual(1, get_counter())
+
+    @parameterized.expand(
+        [
+            ("memo", memo, clear_memo_cache),
+            ("singleton", singleton, clear_singleton_cache),
+        ]
+    )
+    def test_clear_cache(self, _, cache_decorator, clear_cache_func):
+        foo_vals = []
+
+        @cache_decorator
+        def foo(x):
+            foo_vals.append(x)
+            return x
+
+        bar_vals = []
+
+        @cache_decorator
+        def bar(x):
+            bar_vals.append(x)
+            return x
+
+        foo(0), foo(1), foo(2)
+        bar(0), bar(1), bar(2)
+        self.assertEqual([0, 1, 2], foo_vals)
+        self.assertEqual([0, 1, 2], bar_vals)
+
+        # Clear the cache and access our original values again. They
+        # should be recomputed.
+        clear_cache_func()
+
+        foo(0), foo(1), foo(2)
+        bar(0), bar(1), bar(2)
+        self.assertEqual([0, 1, 2, 0, 1, 2], foo_vals)
+        self.assertEqual([0, 1, 2, 0, 1, 2], bar_vals)

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -347,6 +347,18 @@ class CliTest(unittest.TestCase):
         self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
         self.assertEqual(0, result.exit_code)
 
+    @patch("streamlit.legacy_caching.clear_cache")
+    @patch("streamlit.caching.clear_memo_cache")
+    @patch("streamlit.caching.clear_singleton_cache")
+    def test_cache_clear_all_caches(
+        self, clear_singleton_cache, clear_memo_cache, clear_legacy_cache
+    ):
+        """cli.clear_cache should clear st.cache, st.memo and st.singleton"""
+        self.runner.invoke(cli, ["cache", "clear"])
+        clear_singleton_cache.assert_called_once()
+        clear_memo_cache.assert_called_once()
+        clear_legacy_cache.assert_called_once()
+
     @patch("builtins.print")
     def test_cache_clear_command_with_cache(self, mock_print):
         """Tests clear cache announces that cache is cleared when completed"""

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -144,13 +144,24 @@ class ReportSessionTest(unittest.TestCase):
         rs = ReportSession(None, "", "", UploadedFileManager(), None)
         self.assertTrue(isinstance(rs.session_state, SessionState))
 
-    @patch("streamlit.report_session.legacy_caching.clear_cache")
     @patch("streamlit.report_session.LocalSourcesWatcher")
-    def test_clear_cache_resets_session_state(self, _1, _2):
+    def test_clear_cache_resets_session_state(self, _1):
         rs = ReportSession(None, "", "", UploadedFileManager(), None)
         rs._session_state["foo"] = "bar"
         rs.handle_clear_cache_request()
         self.assertTrue("foo" not in rs._session_state)
+
+    @patch("streamlit.legacy_caching.clear_cache")
+    @patch("streamlit.caching.clear_memo_cache")
+    @patch("streamlit.caching.clear_singleton_cache")
+    def test_clear_cache_all_caches(
+        self, clear_singleton_cache, clear_memo_cache, clear_legacy_cache
+    ):
+        rs = ReportSession(MagicMock(), "", "", UploadedFileManager(), None)
+        rs.handle_clear_cache_request()
+        clear_singleton_cache.assert_called_once()
+        clear_memo_cache.assert_called_once()
+        clear_legacy_cache.assert_called_once()
 
     @patch("streamlit.report_session.secrets._file_change_listener.connect")
     @patch("streamlit.report_session.LocalSourcesWatcher")


### PR DESCRIPTION
Clear Cache - when invoked from the CLI or from the hamburger menu - clears st.memo and st.singleton results.

Fixes #3922