### PR TITLE
Add PEP 561 support to Streamlit

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -71,6 +71,8 @@ setuptools.setup(
     author_email="hello@streamlit.io",
     python_requires=">=3.6",
     license="Apache 2",
+    # PEP 561: https://mypy.readthedocs.io/en/stable/installed_packages.html
+    package_data={"streamlit": ["py.typed"]},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     # Requirements
     install_requires=requirements,

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -171,7 +171,14 @@ def is_plotly_chart(obj):
 
 def is_graphviz_chart(obj):
     """True if input looks like a GraphViz chart."""
-    return is_type(obj, "graphviz.dot.Graph") or is_type(obj, "graphviz.dot.Digraph")
+    return (
+        # GraphViz < 0.18
+        is_type(obj, "graphviz.dot.Graph")
+        or is_type(obj, "graphviz.dot.Digraph")
+        # GraphViz >= 0.18
+        or is_type(obj, "graphviz.graphs.Graph")
+        or is_type(obj, "graphviz.graphs.Digraph")
+    )
 
 
 def _is_plotly_obj(obj):
@@ -376,8 +383,8 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
         if _NUMPY_DTYPE_ERROR_MESSAGE in str(e):
             raise errors.NumpyDtypeException(
                 """
-Unable to convert `numpy.dtype` to `pyarrow.DataType`.  
-This is likely due to a bug in Arrow (see https://issues.apache.org/jira/browse/ARROW-14087).  
+Unable to convert `numpy.dtype` to `pyarrow.DataType`.
+This is likely due to a bug in Arrow (see https://issues.apache.org/jira/browse/ARROW-14087).
 As a temporary workaround, you can convert the DataFrame cells to strings with `df.astype(str)`.
 """
             )


### PR DESCRIPTION
Streamlit itself already has (some) type annotations, and we type-check the library itself.

But: apps that install Streamlit via pip can not currently typecheck that Streamlit import because Streamlit is not a "PEP 561 compatible package".

https://mypy.readthedocs.io/en/stable/installed_packages.html

(Note that this does *not* mean we need to type-annotate everything in Streamlit; we can continue to gradually type as we go.)

(This is a pre-req for addressing https://github.com/streamlit/streamlit/issues/4018)