### PR TITLE
Wait for enough elements to load in flaky e2e tests

### DIFF
--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -49,6 +49,7 @@ describe("st.date_input", () => {
 
   it("shows disabled widget correctly", () => {
     cy.get(".stDateInput")
+      .should("have.length.at.least", 6)
       .eq(5)
       .matchThemedSnapshots("disabled date input");
   });
@@ -80,6 +81,7 @@ describe("st.date_input", () => {
   it("handles range end date changes", () => {
     // open date picker
     cy.get(".stDateInput")
+      .should("have.length.at.least", 4)
       .eq(3)
       .click();
 
@@ -104,6 +106,7 @@ describe("st.date_input", () => {
   it("handles range start/end date changes", () => {
     // open date picker
     cy.get(".stDateInput")
+      .should("have.length.at.least", 5)
       .eq(4)
       .click();
 
@@ -211,6 +214,7 @@ describe("st.date_input", () => {
   it("not reset to default range value if calendar closed empty", () => {
     // open date picker
     cy.get(".stDateInput")
+      .should("have.length.at.least", 5)
       .eq(4)
       .click();
 
@@ -250,6 +254,7 @@ describe("st.date_input", () => {
 
     // remove input
     cy.get(".stDateInput")
+      .should("have.length.at.least", 5)
       .eq(4)
       .click()
       .type("{del}{selectall}{backspace}");

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -31,21 +31,26 @@ describe("st.file_uploader", () => {
 
   it("shows widget correctly", () => {
     cy.get("[data-testid='stFileUploader']")
+      .should("have.length.at.least", 1)
       .eq(0)
       .should("exist");
     cy.get("[data-testid='stFileUploader'] label")
+      .should("have.length.at.least", 1)
       .eq(0)
       .should("have.text", "Drop a file:");
 
     cy.get("[data-testid='stFileUploader']")
+      .should("have.length.at.least", 1)
       .eq(0)
       .matchThemedSnapshots("single_file_uploader");
 
     cy.get("[data-testid='stFileUploader']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchThemedSnapshots("disabled_file_uploader");
 
     cy.get("[data-testid='stFileUploader']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .matchThemedSnapshots("multi_file_uploader");
   });
@@ -72,10 +77,12 @@ describe("st.file_uploader", () => {
         );
 
       cy.get("[data-testid='stUploadedFileErrorMessage']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .should("have.text", "application/json files are not allowed.");
 
       cy.get("[data-testid='stFileUploader']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .matchThemedSnapshots("file_uploader-error");
     });
@@ -100,6 +107,7 @@ describe("st.file_uploader", () => {
         ];
 
         cy.get("[data-testid='stFileUploadDropzone']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .attachFile(files[0], {
             force: true,
@@ -112,19 +120,23 @@ describe("st.file_uploader", () => {
         // through.)
         cy.get(".uploadedFileName").should("have.text", fileName1);
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", file1);
 
         cy.get("[data-testid='stMarkdownContainer']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", "True");
 
         cy.get("[data-testid='stFileUploader']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .matchThemedSnapshots("single_file_uploader-uploaded");
 
         // Upload a second file. This one will replace the first.
         cy.get("[data-testid='stFileUploadDropzone']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .attachFile(files[1], {
             force: true,
@@ -136,11 +148,13 @@ describe("st.file_uploader", () => {
           .should("have.text", fileName2)
           .should("not.have.text", fileName1);
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", file2)
           .should("not.contain.text", file1);
 
         cy.get("[data-testid='stMarkdownContainer']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", "True");
 
@@ -148,14 +162,17 @@ describe("st.file_uploader", () => {
         cy.get("body").type("r");
         cy.wait(1000);
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", file2);
 
         // Can delete
         cy.get("[data-testid='fileDeleteBtn'] button")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .click();
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", "No upload");
       });
@@ -180,6 +197,7 @@ describe("st.file_uploader", () => {
         ];
 
         cy.get("[data-testid='stFileUploadDropzone']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .attachFile(files[0], {
             force: true,
@@ -192,6 +210,7 @@ describe("st.file_uploader", () => {
         });
 
         cy.get("[data-testid='stFileUploadDropzone']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .attachFile(files[1], {
             force: true,
@@ -214,10 +233,12 @@ describe("st.file_uploader", () => {
         // through.)
         const content = [file1, file2].join("\n");
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("have.text", content);
 
         cy.get("[data-testid='stFileUploader']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .matchThemedSnapshots("multi_file_uploader-uploaded");
 
@@ -227,9 +248,11 @@ describe("st.file_uploader", () => {
           .first()
           .click();
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", file1);
         cy.get("[data-testid='stMarkdownContainer']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", "True");
       });
@@ -273,6 +296,7 @@ describe("st.file_uploader", () => {
         cy.wait(1000);
 
         cy.get("[data-testid='stFileUploadDropzone']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .attachFile(files[1], {
             force: true,
@@ -295,6 +319,7 @@ describe("st.file_uploader", () => {
         // through.)
         const content = [file1, file2].join("\n");
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("have.text", content);
 
@@ -304,9 +329,11 @@ describe("st.file_uploader", () => {
           .first()
           .click();
         cy.get("[data-testid='stText']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", file1);
         cy.get("[data-testid='stMarkdownContainer']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .should("contain.text", "True");
       });
@@ -323,6 +350,7 @@ describe("st.file_uploader", () => {
       ];
 
       cy.get("[data-testid='stFileUploadDropzone']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .attachFile(files[0], {
           force: true,
@@ -339,6 +367,7 @@ describe("st.file_uploader", () => {
       // But our uploaded text should contain nothing yet, as we haven't
       // submitted.
       cy.get("[data-testid='stText']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .should("contain.text", "No upload");
 
@@ -347,6 +376,7 @@ describe("st.file_uploader", () => {
 
       // Now we should see the file's contents
       cy.get("[data-testid='stText']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .should("contain.text", file1);
 
@@ -357,6 +387,7 @@ describe("st.file_uploader", () => {
         .click();
 
       cy.get("[data-testid='stText']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .should("contain.text", file1);
 
@@ -364,6 +395,7 @@ describe("st.file_uploader", () => {
       cy.get("[data-testid='stFormSubmitButton'] button").click();
 
       cy.get("[data-testid='stText']")
+        .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
         .should("contain.text", "No upload");
     });

--- a/e2e/specs/st_radio.spec.js
+++ b/e2e/specs/st_radio.spec.js
@@ -98,16 +98,19 @@ describe("st.radio", () => {
 
   it("formats display values", () => {
     cy.get('.stRadio [role="radiogroup"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "FemaleMale");
   });
 
   it("handles no options", () => {
     cy.get('.stRadio [role="radiogroup"]')
+      .should("have.length.at.least", 2)
       .eq(2)
       .should("have.text", "No options to select.");
 
     cy.get('.stRadio [role="radiogroup"]')
+      .should("have.length.at.least", 3)
       .eq(2)
       .get("input")
       .should("be.disabled");

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -30,18 +30,22 @@ describe("st.select_slider", () => {
       .should("have.text", "Label 1");
 
     cy.get(".stSlider label")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Label 2");
 
     cy.get(".stSlider label")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "Label 3");
 
     cy.get(".stSlider label")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.text", "Label 4");
 
     cy.get(".stSlider label")
+      .should("have.length.at.least", 5)
       .eq(4)
       .should("have.text", "Label 5");
   });
@@ -52,22 +56,27 @@ describe("st.select_slider", () => {
       .should("have.text", "Value 1: ('orange', 'blue')");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Value 2: 1");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "Value 3: (2, 5)");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.text", "Value 4: 5");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 5)
       .eq(4)
       .should("have.text", "Value 5: 1");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 6)
       .eq(5)
       .should("have.text", "Select slider changed: False");
   });
@@ -78,6 +87,7 @@ describe("st.select_slider", () => {
       .should("have.attr", "aria-valuetext", "orange");
 
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.attr", "aria-valuetext", "blue");
   });
@@ -97,6 +107,7 @@ describe("st.select_slider", () => {
       .should("have.attr", "aria-valuetext", "yellow");
 
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.attr", "aria-valuetext", "blue");
   });
@@ -116,6 +127,7 @@ describe("st.select_slider", () => {
       .should("have.attr", "aria-valuetext", "red");
 
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.attr", "aria-valuetext", "blue");
   });

--- a/e2e/specs/st_selectbox.spec.js
+++ b/e2e/specs/st_selectbox.spec.js
@@ -46,22 +46,26 @@ describe("st.selectbox", () => {
 
   it("formats display values", () => {
     cy.get(".stSelectbox div[aria-selected]")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Male");
   });
 
   it("handles no options", () => {
     cy.get(".stSelectbox div[aria-selected]")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "No options to select.");
 
     cy.get(".stSelectbox input")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("be.disabled");
   });
 
   it("sets value correctly when user clicks", () => {
     cy.get(".stSelectbox")
+      .should("have.length.at.least", 2)
       .eq(1)
       .then(el => {
         cy.wrap(el)
@@ -87,6 +91,7 @@ describe("st.selectbox", () => {
   it("shows the correct options when fuzzy search is applied", () => {
     function typeText(string) {
       cy.get(".stSelectbox")
+        .should("have.length.at.least", 4)
         .eq(3)
         .then(el => {
           cy.wrap(el)

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -25,12 +25,14 @@ describe("st.slider", () => {
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
 
     cy.get(".stSlider")
+      .should("have.length.at.least", 3)
       .eq(2)
       .matchThemedSnapshots("slider");
   });
 
   it("looks right when disabled", () => {
     cy.get(".stSlider")
+      .should("have.length.at.least", 6)
       .eq(5)
       .matchThemedSnapshots("disabled-slider");
   });
@@ -50,18 +52,21 @@ describe("st.slider", () => {
 
   it("shows full label when the label is long", () => {
     cy.get(".stSlider")
+      .should("have.length.at.least", 5)
       .eq(4)
       .matchThemedSnapshots("slider_with_long_label");
   });
 
   it("shows full thumb value when the value is long", () => {
     cy.get(".stSlider")
+      .should("have.length.at.least", 1)
       .eq(0)
       .matchThemedSnapshots("long_thumb_value");
   });
 
   it("does not overlap expander container when thumb value is long", () => {
     cy.get(".stSlider")
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchThemedSnapshots("expander_thumb_value");
   });
@@ -86,39 +91,46 @@ describe("st.slider", () => {
 
     // trigger click in the center of the slider
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 3)
       .eq(2)
       .parent()
       .click();
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "Value 1: 50");
   });
 
   it("increments the value on right arrow key press", () => {
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 3)
       .eq(2)
       .click()
       .type("{rightarrow}", { force: true });
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "Value 1: 26");
   });
 
   it("decrements the value on left arrow key press", () => {
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 3)
       .eq(2)
       .click()
       .type("{leftarrow}", { force: true });
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "Value 1: 24");
   });
 
   it("maintains its state on rerun", () => {
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 3)
       .eq(2)
       .click()
       .type("{leftarrow}", { force: true });
@@ -130,6 +142,7 @@ describe("st.slider", () => {
     });
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.text", "Value 1: 24");
   });


### PR DESCRIPTION
The core problem is described in
https://docs.cypress.io/guides/core-concepts/retry-ability#Only-the-last-command-is-retried

Chaining `get` and then immediately `eq` is prone to flakiness, because
if the get call sees some but not enough elements, the eq call will
fail, but only the eq call will be retried, so it'll continue to fail
even when the actual page loads the elements before the eq call times
out. Adding an assertion that there are enough elements ensures that the
initial query will be retried until enough elements are present.

This doesn't change all instances of this pattern in the specs, just the ones that have flaked recently. It also doesn't address possible other causes of flaky tests.