### PR TITLE
Add frontend/bokeh/public/vendor/bokeh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ eggs/
 *.egg-info/
 *.egg
 
+# Preloaded, minified js (downloaded via script due to dependencies having
+# issues with babel transpilation).
+frontend/public/vendor/bokeh/
+
 # Unit test / coverage reports
 .coverage
 .coverage\.*


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

We recently changed the way that the BokehJS dependency is installed to download the minified JS
due to issues that the library is having with babel transpilation that seem unlikely to be fixed. Now, the
minified JS is pulled in before the frontend is built using a shell script. However, the directory the files
live in isn't included in `.gitignore`, so they get returned by the `git status` command even though we
definitely never want to check these files in.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: local dev env cleanup

## 🧠 Description of Changes

- Added frontend/bokeh/public/vendor/bokeh to .gitignore


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
