### PR TITLE
Remove old 'Machine ID' metrics

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -91,8 +91,6 @@ describe("App", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
-      installationIdV1: "iid1",
-      installationIdV2: "iid2",
       installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,
@@ -270,8 +268,6 @@ describe("App.handleNewReport", () => {
     initialize: {
       userInfo: {
         installationId: "installationId",
-        installationIdV1: "installationIdV1",
-        installationIdV2: "installationIdV2",
         installationIdV3: "installationIdV3",
         email: "email",
       },

--- a/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
+++ b/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
@@ -29,8 +29,6 @@ function setSessionInfo(
     streamlitVersion: "sv",
     pythonVersion: "pv",
     installationId: "iid",
-    installationIdV1: "iid1",
-    installationIdV2: "iid2",
     installationIdV3: "iid3",
     authorEmail: "ae",
     maxCachedMessageAge: 2,

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
@@ -49,8 +49,6 @@ describe("withMapboxToken", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
-      installationIdV1: "iid1",
-      installationIdV2: "iid2",
       installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -43,8 +43,6 @@ describe("FileUploadClient Upload", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
-      installationIdV1: "iid1",
-      installationIdV2: "iid2",
       installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,

--- a/frontend/src/lib/HttpClient.test.ts
+++ b/frontend/src/lib/HttpClient.test.ts
@@ -35,8 +35,6 @@ describe("HttpClient", () => {
       streamlitVersion: "sv",
       pythonVersion: "pv",
       installationId: "iid",
-      installationIdV1: "iid1",
-      installationIdV2: "iid2",
       installationIdV3: "iid3",
       authorEmail: "ae",
       maxCachedMessageAge: 2,

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -30,8 +30,6 @@ const createSessionInfo = (): SessionInfo =>
     streamlitVersion: "sv",
     pythonVersion: "pv",
     installationId: "iid",
-    installationIdV1: "iid1",
-    installationIdV2: "iid2",
     installationIdV3: "iid3",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
@@ -163,13 +161,9 @@ test("tracks installation data", () => {
   mm.enqueue("ev1", { data1: 11 })
 
   expect(mm.identify.mock.calls[0][1]).toMatchObject({
-    machineIdV1: SessionInfo.current.installationIdV1,
-    machineIdV2: SessionInfo.current.installationIdV2,
     machineIdV3: SessionInfo.current.installationIdV3,
   })
   expect(mm.track.mock.calls[0][1]).toMatchObject({
-    machineIdV1: SessionInfo.current.installationIdV1,
-    machineIdV2: SessionInfo.current.installationIdV2,
     machineIdV3: SessionInfo.current.installationIdV3,
   })
 })

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -225,8 +225,6 @@ export class MetricsManager {
   // Get the installation IDs from the session
   private static getInstallationData(): Record<string, unknown> {
     return {
-      machineIdV1: SessionInfo.current.installationIdV1,
-      machineIdV2: SessionInfo.current.installationIdV2,
       machineIdV3: SessionInfo.current.installationIdV3,
     }
   }

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -28,8 +28,6 @@ test("Clears session info", () => {
     streamlitVersion: "sv",
     pythonVersion: "pv",
     installationId: "iid",
-    installationIdV1: "iid1",
-    installationIdV2: "iid2",
     installationIdV3: "iid3",
     authorEmail: "ae",
     maxCachedMessageAge: 2,
@@ -54,8 +52,6 @@ test("Can be initialized from a protobuf", () => {
     initialize: {
       userInfo: {
         installationId: "installationId",
-        installationIdV1: "installationIdV1",
-        installationIdV2: "installationIdV2",
         installationIdV3: "installationIdV3",
         email: "email",
       },
@@ -77,8 +73,6 @@ test("Can be initialized from a protobuf", () => {
   expect(si.streamlitVersion).toEqual("streamlitVersion")
   expect(si.pythonVersion).toEqual("pythonVersion")
   expect(si.installationId).toEqual("installationId")
-  expect(si.installationIdV1).toEqual("installationIdV1")
-  expect(si.installationIdV2).toEqual("installationIdV2")
   expect(si.installationIdV3).toEqual("installationIdV3")
   expect(si.authorEmail).toEqual("email")
   expect(si.maxCachedMessageAge).toEqual(31)

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -28,8 +28,6 @@ export interface Args {
   streamlitVersion: string
   pythonVersion: string
   installationId: string
-  installationIdV1: string
-  installationIdV2: string
   installationIdV3: string
   authorEmail: string
   maxCachedMessageAge: number
@@ -46,10 +44,6 @@ export class SessionInfo {
   public readonly pythonVersion: string
 
   public readonly installationId: string
-
-  public readonly installationIdV1: string
-
-  public readonly installationIdV2: string
 
   public readonly installationIdV3: string
 
@@ -111,8 +105,6 @@ export class SessionInfo {
       streamlitVersion: environmentInfo.streamlitVersion,
       pythonVersion: environmentInfo.pythonVersion,
       installationId: userInfo.installationId,
-      installationIdV1: userInfo.installationIdV1,
-      installationIdV2: userInfo.installationIdV2,
       installationIdV3: userInfo.installationIdV3,
       authorEmail: userInfo.email,
       maxCachedMessageAge: config.maxCachedMessageAge,
@@ -126,8 +118,6 @@ export class SessionInfo {
     streamlitVersion,
     pythonVersion,
     installationId,
-    installationIdV1,
-    installationIdV2,
     installationIdV3,
     authorEmail,
     maxCachedMessageAge,
@@ -139,8 +129,6 @@ export class SessionInfo {
       streamlitVersion == null ||
       pythonVersion == null ||
       installationId == null ||
-      installationIdV1 == null ||
-      installationIdV2 == null ||
       installationIdV3 == null ||
       authorEmail == null ||
       maxCachedMessageAge == null ||
@@ -154,8 +142,6 @@ export class SessionInfo {
     this.streamlitVersion = streamlitVersion
     this.pythonVersion = pythonVersion
     this.installationId = installationId
-    this.installationIdV1 = installationIdV1
-    this.installationIdV2 = installationIdV2
     this.installationIdV3 = installationIdV3
     this.authorEmail = authorEmail
     this.maxCachedMessageAge = maxCachedMessageAge

--- a/lib/streamlit/metrics_util.py
+++ b/lib/streamlit/metrics_util.py
@@ -13,51 +13,15 @@
 # limitations under the License.
 
 import os
-import platform
-import subprocess
 import threading
 import uuid
 
 from typing import Optional
 
-from streamlit import file_util
 from streamlit import util
 
 _ETC_MACHINE_ID_PATH = "/etc/machine-id"
 _DBUS_MACHINE_ID_PATH = "/var/lib/dbus/machine-id"
-
-
-def _get_machine_id():
-    """Get the machine ID
-
-    This is a unique identifier for a user for tracking metrics in Segment,
-    that is broken in different ways in some Linux distros and Docker images.
-    - at times just a hash of '', which means many machines map to the same ID
-    - at times a hash of the same string, when running in a Docker container
-    - we run a sudo command, which is weird and bad in all sorts of ways
-
-    We'll track multiple IDs in Segment for a few months after which
-    we'll remove this one. The goal is to determine a ratio between them
-    that we can use to normalize our metrics.
-
-    """
-    if (
-        platform.system() == "Linux"
-        and os.path.isfile(_ETC_MACHINE_ID_PATH) == False
-        and os.path.isfile(_DBUS_MACHINE_ID_PATH) == False
-    ):
-        subprocess.run(["sudo", "dbus-uuidgen", "--ensure"])
-
-    machine_id = str(uuid.getnode())
-    if os.path.isfile(_ETC_MACHINE_ID_PATH):
-        with open(_ETC_MACHINE_ID_PATH, "r") as f:
-            machine_id = f.read()
-
-    elif os.path.isfile(_DBUS_MACHINE_ID_PATH):
-        with open(_DBUS_MACHINE_ID_PATH, "r") as f:
-            machine_id = f.read()
-
-    return machine_id
 
 
 def _get_machine_id_v3() -> str:
@@ -67,15 +31,6 @@ def _get_machine_id_v3() -> str:
     that is broken in different ways in some Linux distros and Docker images.
     - at times just a hash of '', which means many machines map to the same ID
     - at times a hash of the same string, when running in a Docker container
-
-    This is a replacement for _get_machine_id() that doesn't try to use `sudo`
-    when there is no machine-id file, because it isn't available in all enviroments
-    and is a bad break in the user flow even when it is usable.
-
-    We'll track multiple IDs in Segment for a few months after which
-    we'll drop the others. The goal is to determine a ratio between them
-    that we can use to normalize our metrics.
-
     """
 
     machine_id = str(uuid.getnode())
@@ -88,29 +43,6 @@ def _get_machine_id_v3() -> str:
             machine_id = f.read()
 
     return machine_id
-
-
-def _get_stable_random_id():
-    """Get a stable random ID
-
-    This is a unique identifier for a user for tracking metrics in Segment.
-    Instead of relying on a hardware address in the container or host we'll
-    generate a UUID and store it in the Streamlit hidden folder.
-
-    """
-    filepath = file_util.get_streamlit_file_path(".stable_random_id")
-    stable_id = None
-
-    if os.path.exists(filepath):
-        with file_util.streamlit_read(filepath) as input:
-            stable_id = input.read()
-
-    if not stable_id:
-        stable_id = str(uuid.uuid4())
-        with file_util.streamlit_write(filepath) as output:
-            output.write(stable_id)
-
-    return stable_id
 
 
 class Installation:
@@ -130,10 +62,6 @@ class Installation:
         return cls._instance
 
     def __init__(self):
-        self.installation_id_v1 = str(uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id()))
-        self.installation_id_v2 = str(
-            uuid.uuid5(uuid.NAMESPACE_DNS, _get_stable_random_id())
-        )
         self.installation_id_v3 = str(
             uuid.uuid5(uuid.NAMESPACE_DNS, _get_machine_id_v3())
         )

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -726,8 +726,6 @@ def _populate_theme_msg(msg: CustomThemeConfig) -> None:
 
 def _populate_user_info_msg(msg: UserInfo) -> None:
     msg.installation_id = Installation.instance().installation_id
-    msg.installation_id_v1 = Installation.instance().installation_id_v1
-    msg.installation_id_v2 = Installation.instance().installation_id_v2
     msg.installation_id_v3 = Installation.instance().installation_id_v3
     if Credentials.get_current().activation:
         msg.email = Credentials.get_current().activation.email

--- a/lib/tests/streamlit/metrics_util_test.py
+++ b/lib/tests/streamlit/metrics_util_test.py
@@ -31,57 +31,11 @@ class MetricsUtilTest(unittest.TestCase):
     def tearDown(self):
         self.patch1.stop()
 
-    def test_machine_id_from_etc(self):
-        """Test getting the machine id from /etc"""
-        file_data = "etc"
-
-        with patch("streamlit.metrics_util.platform.system", return_value=False), patch(
-            "streamlit.metrics_util.uuid.getnode", return_value=MAC
-        ), patch(
-            "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
-        ), patch(
-            "streamlit.metrics_util.os.path.isfile"
-        ) as path_isfile:
-
-            def path_isfile(path):
-                return path == "/etc/machine-id"
-
-            machine_id = metrics_util._get_machine_id()
-        self.assertEqual(machine_id, file_data)
-
-    def test_machine_id_from_dbus(self):
-        """Test getting the machine id from /var/lib/dbus"""
-        file_data = "dbus"
-
-        with patch("streamlit.metrics_util.platform.system", return_value=False), patch(
-            "streamlit.metrics_util.uuid.getnode", return_value=MAC
-        ), patch(
-            "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
-        ), patch(
-            "streamlit.metrics_util.os.path.isfile"
-        ) as path_isfile:
-
-            def path_isfile(path):
-                return path == "/var/lib/dbus/machine-id"
-
-            machine_id = metrics_util._get_machine_id()
-        self.assertEqual(machine_id, file_data)
-
-    def test_machine_id_from_node(self):
-        """Test getting the machine id as the mac address"""
-
-        with patch("streamlit.metrics_util.platform.system", return_value=False), patch(
-            "streamlit.metrics_util.uuid.getnode", return_value=MAC
-        ), patch("streamlit.metrics_util.os.path.isfile", return_value=False):
-
-            machine_id = metrics_util._get_machine_id()
-        self.assertEqual(machine_id, MAC)
-
     def test_machine_id_v3_from_etc(self):
         """Test getting the machine id from /etc"""
         file_data = "etc"
 
-        with patch("streamlit.metrics_util.platform.system", return_value=False), patch(
+        with patch(
             "streamlit.metrics_util.uuid.getnode", return_value=MAC
         ), patch(
             "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
@@ -99,7 +53,7 @@ class MetricsUtilTest(unittest.TestCase):
         """Test getting the machine id from /var/lib/dbus"""
         file_data = "dbus"
 
-        with patch("streamlit.metrics_util.platform.system", return_value=False), patch(
+        with patch(
             "streamlit.metrics_util.uuid.getnode", return_value=MAC
         ), patch(
             "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
@@ -116,50 +70,9 @@ class MetricsUtilTest(unittest.TestCase):
     def test_machine_id_v3_from_node(self):
         """Test getting the machine id as the mac address"""
 
-        with patch("streamlit.metrics_util.platform.system", return_value=False), patch(
+        with patch(
             "streamlit.metrics_util.uuid.getnode", return_value=MAC
         ), patch("streamlit.metrics_util.os.path.isfile", return_value=False):
 
             machine_id = metrics_util._get_machine_id_v3()
         self.assertEqual(machine_id, MAC)
-
-    @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
-    def test_stable_id_not_exists(self):
-        """Test creating a stable id"""
-
-        with patch("streamlit.metrics_util.os.path.exists", return_value=False), patch(
-            "streamlit.metrics_util.uuid.uuid4", return_value=UUID
-        ), patch("streamlit.file_util.open", mock_open()) as open, patch(
-            "streamlit.util.os.makedirs"
-        ) as makedirs:
-
-            machine_id = metrics_util._get_stable_random_id()
-            open().write.assert_called_once_with(UUID)
-        self.assertEqual(machine_id, UUID)
-
-    @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
-    def test_stable_id_exists_and_valid(self):
-        """Test getting a stable valid id"""
-
-        with patch("streamlit.metrics_util.os.path.exists", return_value=True), patch(
-            "streamlit.file_util.open", mock_open(read_data=UUID)
-        ) as open:
-
-            machine_id = metrics_util._get_stable_random_id()
-            open().read.assert_called_once()
-        self.assertEqual(machine_id, UUID)
-
-    @patch("streamlit.metrics_util.file_util.get_streamlit_file_path", mock_get_path)
-    def test_stable_id_exists_and_invalid(self):
-        """Test getting a stable invalid id"""
-
-        with patch("streamlit.metrics_util.os.path.exists", return_value=True), patch(
-            "streamlit.metrics_util.uuid.uuid4", return_value=UUID
-        ), patch("streamlit.file_util.open", mock_open(read_data="")) as open, patch(
-            "streamlit.util.os.makedirs"
-        ) as makedirs:
-
-            machine_id = metrics_util._get_stable_random_id()
-            open().read.assert_called_once()
-            open().write.assert_called_once_with(UUID)
-        self.assertEqual(machine_id, UUID)

--- a/lib/tests/streamlit/metrics_util_test.py
+++ b/lib/tests/streamlit/metrics_util_test.py
@@ -35,13 +35,9 @@ class MetricsUtilTest(unittest.TestCase):
         """Test getting the machine id from /etc"""
         file_data = "etc"
 
-        with patch(
-            "streamlit.metrics_util.uuid.getnode", return_value=MAC
-        ), patch(
+        with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC), patch(
             "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
-        ), patch(
-            "streamlit.metrics_util.os.path.isfile"
-        ) as path_isfile:
+        ), patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
 
             def path_isfile(path):
                 return path == "/etc/machine-id"
@@ -53,13 +49,9 @@ class MetricsUtilTest(unittest.TestCase):
         """Test getting the machine id from /var/lib/dbus"""
         file_data = "dbus"
 
-        with patch(
-            "streamlit.metrics_util.uuid.getnode", return_value=MAC
-        ), patch(
+        with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC), patch(
             "streamlit.metrics_util.open", mock_open(read_data=file_data), create=True
-        ), patch(
-            "streamlit.metrics_util.os.path.isfile"
-        ) as path_isfile:
+        ), patch("streamlit.metrics_util.os.path.isfile") as path_isfile:
 
             def path_isfile(path):
                 return path == "/var/lib/dbus/machine-id"
@@ -70,9 +62,9 @@ class MetricsUtilTest(unittest.TestCase):
     def test_machine_id_v3_from_node(self):
         """Test getting the machine id as the mac address"""
 
-        with patch(
-            "streamlit.metrics_util.uuid.getnode", return_value=MAC
-        ), patch("streamlit.metrics_util.os.path.isfile", return_value=False):
+        with patch("streamlit.metrics_util.uuid.getnode", return_value=MAC), patch(
+            "streamlit.metrics_util.os.path.isfile", return_value=False
+        ):
 
             machine_id = metrics_util._get_machine_id_v3()
         self.assertEqual(machine_id, MAC)

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -115,8 +115,6 @@ message CustomThemeConfig {
 // Does not change over the app's lifetime.
 message UserInfo {
   string installation_id = 1;
-  string installation_id_v1 = 3;
-  string installation_id_v2 = 4;
   string installation_id_v3 = 5;
   string email = 2;
 }


### PR DESCRIPTION
This is part 3/3 of the Machine ID work we started early this year. This last step is just to simply remove the old IDs.

For the reason we're doing this, including a description of all 3 parts of this plan, see [the Notion doc](https://www.notion.so/streamlit/Product-Spec-288109647af84c6ea6197a9eb0623155).

For previous PRs, see:
* Part 1: https://github.com/streamlit/streamlit/pull/2572
* Part 2: https://github.com/streamlit/streamlit/pull/2605
* Part 2, fixed: https://github.com/streamlit/streamlit/pull/3216

**This also (finally) fixes https://github.com/streamlit/streamlit/issues/1584!!!**