### PR TITLE
st.echo: improved readability

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -484,6 +484,13 @@ def echo(code_location="above"):
             source_lines = source_file.readlines()
             lines_to_display.extend(source_lines[start_line:end_line])
 
+            # Our "end_line" is not necessarily the last line in the echo
+            # block. Iterate over the remaining lines in the source file
+            # until we find one that's indented less than the rest of the
+            # block. Note that this is *not* a perfect strategy, because
+            # de-denting is not guaranteed to signal "end of block". (A
+            # triple-quoted string might be dedented but still in the
+            # echo block, for example.)
             if len(lines_to_display) > 0:
                 match = _SPACES_RE.match(lines_to_display[0])
                 initial_spaces = match.end() if match else 0

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -69,8 +69,6 @@ from streamlit import code_util as _code_util
 from streamlit import env_util as _env_util
 from streamlit import source_util as _source_util
 from streamlit import string_util as _string_util
-from streamlit.commands import page_config as _page_config
-from streamlit.state.session_state import LazySessionState as _LazySessionState
 from streamlit.delta_generator import DeltaGenerator as _DeltaGenerator
 from streamlit.report_thread import add_report_ctx as _add_report_ctx
 from streamlit.report_thread import get_report_ctx as _get_report_ctx
@@ -81,7 +79,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto import ForwardMsg_pb2 as _ForwardMsg_pb2
 
 # Modules that the user should have access to. These are imported with "as"
-# syntax pass to mypy checking with implicit_reexport disabled.
+# syntax pass mypy checking with implicit_reexport disabled.
 
 from streamlit.echo import echo as echo
 from streamlit.legacy_caching import cache as cache
@@ -188,11 +186,15 @@ _arrow_bar_chart = _main._arrow_bar_chart
 _arrow_line_chart = _main._arrow_line_chart
 _arrow_vega_lite_chart = _main._arrow_vega_lite_chart
 
-# Non-DeltaGenerator APIs
-
+# Config
 get_option = _config.get_option
-session_state = _LazySessionState()
-set_page_config = _page_config.set_page_config
+from streamlit.commands.page_config import set_page_config
+
+# Session State
+
+from streamlit.state.session_state import LazySessionState
+
+session_state = LazySessionState()
 
 
 # Beta APIs

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -1,0 +1,95 @@
+# Copyright 2018-2021 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import re
+import textwrap
+import traceback
+from typing import List
+
+_SPACES_RE = re.compile("\\s*")
+
+
+@contextlib.contextmanager
+def echo(code_location="above"):
+    """Use in a `with` block to draw some code on the app, then execute it.
+
+    Parameters
+    ----------
+    code_location : "above" or "below"
+        Whether to show the echoed code before or after the results of the
+        executed code block.
+
+    Example
+    -------
+
+    >>> with st.echo():
+    >>>     st.write('This code will be printed')
+
+    """
+
+    from streamlit import code, warning, empty, source_util
+
+    if code_location == "below":
+        show_code = code
+        show_warning = warning
+    else:
+        placeholder = empty()
+        show_code = placeholder.code
+        show_warning = placeholder.warning
+
+    try:
+        # Get stack frame *before* running the echoed code. The frame's
+        # line number will point to the `st.echo` statement we're running.
+        frame = traceback.extract_stack()[-3]
+        filename, start_line = frame.filename, frame.lineno
+
+        # Run the echoed code.
+        yield
+
+        # Get stack frame *after* running code. This frame's line number will
+        # point to the last line in the echoed code.
+        frame = traceback.extract_stack()[-3]
+        end_line = frame.lineno
+
+        # Open the file containing the source code of the echoed statement,
+        # and extract the lines inside the `with st.echo` block.
+        lines_to_display: List[str] = []
+        with source_util.open_python_file(filename) as source_file:
+            source_lines = source_file.readlines()
+            lines_to_display.extend(source_lines[start_line:end_line])
+
+            # Our "end_line" is not necessarily the last line in the echo
+            # block. Iterate over the remaining lines in the source file
+            # until we find one that's indented less than the rest of the
+            # block. Note that this is *not* a perfect strategy, because
+            # de-denting is not guaranteed to signal "end of block". (A
+            # triple-quoted string might be dedented but still in the
+            # echo block, for example.)
+            if len(lines_to_display) > 0:
+                match = _SPACES_RE.match(lines_to_display[0])
+                initial_spaces = match.end() if match else 0
+                for line in source_lines[end_line:]:
+                    match = _SPACES_RE.match(line)
+                    indentation = match.end() if match else 0
+                    # The != 1 is because we want to allow '\n' between sections.
+                    if indentation != 1 and indentation < initial_spaces:
+                        break
+                    lines_to_display.append(line)
+
+        line_to_display = textwrap.dedent("".join(lines_to_display))
+        show_code(line_to_display, "python")
+
+    except FileNotFoundError as err:
+        show_warning("Unable to display code. %s" % err)

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -26,6 +26,7 @@ LOGGER = get_logger(__name__)
 
 
 CONFUSING_STREAMLIT_MODULES = (
+    "streamlit.echo",
     "streamlit.delta_generator",
     "streamlit.legacy_caching.caching",
 )

