### PR TITLE
Run mypy also for python_min_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,16 +294,12 @@ jobs:
           when: always
 
       #################################################################
-      # Run mypy. (Only executed in one job.)
+      # Run mypy.
       #################################################################
       - run:
           name: Run mypy
           command: |
-            if [ "${CIRCLE_JOB}" != "python-max-version" ] ; then
-              echo "Mypy is only run in python-max-version job"
-            else
-              scripts/mypy --report
-            fi
+            scripts/mypy --report
 
       - store_test_results:
           path: lib/test-reports


### PR DESCRIPTION
## 📚 Context

Since now [PEP 561 support added](https://github.com/streamlit/streamlit/pull/4025), it makes sense run mypy also for python_min_version.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other: Circle CI workflow change

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
