### PR TITLE
Add live Cloud app to st.radio docstring

### DIFF
--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -95,6 +95,10 @@ class RadioMixin:
         ... else:
         ...     st.write("You didn\'t select comedy.")
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.radio.py
+           height: 260px
+
         """
         key = to_key(key)
         check_callback_rules(self.dg, on_change)


### PR DESCRIPTION
## 📚 Context

This PR adds a [Streamlit Cloud app](https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.radio.py) to the `st.radio` docstring. We hope it can be included in the 1.3.0 release. Once merged, the docs team will create a PR in Q1 to replace all static embedded apps in element docstrings with Streamlit Cloud apps.

## 🧠 Description of Changes

- Adds a [Streamlit Cloud app](https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.radio.py) to the `st.radio` docstring.
- [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/145922115-f3b3492b-e668-4cd3-9b7f-11d66f4225d5.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/145922191-ffe5756e-27db-4476-923d-aaf9de7e3460.png)

## 🧪 Testing Done

- [x] Screenshots included

