### PR TITLE
Use bytecode instead of code object as fallback

### DIFF
--- a/lib/streamlit/caching/cache_utils.py
+++ b/lib/streamlit/caching/cache_utils.py
@@ -300,7 +300,7 @@ def _make_function_key(cache_type: CacheType, func: types.FunctionType) -> str:
 
     # Include the function's source code in its hash. If the source code can't
     # be retrieved, fall back to the function's bytecode instead.
-    source_code: Union[str, types.CodeType]
+    source_code: Union[str, bytes]
     try:
         source_code = inspect.getsource(func)
     except OSError as e:
@@ -308,7 +308,7 @@ def _make_function_key(cache_type: CacheType, func: types.FunctionType) -> str:
             "Failed to retrieve function's source code when building its key; falling back to bytecode. err={0}",
             e,
         )
-        source_code = func.__code__
+        source_code = func.__code__.co_code
 
     update_hash(
         source_code,


### PR DESCRIPTION
## 📚 Context

As pointed out by #4227, the `__code__` attr is an unhashable object, and we
need to access `__code__.co_code` to get the hashable bytecode in
[this line of cache_utils.py](https://github.com/streamlit/streamlit/blob/6c5384f62c1415538347fa751185e5c487673f82/lib/streamlit/caching/cache_utils.py#L311). This PR makes the one-line fix for this.

One not-great thing is that I didn't add any tests for this PR since none
exist currently, and this code path seems particularly tricky to test (and it
doesn't seem worth doing for such a small change). I'm happy to go back and add
some tests if it turns out that I'm overestimating the amount of effort that it
would take, but if it is indeed a lot of work, I think that manually confirming
that `func.__code__.co_code` is indeed the bytecode is sufficient.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] mildly unsatisfactory manual testing

## 🌐 References

- **Issue**: Closes #4227 
