### PR TITLE
/metrics endpoint uses the "Accept" header for content-type negotiation

### DIFF
--- a/lib/streamlit/stats.py
+++ b/lib/streamlit/stats.py
@@ -113,7 +113,7 @@ class StatsHandler(tornado.web.RequestHandler):
 
         # If the request asked for protobuf output, we return a serialized
         # protobuf. Else we return text.
-        if self.request.headers.get("Content-Type", None) == "application/x-protobuf":
+        if "application/x-protobuf" in self.request.headers.get_list("Accept"):
             self.write(self._stats_to_proto(stats).SerializeToString())
             self.set_header("Content-Type", "application/x-protobuf")
             self.set_status(200)

--- a/lib/tests/streamlit/stats_test.py
+++ b/lib/tests/streamlit/stats_test.py
@@ -22,6 +22,7 @@ from google.protobuf.json_format import MessageToDict
 
 from streamlit.proto.openmetrics_data_model_pb2 import MetricSet as MetricSetProto
 from streamlit.stats import StatsHandler, CacheStat, CacheStatsProvider, StatsManager
+from tornado.httputil import HTTPHeaders
 
 
 class MockStatsProvider(CacheStatsProvider):
@@ -97,6 +98,9 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         response = self.fetch("/metrics")
         self.assertEqual(200, response.code)
+        self.assertEqual(
+            "application/openmetrics-text", response.headers.get("Content-Type")
+        )
 
         expected_body = (
             "# TYPE cache_memory_bytes gauge\n"
@@ -126,10 +130,16 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
             ),
         ]
 
-        response = self.fetch(
-            "/metrics", headers={"Content-Type": "application/x-protobuf"}
-        )
+        # Requests can have multiple Accept headers. Only one of them needs
+        # to specify protobuf in order to get back protobuf.
+        headers = HTTPHeaders()
+        headers.add("Accept", "application/openmetrics-text")
+        headers.add("Accept", "application/x-protobuf")
+        headers.add("Accept", "text/html")
+
+        response = self.fetch("/metrics", headers=headers)
         self.assertEqual(200, response.code)
+        self.assertEqual("application/x-protobuf", response.headers.get("Content-Type"))
 
         metric_set = MetricSetProto()
         metric_set.ParseFromString(response.body)


### PR DESCRIPTION
Previously, the /metrics endpoint looked for a `"Content-Type"` header in requests to determine whether to return protobuf results. The correct way to do this is via the `"Accept"` request header, which is what we now do!

(None of this has been publicly released yet, so this is not a breaking change.)