### PR TITLE
Don't hash mtime of tty files and ignore the tell.

### DIFF
--- a/lib/streamlit/legacy_caching/hashing.py
+++ b/lib/streamlit/legacy_caching/hashing.py
@@ -529,8 +529,9 @@ class _CodeHasher:
             h = hashlib.new("md5")
             obj_name = getattr(obj, "name", "wonthappen")  # Just to appease MyPy.
             self.update(h, obj_name)
-            self.update(h, os.path.getmtime(obj_name))
-            self.update(h, obj.tell())
+            if not obj.isatty(): # tty files don't have mtime, and tell is meaningless
+                self.update(h, os.path.getmtime(obj_name))
+                self.update(h, obj.tell())
             return h.digest()
 
         elif isinstance(obj, Pattern):


### PR DESCRIPTION
I think being able to write to console is helpful when you debug your streamlit application and should not be considered as a side effect that you think about when caching. Otherwise one can easily break a streamlit app by simply changing the logging configuration. This is something that has bitten us on several occasions.

alternative fix to #2509, instead of reporting an error let's ppl log to stdout and stderr, to avoid unexpected streamlit behaviour when logging config is changed. 
