### PR TITLE
Update static embedded examples for dataframe and table

### DIFF
--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -62,8 +62,8 @@ class DataFrameSelectorMixin:
         >>> st.dataframe(df)  # Same as st.write(df)
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ
-           height: 330px
+           https://static.streamlit.io/1.2.0-2FAcu/index.html?id=C2AE4xf85jDddBCaY1ugvt
+           height: 365px
 
         >>> st.dataframe(df, 200, 100)
 
@@ -77,8 +77,8 @@ class DataFrameSelectorMixin:
         >>> st.dataframe(df.style.highlight_max(axis=0))
 
         .. output::
-           https://static.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby
-           height: 285px
+           https://static.streamlit.io/1.2.0-2FAcu/index.html?id=AgoA9PCNWzoJuwJL7J9ybD
+           height: 375px
 
         """
         if _use_arrow():
@@ -110,7 +110,7 @@ class DataFrameSelectorMixin:
         >>> st.table(df)
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq
+           https://static.streamlit.io/1.2.0-2FAcu/index.html?id=VQdtFSFvML7uMB8P7JMfT5
            height: 480px
 
         """


### PR DESCRIPTION
## 📚 Context

Update static embedded examples for `st.dataframe` and `st.table`.

- What kind of change does this PR introduce?
 - [x] Other, please describe: Update static embedded examples for `st.dataframe` and `st.table`.

## 🧠 Description of Changes
- While the UI/design of `st.dataframe` and `st.table` has changed since v0.25, the static embedded examples still use the old styling.
- This PR updates the static embedded examples for the above element to use v1.2.0 (see screenshots below).

**Revised:**
![image](https://user-images.githubusercontent.com/20672874/143195370-4a6fe169-9d94-4887-9dc3-afd202d11d0b.png)
![image](https://user-images.githubusercontent.com/20672874/143195440-fa34311b-774b-40e6-b9e2-b0107a3b5f5d.png)

**Current:**
![image](https://user-images.githubusercontent.com/20672874/143195515-1975abc8-e4e5-49b3-ab31-211f3b7f7165.png)
![image](https://user-images.githubusercontent.com/20672874/143195577-a0f27a59-0b44-47d9-a1d0-96fb05efc4fd.png)

## 🧪 Testing Done

- [x] Screenshots included