### PR TITLE
Improve beta_ deprecation message

### DIFF
--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -19,9 +19,8 @@ import streamlit
 
 def _show_beta_warning(name: str, date: str) -> None:
     streamlit.warning(
-        f"`st.{name}` has graduated out of beta. "
-        + f"On {date}, the beta_ version will be removed.\n\n"
-        + f"Before then, update your code from `st.beta_{name}` to `st.{name}`."
+        f"Please replace `st.beta_{name}` with `st.{name}`.\n\n"
+        f"`st.beta_{name}` will be removed after {date}."
     )
 
 

--- a/lib/tests/streamlit/beta_util_test.py
+++ b/lib/tests/streamlit/beta_util_test.py
@@ -28,8 +28,8 @@ class BetaUtilTest(unittest.TestCase):
 
         self.assertEqual(beta_multiply(3, 2), 6)
         mock_warning.assert_called_once_with(
-            "`st.multiply` has graduated out of beta. On 1980-01-01, the beta_ version will be removed."
-            "\n\nBefore then, update your code from `st.beta_multiply` to `st.multiply`."
+            "Please replace `st.beta_multiply` with `st.beta_multiply`.\n\n"
+            "`st.beta_multiply` will be removed after 1980-01-01."
         )
 
     @patch("streamlit.warning")
@@ -41,8 +41,8 @@ class BetaUtilTest(unittest.TestCase):
         beta_multiplier = object_beta_warning(Multiplier(), "multiplier", "1980-01-01")
 
         expected_warning = (
-            "`st.multiplier` has graduated out of beta. On 1980-01-01, the beta_ version will be removed."
-            "\n\nBefore then, update your code from `st.beta_multiplier` to `st.multiplier`."
+            "Please replace `st.beta_multiplier` with `st.multiplier`.\n\n"
+            "`st.beta_multiplier` will be removed after 1980-01-01."
         )
 
         self.assertEqual(beta_multiplier.multiply(3, 2), 6)
@@ -61,8 +61,8 @@ class BetaUtilTest(unittest.TestCase):
         beta_dict = object_beta_warning(DictClass(), "my_dict", "1980-01-01")
 
         expected_warning = (
-            "`st.my_dict` has graduated out of beta. On 1980-01-01, the beta_ version will be removed."
-            "\n\nBefore then, update your code from `st.beta_my_dict` to `st.my_dict`."
+            "Please replace `st.beta_my_dict` with `st.my_dict`.\n\n"
+            "`st.beta_my_dict` will be removed after 1980-01-01."
         )
 
         beta_dict["foo"] = "bar"

--- a/lib/tests/streamlit/beta_util_test.py
+++ b/lib/tests/streamlit/beta_util_test.py
@@ -28,7 +28,7 @@ class BetaUtilTest(unittest.TestCase):
 
         self.assertEqual(beta_multiply(3, 2), 6)
         mock_warning.assert_called_once_with(
-            "Please replace `st.beta_multiply` with `st.beta_multiply`.\n\n"
+            "Please replace `st.beta_multiply` with `st.multiply`.\n\n"
             "`st.beta_multiply` will be removed after 1980-01-01."
         )
 


### PR DESCRIPTION
The current `beta_` deprecation message implies will be removing the `beta_` on an exact date, when in reality it's sometime after that date. So I've rephrased that message for clarity.

In the process I also made it more direct / less wordy.