### PR TITLE
Fix vega lite issue with inline data values

### DIFF
--- a/e2e/scripts/st_arrow_vega_lite_chart.py
+++ b/e2e/scripts/st_arrow_vega_lite_chart.py
@@ -107,14 +107,15 @@ st._arrow_vega_lite_chart(
     use_container_width=True,
 )
 
-# st.write("Putting the `df` inside the spec, as inline `data` (different notation):")
-# This fails now, but not a big deal. It's a weird notation.
+st.write("Putting the `df` inside the spec, as inline `data` (different notation):")
 
-# st._arrow_vega_lite_chart({
-#     'data': {'values': df},
-#     'mark': 'bar',
-#     'encoding': {
-#       'x': {'field': 'a', 'type': 'ordinal'},
-#       'y': {'field': 'b', 'type': 'quantitative'}
-#     }
-#   })
+st._arrow_vega_lite_chart(
+    {
+        "data": {"values": df},
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "a", "type": "ordinal"},
+            "y": {"field": "b", "type": "quantitative"},
+        },
+    }
+)

--- a/e2e/scripts/st_legacy_vega_lite_chart.py
+++ b/e2e/scripts/st_legacy_vega_lite_chart.py
@@ -107,14 +107,15 @@ st._legacy_vega_lite_chart(
     use_container_width=True,
 )
 
-# st.write("Putting the `df` inside the spec, as inline `data` (different notation):")
-# This fails now, but not a big deal. It's a weird notation.
+st.write("Putting the `df` inside the spec, as inline `data` (different notation):")
 
-# st._legacy_vega_lite_chart({
-#     'data': {'values': df},
-#     'mark': 'bar',
-#     'encoding': {
-#       'x': {'field': 'a', 'type': 'ordinal'},
-#       'y': {'field': 'b', 'type': 'quantitative'}
-#     }
-#   })
+st._legacy_vega_lite_chart(
+    {
+        "data": {"values": df},
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "a", "type": "ordinal"},
+            "y": {"field": "b", "type": "quantitative"},
+        },
+    }
+)

--- a/lib/streamlit/elements/arrow_vega_lite.py
+++ b/lib/streamlit/elements/arrow_vega_lite.py
@@ -162,7 +162,7 @@ def marshall(
         if isinstance(data_spec, dict):
             if "values" in data_spec:
                 data = data_spec["values"]
-                del data_spec["values"]
+                del spec["data"]
         else:
             data = data_spec
             del spec["data"]

--- a/lib/streamlit/elements/legacy_vega_lite.py
+++ b/lib/streamlit/elements/legacy_vega_lite.py
@@ -154,7 +154,7 @@ def marshall(proto, data=None, spec=None, use_container_width=False, **kwargs):
         if isinstance(data_spec, dict):
             if "values" in data_spec:
                 data = data_spec["values"]
-                del data_spec["values"]
+                del spec["data"]
         else:
             data = data_spec
             del spec["data"]

--- a/lib/tests/streamlit/arrow_vega_lite_test.py
+++ b/lib/tests/streamlit/arrow_vega_lite_test.py
@@ -81,7 +81,7 @@ class ArrowVegaLiteTest(testutil.DeltaGeneratorTestCase):
         )
         self.assertDictEqual(
             json.loads(proto.spec),
-            merge_dicts(autosize_spec, {"data": {}, "mark": "rect"}),
+            merge_dicts(autosize_spec, {"mark": "rect"}),
         )
 
     def test_datasets_in_spec(self):

--- a/lib/tests/streamlit/legacy_vega_lite_test.py
+++ b/lib/tests/streamlit/legacy_vega_lite_test.py
@@ -85,7 +85,7 @@ class LegacyVegaLiteTest(testutil.DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.vega_lite_chart
         self.assertEqual(c.HasField("data"), True)
         self.assertDictEqual(
-            json.loads(c.spec), merge_dicts(autosize_spec, {"data": {}, "mark": "rect"})
+            json.loads(c.spec), merge_dicts(autosize_spec, {"mark": "rect"})
         )
 
     def test_datasets_in_spec(self):


### PR DESCRIPTION
## 📚 Context

If the data of a vega lite chart is passed via the `data.values`, the frontend will throw an error. The reason is that the Python library currently only removes the `values` properties from the proto message, but not the `data` property. This will forward an empty `data` object, which the vega frontend library is not able to handle.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Delete the full `data` object instead of only the `values` list in the Python library.

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

```python
import streamlit as st

st.vega_lite_chart(
    {
        "data": {
            "values": [
            {"a": "C", "b": 2}, {"a": "C", "b": 7}, {"a": "C", "b": 4},
            {"a": "D", "b": 1}, {"a": "D", "b": 2}, {"a": "D", "b": 6},
            {"a": "E", "b": 8}, {"a": "E", "b": 4}, {"a": "E", "b": 7}
            ]
        },
        "mark": "bar",
        "encoding": {
            "x": {"field": "a", "type": "nominal"},
            "y": {"aggregate": "average", "field": "b", "type": "quantitative"}
        }
    }
)
```

![image](https://user-images.githubusercontent.com/2852129/141998239-33fe9542-b9fc-4047-b04f-00e7ec4d25ad.png)

**Current:**

![image](https://user-images.githubusercontent.com/2852129/141997598-2dd80a99-aeab-4051-9734-b482ce3a290a.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [x] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #4062

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
