### PR TITLE
Support running (most) tests locally on Apple Silicon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
             md5sum $(which python) > ~/python_cache_key.md5
             md5sum lib/Pipfile >> ~/python_cache_key.md5
             md5sum lib/test-requirements.txt >> ~/python_cache_key.md5
-            md5sum lib/test-requirements-python-39-and-earlier.txt >> ~/python_cache_key.md5
+            md5sum lib/test-requirements-with-tensorflow.txt >> ~/python_cache_key.md5
             date +%F >> ~/python_cache_key.md5
 
       - run: &create_yarn_cache_key

--- a/Makefile
+++ b/Makefile
@@ -62,16 +62,20 @@ pipenv-dev-install: lib/Pipfile
 	cd lib; \
 		pipenv install --dev --skip-lock --sequential
 
-PYTHON_39_OR_EARLIER := $(shell python scripts/is_python_39_or_earlier.py)
+SHOULD_INSTALL_TENSORFLOW := $(shell python scripts/should_install_tensorflow.py)
 .PHONY: py-test-install
 py-test-install: lib/test-requirements.txt
 	# As of Python 3.9, we're using pip's legacy-resolver when installing
 	# test-requirements.txt, because otherwise pip takes literal hours to finish.
 	pip install -r lib/test-requirements.txt --use-deprecated=legacy-resolver
-ifeq (${PYTHON_39_OR_EARLIER},true)
-	pip install -r lib/test-requirements-python-39-and-earlier.txt --use-deprecated=legacy-resolver
+ifeq (${SHOULD_INSTALL_TENSORFLOW},true)
+	pip install -r lib/test-requirements-with-tensorflow.txt --use-deprecated=legacy-resolver
 else
-	@echo "Running in Python 3.10 or greater; skipping incompatible dependencies"
+	@echo ""
+	@echo "Your system does not support the official, pre-built tensorflow binaries."
+	@echo "This generally happens because you are running Python 3.10 or have an Apple Silicon machine."
+	@echo "Skipping incompatible dependencies."
+	@echo ""
 endif
 
 .PHONY: pylint

--- a/lib/test-requirements-with-tensorflow.txt
+++ b/lib/test-requirements-with-tensorflow.txt
@@ -1,6 +1,11 @@
 # 2021.12.07: Tensorflow is not installable on Python 3.10, so we
 # only install it (and test against it) in Python 3.9 and earlier.
 # Keras and Pytorch are dependent on Tensorflow, so they're also here.
+#
+# 2021.12.15: Additionally, pre-built tensorflow binaries do not
+# currently include releases supporting Apple Silicon. Apple has a
+# closed-source fork installable via conda, but it doesn't seem
+# worth it to use that just to run a few tests locally.
 
 keras<2.5.0
 tensorflow>=2.6.0

--- a/scripts/should_install_tensorflow.py
+++ b/scripts/should_install_tensorflow.py
@@ -15,9 +15,13 @@
 # Used by our Makefile to check if Python.version <= 3.9
 # There are surely better ways to do this, but Make is a beast I can't tame.
 
+import os
 import sys
 
-if (sys.version_info.major, sys.version_info.minor) <= (3, 9):
+is_m1_mac = (os.uname().sysname, os.uname().machine) == ("Darwin", "arm64")
+is_python_39_or_earlier = (sys.version_info.major, sys.version_info.minor) <= (3, 9)
+
+if is_python_39_or_earlier and not is_m1_mac:
     print("true")
 else:
     print("false")


### PR DESCRIPTION
## 📚 Context

We currently mostly-support development on M1 Macs with the exception of being
able to run Python tests locally. This is because tensorflow's official
pre-built binaries do not currently include releases supporting Apple Silicon.

We recently added some code to avoid installing tensorflow in environments
running Python 3.10 (as tensorflow doesn't support 3.10 yet), so it wasn't
much extra effort from there to also avoid installing those dependencies on M1
machines.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Improved Apple Silicon dev env support

## 🧠 Description of Changes

- Avoid installing tensorflow and related dependencies on M1 Macs
- Rename a few files to no longer reference Python 3.9
