### PR TITLE
Fix recursion error in repr method of report thread

### DIFF
--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -205,9 +205,6 @@ class ReportThread(threading.Thread):
             uploaded_file_mgr=uploaded_file_mgr,
         )
 
-    def __repr__(self) -> str:
-        return util.repr_(self)
-
 
 def add_report_ctx(
     thread: Optional[threading.Thread] = None, ctx: Optional[ReportContext] = None

--- a/lib/tests/streamlit/repr_test.py
+++ b/lib/tests/streamlit/repr_test.py
@@ -22,3 +22,11 @@ def test_repr_dict_class():
     foo = Foo()
     foo.bar = "bar"
     assert repr(foo) == "Foo(bar='bar')"
+
+
+def test_repr_thread_class():
+    import threading
+
+    thread = threading.current_thread()
+    # This should return a non empty string and not raise an exception.
+    assert str(thread) is not None


### PR DESCRIPTION
## 📚 Context

If `str` or `repr` is called on a `ReportThread` instance, a `RecursionError` will be thrown. The reason is that `ReportThread` contains reference to `ScriptRunner` (in `_target`) and `ScriptRunner` contains a reference to the `ReportThread` in `_script_thread`. This is causing a recursion.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Removed the `__repr__` implementation from `ReportThread` since it is not usable because of the self-reference causing a `RecursionError`.

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Code Snippet:**

```python
import streamlit as st
import threading

thread = threading.current_thread()
st.info('Weird case %s' % thread)
```

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4172

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
