### PR TITLE
Log when secrets change

### DIFF
--- a/lib/streamlit/secrets.py
+++ b/lib/streamlit/secrets.py
@@ -196,7 +196,7 @@ class Secrets(Mapping[str, Any]):
 
     def _on_secrets_file_changed(self, _) -> None:
         with self._lock:
-            LOGGER.debug(f"Secrets file {self._file_path} changed, reloading")
+            LOGGER.info(f"Secrets file {self._file_path} changed, reloading")
             self._reset()
             self._parse(print_exceptions=True)
 


### PR DESCRIPTION
## 📚 Context

It's useful to know when secrets get updated in Streamlit Cloud, and it's very
unlikely that this log will get annoying in local development since secrets
probably won't be changed often. This PR upgrades an existing logger call to
an info call instead of a debug call.

- What kind of change does this PR introduce?

  - [x] Other, please describe: additional logging

## 🧠 Description of Changes

- Upgrade the log when secrets are updated to an INFO log

  - [x] This is a visible (user-facing) change
