### PR TITLE
Reformat old string formats to f-strings

### DIFF
--- a/e2e/scripts/st_arrow_dataframe.py
+++ b/e2e/scripts/st_arrow_dataframe.py
@@ -19,7 +19,7 @@ import numpy as np
 
 def highlight_first(value):
     color = "yellow" if value == 0 else "white"
-    return "background-color: %s" % color
+    return f"background-color: {color}"
 
 
 grid = np.arange(0, 100, 1).reshape(10, 10)

--- a/e2e/scripts/st_arrow_table_styling.py
+++ b/e2e/scripts/st_arrow_table_styling.py
@@ -29,12 +29,12 @@ def color_negative_red(val):
     strings, black otherwise.
     """
     color = "red" if val < 0 else "black"
-    return "color: %s" % color
+    return f"color: {color}"
 
 
 def highlight_max(data, color="yellow"):
     """highlight the maximum in a Series or DataFrame"""
-    attr = "background-color: {}".format(color)
+    attr = f"background-color: {color}"
     if data.ndim == 1:  # Series from .apply(axis=0) or axis=1
         is_max = data == data.max()
         return [attr if v else "" for v in is_max]

--- a/e2e/scripts/st_legacy_dataframe.py
+++ b/e2e/scripts/st_legacy_dataframe.py
@@ -19,7 +19,7 @@ import numpy as np
 
 def highlight_first(value):
     color = "yellow" if value == 0 else "white"
-    return "background-color: %s" % color
+    return f"background-color: {color}"
 
 
 grid = np.arange(0, 100, 1).reshape(10, 10)

--- a/e2e/scripts/st_legacy_table_styling.py
+++ b/e2e/scripts/st_legacy_table_styling.py
@@ -29,12 +29,12 @@ def color_negative_red(val):
     strings, black otherwise.
     """
     color = "red" if val < 0 else "black"
-    return "color: %s" % color
+    return f"color: {color}"
 
 
 def highlight_max(data, color="yellow"):
     """highlight the maximum in a Series or DataFrame"""
-    attr = "background-color: {}".format(color)
+    attr = f"background-color: {color}"
     if data.ndim == 1:  # Series from .apply(axis=0) or axis=1
         is_max = data == data.max()
         return [attr if v else "" for v in is_max]

--- a/e2e/scripts/st_multiselect.py
+++ b/e2e/scripts/st_multiselect.py
@@ -16,16 +16,16 @@ import streamlit as st
 
 options = ("male", "female")
 i1 = st.multiselect("multiselect 1", options)
-st.text("value 1: %s" % i1)
+st.text(f"value 1: {i1}")
 
 i2 = st.multiselect("multiselect 2", options, format_func=lambda x: x.capitalize())
-st.text("value 2: %s" % i2)
+st.text(f"value 2: {i2}")
 
 i3 = st.multiselect("multiselect 3", [])
-st.text("value 3: %s" % i3)
+st.text(f"value 3: {i3}")
 
 i4 = st.multiselect("multiselect 4", ["coffee", "tea", "water"], ["tea", "water"])
-st.text("value 4: %s" % i4)
+st.text(f"value 4: {i4}")
 
 i5 = st.multiselect(
     "multiselect 5",
@@ -36,10 +36,10 @@ i5 = st.multiselect(
         )
     ),
 )
-st.text("value 5: %s" % i5)
+st.text(f"value 5: {i5}")
 
 i6 = st.multiselect("multiselect 6", options, disabled=True)
-st.text("value 6: %s" % i6)
+st.text(f"value 6: {i6}")
 
 if st._is_running_with_streamlit:
 
@@ -47,5 +47,5 @@ if st._is_running_with_streamlit:
         st.session_state.multiselect_changed = True
 
     st.multiselect("multiselect 7", options, key="multiselect7", on_change=on_change)
-    st.text("value 7: %s" % st.session_state.multiselect7)
+    st.text(f"value 7: {st.session_state.multiselect7}")
     st.text(f"multiselect changed: {'multiselect_changed' in st.session_state}")

--- a/examples/audio.py
+++ b/examples/audio.py
@@ -54,7 +54,7 @@ if len(audiofiles) == 0:
 
 else:
     filename = st.selectbox(
-        "Select an audio file from your home directory (%s) to play" % avdir,
+        f"Select an audio file from your home directory ({avdir}) to play",
         audiofiles,
         0,
     )

--- a/examples/images.py
+++ b/examples/images.py
@@ -103,7 +103,7 @@ class StreamlitImages(object):
                 i = i.convert("RGB")
             data = io.BytesIO()
             i.save(data, format=fmt.upper())
-            self._data["image.%s" % fmt] = data.getvalue()
+            self._data[f"image.{fmt}"] = data.getvalue()
 
     def generate_image_channel_data(self):
         # np.array(image) returns the following shape
@@ -119,7 +119,7 @@ class StreamlitImages(object):
             data = io.BytesIO()
             img = Image.fromarray(array[idx].astype(np.uint8))
             img.save(data, format="PNG")
-            self._data["%s.png" % name] = data.getvalue()
+            self._data[f"{name}.png"] = data.getvalue()
 
     def generate_bgra_image(self):
         # Split Images and rearrange
@@ -194,7 +194,7 @@ class StreamlitImages(object):
 
     def save(self):
         for name, data in self._data.items():
-            Image.open(io.BytesIO(data)).save("/tmp/%s" % name)
+            Image.open(io.BytesIO(data)).save(f"/tmp/{name}")
 
     def get_images(self):
         return self._data

--- a/examples/mnist-cnn.py
+++ b/examples/mnist-cnn.py
@@ -53,7 +53,7 @@ class MyCallback(keras.callbacks.Callback):
     def on_epoch_begin(self, epoch, logs=None):
         self._ts = time.time()
         self._epoch = epoch
-        st.subheader("Epoch %s" % epoch)
+        st.subheader(f"Epoch {epoch}")
         self._epoch_chart = st.line_chart()
         self._epoch_progress = st.info("No stats yet.")
         self._epoch_summary = st.empty()

--- a/examples/run_on_save.py
+++ b/examples/run_on_save.py
@@ -48,9 +48,9 @@ st.write("This should change every ", secs_to_wait, " seconds: ", random())
 status = st.empty()
 for i in range(secs_to_wait, 0, -1):
     time.sleep(1)
-    status.text("Sleeping %ss..." % i)
+    status.text(f"Sleeping {i}s...")
 
-status.text("Touching %s" % __file__)
+status.text(f"Touching {__file__}")
 
 platform_system = platform.system()
 
@@ -66,10 +66,7 @@ if platform_system == "Linux":
     )
 
 elif platform_system == "Darwin":
-    cmd = "sed -i bak " "'s/^# MODIFIED AT:.*/# MODIFIED AT: %s/' %s" % (
-        time.time(),
-        __file__,
-    )
+    cmd = f"sed -i bak 's/^# MODIFIED AT:.*/# MODIFIED AT: {time.time()}/' {__file__}"
 
 elif platform_system == "Windows":
     raise NotImplementedError("Windows not supported")
@@ -79,6 +76,6 @@ else:
 
 os.system(cmd)
 
-status.text("Touched %s" % __file__)
+status.text(f"Touched {__file__}")
 
 # MODIFIED AT: 1586542219.90599

--- a/examples/video.py
+++ b/examples/video.py
@@ -54,7 +54,7 @@ if len(files) == 0:
 
 else:
     filename = st.selectbox(
-        "Select a video file from your home directory (%s) to play" % avdir,
+        f"Select a video file from your home directory ({avdir}) to play",
         files,
         0,
     )

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -55,9 +55,7 @@ class VerifyVersionCommand(install):
         tag = os.getenv("CIRCLE_TAG")
 
         if tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
-            )
+            info = f"Git tag: {tag} does not match the version of this app: {VERSION}"
             sys.exit(info)
 
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -303,7 +303,7 @@ def experimental_show(*args):
         for idx, input in enumerate(inputs):
             escaped = _string_util.escape_markdown(input)
 
-            markdown("**%s**" % escaped)
+            markdown(f"**{escaped}**")
             write(args[idx])
 
     except Exception:

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -247,7 +247,7 @@ def _print_url(is_running_hello: bool) -> None:
             named_urls.append(("Network URL", Report.get_url(internal_ip)))
 
     click.secho("")
-    click.secho("  %s" % title_message, fg="blue", bold=True)
+    click.secho(f"  {title_message}", fg="blue", bold=True)
     click.secho("")
 
     for url_name, url in named_urls:

--- a/lib/streamlit/caching/cache_errors.py
+++ b/lib/streamlit/caching/cache_errors.py
@@ -114,6 +114,6 @@ to suppress the warning.
     def _get_cached_func_name_md(func: types.FunctionType) -> str:
         """Get markdown representation of the function name."""
         if hasattr(func, "__name__"):
-            return "`%s()`" % func.__name__
+            return f"`{func.__name__}()`"
         else:
             return "a cached function"

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -33,14 +33,14 @@ LOG_LEVELS = ("error", "warning", "info", "debug")
 
 def _convert_config_option_to_click_option(config_option):
     """Composes given config option options as options for click lib."""
