### PR TITLE
Use st.text for arguments of type class in st.write

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import json as json
 import types
 from typing import cast, Any, List, Tuple, Type
@@ -219,6 +220,9 @@ class WriteMixin:
             elif type_util.is_pydeck(arg):
                 flush_buffer()
                 self.dg.pydeck_chart(arg)
+            elif inspect.isclass(arg):
+                flush_buffer()
+                self.dg.text(arg)
             elif hasattr(arg, "_repr_html_"):
                 self.dg.markdown(
                     arg._repr_html_(),

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -206,6 +206,23 @@ class StreamlitWriteTest(unittest.TestCase):
                 "`1 * 2 - 3 = 4 \\`ok\\` !`", unsafe_allow_html=False
             )
 
+    def test_class(self):
+        """Test st.write with a class."""
+
+        class SomeClass(object):
+            pass
+
+        with patch("streamlit.delta_generator.DeltaGenerator.text") as p:
+            st.write(SomeClass)
+
+            p.assert_called_once_with(SomeClass)
+
+        with patch("streamlit.delta_generator.DeltaGenerator.text") as p:
+            empty_df = pd.DataFrame()
+            st.write(type(empty_df))
+
+            p.assert_called_once_with(type(empty_df))
+
     def test_exception(self):
         """Test st.write that raises an exception."""
         # We patch streamlit.exception to observe it, but we also make sure


### PR DESCRIPTION
## 📚 Context

When you call `st.write()` any class that has `_repr_html_` it throws an error. `st.write` uses `_repr_html_()` when it's available. DataFrame contains that method, but it requires a `self` to be passed. So when you call it directly as `DataFrame._repr_html_()` there's no self and we get an exception.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Call `st.text()` when the argument is of type class.

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

```python
import streamlit as st                                                                                   
import pandas as pd                                                                                      
                                                                                                         
x = pd.DataFrame([{"a": 1, "b": 2}, {"a": 3, "b": 4}])                                                   

"## st.text"
st.text(type(x))  # This works.                                                                          

"## st.write"
st.write(type(x))  # This doesn't work.    
```

![image](https://user-images.githubusercontent.com/2852129/142000002-ed94bcd6-2d55-4811-94db-48c51c9c61f5.png)

**Current:**

![image](https://user-images.githubusercontent.com/2852129/141999484-6b450cd1-dd0e-4829-ab2d-893cf44465b1.png)

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4049

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
