### PR TITLE
Rename s4a hoc `items` -> `menuItems`

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -53,7 +53,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
     onModalReset: jest.fn(),
     currentState: {
       queryParams: "",
-      items: [],
+      menuItems: [],
       forcedModalClose: false,
       isOwner: true,
     },
@@ -181,7 +181,7 @@ describe("App", () => {
         sendMessage: jest.fn(),
         currentState: {
           queryParams: "",
-          items: [
+          menuItems: [
             {
               type: "separator",
             },
@@ -222,7 +222,7 @@ describe("App", () => {
           s4aCommunication: {
             onModalReset,
             currentState: {
-              items: [],
+              menuItems: [],
               queryParams: "",
               forcedModalClose: false,
             },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1170,7 +1170,9 @@ export class App extends PureComponent<Props, State> {
                 aboutCallback={this.aboutCallback}
                 screencastCallback={this.screencastCallback}
                 screenCastState={this.props.screenCast.currentState}
-                s4aMenuItems={this.props.s4aCommunication.currentState.items}
+                s4aMenuItems={
+                  this.props.s4aCommunication.currentState.menuItems
+                }
                 s4aIsOwner={this.props.s4aCommunication.currentState.isOwner}
                 sendS4AMessage={this.props.s4aCommunication.sendMessage}
                 gitInfo={gitInfo}

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -30,7 +30,7 @@ import {
 
 interface State {
   queryParams: string
-  items: IMenuItem[]
+  menuItems: IMenuItem[]
   forcedModalClose: boolean
   streamlitShareMetadata: StreamlitShareMetadata
   isOwner: boolean
@@ -59,7 +59,7 @@ function withS4ACommunication(
   WrappedComponent: ComponentType<any>
 ): ComponentType<any> {
   function ComponentWithS4ACommunication(props: any): ReactElement {
-    const [items, setItems] = useState<IMenuItem[]>([])
+    const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
     const [forcedModalClose, setForcedModalClose] = useState(false)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
@@ -87,7 +87,7 @@ function withS4ACommunication(
         }
 
         if (message.type === "SET_MENU_ITEMS") {
-          setItems(message.items)
+          setMenuItems(message.items)
         }
 
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
@@ -120,7 +120,7 @@ function withS4ACommunication(
         s4aCommunication={
           {
             currentState: {
-              items,
+              menuItems,
               queryParams,
               forcedModalClose,
               streamlitShareMetadata,


### PR DESCRIPTION
## 📚 Context

Since we'll soon be adding the ability for the host of a streamlit app to configure the app's
toolbar items, the `items` field that the component exposes configurable menu items from
is now named ambiguously.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Renamed the `items` field in the `withS4ACommunication` hoc to `menuItems`