### PR TITLE
Change st.plotly docstring to fix docs rendering

### DIFF
--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -52,6 +52,9 @@ class PlotlyMixin:
         closely follow the ones for Plotly's `plot()` function. You can find
         more about Plotly at https://plot.ly/python.
 
+        To show Plotly charts in Streamlit, call `st.plotly_chart` wherever you
+        would call Plotly's `py.plot` or `py.iplot`.
+
         Parameters
         ----------
         figure_or_data : plotly.graph_objs.Figure, plotly.graph_objs.Data,
@@ -71,10 +74,6 @@ class PlotlyMixin:
 
         **kwargs
             Any argument accepted by Plotly's `plot()` function.
-
-
-        To show Plotly charts in Streamlit, call `st.plotly_chart`
-        wherever you would call Plotly's `py.plot` or `py.iplot`.
 
         Example
         -------


### PR DESCRIPTION
## 📚 Context

The documentation rendering of the plotly docstring is a bit broken. This PR moves up an explanation section to fix this issue.

![image](https://user-images.githubusercontent.com/2852129/146255030-510839bf-a637-471e-9e4b-ce667f3bc983.png)


- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Fix for documentation

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
