### PR TITLE
Update secrets management docs URL

### DIFF
--- a/lib/streamlit/secrets.py
+++ b/lib/streamlit/secrets.py
@@ -31,7 +31,7 @@ def _missing_attr_error_message(attr_name: str) -> str:
     return (
         f'st.secrets has no attribute "{attr_name}". '
         f"Did you forget to add it to secrets.toml or the app settings on Streamlit Cloud? "
-        f"More info: https://docs.streamlit.io/streamlit-cloud/community#secrets-management"
+        f"More info: https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management"
     )
 
 
@@ -39,7 +39,7 @@ def _missing_key_error_message(key: str) -> str:
     return (
         f'st.secrets has no key "{key}". '
         f"Did you forget to add it to secrets.toml or the app settings on Streamlit Cloud? "
-        f"More info: https://docs.streamlit.io/streamlit-cloud/community#secrets-management"
+        f"More info: https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management"
     )
 
 


### PR DESCRIPTION
### Update secrets management docs URL
-  The error messages returned by `secrets.py` link to an older version of the Secrets management page in our docs:
- > https://docs.streamlit.io/streamlit-cloud/community#secrets-management
- This PR replaces the old link with the up-to-date one:
- > https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management