### PR TITLE
Add context manager for temporarily changing config

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -18,6 +18,7 @@ import copy
 import os
 import secrets
 import threading
+import attr
 import toml
 import urllib
 from collections import OrderedDict
@@ -1276,3 +1277,20 @@ def on_config_parsed(
 # may edit config options based on the values of other config options.
 on_config_parsed(_check_conflicts, lock=True)
 on_config_parsed(_set_development_mode)
+
+
+@attr.s(auto_attribs=True, slots=True)
+class ConfigContext:
+    """Context manager for resetting temporary config changes.
+
+    Useful for unit tests."""
+
+    original_config: Dict[str, ConfigOption] = attr.Factory(dict)
+
+    def __enter__(self):
+        self.original_config = copy.deepcopy(get_config_options())
+
+    def __exit__(self, etype, evalue, tb):
+        global _config_options
+        _config_options = self.original_config
+        return False

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -822,3 +822,27 @@ class ConfigLoadingTest(unittest.TestCase):
             "An update to the [server] config option section was detected."
             " To have these changes be reflected, please restart streamlit."
         )
+
+
+def test_config_manager_reset():
+    with config.ConfigContext():
+        config.set_option("server.address", "my/mock/address")
+
+        assert config.get_option("server.address") == "my/mock/address"
+
+    assert config.get_option("server.address") != "my/mock/address"
+
+
+def test_config_manager_nested():
+    with config.ConfigContext():
+        config.set_option("server.address", "1")
+        with config.ConfigContext():
+            config.set_option("server.address", "2")
+            config.set_option("server.port", 9000)
+
+            assert config.get_option("server.address") == "2"
+
+        assert config.get_option("server.address") == "1"
+
+    assert config.get_option("server.address") is None
+    assert config.get_option("server.port") == 8501


### PR DESCRIPTION
To make it easier to write unit tests without accidentally polluting the execution environment.