### PR TITLE
Stop recording screencast when user clicks "stop" using browser button

### DIFF
--- a/frontend/src/hocs/withScreencast/withScreencast.tsx
+++ b/frontend/src/hocs/withScreencast/withScreencast.tsx
@@ -97,7 +97,10 @@ function withScreencast(
     public startRecording = async (): Promise<any> => {
       const { recordAudio } = this.state
 
-      this.recorder = new ScreenCastRecorder({ recordAudio })
+      this.recorder = new ScreenCastRecorder({
+        recordAudio,
+        onErrorOrStop: () => this.stopRecording(),
+      })
 
       try {
         await this.recorder.initialize()
@@ -125,15 +128,18 @@ function withScreencast(
         })
       }
 
-      if (
-        currentState === "RECORDING" &&
-        this.recorder.getState() !== "inactive"
-      ) {
-        outputBlob = await this.recorder.stop()
-        this.setState({
-          outputBlob,
-          currentState: "PREVIEW_FILE",
-        })
+      if (currentState === "RECORDING") {
+        if (this.recorder.getState() === "inactive") {
+          this.setState({
+            currentState: "OFF",
+          })
+        } else {
+          outputBlob = await this.recorder.stop()
+          this.setState({
+            outputBlob,
+            currentState: "PREVIEW_FILE",
+          })
+        }
       }
     }
 

--- a/frontend/src/lib/ScreenCastRecorder.ts
+++ b/frontend/src/lib/ScreenCastRecorder.ts
@@ -20,6 +20,7 @@ const BLOB_TYPE = "video/webm"
 
 interface ScreenCastRecorderOptions {
   recordAudio: boolean
+  onErrorOrStop: () => void
 }
 
 class ScreenCastRecorder {
@@ -30,6 +31,8 @@ class ScreenCastRecorder {
   private recordedChunks: Blob[]
 
   private mediaRecorder: MediaRecorder | null
+
+  private onErrorOrStopCallback: () => void
 
   /** True if the current browser likely supports screencasts. */
   public static isSupportedBrowser(): boolean {
@@ -42,8 +45,9 @@ class ScreenCastRecorder {
     )
   }
 
-  constructor({ recordAudio }: ScreenCastRecorderOptions) {
+  constructor({ recordAudio, onErrorOrStop }: ScreenCastRecorderOptions) {
     this.recordAudio = recordAudio
+    this.onErrorOrStopCallback = onErrorOrStop
 
     this.inputStream = null
     this.recordedChunks = []
@@ -102,10 +106,21 @@ class ScreenCastRecorder {
       return false
     }
 
+    const logRecorderError = (e: any): void => {
+      logWarning(`mediaRecorder.start threw an error: ${e}`)
+    }
+
+    this.mediaRecorder.onerror = (e: any): void => {
+      logRecorderError(e)
+      this.onErrorOrStopCallback()
+    }
+
+    this.mediaRecorder.onstop = (): void => this.onErrorOrStopCallback()
+
     try {
       this.mediaRecorder.start()
     } catch (e) {
-      logWarning(`mediaRecorder.start threw an error: ${e}`)
+      logRecorderError(e)
       return false
     }
 


### PR DESCRIPTION
## 📚 Context

Today there's the "Record a screencast" feature has a bug where it becomes impossible to stop recording when you do the following:

1. Start recording a screencast for the current tab
2. Click "stop sharing" in the banner that Chrome shows at the top of the tab's contents
3. Try to stop recording.

This PR fixes that.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Add `onstop` and `onerror` handlers to the `MediaRecorder` object.
- Upon an error/stop even, tell the UI's state machine that we're no longer recording.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] ~~Screenshots included~~ n/a
- [ ] ~~Added/Updated unit tests~~ This code is not currently tested or easily testable. Just landing a quick fix. Hopefully this is OK?
- [ ] ~~Added/Updated e2e tests~~ n/a

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes https://github.com/streamlit/streamlit/issues/1740

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
