### PR TITLE
Fix st.slider tests to address flakiness

### DIFF
--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -18,8 +18,6 @@
 describe("st.slider", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
-    // Open sidebar expander
-    cy.get(".streamlit-expanderHeader").click();
   });
 
   it("looks right", () => {
@@ -27,11 +25,16 @@ describe("st.slider", () => {
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
 
     cy.get(".stSlider")
-      .eq(2)
+      .eq(1)
       .matchThemedSnapshots("slider");
   });
 
   it("shows labels", () => {
+    // Open sidebar expander
+    cy.wait(500);
+    cy.get(".streamlit-expanderHeader").click();
+    cy.wait(1000);
+
     cy.get(".stSlider label").should(
       "have.text",
       "Label A" +
@@ -45,7 +48,7 @@ describe("st.slider", () => {
 
   it("shows full label when the label is long", () => {
     cy.get(".stSlider")
-      .eq(4)
+      .eq(3)
       .matchThemedSnapshots("slider_with_long_label");
   });
 
@@ -56,12 +59,22 @@ describe("st.slider", () => {
   });
 
   it("does not overlap expander container when thumb value is long", () => {
+    // Open sidebar expander
+    cy.wait(500);
+    cy.get(".streamlit-expanderHeader").click();
+    cy.wait(1000);
+
     cy.get(".stSlider")
       .eq(1)
       .matchThemedSnapshots("expander_thumb_value");
   });
 
   it("has correct values", () => {
+    // Open sidebar expander
+    cy.wait(500);
+    cy.get(".streamlit-expanderHeader").click();
+    cy.wait(1000);
+
     cy.get(".stMarkdown").should(
       "have.text",
       "Value A: 12345678" +
@@ -80,40 +93,40 @@ describe("st.slider", () => {
 
     // trigger click in the center of the slider
     cy.get('.stSlider [role="slider"]')
-      .eq(2)
+      .eq(1)
       .parent()
       .click();
 
     cy.get(".stMarkdown")
-      .eq(2)
+      .eq(1)
       .should("have.text", "Value 1: 50");
   });
 
   it("increments the value on right arrow key press", () => {
     cy.get('.stSlider [role="slider"]')
-      .eq(2)
+      .eq(1)
       .click()
       .type("{rightarrow}", { force: true });
 
     cy.get(".stMarkdown")
-      .eq(2)
+      .eq(1)
       .should("have.text", "Value 1: 26");
   });
 
   it("decrements the value on left arrow key press", () => {
     cy.get('.stSlider [role="slider"]')
-      .eq(2)
+      .eq(1)
       .click()
       .type("{leftarrow}", { force: true });
 
     cy.get(".stMarkdown")
-      .eq(2)
+      .eq(1)
       .should("have.text", "Value 1: 24");
   });
 
   it("maintains its state on rerun", () => {
     cy.get('.stSlider [role="slider"]')
-      .eq(2)
+      .eq(1)
       .click()
       .type("{leftarrow}", { force: true });
 
@@ -124,7 +137,7 @@ describe("st.slider", () => {
     });
 
     cy.get(".stMarkdown")
-      .eq(2)
+      .eq(1)
       .should("have.text", "Value 1: 24");
   });
 

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -31,7 +31,7 @@ describe("st.slider", () => {
 
   it("shows labels", () => {
     // Open sidebar expander
-    cy.wait(500);
+    cy.wait(1000);
     cy.get(".streamlit-expanderHeader").click();
     cy.wait(1000);
 
@@ -60,7 +60,7 @@ describe("st.slider", () => {
 
   it("does not overlap expander container when thumb value is long", () => {
     // Open sidebar expander
-    cy.wait(500);
+    cy.wait(1000);
     cy.get(".streamlit-expanderHeader").click();
     cy.wait(1000);
 
@@ -71,7 +71,7 @@ describe("st.slider", () => {
 
   it("has correct values", () => {
     // Open sidebar expander
-    cy.wait(500);
+    cy.wait(1000);
     cy.get(".streamlit-expanderHeader").click();
     cy.wait(1000);
 

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -31,9 +31,8 @@ describe("st.slider", () => {
 
   it("shows labels", () => {
     // Open sidebar expander
-    cy.wait(1000);
     cy.get(".streamlit-expanderHeader").click();
-    cy.wait(1000);
+    cy.get(".stSlider label").contains("Label B");
 
     cy.get(".stSlider label").should(
       "have.text",
@@ -60,9 +59,8 @@ describe("st.slider", () => {
 
   it("does not overlap expander container when thumb value is long", () => {
     // Open sidebar expander
-    cy.wait(1000);
     cy.get(".streamlit-expanderHeader").click();
-    cy.wait(1000);
+    cy.get(".stSlider label").contains("Label B");
 
     cy.get(".stSlider")
       .eq(1)
@@ -71,9 +69,8 @@ describe("st.slider", () => {
 
   it("has correct values", () => {
     // Open sidebar expander
-    cy.wait(1000);
     cy.get(".streamlit-expanderHeader").click();
-    cy.wait(1000);
+    cy.get(".stSlider label").contains("Label B");
 
     cy.get(".stMarkdown").should(
       "have.text",


### PR DESCRIPTION
## 📚 Context

The `st.slider` cypress tests are exhibiting some flakiness. Sometimes the expander is not opened in time for the test, despite having a `.click()` command to open the expander before each test run. 

- What kind of change does this PR introduce?
  - [x] Refactoring

## 🧠 Description of Changes

- Revised `st.slider` tests to only open expander when necessary
- Added wait times to ensure expand `.click()` registers

## 🧪 Testing Done

- [x] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
