### PR TITLE
Don't always redownload minified bokeh js files

### DIFF
--- a/frontend/scripts/preload-bokeh.sh
+++ b/frontend/scripts/preload-bokeh.sh
@@ -1,9 +1,41 @@
+#!/bin/bash
+
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+bokeh_version="2.4.1"
+bokeh_release_url="https://cdn.bokeh.org/bokeh/release"
+bokeh_files=(
+  "bokeh-${bokeh_version}.min.js"
+  "bokeh-widgets-${bokeh_version}.min.js"
+  "bokeh-tables-${bokeh_version}.min.js"
+  "bokeh-api-${bokeh_version}.min.js"
+  "bokeh-gl-${bokeh_version}.min.js"
+  "bokeh-mathjax-${bokeh_version}.min.js"
+)
+
 mkdir -p public/vendor/bokeh
 cd public/vendor/bokeh
 
-curl "https://cdn.bokeh.org/bokeh/release/bokeh-2.4.1.min.js" -o "bokeh-2.4.1.min.js"
-curl "https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.1.min.js" -o "bokeh-widgets-2.4.1.min.js"
-curl "https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.1.min.js" -o "bokeh-tables-2.4.1.min.js"
-curl "https://cdn.bokeh.org/bokeh/release/bokeh-api-2.4.1.min.js" -o "bokeh-api-2.4.1.min.js"
-curl "https://cdn.bokeh.org/bokeh/release/bokeh-gl-2.4.1.min.js" -o "bokeh-gl-2.4.1.min.js"
-curl "https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-2.4.1.min.js" -o "bokeh-mathjax-2.4.1.min.js"
+for filename in "${bokeh_files[@]}"
+do
+  if [ ! -f $filename ]
+  then
+    curl "${bokeh_release_url}/${filename}" -O
+  fi
+done


### PR DESCRIPTION
## 📚 Context

A very minor thing that bugged me about the preload-bokeh script was that it
always redownloaded the minified js, even if the files are already there.

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: infra script improvements

## 🧠 Description of Changes

- Teach `preload-bokeh.sh` to only download files if necessary
- Add the Apache License comment to the top of the script
- Refactor the script a bit

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
