### PR TITLE
Ignore type errors introduced by mypy 0.920

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -19,6 +19,7 @@ from streamlit.type_util import Key
 from typing import (
     TYPE_CHECKING,
     Any,
+    KeysView,
     cast,
     Dict,
     Iterator,
@@ -145,10 +146,10 @@ class WStates(MutableMapping[str, Any]):
         for key in self.states:
             yield key
 
-    def keys(self) -> Set[str]:
-        return set(self.states.keys())
+    def keys(self) -> KeysView[str]:
+        return KeysView(self.states)
 
-    def items(self) -> Set[Tuple[str, Any]]:
+    def items(self) -> Set[Tuple[str, Any]]:  # type: ignore
         return {(k, self[k]) for k in self}
 
     def values(self) -> Set[Any]:  # type: ignore
@@ -345,7 +346,7 @@ class SessionState(MutableMapping[str, Any]):
         wid_key_map = {v: k for k, v in self._key_id_mapping.items()}
         return wid_key_map
 
-    def keys(self) -> Set[str]:
+    def keys(self) -> Set[str]:  # type: ignore
         """All keys active in Session State, with widget keys converted
         to widget ids when one is known."""
         old_keys = {self._get_widget_id(k) for k in self._old_state.keys()}


### PR DESCRIPTION
Previously, these functions returning sets was considered valid by mypy
and the python docs, but now they are expected to be actual view
objects. Unfortunately the constructors for the view objects assume your
class is a dumb wrapper around a dict, and so don't work correctly with
`WStates` for items/values (because it relies on you calling
`__getitem__`), and also don't work well with `SessionState` merging and
key translating several dicts. So we will mostly ignore this, except for
keys view for `WStates`, which should work fine as a `KeysView`.
