### PR TITLE
Fix ambiguous behavior description for allow_output_mutation

### DIFF
--- a/lib/streamlit/legacy_caching/caching.py
+++ b/lib/streamlit/legacy_caching/caching.py
@@ -376,7 +376,7 @@ def cache(
         Whether to persist the cache on disk.
 
     allow_output_mutation : boolean
-        Streamlit normally shows a warning when return values are mutated, as that
+        Streamlit shows a warning when return values are mutated, as that
         can have unintended consequences. This is done by hashing the return value internally.
 
         If you know what you're doing and would like to override this warning, set this to True.


### PR DESCRIPTION
### Fix ambiguous behavior description for allow_output_mutation
The docstring for `allow_output_mutation` say: ` Streamlit shows a warning when return values are mutated, as that can have unintended consequences.`, without the `normally`.

We should remove the ambiguity of "normally"...unless there is actually a scenario where you can silently mutate without warning.

Linked issue from the docs repo: https://github.com/streamlit/docs/issues/100#event-5465042508