### PR TITLE
Make get_module_paths always return absolute paths

### DIFF
--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -183,7 +183,9 @@ def get_module_paths(module: types.ModuleType) -> t.Set[str]:
         except Exception as e:
             LOGGER.warning(f"Examining the path of {module.__name__} raised: {e}")
 
-        all_paths.update([str(p) for p in potential_paths if _is_valid_path(p)])
+        all_paths.update(
+            [os.path.abspath(str(p)) for p in potential_paths if _is_valid_path(p)]
+        )
     return all_paths
 
 

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -14,7 +14,7 @@
 
 """streamlit.LocalSourcesWatcher unit test."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import os
 import sys
 import unittest
@@ -280,6 +280,14 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             self.assertNotIn("pkg", sys.modules)
 
         del sys.modules["tests.streamlit.watcher.test_data.namespace_package"]
+
+
+def test_get_module_paths_outputs_abs_paths():
+    mock_module = MagicMock()
+    mock_module.__file__ = os.path.relpath(DUMMY_MODULE_1_FILE)
+
+    module_paths = local_sources_watcher.get_module_paths(mock_module)
+    assert module_paths == {DUMMY_MODULE_1_FILE}
 
 
 def sort_args_list(args_list):


### PR DESCRIPTION
It turns out that #3732 is caused by the path extractor functions in
get_module_paths sometimes returning relative paths, which confuses
file_util.file_is_in_folder_glob a bit later when we're deciding whether
or not to watch a file. The fix here is to just always convert to
absolute paths. Note that this is a no-op if the path is already an
absolute path, which seems to be the case most of the time.

Closes #3732
