### PR TITLE
Make `IToolbarItem`'s `label` and `icon` fields optional

### DIFF
--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -26,8 +26,8 @@ export type StreamlitShareMetadata = {
 }
 
 export type IToolbarItem = {
-  label: string
-  icon: string
+  label?: string
+  icon?: string
   key: string
 }
 


### PR DESCRIPTION
## 📚 Context

When we receive a toolbar item from the host of a streamlit app, it will set _either_ a label or an icon -- not both.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: preemptive types cleanup
