### PR TITLE
Add share-demo environment to CLOUD_COMM_WHITELIST

### DIFF
--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -30,6 +30,7 @@ export const COMPONENT_DEVELOPER_URL =
 export const CLOUD_COMM_WHITELIST = [
   "devel.streamlit.test",
   "share.streamlit.io",
+  "share-demo.streamlit.io",
   "share-head.streamlit.io",
   "share-staging.streamlit.io",
 ]


### PR DESCRIPTION
## 📚 Context

The share-demo env isn't included in the whitelist of URLs that can send
messages to a streamlit app. This PR adds it.

- What kind of change does this PR introduce?

  - [x] Bugfix
