### PR TITLE
Allow host to specify borderless icons

### DIFF
--- a/frontend/src/components/core/MainMenu/__snapshots__/MainMenu.test.tsx.snap
+++ b/frontend/src/components/core/MainMenu/__snapshots__/MainMenu.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`App renders without crashing 1`] = `
             >
               <button
                 autoFocus={false}
-                className="css-izgjtx-StyledBaseButton-StyledIconButton edgvbvh6"
+                className="css-107haio-StyledBaseButton-StyledIconButton edgvbvh6"
                 disabled={false}
                 kind="icon"
                 onClick={[Function]}

--- a/frontend/src/components/core/StatusWidget/__snapshots__/StatusWidget.test.tsx.snap
+++ b/frontend/src/components/core/StatusWidget/__snapshots__/StatusWidget.test.tsx.snap
@@ -894,7 +894,7 @@ exports[`Tooltip element renders running img correctly with custom dark backgrou
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}
@@ -1810,7 +1810,7 @@ exports[`Tooltip element renders running img correctly with custom light backgro
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}
@@ -2726,7 +2726,7 @@ exports[`Tooltip element renders running img correctly with darkTheme 1`] = `
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}
@@ -3642,7 +3642,7 @@ exports[`Tooltip element renders running img correctly with lightTheme 1`] = `
                       >
                         <button
                           autoFocus={false}
-                          className="css-120arus-StyledBaseButton-StyledPrimaryButton edgvbvh1"
+                          className="css-k9xf9f-StyledBaseButton-StyledPrimaryButton edgvbvh1"
                           disabled={false}
                           kind="primary"
                           onClick={[Function]}

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
@@ -29,6 +29,7 @@ describe("ActionButton", () => {
   const getProps = (
     extended?: Partial<ActionButtonProps>
   ): ActionButtonProps => ({
+    borderless: false,
     label: "the label",
     icon: "star.svg",
     onClick: jest.fn(),
@@ -48,15 +49,17 @@ describe("ActionButton", () => {
       <ActionButton {...getProps({ icon: undefined })} />
     )
 
+    expect(wrapper).toMatchSnapshot()
     expect(wrapper.find(StyledActionButtonIcon).exists()).toBe(false)
     expect(wrapper.find("span")).toHaveLength(1)
   })
 
   it("does not render label if not provided", () => {
     const wrapper = shallow(
-      <ActionButton {...getProps({ label: undefined })} />
+      <ActionButton {...getProps({ label: undefined, borderless: true })} />
     )
 
+    expect(wrapper).toMatchSnapshot()
     expect(wrapper.find(StyledActionButtonIcon)).toHaveLength(1)
     expect(wrapper.find("span").exists()).toBe(false)
   })

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -27,19 +27,22 @@ import {
 } from "./styled-components"
 
 export interface ActionButtonProps {
+  borderless?: boolean
   label?: string
   icon?: string
   onClick: () => void
 }
 
 export function ActionButton({
+  borderless,
   label,
   icon,
   onClick,
 }: ActionButtonProps): ReactElement {
+  const kind = borderless ? Kind.BORDERLESS_ICON : Kind.ICON
   return (
     <div className="stActionButton">
-      <Button onClick={onClick} kind={Kind.ICON}>
+      <Button onClick={onClick} kind={kind}>
         <StyledActionButtonContainer>
           {icon && <StyledActionButtonIcon icon={icon} />}
           {label && <span>{label}</span>}
@@ -60,11 +63,12 @@ function ToolbarActions({
 }: ToolbarActionsProps): ReactElement {
   return (
     <>
-      {s4aToolbarItems.map(({ key, label, icon }) => (
+      {s4aToolbarItems.map(({ borderless, key, label, icon }) => (
         <ActionButton
           key={key}
           label={label}
           icon={icon}
+          borderless={borderless}
           onClick={() =>
             sendS4AMessage({
               type: "TOOLBAR_ITEM_CALLBACK",

--- a/frontend/src/components/core/ToolbarActions/__snapshots__/ToolbarActions.test.tsx.snap
+++ b/frontend/src/components/core/ToolbarActions/__snapshots__/ToolbarActions.test.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ActionButton does not render icon if not provided 1`] = `
+<div
+  className="stActionButton"
+>
+  <Button
+    kind="icon"
+    onClick={[MockFunction]}
+  >
+    <StyledActionButtonContainer>
+      <span>
+        the label
+      </span>
+    </StyledActionButtonContainer>
+  </Button>
+</div>
+`;
+
+exports[`ActionButton does not render label if not provided 1`] = `
+<div
+  className="stActionButton"
+>
+  <Button
+    kind="borderlessIcon"
+    onClick={[MockFunction]}
+  >
+    <StyledActionButtonContainer>
+      <StyledActionButtonIcon
+        icon="star.svg"
+      />
+    </StyledActionButtonContainer>
+  </Button>
+</div>
+`;
+
 exports[`ActionButton renders without crashing and matches snapshot 1`] = `
 <div
   className="stActionButton"

--- a/frontend/src/components/core/ToolbarActions/styled-components.ts
+++ b/frontend/src/components/core/ToolbarActions/styled-components.ts
@@ -16,6 +16,7 @@
  */
 
 import styled from "@emotion/styled"
+import { transparentize } from "color2k"
 
 export const StyledActionButtonContainer = styled.div(({ theme }) => ({
   display: "flex",
@@ -41,7 +42,7 @@ export const StyledActionButtonIcon = styled.div<StyledActionButtonIconProps>(
     },
     "&:active, .stActionButton:active &": {
       background: "none",
-      backgroundColor: theme.colors.white,
+      backgroundColor: transparentize(theme.colors.primary, 0.5),
       mask: `url("${icon}") no-repeat center / contain`,
     },
   })

--- a/frontend/src/components/shared/Button/Button.tsx
+++ b/frontend/src/components/shared/Button/Button.tsx
@@ -20,6 +20,7 @@ import {
   ButtonProps as ButtonPropsT,
   Kind,
   Size,
+  StyledBorderlessIconButton,
   StyledIconButton,
   StyledLinkButton,
   StyledMinimalButton,
@@ -45,6 +46,8 @@ function Button({
     ComponentType = StyledLinkButton
   } else if (kind === Kind.ICON) {
     ComponentType = StyledIconButton
+  } else if (kind === Kind.BORDERLESS_ICON) {
+    ComponentType = StyledBorderlessIconButton
   } else if (kind === Kind.MINIMAL) {
     ComponentType = StyledMinimalButton
   } else if (kind === Kind.FORM_SUBMIT) {

--- a/frontend/src/components/shared/Button/styled-components.ts
+++ b/frontend/src/components/shared/Button/styled-components.ts
@@ -25,6 +25,7 @@ export enum Kind {
   SECONDARY = "secondary",
   LINK = "link",
   ICON = "icon",
+  BORDERLESS_ICON = "borderlessIcon",
   MINIMAL = "minimal",
   FORM_SUBMIT = "formSubmit",
 }
@@ -200,9 +201,8 @@ export const StyledIconButton = styled(StyledBaseButton)<RequiredButtonProps>(
         borderColor: theme.colors.primary,
         color: theme.colors.white,
       },
-      "&:focus:not(:active)": {
-        borderColor: theme.colors.primary,
-        color: theme.colors.primary,
+      "&:not(:active)": {
+        boxShadow: "none",
       },
       "&:disabled, &:disabled:hover, &:disabled:active": {
         backgroundColor: theme.colors.lightGray,
@@ -212,6 +212,33 @@ export const StyledIconButton = styled(StyledBaseButton)<RequiredButtonProps>(
     }
   }
 )
+
+export const StyledBorderlessIconButton = styled(StyledBaseButton)<
+  RequiredButtonProps
+>(({ size, theme }) => {
+  const iconPadding: Record<Size, string> = {
+    [Size.XSMALL]: theme.spacing.threeXS,
+    [Size.SMALL]: theme.spacing.twoXS,
+    [Size.MEDIUM]: theme.spacing.md,
+    [Size.LARGE]: theme.spacing.lg,
+  }
+
+  return {
+    backgroundColor: theme.colors.transparent,
+    border: `1px solid ${theme.colors.transparent}`,
+    padding: iconPadding[size],
+
+    "&:focus": {
+      boxShadow: "none",
+      outline: "none",
+    },
+    "&:disabled, &:disabled:hover, &:disabled:active": {
+      backgroundColor: theme.colors.lightGray,
+      borderColor: theme.colors.transparent,
+      color: theme.colors.gray,
+    },
+  }
+})
 
 export const StyledTooltipNormal = styled.div(({ theme }) => ({
   display: "block",

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -28,9 +28,10 @@ export type StreamlitShareMetadata = {
 }
 
 export type IToolbarItem = {
-  label?: string
+  borderless?: boolean
   icon?: string
   key: string
+  label?: string
 }
 
 export type IMenuItem =

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -111,6 +111,7 @@ describe("withS4ACommunication HOC", () => {
             type: "SET_TOOLBAR_ITEMS",
             items: [
               {
+                borderless: true,
                 label: "",
                 icon: "star.svg",
                 key: "favorite",
@@ -127,6 +128,7 @@ describe("withS4ACommunication HOC", () => {
     const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
     expect(props.currentState.toolbarItems).toEqual([
       {
+        borderless: true,
         icon: "star.svg",
         key: "favorite",
         label: "",


### PR DESCRIPTION
## 📚 Context

For the favorite star button that we're about to add, the default button hover state
(a box drawn using the app's primary color around the border) looks a bit odd. In order
to solve this while still keeping the button behavior flexible for buttons with text labels
we may add in the future, this PR adds a new `borderless` flag. 

Buttons added to the top of an app with the new `borderless` flag have their
hover states and active states changed to
* no longer draw a box around the button border on hover
* only slightly change the button's color when active (instead of filling the button
   background with the app's primary color)

Without the flag, the button click and hover states remain unchanged.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add a new `borderless` field to the `IToolbarItem` type
- Add a new `BORDERLESS_ICON` button kind
- Use the new button kind when the flag is set for an `IToolbarItem`

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests