### PR TITLE
Add ability for an app's host to configure its toolbar items

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -221,6 +221,7 @@ describe("App", () => {
       },
     })
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ hideTopBar: false })
 
     expect(wrapper.find(ToolbarActions).prop("s4aToolbarItems")).toStrictEqual(
       [
@@ -316,6 +317,22 @@ describe("App", () => {
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(darkTheme.emotion),
     })
+  })
+
+  it("hides the top bar if hideTopBar === true", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    // hideTopBar is true by default
+
+    expect(wrapper.find("WithTheme(StatusWidget)").exists()).toBe(false)
+    expect(wrapper.find("ToolbarActions").exists()).toBe(false)
+  })
+
+  it("shows the top bar if hideTopBar === false", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    wrapper.setState({ hideTopBar: false })
+
+    expect(wrapper.find("WithTheme(StatusWidget)").exists()).toBe(true)
+    expect(wrapper.find("ToolbarActions").exists()).toBe(true)
   })
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -53,7 +53,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
     onModalReset: jest.fn(),
     currentState: {
       queryParams: "",
-      items: [],
+      menuItems: [],
       forcedModalClose: false,
       isOwner: true,
     },
@@ -181,7 +181,7 @@ describe("App", () => {
         sendMessage: jest.fn(),
         currentState: {
           queryParams: "",
-          items: [
+          menuItems: [
             {
               type: "separator",
             },
@@ -222,7 +222,7 @@ describe("App", () => {
           s4aCommunication: {
             onModalReset,
             currentState: {
-              items: [],
+              menuItems: [],
               queryParams: "",
               forcedModalClose: false,
             },

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,7 +27,7 @@ import {
   PageConfig,
   PageInfo,
 } from "src/autogen/proto"
-import { IMenuItem } from "src/hocs/withS4ACommunication/types"
+import { IMenuItem, IToolbarItem } from "src/hocs/withS4ACommunication/types"
 import { ConnectionState } from "src/lib/ConnectionState"
 import { MetricsManager } from "src/lib/MetricsManager"
 import { getMetricsManagerForTest } from "src/lib/MetricsManagerTestUtils"
@@ -37,6 +37,7 @@ import Modal from "./components/shared/Modal"
 import { DialogType, StreamlitDialog } from "./components/core/StreamlitDialog"
 import { App, Props } from "./App"
 import MainMenu from "./components/core/MainMenu"
+import ToolbarActions from "./components/core/ToolbarActions"
 
 jest.mock("src/lib/ConnectionManager")
 
@@ -195,6 +196,34 @@ describe("App", () => {
     expect(wrapper.find(MainMenu).prop("s4aMenuItems")).toStrictEqual([
       { type: "separator" },
     ])
+  })
+
+  it("shows s4aToolbarItems", () => {
+    const props = getProps({
+      s4aCommunication: {
+        connect: jest.fn(),
+        sendMessage: jest.fn(),
+        currentState: {
+          queryParams: "",
+          toolbarItems: [
+            {
+              key: "favorite",
+              icon: "star.svg",
+            },
+          ] as IToolbarItem[],
+        },
+      },
+    })
+    const wrapper = shallow(<App {...props} />)
+
+    expect(wrapper.find(ToolbarActions).prop("s4aToolbarItems")).toStrictEqual(
+      [
+        {
+          key: "favorite",
+          icon: "star.svg",
+        },
+      ]
+    )
   })
 
   it("closes modals when the modal closure message has been received", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -54,6 +54,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
     currentState: {
       queryParams: "",
       menuItems: [],
+      toolbarItems: [],
       forcedModalClose: false,
       isOwner: true,
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,6 +135,7 @@ interface State {
   themeHash: string | null
   gitInfo: IGitInfo | null
   formsData: FormsData
+  hideTopBar: boolean
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -201,6 +202,11 @@ export class App extends PureComponent<Props, State> {
       themeHash: null,
       gitInfo: null,
       formsData: createFormsData(),
+      // We set this to true by default because this information isn't
+      // available on page load (we get it when the script begins to run), so
+      // the user would see top bar elements for a few ms if this defaulted to
+      // false.
+      hideTopBar: true,
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -610,6 +616,7 @@ export class App extends PureComponent<Props, State> {
     this.setState({
       sharingEnabled: config.sharingEnabled,
       allowRunOnSave: config.allowRunOnSave,
+      hideTopBar: config.hideTopBar,
     })
 
     const { reportHash } = this.state
@@ -1127,6 +1134,7 @@ export class App extends PureComponent<Props, State> {
       sharingEnabled,
       userSettings,
       gitInfo,
+      hideTopBar,
     } = this.state
 
     const outerDivClass = classNames("stApp", {
@@ -1171,20 +1179,24 @@ export class App extends PureComponent<Props, State> {
           <StyledApp className={outerDivClass}>
             {/* The tabindex below is required for testing. */}
             <Header>
-              <StatusWidget
-                connectionState={connectionState}
-                sessionEventDispatcher={this.sessionEventDispatcher}
-                reportRunState={reportRunState}
-                rerunReport={this.rerunScript}
-                stopReport={this.stopReport}
-                allowRunOnSave={allowRunOnSave}
-              />
-              <ToolbarActions
-                s4aToolbarItems={
-                  this.props.s4aCommunication.currentState.toolbarItems
-                }
-                sendS4AMessage={this.props.s4aCommunication.sendMessage}
-              />
+              {!hideTopBar && (
+                <>
+                  <StatusWidget
+                    connectionState={connectionState}
+                    sessionEventDispatcher={this.sessionEventDispatcher}
+                    reportRunState={reportRunState}
+                    rerunReport={this.rerunScript}
+                    stopReport={this.stopReport}
+                    allowRunOnSave={allowRunOnSave}
+                  />
+                  <ToolbarActions
+                    s4aToolbarItems={
+                      this.props.s4aCommunication.currentState.toolbarItems
+                    }
+                    sendS4AMessage={this.props.s4aCommunication.sendMessage}
+                  />
+                </>
+              )}
               <MainMenu
                 sharingEnabled={sharingEnabled === true}
                 isServerConnected={this.isServerConnected()}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1170,7 +1170,9 @@ export class App extends PureComponent<Props, State> {
                 aboutCallback={this.aboutCallback}
                 screencastCallback={this.screencastCallback}
                 screenCastState={this.props.screenCast.currentState}
-                s4aMenuItems={this.props.s4aCommunication.currentState.items}
+                s4aMenuItems={
+                  this.props.s4aCommunication.currentState.menuItems
+                }
                 s4aIsOwner={this.props.s4aCommunication.currentState.isOwner}
                 sendS4AMessage={this.props.s4aCommunication.sendMessage}
                 gitInfo={gitInfo}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import PageLayoutContext from "src/components/core/PageLayoutContext"
 import ReportView from "src/components/core/ReportView"
 import StatusWidget from "src/components/core/StatusWidget"
 import MainMenu, { isLocalhost } from "src/components/core/MainMenu"
+import ToolbarButtons from "src/components/core/ToolbarButtons"
 import Header from "src/components/core/Header"
 import {
   DialogProps,
@@ -1159,6 +1160,12 @@ export class App extends PureComponent<Props, State> {
                 rerunReport={this.rerunScript}
                 stopReport={this.stopReport}
                 allowRunOnSave={allowRunOnSave}
+              />
+              <ToolbarButtons
+                s4aToolbarItems={
+                  this.props.s4aCommunication.currentState.toolbarItems
+                }
+                sendS4AMessage={this.props.s4aCommunication.sendMessage}
               />
               <MainMenu
                 sharingEnabled={sharingEnabled === true}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ import PageLayoutContext from "src/components/core/PageLayoutContext"
 import ReportView from "src/components/core/ReportView"
 import StatusWidget from "src/components/core/StatusWidget"
 import MainMenu, { isLocalhost } from "src/components/core/MainMenu"
-import ToolbarButtons from "src/components/core/ToolbarButtons"
+import ToolbarActions from "src/components/core/ToolbarActions"
 import Header from "src/components/core/Header"
 import {
   DialogProps,
@@ -1161,7 +1161,7 @@ export class App extends PureComponent<Props, State> {
                 stopReport={this.stopReport}
                 allowRunOnSave={allowRunOnSave}
               />
-              <ToolbarButtons
+              <ToolbarActions
                 s4aToolbarItems={
                   this.props.s4aCommunication.currentState.toolbarItems
                 }

--- a/frontend/src/components/core/MainMenu/__snapshots__/MainMenu.test.tsx.snap
+++ b/frontend/src/components/core/MainMenu/__snapshots__/MainMenu.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`App renders without crashing 1`] = `
             >
               <button
                 autoFocus={false}
-                className="css-izgjtx-StyledBaseButton-StyledIconButton edgvbvh6"
+                className="css-107haio-StyledBaseButton-StyledIconButton edgvbvh6"
                 disabled={false}
                 kind="icon"
                 onClick={[Function]}

--- a/frontend/src/components/core/StatusWidget/__snapshots__/StatusWidget.test.tsx.snap
+++ b/frontend/src/components/core/StatusWidget/__snapshots__/StatusWidget.test.tsx.snap
@@ -894,7 +894,7 @@ exports[`Tooltip element renders running img correctly with custom dark backgrou
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}
@@ -1810,7 +1810,7 @@ exports[`Tooltip element renders running img correctly with custom light backgro
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}
@@ -2726,7 +2726,7 @@ exports[`Tooltip element renders running img correctly with darkTheme 1`] = `
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}
@@ -3642,7 +3642,7 @@ exports[`Tooltip element renders running img correctly with lightTheme 1`] = `
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from "react"
+
+import { shallow } from "src/lib/test_util"
+
+import { StyledActionButtonIcon } from "./styled-components"
+import ToolbarActions, {
+  ActionButton,
+  ActionButtonProps,
+  ToolbarActionsProps,
+} from "./ToolbarActions"
+
+describe("ActionButton", () => {
+  const getProps = (
+    extended?: Partial<ActionButtonProps>
+  ): ActionButtonProps => ({
+    label: "the label",
+    icon: "star.svg",
+    onClick: jest.fn(),
+    ...extended,
+  })
+
+  it("renders without crashing and matches snapshot", () => {
+    const wrapper = shallow(<ActionButton {...getProps()} />)
+
+    expect(wrapper).toMatchSnapshot()
+    expect(wrapper.find(StyledActionButtonIcon)).toHaveLength(1)
+    expect(wrapper.find("span")).toHaveLength(1)
+  })
+
+  it("does not render icon if not provided", () => {
+    const wrapper = shallow(
+      <ActionButton {...getProps({ icon: undefined })} />
+    )
+
+    expect(wrapper.find(StyledActionButtonIcon).exists()).toBe(false)
+    expect(wrapper.find("span")).toHaveLength(1)
+  })
+
+  it("does not render label if not provided", () => {
+    const wrapper = shallow(
+      <ActionButton {...getProps({ label: undefined })} />
+    )
+
+    expect(wrapper.find(StyledActionButtonIcon)).toHaveLength(1)
+    expect(wrapper.find("span").exists()).toBe(false)
+  })
+})
+
+describe("ToolbarActions", () => {
+  const getProps = (
+    extended?: Partial<ToolbarActionsProps>
+  ): ToolbarActionsProps => ({
+    s4aToolbarItems: [
+      { key: "favorite", icon: "star.svg" },
+      { key: "share", label: "Share" },
+    ],
+    sendS4AMessage: jest.fn(),
+    ...extended,
+  })
+
+  it("renders without crashing", () => {
+    const wrapper = shallow(<ToolbarActions {...getProps()} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it("calls sendS4AMessage with correct args when clicked", () => {
+    const props = getProps()
+    const wrapper = shallow(<ToolbarActions {...props} />)
+
+    wrapper
+      .find(ActionButton)
+      .at(0)
+      .simulate("click")
+    expect(props.sendS4AMessage).toHaveBeenLastCalledWith({
+      type: "TOOLBAR_ITEM_CALLBACK",
+      key: "favorite",
+    })
+
+    wrapper
+      .find(ActionButton)
+      .at(1)
+      .simulate("click")
+    expect(props.sendS4AMessage).toHaveBeenLastCalledWith({
+      type: "TOOLBAR_ITEM_CALLBACK",
+      key: "share",
+    })
+  })
+})

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
@@ -29,6 +29,7 @@ describe("ActionButton", () => {
   const getProps = (
     extended?: Partial<ActionButtonProps>
   ): ActionButtonProps => ({
+    borderless: false,
     label: "the label",
     icon: "star.svg",
     onClick: jest.fn(),
@@ -48,15 +49,17 @@ describe("ActionButton", () => {
       <ActionButton {...getProps({ icon: undefined })} />
     )
 
+    expect(wrapper).toMatchSnapshot()
     expect(wrapper.find(StyledActionButtonIcon).exists()).toBe(false)
     expect(wrapper.find("span")).toHaveLength(1)
   })
 
   it("does not render label if not provided", () => {
     const wrapper = shallow(
-      <ActionButton {...getProps({ label: undefined })} />
+      <ActionButton {...getProps({ label: undefined, borderless: true })} />
     )
 
+    expect(wrapper).toMatchSnapshot()
     expect(wrapper.find(StyledActionButtonIcon)).toHaveLength(1)
     expect(wrapper.find("span").exists()).toBe(false)
   })

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -16,11 +16,15 @@
  */
 
 import React, { ReactElement } from "react"
-import Button, { Kind } from "src/components/shared/Button"
 import {
   IGuestToHostMessage,
   IToolbarItem,
 } from "src/hocs/withS4ACommunication/types"
+import Button, { Kind } from "src/components/shared/Button"
+import {
+  StyledActionButtonContainer,
+  StyledActionButtonIcon,
+} from "./styled-components"
 
 export interface ActionButtonProps {
   label?: string
@@ -36,8 +40,10 @@ function ActionButton({
   return (
     <div className="stActionButton">
       <Button onClick={onClick} kind={Kind.ICON}>
-        {icon && <img src={icon}></img>}
-        {label && <span>{label}</span>}
+        <StyledActionButtonContainer>
+          {icon && <StyledActionButtonIcon icon={icon} />}
+          {label && <span>{label}</span>}
+        </StyledActionButtonContainer>
       </Button>
     </div>
   )

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -32,7 +32,7 @@ export interface ActionButtonProps {
   onClick: () => void
 }
 
-function ActionButton({
+export function ActionButton({
   label,
   icon,
   onClick,

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -27,19 +27,22 @@ import {
 } from "./styled-components"
 
 export interface ActionButtonProps {
+  borderless?: boolean
   label?: string
   icon?: string
   onClick: () => void
 }
 
 export function ActionButton({
+  borderless,
   label,
   icon,
   onClick,
 }: ActionButtonProps): ReactElement {
+  const kind = borderless ? Kind.BORDERLESS_ICON : Kind.ICON
   return (
     <div className="stActionButton">
-      <Button onClick={onClick} kind={Kind.ICON}>
+      <Button onClick={onClick} kind={kind}>
         <StyledActionButtonContainer>
           {icon && <StyledActionButtonIcon icon={icon} />}
           {label && <span>{label}</span>}
@@ -60,11 +63,12 @@ function ToolbarActions({
 }: ToolbarActionsProps): ReactElement {
   return (
     <>
-      {s4aToolbarItems.map(({ key, label, icon }) => (
+      {s4aToolbarItems.map(({ borderless, key, label, icon }) => (
         <ActionButton
           key={key}
           label={label}
           icon={icon}
+          borderless={borderless}
           onClick={() =>
             sendS4AMessage({
               type: "TOOLBAR_ITEM_CALLBACK",

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -22,19 +22,19 @@ import {
   IToolbarItem,
 } from "src/hocs/withS4ACommunication/types"
 
-export interface ToolbarButtonProps {
+export interface ActionButtonProps {
   label?: string
   icon?: string
   onClick: () => void
 }
 
-function ToolbarButton({
+function ActionButton({
   label,
   icon,
   onClick,
-}: ToolbarButtonProps): ReactElement {
+}: ActionButtonProps): ReactElement {
   return (
-    <div className="stToolbarButton">
+    <div className="stActionButton">
       <Button onClick={onClick} kind={Kind.ICON}>
         {icon && <img src={icon}></img>}
         {label && <span>{label}</span>}
@@ -43,19 +43,19 @@ function ToolbarButton({
   )
 }
 
-export interface ToolbarButtonsProps {
+export interface ToolbarActionsProps {
   sendS4AMessage: (message: IGuestToHostMessage) => void
   s4aToolbarItems: IToolbarItem[]
 }
 
-function ToolbarButtons({
+function ToolbarActions({
   sendS4AMessage,
   s4aToolbarItems,
-}: ToolbarButtonsProps): ReactElement {
+}: ToolbarActionsProps): ReactElement {
   return (
     <>
       {s4aToolbarItems.map(({ key, label, icon }) => (
-        <ToolbarButton
+        <ActionButton
           key={key}
           label={label}
           icon={icon}
@@ -71,4 +71,4 @@ function ToolbarButtons({
   )
 }
 
-export default ToolbarButtons
+export default ToolbarActions

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -16,11 +16,12 @@
  */
 
 import React, { ReactElement } from "react"
+
+import Button, { Kind } from "src/components/shared/Button"
 import {
   IGuestToHostMessage,
   IToolbarItem,
 } from "src/hocs/withS4ACommunication/types"
-import Button, { Kind } from "src/components/shared/Button"
 import {
   StyledActionButtonContainer,
   StyledActionButtonIcon,

--- a/frontend/src/components/core/ToolbarActions/__snapshots__/ToolbarActions.test.tsx.snap
+++ b/frontend/src/components/core/ToolbarActions/__snapshots__/ToolbarActions.test.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ActionButton does not render icon if not provided 1`] = `
+<div
+  className="stActionButton"
+>
+  <Button
+    kind="icon"
+    onClick={[MockFunction]}
+  >
+    <StyledActionButtonContainer>
+      <span>
+        the label
+      </span>
+    </StyledActionButtonContainer>
+  </Button>
+</div>
+`;
+
+exports[`ActionButton does not render label if not provided 1`] = `
+<div
+  className="stActionButton"
+>
+  <Button
+    kind="borderlessIcon"
+    onClick={[MockFunction]}
+  >
+    <StyledActionButtonContainer>
+      <StyledActionButtonIcon
+        icon="star.svg"
+      />
+    </StyledActionButtonContainer>
+  </Button>
+</div>
+`;
+
 exports[`ActionButton renders without crashing and matches snapshot 1`] = `
 <div
   className="stActionButton"

--- a/frontend/src/components/core/ToolbarActions/__snapshots__/ToolbarActions.test.tsx.snap
+++ b/frontend/src/components/core/ToolbarActions/__snapshots__/ToolbarActions.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionButton renders without crashing and matches snapshot 1`] = `
+<div
+  className="stActionButton"
+>
+  <Button
+    kind="icon"
+    onClick={[MockFunction]}
+  >
+    <StyledActionButtonContainer>
+      <StyledActionButtonIcon
+        icon="star.svg"
+      />
+      <span>
+        the label
+      </span>
+    </StyledActionButtonContainer>
+  </Button>
+</div>
+`;
+
+exports[`ToolbarActions renders without crashing 1`] = `
+<Fragment>
+  <ActionButton
+    icon="star.svg"
+    key="favorite"
+    onClick={[Function]}
+  />
+  <ActionButton
+    key="share"
+    label="Share"
+    onClick={[Function]}
+  />
+</Fragment>
+`;

--- a/frontend/src/components/core/ToolbarActions/index.tsx
+++ b/frontend/src/components/core/ToolbarActions/index.tsx
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export { default } from "./ToolbarButtons"
+export { default } from "./ToolbarActions"

--- a/frontend/src/components/core/ToolbarActions/styled-components.ts
+++ b/frontend/src/components/core/ToolbarActions/styled-components.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+export const StyledActionButtonContainer = styled.div(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing.sm,
+  alignItems: "center",
+  // line height should be the same as the icon size
+  lineHeight: theme.iconSizes.md,
+}))
+
+export interface StyledActionButtonIconProps {
+  icon: string
+}
+
+export const StyledActionButtonIcon = styled.div<StyledActionButtonIconProps>(
+  ({ theme, icon }) => ({
+    background: `url("${icon}") no-repeat center / contain`,
+    width: theme.iconSizes.md,
+    height: theme.iconSizes.md,
+    ".stActionButton:hover &, .stActionButton:focus &": {
+      background: "none",
+      backgroundColor: theme.colors.primary,
+      mask: `url("${icon}") no-repeat center / contain`,
+    },
+    "&:active, .stActionButton:active &": {
+      background: "none",
+      backgroundColor: theme.colors.white,
+      mask: `url("${icon}") no-repeat center / contain`,
+    },
+  })
+)

--- a/frontend/src/components/core/ToolbarActions/styled-components.ts
+++ b/frontend/src/components/core/ToolbarActions/styled-components.ts
@@ -16,6 +16,7 @@
  */
 
 import styled from "@emotion/styled"
+import { transparentize } from "color2k"
 
 export const StyledActionButtonContainer = styled.div(({ theme }) => ({
   display: "flex",
@@ -41,7 +42,7 @@ export const StyledActionButtonIcon = styled.div<StyledActionButtonIconProps>(
     },
     "&:active, .stActionButton:active &": {
       background: "none",
-      backgroundColor: theme.colors.white,
+      backgroundColor: transparentize(theme.colors.primary, 0.5),
       mask: `url("${icon}") no-repeat center / contain`,
     },
   })

--- a/frontend/src/components/core/ToolbarActions/styled-components.ts
+++ b/frontend/src/components/core/ToolbarActions/styled-components.ts
@@ -33,8 +33,13 @@ export interface StyledActionButtonIconProps {
 export const StyledActionButtonIcon = styled.div<StyledActionButtonIconProps>(
   ({ theme, icon }) => ({
     background: `url("${icon}") no-repeat center / contain`,
-    width: theme.iconSizes.md,
-    height: theme.iconSizes.md,
+
+    // NOTE: We intentionally don't use any of the preset theme iconSizes here
+    // so that icon scaling is unchanged from what we receive from the
+    // withS4ACommunication hoc.
+    width: "1rem",
+    height: "1rem",
+
     ".stActionButton:hover &, .stActionButton:focus &": {
       background: "none",
       backgroundColor: theme.colors.primary,

--- a/frontend/src/components/core/ToolbarButtons/ToolbarButtons.tsx
+++ b/frontend/src/components/core/ToolbarButtons/ToolbarButtons.tsx
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement } from "react"
+import Button, { Kind } from "src/components/shared/Button"
+import {
+  IGuestToHostMessage,
+  IToolbarItem,
+} from "src/hocs/withS4ACommunication/types"
+
+export interface ToolbarButtonProps {
+  label?: string
+  icon?: string
+  onClick: () => void
+}
+
+function ToolbarButton({
+  label,
+  icon,
+  onClick,
+}: ToolbarButtonProps): ReactElement {
+  return (
+    <div className="stToolbarButton">
+      <Button onClick={onClick} kind={Kind.ICON}>
+        {icon && <img src={icon}></img>}
+        {label && <span>{label}</span>}
+      </Button>
+    </div>
+  )
+}
+
+export interface ToolbarButtonsProps {
+  sendS4AMessage: (message: IGuestToHostMessage) => void
+  s4aToolbarItems: IToolbarItem[]
+}
+
+function ToolbarButtons({
+  sendS4AMessage,
+  s4aToolbarItems,
+}: ToolbarButtonsProps): ReactElement {
+  return (
+    <>
+      {s4aToolbarItems.map(({ key, label, icon }) => (
+        <ToolbarButton
+          key={key}
+          label={label}
+          icon={icon}
+          onClick={() =>
+            sendS4AMessage({
+              type: "TOOLBAR_ITEM_CALLBACK",
+              key,
+            })
+          }
+        />
+      ))}
+    </>
+  )
+}
+
+export default ToolbarButtons

--- a/frontend/src/components/core/ToolbarButtons/index.tsx
+++ b/frontend/src/components/core/ToolbarButtons/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2018-2021 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./ToolbarButtons"

--- a/frontend/src/components/shared/Button/Button.tsx
+++ b/frontend/src/components/shared/Button/Button.tsx
@@ -20,6 +20,7 @@ import {
   ButtonProps as ButtonPropsT,
   Kind,
   Size,
+  StyledBorderlessIconButton,
   StyledIconButton,
   StyledLinkButton,
   StyledMinimalButton,
@@ -45,6 +46,8 @@ function Button({
     ComponentType = StyledLinkButton
   } else if (kind === Kind.ICON) {
     ComponentType = StyledIconButton
+  } else if (kind === Kind.BORDERLESS_ICON) {
+    ComponentType = StyledBorderlessIconButton
   } else if (kind === Kind.MINIMAL) {
     ComponentType = StyledMinimalButton
   } else if (kind === Kind.FORM_SUBMIT) {

--- a/frontend/src/components/shared/Button/styled-components.ts
+++ b/frontend/src/components/shared/Button/styled-components.ts
@@ -25,6 +25,7 @@ export enum Kind {
   SECONDARY = "secondary",
   LINK = "link",
   ICON = "icon",
+  BORDERLESS_ICON = "borderlessIcon",
   MINIMAL = "minimal",
   FORM_SUBMIT = "formSubmit",
 }
@@ -200,9 +201,8 @@ export const StyledIconButton = styled(StyledBaseButton)<RequiredButtonProps>(
         borderColor: theme.colors.primary,
         color: theme.colors.white,
       },
-      "&:focus:not(:active)": {
-        borderColor: theme.colors.primary,
-        color: theme.colors.primary,
+      "&:not(:active)": {
+        boxShadow: "none",
       },
       "&:disabled, &:disabled:hover, &:disabled:active": {
         backgroundColor: theme.colors.lightGray,
@@ -212,6 +212,33 @@ export const StyledIconButton = styled(StyledBaseButton)<RequiredButtonProps>(
     }
   }
 )
+
+export const StyledBorderlessIconButton = styled(StyledBaseButton)<
+  RequiredButtonProps
+>(({ size, theme }) => {
+  const iconPadding: Record<Size, string> = {
+    [Size.XSMALL]: theme.spacing.threeXS,
+    [Size.SMALL]: theme.spacing.twoXS,
+    [Size.MEDIUM]: theme.spacing.md,
+    [Size.LARGE]: theme.spacing.lg,
+  }
+
+  return {
+    backgroundColor: theme.colors.transparent,
+    border: `1px solid ${theme.colors.transparent}`,
+    padding: iconPadding[size],
+
+    "&:focus": {
+      boxShadow: "none",
+      outline: "none",
+    },
+    "&:disabled, &:disabled:hover, &:disabled:active": {
+      backgroundColor: theme.colors.lightGray,
+      borderColor: theme.colors.transparent,
+      color: theme.colors.gray,
+    },
+  }
+})
 
 export const StyledTooltipNormal = styled.div(({ theme }) => ({
   display: "block",

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -31,7 +31,7 @@ import { mount } from "src/lib/test_util"
 import { buildHttpUri } from "src/lib/UriUtil"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import React from "react"
-import { darkTheme, lightTheme, toThemeInput } from "src/theme"
+import { darkTheme, lightTheme, toExportedTheme } from "src/theme"
 import { fonts } from "src/theme/primitives/typography"
 import {
   COMPONENT_READY_WARNING_TIME_MS,
@@ -339,7 +339,7 @@ describe("ComponentInstance", () => {
     // We should get the theme object in our receiveForwardMsg callback.
     expect(mc.receiveForwardMsg).toHaveBeenLastCalledWith(
       renderMsg(jsonArgs, [], false, {
-        ...toThemeInput(darkTheme.emotion),
+        ...toExportedTheme(darkTheme.emotion),
         base: "dark",
         font: fonts.sansSerif,
       }),
@@ -578,7 +578,7 @@ function renderMsg(
   dataframes: any[],
   disabled = false,
   theme = {
-    ...toThemeInput(lightTheme.emotion),
+    ...toExportedTheme(lightTheme.emotion),
     base: "light",
     font: fonts.sansSerif,
   }

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -34,12 +34,7 @@ import { Timer } from "src/lib/Timer"
 import { Source, WidgetStateManager } from "src/lib/WidgetStateManager"
 import queryString from "query-string"
 import React, { createRef, ReactNode } from "react"
-import {
-  bgColorToBaseString,
-  fontEnumToString,
-  toThemeInput,
-  Theme,
-} from "src/theme"
+import { Theme, toExportedTheme } from "src/theme"
 import { COMMUNITY_URL, COMPONENT_DEVELOPER_URL } from "src/urls"
 import { ComponentRegistry } from "./ComponentRegistry"
 import { ComponentMessageType, StreamlitMessageType } from "./enums"
@@ -309,9 +304,6 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
    * received from Python.
    */
   private sendRenderMessage = (): void => {
-    const { theme } = this.props
-    const themeInput = toThemeInput(theme)
-
     // NB: if you change or remove any of the arguments here, you'll break
     // existing components. You can *add* more arguments safely, but any
     // other modifications require a CUSTOM_COMPONENT_API_VERSION bump.
@@ -319,11 +311,7 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       args: this.curArgs,
       dfs: this.curDataframeArgs,
       disabled: this.props.disabled,
-      theme: {
-        ...themeInput,
-        base: bgColorToBaseString(themeInput.backgroundColor),
-        font: fontEnumToString(themeInput.font),
-      },
+      theme: toExportedTheme(this.props.theme),
     })
   }
 

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { ExportedTheme } from "src/theme"
+
 export type StreamlitShareMetadata = {
   hostedAt?: string
   creatorId?: string
@@ -96,6 +98,10 @@ export type IGuestToHostMessage =
   | {
       type: "SET_QUERY_PARAM"
       queryParams: string
+    }
+  | {
+      type: "SET_THEME_CONFIG"
+      themeInfo: ExportedTheme
     }
   | {
       type: "UPDATE_HASH"

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -25,6 +25,12 @@ export type StreamlitShareMetadata = {
   isOwner?: boolean
 }
 
+export type IToolbarItem = {
+  label: string
+  icon: string
+  key: string
+}
+
 export type IMenuItem =
   | {
       type: "text"
@@ -41,6 +47,10 @@ export type IHostToGuestMessage = {
   | {
       type: "SET_MENU_ITEMS"
       items: IMenuItem[]
+    }
+  | {
+      type: "SET_TOOLBAR_ITEMS"
+      items: IToolbarItem[]
     }
   | {
       type: "UPDATE_FROM_QUERY_PARAMS"
@@ -72,12 +82,16 @@ export type IGuestToHostMessage =
       key: string
     }
   | {
-      type: "SET_PAGE_TITLE"
-      title: string
+      type: "TOOLBAR_ITEM_CALLBACK"
+      key: string
     }
   | {
       type: "SET_PAGE_FAVICON"
       favicon: string
+    }
+  | {
+      type: "SET_PAGE_TITLE"
+      title: string
     }
   | {
       type: "SET_QUERY_PARAM"

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -28,9 +28,10 @@ export type StreamlitShareMetadata = {
 }
 
 export type IToolbarItem = {
-  label?: string
+  borderless?: boolean
   icon?: string
   key: string
+  label?: string
 }
 
 export type IMenuItem =

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -26,8 +26,8 @@ export type StreamlitShareMetadata = {
 }
 
 export type IToolbarItem = {
-  label: string
-  icon: string
+  label?: string
+  icon?: string
   key: string
 }
 

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -16,6 +16,8 @@
  */
 
 import React, { ReactElement } from "react"
+import { act } from "react-dom/test-utils"
+
 import { shallow, mount } from "src/lib/test_util"
 
 import withS4ACommunication, {
@@ -94,5 +96,41 @@ describe("withS4ACommunication HOC", () => {
     )
 
     expect(window.location.hash).toEqual("#somehash")
+  })
+
+  it("can process a received SET_TOOLBAR_ITEMS message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "SET_TOOLBAR_ITEMS",
+            items: [
+              {
+                label: "",
+                icon: "star.svg",
+                key: "favorite",
+              },
+            ],
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+
+    wrapper.update()
+
+    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    expect(props.currentState.toolbarItems).toEqual([
+      {
+        icon: "star.svg",
+        key: "favorite",
+        label: "",
+      },
+    ])
   })
 })

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -111,6 +111,7 @@ describe("withS4ACommunication HOC", () => {
             type: "SET_TOOLBAR_ITEMS",
             items: [
               {
+                borderless: true,
                 label: "",
                 icon: "star.svg",
                 key: "favorite",
@@ -127,6 +128,7 @@ describe("withS4ACommunication HOC", () => {
     const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
     expect(props.currentState.toolbarItems).toEqual([
       {
+        borderless: true,
         icon: "star.svg",
         key: "favorite",
         label: "",

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -30,7 +30,7 @@ import {
 
 interface State {
   queryParams: string
-  items: IMenuItem[]
+  menuItems: IMenuItem[]
   forcedModalClose: boolean
   streamlitShareMetadata: StreamlitShareMetadata
   isOwner: boolean
@@ -59,7 +59,7 @@ function withS4ACommunication(
   WrappedComponent: ComponentType<any>
 ): ComponentType<any> {
   function ComponentWithS4ACommunication(props: any): ReactElement {
-    const [items, setItems] = useState<IMenuItem[]>([])
+    const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
     const [forcedModalClose, setForcedModalClose] = useState(false)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
@@ -87,7 +87,7 @@ function withS4ACommunication(
         }
 
         if (message.type === "SET_MENU_ITEMS") {
-          setItems(message.items)
+          setMenuItems(message.items)
         }
 
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
@@ -120,7 +120,7 @@ function withS4ACommunication(
         s4aCommunication={
           {
             currentState: {
-              items,
+              menuItems,
               queryParams,
               forcedModalClose,
               streamlitShareMetadata,

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -21,19 +21,21 @@ import hoistNonReactStatics from "hoist-non-react-statics"
 import { CLOUD_COMM_WHITELIST } from "src/urls"
 
 import {
-  IMenuItem,
-  StreamlitShareMetadata,
-  IHostToGuestMessage,
   IGuestToHostMessage,
+  IHostToGuestMessage,
+  IMenuItem,
+  IToolbarItem,
+  StreamlitShareMetadata,
   VersionedMessage,
 } from "./types"
 
 interface State {
-  queryParams: string
-  menuItems: IMenuItem[]
   forcedModalClose: boolean
-  streamlitShareMetadata: StreamlitShareMetadata
   isOwner: boolean
+  menuItems: IMenuItem[]
+  queryParams: string
+  streamlitShareMetadata: StreamlitShareMetadata
+  toolbarItems: IToolbarItem[]
 }
 
 export interface S4ACommunicationHOC {
@@ -64,6 +66,7 @@ function withS4ACommunication(
     const [forcedModalClose, setForcedModalClose] = useState(false)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
     const [isOwner, setIsOwner] = useState(false)
+    const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -86,25 +89,32 @@ function withS4ACommunication(
           return
         }
 
+        if (message.type === "CLOSE_MODAL") {
+          setForcedModalClose(true)
+        }
+
+        if (message.type === "SET_IS_OWNER") {
+          setIsOwner(message.isOwner)
+        }
+
         if (message.type === "SET_MENU_ITEMS") {
           setMenuItems(message.items)
+        }
+
+        if (message.type === "SET_METADATA") {
+          setStreamlitShareMetadata(message.metadata)
+        }
+
+        if (message.type === "SET_TOOLBAR_ITEMS") {
+          setToolbarItems(message.items)
         }
 
         if (message.type === "UPDATE_FROM_QUERY_PARAMS") {
           setQueryParams(message.queryParams)
         }
 
-        if (message.type === "CLOSE_MODAL") {
-          setForcedModalClose(true)
-        }
-        if (message.type === "SET_METADATA") {
-          setStreamlitShareMetadata(message.metadata)
-        }
         if (message.type === "UPDATE_HASH") {
           window.location.hash = message.hash
-        }
-        if (message.type === "SET_IS_OWNER") {
-          setIsOwner(message.isOwner)
         }
       }
 
@@ -120,11 +130,12 @@ function withS4ACommunication(
         s4aCommunication={
           {
             currentState: {
+              forcedModalClose,
+              isOwner,
               menuItems,
               queryParams,
-              forcedModalClose,
               streamlitShareMetadata,
-              isOwner,
+              toolbarItems,
             },
             connect: () => {
               sendS4AMessage({

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -265,9 +265,22 @@ export const createBaseUiTheme = (
     createThemeOverrides(theme)
   )
 
+type DerivedColors = {
+  linkText: string
+  fadedText05: string
+  fadedText10: string
+  fadedText40: string
+  fadedText60: string
+
+  bgMix: string
+  darkenedBgMix60: string
+  transparentDarkenedBgMix60: string
+  lightenedBg05: string
+}
+
 const computeDerivedColors = (
   genericColors: Record<string, string>
-): Record<string, string> => {
+): DerivedColors => {
   const { bodyText, secondaryBg, bgColor } = genericColors
 
   const hasLightBg = getLuminance(bgColor) > 0.5
@@ -408,6 +421,35 @@ export const toThemeInput = (theme: Theme): Partial<CustomThemeConfig> => {
     secondaryBackgroundColor: colors.secondaryBg,
     textColor: colors.bodyText,
     font: fontToEnum(genericFonts.bodyFont),
+  }
+}
+
+export type ExportedTheme = {
+  base: string
+  primaryColor: string
+  backgroundColor: string
+  secondaryBackgroundColor: string
+  textColor: string
+  font: string
+} & DerivedColors
+
+export const toExportedTheme = (theme: Theme): ExportedTheme => {
+  const { genericColors } = theme
+  const themeInput = toThemeInput(theme)
+
+  // At this point, we know that all of the fields of themeInput are populated
+  // (since we went "backwards" from a theme -> themeInput), but typescript
+  // doesn't know this, so we have to cast each field to string.
+  return {
+    primaryColor: themeInput.primaryColor as string,
+    backgroundColor: themeInput.backgroundColor as string,
+    secondaryBackgroundColor: themeInput.secondaryBackgroundColor as string,
+    textColor: themeInput.textColor as string,
+
+    base: bgColorToBaseString(themeInput.backgroundColor),
+    font: fontEnumToString(themeInput.font) as string,
+
+    ...computeDerivedColors(genericColors),
   }
 }
 

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -30,6 +30,7 @@ export const COMPONENT_DEVELOPER_URL =
 export const CLOUD_COMM_WHITELIST = [
   "devel.streamlit.test",
   "share.streamlit.io",
+  "share-demo.streamlit.io",
   "share-head.streamlit.io",
   "share-staging.streamlit.io",
 ]

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -662,7 +662,7 @@ def _server_enable_websocket_compression() -> bool:
 
 # Config Section: Browser #
 
-_create_section("browser", "Configuration of browser front-end.")
+_create_section("browser", "Configuration of non-UI browser options.")
 
 
 @_create_option("browser.serverAddress")
@@ -704,6 +704,22 @@ def _browser_server_port() -> int:
     Default: whatever value is set in server.port.
     """
     return int(get_option("server.port"))
+
+
+# Config Section: UI #
+
+_create_section("ui", "Configuration of UI elements displayed in the browser.")
+
+_create_option(
+    "ui.hideTopBar",
+    description="""
+    Flag to hide most of the UI elements found at the top of a Streamlit app.
+
+    NOTE: This does *not* hide the hamburger menu in the top-right of an app.
+    """,
+    default_val=False,
+    type_=bool,
+)
 
 
 # Config Section: Mapbox #

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -675,6 +675,7 @@ def _populate_config_msg(msg: Config) -> None:
     msg.max_cached_message_age = config.get_option("global.maxCachedMessageAge")
     msg.mapbox_token = config.get_option("mapbox.token")
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
+    msg.hide_top_bar = config.get_option("ui.hideTopBar")
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -278,6 +278,7 @@ class ConfigTest(unittest.TestCase):
                 "runner",
                 "s3",
                 "server",
+                "ui",
             ]
         )
         keys = sorted(list(config._section_descriptions.keys()))
@@ -341,6 +342,7 @@ class ConfigTest(unittest.TestCase):
                 "server.runOnSave",
                 "server.maxUploadSize",
                 "server.maxMessageSize",
+                "ui.hideTopBar",
             ]
         )
         keys = sorted(config._config_options.keys())

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -87,6 +87,9 @@ message Config {
 
   // See config option "server.allowRunOnSave".
   bool allow_run_on_save = 5;
+
+  // See config option "ui.hideTopBar".
+  bool hide_top_bar = 6;
 }
 
 // Custom theme configuration options. Like other config options, these are set


### PR DESCRIPTION
## 📚 Context

Services hosting streamlit apps (I'm writing this generally, but for now I mean Streamlit Cloud 😅)
want to be able to add buttons to the top bar where the hamburger menu currently lives.

To support this, we take the same approach that currently allows the host of a streamlit app to
add items to the hamburger menu: messages defining the items to add are sent from host -> guest,
and when the items are clicked, messages are sent from guest -> host to inform the host of the click
event.

Additionally, we send an object describing the active theme from guest -> host so that the host can
seamlessly style itself to work well visually with a streamlit app's theme.

- What kind of change does this PR introduce?

  - [x] Feature
  - [x] Refactoring

## 🧠 Description of Changes

- Add new message types to `withS4ACommunication` allowing the host of a streamlit app to
  specify items to add to an app's toolbar
- Teach `withS4ACommunication` to receive these new messages and forward them to the
  streamlit app
- Use these messages to render the specified toolbar icons/buttons and send click events
  back to the host
- Send theme info from guest -> host
- Slightly refactor how theme info is sent to custom components to share code

<br />

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests
