### PR TITLE
Teach `withS4ACommunication` to process `SET_TOOLBAR_ITEMS` messages

### DIFF
--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -25,6 +25,12 @@ export type StreamlitShareMetadata = {
   isOwner?: boolean
 }
 
+export type IToolbarItem = {
+  label: string
+  icon: string
+  key: string
+}
+
 export type IMenuItem =
   | {
       type: "text"
@@ -41,6 +47,10 @@ export type IHostToGuestMessage = {
   | {
       type: "SET_MENU_ITEMS"
       items: IMenuItem[]
+    }
+  | {
+      type: "SET_TOOLBAR_ITEMS"
+      items: IToolbarItem[]
     }
   | {
       type: "UPDATE_FROM_QUERY_PARAMS"

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -82,12 +82,16 @@ export type IGuestToHostMessage =
       key: string
     }
   | {
-      type: "SET_PAGE_TITLE"
-      title: string
+      type: "TOOLBAR_ITEM_CALLBACK"
+      key: string
     }
   | {
       type: "SET_PAGE_FAVICON"
       favicon: string
+    }
+  | {
+      type: "SET_PAGE_TITLE"
+      title: string
     }
   | {
       type: "SET_QUERY_PARAM"

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -16,6 +16,8 @@
  */
 
 import React, { ReactElement } from "react"
+import { act } from "react-dom/test-utils"
+
 import { shallow, mount } from "src/lib/test_util"
 
 import withS4ACommunication, {
@@ -94,5 +96,41 @@ describe("withS4ACommunication HOC", () => {
     )
 
     expect(window.location.hash).toEqual("#somehash")
+  })
+
+  it("can process a received SET_TOOLBAR_ITEMS message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "SET_TOOLBAR_ITEMS",
+            items: [
+              {
+                label: "",
+                icon: "star.svg",
+                key: "favorite",
+              },
+            ],
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+
+    wrapper.update()
+
+    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    expect(props.currentState.toolbarItems).toEqual([
+      {
+        icon: "star.svg",
+        key: "favorite",
+        label: "",
+      },
+    ])
   })
 })

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -21,19 +21,21 @@ import hoistNonReactStatics from "hoist-non-react-statics"
 import { CLOUD_COMM_WHITELIST } from "src/urls"
 
 import {
-  IMenuItem,
-  StreamlitShareMetadata,
-  IHostToGuestMessage,
   IGuestToHostMessage,
+  IHostToGuestMessage,
+  IMenuItem,
+  IToolbarItem,
+  StreamlitShareMetadata,
   VersionedMessage,
 } from "./types"
 
 interface State {
-  queryParams: string
-  menuItems: IMenuItem[]
   forcedModalClose: boolean
-  streamlitShareMetadata: StreamlitShareMetadata
   isOwner: boolean
+  menuItems: IMenuItem[]
+  queryParams: string
+  streamlitShareMetadata: StreamlitShareMetadata
+  toolbarItems: IToolbarItem[]
 }
 
 export interface S4ACommunicationHOC {
@@ -64,6 +66,7 @@ function withS4ACommunication(
     const [forcedModalClose, setForcedModalClose] = useState(false)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
     const [isOwner, setIsOwner] = useState(false)
+    const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -86,25 +89,32 @@ function withS4ACommunication(
           return
         }
 
+        if (message.type === "CLOSE_MODAL") {
+          setForcedModalClose(true)
+        }
+
+        if (message.type === "SET_IS_OWNER") {
+          setIsOwner(message.isOwner)
+        }
+
         if (message.type === "SET_MENU_ITEMS") {
           setMenuItems(message.items)
+        }
+
+        if (message.type === "SET_METADATA") {
+          setStreamlitShareMetadata(message.metadata)
+        }
+
+        if (message.type === "SET_TOOLBAR_ITEMS") {
+          setToolbarItems(message.items)
         }
 
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
           setQueryParams(message.queryParams)
         }
 
-        if (message.type === "CLOSE_MODAL") {
-          setForcedModalClose(true)
-        }
-        if (message.type === "SET_METADATA") {
-          setStreamlitShareMetadata(message.metadata)
-        }
         if (message.type === "UPDATE_HASH") {
           window.location.hash = message.hash
-        }
-        if (message.type === "SET_IS_OWNER") {
-          setIsOwner(message.isOwner)
         }
       }
 
@@ -120,11 +130,12 @@ function withS4ACommunication(
         s4aCommunication={
           {
             currentState: {
+              forcedModalClose,
+              isOwner,
               menuItems,
               queryParams,
-              forcedModalClose,
               streamlitShareMetadata,
-              isOwner,
+              toolbarItems,
             },
             connect: () => {
               sendS4AMessage({


### PR DESCRIPTION
## 📚 Context

We want the host of a streamlit app to have the ability to set icons in the app
toolbar (to the left of the hamburger menu). This PR is the first real step
toward doing this -- teaching the `withS4ACommunication` hoc to accept a message
allowing the host to define the icons to be added.

A future PR will use the received message to actually do things.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Added new types for the `SET_TOOLBAR_ITEMS` message type
- Had the `withS4ACommunication` hoc process incoming `SET_TOOLBAR_ITEMS`
  messages
- Alphabetized some imports, etc

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: https://github.com/streamlit/streamlit-issues/issues/274