### PR TITLE
Fix intermittent mypy issues in print_command_line test

### DIFF
--- a/scripts/test_data/print_command_line.py
+++ b/scripts/test_data/print_command_line.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import streamlit as st
+from streamlit.server.server import Server
 
-server = st.server.server.Server.get_current()  # type: ignore
-print(
-    f'{{"server._command_line": "{server._command_line}"}}'  # pylint: disable = protected-access
-)
+server = Server.get_current()
+print(f'{{"server._command_line": "{server._command_line}"}}')
 
 server.stop()


### PR DESCRIPTION
Sometimes, mypy claims this file's `# type: ignore` comment is unnecessary, and fails. Other times, mypy remains silent on the issue, and succeeds. Mysterious! And annoying.

Also remove a pylint comment (we don't use pylint)