### PR TITLE
Give app host the ability to set the sidebar chevron position

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
   "devDependencies": {
     "@craco/craco": "^6.1.2",
     "@deck.gl/json": "^8.2.5",
+    "@emotion/jest": "^11.7.1",
     "@testing-library/dom": "^7.31.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^13.1.9",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1168,6 +1168,8 @@ export class App extends PureComponent<Props, State> {
           availableThemes: this.props.theme.availableThemes,
           setTheme: this.setAndSendTheme,
           addThemes: this.props.theme.addThemes,
+          sidebarChevronDownshift: this.props.s4aCommunication.currentState
+            .sidebarChevronDownshift,
         }}
       >
         <HotKeys

--- a/frontend/src/components/core/PageLayoutContext/index.tsx
+++ b/frontend/src/components/core/PageLayoutContext/index.tsx
@@ -32,6 +32,7 @@ export interface Props {
   setTheme: (theme: ThemeConfig) => void
   availableThemes: ThemeConfig[]
   addThemes: (themes: ThemeConfig[]) => void
+  sidebarChevronDownshift: number
 }
 
 export default React.createContext<Props>({
@@ -47,4 +48,5 @@ export default React.createContext<Props>({
   setTheme: (theme: ThemeConfig) => {},
   availableThemes: [],
   addThemes: (themes: ThemeConfig[]) => {},
+  sidebarChevronDownshift: 0,
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -15,12 +15,16 @@
  * limitations under the License.
  */
 
+import { matchers } from "@emotion/jest"
 import React from "react"
 import { ReactWrapper } from "enzyme"
-import { mount } from "src/lib/test_util"
-import { PageConfig } from "src/autogen/proto"
 
+import { PageConfig } from "src/autogen/proto"
+import { mount } from "src/lib/test_util"
+import { spacing } from "src/theme/primitives/spacing"
 import Sidebar, { SidebarProps } from "./Sidebar"
+
+expect.extend(matchers)
 
 function renderSideBar(props: Partial<SidebarProps>): ReactWrapper {
   return mount(<Sidebar {...props} />)
@@ -74,6 +78,30 @@ describe("Sidebar Component", () => {
       .simulate("click")
     expect(wrapper.find("StyledSidebarContent").prop("isCollapsed")).toBe(
       false
+    )
+  })
+
+  it("uses the default chevron spacing if chevronDownshift is zero", () => {
+    const wrapper = renderSideBar({
+      chevronDownshift: 0,
+      initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+    })
+
+    expect(wrapper.find("StyledSidebarCollapsedControl")).toHaveStyleRule(
+      "top",
+      spacing.sm
+    )
+  })
+
+  it("uses the given chevron spacing if chevronDownshift is nonzero", () => {
+    const wrapper = renderSideBar({
+      chevronDownshift: 50,
+      initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+    })
+
+    expect(wrapper.find("StyledSidebarCollapsedControl")).toHaveStyleRule(
+      "top",
+      "50px"
     )
   })
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -31,6 +31,7 @@ import {
 import IsSidebarContext from "./IsSidebarContext"
 
 export interface SidebarProps {
+  chevronDownshift: number
   children?: ReactElement
   initialSidebarState?: PageConfig.SidebarState
   theme: Theme
@@ -145,7 +146,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
 
   public render = (): ReactElement => {
     const { collapsedSidebar } = this.state
-    const { children } = this.props
+    const { chevronDownshift, children } = this.props
 
     // The tabindex is required to support scrolling by arrow keys.
     return (
@@ -162,7 +163,10 @@ class Sidebar extends PureComponent<SidebarProps, State> {
           </StyledSidebarCloseButton>
           {children}
         </StyledSidebarContent>
-        <StyledSidebarCollapsedControl isCollapsed={collapsedSidebar}>
+        <StyledSidebarCollapsedControl
+          chevronDownshift={chevronDownshift}
+          isCollapsed={collapsedSidebar}
+        >
           <Button kind={Kind.ICON} onClick={this.toggleCollapse}>
             <Icon content={ChevronRight} />
           </Button>

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
@@ -38,7 +38,10 @@ const ThemedSidebar = ({
   children,
   ...sidebarProps
 }: Partial<SidebarProps>): ReactElement => {
-  const { activeTheme } = React.useContext(PageLayoutContext)
+  const {
+    activeTheme,
+    sidebarChevronDownshift: chevronDownshift,
+  } = React.useContext(PageLayoutContext)
   const sidebarTheme = createSidebarTheme(activeTheme)
 
   return (
@@ -46,7 +49,9 @@ const ThemedSidebar = ({
       theme={sidebarTheme.emotion}
       baseuiTheme={sidebarTheme.basewebTheme}
     >
-      <Sidebar {...sidebarProps}>{children}</Sidebar>
+      <Sidebar {...sidebarProps} chevronDownshift={chevronDownshift}>
+        {children}
+      </Sidebar>
     </ThemeProvider>
   )
 }

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -152,13 +152,14 @@ export const StyledSidebarCloseButton = styled.div(({ theme }) => ({
 }))
 
 export interface StyledSidebarCollapsedControlProps {
+  chevronDownshift: number
   isCollapsed: boolean
 }
 export const StyledSidebarCollapsedControl = styled.div<
   StyledSidebarCollapsedControlProps
->(({ isCollapsed, theme }) => ({
+>(({ chevronDownshift, isCollapsed, theme }) => ({
   position: "fixed",
-  top: theme.spacing.sm,
+  top: chevronDownshift ? `${chevronDownshift}px` : theme.spacing.sm,
   left: isCollapsed ? theme.spacing.sm : `-${theme.spacing.sm}`,
   zIndex: theme.zIndices.sidebar - 1,
 

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -48,8 +48,23 @@ export type IHostToGuestMessage = {
   stCommVersion: number
 } & (
   | {
+      type: "CLOSE_MODALS"
+    }
+  | {
+      type: "SET_IS_OWNER"
+      isOwner: boolean
+    }
+  | {
       type: "SET_MENU_ITEMS"
       items: IMenuItem[]
+    }
+  | {
+      type: "SET_METADATA"
+      metadata: StreamlitShareMetadata
+    }
+  | {
+      type: "SET_SIDEBAR_CHEVRON_DOWNSHIFT"
+      sidebarChevronDownshift: number
     }
   | {
       type: "SET_TOOLBAR_ITEMS"
@@ -60,19 +75,8 @@ export type IHostToGuestMessage = {
       queryParams: string
     }
   | {
-      type: "CLOSE_MODALS"
-    }
-  | {
-      type: "SET_METADATA"
-      metadata: StreamlitShareMetadata
-    }
-  | {
       type: "UPDATE_HASH"
       hash: string
-    }
-  | {
-      type: "SET_IS_OWNER"
-      isOwner: boolean
     }
 )
 

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -135,4 +135,28 @@ describe("withS4ACommunication HOC", () => {
       },
     ])
   })
+
+  it("can process a received SET_SIDEBAR_CHEVRON_DOWNSHIFT message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "SET_SIDEBAR_CHEVRON_DOWNSHIFT",
+            sidebarChevronDownshift: 50,
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+
+    wrapper.update()
+
+    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    expect(props.currentState.sidebarChevronDownshift).toBe(50)
+  })
 })

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -34,6 +34,7 @@ interface State {
   isOwner: boolean
   menuItems: IMenuItem[]
   queryParams: string
+  sidebarChevronDownshift: number
   streamlitShareMetadata: StreamlitShareMetadata
   toolbarItems: IToolbarItem[]
 }
@@ -61,12 +62,15 @@ function withS4ACommunication(
   WrappedComponent: ComponentType<any>
 ): ComponentType<any> {
   function ComponentWithS4ACommunication(props: any): ReactElement {
+    // TODO(vdonato): Refactor this to use useReducer to make this less
+    // unwieldy.
     const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
     const [forcedModalClose, setForcedModalClose] = useState(false)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
     const [isOwner, setIsOwner] = useState(false)
     const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
+    const [sidebarChevronDownshift, setSidebarChevronDownshift] = useState(0)
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -105,6 +109,10 @@ function withS4ACommunication(
           setStreamlitShareMetadata(message.metadata)
         }
 
+        if (message.type === "SET_SIDEBAR_CHEVRON_DOWNSHIFT") {
+          setSidebarChevronDownshift(message.sidebarChevronDownshift)
+        }
+
         if (message.type === "SET_TOOLBAR_ITEMS") {
           setToolbarItems(message.items)
         }
@@ -134,6 +142,7 @@ function withS4ACommunication(
               isOwner,
               menuItems,
               queryParams,
+              sidebarChevronDownshift,
               streamlitShareMetadata,
               toolbarItems,
             },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1158,6 +1158,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1440,6 +1447,14 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
+"@emotion/css-prettifier@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.1.tgz#a3ce1667398e83701f52ec43938208faeef2e0a5"
+  integrity sha512-cA9Dtol47mtvWKasPC+8tkh2DS0wBkX0MMHKieXGSkGyx079V7yFY85KC0pPalcIy+vi0LbMR9DNyiJBqYgJ1Q==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    stylis "4.0.13"
+
 "@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
@@ -1467,6 +1482,17 @@
   integrity sha512-G5X0t7eR9pkhUvAY32QS3lToP9JyNF8It5CcmMvbWjmC9/Yq7IhevaKqxl+me2BKR93iTPiL/h3En1ZX/1G3PQ==
   dependencies:
     "@emotion/memoize" "^0.7.4"
+
+"@emotion/jest@^11.7.1":
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.7.1.tgz#cb80a98a922c1bec8906e4ee04bf7f2d101c96b8"
+  integrity sha512-IYKyiIm4a7LINESYTa6aAizRj6YTwIvpD9s9yDzkrOEJXKwCqWWOTVNNOJKBygim3fv4lC9KM5jG5qzHvy4ZJg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/css-prettifier" "^1.0.1"
+    chalk "^4.1.0"
+    specificity "^0.4.1"
+    stylis "4.0.13"
 
 "@emotion/memoize@0.7.4":
   version "0.7.4"
@@ -15589,6 +15615,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+specificity@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
+  integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
+
 split-on-first@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
@@ -16006,6 +16037,11 @@ styletron-standard@^3.0.4:
   dependencies:
     "@rtsao/csstype" "2.6.5-forked.0"
     inline-style-prefixer "^5.1.0"
+
+stylis@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
 supercluster@^7.0.0, supercluster@^7.1.0:
   version "7.1.2"


### PR DESCRIPTION
## 📚 Context

To ensure that apps hosted in Streamlit Cloud are able to change their styling
in case the host wants to overlay UI elements on the left-hand side of the page,
this PR adds the ability for the host of a streamlit app to configure the
placement of the sidebar toggle chevron by shifting it down a given number of
pixels.

Note that we initially thought that this could be done via a config option, but
I realized that this likely isn't flexible enough as the sidebar chevron may
need to be in different positions depending on whether the (currently
nonexistent) Streamlit Cloud sidenav component is expanded or not.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
