### PR TITLE
Include link to wheel file in PR preview output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,6 +557,12 @@ jobs:
       - run:
           name: Ready to deploy!
           command: |
+            echo -e "Wheel file download:"
+            cat S3_URL
+
+            echo -e "\n"
+
+            echo -e "Cloud deploy link:"
             echo -e "https://share.streamlit.io/deploy?repository=streamlit/core-previews&branch=${PREVIEW_BRANCH}&mainModule=streamlit_app.py"
 
   cypress:


### PR DESCRIPTION
## 📚 Context

I often find myself wanting to download the wheel created by the pr-preview CI
build stage, which involves deploying the PR preview app to click on the wheel
download button or manually constructing the public S3 link from the bucket name
and branch name.

Doing all of this work turns out to be a bit silly since we could just have the
build stage output the download link :neutral_face:

- What kind of change does this PR introduce?

  - [x] Other, please describe: CI tweaks

## 🧠 Description of Changes

- output a download link to the wheel file uploaded to S3
- label both the wheel download link and Cloud deploy link

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
