### PR TITLE
Fix breaking Python 3.7 build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
   python-min-version:
     <<: *job-template
     docker:
-      - image: circleci/python:3.7.9
+      - image: circleci/python:3.7.12
 
   create-tag:
     docker:


### PR DESCRIPTION
I'm not *exactly* sure why using the `circleci/python:3.7.9` docker base
image is causing trouble with what appears to be a missing system
dependency when running unit tests, but this appears to be a non-issue
with the `circleci/python:3.7.12` image. We might as well upgrade the
image to revive the build even without knowing precisely what's going on
😬.