### PR TITLE
Add option to show/hide developer options menu

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -261,6 +261,7 @@ describe("App.handleNewReport", () => {
       maxCachedMessageAge: 0,
       mapboxToken: "mapboxToken",
       allowRunOnSave: false,
+      developerOptionsMenu: "auto",
     },
     customTheme: {
       primaryColor: "red",
@@ -688,5 +689,85 @@ describe("Test Main Menu shortcut functionality", () => {
     wrapper.instance().keyHandlers.CLEAR_CACHE()
 
     expect(wrapper.instance().openClearCacheDialog).toBeCalled()
+  })
+})
+
+describe("Test Developer Options Menu shows up as expected", () => {
+  const NEW_REPORT_JSON = {
+    config: {
+      sharingEnabled: false,
+      gatherUsageStats: false,
+      maxCachedMessageAge: 0,
+      mapboxToken: "mapboxToken",
+      allowRunOnSave: false,
+      developerOptionsMenu: "auto",
+    },
+    customTheme: {
+      primaryColor: "red",
+    },
+    initialize: {
+      userInfo: {
+        installationId: "installationId",
+        installationIdV3: "installationIdV3",
+        email: "email",
+      },
+      environmentInfo: {
+        streamlitVersion: "streamlitVersion",
+        pythonVersion: "pythonVersion",
+      },
+      sessionState: {
+        runOnSave: false,
+        reportIsRunning: false,
+      },
+      sessionId: "sessionId",
+      commandLine: "commandLine",
+    },
+  }
+
+  it("Should be present if developerOptionsMenu is set to on", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    const report: NewReport = new NewReport(NEW_REPORT_JSON)
+    report.developerOptionsMenu = "on"
+    wrapper.instance().handleNewReport(report)
+
+    expect(wrapper.find(MainMenu).props().showDeveloperOptionsMenu === true)
+  })
+
+  it("Should be absent if developerOptionsMenu is set to on", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    const report: NewReport = new NewReport(NEW_REPORT_JSON)
+    report.developerOptionsMenu = "off"
+    wrapper.instance().handleNewReport(report)
+
+    expect(wrapper.find(MainMenu).props().showDeveloperOptionsMenu === false)
+  })
+
+  it("Should be present if developerOptionsMenu is set to 'auto' and we are on localhost", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    const report: NewReport = new NewReport(NEW_REPORT_JSON)
+    report.developerOptionsMenu = "auto"
+    wrapper.instance().handleNewReport(report)
+
+    expect(wrapper.find(MainMenu).props().showDeveloperOptionsMenu === true)
+  })
+
+  it("Should be absent if developerOptionsMenu is set to 'auto' and we are not on localhost", () => {
+    delete window.location
+    window.location = {
+      assign: jest.fn(),
+      host: "example.com",
+      href: "example.com",
+    }
+
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    const report: NewReport = new NewReport(NEW_REPORT_JSON)
+    report.developerOptionsMenu = "auto"
+    wrapper.instance().handleNewReport(report)
+
+    expect(wrapper.find(MainMenu).props().showDeveloperOptionsMenu === false)
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,6 +133,7 @@ interface State {
   themeHash: string | null
   gitInfo: IGitInfo | null
   formsData: FormsData
+  developerOptionsMenu: string
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -199,6 +200,7 @@ export class App extends PureComponent<Props, State> {
       themeHash: null,
       gitInfo: null,
       formsData: createFormsData(),
+      developerOptionsMenu: "auto",
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -248,12 +250,22 @@ export class App extends PureComponent<Props, State> {
     STOP_RECORDING: { sequence: "esc", action: "keyup" },
   }
 
+  shouldDisplayDeveloperOptionsMenu(): boolean {
+    if (this.state.developerOptionsMenu === "auto") {
+      return isLocalhost()
+    }
+    return this.state.developerOptionsMenu === "on"
+  }
+
   keyHandlers = {
     RERUN: () => {
       this.rerunScript()
     },
     CLEAR_CACHE: () => {
-      if (isLocalhost() || this.props.s4aCommunication.currentState.isOwner) {
+      if (
+        this.shouldDisplayDeveloperOptionsMenu() ||
+        this.props.s4aCommunication.currentState.isOwner
+      ) {
         this.openClearCacheDialog()
       }
     },
@@ -603,6 +615,7 @@ export class App extends PureComponent<Props, State> {
     this.setState({
       sharingEnabled: config.sharingEnabled,
       allowRunOnSave: config.allowRunOnSave,
+      developerOptionsMenu: config.developerOptionsMenu,
     })
 
     const { reportHash } = this.state
@@ -1182,6 +1195,7 @@ export class App extends PureComponent<Props, State> {
                 loadGitInfo={this.sendLoadGitInfoBackMsg}
                 canDeploy={SessionInfo.isSet() && !SessionInfo.isHello}
                 menuItems={menuItems}
+                showDeveloperOptionsMenu={this.shouldDisplayDeveloperOptionsMenu()}
               />
             </Header>
 

--- a/frontend/src/components/core/MainMenu/MainMenu.test.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.test.tsx
@@ -54,6 +54,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
   canDeploy: true,
   menuItems: {},
   s4aIsOwner: false,
+  showDeveloperOptionsMenu: true,
   ...extend,
 })
 
@@ -392,15 +393,11 @@ describe("App", () => {
     ])
   })
 
-  it("should not render dev menu when s4aIsOwner is false and not on localhost", () => {
-    // set isLocalhost to false by deleting window.location.
-    // Source: https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
-    delete window.location
-
-    window.location = {
-      assign: jest.fn(),
-    }
-    const props = getProps()
+  it("should not render dev menu when s4aIsOwner is false and showDeveloperOptionsMenu is false", () => {
+    const props = getProps({
+      s4aIsOwner: false,
+      showDeveloperOptionsMenu: false,
+    })
     const wrapper = mount(<MainMenu {...props} />)
     const popoverContent = wrapper.find("StatefulPopover").prop("content")
     // @ts-ignore

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -123,6 +123,8 @@ export interface Props {
   menuItems?: PageConfig.IMenuItems | null
 
   s4aIsOwner?: boolean
+
+  showDeveloperOptionsMenu: boolean
 }
 
 const getOpenInWindowCallback = (url: string) => (): void => {
@@ -541,7 +543,7 @@ function MainMenu(props: Props): ReactElement {
     }
   }
 
-  const { s4aIsOwner } = props
+  const { s4aIsOwner, showDeveloperOptionsMenu } = props
 
   return (
     <StatefulPopover
@@ -555,7 +557,7 @@ function MainMenu(props: Props): ReactElement {
       content={({ close }) => (
         <>
           <SubMenu menuItems={menuItems} closeMenu={close} isDevMenu={false} />
-          {(s4aIsOwner || isLocalhost()) && (
+          {(s4aIsOwner || showDeveloperOptionsMenu) && (
             <StyledUl>
               <SubMenu
                 menuItems={devMenuItems}

--- a/frontend/src/components/core/MainMenu/__snapshots__/MainMenu.test.tsx.snap
+++ b/frontend/src/components/core/MainMenu/__snapshots__/MainMenu.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`App renders without crashing 1`] = `
   shareCallback={[MockFunction]}
   sharingEnabled={false}
   showDeployError={[MockFunction]}
+  showDeveloperOptionsMenu={true}
 >
   <StatefulPopover
     accessibilityType="menu"

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -656,6 +656,17 @@ def _server_enable_websocket_compression() -> bool:
 _create_section("browser", "Configuration of browser front-end.")
 
 
+@_create_option("browser.developerOptionsMenu", type_=str)
+def _browser_show_developer_options() -> str:
+    """Determines whether the developer options menu is visible or not.
+    It can take the value of on, off or auto. If this is auto, then it
+    is shown only if the server is running on localhost.
+
+    Default: "auto"
+    """
+    return "auto"
+
+
 @_create_option("browser.serverAddress")
 def _browser_server_address() -> str:
     """Internet address where users should point their browsers in order to

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -669,12 +669,20 @@ class ReportSession(object):
         return self._storage
 
 
+def _get_developer_options_menu() -> str:
+    option = config.get_option("browser.developerOptionsMenu").lower()
+    if option in ["on", "off", "auto"]:
+        return option
+    raise ValueError(f"Unsupported value for browser.developerOptionsMenu: '{option}'.")
+
+
 def _populate_config_msg(msg: Config) -> None:
     msg.sharing_enabled = config.get_option("global.sharingMode") != "off"
     msg.gather_usage_stats = config.get_option("browser.gatherUsageStats")
     msg.max_cached_message_age = config.get_option("global.maxCachedMessageAge")
     msg.mapbox_token = config.get_option("mapbox.token")
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
+    msg.developer_options_menu = _get_developer_options_menu()
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -286,6 +286,7 @@ class ConfigTest(unittest.TestCase):
     def test_config_option_keys(self):
         config_options = sorted(
             [
+                "browser.developerOptionsMenu",
                 "browser.gatherUsageStats",
                 "browser.serverAddress",
                 "browser.serverPort",

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -87,6 +87,9 @@ message Config {
 
   // See config option "server.allowRunOnSave".
   bool allow_run_on_save = 5;
+
+  // See config option "browser.developerOptionsMenu".
+  string developer_options_menu = 6;
 }
 
 // Custom theme configuration options. Like other config options, these are set


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This fixes the bug originally identified in #4150.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes
 It does so by introducing a new config parameter 'browser.developerOptionsMenu'. This parameter can be 'on', 'off' or 'auto'. 
- on means the developer options menu is always visible.
- off means it's invisible
- auto means it's visible only on localhost and invisible otherwise.

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Resolves #4150

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
