### PR TITLE
Allow st.session_state to be used to set number_input values with no warning

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -21,7 +21,7 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
 from streamlit.report_thread import get_report_ctx
-from streamlit.state.widgets import register_widget, NoValue
+from streamlit.state.widgets import register_widget
 from streamlit.state.session_state import (
     WidgetArgs,
     WidgetCallback,

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -98,7 +98,9 @@ class NumberInputMixin:
         """
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
-        check_session_state_rules(default_value=value, key=key)
+        check_session_state_rules(
+            default_value=None if isinstance(value, NoValue) else value, key=key
+        )
 
         # Ensure that all arguments are of the same type.
         number_input_args = [min_value, max_value, value, step]

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -23,7 +23,7 @@ from streamlit.state.session_state import (
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget, NoValue
+from streamlit.state.widgets import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id

--- a/lib/tests/streamlit/number_input_test.py
+++ b/lib/tests/streamlit/number_input_test.py
@@ -14,7 +14,7 @@
 
 """number_input unit test."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import pytest
 
 import streamlit as st
@@ -234,3 +234,20 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(number_input_proto.label, "foo")
         self.assertEqual(number_input_proto.step, 1.0)
         self.assertEqual(number_input_proto.default, 0)
+
+    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.elements.utils.get_session_state")
+    def test_no_warning_with_value_set_in_state(self, patched_get_session_state):
+        mock_session_state = MagicMock()
+        mock_session_state.is_new_state_value.return_value = True
+        patched_get_session_state.return_value = mock_session_state
+
+        st.number_input("the label", min_value=1, max_value=10, key="number_input")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        self.assertEqual(c.label, "the label")
+        self.assertEqual(c.default, 1)
+
+        # Assert that no warning delta is enqueued when setting the widget
+        # value via st.session_state.
+        self.assertEqual(len(self.get_all_deltas_from_queue()), 1)


### PR DESCRIPTION
## 📚 Context

Currently, setting a value for an `st.number_input` widget via `st.session_state`
always prints a warning that both a default value and a value in `st.session_state`
were set for the widget, even if no default value was set.

This is because the `st.number_input` widget uses a special `NoValue` value
instead of `None` as a default to assist with ensuring that all numerical args
passed to the `st.number_input` widget are of the same type, and we must have
forgotten to take this into account when building `st.session_state`.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Fixes the behavior described above by passing `None` to
  `check_session_state_rules` if `isinstance(value, NoValue)`.
- Adds a unit test

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #3921

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
