### PR TITLE
Add length checking before indexing in every e2e

### DIFF
--- a/e2e/specs/component_template.spec.js
+++ b/e2e/specs/component_template.spec.js
@@ -18,6 +18,7 @@
 function getIframeBody(index) {
   return cy
     .get(".element-container > iframe")
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should(iframe => {
       // Wait for a known element of the iframe to exist. In this case,

--- a/e2e/specs/component_template.spec.js
+++ b/e2e/specs/component_template.spec.js
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { cyGetIndexed } from "./spec_utils";
 
 function getIframeBody(index) {
-  return cy
-    .get(".element-container > iframe")
-    .should("have.length.at.least", index + 1)
-    .eq(index)
+  return cyGetIndexed(".element-container > iframe", index)
     .should(iframe => {
       // Wait for a known element of the iframe to exist. In this case,
       // we wait for its button to appear. This will happen after the

--- a/e2e/specs/linked_sliders.spec.js
+++ b/e2e/specs/linked_sliders.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { cyGetIndexed } from "./spec_utils";
 
 describe("st.slider", () => {
   beforeEach(() => {
@@ -41,59 +42,37 @@ describe("st.slider", () => {
       .eq(0)
       .should("have.text", "Celsius 0.0");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.text", "Fahrenheit 32.0");
+    cyGetIndexed(".stMarkdown", 1).should("have.text", "Fahrenheit 32.0");
   });
 
   it("updates both sliders when the second is changed", () => {
     // 748 is the width of the slider. Asking cypress to click on the "right"
     // side ends up just short of the actual end, so the numbers aren't quite right.
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed('.stSlider [role="slider"]', 1)
       .parent()
       .click(748, 0, { force: true });
     cy.wait(1000);
 
-    cy.get(".stMarkdown")
-      .eq(0)
-      .should("have.text", "Celsius 100.0");
+    cyGetIndexed(".stMarkdown", 0).should("have.text", "Celsius 100.0");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.text", "Fahrenheit 212.0");
+    cyGetIndexed(".stMarkdown", 1).should("have.text", "Fahrenheit 212.0");
   });
 
   it("updates when a slider is changed repeatedly", () => {
-    cy.get('.stSlider [role="slider"]')
-      .eq(0)
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .parent()
       .click();
     cy.wait(1000);
 
-    cy.get(".stMarkdown")
-      .eq(0)
-      .should("have.text", "Celsius 0.0");
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.text", "Fahrenheit 32.0");
+    cyGetIndexed(".stMarkdown", 0).should("have.text", "Celsius 0.0");
+    cyGetIndexed(".stMarkdown", 1).should("have.text", "Fahrenheit 32.0");
 
-    cy.get('.stSlider [role="slider"]')
-      .eq(0)
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .parent()
       .click(748, 0, { force: true });
 
-    cy.get(".stMarkdown")
-      .eq(0)
-      .should("have.text", "Celsius 100.0");
+    cyGetIndexed(".stMarkdown", 0).should("have.text", "Celsius 100.0");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.text", "Fahrenheit 212.0");
+    cyGetIndexed(".stMarkdown", 1).should("have.text", "Fahrenheit 212.0");
   });
 });

--- a/e2e/specs/linked_sliders.spec.js
+++ b/e2e/specs/linked_sliders.spec.js
@@ -42,6 +42,7 @@ describe("st.slider", () => {
       .should("have.text", "Celsius 0.0");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Fahrenheit 32.0");
   });
@@ -50,6 +51,7 @@ describe("st.slider", () => {
     // 748 is the width of the slider. Asking cypress to click on the "right"
     // side ends up just short of the actual end, so the numbers aren't quite right.
     cy.get('.stSlider [role="slider"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .parent()
       .click(748, 0, { force: true });
@@ -60,6 +62,7 @@ describe("st.slider", () => {
       .should("have.text", "Celsius 100.0");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Fahrenheit 212.0");
   });
@@ -75,6 +78,7 @@ describe("st.slider", () => {
       .eq(0)
       .should("have.text", "Celsius 0.0");
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Fahrenheit 32.0");
 
@@ -88,6 +92,7 @@ describe("st.slider", () => {
       .should("have.text", "Celsius 100.0");
 
     cy.get(".stMarkdown")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", "Fahrenheit 212.0");
   });

--- a/e2e/specs/redisplayed_widgets.spec.js
+++ b/e2e/specs/redisplayed_widgets.spec.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { cyGetIndexed } from "./spec_utils";
 
 describe("redisplayed widgets", () => {
   beforeEach(() => {
@@ -21,16 +22,11 @@ describe("redisplayed widgets", () => {
   });
 
   it("does not save widget state when widget is removed and redisplayed", () => {
-    cy.get(".stCheckbox")
-      .eq(0)
-      .click();
+    cyGetIndexed(".stCheckbox", 0).click();
 
     cy.wait(1000);
 
-    cy.get(".stCheckbox")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .click();
+    cyGetIndexed(".stCheckbox", 1).click();
 
     cy.wait(1000);
 
@@ -38,30 +34,21 @@ describe("redisplayed widgets", () => {
       .first()
       .should("have.text", "hello");
 
-    cy.get(".stCheckbox")
-      .eq(0)
-      .click();
+    cyGetIndexed(".stCheckbox", 0).click();
 
     cy.wait(1000);
 
-    cy.get(".stCheckbox")
-      .eq(0)
-      .click();
+    cyGetIndexed(".stCheckbox", 0).click();
 
     cy.contains("hello").should("not.exist");
   });
 
   it("does not save state when widget is removed and redisplayed if widget is keyed", () => {
-    cy.get(".stCheckbox")
-      .eq(0)
-      .click();
+    cyGetIndexed(".stCheckbox", 0).click();
 
     cy.wait(1000);
 
-    cy.get(".stCheckbox")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .click();
+    cyGetIndexed(".stCheckbox", 2).click();
 
     cy.wait(1000);
 
@@ -69,15 +56,11 @@ describe("redisplayed widgets", () => {
       .first()
       .should("have.text", "goodbye");
 
-    cy.get(".stCheckbox")
-      .eq(0)
-      .click();
+    cyGetIndexed(".stCheckbox", 0).click();
 
     cy.wait(1000);
 
-    cy.get(".stCheckbox")
-      .eq(0)
-      .click();
+    cyGetIndexed(".stCheckbox", 0).click();
 
     cy.contains("goodbye").should("not.exist");
   });

--- a/e2e/specs/redisplayed_widgets.spec.js
+++ b/e2e/specs/redisplayed_widgets.spec.js
@@ -28,6 +28,7 @@ describe("redisplayed widgets", () => {
     cy.wait(1000);
 
     cy.get(".stCheckbox")
+      .should("have.length.at.least", 2)
       .eq(1)
       .click();
 
@@ -58,6 +59,7 @@ describe("redisplayed widgets", () => {
     cy.wait(1000);
 
     cy.get(".stCheckbox")
+      .should("have.length.at.least", 3)
       .eq(2)
       .click();
 

--- a/e2e/specs/session_state_frontend_sync.spec.js
+++ b/e2e/specs/session_state_frontend_sync.spec.js
@@ -28,16 +28,19 @@ describe("checkbox state update regression", () => {
       .eq(0)
       .should("have.attr", "aria-checked", "true");
     cy.get("[role='checkbox']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.attr", "aria-checked", "false");
 
     cy.get("[role='checkbox']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .click();
     cy.get("[role='checkbox']")
       .eq(0)
       .should("have.attr", "aria-checked", "false");
     cy.get("[role='checkbox']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.attr", "aria-checked", "true");
   });

--- a/e2e/specs/session_state_frontend_sync.spec.js
+++ b/e2e/specs/session_state_frontend_sync.spec.js
@@ -17,6 +17,8 @@
 
 // Regression test for https://github.com/streamlit/streamlit/issues/3873
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("checkbox state update regression", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -24,24 +26,27 @@ describe("checkbox state update regression", () => {
 
   it("checking one disables the other", () => {
     cy.get("[role='checkbox']").should("have.length", 2);
-    cy.get("[role='checkbox']")
-      .eq(0)
-      .should("have.attr", "aria-checked", "true");
-    cy.get("[role='checkbox']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.attr", "aria-checked", "false");
+    cyGetIndexed("[role='checkbox']", 0).should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
+    cyGetIndexed("[role='checkbox']", 1).should(
+      "have.attr",
+      "aria-checked",
+      "false"
+    );
 
-    cy.get("[role='checkbox']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .click();
-    cy.get("[role='checkbox']")
-      .eq(0)
-      .should("have.attr", "aria-checked", "false");
-    cy.get("[role='checkbox']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.attr", "aria-checked", "true");
+    cyGetIndexed("[role='checkbox']", 1).click();
+    cyGetIndexed("[role='checkbox']", 0).should(
+      "have.attr",
+      "aria-checked",
+      "false"
+    );
+    cyGetIndexed("[role='checkbox']", 1).should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
   });
 });

--- a/e2e/specs/spec_utils.js
+++ b/e2e/specs/spec_utils.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018-2021 Streamlit Inc.
+ * Copyright 2018-2022 Streamlit Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,14 @@
  * limitations under the License.
  */
 
-import { cyGetIndexed } from "./spec_utils";
-
-describe("st.latex", () => {
-  before(() => {
-    cy.visit("http://localhost:3000/");
-  });
-
-  it("displays LaTeX symbol", () => {
-    cyGetIndexed(".element-container .stMarkdown", 0).should(
-      "contain",
-      "LATE​X"
-    );
-  });
-
-  it("displays Sympy expression as LaTeX", () => {
-    cyGetIndexed(".element-container .stMarkdown", 1).should(
-      "contain",
-      "a + b"
-    );
-  });
-});
+// Indexing into a list of elements produced by `cy.get()` may fail if not enough
+// elements are rendered, but this does not prompt cypress to retry the `get` call,
+// so the list will never update. This is a major cause of flakiness in tests.
+// The solution is to use `should` to wait for enough elements to be available first.
+// This is a convenience function for doing this automatically.
+export function cyGetIndexed(selector, index) {
+  return cy
+    .get(selector)
+    .should("have.length.at.least", index + 1)
+    .eq(index);
+}

--- a/e2e/specs/st_alert.spec.js
+++ b/e2e/specs/st_alert.spec.js
@@ -33,18 +33,21 @@ describe("st.error and friends", () => {
 
   it("displays a warning message correctly", () => {
     cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .contains("This is a warning");
   });
 
   it("displays an info message correctly", () => {
     cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .contains("This is an info message");
   });
 
   it("displays a success message correctly", () => {
     cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .contains("This is a success message");
   });

--- a/e2e/specs/st_alert.spec.js
+++ b/e2e/specs/st_alert.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.error and friends", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -26,30 +28,31 @@ describe("st.error and friends", () => {
   });
 
   it("displays an error message correctly", () => {
-    cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
-      .eq(0)
-      .contains("This is an error");
+    cyGetIndexed(
+      ".element-container .stAlert [data-testid='stMarkdownContainer']",
+      0
+    ).contains("This is an error");
   });
 
   it("displays a warning message correctly", () => {
-    cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .contains("This is a warning");
+    cyGetIndexed(
+      ".element-container .stAlert [data-testid='stMarkdownContainer']",
+      1
+    ).contains("This is a warning");
   });
 
   it("displays an info message correctly", () => {
-    cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .contains("This is an info message");
+    cyGetIndexed(
+      ".element-container .stAlert [data-testid='stMarkdownContainer']",
+      2
+    ).contains("This is an info message");
   });
 
   it("displays a success message correctly", () => {
-    cy.get(".element-container .stAlert [data-testid='stMarkdownContainer']")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .contains("This is a success message");
+    cyGetIndexed(
+      ".element-container .stAlert [data-testid='stMarkdownContainer']",
+      3
+    ).contains("This is a success message");
   });
 
   it("matches the snapshot", () => {

--- a/e2e/specs/st_arrow_datetimes_dataframe.spec.js
+++ b/e2e/specs/st_arrow_datetimes_dataframe.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st._arrow_dataframe", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -39,21 +41,15 @@ describe("st._arrow_dataframe", () => {
     // actual important thing, the notz/yaytz logic.
 
     // notz column should show datetime in current timezone
-    cy.get("@cells")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should(
-        "have.text",
-        Cypress.moment(datetimeString).format("YYYY-MM-DDTHH:mm:ss")
-      );
+    cyGetIndexed("@cells", 1).should(
+      "have.text",
+      Cypress.moment(datetimeString).format("YYYY-MM-DDTHH:mm:ss")
+    );
 
     // yaytz column should show datetime in provided timezone
-    cy.get("@cells")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .should(
-        "have.text",
-        Cypress.moment.parseZone(`${datetimeString}+03:00`).format()
-      );
+    cyGetIndexed("@cells", 2).should(
+      "have.text",
+      Cypress.moment.parseZone(`${datetimeString}+03:00`).format()
+    );
   });
 });

--- a/e2e/specs/st_arrow_datetimes_dataframe.spec.js
+++ b/e2e/specs/st_arrow_datetimes_dataframe.spec.js
@@ -40,6 +40,7 @@ describe("st._arrow_dataframe", () => {
 
     // notz column should show datetime in current timezone
     cy.get("@cells")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should(
         "have.text",
@@ -48,6 +49,7 @@ describe("st._arrow_dataframe", () => {
 
     // yaytz column should show datetime in provided timezone
     cy.get("@cells")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should(
         "have.text",

--- a/e2e/specs/st_arrow_empty_charts.spec.js
+++ b/e2e/specs/st_arrow_empty_charts.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("handles arrow empty charts", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -45,43 +47,29 @@ describe("handles arrow empty charts", () => {
   });
 
   it("handles no data with exception", () => {
-    cy.get(".stException .message")
-      .eq(0)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 0).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 1).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 2).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 3).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .should(
-        "have.text",
-        "TypeError: _arrow_altair_chart() missing 1 required positional argument: 'altair_chart'"
-      );
+    cyGetIndexed(".stException .message", 4).should(
+      "have.text",
+      "TypeError: _arrow_altair_chart() missing 1 required positional argument: 'altair_chart'"
+    );
   });
 });

--- a/e2e/specs/st_arrow_empty_charts.spec.js
+++ b/e2e/specs/st_arrow_empty_charts.spec.js
@@ -53,6 +53,7 @@ describe("handles arrow empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should(
         "have.text",
@@ -60,6 +61,7 @@ describe("handles arrow empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should(
         "have.text",
@@ -67,6 +69,7 @@ describe("handles arrow empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should(
         "have.text",
@@ -74,6 +77,7 @@ describe("handles arrow empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 5)
       .eq(4)
       .should(
         "have.text",

--- a/e2e/specs/st_arrow_empty_dataframes.spec.js
+++ b/e2e/specs/st_arrow_empty_dataframes.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("Arrow Dataframes", () => {
   const DF_SELECTOR = ".stDataFrame";
   const TABLE_SELECTOR = "[data-testid='stTable'] > table";
@@ -35,12 +37,9 @@ describe("Arrow Dataframes", () => {
   });
 
   it("have consistent empty list visuals", () => {
-    cy.get(".element-container")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .each(el => {
-        return cy.wrap(el).matchThemedSnapshots("arrow_empty_dataframes_list");
-      });
+    cyGetIndexed(".element-container", 1).each(el => {
+      return cy.wrap(el).matchThemedSnapshots("arrow_empty_dataframes_list");
+    });
   });
 
   it("have consistent empty visuals", () => {
@@ -85,24 +84,18 @@ describe("Arrow Dataframes", () => {
   });
 
   it("have consistent empty one-column table visuals", () => {
-    cy.get(TABLE_SELECTOR)
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .each((el, idx) => {
-        return cy
-          .wrap(el)
-          .matchThemedSnapshots(`arrow_empty_tables_one_col${idx}`);
-      });
+    cyGetIndexed(TABLE_SELECTOR, 4).each((el, idx) => {
+      return cy
+        .wrap(el)
+        .matchThemedSnapshots(`arrow_empty_tables_one_col${idx}`);
+    });
   });
 
   it("have consistent empty two-column table visuals", () => {
-    cy.get(TABLE_SELECTOR)
-      .should("have.length.at.least", 6)
-      .eq(5)
-      .each((el, idx) => {
-        return cy
-          .wrap(el)
-          .matchThemedSnapshots(`arrow_empty_tables_two_col${idx}`);
-      });
+    cyGetIndexed(TABLE_SELECTOR, 5).each((el, idx) => {
+      return cy
+        .wrap(el)
+        .matchThemedSnapshots(`arrow_empty_tables_two_col${idx}`);
+    });
   });
 });

--- a/e2e/specs/st_arrow_empty_dataframes.spec.js
+++ b/e2e/specs/st_arrow_empty_dataframes.spec.js
@@ -36,6 +36,7 @@ describe("Arrow Dataframes", () => {
 
   it("have consistent empty list visuals", () => {
     cy.get(".element-container")
+      .should("have.length.at.least", 2)
       .eq(1)
       .each(el => {
         return cy.wrap(el).matchThemedSnapshots("arrow_empty_dataframes_list");
@@ -85,6 +86,7 @@ describe("Arrow Dataframes", () => {
 
   it("have consistent empty one-column table visuals", () => {
     cy.get(TABLE_SELECTOR)
+      .should("have.length.at.least", 5)
       .eq(4)
       .each((el, idx) => {
         return cy
@@ -95,6 +97,7 @@ describe("Arrow Dataframes", () => {
 
   it("have consistent empty two-column table visuals", () => {
     cy.get(TABLE_SELECTOR)
+      .should("have.length.at.least", 6)
       .eq(5)
       .each((el, idx) => {
         return cy

--- a/e2e/specs/st_arrow_table_styling.spec.js
+++ b/e2e/specs/st_arrow_table_styling.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st._arrow_table styling", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -38,23 +40,18 @@ describe("st._arrow_table styling", () => {
   });
 
   it("displays table with custom formatted cells", () => {
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed("[data-testid='stTable']", 1)
       .find("table tbody tr td")
       .eq(0)
       .should("contain", "100.00%");
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchThemedSnapshots("arrow-table-formatted-cells");
+    cyGetIndexed("[data-testid='stTable']", 1).matchThemedSnapshots(
+      "arrow-table-formatted-cells"
+    );
   });
 
   it("displays table with colored cells", () => {
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed("[data-testid='stTable']", 2)
       .find("table tbody tr")
       .eq(0)
       .find("td")
@@ -66,10 +63,9 @@ describe("st._arrow_table styling", () => {
         }
       });
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .matchThemedSnapshots("arrow-table-colored-cells");
+    cyGetIndexed("[data-testid='stTable']", 2).matchThemedSnapshots(
+      "arrow-table-colored-cells"
+    );
   });
 
   it("raises an exception when the dataframe has a Styler", () => {

--- a/e2e/specs/st_arrow_table_styling.spec.js
+++ b/e2e/specs/st_arrow_table_styling.spec.js
@@ -39,18 +39,21 @@ describe("st._arrow_table styling", () => {
 
   it("displays table with custom formatted cells", () => {
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .find("table tbody tr td")
       .eq(0)
       .should("contain", "100.00%");
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchThemedSnapshots("arrow-table-formatted-cells");
   });
 
   it("displays table with colored cells", () => {
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .find("table tbody tr")
       .eq(0)
@@ -64,6 +67,7 @@ describe("st._arrow_table styling", () => {
       });
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .matchThemedSnapshots("arrow-table-colored-cells");
   });

--- a/e2e/specs/st_arrow_vega_lite_chart.spec.js
+++ b/e2e/specs/st_arrow_vega_lite_chart.spec.js
@@ -40,10 +40,12 @@ describe("st._arrow_vega_lite_chart", () => {
       .should("have.css", "width", "666px");
 
     cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.css", "width", "666px");
 
     cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.css", "width")
       .and(width => {
@@ -54,6 +56,7 @@ describe("st._arrow_vega_lite_chart", () => {
       });
 
     cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.css", "width", "500px");
   });

--- a/e2e/specs/st_arrow_vega_lite_chart.spec.js
+++ b/e2e/specs/st_arrow_vega_lite_chart.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st._arrow_vega_lite_chart", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -35,18 +37,19 @@ describe("st._arrow_vega_lite_chart", () => {
   });
 
   it("sets the correct chart width", () => {
-    cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
-      .eq(0)
-      .should("have.css", "width", "666px");
+    cyGetIndexed("[data-testid='stArrowVegaLiteChart'] canvas", 0).should(
+      "have.css",
+      "width",
+      "666px"
+    );
 
-    cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.css", "width", "666px");
+    cyGetIndexed("[data-testid='stArrowVegaLiteChart'] canvas", 1).should(
+      "have.css",
+      "width",
+      "666px"
+    );
 
-    cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed("[data-testid='stArrowVegaLiteChart'] canvas", 2)
       .should("have.css", "width")
       .and(width => {
         // Tests run on mac expect 282px while running on linux expects 284px
@@ -55,10 +58,11 @@ describe("st._arrow_vega_lite_chart", () => {
         }
       });
 
-    cy.get("[data-testid='stArrowVegaLiteChart'] canvas")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should("have.css", "width", "500px");
+    cyGetIndexed("[data-testid='stArrowVegaLiteChart'] canvas", 3).should(
+      "have.css",
+      "width",
+      "500px"
+    );
   });
 
   it("supports different ways to get the same plot", () => {

--- a/e2e/specs/st_bokeh_chart.spec.js
+++ b/e2e/specs/st_bokeh_chart.spec.js
@@ -26,9 +26,11 @@ describe("st.bokeh_chart", () => {
 
   it("shows left and right graph", () => {
     cy.get(".stBokehChart")
+      .should("have.length.at.least", 2)
       .eq(1)
       .find("canvas");
     cy.get(".stBokehChart")
+      .should("have.length.at.least", 3)
       .eq(2)
       .find("canvas");
   });

--- a/e2e/specs/st_bokeh_chart.spec.js
+++ b/e2e/specs/st_bokeh_chart.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.bokeh_chart", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -25,13 +27,7 @@ describe("st.bokeh_chart", () => {
   });
 
   it("shows left and right graph", () => {
-    cy.get(".stBokehChart")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .find("canvas");
-    cy.get(".stBokehChart")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .find("canvas");
+    cyGetIndexed(".stBokehChart", 1).find("canvas");
+    cyGetIndexed(".stBokehChart", 2).find("canvas");
   });
 });

--- a/e2e/specs/st_button.spec.js
+++ b/e2e/specs/st_button.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.button", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -34,10 +36,7 @@ describe("st.button", () => {
   it("shows disabled widget correctly", () => {
     cy.get(".stButton").should("have.length", 2);
 
-    cy.get(".stButton")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchThemedSnapshots("disabled-button");
+    cyGetIndexed(".stButton", 1).matchThemedSnapshots("disabled-button");
   });
 
   it("has correct default values", () => {

--- a/e2e/specs/st_button.spec.js
+++ b/e2e/specs/st_button.spec.js
@@ -35,6 +35,7 @@ describe("st.button", () => {
     cy.get(".stButton").should("have.length", 2);
 
     cy.get(".stButton")
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchThemedSnapshots("disabled-button");
   });

--- a/e2e/specs/st_columns.spec.js
+++ b/e2e/specs/st_columns.spec.js
@@ -15,42 +15,45 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.column", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
   });
 
   it("creates 2 equal-width columns", () => {
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .eq(0)
-      .should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      0
+    ).should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      1
+    ).should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      2
+    ).should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
   });
 
   it("creates 4 variable-width columns", () => {
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should("have.css", "flex", "1 1 calc(10% - 16px)");
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .should("have.css", "flex", "1 1 calc(20% - 16px)");
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 6)
-      .eq(5)
-      .should("have.css", "flex", "1 1 calc(30% - 16px)");
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 7)
-      .eq(6)
-      .should("have.css", "flex", "1 1 calc(40% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      3
+    ).should("have.css", "flex", "1 1 calc(10% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      4
+    ).should("have.css", "flex", "1 1 calc(20% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      5
+    ).should("have.css", "flex", "1 1 calc(30% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      6
+    ).should("have.css", "flex", "1 1 calc(40% - 16px)");
   });
 
   it("does not shift layout on a new element", () => {
@@ -64,9 +67,9 @@ describe("st.column", () => {
     );
 
     // When layout was shifting, there was an old "flex: 8" block here.
-    cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should("have.css", "flex", "1 1 calc(10% - 16px)");
+    cyGetIndexed(
+      "[data-testid='stHorizontalBlock'] [data-testid='column']",
+      3
+    ).should("have.css", "flex", "1 1 calc(10% - 16px)");
   });
 });

--- a/e2e/specs/st_columns.spec.js
+++ b/e2e/specs/st_columns.spec.js
@@ -25,24 +25,30 @@ describe("st.column", () => {
       .eq(0)
       .should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.css", "flex", "1 1 calc(33.3333% - 16px)");
   });
 
   it("creates 4 variable-width columns", () => {
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.css", "flex", "1 1 calc(10% - 16px)");
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 5)
       .eq(4)
       .should("have.css", "flex", "1 1 calc(20% - 16px)");
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 6)
       .eq(5)
       .should("have.css", "flex", "1 1 calc(30% - 16px)");
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 7)
       .eq(6)
       .should("have.css", "flex", "1 1 calc(40% - 16px)");
   });
@@ -59,6 +65,7 @@ describe("st.column", () => {
 
     // When layout was shifting, there was an old "flex: 8" block here.
     cy.get("[data-testid='stHorizontalBlock'] [data-testid='column']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.css", "flex", "1 1 calc(10% - 16px)");
   });

--- a/e2e/specs/st_columns_layout.spec.js
+++ b/e2e/specs/st_columns_layout.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.columns layout", () => {
   it("shows columns horizontally when viewport > 640", () => {
     cy.viewport(641, 800);
@@ -29,15 +31,14 @@ describe("st.columns layout", () => {
     cy.viewport(640, 800);
     cy.visit("http://localhost:3000/");
 
-    cy.get("[data-testid='stHorizontalBlock']")
-      .first()
-      .matchImageSnapshot("columns-layout-vertical");
+    cyGetIndexed("[data-testid='stHorizontalBlock']", 0).matchImageSnapshot(
+      "columns-layout-vertical"
+    );
   });
 
   it("still takes up space with no elements present", () => {
-    cy.get("[data-testid='stHorizontalBlock']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchImageSnapshot("columns-with-one-element");
+    cyGetIndexed("[data-testid='stHorizontalBlock']", 1).matchImageSnapshot(
+      "columns-with-one-element"
+    );
   });
 });

--- a/e2e/specs/st_container.spec.js
+++ b/e2e/specs/st_container.spec.js
@@ -15,27 +15,18 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.container", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
   });
 
   it("permits multiple out-of-order elements", () => {
-    cy.get(".stMarkdown p")
-      .eq(0)
-      .contains("Line 2");
-    cy.get(".stMarkdown p")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .contains("Line 3");
-    cy.get(".stMarkdown p")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .contains("Line 1");
-    cy.get(".stMarkdown p")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .contains("Line 4");
+    cyGetIndexed(".stMarkdown p", 0).contains("Line 2");
+    cyGetIndexed(".stMarkdown p", 1).contains("Line 3");
+    cyGetIndexed(".stMarkdown p", 2).contains("Line 1");
+    cyGetIndexed(".stMarkdown p", 3).contains("Line 4");
   });
 
   it("persists widget state across reruns", () => {

--- a/e2e/specs/st_container.spec.js
+++ b/e2e/specs/st_container.spec.js
@@ -25,12 +25,15 @@ describe("st.container", () => {
       .eq(0)
       .contains("Line 2");
     cy.get(".stMarkdown p")
+      .should("have.length.at.least", 2)
       .eq(1)
       .contains("Line 3");
     cy.get(".stMarkdown p")
+      .should("have.length.at.least", 3)
       .eq(2)
       .contains("Line 1");
     cy.get(".stMarkdown p")
+      .should("have.length.at.least", 4)
       .eq(3)
       .contains("Line 4");
   });

--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.date_input", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -48,10 +50,9 @@ describe("st.date_input", () => {
   });
 
   it("shows disabled widget correctly", () => {
-    cy.get(".stDateInput")
-      .should("have.length.at.least", 6)
-      .eq(5)
-      .matchThemedSnapshots("disabled date input");
+    cyGetIndexed(".stDateInput", 5).matchThemedSnapshots(
+      "disabled date input"
+    );
   });
 
   it("handles value changes", () => {
@@ -80,10 +81,7 @@ describe("st.date_input", () => {
 
   it("handles range end date changes", () => {
     // open date picker
-    cy.get(".stDateInput")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .click();
+    cyGetIndexed(".stDateInput", 3).click();
 
     // select end date '2019/07/10'
     cy.get(
@@ -105,10 +103,7 @@ describe("st.date_input", () => {
 
   it("handles range start/end date changes", () => {
     // open date picker
-    cy.get(".stDateInput")
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .click();
+    cyGetIndexed(".stDateInput", 4).click();
 
     // select start date '2019/07/10'
     cy.get(
@@ -213,10 +208,7 @@ describe("st.date_input", () => {
 
   it("not reset to default range value if calendar closed empty", () => {
     // open date picker
-    cy.get(".stDateInput")
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .click();
+    cyGetIndexed(".stDateInput", 4).click();
 
     // select start date '2019/07/10'
     cy.get(
@@ -253,9 +245,7 @@ describe("st.date_input", () => {
     );
 
     // remove input
-    cy.get(".stDateInput")
-      .should("have.length.at.least", 5)
-      .eq(4)
+    cyGetIndexed(".stDateInput", 4)
       .click()
       .type("{del}{selectall}{backspace}");
 

--- a/e2e/specs/st_download_button.spec.js
+++ b/e2e/specs/st_download_button.spec.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { cyGetIndexed } from "./spec_utils";
+
 const path = require("path");
 
 describe("st.download_button", () => {
@@ -33,10 +35,9 @@ describe("st.download_button", () => {
 
   it("shows disabled widget correctly", () => {
     cy.get(".stDownloadButton").should("have.length", 3);
-    cy.get(".stDownloadButton")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchThemedSnapshots("disabled-download-button");
+    cyGetIndexed(".stDownloadButton", 1).matchThemedSnapshots(
+      "disabled-download-button"
+    );
   });
 
   it("downloads txt file when the button is clicked", () => {

--- a/e2e/specs/st_download_button.spec.js
+++ b/e2e/specs/st_download_button.spec.js
@@ -34,6 +34,7 @@ describe("st.download_button", () => {
   it("shows disabled widget correctly", () => {
     cy.get(".stDownloadButton").should("have.length", 3);
     cy.get(".stDownloadButton")
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchThemedSnapshots("disabled-download-button");
   });

--- a/e2e/specs/st_expander.spec.js
+++ b/e2e/specs/st_expander.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 const expanderHeaderIdentifier = ".streamlit-expanderHeader";
 
 describe("st.expander", () => {
@@ -23,23 +25,19 @@ describe("st.expander", () => {
   });
 
   it("displays expander + regular containers properly", () => {
-    cy.get(".main [data-testid='stExpander']")
-      .eq(0)
-      .within(() => {
-        cy.get(expanderHeaderIdentifier).should("exist");
-      });
-    cy.get(".main [data-testid='stExpander']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .within(() => {
-        cy.get(expanderHeaderIdentifier).should("exist");
-      });
+    cyGetIndexed(".main [data-testid='stExpander']", 0).within(() => {
+      cy.get(expanderHeaderIdentifier).should("exist");
+    });
+    cyGetIndexed(".main [data-testid='stExpander']", 1).within(() => {
+      cy.get(expanderHeaderIdentifier).should("exist");
+    });
 
-    cy.get("[data-testid='stSidebar'] [data-testid='stExpander']")
-      .eq(0)
-      .within(() => {
-        cy.get(expanderHeaderIdentifier).should("exist");
-      });
+    cyGetIndexed(
+      "[data-testid='stSidebar'] [data-testid='stExpander']",
+      0
+    ).within(() => {
+      cy.get(expanderHeaderIdentifier).should("exist");
+    });
   });
 
   it("displays correctly", () => {
@@ -54,34 +52,29 @@ describe("st.expander", () => {
 
   it("collapses + expands", () => {
     // Starts expanded
-    cy.get(".main [data-testid='stExpander']")
-      .eq(0)
-      .within(() => {
-        const expanderHeader = cy.get(expanderHeaderIdentifier);
-        expanderHeader.should("exist");
+    cyGetIndexed(".main [data-testid='stExpander']", 0).within(() => {
+      const expanderHeader = cy.get(expanderHeaderIdentifier);
+      expanderHeader.should("exist");
 
-        let toggle = cy.get("svg[title='Collapse']");
-        toggle.should("exist");
-        expanderHeader.click();
+      let toggle = cy.get("svg[title='Collapse']");
+      toggle.should("exist");
+      expanderHeader.click();
 
-        toggle = cy.get("svg[title='Expand']");
-        toggle.should("exist");
-      });
+      toggle = cy.get("svg[title='Expand']");
+      toggle.should("exist");
+    });
 
     // Starts collapsed
-    cy.get(".main [data-testid='stExpander']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .within(() => {
-        let expanderHeader = cy.get(expanderHeaderIdentifier);
-        expanderHeader.should("exist");
+    cyGetIndexed(".main [data-testid='stExpander']", 1).within(() => {
+      let expanderHeader = cy.get(expanderHeaderIdentifier);
+      expanderHeader.should("exist");
 
-        let toggle = cy.get("svg[title='Expand']");
-        toggle.should("exist");
-        expanderHeader.click();
+      let toggle = cy.get("svg[title='Expand']");
+      toggle.should("exist");
+      expanderHeader.click();
 
-        toggle = cy.get("svg[title='Collapse']");
-        toggle.should("exist");
-      });
+      toggle = cy.get("svg[title='Collapse']");
+      toggle.should("exist");
+    });
   });
 });

--- a/e2e/specs/st_expander.spec.js
+++ b/e2e/specs/st_expander.spec.js
@@ -29,6 +29,7 @@ describe("st.expander", () => {
         cy.get(expanderHeaderIdentifier).should("exist");
       });
     cy.get(".main [data-testid='stExpander']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .within(() => {
         cy.get(expanderHeaderIdentifier).should("exist");
@@ -69,6 +70,7 @@ describe("st.expander", () => {
 
     // Starts collapsed
     cy.get(".main [data-testid='stExpander']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .within(() => {
         let expanderHeader = cy.get(expanderHeaderIdentifier);

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -361,8 +361,10 @@ describe("st.file_uploader", () => {
 
       // But our uploaded text should contain nothing yet, as we haven't
       // submitted.
-      cyGetIndexed("[data-testid='stText']", uploaderIndex);
-        .should("contain.text", "No upload");
+      cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+        "contain.text",
+        "No upload"
+      );
 
       // Submit the form
       cy.get("[data-testid='stFormSubmitButton'] button").click();

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -362,9 +362,6 @@ describe("st.file_uploader", () => {
       // But our uploaded text should contain nothing yet, as we haven't
       // submitted.
       cyGetIndexed("[data-testid='stText']", uploaderIndex);
-      cy.get("[data-testid='stText']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
         .should("contain.text", "No upload");
 
       // Submit the form

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -282,6 +282,7 @@ describe("st.file_uploader", () => {
         ];
 
         cy.get("[data-testid='stFileUploadDropzone']")
+          .should("have.length.at.least", uploaderIndex + 1)
           .eq(uploaderIndex)
           .attachFile(files[0], {
             force: true,

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.file_uploader", () => {
   beforeEach(() => {
     Cypress.Cookies.defaults({
@@ -30,29 +32,23 @@ describe("st.file_uploader", () => {
   });
 
   it("shows widget correctly", () => {
-    cy.get("[data-testid='stFileUploader']")
-      .should("have.length.at.least", 1)
-      .eq(0)
-      .should("exist");
-    cy.get("[data-testid='stFileUploader'] label")
-      .should("have.length.at.least", 1)
-      .eq(0)
-      .should("have.text", "Drop a file:");
+    cyGetIndexed("[data-testid='stFileUploader']", 0).should("exist");
+    cyGetIndexed("[data-testid='stFileUploader'] label", 0).should(
+      "have.text",
+      "Drop a file:"
+    );
 
-    cy.get("[data-testid='stFileUploader']")
-      .should("have.length.at.least", 1)
-      .eq(0)
-      .matchThemedSnapshots("single_file_uploader");
+    cyGetIndexed("[data-testid='stFileUploader']", 0).matchThemedSnapshots(
+      "single_file_uploader"
+    );
 
-    cy.get("[data-testid='stFileUploader']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchThemedSnapshots("disabled_file_uploader");
+    cyGetIndexed("[data-testid='stFileUploader']", 1).matchThemedSnapshots(
+      "disabled_file_uploader"
+    );
 
-    cy.get("[data-testid='stFileUploader']")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .matchThemedSnapshots("multi_file_uploader");
+    cyGetIndexed("[data-testid='stFileUploader']", 2).matchThemedSnapshots(
+      "multi_file_uploader"
+    );
   });
 
   it("shows error message for disallowed files", () => {
@@ -76,15 +72,15 @@ describe("st.file_uploader", () => {
           }
         );
 
-      cy.get("[data-testid='stUploadedFileErrorMessage']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
-        .should("have.text", "application/json files are not allowed.");
+      cyGetIndexed(
+        "[data-testid='stUploadedFileErrorMessage']",
+        uploaderIndex
+      ).should("have.text", "application/json files are not allowed.");
 
-      cy.get("[data-testid='stFileUploader']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
-        .matchThemedSnapshots("file_uploader-error");
+      cyGetIndexed(
+        "[data-testid='stFileUploader']",
+        uploaderIndex
+      ).matchThemedSnapshots("file_uploader-error");
     });
   });
 
@@ -106,75 +102,73 @@ describe("st.file_uploader", () => {
           { fileContent: file2, fileName: fileName2, mimeType: "text/plain" }
         ];
 
-        cy.get("[data-testid='stFileUploadDropzone']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .attachFile(files[0], {
-            force: true,
-            subjectType: "drag-n-drop",
-            events: ["dragenter", "drop"]
-          });
+        cyGetIndexed(
+          "[data-testid='stFileUploadDropzone']",
+          uploaderIndex
+        ).attachFile(files[0], {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"]
+        });
 
         // The script should have printed the contents of the first files
         // into an st.text. (This tests that the upload actually went
         // through.)
         cy.get(".uploadedFileName").should("have.text", fileName1);
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", file1);
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "contain.text",
+          file1
+        );
 
-        cy.get("[data-testid='stMarkdownContainer']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", "True");
+        cyGetIndexed(
+          "[data-testid='stMarkdownContainer']",
+          uploaderIndex
+        ).should("contain.text", "True");
 
-        cy.get("[data-testid='stFileUploader']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .matchThemedSnapshots("single_file_uploader-uploaded");
+        cyGetIndexed(
+          "[data-testid='stFileUploader']",
+          uploaderIndex
+        ).matchThemedSnapshots("single_file_uploader-uploaded");
 
         // Upload a second file. This one will replace the first.
-        cy.get("[data-testid='stFileUploadDropzone']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .attachFile(files[1], {
-            force: true,
-            subjectType: "drag-n-drop",
-            events: ["dragenter", "drop"]
-          });
+        cyGetIndexed(
+          "[data-testid='stFileUploadDropzone']",
+          uploaderIndex
+        ).attachFile(files[1], {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"]
+        });
 
         cy.get(".uploadedFileName")
           .should("have.text", fileName2)
           .should("not.have.text", fileName1);
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
+        cyGetIndexed("[data-testid='stText']", uploaderIndex)
           .should("contain.text", file2)
           .should("not.contain.text", file1);
 
-        cy.get("[data-testid='stMarkdownContainer']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", "True");
+        cyGetIndexed(
+          "[data-testid='stMarkdownContainer']",
+          uploaderIndex
+        ).should("contain.text", "True");
 
         // On rerun, make sure file is still returned
         cy.get("body").type("r");
         cy.wait(1000);
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", file2);
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "contain.text",
+          file2
+        );
 
         // Can delete
-        cy.get("[data-testid='fileDeleteBtn'] button")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .click();
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", "No upload");
+        cyGetIndexed(
+          "[data-testid='fileDeleteBtn'] button",
+          uploaderIndex
+        ).click();
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "contain.text",
+          "No upload"
+        );
       });
     });
   });
@@ -196,27 +190,27 @@ describe("st.file_uploader", () => {
           { fileContent: file2, fileName: fileName2, mimeType: "text/plain" }
         ];
 
-        cy.get("[data-testid='stFileUploadDropzone']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .attachFile(files[0], {
-            force: true,
-            subjectType: "drag-n-drop",
-            events: ["dragenter", "drop"]
-          });
+        cyGetIndexed(
+          "[data-testid='stFileUploadDropzone']",
+          uploaderIndex
+        ).attachFile(files[0], {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"]
+        });
 
         cy.get(".uploadedFileName").each(uploadedFileName => {
           cy.get(uploadedFileName).should("have.text", fileName1);
         });
 
-        cy.get("[data-testid='stFileUploadDropzone']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .attachFile(files[1], {
-            force: true,
-            subjectType: "drag-n-drop",
-            events: ["dragenter", "drop"]
-          });
+        cyGetIndexed(
+          "[data-testid='stFileUploadDropzone']",
+          uploaderIndex
+        ).attachFile(files[1], {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"]
+        });
 
         // Wait for the HTTP request to complete
         cy.wait("@uploadFile");
@@ -232,29 +226,29 @@ describe("st.file_uploader", () => {
         // into an st.text. (This tests that the upload actually went
         // through.)
         const content = [file1, file2].join("\n");
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("have.text", content);
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "have.text",
+          content
+        );
 
-        cy.get("[data-testid='stFileUploader']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .matchThemedSnapshots("multi_file_uploader-uploaded");
+        cyGetIndexed(
+          "[data-testid='stFileUploader']",
+          uploaderIndex
+        ).matchThemedSnapshots("multi_file_uploader-uploaded");
 
         // Delete the second file. The second file is on top because it was
         // most recently uploaded. The first file should still exist.
         cy.get("[data-testid='fileDeleteBtn'] button")
           .first()
           .click();
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", file1);
-        cy.get("[data-testid='stMarkdownContainer']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", "True");
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "contain.text",
+          file1
+        );
+        cyGetIndexed(
+          "[data-testid='stMarkdownContainer']",
+          uploaderIndex
+        ).should("contain.text", "True");
       });
     });
   });
@@ -281,14 +275,14 @@ describe("st.file_uploader", () => {
           { fileContent: file2, fileName: fileName2, mimeType: "text/plain" }
         ];
 
-        cy.get("[data-testid='stFileUploadDropzone']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .attachFile(files[0], {
-            force: true,
-            subjectType: "drag-n-drop",
-            events: ["dragenter", "drop"]
-          });
+        cyGetIndexed(
+          "[data-testid='stFileUploadDropzone']",
+          uploaderIndex
+        ).attachFile(files[0], {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"]
+        });
 
         cy.get(".uploadedFileName").each(uploadedFileName => {
           cy.get(uploadedFileName).should("have.text", fileName1);
@@ -296,14 +290,14 @@ describe("st.file_uploader", () => {
 
         cy.wait(1000);
 
-        cy.get("[data-testid='stFileUploadDropzone']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .attachFile(files[1], {
-            force: true,
-            subjectType: "drag-n-drop",
-            events: ["dragenter", "drop"]
-          });
+        cyGetIndexed(
+          "[data-testid='stFileUploadDropzone']",
+          uploaderIndex
+        ).attachFile(files[1], {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"]
+        });
 
         // Wait for the HTTP request to complete
         cy.wait("@uploadFile");
@@ -319,24 +313,24 @@ describe("st.file_uploader", () => {
         // into an st.text. (This tests that the upload actually went
         // through.)
         const content = [file1, file2].join("\n");
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("have.text", content);
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "have.text",
+          content
+        );
 
         // Delete the second file. The second file is on top because it was
         // most recently uploaded. The first file should still exist.
         cy.get("[data-testid='fileDeleteBtn'] button")
           .first()
           .click();
-        cy.get("[data-testid='stText']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", file1);
-        cy.get("[data-testid='stMarkdownContainer']")
-          .should("have.length.at.least", uploaderIndex + 1)
-          .eq(uploaderIndex)
-          .should("contain.text", "True");
+        cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+          "contain.text",
+          file1
+        );
+        cyGetIndexed(
+          "[data-testid='stMarkdownContainer']",
+          uploaderIndex
+        ).should("contain.text", "True");
       });
     });
   });
@@ -350,14 +344,14 @@ describe("st.file_uploader", () => {
         { fileContent: file1, fileName: fileName1, mimeType: "text/plain" }
       ];
 
-      cy.get("[data-testid='stFileUploadDropzone']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
-        .attachFile(files[0], {
-          force: true,
-          subjectType: "drag-n-drop",
-          events: ["dragenter", "drop"]
-        });
+      cyGetIndexed(
+        "[data-testid='stFileUploadDropzone']",
+        uploaderIndex
+      ).attachFile(files[0], {
+        force: true,
+        subjectType: "drag-n-drop",
+        events: ["dragenter", "drop"]
+      });
 
       // Wait for the HTTP request to complete
       cy.wait("@uploadFile");
@@ -367,6 +361,7 @@ describe("st.file_uploader", () => {
 
       // But our uploaded text should contain nothing yet, as we haven't
       // submitted.
+      cyGetIndexed("[data-testid='stText']", uploaderIndex);
       cy.get("[data-testid='stText']")
         .should("have.length.at.least", uploaderIndex + 1)
         .eq(uploaderIndex)
@@ -376,10 +371,10 @@ describe("st.file_uploader", () => {
       cy.get("[data-testid='stFormSubmitButton'] button").click();
 
       // Now we should see the file's contents
-      cy.get("[data-testid='stText']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
-        .should("contain.text", file1);
+      cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+        "contain.text",
+        file1
+      );
 
       // Press the delete button. Again, nothing should happen - we
       // should still see the file's contents.
@@ -387,18 +382,18 @@ describe("st.file_uploader", () => {
         .first()
         .click();
 
-      cy.get("[data-testid='stText']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
-        .should("contain.text", file1);
+      cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+        "contain.text",
+        file1
+      );
 
       // Submit again. Now the file should be gone.
       cy.get("[data-testid='stFormSubmitButton'] button").click();
 
-      cy.get("[data-testid='stText']")
-        .should("have.length.at.least", uploaderIndex + 1)
-        .eq(uploaderIndex)
-        .should("contain.text", "No upload");
+      cyGetIndexed("[data-testid='stText']", uploaderIndex).should(
+        "contain.text",
+        "No upload"
+      );
     });
   });
 });

--- a/e2e/specs/st_form.spec.js
+++ b/e2e/specs/st_form.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.form", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -29,108 +31,40 @@ describe("st.form", () => {
   it("doesn't change widget values before the form is submitted", () => {
     changeWidgetValues();
 
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(0)
-      .should("have.text", "Checkbox: False");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(1)
-      .should("have.text", "Color Picker: #000000");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(2)
-      .should("have.text", "Date Input: 2019-07-06");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(3)
-      .should("have.text", "Multiselect: foo");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(4)
-      .should("have.text", "Number Input: 0.0");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(5)
-      .should("have.text", "Radio: foo");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(6)
-      .should("have.text", "Selectbox: foo");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(7)
-      .should("have.text", "Select Slider: foo");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(8)
-      .should("have.text", "Slider: 0");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(9)
-      .should("have.text", "Text Area: foo");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(10)
-      .should("have.text", "Text Input: foo");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(11)
-      .should("have.text", "Time Input: 08:45:00");
+    cyGetIndexed("@markdown", 0).should("have.text", "Checkbox: False");
+    cyGetIndexed("@markdown", 1).should("have.text", "Color Picker: #000000");
+    cyGetIndexed("@markdown", 2).should("have.text", "Date Input: 2019-07-06");
+    cyGetIndexed("@markdown", 3).should("have.text", "Multiselect: foo");
+    cyGetIndexed("@markdown", 4).should("have.text", "Number Input: 0.0");
+    cyGetIndexed("@markdown", 5).should("have.text", "Radio: foo");
+    cyGetIndexed("@markdown", 6).should("have.text", "Selectbox: foo");
+    cyGetIndexed("@markdown", 7).should("have.text", "Select Slider: foo");
+    cyGetIndexed("@markdown", 8).should("have.text", "Slider: 0");
+    cyGetIndexed("@markdown", 9).should("have.text", "Text Area: foo");
+    cyGetIndexed("@markdown", 10).should("have.text", "Text Input: foo");
+    cyGetIndexed("@markdown", 11).should("have.text", "Time Input: 08:45:00");
   });
 
   it("changes widget values after the form has been submitted", () => {
     changeWidgetValues();
     cy.get(".stButton [kind='formSubmit']").click();
     cy.get("@markdown").should("have.length", 12);
-    cy.get("@markdown")
-      .eq(0)
-      .should("have.text", "Checkbox: True");
+
+    cyGetIndexed("@markdown", 0).should("have.text", "Checkbox: True");
     // Cypress has a weird issue with Chrome's color picker.
     // Commenting out the check for color picker value before we find a solution.
-    // cy.get("@markdown")
-    //   .eq(1)
+    // cyGetIndexed("@markdown", 1)
     //   .should("have.text", "Color Picker: #ff0000");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(2)
-      .should("have.text", "Date Input: 2019-07-17");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(3)
-      .should("have.text", "Multiselect: foo, bar");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(4)
-      .should("have.text", "Number Input: 42.0");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(5)
-      .should("have.text", "Radio: bar");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(6)
-      .should("have.text", "Selectbox: bar");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(7)
-      .should("have.text", "Select Slider: bar");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(8)
-      .should("have.text", "Slider: 1");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(9)
-      .should("have.text", "Text Area: bar");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(10)
-      .should("have.text", "Text Input: bar");
-    cy.get("@markdown")
-      .should("have.length.at.least", 12)
-      .eq(11)
-      .should("have.text", "Time Input: 00:00:00");
+    cyGetIndexed("@markdown", 2).should("have.text", "Date Input: 2019-07-17");
+    cyGetIndexed("@markdown", 3).should("have.text", "Multiselect: foo, bar");
+    cyGetIndexed("@markdown", 4).should("have.text", "Number Input: 42.0");
+    cyGetIndexed("@markdown", 5).should("have.text", "Radio: bar");
+    cyGetIndexed("@markdown", 6).should("have.text", "Selectbox: bar");
+    cyGetIndexed("@markdown", 7).should("have.text", "Select Slider: bar");
+    cyGetIndexed("@markdown", 8).should("have.text", "Slider: 1");
+    cyGetIndexed("@markdown", 9).should("have.text", "Text Area: bar");
+    cyGetIndexed("@markdown", 10).should("have.text", "Text Input: bar");
+    cyGetIndexed("@markdown", 11).should("have.text", "Time Input: 00:00:00");
   });
 });
 
@@ -164,19 +98,13 @@ function changeWidgetValues() {
     .type("42");
 
   // Change the radio value.
-  cy.get(".stRadio div label")
-    .should("have.length.at.least", 2)
-    .eq(1)
-    .click();
+  cyGetIndexed(".stRadio div label", 1).click();
 
   // Change the selectbox value.
   cy.get(".stSelectbox")
     .find("input")
     .click();
-  cy.get("[data-baseweb='popover'] li")
-    .should("have.length.at.least", 2)
-    .eq(1)
-    .click();
+  cyGetIndexed("[data-baseweb='popover'] li", 1).click();
 
   // Change the select slider value.
   cy.get('.stSlider [role="slider"]')

--- a/e2e/specs/st_form.spec.js
+++ b/e2e/specs/st_form.spec.js
@@ -30,39 +30,51 @@ describe("st.form", () => {
     changeWidgetValues();
 
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(0)
       .should("have.text", "Checkbox: False");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(1)
       .should("have.text", "Color Picker: #000000");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(2)
       .should("have.text", "Date Input: 2019-07-06");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(3)
       .should("have.text", "Multiselect: foo");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(4)
       .should("have.text", "Number Input: 0.0");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(5)
       .should("have.text", "Radio: foo");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(6)
       .should("have.text", "Selectbox: foo");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(7)
       .should("have.text", "Select Slider: foo");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(8)
       .should("have.text", "Slider: 0");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(9)
       .should("have.text", "Text Area: foo");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(10)
       .should("have.text", "Text Input: foo");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(11)
       .should("have.text", "Time Input: 08:45:00");
   });
@@ -80,33 +92,43 @@ describe("st.form", () => {
     //   .eq(1)
     //   .should("have.text", "Color Picker: #ff0000");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(2)
       .should("have.text", "Date Input: 2019-07-17");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(3)
       .should("have.text", "Multiselect: foo, bar");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(4)
       .should("have.text", "Number Input: 42.0");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(5)
       .should("have.text", "Radio: bar");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(6)
       .should("have.text", "Selectbox: bar");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(7)
       .should("have.text", "Select Slider: bar");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(8)
       .should("have.text", "Slider: 1");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(9)
       .should("have.text", "Text Area: bar");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(10)
       .should("have.text", "Text Input: bar");
     cy.get("@markdown")
+      .should("have.length.at.least", 12)
       .eq(11)
       .should("have.text", "Time Input: 00:00:00");
   });
@@ -143,6 +165,7 @@ function changeWidgetValues() {
 
   // Change the radio value.
   cy.get(".stRadio div label")
+    .should("have.length.at.least", 2)
     .eq(1)
     .click();
 
@@ -151,6 +174,7 @@ function changeWidgetValues() {
     .find("input")
     .click();
   cy.get("[data-baseweb='popover'] li")
+    .should("have.length.at.least", 2)
     .eq(1)
     .click();
 

--- a/e2e/specs/st_form_column_association.spec.js
+++ b/e2e/specs/st_form_column_association.spec.js
@@ -54,6 +54,7 @@ describe("Form/column association", () => {
 
 function changeCheckboxValue(index) {
   cy.get(".stCheckbox")
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .click();
 }
@@ -61,9 +62,11 @@ function changeCheckboxValue(index) {
 function testCheckboxInsideForm(index) {
   // Check that the form has no pending changes.
   cy.get(buttonSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.attr", "kind", "formSubmit");
   cy.get(markdownSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.text", "False");
 
@@ -73,19 +76,23 @@ function testCheckboxInsideForm(index) {
   // Check that the checkbox value hasn't been changed,
   // and that there the form has pending changes now.
   cy.get(buttonSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.attr", "kind", "formSubmit");
   cy.get(markdownSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.text", "False");
 
   // Submit the form.
   cy.get(buttonSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .click();
 
   // Check that the checkbox value has been updated.
   cy.get(markdownSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.text", "True");
 }
@@ -93,9 +100,11 @@ function testCheckboxInsideForm(index) {
 function testCheckboxOutsideForm(index) {
   // Check that the form has no pending changes.
   cy.get(buttonSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.attr", "kind", "formSubmit");
   cy.get(markdownSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.text", "False");
 
@@ -104,9 +113,11 @@ function testCheckboxOutsideForm(index) {
 
   // Check the checkbox value has been updated without a form submission.
   cy.get(buttonSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.attr", "kind", "formSubmit");
   cy.get(markdownSelector)
+    .should("have.length.at.least", index + 1)
     .eq(index)
     .should("have.text", "True");
 }

--- a/e2e/specs/st_form_column_association.spec.js
+++ b/e2e/specs/st_form_column_association.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 const buttonSelector = ".stButton button";
 const markdownSelector = "[data-testid='stMarkdownContainer'] p code";
 
@@ -53,71 +55,54 @@ describe("Form/column association", () => {
 });
 
 function changeCheckboxValue(index) {
-  cy.get(".stCheckbox")
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .click();
+  cyGetIndexed(".stCheckbox", index).click();
 }
 
 function testCheckboxInsideForm(index) {
   // Check that the form has no pending changes.
-  cy.get(buttonSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.attr", "kind", "formSubmit");
-  cy.get(markdownSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.text", "False");
+  cyGetIndexed(buttonSelector, index).should(
+    "have.attr",
+    "kind",
+    "formSubmit"
+  );
+  cyGetIndexed(markdownSelector, index).should("have.text", "False");
 
   // Toggle checkbox.
   changeCheckboxValue(index);
 
   // Check that the checkbox value hasn't been changed,
   // and that there the form has pending changes now.
-  cy.get(buttonSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.attr", "kind", "formSubmit");
-  cy.get(markdownSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.text", "False");
+  cyGetIndexed(buttonSelector, index).should(
+    "have.attr",
+    "kind",
+    "formSubmit"
+  );
+  cyGetIndexed(markdownSelector, index).should("have.text", "False");
 
   // Submit the form.
-  cy.get(buttonSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .click();
+  cyGetIndexed(buttonSelector, index).click();
 
   // Check that the checkbox value has been updated.
-  cy.get(markdownSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.text", "True");
+  cyGetIndexed(markdownSelector, index).should("have.text", "True");
 }
 
 function testCheckboxOutsideForm(index) {
   // Check that the form has no pending changes.
-  cy.get(buttonSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.attr", "kind", "formSubmit");
-  cy.get(markdownSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.text", "False");
+  cyGetIndexed(buttonSelector, index).should(
+    "have.attr",
+    "kind",
+    "formSubmit"
+  );
+  cyGetIndexed(markdownSelector, index).should("have.text", "False");
 
   // Toggle checkbox.
   changeCheckboxValue(index);
 
   // Check the checkbox value has been updated without a form submission.
-  cy.get(buttonSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.attr", "kind", "formSubmit");
-  cy.get(markdownSelector)
-    .should("have.length.at.least", index + 1)
-    .eq(index)
-    .should("have.text", "True");
+  cyGetIndexed(buttonSelector, index).should(
+    "have.attr",
+    "kind",
+    "formSubmit"
+  );
+  cyGetIndexed(markdownSelector, index).should("have.text", "True");
 }

--- a/e2e/specs/st_graphviz_chart.spec.js
+++ b/e2e/specs/st_graphviz_chart.spec.js
@@ -31,9 +31,11 @@ describe("st.graphviz_chart", () => {
 
   it("shows left and right graph", () => {
     cy.get(".stGraphVizChart > svg > g > title")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("contain", "Left");
     cy.get(".stGraphVizChart > svg > g > title")
+      .should("have.length.at.least", 5)
       .eq(4)
       .should("contain", "Right");
   });

--- a/e2e/specs/st_graphviz_chart.spec.js
+++ b/e2e/specs/st_graphviz_chart.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.graphviz_chart", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -30,13 +32,13 @@ describe("st.graphviz_chart", () => {
   });
 
   it("shows left and right graph", () => {
-    cy.get(".stGraphVizChart > svg > g > title")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should("contain", "Left");
-    cy.get(".stGraphVizChart > svg > g > title")
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .should("contain", "Right");
+    cyGetIndexed(".stGraphVizChart > svg > g > title", 3).should(
+      "contain",
+      "Left"
+    );
+    cyGetIndexed(".stGraphVizChart > svg > g > title", 4).should(
+      "contain",
+      "Right"
+    );
   });
 });

--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.image", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -48,44 +50,38 @@ describe("st.image", () => {
   });
 
   it("displays a PNG image when specified", () => {
-    cy.get(".element-container [data-testid='stImage'] img")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".element-container [data-testid='stImage'] img", 1)
       .should("have.attr", "src")
       .should("match", /^.*\.png$/);
   });
 
   it("displays a JPEG image when not specified with no alpha channel", () => {
-    cy.get(".element-container [data-testid='stImage'] img")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".element-container [data-testid='stImage'] img", 2)
       .should("have.attr", "src")
       .should("match", /^.*\.jpeg$/);
   });
 
   it("displays a PNG image when not specified with alpha channel", () => {
-    cy.get(".element-container [data-testid='stImage'] img")
-      .should("have.length.at.least", 4)
-      .eq(3)
+    cyGetIndexed(".element-container [data-testid='stImage'] img", 3)
       .should("have.attr", "src")
       .should("match", /^.*\.png$/);
   });
 
   it("displays a 100x100 image when use_column_width is default, 'auto', 'never', or False", () => {
     for (const index of [4, 5, 6, 7]) {
-      cy.get(".element-container [data-testid='stImage'] img")
-        .should("have.length.at.least", index + 1)
-        .eq(index)
-        .matchImageSnapshot("black-square-100px");
+      cyGetIndexed(
+        ".element-container [data-testid='stImage'] img",
+        index
+      ).matchImageSnapshot("black-square-100px");
     }
   });
 
   it("displays a column-width image when use_column_width is 'always', True, or size > column", () => {
     for (const index of [8, 9, 10]) {
-      cy.get(".element-container [data-testid='stImage'] img")
-        .should("have.length.at.least", index + 1)
-        .eq(index)
-        .matchImageSnapshot(`black-square-column-${index}`);
+      cyGetIndexed(
+        ".element-container [data-testid='stImage'] img",
+        index
+      ).matchImageSnapshot(`black-square-column-${index}`);
     }
   });
 
@@ -96,16 +92,16 @@ describe("st.image", () => {
   });
 
   it("displays links in text as text", () => {
-    cy.get("[data-testid='stImage'] svg")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("contain", "avatars.githubusercontent");
+    cyGetIndexed("[data-testid='stImage'] svg", 1).should(
+      "contain",
+      "avatars.githubusercontent"
+    );
   });
 
   it("displays SVG tags prefixed with meta xml tags", () => {
-    cy.get("[data-testid='stImage'] svg")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .should("contain", "I am prefixed with some meta tags");
+    cyGetIndexed("[data-testid='stImage'] svg", 2).should(
+      "contain",
+      "I am prefixed with some meta tags"
+    );
   });
 });

--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -49,6 +49,7 @@ describe("st.image", () => {
 
   it("displays a PNG image when specified", () => {
     cy.get(".element-container [data-testid='stImage'] img")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.attr", "src")
       .should("match", /^.*\.png$/);
@@ -56,6 +57,7 @@ describe("st.image", () => {
 
   it("displays a JPEG image when not specified with no alpha channel", () => {
     cy.get(".element-container [data-testid='stImage'] img")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.attr", "src")
       .should("match", /^.*\.jpeg$/);
@@ -63,6 +65,7 @@ describe("st.image", () => {
 
   it("displays a PNG image when not specified with alpha channel", () => {
     cy.get(".element-container [data-testid='stImage'] img")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.attr", "src")
       .should("match", /^.*\.png$/);
@@ -71,6 +74,7 @@ describe("st.image", () => {
   it("displays a 100x100 image when use_column_width is default, 'auto', 'never', or False", () => {
     for (const index of [4, 5, 6, 7]) {
       cy.get(".element-container [data-testid='stImage'] img")
+        .should("have.length.at.least", index + 1)
         .eq(index)
         .matchImageSnapshot("black-square-100px");
     }
@@ -79,6 +83,7 @@ describe("st.image", () => {
   it("displays a column-width image when use_column_width is 'always', True, or size > column", () => {
     for (const index of [8, 9, 10]) {
       cy.get(".element-container [data-testid='stImage'] img")
+        .should("have.length.at.least", index + 1)
         .eq(index)
         .matchImageSnapshot(`black-square-column-${index}`);
     }
@@ -92,12 +97,14 @@ describe("st.image", () => {
 
   it("displays links in text as text", () => {
     cy.get("[data-testid='stImage'] svg")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("contain", "avatars.githubusercontent");
   });
 
   it("displays SVG tags prefixed with meta xml tags", () => {
     cy.get("[data-testid='stImage'] svg")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("contain", "I am prefixed with some meta tags");
   });

--- a/e2e/specs/st_latex.spec.js
+++ b/e2e/specs/st_latex.spec.js
@@ -28,6 +28,7 @@ describe("st.latex", () => {
 
   it("displays Sympy expression as LaTeX", () => {
     cy.get(".element-container .stMarkdown")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("contain", "a + b");
   });

--- a/e2e/specs/st_legacy_datetimes_dataframe.spec.js
+++ b/e2e/specs/st_legacy_datetimes_dataframe.spec.js
@@ -40,11 +40,13 @@ describe("st._legacy_dataframe", () => {
 
     // notz column should show datetime in current timezone
     cy.get("@cells")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.text", Cypress.moment(datetimeString).format());
 
     // yaytz column should show datetime in provided timezone
     cy.get("@cells")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should(
         "have.text",

--- a/e2e/specs/st_legacy_datetimes_dataframe.spec.js
+++ b/e2e/specs/st_legacy_datetimes_dataframe.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st._legacy_dataframe", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -39,18 +41,15 @@ describe("st._legacy_dataframe", () => {
     // actual important thing, the notz/yaytz logic.
 
     // notz column should show datetime in current timezone
-    cy.get("@cells")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.text", Cypress.moment(datetimeString).format());
+    cyGetIndexed("@cells", 1).should(
+      "have.text",
+      Cypress.moment(datetimeString).format()
+    );
 
     // yaytz column should show datetime in provided timezone
-    cy.get("@cells")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .should(
-        "have.text",
-        Cypress.moment.parseZone(`${datetimeString}+03:00`).format()
-      );
+    cyGetIndexed("@cells", 2).should(
+      "have.text",
+      Cypress.moment.parseZone(`${datetimeString}+03:00`).format()
+    );
   });
 });

--- a/e2e/specs/st_legacy_empty_charts.spec.js
+++ b/e2e/specs/st_legacy_empty_charts.spec.js
@@ -53,6 +53,7 @@ describe("handles legacy empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should(
         "have.text",
@@ -60,6 +61,7 @@ describe("handles legacy empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should(
         "have.text",
@@ -67,6 +69,7 @@ describe("handles legacy empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should(
         "have.text",
@@ -74,6 +77,7 @@ describe("handles legacy empty charts", () => {
       );
 
     cy.get(".stException .message")
+      .should("have.length.at.least", 5)
       .eq(4)
       .should(
         "have.text",

--- a/e2e/specs/st_legacy_empty_charts.spec.js
+++ b/e2e/specs/st_legacy_empty_charts.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("handles legacy empty charts", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -45,43 +47,29 @@ describe("handles legacy empty charts", () => {
   });
 
   it("handles no data with exception", () => {
-    cy.get(".stException .message")
-      .eq(0)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 0).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 1).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 2).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should(
-        "have.text",
-        "ValueError: Vega-Lite charts require a non-empty spec dict."
-      );
+    cyGetIndexed(".stException .message", 3).should(
+      "have.text",
+      "ValueError: Vega-Lite charts require a non-empty spec dict."
+    );
 
-    cy.get(".stException .message")
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .should(
-        "have.text",
-        "TypeError: _legacy_altair_chart() missing 1 required positional argument: 'altair_chart'"
-      );
+    cyGetIndexed(".stException .message", 4).should(
+      "have.text",
+      "TypeError: _legacy_altair_chart() missing 1 required positional argument: 'altair_chart'"
+    );
   });
 });

--- a/e2e/specs/st_legacy_empty_dataframes.spec.js
+++ b/e2e/specs/st_legacy_empty_dataframes.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("Legacy Dataframes", () => {
   const DF_SELECTOR = ".stDataFrame";
   const TABLE_SELECTOR = "[data-testid='stTable'] > table";
@@ -35,14 +37,9 @@ describe("Legacy Dataframes", () => {
   });
 
   it("have consistent empty list visuals", () => {
-    cy.get(".element-container")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .each(el => {
-        return cy
-          .wrap(el)
-          .matchThemedSnapshots("legacy_empty_dataframes_list");
-      });
+    cyGetIndexed(".element-container", 1).each(el => {
+      return cy.wrap(el).matchThemedSnapshots("legacy_empty_dataframes_list");
+    });
   });
 
   it("have consistent empty visuals", () => {
@@ -87,24 +84,18 @@ describe("Legacy Dataframes", () => {
   });
 
   it("have consistent empty one-column table visuals", () => {
-    cy.get(TABLE_SELECTOR)
-      .should("have.length.at.least", 5)
-      .eq(4)
-      .each((el, idx) => {
-        return cy
-          .wrap(el)
-          .matchThemedSnapshots(`legacy_empty_tables_one_col${idx}`);
-      });
+    cyGetIndexed(TABLE_SELECTOR, 4).each((el, idx) => {
+      return cy
+        .wrap(el)
+        .matchThemedSnapshots(`legacy_empty_tables_one_col${idx}`);
+    });
   });
 
   it("have consistent empty two-column table visuals", () => {
-    cy.get(TABLE_SELECTOR)
-      .should("have.length.at.least", 6)
-      .eq(5)
-      .each((el, idx) => {
-        return cy
-          .wrap(el)
-          .matchThemedSnapshots(`legacy_empty_tables_two_col${idx}`);
-      });
+    cyGetIndexed(TABLE_SELECTOR, 5).each((el, idx) => {
+      return cy
+        .wrap(el)
+        .matchThemedSnapshots(`legacy_empty_tables_two_col${idx}`);
+    });
   });
 });

--- a/e2e/specs/st_legacy_empty_dataframes.spec.js
+++ b/e2e/specs/st_legacy_empty_dataframes.spec.js
@@ -36,6 +36,7 @@ describe("Legacy Dataframes", () => {
 
   it("have consistent empty list visuals", () => {
     cy.get(".element-container")
+      .should("have.length.at.least", 2)
       .eq(1)
       .each(el => {
         return cy
@@ -87,6 +88,7 @@ describe("Legacy Dataframes", () => {
 
   it("have consistent empty one-column table visuals", () => {
     cy.get(TABLE_SELECTOR)
+      .should("have.length.at.least", 5)
       .eq(4)
       .each((el, idx) => {
         return cy
@@ -97,6 +99,7 @@ describe("Legacy Dataframes", () => {
 
   it("have consistent empty two-column table visuals", () => {
     cy.get(TABLE_SELECTOR)
+      .should("have.length.at.least", 6)
       .eq(5)
       .each((el, idx) => {
         return cy

--- a/e2e/specs/st_legacy_table_styling.spec.js
+++ b/e2e/specs/st_legacy_table_styling.spec.js
@@ -39,18 +39,21 @@ describe("st._legacy_table styling", () => {
 
   it("displays table with custom formatted cells", () => {
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .find("table tbody tr td")
       .eq(0)
       .should("contain", "100.00%");
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchThemedSnapshots("legacy-table-formatted-cells");
   });
 
   it("displays table with colored cells", () => {
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .find("table tbody tr")
       .eq(0)
@@ -64,17 +67,20 @@ describe("st._legacy_table styling", () => {
       });
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 3)
       .eq(2)
       .matchThemedSnapshots("legacy-table-colored-cells");
   });
 
   it("displays table with differently styled rows", () => {
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .find("table tbody tr")
       .should("have.length", 10);
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .find("table tbody tr")
       .eq(0)
@@ -83,14 +89,17 @@ describe("st._legacy_table styling", () => {
       .should("have.css", "color", "rgb(124, 252, 0)");
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .find("table tbody tr")
+      .should("have.length.at.least", 6)
       .eq(5)
       .find("td")
       .eq(0)
       .should("have.css", "color", "rgb(0, 0, 0)");
 
     cy.get("[data-testid='stTable']")
+      .should("have.length.at.least", 4)
       .eq(3)
       .matchThemedSnapshots("legacy-table-styled-rows");
   });

--- a/e2e/specs/st_legacy_table_styling.spec.js
+++ b/e2e/specs/st_legacy_table_styling.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st._legacy_table styling", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -26,35 +28,29 @@ describe("st._legacy_table styling", () => {
   });
 
   it("displays unstyled table", () => {
-    cy.get("[data-testid='stTable']")
-      .eq(0)
+    cyGetIndexed("[data-testid='stTable']", 0)
       .find("table tbody tr td")
       .eq(0)
       .should("contain", "1");
 
-    cy.get("[data-testid='stTable']")
-      .eq(0)
-      .matchThemedSnapshots("legacy-table-unstyled");
+    cyGetIndexed("[data-testid='stTable']", 0).matchThemedSnapshots(
+      "legacy-table-unstyled"
+    );
   });
 
   it("displays table with custom formatted cells", () => {
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed("[data-testid='stTable']", 1)
       .find("table tbody tr td")
       .eq(0)
       .should("contain", "100.00%");
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchThemedSnapshots("legacy-table-formatted-cells");
+    cyGetIndexed("[data-testid='stTable']", 1).matchThemedSnapshots(
+      "legacy-table-formatted-cells"
+    );
   });
 
   it("displays table with colored cells", () => {
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed("[data-testid='stTable']", 2)
       .find("table tbody tr")
       .eq(0)
       .find("td")
@@ -66,31 +62,24 @@ describe("st._legacy_table styling", () => {
         }
       });
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 3)
-      .eq(2)
-      .matchThemedSnapshots("legacy-table-colored-cells");
+    cyGetIndexed("[data-testid='stTable']", 2).matchThemedSnapshots(
+      "legacy-table-colored-cells"
+    );
   });
 
   it("displays table with differently styled rows", () => {
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 4)
-      .eq(3)
+    cyGetIndexed("[data-testid='stTable']", 3)
       .find("table tbody tr")
       .should("have.length", 10);
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 4)
-      .eq(3)
+    cyGetIndexed("[data-testid='stTable']", 3)
       .find("table tbody tr")
       .eq(0)
       .find("td")
       .eq(0)
       .should("have.css", "color", "rgb(124, 252, 0)");
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 4)
-      .eq(3)
+    cyGetIndexed("[data-testid='stTable']", 3)
       .find("table tbody tr")
       .should("have.length.at.least", 6)
       .eq(5)
@@ -98,9 +87,8 @@ describe("st._legacy_table styling", () => {
       .eq(0)
       .should("have.css", "color", "rgb(0, 0, 0)");
 
-    cy.get("[data-testid='stTable']")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .matchThemedSnapshots("legacy-table-styled-rows");
+    cyGetIndexed("[data-testid='stTable']", 3).matchThemedSnapshots(
+      "legacy-table-styled-rows"
+    );
   });
 });

--- a/e2e/specs/st_legacy_vega_lite_chart.spec.js
+++ b/e2e/specs/st_legacy_vega_lite_chart.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st._legacy_vega_lite_chart", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -35,18 +37,19 @@ describe("st._legacy_vega_lite_chart", () => {
   });
 
   it("sets the correct chart width", () => {
-    cy.get("[data-testid='stVegaLiteChart'] canvas")
-      .eq(0)
-      .should("have.css", "width", "666px");
+    cyGetIndexed("[data-testid='stVegaLiteChart'] canvas", 0).should(
+      "have.css",
+      "width",
+      "666px"
+    );
 
-    cy.get("[data-testid='stVegaLiteChart'] canvas")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .should("have.css", "width", "666px");
+    cyGetIndexed("[data-testid='stVegaLiteChart'] canvas", 1).should(
+      "have.css",
+      "width",
+      "666px"
+    );
 
-    cy.get("[data-testid='stVegaLiteChart'] canvas")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed("[data-testid='stVegaLiteChart'] canvas", 2)
       .should("have.css", "width")
       .and(width => {
         // Tests run on mac expect 282px while running on linux expects 284px
@@ -55,10 +58,11 @@ describe("st._legacy_vega_lite_chart", () => {
         }
       });
 
-    cy.get("[data-testid='stVegaLiteChart'] canvas")
-      .should("have.length.at.least", 4)
-      .eq(3)
-      .should("have.css", "width", "500px");
+    cyGetIndexed("[data-testid='stVegaLiteChart'] canvas", 3).should(
+      "have.css",
+      "width",
+      "500px"
+    );
   });
 
   it("supports different ways to get the same plot", () => {

--- a/e2e/specs/st_legacy_vega_lite_chart.spec.js
+++ b/e2e/specs/st_legacy_vega_lite_chart.spec.js
@@ -40,10 +40,12 @@ describe("st._legacy_vega_lite_chart", () => {
       .should("have.css", "width", "666px");
 
     cy.get("[data-testid='stVegaLiteChart'] canvas")
+      .should("have.length.at.least", 2)
       .eq(1)
       .should("have.css", "width", "666px");
 
     cy.get("[data-testid='stVegaLiteChart'] canvas")
+      .should("have.length.at.least", 3)
       .eq(2)
       .should("have.css", "width")
       .and(width => {
@@ -54,6 +56,7 @@ describe("st._legacy_vega_lite_chart", () => {
       });
 
     cy.get("[data-testid='stVegaLiteChart'] canvas")
+      .should("have.length.at.least", 4)
       .eq(3)
       .should("have.css", "width", "500px");
   });

--- a/e2e/specs/st_magic.spec.js
+++ b/e2e/specs/st_magic.spec.js
@@ -45,6 +45,7 @@ describe("streamlit magic", () => {
 
     expected.forEach((text, index) => {
       cy.get(selector)
+        .should("have.length.at.least", index + 1)
         .eq(index)
         .contains(text);
     });

--- a/e2e/specs/st_magic.spec.js
+++ b/e2e/specs/st_magic.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("streamlit magic", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -44,10 +46,7 @@ describe("streamlit magic", () => {
     cy.get(selector).should("have.length", expected.length);
 
     expected.forEach((text, index) => {
-      cy.get(selector)
-        .should("have.length.at.least", index + 1)
-        .eq(index)
-        .contains(text);
+      cyGetIndexed(selector, index).contains(text);
     });
   });
 });

--- a/e2e/specs/st_main_menu.spec.js
+++ b/e2e/specs/st_main_menu.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("main menu", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -37,14 +39,13 @@ describe("main menu", () => {
       "transform: translate3d(20px, 20px, 0px)"
     );
 
-    cy.get('[data-testid="main-menu-list"]')
-      .eq(0)
-      .matchImageSnapshot("main_menu");
+    cyGetIndexed('[data-testid="main-menu-list"]', 0).matchImageSnapshot(
+      "main_menu"
+    );
 
-    cy.get('[data-testid="main-menu-list"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchImageSnapshot("dev_main_menu");
+    cyGetIndexed('[data-testid="main-menu-list"]', 1).matchImageSnapshot(
+      "dev_main_menu"
+    );
 
     // Not possible to test the urls in the menu as they are hidden behind
     // the click handler of the button
@@ -66,14 +67,13 @@ describe("main menu", () => {
       "transform: translate3d(20px, 20px, 0px)"
     );
 
-    cy.get('[data-testid="main-menu-list"]')
-      .eq(0)
-      .matchImageSnapshot("main_menu-dark");
+    cyGetIndexed('[data-testid="main-menu-list"]', 0).matchImageSnapshot(
+      "main_menu-dark"
+    );
 
-    cy.get('[data-testid="main-menu-list"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .matchImageSnapshot("dev_main_menu-dark");
+    cyGetIndexed('[data-testid="main-menu-list"]', 1).matchImageSnapshot(
+      "dev_main_menu-dark"
+    );
 
     // Need to add testing for about section
   });

--- a/e2e/specs/st_main_menu.spec.js
+++ b/e2e/specs/st_main_menu.spec.js
@@ -42,6 +42,7 @@ describe("main menu", () => {
       .matchImageSnapshot("main_menu");
 
     cy.get('[data-testid="main-menu-list"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchImageSnapshot("dev_main_menu");
 
@@ -70,6 +71,7 @@ describe("main menu", () => {
       .matchImageSnapshot("main_menu-dark");
 
     cy.get('[data-testid="main-menu-list"]')
+      .should("have.length.at.least", 2)
       .eq(1)
       .matchImageSnapshot("dev_main_menu-dark");
 

--- a/e2e/specs/st_metric.spec.js
+++ b/e2e/specs/st_metric.spec.js
@@ -43,18 +43,21 @@ describe("st.metric", () => {
   describe("Test second metric", () => {
     it("displays the correct label text", () => {
       cy.get("[data-testid='stMetricLabel']")
+        .should("have.length.at.least", 2)
         .eq(1)
         .should("have.text", " S&P 500 ");
     });
 
     it("displays the correct value text", () => {
       cy.get("[data-testid='stMetricValue']")
+        .should("have.length.at.least", 2)
         .eq(1)
         .should("have.text", " -4.56 ");
     });
 
     it("displays the correct delta text", () => {
       cy.get("[data-testid='stMetricDelta']")
+        .should("have.length.at.least", 2)
         .eq(1)
         .should("have.text", " -50 ");
     });
@@ -63,18 +66,21 @@ describe("st.metric", () => {
   describe("Test third metric", () => {
     it("displays the correct metric label text", () => {
       cy.get("[data-testid='stMetricLabel']")
+        .should("have.length.at.least", 3)
         .eq(2)
         .should("have.text", " Apples I've eaten ");
     });
 
     it("displays the correct metric value text", () => {
       cy.get("[data-testid='stMetricValue']")
+        .should("have.length.at.least", 3)
         .eq(2)
         .should("have.text", " 23k ");
     });
 
     it("displays the correct metric delta text", () => {
       cy.get("[data-testid='stMetricDelta']")
+        .should("have.length.at.least", 3)
         .eq(2)
         .should("have.text", " -20 ");
     });
@@ -91,6 +97,7 @@ describe("st.metric", () => {
   describe("Test the dark and light theme for red down arrow render", () => {
     it("Check Metric Snapshot", () => {
       cy.get('[data-testid="metric-container"]')
+        .should("have.length.at.least", 2)
         .eq(1)
         .matchThemedSnapshots("metric-container-red");
     });
@@ -99,6 +106,7 @@ describe("st.metric", () => {
   describe("Test the dark and light theme for gray down arrow render", () => {
     it("Check Metric Snapshot", () => {
       cy.get('[data-testid="metric-container"]')
+        .should("have.length.at.least", 3)
         .eq(2)
         .matchThemedSnapshots("metric-container-gray");
     });

--- a/e2e/specs/st_metric.spec.js
+++ b/e2e/specs/st_metric.spec.js
@@ -31,17 +31,17 @@ describe("st.metric", () => {
     });
 
     it("displays the correct value text", () => {
-      cyGetIndexed("[data-testid='stMetricValue']", 0);
-      cy.get("[data-testid='stMetricValue']")
-        .eq(0)
-        .should("have.text", " 123 ");
+      cyGetIndexed("[data-testid='stMetricValue']", 0).should(
+        "have.text",
+        " 123 "
+      );
     });
 
     it("displays the correct delta text", () => {
-      cyGetIndexed("[data-testid='stMetricDelta']", 0);
-      cy.get("[data-testid='stMetricDelta']")
-        .eq(0)
-        .should("have.text", " 123 ");
+      cyGetIndexed("[data-testid='stMetricDelta']", 0).should(
+        "have.text",
+        " 123 "
+      );
     });
   });
 

--- a/e2e/specs/st_metric.spec.js
+++ b/e2e/specs/st_metric.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.metric", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -22,18 +24,21 @@ describe("st.metric", () => {
 
   describe("Test first metric", () => {
     it("displays the correct label text", () => {
-      cy.get("[data-testid='stMetricLabel']")
-        .eq(0)
-        .should("have.text", " User growth ");
+      cyGetIndexed("[data-testid='stMetricLabel']", 0).should(
+        "have.text",
+        " User growth "
+      );
     });
 
     it("displays the correct value text", () => {
+      cyGetIndexed("[data-testid='stMetricValue']", 0);
       cy.get("[data-testid='stMetricValue']")
         .eq(0)
         .should("have.text", " 123 ");
     });
 
     it("displays the correct delta text", () => {
+      cyGetIndexed("[data-testid='stMetricDelta']", 0);
       cy.get("[data-testid='stMetricDelta']")
         .eq(0)
         .should("have.text", " 123 ");
@@ -42,73 +47,71 @@ describe("st.metric", () => {
 
   describe("Test second metric", () => {
     it("displays the correct label text", () => {
-      cy.get("[data-testid='stMetricLabel']")
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .should("have.text", " S&P 500 ");
+      cyGetIndexed("[data-testid='stMetricLabel']", 1).should(
+        "have.text",
+        " S&P 500 "
+      );
     });
 
     it("displays the correct value text", () => {
-      cy.get("[data-testid='stMetricValue']")
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .should("have.text", " -4.56 ");
+      cyGetIndexed("[data-testid='stMetricValue']", 1).should(
+        "have.text",
+        " -4.56 "
+      );
     });
 
     it("displays the correct delta text", () => {
-      cy.get("[data-testid='stMetricDelta']")
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .should("have.text", " -50 ");
+      cyGetIndexed("[data-testid='stMetricDelta']", 1).should(
+        "have.text",
+        " -50 "
+      );
     });
   });
 
   describe("Test third metric", () => {
     it("displays the correct metric label text", () => {
-      cy.get("[data-testid='stMetricLabel']")
-        .should("have.length.at.least", 3)
-        .eq(2)
-        .should("have.text", " Apples I've eaten ");
+      cyGetIndexed("[data-testid='stMetricLabel']", 2).should(
+        "have.text",
+        " Apples I've eaten "
+      );
     });
 
     it("displays the correct metric value text", () => {
-      cy.get("[data-testid='stMetricValue']")
-        .should("have.length.at.least", 3)
-        .eq(2)
-        .should("have.text", " 23k ");
+      cyGetIndexed("[data-testid='stMetricValue']", 2).should(
+        "have.text",
+        " 23k "
+      );
     });
 
     it("displays the correct metric delta text", () => {
-      cy.get("[data-testid='stMetricDelta']")
-        .should("have.length.at.least", 3)
-        .eq(2)
-        .should("have.text", " -20 ");
+      cyGetIndexed("[data-testid='stMetricDelta']", 2).should(
+        "have.text",
+        " -20 "
+      );
     });
   });
 
   describe("Test the dark and light theme for green up arrow render", () => {
     it("Check Metric Snapshot", () => {
-      cy.get('[data-testid="metric-container"]')
-        .eq(0)
-        .matchThemedSnapshots("metric-container-green");
+      cyGetIndexed('[data-testid="metric-container"]', 0).matchThemedSnapshots(
+        "metric-container-green"
+      );
     });
   });
 
   describe("Test the dark and light theme for red down arrow render", () => {
     it("Check Metric Snapshot", () => {
-      cy.get('[data-testid="metric-container"]')
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .matchThemedSnapshots("metric-container-red");
+      cyGetIndexed('[data-testid="metric-container"]', 1).matchThemedSnapshots(
+        "metric-container-red"
+      );
     });
   });
 
   describe("Test the dark and light theme for gray down arrow render", () => {
     it("Check Metric Snapshot", () => {
-      cy.get('[data-testid="metric-container"]')
-        .should("have.length.at.least", 3)
-        .eq(2)
-        .matchThemedSnapshots("metric-container-gray");
+      cyGetIndexed('[data-testid="metric-container"]', 2).matchThemedSnapshots(
+        "metric-container-gray"
+      );
     });
   });
 });

--- a/e2e/specs/st_multiselect.spec.js
+++ b/e2e/specs/st_multiselect.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.multiselect", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -57,50 +59,45 @@ describe("st.multiselect", () => {
     });
     describe("when there are no valid options", () => {
       it("should show the correct placeholder", () => {
-        cy.get(".stMultiSelect")
-          .should("have.length.at.least", 3)
-          .eq(2)
-          .should("have.text", "multiselect 3No options to select.open");
+        cyGetIndexed(".stMultiSelect", 2).should(
+          "have.text",
+          "multiselect 3No options to select.open"
+        );
       });
     });
   });
 
   describe("when clicking on the input", () => {
     it("should show values correctly in the dropdown menu", () => {
-      cy.get(".stMultiSelect")
-        .eq(0)
-        .then(el => {
-          return cy
-            .wrap(el)
-            .find("input")
-            .click()
-            .get("li")
-            .should("have.length", 2)
-            .should("have.text", "malefemale")
-            .each((el, idx) => {
-              return cy
-                .wrap(el)
-                .matchImageSnapshot("multiselect-dropdown-" + idx);
-            });
-        });
+      cyGetIndexed(".stMultiSelect", 0).then(el => {
+        return cy
+          .wrap(el)
+          .find("input")
+          .click()
+          .get("li")
+          .should("have.length", 2)
+          .should("have.text", "malefemale")
+          .each((el, idx) => {
+            return cy
+              .wrap(el)
+              .matchImageSnapshot("multiselect-dropdown-" + idx);
+          });
+      });
     });
     it("should show long values correctly (with ellipses) in the dropdown menu", () => {
-      cy.get(".stMultiSelect")
-        .should("have.length.at.least", 5)
-        .eq(4)
-        .then(el => {
-          return cy
-            .wrap(el)
-            .find("input")
-            .click()
-            .get("li")
-            .should("have.length", 5)
-            .each((el, idx) => {
-              return cy
-                .wrap(el)
-                .matchImageSnapshot("multiselect-dropdown-long-label-" + idx);
-            });
-        });
+      cyGetIndexed(".stMultiSelect", 4).then(el => {
+        return cy
+          .wrap(el)
+          .find("input")
+          .click()
+          .get("li")
+          .should("have.length", 5)
+          .each((el, idx) => {
+            return cy
+              .wrap(el)
+              .matchImageSnapshot("multiselect-dropdown-long-label-" + idx);
+          });
+      });
     });
   });
 
@@ -110,33 +107,25 @@ describe("st.multiselect", () => {
       .eq(1)
       .find("input")
       .click();
-    cy.get("li")
-      .should("have.length.at.least", idx + 1)
-      .eq(idx)
-      .click();
+    cyGetIndexed("li", idx).click();
   }
 
   describe("when the user makes a selection", () => {
     beforeEach(() => selectOption(1));
 
     it("sets the value correctly", () => {
-      cy.get(".stMultiSelect span")
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .should("have.text", "Female");
+      cyGetIndexed(".stMultiSelect span", 1).should("have.text", "Female");
 
       // Wait for 'data-stale' attr to go away, so the snapshot looks right.
-      cy.get(".stMultiSelect")
-        .should("have.length.at.least", 2)
-        .eq(1)
+      cyGetIndexed(".stMultiSelect", 1)
         .parent()
         .should("have.attr", "data-stale", "false")
         .invoke("css", "opacity", "1");
 
-      cy.get(".stMultiSelect")
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .matchThemedSnapshots("multiselect-selection", { focus: "input" });
+      cyGetIndexed(
+        ".stMultiSelect",
+        1
+      ).matchThemedSnapshots("multiselect-selection", { focus: "input" });
     });
 
     it("outputs the correct value", () => {

--- a/e2e/specs/st_multiselect.spec.js
+++ b/e2e/specs/st_multiselect.spec.js
@@ -58,6 +58,7 @@ describe("st.multiselect", () => {
     describe("when there are no valid options", () => {
       it("should show the correct placeholder", () => {
         cy.get(".stMultiSelect")
+          .should("have.length.at.least", 3)
           .eq(2)
           .should("have.text", "multiselect 3No options to select.open");
       });
@@ -110,6 +111,7 @@ describe("st.multiselect", () => {
       .find("input")
       .click();
     cy.get("li")
+      .should("have.length.at.least", idx + 1)
       .eq(idx)
       .click();
   }
@@ -119,17 +121,20 @@ describe("st.multiselect", () => {
 
     it("sets the value correctly", () => {
       cy.get(".stMultiSelect span")
+        .should("have.length.at.least", 2)
         .eq(1)
         .should("have.text", "Female");
 
       // Wait for 'data-stale' attr to go away, so the snapshot looks right.
       cy.get(".stMultiSelect")
+        .should("have.length.at.least", 2)
         .eq(1)
         .parent()
         .should("have.attr", "data-stale", "false")
         .invoke("css", "opacity", "1");
 
       cy.get(".stMultiSelect")
+        .should("have.length.at.least", 2)
         .eq(1)
         .matchThemedSnapshots("multiselect-selection", { focus: "input" });
     });

--- a/e2e/specs/st_pyplot.spec.js
+++ b/e2e/specs/st_pyplot.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.pyplot", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -55,9 +57,7 @@ describe("st.pyplot", () => {
   });
 
   it("hides deprecation warning", () => {
-    cy.get("[data-testid='stImage']")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed("[data-testid='stImage']", 1)
       .closest(".element-container")
       .prev()
       .should("not.contain", "PyplotGlobalUseWarning");

--- a/e2e/specs/st_pyplot.spec.js
+++ b/e2e/specs/st_pyplot.spec.js
@@ -56,6 +56,7 @@ describe("st.pyplot", () => {
 
   it("hides deprecation warning", () => {
     cy.get("[data-testid='stImage']")
+      .should("have.length.at.least", 2)
       .eq(1)
       .closest(".element-container")
       .prev()

--- a/e2e/specs/st_radio.spec.js
+++ b/e2e/specs/st_radio.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.radio", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -47,9 +49,9 @@ describe("st.radio", () => {
       .should(
         "have.text",
         "value 1: female" +
-          "value 2: female" +
-          "value 3: None" +
-          "value 4: female"
+        "value 2: female" +
+        "value 3: None" +
+        "value 4: female"
       )
       .then(() => {
         return cy
@@ -72,9 +74,9 @@ describe("st.radio", () => {
       .should(
         "have.text",
         "value 1: female" +
-          "value 2: female" +
-          "value 3: None" +
-          "value 4: female"
+        "value 2: female" +
+        "value 3: None" +
+        "value 4: female"
       )
       .then(() => {
         return cy
@@ -88,30 +90,24 @@ describe("st.radio", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "value 1: male" +
-        "value 2: female" +
-        "value 3: None" +
-        "value 4: female" +
-        "value 5: male" +
-        "radio changed: False"
+      "value 2: female" +
+      "value 3: None" +
+      "value 4: female" +
+      "value 5: male" +
+      "radio changed: False"
     );
   });
 
   it("formats display values", () => {
-    cy.get('.stRadio [role="radiogroup"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed('.stRadio [role="radiogroup"]', 1)
       .should("have.text", "FemaleMale");
   });
 
   it("handles no options", () => {
-    cy.get('.stRadio [role="radiogroup"]')
-      .should("have.length.at.least", 2)
-      .eq(2)
+    cyGetIndexed('.stRadio [role="radiogroup"]', 2)
       .should("have.text", "No options to select.");
 
-    cy.get('.stRadio [role="radiogroup"]')
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed('.stRadio [role="radiogroup"]', 2)
       .get("input")
       .should("be.disabled");
   });
@@ -130,18 +126,16 @@ describe("st.radio", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "value 1: male" +
-        "value 2: male" +
-        "value 3: None" +
-        "value 4: female" +
-        "value 5: male" +
-        "radio changed: False"
+      "value 2: male" +
+      "value 3: None" +
+      "value 4: female" +
+      "value 5: male" +
+      "radio changed: False"
     );
   });
 
   it("calls callback if one is registered", () => {
-    cy.get(".stRadio")
-      .should("have.length.at.least", 5)
-      .last()
+    cyGetIndexed(".stRadio", 4)
       .then(el => {
         return cy
           .wrap(el)
@@ -153,11 +147,11 @@ describe("st.radio", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "value 1: male" +
-        "value 2: female" +
-        "value 3: None" +
-        "value 4: female" +
-        "value 5: female" +
-        "radio changed: True"
+      "value 2: female" +
+      "value 3: None" +
+      "value 4: female" +
+      "value 5: female" +
+      "radio changed: True"
     );
   });
 });

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -136,7 +136,7 @@ describe("st.select_slider", () => {
   });
 
   it("calls callback if one is registered", () => {
-    cyGetIndexed('.stSlider [role="slider"]', 4)
+    cyGetIndexed('.stSlider [role="slider"]', 5)
       .click()
       .type("{rightarrow}", { force: true });
 

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -136,7 +136,9 @@ describe("st.select_slider", () => {
   });
 
   it("calls callback if one is registered", () => {
-    cyGetIndexed('.stSlider [role="slider"]', 5)
+    // This selects the slider ends, so range sliders have two, and this is the
+    // seventh element in the list.
+    cyGetIndexed('.stSlider [role="slider"]', 6)
       .click()
       .type("{rightarrow}", { force: true });
 

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -27,49 +27,49 @@ describe("st.select_slider", () => {
   });
 
   it("shows labels", () => {
-    cy.get(".stSlider label")
-      .first()
-      .should("have.text", "Label 1");
+    cyGetIndexed(".stSlider label", 0).should("have.text", "Label 1");
 
-    cyGetIndexed(".stSlider label", 1)
-      .should("have.text", "Label 2");
+    cyGetIndexed(".stSlider label", 1).should("have.text", "Label 2");
 
-    cyGetIndexed(".stSlider label", 2)
-      .should("have.text", "Label 3");
+    cyGetIndexed(".stSlider label", 2).should("have.text", "Label 3");
 
-    cyGetIndexed(".stSlider label", 3)
-      .should("have.text", "Label 4");
+    cyGetIndexed(".stSlider label", 3).should("have.text", "Label 4");
 
-    cyGetIndexed(".stSlider label", 4)
-      .should("have.text", "Label 5");
+    cyGetIndexed(".stSlider label", 4).should("have.text", "Label 5");
   });
 
   it("has correct values", () => {
-    cyGetIndexed(".stMarkdown", 0)
-      .should("have.text", "Value 1: ('orange', 'blue')");
+    cyGetIndexed(".stMarkdown", 0).should(
+      "have.text",
+      "Value 1: ('orange', 'blue')"
+    );
 
-    cyGetIndexed(".stMarkdown", 1)
-      .should("have.text", "Value 2: 1");
+    cyGetIndexed(".stMarkdown", 1).should("have.text", "Value 2: 1");
 
-    cyGetIndexed(".stMarkdown", 2)
-      .should("have.text", "Value 3: (2, 5)");
+    cyGetIndexed(".stMarkdown", 2).should("have.text", "Value 3: (2, 5)");
 
-    cyGetIndexed(".stMarkdown", 3)
-      .should("have.text", "Value 4: 5");
+    cyGetIndexed(".stMarkdown", 3).should("have.text", "Value 4: 5");
 
-    cyGetIndexed(".stMarkdown", 4)
-      .should("have.text", "Value 5: 1");
+    cyGetIndexed(".stMarkdown", 4).should("have.text", "Value 5: 1");
 
-    cyGetIndexed(".stMarkdown", 5)
-      .should("have.text", "Select slider changed: False");
+    cyGetIndexed(".stMarkdown", 5).should(
+      "have.text",
+      "Select slider changed: False"
+    );
   });
 
   it("has correct aria-valuetext", () => {
-    cyGetIndexed('.stSlider [role="slider"]', 0)
-      .should("have.attr", "aria-valuetext", "orange");
+    cyGetIndexed('.stSlider [role="slider"]', 0).should(
+      "have.attr",
+      "aria-valuetext",
+      "orange"
+    );
 
-    cyGetIndexed('.stSlider [role="slider"]', 1)
-      .should("have.attr", "aria-valuetext", "blue");
+    cyGetIndexed('.stSlider [role="slider"]', 1).should(
+      "have.attr",
+      "aria-valuetext",
+      "blue"
+    );
   });
 
   it("increments the value on right arrow key press", () => {
@@ -77,15 +77,22 @@ describe("st.select_slider", () => {
       .click()
       .type("{rightarrow}", { force: true });
 
-    cyGetIndexed(".stMarkdown", 0)
-      .should("have.text", "Value 1: ('yellow', 'blue')");
+    cyGetIndexed(".stMarkdown", 0).should(
+      "have.text",
+      "Value 1: ('yellow', 'blue')"
+    );
 
-    cyGetIndexed('.stSlider [role="slider"]', 0)
-      .first()
-      .should("have.attr", "aria-valuetext", "yellow");
+    cyGetIndexed('.stSlider [role="slider"]', 0).should(
+      "have.attr",
+      "aria-valuetext",
+      "yellow"
+    );
 
-    cyGetIndexed('.stSlider [role="slider"]', 1)
-      .should("have.attr", "aria-valuetext", "blue");
+    cyGetIndexed('.stSlider [role="slider"]', 1).should(
+      "have.attr",
+      "aria-valuetext",
+      "blue"
+    );
   });
 
   it("decrements the value on left arrow key press", () => {
@@ -93,14 +100,22 @@ describe("st.select_slider", () => {
       .click()
       .type("{leftarrow}", { force: true });
 
-    cyGetIndexed(".stMarkdown", 0)
-      .should("have.text", "Value 1: ('red', 'blue')");
+    cyGetIndexed(".stMarkdown", 0).should(
+      "have.text",
+      "Value 1: ('red', 'blue')"
+    );
 
-    cyGetIndexed('.stSlider [role="slider"]', 0)
-      .should("have.attr", "aria-valuetext", "red");
+    cyGetIndexed('.stSlider [role="slider"]', 0).should(
+      "have.attr",
+      "aria-valuetext",
+      "red"
+    );
 
-    cyGetIndexed('.stSlider [role="slider"]', 1)
-      .should("have.attr", "aria-valuetext", "blue");
+    cyGetIndexed('.stSlider [role="slider"]', 1).should(
+      "have.attr",
+      "aria-valuetext",
+      "blue"
+    );
   });
 
   it("maintains its state on rerun", () => {
@@ -114,8 +129,10 @@ describe("st.select_slider", () => {
       which: 82 // "r"
     });
 
-    cyGetIndexed(".stMarkdown", 0)
-      .should("have.text", "Value 1: ('red', 'blue')");
+    cyGetIndexed(".stMarkdown", 0).should(
+      "have.text",
+      "Value 1: ('red', 'blue')"
+    );
   });
 
   it("calls callback if one is registered", () => {

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.select_slider", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -29,112 +31,80 @@ describe("st.select_slider", () => {
       .first()
       .should("have.text", "Label 1");
 
-    cy.get(".stSlider label")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".stSlider label", 1)
       .should("have.text", "Label 2");
 
-    cy.get(".stSlider label")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stSlider label", 2)
       .should("have.text", "Label 3");
 
-    cy.get(".stSlider label")
-      .should("have.length.at.least", 4)
-      .eq(3)
+    cyGetIndexed(".stSlider label", 3)
       .should("have.text", "Label 4");
 
-    cy.get(".stSlider label")
-      .should("have.length.at.least", 5)
-      .eq(4)
+    cyGetIndexed(".stSlider label", 4)
       .should("have.text", "Label 5");
   });
 
   it("has correct values", () => {
-    cy.get(".stMarkdown")
-      .first()
+    cyGetIndexed(".stMarkdown", 0)
       .should("have.text", "Value 1: ('orange', 'blue')");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".stMarkdown", 1)
       .should("have.text", "Value 2: 1");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stMarkdown", 2)
       .should("have.text", "Value 3: (2, 5)");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 4)
-      .eq(3)
+    cyGetIndexed(".stMarkdown", 3)
       .should("have.text", "Value 4: 5");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 5)
-      .eq(4)
+    cyGetIndexed(".stMarkdown", 4)
       .should("have.text", "Value 5: 1");
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 6)
-      .eq(5)
+    cyGetIndexed(".stMarkdown", 5)
       .should("have.text", "Select slider changed: False");
   });
 
   it("has correct aria-valuetext", () => {
-    cy.get('.stSlider [role="slider"]')
-      .first()
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .should("have.attr", "aria-valuetext", "orange");
 
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed('.stSlider [role="slider"]', 1)
       .should("have.attr", "aria-valuetext", "blue");
   });
 
   it("increments the value on right arrow key press", () => {
-    cy.get('.stSlider [role="slider"]')
-      .first()
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .click()
       .type("{rightarrow}", { force: true });
 
-    cy.get(".stMarkdown")
-      .first()
+    cyGetIndexed(".stMarkdown", 0)
       .should("have.text", "Value 1: ('yellow', 'blue')");
 
-    cy.get('.stSlider [role="slider"]')
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .first()
       .should("have.attr", "aria-valuetext", "yellow");
 
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed('.stSlider [role="slider"]', 1)
       .should("have.attr", "aria-valuetext", "blue");
   });
 
   it("decrements the value on left arrow key press", () => {
-    cy.get('.stSlider [role="slider"]')
-      .first()
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .click()
       .type("{leftarrow}", { force: true });
 
-    cy.get(".stMarkdown")
-      .first()
+    cyGetIndexed(".stMarkdown", 0)
       .should("have.text", "Value 1: ('red', 'blue')");
 
-    cy.get('.stSlider [role="slider"]')
-      .first()
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .should("have.attr", "aria-valuetext", "red");
 
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed('.stSlider [role="slider"]', 1)
       .should("have.attr", "aria-valuetext", "blue");
   });
 
   it("maintains its state on rerun", () => {
-    cy.get('.stSlider [role="slider"]')
-      .first()
+    cyGetIndexed('.stSlider [role="slider"]', 0)
       .click()
       .type("{leftarrow}", { force: true });
 
@@ -144,15 +114,12 @@ describe("st.select_slider", () => {
       which: 82 // "r"
     });
 
-    cy.get(".stMarkdown")
-      .first()
+    cyGetIndexed(".stMarkdown", 0)
       .should("have.text", "Value 1: ('red', 'blue')");
   });
 
   it("calls callback if one is registered", () => {
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 5)
-      .last()
+    cyGetIndexed('.stSlider [role="slider"]', 4)
       .click()
       .type("{rightarrow}", { force: true });
 

--- a/e2e/specs/st_selectbox.spec.js
+++ b/e2e/specs/st_selectbox.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.selectbox", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -35,38 +37,30 @@ describe("st.selectbox", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "value 1: female" +
-        "value 2: male" +
-        "value 3: None" +
-        "value 4: e2e/scripts/components_iframe.py" +
-        "value 5: male" +
-        "value 6: female" +
-        "select box changed: False"
+      "value 2: male" +
+      "value 3: None" +
+      "value 4: e2e/scripts/components_iframe.py" +
+      "value 5: male" +
+      "value 6: female" +
+      "select box changed: False"
     );
   });
 
   it("formats display values", () => {
-    cy.get(".stSelectbox div[aria-selected]")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".stSelectbox div[aria-selected]", 1)
       .should("have.text", "Male");
   });
 
   it("handles no options", () => {
-    cy.get(".stSelectbox div[aria-selected]")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stSelectbox div[aria-selected]", 2)
       .should("have.text", "No options to select.");
 
-    cy.get(".stSelectbox input")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stSelectbox input", 2)
       .should("be.disabled");
   });
 
   it("sets value correctly when user clicks", () => {
-    cy.get(".stSelectbox")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".stSelectbox", 1)
       .then(el => {
         cy.wrap(el)
           .find("input")
@@ -79,20 +73,18 @@ describe("st.selectbox", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "value 1: female" +
-        "value 2: female" +
-        "value 3: None" +
-        "value 4: e2e/scripts/components_iframe.py" +
-        "value 5: male" +
-        "value 6: female" +
-        "select box changed: False"
+      "value 2: female" +
+      "value 3: None" +
+      "value 4: e2e/scripts/components_iframe.py" +
+      "value 5: male" +
+      "value 6: female" +
+      "select box changed: False"
     );
   });
 
   it("shows the correct options when fuzzy search is applied", () => {
     function typeText(string) {
-      cy.get(".stSelectbox")
-        .should("have.length.at.least", 4)
-        .eq(3)
+      cyGetIndexed(".stSelectbox", 3)
         .then(el => {
           cy.wrap(el)
             .find("input")
@@ -123,9 +115,7 @@ describe("st.selectbox", () => {
   });
 
   it("calls callback if one is registered", () => {
-    cy.get(".stSelectbox")
-      .should("have.length.at.least", 6)
-      .last()
+    cyGetIndexed(".stSelectbox", 5)
       .then(el => {
         cy.wrap(el)
           .find("input")
@@ -138,12 +128,12 @@ describe("st.selectbox", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "value 1: female" +
-        "value 2: male" +
-        "value 3: None" +
-        "value 4: e2e/scripts/components_iframe.py" +
-        "value 5: male" +
-        "value 6: male" +
-        "select box changed: True"
+      "value 2: male" +
+      "value 3: None" +
+      "value 4: e2e/scripts/components_iframe.py" +
+      "value 5: male" +
+      "value 6: male" +
+      "select box changed: True"
     );
   });
 });

--- a/e2e/specs/st_set_page_config.spec.js
+++ b/e2e/specs/st_set_page_config.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.set_page_config", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -62,20 +64,14 @@ describe("st.set_page_config", () => {
     });
 
     it("should not display an error when st.set_page_config is used after an st.* command in a callback", () => {
-      cy.get(".stButton button")
-        .should("have.length.at.least", 2)
-        .eq(1)
-        .click();
+      cyGetIndexed(".stButton button", 1).click();
 
       cy.get(".stException").should("not.exist");
       cy.title().should("eq", "Heya, world?");
     });
 
     it("should display an error when st.set_page_config is called multiple times in a callback", () => {
-      cy.get(".stButton button")
-        .should("have.length.at.least", 3)
-        .eq(2)
-        .click();
+      cyGetIndexed(".stButton button", 2).click();
 
       cy.get(".stException")
         .contains("set_page_config() can only be called once per app")
@@ -85,10 +81,7 @@ describe("st.set_page_config", () => {
     });
 
     it("should display an error when st.set_page_config is called after being called in a callback", () => {
-      cy.get(".stButton button")
-        .should("have.length.at.least", 4)
-        .eq(3)
-        .click();
+      cyGetIndexed(".stButton button", 3).click();
 
       cy.get(".stException")
         .contains("set_page_config() can only be called once per app")

--- a/e2e/specs/st_set_page_config.spec.js
+++ b/e2e/specs/st_set_page_config.spec.js
@@ -63,6 +63,7 @@ describe("st.set_page_config", () => {
 
     it("should not display an error when st.set_page_config is used after an st.* command in a callback", () => {
       cy.get(".stButton button")
+        .should("have.length.at.least", 2)
         .eq(1)
         .click();
 
@@ -72,6 +73,7 @@ describe("st.set_page_config", () => {
 
     it("should display an error when st.set_page_config is called multiple times in a callback", () => {
       cy.get(".stButton button")
+        .should("have.length.at.least", 3)
         .eq(2)
         .click();
 
@@ -84,6 +86,7 @@ describe("st.set_page_config", () => {
 
     it("should display an error when st.set_page_config is called after being called in a callback", () => {
       cy.get(".stButton button")
+        .should("have.length.at.least", 4)
         .eq(3)
         .click();
 

--- a/e2e/specs/st_sidebar.spec.js
+++ b/e2e/specs/st_sidebar.spec.js
@@ -64,6 +64,7 @@ describe("st.sidebar", () => {
     cy.viewport(400, 800);
     // Expand the sidebar on mobile, with a manual click
     cy.get("[data-testid='stSidebar'] button")
+      .should("have.length.at.least", 2)
       .eq(1)
       .click();
 

--- a/e2e/specs/st_sidebar.spec.js
+++ b/e2e/specs/st_sidebar.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.sidebar", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -63,10 +65,7 @@ describe("st.sidebar", () => {
   it("does not collapse on text input on mobile", () => {
     cy.viewport(400, 800);
     // Expand the sidebar on mobile, with a manual click
-    cy.get("[data-testid='stSidebar'] button")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .click();
+    cyGetIndexed("[data-testid='stSidebar'] button", 1).click();
 
     cy.get("[data-testid='stSidebar'] .stTextInput input").click();
 

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.slider", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -24,16 +26,12 @@ describe("st.slider", () => {
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
 
-    cy.get(".stSlider")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stSlider", 2)
       .matchThemedSnapshots("slider");
   });
 
   it("looks right when disabled", () => {
-    cy.get(".stSlider")
-      .should("have.length.at.least", 6)
-      .eq(5)
+    cyGetIndexed(".stSlider", 5)
       .matchThemedSnapshots("disabled-slider");
   });
 
@@ -41,33 +39,27 @@ describe("st.slider", () => {
     cy.get(".stSlider label").should(
       "have.text",
       "Label A" +
-        "Label B" +
-        "Label 1" +
-        "Label 2" +
-        "Label 3 - This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long label" +
-        "Label 4" +
-        "Label 5"
+      "Label B" +
+      "Label 1" +
+      "Label 2" +
+      "Label 3 - This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long label" +
+      "Label 4" +
+      "Label 5"
     );
   });
 
   it("shows full label when the label is long", () => {
-    cy.get(".stSlider")
-      .should("have.length.at.least", 5)
-      .eq(4)
+    cyGetIndexed(".stSlider", 4)
       .matchThemedSnapshots("slider_with_long_label");
   });
 
   it("shows full thumb value when the value is long", () => {
-    cy.get(".stSlider")
-      .should("have.length.at.least", 1)
-      .eq(0)
+    cyGetIndexed(".stSlider", 0)
       .matchThemedSnapshots("long_thumb_value");
   });
 
   it("does not overlap expander container when thumb value is long", () => {
-    cy.get(".stSlider")
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".stSlider", 1)
       .matchThemedSnapshots("expander_thumb_value");
   });
 
@@ -75,13 +67,13 @@ describe("st.slider", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "Value A: 12345678" +
-        "Value B: 10000" +
-        "Value 1: 25" +
-        "Value 2: (25.0, 75.0)" +
-        "Value 3: 1" +
-        "Value 4: 10000" +
-        "Value 5: 25" +
-        "Slider changed: False"
+      "Value B: 10000" +
+      "Value 1: 25" +
+      "Value 2: (25.0, 75.0)" +
+      "Value 3: 1" +
+      "Value 4: 10000" +
+      "Value 5: 25" +
+      "Slider changed: False"
     );
   });
 
@@ -90,48 +82,34 @@ describe("st.slider", () => {
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
 
     // trigger click in the center of the slider
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed('.stSlider [role="slider"]', 2)
       .parent()
       .click();
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stMarkdown", 2)
       .should("have.text", "Value 1: 50");
   });
 
   it("increments the value on right arrow key press", () => {
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed('.stSlider [role="slider"]', 2)
       .click()
       .type("{rightarrow}", { force: true });
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stMarkdown", 2)
       .should("have.text", "Value 1: 26");
   });
 
   it("decrements the value on left arrow key press", () => {
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed('.stSlider [role="slider"]', 2)
       .click()
       .type("{leftarrow}", { force: true });
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stMarkdown", 2)
       .should("have.text", "Value 1: 24");
   });
 
   it("maintains its state on rerun", () => {
-    cy.get('.stSlider [role="slider"]')
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed('.stSlider [role="slider"]', 2)
       .click()
       .type("{leftarrow}", { force: true });
 
@@ -141,9 +119,7 @@ describe("st.slider", () => {
       which: 82 // "r"
     });
 
-    cy.get(".stMarkdown")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stMarkdown", 2)
       .should("have.text", "Value 1: 24");
   });
 

--- a/e2e/specs/st_text_area.spec.js
+++ b/e2e/specs/st_text_area.spec.js
@@ -125,6 +125,7 @@ describe("st.text_area", () => {
 
   it("sets value correctly with max_chars enabled", () => {
     cy.get(".stTextArea textarea")
+      .should("have.length.at.least", 5)
       .eq(4)
       .type("test area! this shouldn't be returned")
       .blur();

--- a/e2e/specs/st_text_area.spec.js
+++ b/e2e/specs/st_text_area.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.text_area", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -124,9 +126,7 @@ describe("st.text_area", () => {
   });
 
   it("sets value correctly with max_chars enabled", () => {
-    cy.get(".stTextArea textarea")
-      .should("have.length.at.least", 5)
-      .eq(4)
+    cyGetIndexed(".stTextArea textarea", 4)
       .type("test area! this shouldn't be returned")
       .blur();
 

--- a/e2e/specs/st_text_input.spec.js
+++ b/e2e/specs/st_text_input.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.text_input", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");
@@ -101,9 +103,7 @@ describe("st.text_input", () => {
   });
 
   it("calls callback if one is registered", () => {
-    cy.get(".stTextInput input")
-      .should("have.length.at.least", 7)
-      .last()
+    cyGetIndexed(".stTextInput input", 6)
       .type("test input")
       .blur();
 

--- a/e2e/specs/st_time_input.spec.js
+++ b/e2e/specs/st_time_input.spec.js
@@ -37,9 +37,7 @@ describe("st.time_input", () => {
   });
 
   it("shows disabled widget correctly", () => {
-    cy.get(".stTimeInput")
-      .should("have.length.at.least", 3)
-      .eq(2)
+    cyGetIndexed(".stTimeInput", 2)
       .matchThemedSnapshots("disabled time input");
   });
 

--- a/e2e/specs/st_time_input.spec.js
+++ b/e2e/specs/st_time_input.spec.js
@@ -36,6 +36,7 @@ describe("st.time_input", () => {
 
   it("shows disabled widget correctly", () => {
     cy.get(".stTimeInput")
+      .should("have.length.at.least", 3)
       .eq(2)
       .matchThemedSnapshots("disabled time input");
   });

--- a/e2e/specs/st_time_input.spec.js
+++ b/e2e/specs/st_time_input.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.time_input", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/");

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 const defaultTooltip = `This is a really long tooltip.Lorem ipsum dolor sit am\
 et, consectetur adipiscing elit. Ut ut turpis vitae\njusto ornare venenatis a \
 vitae leo. Donec mollis ornare ante, eu ultricies\ntellus ornare eu. Donec ero\
@@ -247,9 +249,7 @@ describe("tooltip text with dedent on widgets", () => {
   });
 
   it("Display text properly on tooltips on sliders", () => {
-    cy.get(`.stSlider .stTooltipIcon`)
-      .should("have.length.at.least", 2)
-      .eq(1)
+    cyGetIndexed(".stSlider .stTooltipIcon", 1)
       .invoke("show")
       .trigger("mouseenter")
       .trigger("mouseover");

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -248,6 +248,7 @@ describe("tooltip text with dedent on widgets", () => {
 
   it("Display text properly on tooltips on sliders", () => {
     cy.get(`.stSlider .stTooltipIcon`)
+      .should("have.length.at.least", 2)
       .eq(1)
       .invoke("show")
       .trigger("mouseenter")

--- a/e2e/specs/st_write.spec.js
+++ b/e2e/specs/st_write.spec.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { cyGetIndexed } from "./spec_utils";
+
 describe("st.write", () => {
   before(() => {
     cy.visit("http://localhost:3000/");
@@ -25,16 +27,15 @@ describe("st.write", () => {
   });
 
   it("displays markdown", () => {
-    cy.get(".element-container .stMarkdown p")
-      .first()
-      .contains("This markdown is awesome! 😎");
+    cyGetIndexed(".element-container .stMarkdown p", 0).contains(
+      "This markdown is awesome! 😎"
+    );
   });
 
   it("escapes HTML", () => {
-    cy.get(".element-container .stMarkdown p")
-      .should("have.length.at.least", 2)
-      .eq(1)
-      .contains("This <b>HTML tag</b> is escaped!");
+    cyGetIndexed(".element-container .stMarkdown p", 1).contains(
+      "This <b>HTML tag</b> is escaped!"
+    );
   });
 
   it("allows HTML if defined explicitly", () => {

--- a/e2e/specs/st_write.spec.js
+++ b/e2e/specs/st_write.spec.js
@@ -32,6 +32,7 @@ describe("st.write", () => {
 
   it("escapes HTML", () => {
     cy.get(".element-container .stMarkdown p")
+      .should("have.length.at.least", 2)
       .eq(1)
       .contains("This <b>HTML tag</b> is escaped!");
   });


### PR DESCRIPTION
This is a sledgehammer. Not all of the places changed were vulnerable to
flakiness, as I did not have a convenient way to exclude those from my
semgrep check.

This does not address indexing using `.last()`, which requires I figure
out how many elements are actually expected. Possibly it should be
replaced by an explicit index.

This does not address other ways of querying (like `.find()`) that we
then index into, which are probably also vulnerable to flakiness.

Probably we should see how difficult it is to write and use a
checked-indexing function, which would cut down on the repetiton.
**Edit:** Now adds and uses a checked indexing function