### PR TITLE
Fix issue 3555 - Long values on slider get cut off or overlap

### DIFF
--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -37,8 +37,6 @@ import {
   StyledThumbValue,
   StyledTickBar,
   StyledTickBarItem,
-  // StyleThumbValueLeft,
-  // StyleThumbValueRight
 } from "./styled-components"
 
 const DEBOUNCE_TIME_MS = 200

--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -37,6 +37,8 @@ import {
   StyledThumbValue,
   StyledTickBar,
   StyledTickBarItem,
+  // StyleThumbValueLeft,
+  // StyleThumbValueRight
 } from "./styled-components"
 
 const DEBOUNCE_TIME_MS = 200
@@ -209,7 +211,19 @@ class Slider extends React.PureComponent<Props, State> {
         "draggable",
       ])
       const ariaValueText: Record<string, string> = {}
-
+      const delta = 0.1
+      let left
+      let right
+      if (
+        this.props.element.min + this.props.element.max * delta >
+        $value[$thumbIndex]
+      )
+        left = "0px"
+      else if (
+        this.props.element.max - this.props.element.max * delta <
+        $value[$thumbIndex]
+      )
+        right = "0px"
       if (this.props.element.options.length > 0 || this.isDateTimeType()) {
         ariaValueText["aria-valuetext"] = formattedValue
       }
@@ -224,6 +238,8 @@ class Slider extends React.PureComponent<Props, State> {
           <StyledThumbValue
             data-testid="stThumbValue"
             isDisabled={props.$disabled}
+            reachLeft={left}
+            reachRight={right}
           >
             {formattedValue}
           </StyledThumbValue>

--- a/frontend/src/components/widgets/Slider/styled-components.ts
+++ b/frontend/src/components/widgets/Slider/styled-components.ts
@@ -20,6 +20,8 @@ import { transparentize } from "color2k"
 
 export interface StyledThumbProps {
   isDisabled: boolean
+  reachLeft?: string
+  reachRight?: string
 }
 
 export const StyledThumb = styled.div<StyledThumbProps>(
@@ -47,12 +49,14 @@ export const StyledThumb = styled.div<StyledThumbProps>(
 )
 
 export const StyledThumbValue = styled.div<StyledThumbProps>(
-  ({ isDisabled, theme }) => ({
+  ({ isDisabled, theme, reachLeft, reachRight }) => ({
     fontFamily: theme.fonts.monospace,
     fontSize: theme.fontSizes.sm,
     paddingBottom: theme.spacing.twoThirdsSmFont,
     color: isDisabled ? theme.colors.gray : theme.colors.primary,
     top: "-22px",
+    left: reachLeft,
+    right: reachRight,
     position: "absolute",
     whiteSpace: "nowrap",
     backgroundColor: theme.colors.transparent,


### PR DESCRIPTION
…f the slider

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_
In issue 3555 was reported a problem with the slider value. Long values on slider get cut off or overlap.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Change StyledThumbValue right value to 0 when value reaches more than 90% os its value.
- Change StyledThumbValue left value to 0 when value reaches less than 10% os its value.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![issue3555](https://user-images.githubusercontent.com/26447582/141154214-f7d92d33-1c37-4cd5-8270-6e34334e8423.png)
![issue3555-2](https://user-images.githubusercontent.com/26447582/141154232-cfb71806-6d5a-4696-9cb5-c1a40bbcfaee.png)

**Current:**

![issue3555-problem](https://user-images.githubusercontent.com/26447582/141154260-c4069b64-0166-4095-9f1b-926668a466ce.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #3555 

---

**Contribution License Agreement**

By submitting this pull request you agree that 
all contributions to this project are made under the Apache 2.0 license.



