### PR TITLE
Log warning when trying to set log level with --log_level flag

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -95,9 +95,13 @@ def main(ctx, log_level="info"):
     """
 
     if log_level:
-        import streamlit.logger
+        from streamlit.logger import get_logger
 
-        streamlit.logger.set_log_level(log_level.upper())
+        LOGGER = get_logger(__name__)
+        LOGGER.warning(
+            "Setting the log level using the --log_level flag is unsupported."
+            "\nUse the --logger.level flag (after your streamlit command) instead."
+        )
 
 
 @main.command("help")

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -305,15 +305,16 @@ class CliTest(unittest.TestCase):
             positional_args = mock_main_run.call_args[0]
             self.assertEqual(positional_args[0], hello.__file__)
 
-    def test_hello_command_with_logs(self):
-        """Tests the log level gets specified (using hello as an example"""
+    @patch("streamlit.logger.get_logger")
+    def test_hello_command_with_logs(self, get_logger):
+        """Tests setting log level using --log_level prints a warning."""
         from streamlit.hello import hello
 
-        with patch("streamlit.cli._main_run"), patch(
-            "streamlit.logger.set_log_level"
-        ) as mock_set_log_level:
+        with patch("streamlit.cli._main_run"):
             self.runner.invoke(cli, ["--log_level", "error", "hello"])
-            mock_set_log_level.assert_called_with("ERROR")
+
+            mock_logger = get_logger()
+            mock_logger.warning.assert_called_once()
 
     def test_hello_command_with_flag_config_options(self):
         with patch("validators.url", return_value=False), patch(


### PR DESCRIPTION
## 📚 Context

A recently filed issue pointed out that the `--log_level` flag is broken. The reason that it's broken is
because when config options are read, the `logger.level` config option is used to set the log level,
and this overrides what's passed in the first flag.

Some investigation shows that this flag hasn't been working since at least v0.67 (I just picked a random
old version to see if it was still broken), which suggests that people aren't using this flag in practice. The
flag has most likely been broken since config options were introduced, which means that it hasn't been
useful for most of streamlit's existence.

I initially wanted to remove this flag entirely, but doing so is technically a breaking change that may cause
people setting this flag's deployments to break on a version upgrade. Instead of removing it entirely, we
simply log a warning for now, and we'll remove the broken flag eventually in version 2.0.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Log a warning when the `--log_level` flag is used 


  - [x] This is a visible (user-facing) change

## 🌐 References

- **Issue**: Closes #4236 