--- a/lib/tests/streamlit/echo_test.py
+++ b/lib/tests/streamlit/echo_test.py
@@ -12,37 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
+
 from tests import testutil
 import streamlit as st
 
 
 class EchoTest(testutil.DeltaGeneratorTestCase):
-    def test_echo(self):
-        for echo, echo_index, output_index in [
-            (lambda: st.echo(), 0, 1),
-            (lambda: st.echo("above"), 0, 1),
-            (lambda: st.echo("below"), 1, 0),
-        ]:
+    @parameterized.expand(
+        [
+            ("code_location default", lambda: st.echo(), 0, 1),
+            ("code_location above", lambda: st.echo("above"), 0, 1),
+            ("code_location below", lambda: st.echo("below"), 1, 0),
+        ]
+    )
+    def test_echo(self, _, echo, echo_index, output_index):
+        # The empty lines below are part of the test. Do not remove them.
+        with echo():
+            st.write("Hello")
 
-            # The empty lines below are part of the test. Do not remove them.
-            with echo():
-                st.write("Hello")
+            "hi"
 
-                "hi"
+            def foo(x):
+                y = x + 10
 
-                def foo(x):
-                    y = x + 10
+                print(y)
 
-                    print(y)
+            class MyClass(object):
+                def do_x(self):
+                    pass
 
-                class MyClass(object):
-                    def do_x(self):
-                        pass
+                def do_y(self):
+                    pass
 
-                    def do_y(self):
-                        pass
-
-            echo_str = """```python
+        echo_str = """```python
 st.write("Hello")
 
 "hi"
@@ -62,13 +65,13 @@ class MyClass(object):
 
 ```"""
 
-            element = self.get_delta_from_queue(echo_index).new_element
-            self.assertEqual(echo_str, element.markdown.body)
+        element = self.get_delta_from_queue(echo_index).new_element
+        self.assertEqual(echo_str, element.markdown.body)
 
-            element = self.get_delta_from_queue(output_index).new_element
-            self.assertEqual("Hello", element.markdown.body)
+        element = self.get_delta_from_queue(output_index).new_element
+        self.assertEqual("Hello", element.markdown.body)
 
-            self.clear_queue()
+        self.clear_queue()
 
     def test_root_level_echo(self):
         import tests.streamlit.echo_test_data.root_level_echo


### PR DESCRIPTION
Some drive-by cleanup on st.echo as I was investigating a related issue

- Pulls `st.echo` out of `__init__.py` and into `echo.py`
- `st.echo()` gets more inline comments explaining what the code is doing
- `EchoTest.test_echo` is parameterized