### PR TITLE
Send theme info to the app host on render and theme change

### DIFF
--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -31,7 +31,7 @@ import { mount } from "src/lib/test_util"
 import { buildHttpUri } from "src/lib/UriUtil"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import React from "react"
-import { darkTheme, lightTheme, toThemeInput } from "src/theme"
+import { darkTheme, lightTheme, toExportedTheme } from "src/theme"
 import { fonts } from "src/theme/primitives/typography"
 import {
   COMPONENT_READY_WARNING_TIME_MS,
@@ -339,7 +339,7 @@ describe("ComponentInstance", () => {
     // We should get the theme object in our receiveForwardMsg callback.
     expect(mc.receiveForwardMsg).toHaveBeenLastCalledWith(
       renderMsg(jsonArgs, [], false, {
-        ...toThemeInput(darkTheme.emotion),
+        ...toExportedTheme(darkTheme.emotion),
         base: "dark",
         font: fonts.sansSerif,
       }),
@@ -578,7 +578,7 @@ function renderMsg(
   dataframes: any[],
   disabled = false,
   theme = {
-    ...toThemeInput(lightTheme.emotion),
+    ...toExportedTheme(lightTheme.emotion),
     base: "light",
     font: fonts.sansSerif,
   }

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -34,12 +34,7 @@ import { Timer } from "src/lib/Timer"
 import { Source, WidgetStateManager } from "src/lib/WidgetStateManager"
 import queryString from "query-string"
 import React, { createRef, ReactNode } from "react"
-import {
-  bgColorToBaseString,
-  fontEnumToString,
-  toThemeInput,
-  Theme,
-} from "src/theme"
+import { Theme, toExportedTheme } from "src/theme"
 import { COMMUNITY_URL, COMPONENT_DEVELOPER_URL } from "src/urls"
 import { ComponentRegistry } from "./ComponentRegistry"
 import { ComponentMessageType, StreamlitMessageType } from "./enums"
@@ -309,9 +304,6 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
    * received from Python.
    */
   private sendRenderMessage = (): void => {
-    const { theme } = this.props
-    const themeInput = toThemeInput(theme)
-
     // NB: if you change or remove any of the arguments here, you'll break
     // existing components. You can *add* more arguments safely, but any
     // other modifications require a CUSTOM_COMPONENT_API_VERSION bump.
@@ -319,11 +311,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       args: this.curArgs,
       dfs: this.curDataframeArgs,
       disabled: this.props.disabled,
-      theme: {
-        ...themeInput,
-        base: bgColorToBaseString(themeInput.backgroundColor),
-        font: fontEnumToString(themeInput.font),
-      },
+      theme: toExportedTheme(this.props.theme),
     })
   }
 

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { ExportedTheme } from "src/theme"
+
 export type StreamlitShareMetadata = {
   hostedAt?: string
   creatorId?: string
@@ -96,6 +98,10 @@ export type IGuestToHostMessage =
   | {
       type: "SET_QUERY_PARAM"
       queryParams: string
+    }
+  | {
+      type: "SET_THEME_CONFIG"
+      themeInfo: ExportedTheme
     }
   | {
       type: "UPDATE_HASH"

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -265,9 +265,22 @@ export const createBaseUiTheme = (
     createThemeOverrides(theme)
   )
 
+type DerivedColors = {
+  linkText: string
+  fadedText05: string
+  fadedText10: string
+  fadedText40: string
+  fadedText60: string
+
+  bgMix: string
+  darkenedBgMix60: string
+  transparentDarkenedBgMix60: string
+  lightenedBg05: string
+}
+
 const computeDerivedColors = (
   genericColors: Record<string, string>
-): Record<string, string> => {
+): DerivedColors => {
   const { bodyText, secondaryBg, bgColor } = genericColors
 
   const hasLightBg = getLuminance(bgColor) > 0.5
@@ -408,6 +421,35 @@ export const toThemeInput = (theme: Theme): Partial<CustomThemeConfig> => {
     secondaryBackgroundColor: colors.secondaryBg,
     textColor: colors.bodyText,
     font: fontToEnum(genericFonts.bodyFont),
+  }
+}
+
+export type ExportedTheme = {
+  base: string
+  primaryColor: string
+  backgroundColor: string
+  secondaryBackgroundColor: string
+  textColor: string
+  font: string
+} & DerivedColors
+
+export const toExportedTheme = (theme: Theme): ExportedTheme => {
+  const { genericColors } = theme
+  const themeInput = toThemeInput(theme)
+
+  // At this point, we know that all of the fields of themeInput are populated
+  // (since we went "backwards" from a theme -> themeInput), but typescript
+  // doesn't know this, so we have to cast each field to string.
+  return {
+    primaryColor: themeInput.primaryColor as string,
+    backgroundColor: themeInput.backgroundColor as string,
+    secondaryBackgroundColor: themeInput.secondaryBackgroundColor as string,
+    textColor: themeInput.textColor as string,
+
+    base: bgColorToBaseString(themeInput.backgroundColor),
+    font: fontEnumToString(themeInput.font) as string,
+
+    ...computeDerivedColors(genericColors),
   }
 }
 


### PR DESCRIPTION
## 📚 Context

There are some use cases when the host of a streamlit app will find it useful to know
what the active theme of an app is. This will generally occur when the host wants to
display its own UI elements over the app and wants them to match the app's color palette.

To facilitate this, this PR uses the `withS4ACommunication` component to send a new
`SET_THEME_CONFIG` type containing this data to the host of a streamlit app. It
additionally refactors the code used to send theme info to custom components to share
code with our new use case, and finally it adds "derived colors" to the data that gets sent.

<br />

- What kind of change does this PR introduce?

  - [x] Feature
  - [x] Refactoring

## 🧠 Description of Changes

- Adds a new message type to `withS4ACommunication` allowing theme config info to be sent
- Sends messages of this type on first app render and on theme changes
- Refactors the way custom components receive theme info to use the same code

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes (https://github.com/streamlit/streamlit-issues/issues/311)
