### PR TITLE
Stop collecting telemetry by default

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -676,9 +676,9 @@ def _browser_server_address() -> str:
 def _gather_usage_stats() -> bool:
     """Whether to send usage statistics to Streamlit.
 
-    Default: true
+    Default: false
     """
-    return True
+    return False
 
 
 @_create_option("browser.serverPort", type_=int)

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -70,11 +70,11 @@ _TELEMETRY_TEXT = """
   not store information contained in Streamlit apps. You can find out more by
   reading our privacy policy at: %(link)s
 
-  If you'd like to opt out of usage statistics, add the following to
+  If you'd like to allow us to collect usage statistics, add the following to
   %(config)s, creating that file if necessary:
 
     [browser]
-    gatherUsageStats = false
+    gatherUsageStats = true
 """ % {
     "privacy": click.style("Privacy Policy:", bold=True),
     "link": click.style("https://streamlit.io/privacy-policy", underline=True),


### PR DESCRIPTION
It's quite clear from https://github.com/cbeuw/streamlit/blob/b9958205ae2c3a75f6e7b14820c51a5624a2f372/frontend/src/lib/MetricsManager.ts that when `gatherUsageStats` is set to `true` (which is the default), streamlit sends off a plethora of data both about the server running streamlit and the visitor.

Your [privacy policy](https://streamlit.io/privacy-policy), particularly section 2.6 Automatic data collection, states that you do collect personal information.

Opt-in by default does NOT constitute valid consent under GDPR if you want to use this as a basis for your data processing activities. At the very least it is not an _unambiguous indication of the data subject's wishes by which he or she, by a statement or by a clear affirmative action, signifies agreement to the processing of personal data relating to him or her_ (https://edpb.europa.eu/sites/default/files/files/file1/edpb_guidelines_202005_consent_en.pdf). Although some information on data collection gets displayed on the first run, there is no affirmative user interaction that lets them enable `gatherUsageStats` flag.

So unless you have another legal basis to collect these personal information, the manner which telemetry is collected by streamlit is almost certainly not GDPR/DPA compliant