### PR TITLE
Propagate widget state when calling st.experimental_rerun

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -556,7 +556,7 @@ def experimental_rerun():
     If this function is called outside of Streamlit, it will raise an
     Exception.
     """
-
-    ctx = _get_report_ctx()
-    query_string = None if ctx is None else ctx.query_string
-    raise _RerunException(_RerunData(query_string=query_string))
+    # We set the argument of _RerunException to None so that the script_runner
+    # determines the rerun_data to use for the next script run from the script's
+    # current state.
+    raise _RerunException(None)

--- a/lib/tests/streamlit/scriptrunner/test_data/rerun_script.py
+++ b/lib/tests/streamlit/scriptrunner/test_data/rerun_script.py
@@ -1,0 +1,33 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A script for ScriptRunnerTest that uses st.experimental_rerun"""
+
+import streamlit as st
+
+state = st.session_state
+
+if "run_count" not in state:
+    state.run_count = 1
+else:
+    state.run_count += 1
+
+st.text(f"run count: {state.run_count}")
+
+if st.button("rerun me!"):
+    st.experimental_rerun()
+
+
+t = st.checkbox("toggle me!")
+st.text(f"you picked: {t}")


### PR DESCRIPTION
Widget state isn't properly plumbed to the next script run when
`st.experimental_rerun` is called. This PR fixes this issue by having
`st.experimental_rerun` throw a `RerunException` with a `None` arg. 
Upon seeing this, the `ScriptRunner` then uses the current script state
to populate the `rerun_data` for the next script run.

Note that fixing this seems to have uncovered a weird Heisenbug where
widget state is dropped entirely if rapid script runs are batched together
in some way. We'll want to figure out exactly what's going on here before
this can be merged.

Closes #3533