### PR TITLE
Allow user to resize st.text_area

### DIFF
--- a/frontend/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.tsx
@@ -206,7 +206,7 @@ class TextArea extends React.PureComponent<Props, State> {
               style: {
                 height: height ? `${height}px` : "",
                 minHeight: "95px",
-                resize: height ? "vertical" : "none",
+                resize: "vertical",
               },
             },
           }}


### PR DESCRIPTION
## 📚 Context 

We want to add the consistent ability for the user to resize the `st.text_area` field. Current functionality only allows the user to resize `st.text_area` if the developer specified a height parameter.

## 🧠 Description of Changes

* Updated Baseweb override styling for resizing

**Revised:**
<img width="500" alt="Screen Shot 2021-10-22 at 12 15 31 PM" src="https://user-images.githubusercontent.com/63436329/138512964-5016f344-943f-4073-bb78-e9e21d0f728c.png">

**Current:**
<img width="500" alt="Screen Shot 2021-10-22 at 12 16 16 PM" src="https://user-images.githubusercontent.com/63436329/138512826-dc5a03d5-07be-491a-b090-256c73cd9288.png">

## 🧪 Testing Done

- [x] Screenshot included
- [ ] Added Unit tests
- [ ] Added e2e tests
