### PR TITLE
Remove CLA agreement in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,9 +50,3 @@ _Insert screenshot of existing UI/code here_
 _Does this depend on other work, documents, or tickets?_
 
 - **Issue**: Closes #XXXX
-
----
-
-**Contribution License Agreement**
-
-By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


### PR DESCRIPTION
## 📚 Context

We now use a bot to handle having people sign our CLA, so there's no longer a
reason to have it at the bottom of the PR template.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: PR template cleanup
