### PR TITLE
Ensure that session_state.filtered_state can handle missing metadata

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -308,13 +308,18 @@ class SessionState(MutableMapping[str, Any]):
         wid_key_map = self.reverse_key_wid_map
 
         state: Dict[str, Any] = {}
-        for k, v in self.items():
+
+        # We can't write `for k, v in self.items()` here because doing so will
+        # run into a `KeyError` if widget metadata has been cleared (which
+        # happens when the streamlit server restarted or the cache was cleared),
+        # then we receive a widget's state from a browser.
+        for k in self.keys():
             if not is_widget_id(k) and not is_internal_key(k):
-                state[k] = v
+                state[k] = self[k]
             elif is_keyed_widget_id(k):
                 try:
                     key = wid_key_map[k]
-                    state[key] = v
+                    state[key] = self[k]
                 except KeyError:
                     # Widget id no longer maps to a key, it is a not yet
                     # cleared value in old state for a reset widget

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -497,6 +497,21 @@ class SessionStateMethodTests(unittest.TestCase):
             "corge": "grault",
         }
 
+    def test_filtered_state_resilient_to_missing_metadata(self):
+        old_state = {"foo": "bar", "corge": "grault"}
+        new_session_state = {}
+        new_widget_state = WStates(
+            {f"{GENERATED_WIDGET_KEY_PREFIX}-baz": Serialized(None)},
+        )
+        self.session_state = SessionState(
+            old_state, new_session_state, new_widget_state
+        )
+
+        assert self.session_state.filtered_state == {
+            "foo": "bar",
+            "corge": "grault",
+        }
+
     def is_new_state_value(self):
         assert self.session_state.is_new_state_value("foo")
         assert not self.session_state.is_new_state_value("corge")


### PR DESCRIPTION
It turns out that using self.items() in the filtered_state method
sometimes breaks in the case that both

1. widget metadata is cleared (because the streamlit server was
   restarted or the cache+session_state was cleared)
2. we receive the current state of a widget with no metadata from
   the frontend.

In this scenario, the code that we have in the for loop to guard against
this case doesn't help us because the KeyError is thrown in the call to
self.items()

Closes #3843