-    option = "--{}".format(config_option.key)
+    option = f"--{config_option.key}"
     param = config_option.key.replace(".", "_")
     description = config_option.description
     if config_option.deprecated:
         description += "\n {} - {}".format(
             config_option.deprecation_text, config_option.expiration_date
         )
-    envvar = "STREAMLIT_{}".format(to_snake_case(param).upper())
+    envvar = f"STREAMLIT_{to_snake_case(param).upper()}"
 
     return {
         "param": param,
@@ -77,7 +77,7 @@ def _download_remote(script_path, url_path):
             resp.raise_for_status()
             fp.write(resp.content)
         except requests.exceptions.RequestException as e:
-            raise click.BadParameter(("Unable to fetch {}.\n{}".format(url_path, e)))
+            raise click.BadParameter(f"Unable to fetch {url_path}.\n{e}")
 
 
 @click.group(context_settings={"auto_envvar_prefix": "STREAMLIT"})
@@ -186,7 +186,7 @@ def main_run(target, args=None, **kwargs):
             _main_run(script_path, args, flag_options=kwargs)
     else:
         if not os.path.exists(target):
-            raise click.BadParameter("File does not exist: {}".format(target))
+            raise click.BadParameter(f"File does not exist: {target}")
         _main_run(target, args, flag_options=kwargs)
 
 
@@ -236,9 +236,9 @@ def cache_clear():
     result = streamlit.legacy_caching.clear_cache()
     cache_path = streamlit.legacy_caching.get_cache_path()
     if result:
-        print("Cleared directory %s." % cache_path)
+        print(f"Cleared directory {cache_path}.")
     else:
-        print("Nothing to clear at %s." % cache_path)
+        print(f"Nothing to clear at {cache_path}.")
 
     streamlit.caching.clear_memo_cache()
     streamlit.caching.clear_singleton_cache()

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -376,7 +376,7 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
     @staticmethod
     def get_url(file_id: str) -> str:
         """Return the URL for a component file with the given ID."""
-        return "components/{}".format(file_id)
+        return f"components/{file_id}"
 
 
 class ComponentRegistry:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -103,7 +103,7 @@ def get_option(key: str) -> Any:
         config_options = get_config_options()
 
         if key not in config_options:
-            raise RuntimeError('Config key "%s" not defined.' % key)
+            raise RuntimeError(f'Config key "{key}" not defined.')
         return config_options[key].value
 
 
@@ -135,9 +135,9 @@ def get_options_for_section(section: str) -> Dict[str, Any]:
 
 def _create_section(section: str, description: str) -> None:
     """Create a config section and store it globally in this module."""
-    assert section not in _section_descriptions, (
-        'Cannot define section "%s" twice.' % section
-    )
+    assert (
+        section not in _section_descriptions
+    ), f'Cannot define section "{section}" twice.'
     _section_descriptions[section] = description
 
 
@@ -206,7 +206,7 @@ def _create_option(
         option.section,
         ", ".join(_section_descriptions.keys()),
     )
-    assert key not in _config_options_template, 'Cannot define option "%s" twice.' % key
+    assert key not in _config_options_template, f'Cannot define option "{key}" twice.'
     _config_options_template[key] = option
     return option
 
@@ -881,7 +881,7 @@ def get_where_defined(key: str) -> str:
         config_options = get_config_options()
 
         if key not in config_options:
-            raise RuntimeError('Config key "%s" not defined.' % key)
+            raise RuntimeError(f'Config key "{key}" not defined.')
         return config_options[key].where_defined
 
 
@@ -1008,7 +1008,7 @@ def _maybe_read_env_variable(value: Any) -> Any:
 
             LOGGER = get_logger(__name__)
 
-            LOGGER.error("No environment variable called %s" % var_name)
+            LOGGER.error(f"No environment variable called {var_name}")
         else:
             return _maybe_convert_to_number(env_var)
 

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -170,7 +170,7 @@ class ConfigOption:
         if self.replaced_by:
             self.deprecated = True
             if deprecation_text is None:
-                deprecation_text = "Replaced by %s." % self.replaced_by
+                deprecation_text = f"Replaced by {self.replaced_by}."
 
         if self.deprecated:
             assert expiration_date, "expiration_date is required for deprecated items"

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -60,7 +60,7 @@ def show_config(
             continue
 
         append_newline()
-        append_section("[%s]" % section)
+        append_section(f"[{section}]")
         append_newline()
 
         for key, option in config_options.items():
@@ -78,15 +78,15 @@ def show_config(
 
             for i, txt in enumerate(description_paragraphs):
                 if i == 0:
-                    append_desc("# %s" % txt)
+                    append_desc(f"# {txt}")
                 else:
-                    append_comment("# %s" % txt)
+                    append_comment(f"# {txt}")
 
             toml_default = toml.dumps({"default": option.default_val})
             toml_default = toml_default[10:].strip()
 
             if len(toml_default) > 0:
-                append_comment("# Default: %s" % toml_default)
+                append_comment(f"# Default: {toml_default}")
             else:
                 # Don't say "Default: (unset)" here because this branch applies
                 # to complex config settings too.
@@ -109,12 +109,12 @@ def show_config(
             )
 
             if option_is_manually_set:
-                append_comment("# The value below was set in %s" % option.where_defined)
+                append_comment(f"# The value below was set in {option.where_defined}")
 
             toml_setting = toml.dumps({key: option.value})
 
             if len(toml_setting) == 0:
-                toml_setting = "#%s =\n" % key
+                toml_setting = f"#{key} =\n"
 
             append_setting(toml_setting)
 

--- a/lib/streamlit/credentials.py
+++ b/lib/streamlit/credentials.py
@@ -178,7 +178,7 @@ class Credentials(object):
         try:
             os.remove(c._conf_file)
         except OSError as e:
-            LOGGER.error("Error removing credentials file: %s" % e)
+            LOGGER.error(f"Error removing credentials file: {e}")
 
     def save(self):
         """Save to toml file."""

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -284,9 +284,7 @@ class DeltaGenerator(
                         "`st.%(name)s()`?" % {"name": name}
                     )
             else:
-                message = "`%(name)s()` is not a valid Streamlit command." % {
-                    "name": name
-                }
+                message = f"`{name}()` is not a valid Streamlit command."
 
             raise StreamlitAPIException(message)
 

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -89,7 +89,7 @@ def echo(code_location="above"):
         show_code(code_string, "python")
 
     except FileNotFoundError as err:
-        show_warning("Unable to display code. %s" % err)
+        show_warning(f"Unable to display code. {err}")
 
 
 def _get_initial_indent(lines: Iterable[str]) -> int:

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -325,7 +325,7 @@ def marshall_file(coordinates, data, proto_download_button, mimetype, file_name=
         data = data.read()
         mimetype = mimetype or "application/octet-stream"
     else:
-        raise RuntimeError("Invalid binary data format: %s" % type(data))
+        raise RuntimeError(f"Invalid binary data format: {type(data)}")
 
     this_file = in_memory_file_manager.add(
         data, mimetype, coordinates, file_name=file_name, is_for_static_download=True

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -116,7 +116,7 @@ def marshall(proto, figure_or_dot, use_container_width, element_id):
         dot = figure_or_dot
     else:
         raise StreamlitAPIException(
-            "Unhandled type for graphviz chart: %s" % type(figure_or_dot)
+            f"Unhandled type for graphviz chart: {type(figure_or_dot)}"
         )
 
     proto.spec = dot

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -207,7 +207,7 @@ def _normalize_to_bytes(data, width, output_format):
     format = _format_from_image_type(image, output_format)
     if output_format.lower() == "auto":
         ext = imghdr.what(None, data)
-        mimetype = mimetypes.guess_type("image.%s" % ext)[0]
+        mimetype = mimetypes.guess_type(f"image.{ext}")[0]
     else:
         mimetype = "image/" + format.lower()
 

--- a/lib/streamlit/elements/legacy_data_frame.py
+++ b/lib/streamlit/elements/legacy_data_frame.py
@@ -246,7 +246,7 @@ def _get_css_styles(translated_style):
             match = cell_selector_regex.match(cell_selector)
             if not match:
                 raise RuntimeError(
-                    'Failed to parse cellstyle selector "%s"' % cell_selector
+                    f'Failed to parse cellstyle selector "{cell_selector}"'
                 )
             row = int(match.group(1))
             col = int(match.group(2))
@@ -254,7 +254,7 @@ def _get_css_styles(translated_style):
             props = cell_style["props"]
             for prop in props:
                 if not isinstance(prop, (tuple, list)) or len(prop) != 2:
-                    raise RuntimeError('Unexpected cellstyle props "%s"' % prop)
+                    raise RuntimeError(f'Unexpected cellstyle props "{prop}"')
                 name = str(prop[0]).strip()
                 value = str(prop[1]).strip()
                 if name and value:
@@ -316,10 +316,10 @@ def _get_custom_display_values(df, translated_style):
                     found_row_header = True
                     continue
                 else:
-                    raise RuntimeError('Found unexpected row header "%s"' % cell)
+                    raise RuntimeError(f'Found unexpected row header "{cell}"')
             match = cell_selector_regex.match(cell_id)
             if not match:
-                raise RuntimeError('Failed to parse cell selector "%s"' % cell_id)
+                raise RuntimeError(f'Failed to parse cell selector "{cell_id}"')
 
             # Only store display values that differ from the cell's default
             if has_custom_display_value(cell):
@@ -374,7 +374,7 @@ def _marshall_index(pandas_index, proto_index):
     elif type(pandas_index) == pd.Float64Index:
         proto_index.float_64_index.data.data.extend(pandas_index)
     else:
-        raise NotImplementedError("Can't handle %s yet." % type(pandas_index))
+        raise NotImplementedError(f"Can't handle {type(pandas_index)} yet.")
 
 
 def _marshall_table(pandas_table, proto_table):
@@ -430,7 +430,7 @@ def _marshall_any_array(pandas_array, proto_array):
         # awareness/unawareness. The frontend will render it correctly.
         proto_array.datetimes.data.extend(pandas_array.map(datetime.datetime.isoformat))
     else:
-        raise NotImplementedError("Dtype %s not understood." % pandas_array.dtype)
+        raise NotImplementedError(f"Dtype {pandas_array.dtype} not understood.")
 
 
 def add_rows(delta1, delta2, name=None):
@@ -483,10 +483,7 @@ def _concat_index(index1, index2):
     type2 = index2.WhichOneof("type")
     # This branch is covered with tests but pytest doesnt seem to realize it.
     if type1 != type2:  # pragma: no cover
-        raise ValueError(
-            "Cannot concatenate %(type1)s with %(type2)s."
-            % {"type1": type1, "type2": type2}
-        )
+        raise ValueError(f"Cannot concatenate {type1} with {type2}.")
 
     if type1 == "plain_index":
         _concat_any_array(index1.plain_index.data, index2.plain_index.data)
@@ -501,7 +498,7 @@ def _concat_index(index1, index2):
     elif type1 == "timedelta_index":
         index1.timedelta_index.data.data.extend(index2.timedelta_index.data.data)
     else:
-        raise NotImplementedError('Cannot concatenate "%s" indices.' % type1)
+        raise NotImplementedError(f'Cannot concatenate "{type1}" indices.')
 
 
 def _concat_any_array(any_array_1, any_array_2):
@@ -514,10 +511,7 @@ def _concat_any_array(any_array_1, any_array_2):
     type1 = any_array_1.WhichOneof("type")
     type2 = any_array_2.WhichOneof("type")
     if type1 != type2:
-        raise ValueError(
-            "Cannot concatenate %(type1)s with %(type2)s."
-            % {"type1": type1, "type2": type2}
-        )
+        raise ValueError(f"Cannot concatenate {type1} with {type2}.")
     getattr(any_array_1, type1).data.extend(getattr(any_array_2, type2).data)
 
 
@@ -540,7 +534,7 @@ def _get_data_frame(delta, name=None):
 
         # Some element types don't support named datasets.
         if name and element_type in ("data_frame", "table", "chart"):
-            raise ValueError("Dataset names not supported for st.%s" % element_type)
+            raise ValueError(f"Dataset names not supported for st.{element_type}")
 
         if element_type in "data_frame":
             return delta.new_element.data_frame
@@ -564,10 +558,10 @@ def _get_data_frame(delta, name=None):
 
     elif delta_type == "add_rows":
         if delta.add_rows.has_name and name != delta.add_rows.name:
-            raise ValueError('No dataset found with name "%s".' % name)
+            raise ValueError(f'No dataset found with name "{name}".')
         return delta.add_rows.data
     else:
-        raise ValueError("Cannot extract DataFrame from %s." % delta_type)
+        raise ValueError(f"Cannot extract DataFrame from {delta_type}.")
 
 
 def _get_or_create_dataset(datasets_proto, name):

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -163,10 +163,7 @@ class MarkdownMixin:
 
         """
         code_proto = MarkdownProto()
-        markdown = "```%(language)s\n%(body)s\n```" % {
-            "language": language or "",
-            "body": body,
-        }
+        markdown = f"```{language or ''}\n{body}\n```"
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
@@ -284,7 +281,7 @@ class MarkdownMixin:
             body = sympy.latex(body)
 
         latex_proto = MarkdownProto()
-        latex_proto.body = "$$\n%s\n$$" % clean_text(body)
+        latex_proto.body = f"$$\n{clean_text(body)}\n$$"
         return self.dg._enqueue("markdown", latex_proto)
 
     @property

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -175,7 +175,7 @@ def _marshall_av_media(coordinates, proto, data, mimetype):
     elif type_util.is_type(data, "numpy.ndarray"):
         data = data.tobytes()
     else:
-        raise RuntimeError("Invalid binary data format: %s" % type(data))
+        raise RuntimeError(f"Invalid binary data format: {type(data)}")
 
     this_file = in_memory_file_manager.add(data, mimetype, coordinates)
     proto.url = this_file.url

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -143,7 +143,7 @@ def marshall(proto, figure_or_data, use_container_width, sharing, **kwargs):
         )
 
     if not isinstance(sharing, str) or sharing.lower() not in SHARING_MODES:
-        raise ValueError("Invalid sharing mode for Plotly chart: %s" % sharing)
+        raise ValueError(f"Invalid sharing mode for Plotly chart: {sharing}")
 
     proto.use_container_width = use_container_width
 

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -51,7 +51,7 @@ class ProgressMixin:
                 progress_proto.value = int(value * 100)
             else:
                 raise StreamlitAPIException(
-                    "Progress Value has invalid value [0.0, 1.0]: %f" % value
+                    f"Progress Value has invalid value [0.0, 1.0]: {value:f}"
                 )
 
         elif isinstance(value, int):
@@ -63,7 +63,7 @@ class ProgressMixin:
                 )
         else:
             raise StreamlitAPIException(
-                "Progress Value has invalid type: %s" % type(value).__name__
+                f"Progress Value has invalid type: {type(value).__name__}"
             )
 
         return self.dg._enqueue("progress", progress_proto)

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -108,7 +108,7 @@ class RadioMixin:
 
         if not isinstance(index, int):
             raise StreamlitAPIException(
-                "Radio Value has invalid type: %s" % type(index).__name__
+                f"Radio Value has invalid type: {type(index).__name__}"
             )
 
         if len(opt) > 0 and not 0 <= index < len(opt):

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -98,7 +98,7 @@ class SelectboxMixin:
 
         if not isinstance(index, int):
             raise StreamlitAPIException(
-                "Selectbox Value has invalid type: %s" % type(index).__name__
+                f"Selectbox Value has invalid type: {type(index).__name__}"
             )
 
         if len(opt) > 0 and not 0 <= index < len(opt):

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -59,21 +59,21 @@ def get_encoded_file_data(data, encoding="auto"):
 
 @contextlib.contextmanager
 def streamlit_read(path, binary=False):
-    """Opens a context to read this file relative to the streamlit path.
+    f"""Opens a context to read this file relative to the streamlit path.
 
     For example:
 
     with streamlit_read('foo.txt') as foo:
         ...
 
-    opens the file `%s/foo.txt`
+    opens the file `{CONFIG_FOLDER_NAME}/foo.txt`
 
     path   - the path to write to (within the streamlit directory)
     binary - set to True for binary IO
-    """ % CONFIG_FOLDER_NAME
+    """
     filename = get_streamlit_file_path(path)
     if os.stat(filename).st_size == 0:
-        raise util.Error('Read zero byte file: "%s"' % filename)
+        raise util.Error(f'Read zero byte file: "{filename}"')
 
     mode = "r"
     if binary:
@@ -84,19 +84,19 @@ def streamlit_read(path, binary=False):
 
 @contextlib.contextmanager
 def streamlit_write(path, binary=False):
-    """
+    f"""
     Opens a file for writing within the streamlit path, and
     ensuring that the path exists. For example:
 
         with streamlit_write('foo/bar.txt') as bar:
             ...
 
-    opens the file %s/foo/bar.txt for writing,
+    opens the file {CONFIG_FOLDER_NAME}/foo/bar.txt for writing,
     creating any necessary directories along the way.
 
     path   - the path to write to (within the streamlit directory)
     binary - set to True for binary IO
-    """ % CONFIG_FOLDER_NAME
+    """
     mode = "w"
     if binary:
         mode += "b"
@@ -106,7 +106,7 @@ def streamlit_write(path, binary=False):
         with open(path, mode) as handle:
             yield handle
     except OSError as e:
-        msg = ["Unable to write file: %s" % os.path.abspath(path)]
+        msg = [f"Unable to write file: {os.path.abspath(path)}"]
         if e.errno == errno.EINVAL and env_util.IS_DARWIN:
             msg.append(
                 "Python is limited to files below 2GB on OSX. "

--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -119,11 +119,11 @@ def mapping_demo():
         else:
             st.error("Please choose at least one layer above.")
     except URLError as e:
-        st.error("""
+        st.error(f"""
             **This demo requires internet access.**
 
-            Connection error: %s
-        """ % e.reason)
+            Connection error: {e.reason}
+        """)
 # fmt: on
 
 # Turn off black formatting for this function to present the user with more
@@ -260,12 +260,11 @@ def data_frame_demo():
             st.altair_chart(chart, use_container_width=True)
     except URLError as e:
         st.error(
-            """
+            f"""
             **This demo requires internet access.**
 
-            Connection error: %s
+            Connection error: {e.reason}
         """
-            % e.reason
         )
 
 

--- a/lib/streamlit/hello/hello.py
+++ b/lib/streamlit/hello/hello.py
@@ -84,7 +84,7 @@ def run():
         st.write("# Welcome to Streamlit! 👋")
     else:
         show_code = st.sidebar.checkbox("Show code", True)
-        st.markdown("# %s" % demo_name)
+        st.markdown(f"# {demo_name}")
         description = DEMOS[demo_name][1]
         if description:
             st.write(description)

--- a/lib/streamlit/js_number.py
+++ b/lib/streamlit/js_number.py
@@ -66,11 +66,11 @@ class JSNumber(object):
 
         if value < cls.MIN_SAFE_INTEGER:
             raise JSNumberBoundsException(
-                "%s (%s) must be >= -((1 << 53) - 1)" % (value_name, value)
+                f"{value_name} ({value}) must be >= -((1 << 53) - 1)"
             )
         elif value > cls.MAX_SAFE_INTEGER:
             raise JSNumberBoundsException(
-                "%s (%s) must be <= (1 << 53) - 1" % (value_name, value)
+                f"{value_name} ({value}) must be <= (1 << 53) - 1"
             )
 
     @classmethod
@@ -97,14 +97,12 @@ class JSNumber(object):
             value_name = "value"
 
         if not isinstance(value, (numbers.Integral, float)):
-            raise JSNumberBoundsException(
-                "%s (%s) is not a float" % (value_name, value)
-            )
+            raise JSNumberBoundsException(f"{value_name} ({value}) is not a float")
         elif value < cls.MIN_NEGATIVE_VALUE:
             raise JSNumberBoundsException(
-                "%s (%s) must be >= -1.797e+308" % (value_name, value)
+                f"{value_name} ({value}) must be >= -1.797e+308"
             )
         elif value > cls.MAX_VALUE:
             raise JSNumberBoundsException(
-                "%s (%s) must be <= 1.797e+308" % (value_name, value)
+                f"{value_name} ({value}) must be <= 1.797e+308"
             )

--- a/lib/streamlit/legacy_caching/caching.py
+++ b/lib/streamlit/legacy_caching/caching.py
@@ -273,7 +273,7 @@ def _get_output_hash(
 
 
 def _read_from_disk_cache(key: str) -> Any:
-    path = file_util.get_streamlit_file_path("cache", "%s.pickle" % key)
+    path = file_util.get_streamlit_file_path("cache", f"{key}.pickle")
     try:
         with file_util.streamlit_read(path, binary=True) as input:
             entry = pickle.load(input)
@@ -281,7 +281,7 @@ def _read_from_disk_cache(key: str) -> Any:
             _LOGGER.debug("Disk cache HIT: %s", type(value))
     except util.Error as e:
         _LOGGER.error(e)
-        raise CacheError("Unable to read from cache: %s" % e)
+        raise CacheError(f"Unable to read from cache: {e}")
 
     except FileNotFoundError:
         raise CacheKeyNotFoundError("Key not found in disk cache")
@@ -289,7 +289,7 @@ def _read_from_disk_cache(key: str) -> Any:
 
 
 def _write_to_disk_cache(key: str, value: Any) -> None:
-    path = file_util.get_streamlit_file_path("cache", "%s.pickle" % key)
+    path = file_util.get_streamlit_file_path("cache", f"{key}.pickle")
 
     try:
         with file_util.streamlit_write(path, binary=True) as output:
@@ -302,7 +302,7 @@ def _write_to_disk_cache(key: str, value: Any) -> None:
             os.remove(path)
         except (FileNotFoundError, IOError, OSError):
             pass
-        raise CacheError("Unable to write to cache: %s" % e)
+        raise CacheError(f"Unable to write to cache: {e}")
 
 
 def _read_from_cache(
@@ -483,9 +483,9 @@ def cache(
         name = func.__qualname__
 
         if len(args) == 0 and len(kwargs) == 0:
-            message = "Running `%s()`." % name
+            message = f"Running `{name}()`."
         else:
-            message = "Running `%s(...)`." % name
+            message = f"Running `{name}(...)`."
 
         def get_or_create_cached_value():
             nonlocal cache_key
@@ -531,7 +531,7 @@ def cache(
 
             # Avoid recomputing the body's hash by just appending the
             # previously-computed hash to the arg hash.
-            value_key = "%s-%s" % (value_key, cache_key)
+            value_key = f"{value_key}-{cache_key}"
 
             _LOGGER.debug("Cache key: %s", value_key)
 
@@ -698,7 +698,7 @@ class CachedStFunctionWarning(StreamlitAPIWarning):
 
     def _get_message(self, st_func_name, cached_func):
         args = {
-            "st_func_name": "`st.%s()` or `st.write()`" % st_func_name,
+            "st_func_name": f"`st.{st_func_name}()` or `st.write()`",
             "func_name": _get_cached_func_name_md(cached_func),
         }
 
@@ -749,6 +749,6 @@ For more information and detailed solutions check out [our documentation.]
 def _get_cached_func_name_md(func: types.FunctionType) -> str:
     """Get markdown representation of the function name."""
     if hasattr(func, "__name__"):
-        return "`%s()`" % func.__name__
+        return f"`{func.__name__}()`"
     else:
         return "a cached function"

--- a/lib/streamlit/legacy_caching/hashing.py
+++ b/lib/streamlit/legacy_caching/hashing.py
@@ -154,7 +154,7 @@ class _HashStack:
     def pretty_print(self):
         def to_str(v):
             try:
-                return "Object of type %s: %s" % (type_util.get_fqn_type(v), str(v))
+                return f"Object of type {type_util.get_fqn_type(v)}: {str(v)}"
             except:
                 return "<Unable to convert item to string>"
 
@@ -625,7 +625,7 @@ class _CodeHasher:
             if obj.__module__.startswith("streamlit"):
                 # Ignore streamlit modules even if they are in the CWD
                 # (e.g. during development).
-                return self.to_bytes("%s.%s" % (obj.__module__, obj.__name__))
+                return self.to_bytes(f"{obj.__module__}.{obj.__name__}")
 
             h = hashlib.new("md5")
 
@@ -854,7 +854,7 @@ class UserHashError(StreamlitAPIException):
         args = _get_error_message_args(orig_exc, cached_func)
 
         if hasattr(hash_func, "__name__"):
-            args["hash_func_name"] = "`%s()`" % hash_func.__name__
+            args["hash_func_name"] = f"`{hash_func.__name__}()`"
         else:
             args["hash_func_name"] = "a function"
 
@@ -981,7 +981,7 @@ def _get_error_message_args(orig_exc: BaseException, failed_obj: Any) -> Dict[st
 
     else:
         if hasattr(hash_source, "__name__"):
-            object_desc = "`%s()`" % hash_source.__name__
+            object_desc = f"`{hash_source.__name__}()`"
             object_desc_specific = object_desc
         else:
             object_desc = "a function"

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -46,7 +46,7 @@ def set_log_level(level: Union[str, int]) -> None:
     elif level == "DEBUG" or level == logging.DEBUG:
         log_level = logging.DEBUG
     else:
-        msg = 'undefined log level "%s"' % level
+        msg = f'undefined log level "{level}"'
         logger.critical(msg)
         sys.exit(1)
 
@@ -93,7 +93,7 @@ def init_tornado_logs() -> None:
     # http://www.tornadoweb.org/en/stable/log.html
     logs = ["access", "application", "general"]
     for log in logs:
-        name = "tornado.%s" % log
+        name = f"tornado.{log}"
         get_logger(name)
 
     logger = get_logger(__name__)

--- a/lib/streamlit/report.py
+++ b/lib/streamlit/report.py
@@ -57,11 +57,7 @@ class Report(object):
         if base_path:
             base_path = "/" + base_path
 
-        return "http://%(host_ip)s:%(port)s%(base_path)s" % {
-            "host_ip": host_ip.strip("/"),
-            "port": port,
-            "base_path": base_path,
-        }
+        return f"http://{host_ip.strip('/')}:{port}{base_path}"
 
     def __init__(self, script_path, command_line):
         """Constructor.
@@ -156,9 +152,7 @@ class Report(object):
             internal_server_ip=net_util.get_internal_ip(),
         )
 
-        return [
-            ("reports/%s/manifest.pb" % self.report_id, manifest.SerializeToString())
-        ]
+        return [(f"reports/{self.report_id}/manifest.pb", manifest.SerializeToString())]
 
     def serialize_final_report_to_files(self):
         """Return the report as an easily-serializable list of tuples.
@@ -186,7 +180,7 @@ class Report(object):
         # Build a list of message tuples: (message_location, serialized_message)
         message_tuples = [
             (
-                "reports/%(id)s/%(idx)s.pb" % {"id": self.report_id, "idx": msg_idx},
+                f"reports/{self.report_id}/{msg_idx}.pb",
                 msg.SerializeToString(),
             )
             for msg_idx, msg in enumerate(messages)
@@ -194,7 +188,7 @@ class Report(object):
 
         manifest_tuples = [
             (
-                "reports/%(id)s/manifest.pb" % {"id": self.report_id},
+                f"reports/{self.report_id}/manifest.pb",
                 manifest.SerializeToString(),
             )
         ]

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -544,7 +544,7 @@ class ReportSession(object):
 
         """
         if self._state == ReportSessionState.SHUTDOWN_REQUESTED:
-            LOGGER.warning("Discarding %s request after shutdown" % request)
+            LOGGER.warning(f"Discarding {request} request after shutdown")
             return
 
         self._script_request_queue.enqueue(request, data)
@@ -619,7 +619,7 @@ class ReportSession(object):
 
         except Exception as e:
             # Horrible hack to show something if something breaks.
-            err_msg = "%s: %s" % (type(e).__name__, str(e) or "No further details.")
+            err_msg = f"{type(e).__name__}: {str(e) or 'No further details.'}"
             progress_msg = ForwardMsg()
             progress_msg.report_uploaded = err_msg
             yield ws.write_message(
@@ -665,7 +665,7 @@ class ReportSession(object):
             elif sharing_mode == "file":
                 self._storage = FileStorage()
             else:
-                raise RuntimeError("Unsupported sharing mode '%s'" % sharing_mode)
+                raise RuntimeError(f"Unsupported sharing mode '{sharing_mode}'")
         return self._storage
 
 

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -544,7 +544,7 @@ class ReportSession(object):
 
         """
         if self._state == ReportSessionState.SHUTDOWN_REQUESTED:
-            LOGGER.warning(f"Discarding {request} request after shutdown")
+            LOGGER.warning("Discarding %s request after shutdown", request)
             return
 
         self._script_request_queue.enqueue(request, data)

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -252,7 +252,7 @@ def get_report_ctx() -> Optional[ReportContext]:
         # via `streamlit run`. Otherwise, the user is likely running a
         # script "bare", and doesn't need to be warned about streamlit
         # bits that are irrelevant when not connected to a report.
-        LOGGER.warning("Thread '%s': missing ReportContext" % thread.name)
+        LOGGER.warning(f"Thread '{thread.name}': missing ReportContext")
 
     return ctx
 

--- a/lib/streamlit/report_thread.py
+++ b/lib/streamlit/report_thread.py
@@ -252,7 +252,7 @@ def get_report_ctx() -> Optional[ReportContext]:
         # via `streamlit run`. Otherwise, the user is likely running a
         # script "bare", and doesn't need to be warned about streamlit
         # bits that are irrelevant when not connected to a report.
-        LOGGER.warning(f"Thread '{thread.name}': missing ReportContext")
+        LOGGER.warning("Thread '%s': missing ReportContext", thread.name)
 
     return ctx
 

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -174,7 +174,7 @@ class ScriptRunner(object):
             elif request == ScriptRequest.RERUN:
                 self._run_script(data)
             else:
-                raise RuntimeError("Unrecognized ScriptRequest: %s" % request)
+                raise RuntimeError(f"Unrecognized ScriptRequest: {request}")
 
         # Send a SHUTDOWN event before exiting. This includes the widget values
         # as they existed after our last successful script run, which the
@@ -219,7 +219,7 @@ class ScriptRunner(object):
         elif request == ScriptRequest.RERUN:
             raise RerunException(data)
         else:
-            raise RuntimeError("Unrecognized ScriptRequest: %s" % request)
+            raise RuntimeError(f"Unrecognized ScriptRequest: {request}")
 
     def _install_tracer(self):
         """Install function that runs before each line of the script."""
@@ -301,7 +301,7 @@ class ScriptRunner(object):
 
         except BaseException as e:
             # We got a compile error. Send an error event and bail immediately.
-            LOGGER.debug("Fatal script error: %s" % e)
+            LOGGER.debug(f"Fatal script error: {e}")
             self._session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY] = False
             self.on_event.send(
                 ScriptRunnerEvent.SCRIPT_STOPPED_WITH_COMPILE_ERROR, exception=e

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -301,7 +301,7 @@ class ScriptRunner(object):
 
         except BaseException as e:
             # We got a compile error. Send an error event and bail immediately.
-            LOGGER.debug(f"Fatal script error: {e}")
+            LOGGER.debug("Fatal script error: %s", e)
             self._session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY] = False
             self.on_event.send(
                 ScriptRunnerEvent.SCRIPT_STOPPED_WITH_COMPILE_ERROR, exception=e

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -116,7 +116,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         try:
             in_memory_file_manager.get(absolute_path)
         except KeyError:
-            LOGGER.error(f"InMemoryFileManager: Missing file {absolute_path}")
+            LOGGER.error("InMemoryFileManager: Missing file %s", absolute_path)
             raise tornado.web.HTTPError(404, "not found")
 
         return absolute_path
@@ -142,17 +142,20 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
     @classmethod
     def get_content(cls, abspath, start=None, end=None):
-        LOGGER.debug(f"MediaFileHandler: GET {abspath}")
+        LOGGER.debug("MediaFileHandler: GET %s", abspath)
 
         try:
             # abspath is the hash as used `get_absolute_path`
             in_memory_file = in_memory_file_manager.get(abspath)
         except:
-            LOGGER.error(f"InMemoryFileManager: Missing file {abspath}")
+            LOGGER.error("InMemoryFileManager: Missing file %s", abspath)
             return
 
         LOGGER.debug(
-            f"InMemoryFileManager: Sending {in_memory_file.mimetype} file {abspath}"
+            LOGGER.debug(
+    "InMemoryFileManager: Sending %s file %s",
+    in_memory_file.mimetype, abspath
+)
         )
 
         # If there is no start and end, just return the full content
@@ -277,7 +280,7 @@ class MessageCacheHandler(tornado.web.RequestHandler):
             self.set_status(404)
             raise tornado.web.Finish()
 
-        LOGGER.debug(f"MessageCache HIT [hash={msg_hash}]")
+       LOGGER.debug("MessageCache HIT [hash=%s]", msg_hash)
         msg_str = serialize_forward_msg(message)
         self.set_header("Content-Type", "application/octet-stream")
         self.write(msg_str)

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -99,9 +99,9 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
             try:
                 file_name.encode("ascii")
-                file_expr = 'filename="{}"'.format(file_name)
+                file_expr = f'filename="{file_name}"'
             except UnicodeEncodeError:
-                file_expr = "filename*=utf-8''{}".format(quote(file_name))
+                file_expr = f"filename*=utf-8''{quote(file_name)}"
 
             self.set_header("Content-Disposition", f"attachment; {file_expr}")
 
@@ -116,7 +116,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         try:
             in_memory_file_manager.get(absolute_path)
         except KeyError:
-            LOGGER.error("InMemoryFileManager: Missing file %s" % absolute_path)
+            LOGGER.error(f"InMemoryFileManager: Missing file {absolute_path}")
             raise tornado.web.HTTPError(404, "not found")
 
         return absolute_path
@@ -142,18 +142,17 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
     @classmethod
     def get_content(cls, abspath, start=None, end=None):
-        LOGGER.debug("MediaFileHandler: GET %s" % abspath)
+        LOGGER.debug(f"MediaFileHandler: GET {abspath}")
 
         try:
             # abspath is the hash as used `get_absolute_path`
             in_memory_file = in_memory_file_manager.get(abspath)
         except:
-            LOGGER.error("InMemoryFileManager: Missing file %s" % abspath)
+            LOGGER.error(f"InMemoryFileManager: Missing file {abspath}")
             return
 
         LOGGER.debug(
-            "InMemoryFileManager: Sending %s file %s"
-            % (in_memory_file.mimetype, abspath)
+            f"InMemoryFileManager: Sending {in_memory_file.mimetype} file {abspath}"
         )
 
         # If there is no start and end, just return the full content
@@ -237,7 +236,7 @@ class DebugHandler(_SpecialRequestHandler):
     def get(self):
         self.add_header("Cache-Control", "no-cache")
         self.write(
-            "<code><pre>%s</pre><code>" % json.dumps(self._server.get_debug(), indent=2)
+            f"<code><pre>{json.dumps(self._server.get_debug(), indent=2)}</pre><code>"
         )
 
 
@@ -278,7 +277,7 @@ class MessageCacheHandler(tornado.web.RequestHandler):
             self.set_status(404)
             raise tornado.web.Finish()
 
-        LOGGER.debug("MessageCache HIT [hash=%s]" % msg_hash)
+        LOGGER.debug(f"MessageCache HIT [hash={msg_hash}]")
         msg_str = serialize_forward_msg(message)
         self.set_header("Content-Type", "application/octet-stream")
         self.write(msg_str)

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -438,7 +438,7 @@ class Server:
         )
 
     def _set_state(self, new_state: State) -> None:
-        LOGGER.debug(f"Server state: {self._state} -> {new_state}")
+       LOGGER.debug("Server state: %s -> %s", self._state, new_state)
         self._state = new_state
 
     @property
@@ -606,13 +606,13 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 
                 # This session has probably cached this message. Send
                 # a reference instead.
-                LOGGER.debug(f"Sending cached message ref (hash={msg.hash})")
+                LOGGER.debug("Sending cached message ref (hash=%s)", msg.hash)
                 msg_to_send = create_reference_msg(msg)
 
             # Cache the message so it can be referenced in the future.
             # If the message is already cached, this will reset its
             # age.
-            LOGGER.debug(f"Caching message (hash={msg.hash})")
+            LOGGER.debug("Caching message (hash=%s)", msg.hash)
             self._message_cache.add_message(
                 msg, session_info.session, session_info.report_run_count
             )

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -390,7 +390,7 @@ class Server:
             (
                 make_url_path_regex(base, "assets/(.*)"),
                 AssetsFileHandler,
-                {"path": "%s/" % file_util.get_assets_dir()},
+                {"path": f"{file_util.get_assets_dir()}/"},
             ),
             (make_url_path_regex(base, "media/(.*)"), MediaFileHandler, {"path": ""}),
             (
@@ -422,7 +422,7 @@ class Server:
                     (
                         make_url_path_regex(base, "(.*)"),
                         StaticFileHandler,
-                        {"path": "%s/" % static_path, "default_filename": "index.html"},
+                        {"path": f"{static_path}/", "default_filename": "index.html"},
                     ),
                     (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),
                 ]
@@ -438,7 +438,7 @@ class Server:
         )
 
     def _set_state(self, new_state: State) -> None:
-        LOGGER.debug("Server state: %s -> %s" % (self._state, new_state))
+        LOGGER.debug(f"Server state: {self._state} -> {new_state}")
         self._state = new_state
 
     @property
@@ -504,7 +504,7 @@ class Server:
             elif self._state == State.ONE_OR_MORE_BROWSERS_CONNECTED:
                 pass
             else:
-                raise RuntimeError("Bad server state at start: %s" % self._state)
+                raise RuntimeError(f"Bad server state at start: {self._state}")
 
             if on_started is not None:
                 on_started(self)
@@ -606,13 +606,13 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 
                 # This session has probably cached this message. Send
                 # a reference instead.
-                LOGGER.debug("Sending cached message ref (hash=%s)" % msg.hash)
+                LOGGER.debug(f"Sending cached message ref (hash={msg.hash})")
                 msg_to_send = create_reference_msg(msg)
 
             # Cache the message so it can be referenced in the future.
             # If the message is already cached, this will reset its
             # age.
-            LOGGER.debug("Caching message (hash=%s)" % msg.hash)
+            LOGGER.debug(f"Caching message (hash={msg.hash})")
             self._message_cache.add_message(
                 msg, session_info.session, session_info.report_run_count
             )
@@ -714,9 +714,9 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
                 "Created new session for ws %s. Session ID: %s", id(ws), session.id
             )
 
-            assert session.id not in self._session_info_by_id, (
-                "session.id '%s' registered multiple times!" % session.id
-            )
+            assert (
+                session.id not in self._session_info_by_id
+            ), f"session.id '{session.id}' registered multiple times!"
 
         self._session_info_by_id[session.id] = SessionInfo(ws, session)
 

--- a/lib/streamlit/storage/file_storage.py
+++ b/lib/streamlit/storage/file_storage.py
@@ -74,7 +74,7 @@ class FileStorage(AbstractStorage):
                     yield
 
         LOGGER.debug("Done writing files!")
-        raise gen.Return("index.html?id=%s" % report_id)
+        raise gen.Return(f"index.html?id={report_id}")
 
 
 def _recursively_create_folder(path):

--- a/lib/streamlit/storage/s3_storage.py
+++ b/lib/streamlit/storage/s3_storage.py
@@ -69,7 +69,7 @@ class S3Storage(AbstractStorage):
 
         if not self._url:
             self._web_app_url = os.path.join(
-                "https://%s.%s" % (self._bucketname, "s3.amazonaws.com"),
+                f"https://{self._bucketname}.{'s3.amazonaws.com'}",
                 self._s3_key("index.html"),
             )
         else:
@@ -189,7 +189,7 @@ class S3Storage(AbstractStorage):
 
         yield self._s3_upload_files(files_to_upload, progress_coroutine)
 
-        raise gen.Return("%s?id=%s" % (self._web_app_url, report_id))
+        raise gen.Return(f"{self._web_app_url}?id={report_id}")
 
     @gen.coroutine
     def _s3_upload_files(self, files, progress_coroutine):

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -74,7 +74,7 @@ def clean_filename(name: str) -> str:
     s = re.sub(r"(?u)[^-\w.]", "", s)
 
     if s in {"", ".", ".."}:
-        raise StreamlitAPIException("Could not derive file name from '%s'" % name)
+        raise StreamlitAPIException(f"Could not derive file name from '{name}'")
     return s
 
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -58,7 +58,7 @@ def get_fqn(the_type):
     """Get module.type_name for a given type."""
     module = the_type.__module__
     name = the_type.__qualname__
-    return "%s.%s" % (module, name)
+    return f"{module}.{name}"
 
 
 def get_fqn_type(obj):
@@ -278,17 +278,13 @@ def convert_anything_to_df(df):
 
     except ValueError:
         raise errors.StreamlitAPIException(
-            """
-Unable to convert object of type `%(type)s` to `pandas.DataFrame`.
+            f"""
+Unable to convert object of type `{type(df)}` to `pandas.DataFrame`.
 
 Offending object:
 ```py
-%(object)s
+{df}
 ```"""
-            % {
-                "type": type(df),
-                "object": df,
-            }
         )
 
 

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -213,7 +213,7 @@ class UploadedFileManager(CacheStatsProvider):
             num_removed = len(file_list) - len(new_list)
 
         if num_removed > 0:
-            LOGGER.debug("Removed %s orphaned files" % num_removed)
+            LOGGER.debug(f"Removed {num_removed} orphaned files")
 
     def remove_file(self, session_id: str, widget_id: str, file_id: int) -> bool:
         """Remove the file list with the given ID, if it exists.

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -213,7 +213,7 @@ class UploadedFileManager(CacheStatsProvider):
             num_removed = len(file_list) - len(new_list)
 
         if num_removed > 0:
-            LOGGER.debug(f"Removed {num_removed} orphaned files")
+            LOGGER.debug("Removed %s orphaned files", num_removed)
 
     def remove_file(self, session_id: str, widget_id: str, file_id: int) -> bool:
         """Remove the file list with the given ID, if it exists.

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -55,7 +55,7 @@ def get_hostname(url: str) -> Optional[str]:
     # Just so urllib can parse the URL, make sure there's a protocol.
     # (The actual protocol doesn't matter to us)
     if "://" not in url:
-        url = "http://%s" % url
+        url = f"http://{url}"
 
     parsed = urllib.parse.urlparse(url)
     return parsed.hostname
@@ -65,5 +65,5 @@ def print_url(title, url):
     """Pretty-print a URL on the terminal."""
     import click
 
-    click.secho("  %s: " % title, nl=False, fg="blue")
+    click.secho(f"  {title}: ", nl=False, fg="blue")
     click.secho(url, bold=True)

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -79,7 +79,7 @@ def open_browser(url):
 
     import platform
 
-    raise Error('Cannot open browser in platform "%s"' % platform.system())
+    raise Error(f'Cannot open browser in platform "{platform.system()}"')
 
 
 def _open_browser_with_webbrowser(url):
@@ -126,7 +126,7 @@ def index_(iterable, x) -> int:
     for i, value in enumerate(iterable):
         if x == value:
             return i
-    raise ValueError("{} is not in iterable".format(str(x)))
+    raise ValueError(f"{str(x)} is not in iterable")
 
 
 def lower_clean_dict_keys(dict):

--- a/lib/streamlit/watcher/file_watcher.py
+++ b/lib/streamlit/watcher/file_watcher.py
@@ -69,15 +69,14 @@ def report_watchdog_availability():
             msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
 
             click.secho(
-                "  %s" % "For better performance, install the Watchdog module:",
+                f"  {'For better performance, install the Watchdog module:'}",
                 fg="blue",
                 bold=True,
             )
             click.secho(
-                """%s
+                f"""{msg}
   $ pip install watchdog
             """
-                % msg
             )
 
 

--- a/lib/tests/server_test_case.py
+++ b/lib/tests/server_test_case.py
@@ -105,7 +105,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         """Create a mock ReportSession. Each mocked instance will have
         its own unique ID."""
         mock_id = mock.PropertyMock(
-            return_value="mock_id:%s" % ServerTestCase._next_report_id
+            return_value=f"mock_id:{ServerTestCase._next_report_id}"
         )
         ServerTestCase._next_report_id += 1
 

--- a/lib/tests/streamlit/caching/hashing_test.py
+++ b/lib/tests/streamlit/caching/hashing_test.py
@@ -281,7 +281,7 @@ class NotHashableTest(unittest.TestCase):
     def _build_cffi(self, name):
         ffibuilder = cffi.FFI()
         ffibuilder.set_source(
-            "cffi_bin._%s" % name,
+            f"cffi_bin._{name}",
             r"""
                 static int %s(int x)
                 {
@@ -291,7 +291,7 @@ class NotHashableTest(unittest.TestCase):
             % name,
         )
 
-        ffibuilder.cdef("int %s(int);" % name)
+        ffibuilder.cdef(f"int {name}(int);")
         ffibuilder.compile(verbose=True)
 
     def test_compiled_ffi_not_hashable(self):

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -416,7 +416,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         )
 
     def _request_component(self, path):
-        return self.fetch("/component/%s" % path, method="GET")
+        return self.fetch(f"/component/{path}", method="GET")
 
     def test_success_request(self):
         """Test request success when valid parameters are provided."""

--- a/lib/tests/streamlit/config_option_test.py
+++ b/lib/tests/streamlit/config_option_test.py
@@ -33,7 +33,7 @@ class ConfigOptionTest(unittest.TestCase):
     def test_invalid_key(self, key):
         with pytest.raises(AssertionError) as e:
             ConfigOption(key)
-        self.assertEqual('Key "%s" has invalid format.' % key, str(e.value))
+        self.assertEqual(f'Key "{key}" has invalid format.', str(e.value))
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -204,13 +204,10 @@ class ConfigTest(unittest.TestCase):
         )
 
         # Override it with some TOML
-        NEW_TOML = (
-            """
+        NEW_TOML = f"""
             [_test]
-            tomlTest="%s"
+            tomlTest="{DUMMY_VAL_2}"
         """
-            % DUMMY_VAL_2
-        )
         config._update_config_with_toml(NEW_TOML, DUMMY_DEFINITION)
         self.assertEqual(config.get_option("_test.tomlTest"), DUMMY_VAL_2)
         self.assertEqual(config.get_where_defined("_test.tomlTest"), DUMMY_DEFINITION)

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -77,9 +77,7 @@ class FakeDeltaGenerator(object):
                         "`st.%(name)s()`?" % {"name": name}
                     )
             else:
-                message = "`%(name)s()` is not a valid Streamlit command." % {
-                    "name": name
-                }
+                message = f"`{name}()` is not a valid Streamlit command."
 
             raise AttributeError(message)
 
@@ -418,7 +416,7 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
     def test_code(self):
         """Test st.code()"""
         code = "print('Hello, %s!' % 'Streamlit')"
-        expected_body = "```python\n%s\n```" % code
+        expected_body = f"```python\n{code}\n```"
 
         st.code(code, language="python")
         element = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/legacy_caching/hashing_test.py
@@ -509,7 +509,7 @@ class HashTest(unittest.TestCase):
     def _build_cffi(self, name):
         ffibuilder = cffi.FFI()
         ffibuilder.set_source(
-            "cffi_bin._%s" % name,
+            f"cffi_bin._{name}",
             r"""
                 static int %s(int x)
                 {
@@ -519,7 +519,7 @@ class HashTest(unittest.TestCase):
             % name,
         )
 
-        ffibuilder.cdef("int %s(int);" % name)
+        ffibuilder.cdef(f"int {name}(int);")
         ffibuilder.compile(verbose=True)
 
     def test_compiled_ffi(self):
@@ -586,24 +586,24 @@ class HashTest(unittest.TestCase):
 
         self.assertEqual(
             hash_engine(auth_url),
-            hash_engine("%s=%s" % (url, params_foo)),
+            hash_engine(f"{url}={params_foo}"),
         )
         self.assertNotEqual(
-            hash_engine("%s=%s" % (url, params_foo)),
-            hash_engine("%s=%s" % (url, params_bar)),
+            hash_engine(f"{url}={params_foo}"),
+            hash_engine(f"{url}={params_bar}"),
         )
 
         # Note: False negative because the ordering of the keys affects
         # the hash
         self.assertNotEqual(
-            hash_engine("%s=%s" % (url, params_foo)),
-            hash_engine("%s=%s" % (url, params_foo_order)),
+            hash_engine(f"{url}={params_foo}"),
+            hash_engine(f"{url}={params_foo_order}"),
         )
 
         # Note: False negative because the keys are case insensitive
         self.assertNotEqual(
-            hash_engine("%s=%s" % (url, params_foo)),
-            hash_engine("%s=%s" % (url, params_foo_caps)),
+            hash_engine(f"{url}={params_foo}"),
+            hash_engine(f"{url}={params_foo_caps}"),
         )
 
         # Note: False negative because `connect_args` doesn't affect the
@@ -625,8 +625,8 @@ class HashTest(unittest.TestCase):
         def connect():
             pass
 
-        url = "%s://localhost/db" % dialect
-        auth_url = "%s://user:pass@localhost/db" % dialect
+        url = f"{dialect}://localhost/db"
+        auth_url = f"{dialect}://user:pass@localhost/db"
 
         self.assertEqual(hash_engine(url), hash_engine(url))
         self.assertEqual(

--- a/lib/tests/streamlit/number_input_test.py
+++ b/lib/tests/streamlit/number_input_test.py
@@ -89,7 +89,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         st.number_input("the label", value=10.5)
 
         c = self.get_delta_from_queue().new_element.number_input
-        self.assertEqual("%0.2f" % c.step, "0.01")
+        self.assertEqual(f"{c.step:0.2f}", "0.01")
 
     def test_default_format_int(self):
         st.number_input("the label", value=10)
@@ -115,7 +115,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(c.format, "%f")
-        self.assertEqual("%0.2f" % c.step, "0.01")
+        self.assertEqual(f"{c.step:0.2f}", "0.01")
 
     def test_value_outrange(self):
         with pytest.raises(StreamlitAPIException) as exc_message:
@@ -177,7 +177,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
             value = JSNumber.MAX_SAFE_INTEGER + 1
             st.number_input("Label", value=value)
         self.assertEqual(
-            "`value` (%s) must be <= (1 << 53) - 1" % str(value), str(exc.value)
+            f"`value` ({str(value)}) must be <= (1 << 53) - 1", str(exc.value)
         )
 
         # Min int
@@ -185,7 +185,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
             value = JSNumber.MIN_SAFE_INTEGER - 1
             st.number_input("Label", value=value)
         self.assertEqual(
-            "`value` (%s) must be >= -((1 << 53) - 1)" % str(value), str(exc.value)
+            f"`value` ({str(value)}) must be >= -((1 << 53) - 1)", str(exc.value)
         )
 
         # Max float
@@ -193,7 +193,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
             value = 2e308
             st.number_input("Label", value=value)
         self.assertEqual(
-            "`value` (%s) must be <= 1.797e+308" % str(value), str(exc.value)
+            f"`value` ({str(value)}) must be <= 1.797e+308", str(exc.value)
         )
 
         # Min float
@@ -201,7 +201,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
             value = -2e308
             st.number_input("Label", value=value)
         self.assertEqual(
-            "`value` (%s) must be >= -1.797e+308" % str(value), str(exc.value)
+            f"`value` ({str(value)}) must be >= -1.797e+308", str(exc.value)
         )
 
     def test_outside_form(self):

--- a/lib/tests/streamlit/report_session_test.py
+++ b/lib/tests/streamlit/report_session_test.py
@@ -52,7 +52,7 @@ class ReportSessionTest(unittest.TestCase):
                 return True
             if name == "runner.installTracer":
                 return False
-            raise RuntimeError("Unexpected argument to get_option: %s" % name)
+            raise RuntimeError(f"Unexpected argument to get_option: {name}")
 
         patched_config.get_option.side_effect = get_option
 
@@ -93,7 +93,7 @@ class ReportSessionTest(unittest.TestCase):
                 return True
             if name == "runner.installTracer":
                 return True
-            raise RuntimeError("Unexpected argument to get_option: %s" % name)
+            raise RuntimeError(f"Unexpected argument to get_option: {name}")
 
         patched_config.get_option.side_effect = get_option
 

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -454,7 +454,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # Ensure that each runner's radio value is as expected.
         for ii, runner in enumerate(runners):
             self._assert_text_deltas(
-                runner, ["False", "ahoy!", "%s" % ii, "False", "loop_forever"]
+                runner, ["False", "ahoy!", f"{ii}", "False", "loop_forever"]
             )
             runner.enqueue_shutdown()
 
@@ -717,7 +717,7 @@ def require_widgets_deltas(
     )
     for runner in runners:
         if len(runner.deltas()) < NUM_DELTAS:
-            err_string += "\n- incomplete deltas: {}".format(runner.text_deltas())
+            err_string += f"\n- incomplete deltas: {runner.text_deltas()}"
 
     # Shutdown all runners before throwing an error, so that the script
     # doesn't hang forever.

--- a/lib/tests/streamlit/scriptrunner/test_data/widgets_script.py
+++ b/lib/tests/streamlit/scriptrunner/test_data/widgets_script.py
@@ -22,16 +22,16 @@ import streamlit as st
 # 1-delta loop. If you change this, please change that file too.
 
 checkbox = st.checkbox("checkbox", False)
-st.text("%s" % checkbox)
+st.text(f"{checkbox}")
 
 text_area = st.text_area("text_area", "ahoy!")
-st.text("%s" % text_area)
+st.text(f"{text_area}")
 
 radio = st.radio("radio", ("0", "1", "2"), 0)
-st.text("%s" % radio)
+st.text(f"{radio}")
 
 button = st.button("button")
-st.text("%s" % button)
+st.text(f"{button}")
 
 # Loop forever so that our test can check widget states
 # without the scriptrunner shutting down.

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -587,7 +587,7 @@ class MessageCacheHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self._cache.add_message(msg, MagicMock(), 0)
 
         # Cache hit
-        response = self.fetch("/message?hash=%s" % msg_hash)
+        response = self.fetch(f"/message?hash={msg_hash}")
         self.assertEqual(200, response.code)
         self.assertEqual(serialize_forward_msg(msg), response.body)
 

--- a/lib/tests/streamlit/slider_test.py
+++ b/lib/tests/streamlit/slider_test.py
@@ -172,7 +172,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
             max_value = JSNumber.MAX_SAFE_INTEGER + 1
             st.slider("Label", max_value=max_value)
         self.assertEqual(
-            "`max_value` (%s) must be <= (1 << 53) - 1" % str(max_value), str(exc.value)
+            f"`max_value` ({str(max_value)}) must be <= (1 << 53) - 1", str(exc.value)
         )
 
         # Min int
@@ -180,7 +180,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
             min_value = JSNumber.MIN_SAFE_INTEGER - 1
             st.slider("Label", min_value=min_value)
         self.assertEqual(
-            "`min_value` (%s) must be >= -((1 << 53) - 1)" % str(min_value),
+            f"`min_value` ({str(min_value)}) must be >= -((1 << 53) - 1)",
             str(exc.value),
         )
 
@@ -189,7 +189,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
             max_value = 2e308
             st.slider("Label", value=0.5, max_value=max_value)
         self.assertEqual(
-            "`max_value` (%s) must be <= 1.797e+308" % str(max_value), str(exc.value)
+            f"`max_value` ({str(max_value)}) must be <= 1.797e+308", str(exc.value)
         )
 
         # Min float
@@ -197,7 +197,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
             min_value = -2e308
             st.slider("Label", value=0.5, min_value=min_value)
         self.assertEqual(
-            "`min_value` (%s) must be >= -1.797e+308" % str(min_value), str(exc.value)
+            f"`min_value` ({str(min_value)}) must be >= -1.797e+308", str(exc.value)
         )
 
     def test_step_zero(self):

--- a/lib/tests/streamlit/watcher/file_watcher_test.py
+++ b/lib/tests/streamlit/watcher/file_watcher_test.py
@@ -41,15 +41,14 @@ class FileWatcherTest(unittest.TestCase):
         msg = "\n  $ xcode-select --install"
         calls = [
             call(
-                "  %s" % "For better performance, install the Watchdog module:",
+                f"  {'For better performance, install the Watchdog module:'}",
                 fg="blue",
                 bold=True,
             ),
             call(
-                """%s
+                f"""{msg}
   $ pip install watchdog
             """
-                % msg
             ),
         ]
         mock_echo.assert_has_calls(calls)
@@ -65,15 +64,14 @@ class FileWatcherTest(unittest.TestCase):
         msg = ""
         calls = [
             call(
-                "  %s" % "For better performance, install the Watchdog module:",
+                f"  {'For better performance, install the Watchdog module:'}",
                 fg="blue",
                 bold=True,
             ),
             call(
-                """%s
+                f"""{msg}
   $ pip install watchdog
             """
-                % msg
             ),
         ]
         mock_echo.assert_has_calls(calls)

--- a/scripts/add_license_headers.py
+++ b/scripts/add_license_headers.py
@@ -79,7 +79,7 @@ COMMENT_STYLES = {
 
 
 def get_glob_string(folder, extension):
-    return "%s/**/*.%s" % (folder, extension)
+    return f"{folder}/**/*.{extension}"
 
 
 def get_header_bounds(lines, comment_style):
@@ -146,7 +146,7 @@ files_seen = 0
 files_modified = 0
 
 for glob_pattern, comment_style in glob_to_comment_style.items():
-    print("Pattern %s:" % glob_pattern)
+    print(f"Pattern {glob_pattern}:")
 
     filenames = glob.glob(glob_pattern, recursive=True)
 

--- a/scripts/run_all_examples.py
+++ b/scripts/run_all_examples.py
@@ -47,10 +47,12 @@ def run_commands(section_header, commands, skip_last_input=False, comment=None):
             "v": i + 1,
         }
         click.secho(
-            "\nRunning %(section_header)s %(v)s/%(total)s : %(command)s" % vars,
+            f"\nRunning {vars['section_header']} {vars['v']}/{vars['total']} : {vars['command']}",
             bold=True,
         )
-        click.secho("\n%(v)s/%(total)s : %(command)s" % vars, fg="yellow", bold=True)
+        click.secho(
+            f"\n{vars['v']}/{vars['total']} : {vars['command']}", fg="yellow", bold=True
+        )
 
         if comment:
             click.secho(comment)
@@ -84,8 +86,7 @@ def main():
     run_commands(
         "Examples",
         [
-            "streamlit run %(EXAMPLE_DIR)s/%(filename)s"
-            % {"EXAMPLE_DIR": EXAMPLE_DIR, "filename": filename}
+            f"streamlit run {EXAMPLE_DIR}/{filename}"
             for filename in os.listdir(EXAMPLE_DIR)
             if filename.endswith(".py") and filename not in EXCLUDED_FILENAMES
         ],
@@ -93,11 +94,11 @@ def main():
 
     run_commands(
         "Caching",
-        ["streamlit cache clear", "streamlit run %s/caching.py" % EXAMPLE_DIR],
+        ["streamlit cache clear", f"streamlit run {EXAMPLE_DIR}/caching.py"],
     )
 
     run_commands(
-        "MNIST", ["streamlit run %s/mnist-cnn.py" % EXAMPLE_DIR], skip_last_input=True
+        "MNIST", [f"streamlit run {EXAMPLE_DIR}/mnist-cnn.py"], skip_last_input=True
     )
 
     click.secho("\n\nCompleted all tests!", bold=True)

--- a/scripts/run_bare_integration_tests.py
+++ b/scripts/run_bare_integration_tests.py
@@ -86,7 +86,7 @@ def run_commands(section_header, commands):
             "v": i + 1,
         }
         click.secho(
-            "\nRunning %(section_header)s %(v)s/%(total)s : %(command)s" % vars,
+            f"\nRunning {vars['section_header']} {vars['v']}/{vars['total']} : {vars['command']}",
             bold=True,
         )
 
@@ -104,7 +104,7 @@ def run_commands(section_header, commands):
 
 def main():
     filenames = _get_filenames(E2E_DIR)
-    commands = ["python %s" % filename for filename in filenames]
+    commands = [f"python {filename}" for filename in filenames]
     failed = run_commands("bare scripts", commands)
 
     if len(failed) == 0:
@@ -114,7 +114,7 @@ def main():
         click.secho(
             "\n".join(_command_to_string(command) for command in failed), fg="red"
         )
-        click.secho("\n%s failed scripts" % len(failed), fg="red", bold=True)
+        click.secho(f"\n{len(failed)} failed scripts", fg="red", bold=True)
         sys.exit(-1)
 
 

--- a/scripts/update_name.py
+++ b/scripts/update_name.py
@@ -37,7 +37,7 @@ def update_files(data, python=True):
     """Update files with new project name."""
 
     if len(sys.argv) != 2:
-        e = Exception('Specify project name: "%s streamlit"' % sys.argv[0])
+        e = Exception(f'Specify project name: "{sys.argv[0]} streamlit"')
         raise (e)
 
     project_name = sys.argv[1]
@@ -52,7 +52,7 @@ def update_files(data, python=True):
             line = re.sub(regex, r"\g<pre>%s\g<post>" % project_name, line.rstrip())
             print(line)
         if not matched:
-            raise Exception('In file "%s", did not find regex "%s"' % (filename, regex))
+            raise Exception(f'In file "{filename}", did not find regex "{regex}"')
 
 
 def main():

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -81,7 +81,7 @@ def update_files(data, python=True):
     """Update files with new version number."""
 
     if len(sys.argv) != 2:
-        e = Exception('Specify PEP440 version: "%s 1.2.3"' % sys.argv[0])
+        e = Exception(f'Specify PEP440 version: "{sys.argv[0]} 1.2.3"')
         raise (e)
 
     version = verify_pep440(sys.argv[1])
@@ -100,7 +100,7 @@ def update_files(data, python=True):
             line = re.sub(regex, r"\g<pre>%s\g<post>" % version, line.rstrip())
             print(line)
         if not matched:
-            raise Exception('In file "%s", did not find regex "%s"' % (filename, regex))
+            raise Exception(f'In file "{filename}", did not find regex "{regex}"')
 
 
 def main():


### PR DESCRIPTION
Reformats all the text from the old "%-formatted" and .format(...) format to the newer f-string format, as defined in [PEP 498](https://www.python.org/dev/peps/pep-0498/). This requires Python 3.6+.

[Flynt](https://github.com/ikamensh/flynt) 0.69 was used to reformat the strings. 199 f-strings were created in 72 files.

F-strings are in general more readable, concise and performant. See also: [PEP 498#Rationale](https://www.python.org/dev/peps/pep-0498/#rationale)

```
Running flynt v.0.69

Flynt run has finished. Stats:

Execution time:                            4.080s
Files modified:                            75
Character count reduction:                 1322 (0.06%)

Per expression type:
Old style (`%`) expressions attempted:     211/235 (89.8%)
`.format(...)` calls attempted:            16/20 (80.0%)
No concatenations attempted.
F-string expressions created:              199
```