### PR TITLE
Add a config option to hide the topbar (but not the 🍔 menu)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -221,6 +221,7 @@ describe("App", () => {
       },
     })
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ hideTopBar: false })
 
     expect(wrapper.find(ToolbarActions).prop("s4aToolbarItems")).toStrictEqual(
       [
@@ -316,6 +317,22 @@ describe("App", () => {
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(darkTheme.emotion),
     })
+  })
+
+  it("hides the top bar if hideTopBar === true", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    // hideTopBar is true by default
+
+    expect(wrapper.find("WithTheme(StatusWidget)").exists()).toBe(false)
+    expect(wrapper.find("ToolbarActions").exists()).toBe(false)
+  })
+
+  it("shows the top bar if hideTopBar === false", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    wrapper.setState({ hideTopBar: false })
+
+    expect(wrapper.find("WithTheme(StatusWidget)").exists()).toBe(true)
+    expect(wrapper.find("ToolbarActions").exists()).toBe(true)
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,6 +135,7 @@ interface State {
   themeHash: string | null
   gitInfo: IGitInfo | null
   formsData: FormsData
+  hideTopBar: boolean
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -201,6 +202,11 @@ export class App extends PureComponent<Props, State> {
       themeHash: null,
       gitInfo: null,
       formsData: createFormsData(),
+      // We set this to true by default because this information isn't
+      // available on page load (we get it when the script begins to run), so
+      // the user would see top bar elements for a few ms if this defaulted to
+      // false.
+      hideTopBar: true,
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -610,6 +616,7 @@ export class App extends PureComponent<Props, State> {
     this.setState({
       sharingEnabled: config.sharingEnabled,
       allowRunOnSave: config.allowRunOnSave,
+      hideTopBar: config.hideTopBar,
     })
 
     const { reportHash } = this.state
@@ -1127,6 +1134,7 @@ export class App extends PureComponent<Props, State> {
       sharingEnabled,
       userSettings,
       gitInfo,
+      hideTopBar,
     } = this.state
 
     const outerDivClass = classNames("stApp", {
@@ -1171,20 +1179,24 @@ export class App extends PureComponent<Props, State> {
           <StyledApp className={outerDivClass}>
             {/* The tabindex below is required for testing. */}
             <Header>
-              <StatusWidget
-                connectionState={connectionState}
-                sessionEventDispatcher={this.sessionEventDispatcher}
-                reportRunState={reportRunState}
-                rerunReport={this.rerunScript}
-                stopReport={this.stopReport}
-                allowRunOnSave={allowRunOnSave}
-              />
-              <ToolbarActions
-                s4aToolbarItems={
-                  this.props.s4aCommunication.currentState.toolbarItems
-                }
-                sendS4AMessage={this.props.s4aCommunication.sendMessage}
-              />
+              {!hideTopBar && (
+                <>
+                  <StatusWidget
+                    connectionState={connectionState}
+                    sessionEventDispatcher={this.sessionEventDispatcher}
+                    reportRunState={reportRunState}
+                    rerunReport={this.rerunScript}
+                    stopReport={this.stopReport}
+                    allowRunOnSave={allowRunOnSave}
+                  />
+                  <ToolbarActions
+                    s4aToolbarItems={
+                      this.props.s4aCommunication.currentState.toolbarItems
+                    }
+                    sendS4AMessage={this.props.s4aCommunication.sendMessage}
+                  />
+                </>
+              )}
               <MainMenu
                 sharingEnabled={sharingEnabled === true}
                 isServerConnected={this.isServerConnected()}

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -662,7 +662,7 @@ def _server_enable_websocket_compression() -> bool:
 
 # Config Section: Browser #
 
-_create_section("browser", "Configuration of browser front-end.")
+_create_section("browser", "Configuration of non-UI browser options.")
 
 
 @_create_option("browser.serverAddress")
@@ -704,6 +704,22 @@ def _browser_server_port() -> int:
     Default: whatever value is set in server.port.
     """
     return int(get_option("server.port"))
+
+
+# Config Section: UI #
+
+_create_section("ui", "Configuration of UI elements displayed in the browser.")
+
+_create_option(
+    "ui.hideTopBar",
+    description="""
+    Flag to hide most of the UI elements found at the top of a Streamlit app.
+
+    NOTE: This does *not* hide the hamburger menu in the top-right of an app.
+    """,
+    default_val=False,
+    type_=bool,
+)
 
 
 # Config Section: Mapbox #

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -675,6 +675,7 @@ def _populate_config_msg(msg: Config) -> None:
     msg.max_cached_message_age = config.get_option("global.maxCachedMessageAge")
     msg.mapbox_token = config.get_option("mapbox.token")
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
+    msg.hide_top_bar = config.get_option("ui.hideTopBar")
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -278,6 +278,7 @@ class ConfigTest(unittest.TestCase):
                 "runner",
                 "s3",
                 "server",
+                "ui",
             ]
         )
         keys = sorted(list(config._section_descriptions.keys()))
@@ -341,6 +342,7 @@ class ConfigTest(unittest.TestCase):
                 "server.runOnSave",
                 "server.maxUploadSize",
                 "server.maxMessageSize",
+                "ui.hideTopBar",
             ]
         )
         keys = sorted(config._config_options.keys())

--- a/proto/streamlit/proto/NewReport.proto
+++ b/proto/streamlit/proto/NewReport.proto
@@ -87,6 +87,9 @@ message Config {
 
   // See config option "server.allowRunOnSave".
   bool allow_run_on_save = 5;
+
+  // See config option "ui.hideTopBar".
+  bool hide_top_bar = 6;
 }
 
 // Custom theme configuration options. Like other config options, these are set


### PR DESCRIPTION
## 📚 Context

In order to prepare for a future where we move everything to the left of the
hamburger menu into Streamlit Cloud, we need a way to tell a streamlit app to
hide its top bar. This PR adds this config option in a new `ui` config section.

Note that
* We choose the name topbar instead of toolbar despite the internal code
   referring to this part of the UI as the toolbar. This is because topbar is the
   more correct name here, and we can later change the name used in the
   code without any user-visible impact.
* this does *not* hide the hamburger menu itself. This is because it's likely
   that the hamburger menu may continue to live in the core codebase
   indefinitely
* there's still a relatively high probability that we add a separate config option
   to hide the hamburger menu as there have been community requests for this.
   If we do add this, it will be a separate option in the `ui` section.

<br />

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add a new `ui` config section
- Add the `ui.hideTopBar` config option, which does what its name suggests
   and defaults to `false`

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests