### PR TITLE
Move state of `facingMode` to CameraInput component to keep that stat…

### DIFF
--- a/frontend/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -21,6 +21,7 @@ import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import { CameraInput as CameraInputProto } from "src/autogen/proto"
 import { enableFetchMocks } from "jest-fetch-mock"
 import CameraInput, { Props } from "./CameraInput"
+import { FacingMode } from "./SwitchFacingModeButton"
 import WebcamComponent from "./WebcamComponent"
 import { StyledBox } from "./styled-components"
 import { WidgetLabel } from "../BaseWidget"
@@ -76,6 +77,7 @@ describe("CameraInput widget", () => {
       files: [],
       newestServerFileId: 0,
       clearPhotoInProgress: false,
+      facingMode: FacingMode.USER,
       imgSrc: null,
       shutter: false,
       minShutterEffectPassed: true,
@@ -116,6 +118,7 @@ describe("CameraInput widget", () => {
       files: [],
       newestServerFileId: 1,
       clearPhotoInProgress: true,
+      facingMode: FacingMode.USER,
       imgSrc: null,
       shutter: false,
       minShutterEffectPassed: true,

--- a/frontend/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.tsx
@@ -94,7 +94,7 @@ interface State {
   clearPhotoInProgress: boolean
 
   /**
-   * User facing mode for mobile. If `user`, the camera will be facing the user (front camera).
+   * User facing mode for mobile devices. If `user`, the camera will be facing the user (front camera).
    * If `environment`, the camera will be facing the environment (back camera).
    */
   facingMode: FacingMode

--- a/frontend/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.tsx
@@ -42,6 +42,7 @@ import {
   UploadingStatus,
 } from "../FileUploader/UploadFileInfo"
 import CameraInputButton from "./CameraInputButton"
+import { FacingMode } from "./SwitchFacingModeButton"
 import {
   StyledBox,
   StyledCameraInput,
@@ -91,6 +92,12 @@ interface State {
    * Time interval between `Clear Photo` button clicked and access to Webcam recived again
    */
   clearPhotoInProgress: boolean
+
+  /**
+   * User facing mode for mobile. If `user`, the camera will be facing the user (front camera).
+   * If `environment`, the camera will be facing the environment (back camera).
+   */
+  facingMode: FacingMode
 }
 
 const MIN_SHUTTER_EFFECT_TIME_MS = 150
@@ -121,6 +128,15 @@ class CameraInput extends React.PureComponent<Props, State> {
 
   private setClearPhotoInProgress = (clearPhotoInProgress: boolean): void => {
     this.setState({ clearPhotoInProgress })
+  }
+
+  private setFacingMode = (): void => {
+    this.setState(prevState => ({
+      facingMode:
+        prevState.facingMode === FacingMode.USER
+          ? FacingMode.ENVIRONMENT
+          : FacingMode.USER,
+    }))
   }
 
   private handleCapture = (imgSrc: string | null): Promise<void> => {
@@ -178,6 +194,7 @@ class CameraInput extends React.PureComponent<Props, State> {
       shutter: false,
       minShutterEffectPassed: true,
       clearPhotoInProgress: false,
+      facingMode: FacingMode.USER,
     }
     const { widgetMgr, element } = this.props
 
@@ -209,9 +226,8 @@ class CameraInput extends React.PureComponent<Props, State> {
       shutter: false,
       minShutterEffectPassed: false,
       clearPhotoInProgress: false,
+      facingMode: FacingMode.USER,
     }
-
-    return emptyState
   }
 
   public componentWillUnmount(): void {
@@ -395,6 +411,8 @@ class CameraInput extends React.PureComponent<Props, State> {
             disabled={disabled}
             clearPhotoInProgress={this.state.clearPhotoInProgress}
             setClearPhotoInProgress={this.setClearPhotoInProgress}
+            facingMode={this.state.facingMode}
+            setFacingMode={this.setFacingMode}
           />
         )}
       </StyledCameraInput>

--- a/frontend/src/components/widgets/CameraInput/SwitchFacingModeButton.tsx
+++ b/frontend/src/components/widgets/CameraInput/SwitchFacingModeButton.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from "react"
+import { SwitchCamera } from "@emotion-icons/material-rounded"
+
+import Button, { Kind } from "src/components/shared/Button"
+import Icon from "src/components/shared/Icon"
+import Tooltip, { Placement } from "src/components/shared/Tooltip"
+import themeColors from "src/theme/baseTheme/themeColors"
+import { StyledSwitchFacingModeButton } from "./styled-components"
+
+export enum FacingMode {
+  USER = "user",
+  ENVIRONMENT = "environment",
+}
+
+export interface SwitchFacingModeButtonProps {
+  switchFacingMode: () => void
+}
+
+const SwitchFacingModeButton = ({
+  switchFacingMode,
+}: SwitchFacingModeButtonProps): ReactElement => {
+  return (
+    <StyledSwitchFacingModeButton>
+      <Tooltip content={"Switch camera"} placement={Placement.TOP_RIGHT}>
+        <Button kind={Kind.MINIMAL} onClick={switchFacingMode}>
+          <Icon
+            content={SwitchCamera}
+            size="twoXL"
+            color={themeColors.white}
+          />
+        </Button>
+      </Tooltip>
+    </StyledSwitchFacingModeButton>
+  )
+}
+
+export default SwitchFacingModeButton

--- a/frontend/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -5,6 +5,7 @@ import { mount } from "src/lib/test_util"
 import { StyledBox } from "./styled-components"
 import WebcamComponent, { Props } from "./WebcamComponent"
 
+jest.mock("react-webcam")
 const getProps = (props: Partial<Props> = {}): Props => {
   return {
     handleCapture: jest.fn(),

--- a/frontend/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -15,25 +15,23 @@
  * limitations under the License.
  */
 
-import { SwitchCamera } from "@emotion-icons/material-rounded"
 import { Video } from "@emotion-icons/open-iconic"
 import { useTheme } from "emotion-theming"
 import React, { ReactElement, useRef, useState } from "react"
 import { isMobile } from "react-device-detect"
 import Webcam from "react-webcam"
 
-import Button, { Kind } from "src/components/shared/Button"
 import Icon from "src/components/shared/Icon"
-import Tooltip, { Placement } from "src/components/shared/Tooltip"
 import { Theme } from "src/theme"
 import themeColors from "src/theme/baseTheme/themeColors"
+
 import CameraInputButton from "./CameraInputButton"
+import SwitchFacingModeButton, { FacingMode } from "./SwitchFacingModeButton"
 import {
   StyledBox,
   StyledCameraInput,
   StyledDescription,
   StyledLink,
-  StyledSwitchFacingModeButton,
 } from "./styled-components"
 
 export interface Props {
@@ -42,11 +40,8 @@ export interface Props {
   disabled: boolean
   clearPhotoInProgress: boolean
   setClearPhotoInProgress: (clearPhotoInProgress: boolean) => void
-}
-
-export enum FacingMode {
-  USER = "user",
-  ENVIRONMENT = "environment",
+  facingMode: FacingMode
+  setFacingMode: () => void
 }
 
 export enum WebcamPermission {
@@ -79,52 +74,25 @@ export const AskForCameraPermission = ({
   )
 }
 
-interface SwitchFacingModeButtonProps {
-  switchFacingMode: () => void
-}
-
-export const SwitchFacingModeButton = ({
-  switchFacingMode,
-}: SwitchFacingModeButtonProps): ReactElement => {
-  return (
-    <StyledSwitchFacingModeButton>
-      <Tooltip content={"Switch camera"} placement={Placement.TOP_RIGHT}>
-        <Button kind={Kind.MINIMAL} onClick={switchFacingMode}>
-          <Icon
-            content={SwitchCamera}
-            size="twoXL"
-            color={themeColors.white}
-          />
-        </Button>
-      </Tooltip>
-    </StyledSwitchFacingModeButton>
-  )
-}
-
 const WebcamComponent = ({
   handleCapture,
   width,
   disabled,
   clearPhotoInProgress,
   setClearPhotoInProgress,
+  facingMode,
+  setFacingMode,
 }: Props): ReactElement => {
   const [webcamPermission, setWebcamPermissionState] = useState(
     WebcamPermission.PENDING
   )
   const videoRef = useRef<Webcam>(null)
-  const [facingMode, setFacingMode] = useState(FacingMode.USER)
 
   function capture(): void {
     if (videoRef.current !== null) {
       const imageSrc = videoRef.current.getScreenshot()
       handleCapture(imageSrc)
     }
-  }
-
-  function switchFacingMode(): void {
-    setFacingMode(prevState =>
-      prevState === FacingMode.USER ? FacingMode.ENVIRONMENT : FacingMode.USER
-    )
   }
 
   const theme: Theme = useTheme()
@@ -136,9 +104,7 @@ const WebcamComponent = ({
       !clearPhotoInProgress ? (
         <AskForCameraPermission width={width} />
       ) : (
-        isMobile && (
-          <SwitchFacingModeButton switchFacingMode={switchFacingMode} />
-        )
+        isMobile && <SwitchFacingModeButton switchFacingMode={setFacingMode} />
       )}
       <StyledBox
         hidden={


### PR DESCRIPTION
…e after Clear Photo

Move SwitchFacingModeButton component to separate file

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Bug description (and video): https://www.notion.so/streamlit/Mobile-Tablet-Front-camera-is-always-selected-by-default-after-clearing-a-photo-8506d195e6ac402395f2466b20500a4c

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

 Keeping the state of `facingMode` inside WebcamComponent leads to always set it to default value `user` after `Clear Photo` clicked. 

Now the state of `facingMode` moved to the main `CameraInput` component since it is not remounted during a clear photo.

I moved `SwitchFacingModeButton` component to a separate file, since defining `FacinMode` enum inside `WebcamComponent.tsx` and then importing it in `CameraInput.tsx` leads to a circular dependency. 

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
