### PR TITLE
st.memo.clear() and st.singleton.clear() public APIs

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -518,8 +518,8 @@ class AppSession:
 
         """
         legacy_caching.clear_cache()
-        caching.clear_memo_cache()
-        caching.clear_singleton_cache()
+        caching.memo.clear()
+        caching.singleton.clear()
         self._session_state.clear_state()
 
     def handle_set_run_on_save_request(self, new_value):

--- a/lib/streamlit/caching/__init__.py
+++ b/lib/streamlit/caching/__init__.py
@@ -14,8 +14,8 @@
 import contextlib
 from typing import Iterator
 
-from .memo_decorator import MEMO_CALL_STACK, _memo_caches
-from .singleton_decorator import SINGLETON_CALL_STACK, _singleton_caches
+from .memo_decorator import MEMO_CALL_STACK, _memo_caches, MemoAPI
+from .singleton_decorator import SINGLETON_CALL_STACK, _singleton_caches, SingletonAPI
 
 
 def maybe_show_cached_st_function_warning(dg, st_func_name: str) -> None:
@@ -29,20 +29,14 @@ def suppress_cached_st_function_warning() -> Iterator[None]:
         yield
 
 
-def clear_singleton_cache() -> None:
-    _singleton_caches.clear_all()
-
-
-def clear_memo_cache() -> None:
-    _memo_caches.clear_all()
-
-
 # Explicitly export public symobls
 from .memo_decorator import (
-    memo as memo,
     get_memo_stats_provider as get_memo_stats_provider,
 )
 from .singleton_decorator import (
-    singleton as singleton,
     get_singleton_stats_provider as get_singleton_stats_provider,
 )
+
+# Create and export public API singletons.
+memo = MemoAPI()
+singleton = SingletonAPI()

--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -199,13 +199,14 @@ class MemoAPI:
 
     # Bare decorator usage
     @overload
-    def __call__(self, func: F) -> F:
+    @staticmethod
+    def __call__(func: F) -> F:
         ...
 
     # Decorator with arguments
     @overload
+    @staticmethod
     def __call__(
-        self,
         *,
         persist: Optional[str] = None,
         show_spinner: bool = True,
@@ -215,8 +216,8 @@ class MemoAPI:
     ) -> Callable[[F], F]:
         ...
 
+    @staticmethod
     def __call__(
-        self,
         func: Optional[F] = None,
         *,
         persist: Optional[str] = None,

--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -210,7 +210,7 @@ class MemoAPI:
         *,
         persist: Optional[str] = None,
         show_spinner: bool = True,
-        suppress_st_warning=False,
+        suppress_st_warning: bool = False,
         max_entries: Optional[int] = None,
         ttl: Optional[float] = None,
     ) -> Callable[[F], F]:
@@ -222,7 +222,7 @@ class MemoAPI:
         *,
         persist: Optional[str] = None,
         show_spinner: bool = True,
-        suppress_st_warning=False,
+        suppress_st_warning: bool = False,
         max_entries: Optional[int] = None,
         ttl: Optional[float] = None,
     ):

--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -189,8 +189,8 @@ class MemoizedFunction(CachedFunction):
 
 
 class MemoAPI:
-    """Implements the public st.memo API. (We have a single MemoAPI instance
-    declared below.)
+    """Implements the public st.memo API: the @st.memo decorator, and
+    st.memo.clear().
     """
 
     # Type-annotate the decorator function.

--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -188,143 +188,158 @@ class MemoizedFunction(CachedFunction):
         )
 
 
-# Type-annotate the decorator.
-# (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-# Bare decorator usage
-@overload
-def memo(func: F) -> F:
-    ...
-
-
-# Decorator with arguments
-@overload
-def memo(
-    *,
-    persist: Optional[str] = None,
-    show_spinner: bool = True,
-    suppress_st_warning=False,
-    max_entries: Optional[int] = None,
-    ttl: Optional[float] = None,
-) -> Callable[[F], F]:
-    ...
-
-
-def memo(
-    func: Optional[F] = None,
-    *,
-    persist: Optional[str] = None,
-    show_spinner: bool = True,
-    suppress_st_warning=False,
-    max_entries: Optional[int] = None,
-    ttl: Optional[float] = None,
-):
-    """Function decorator to memoize function executions.
-
-    Memoized data is stored in "pickled" form, which means that the return
-    value of a memoized function must be pickleable.
-
-    Each caller of a memoized function gets its own copy of the cached data.
-
-    You can clear a memoized function's cache with f.clear().
-
-    Parameters
-    ----------
-    func : callable
-        The function to memoize. Streamlit hashes the function's source code.
-
-    persist : str or None
-        Optional location to persist cached data to. Currently, the only
-        valid value is "disk", which will persist to the local disk.
-
-    show_spinner : boolean
-        Enable the spinner. Default is True to show a spinner when there is
-        a cache miss.
-
-    suppress_st_warning : boolean
-        Suppress warnings about calling Streamlit functions from within
-        the cached function.
-
-    max_entries : int or None
-        The maximum number of entries to keep in the cache, or None
-        for an unbounded cache. (When a new entry is added to a full cache,
-        the oldest cached entry will be removed.) The default is None.
-
-    ttl : float or None
-        The maximum number of seconds to keep an entry in the cache, or
-        None if cache entries should not expire. The default is None.
-
-    Example
-    -------
-    >>> @st.experimental_memo
-    ... def fetch_and_clean_data(url):
-    ...     # Fetch data from URL here, and then clean it up.
-    ...     return data
-    ...
-    >>> d1 = fetch_and_clean_data(DATA_URL_1)
-    >>> # Actually executes the function, since this is the first time it was
-    >>> # encountered.
-    >>>
-    >>> d2 = fetch_and_clean_data(DATA_URL_1)
-    >>> # Does not execute the function. Instead, returns its previously computed
-    >>> # value. This means that now the data in d1 is the same as in d2.
-    >>>
-    >>> d3 = fetch_and_clean_data(DATA_URL_2)
-    >>> # This is a different URL, so the function executes.
-
-    To set the ``persist`` parameter, use this command as follows:
-
-    >>> @st.experimental_memo(persist="disk")
-    ... def fetch_and_clean_data(url):
-    ...     # Fetch data from URL here, and then clean it up.
-    ...     return data
-
-    By default, all parameters to a memoized function must be hashable.
-    Any parameter whose name begins with ``_`` will not be hashed. You can use
-    this as an "escape hatch" for parameters that are not hashable:
-
-    >>> @st.experimental_memo
-    ... def fetch_and_clean_data(_db_connection, num_rows):
-    ...     # Fetch data from _db_connection here, and then clean it up.
-    ...     return data
-    ...
-    >>> connection = make_database_connection()
-    >>> d1 = fetch_and_clean_data(connection, num_rows=10)
-    >>> # Actually executes the function, since this is the first time it was
-    >>> # encountered.
-    >>>
-    >>> another_connection = make_database_connection()
-    >>> d2 = fetch_and_clean_data(another_connection, num_rows=10)
-    >>> # Does not execute the function. Instead, returns its previously computed
-    >>> # value - even though the _database_connection parameter was different
-    >>> # in both calls.
-
-    A memoized function's cache can be procedurally cleared:
-
-    >>> @st.experimental_memo
-    ... def fetch_and_clean_data(_db_connection, num_rows):
-    ...     # Fetch data from _db_connection here, and then clean it up.
-    ...     return data
-    ...
-    >>> fetch_and_clean_data.clear()
-    >>> # Clear all cached entries for this function.
-
+class MemoAPI:
+    """Implements the public st.memo API. (We have a single MemoAPI instance
+    declared below.)
     """
 
-    if persist not in (None, "disk"):
-        # We'll eventually have more persist options.
-        raise StreamlitAPIException(
-            f"Unsupported persist option '{persist}'. Valid values are 'disk' or None."
-        )
+    # Type-annotate the decorator function.
+    # (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
+    F = TypeVar("F", bound=Callable[..., Any])
 
-    # Support passing the params via function decorator, e.g.
-    # @st.memo(persist=True, show_spinner=False)
-    if func is None:
-        return lambda f: create_cache_wrapper(
+    # Bare decorator usage
+    @overload
+    def __call__(self, func: F) -> F:
+        ...
+
+    # Decorator with arguments
+    @overload
+    def __call__(
+        self,
+        *,
+        persist: Optional[str] = None,
+        show_spinner: bool = True,
+        suppress_st_warning=False,
+        max_entries: Optional[int] = None,
+        ttl: Optional[float] = None,
+    ) -> Callable[[F], F]:
+        ...
+
+    def __call__(
+        self,
+        func: Optional[F] = None,
+        *,
+        persist: Optional[str] = None,
+        show_spinner: bool = True,
+        suppress_st_warning=False,
+        max_entries: Optional[int] = None,
+        ttl: Optional[float] = None,
+    ):
+        """Function decorator to memoize function executions.
+
+        Memoized data is stored in "pickled" form, which means that the return
+        value of a memoized function must be pickleable.
+
+        Each caller of a memoized function gets its own copy of the cached data.
+
+        You can clear a memoized function's cache with f.clear().
+
+        Parameters
+        ----------
+        func : callable
+            The function to memoize. Streamlit hashes the function's source code.
+
+        persist : str or None
+            Optional location to persist cached data to. Currently, the only
+            valid value is "disk", which will persist to the local disk.
+
+        show_spinner : boolean
+            Enable the spinner. Default is True to show a spinner when there is
+            a cache miss.
+
+        suppress_st_warning : boolean
+            Suppress warnings about calling Streamlit functions from within
+            the cached function.
+
+        max_entries : int or None
+            The maximum number of entries to keep in the cache, or None
+            for an unbounded cache. (When a new entry is added to a full cache,
+            the oldest cached entry will be removed.) The default is None.
+
+        ttl : float or None
+            The maximum number of seconds to keep an entry in the cache, or
+            None if cache entries should not expire. The default is None.
+
+        Example
+        -------
+        >>> @st.experimental_memo
+        ... def fetch_and_clean_data(url):
+        ...     # Fetch data from URL here, and then clean it up.
+        ...     return data
+        ...
+        >>> d1 = fetch_and_clean_data(DATA_URL_1)
+        >>> # Actually executes the function, since this is the first time it was
+        >>> # encountered.
+        >>>
+        >>> d2 = fetch_and_clean_data(DATA_URL_1)
+        >>> # Does not execute the function. Instead, returns its previously computed
+        >>> # value. This means that now the data in d1 is the same as in d2.
+        >>>
+        >>> d3 = fetch_and_clean_data(DATA_URL_2)
+        >>> # This is a different URL, so the function executes.
+
+        To set the ``persist`` parameter, use this command as follows:
+
+        >>> @st.experimental_memo(persist="disk")
+        ... def fetch_and_clean_data(url):
+        ...     # Fetch data from URL here, and then clean it up.
+        ...     return data
+
+        By default, all parameters to a memoized function must be hashable.
+        Any parameter whose name begins with ``_`` will not be hashed. You can use
+        this as an "escape hatch" for parameters that are not hashable:
+
+        >>> @st.experimental_memo
+        ... def fetch_and_clean_data(_db_connection, num_rows):
+        ...     # Fetch data from _db_connection here, and then clean it up.
+        ...     return data
+        ...
+        >>> connection = make_database_connection()
+        >>> d1 = fetch_and_clean_data(connection, num_rows=10)
+        >>> # Actually executes the function, since this is the first time it was
+        >>> # encountered.
+        >>>
+        >>> another_connection = make_database_connection()
+        >>> d2 = fetch_and_clean_data(another_connection, num_rows=10)
+        >>> # Does not execute the function. Instead, returns its previously computed
+        >>> # value - even though the _database_connection parameter was different
+        >>> # in both calls.
+
+        A memoized function's cache can be procedurally cleared:
+
+        >>> @st.experimental_memo
+        ... def fetch_and_clean_data(_db_connection, num_rows):
+        ...     # Fetch data from _db_connection here, and then clean it up.
+        ...     return data
+        ...
+        >>> fetch_and_clean_data.clear()
+        >>> # Clear all cached entries for this function.
+
+        """
+
+        if persist not in (None, "disk"):
+            # We'll eventually have more persist options.
+            raise StreamlitAPIException(
+                f"Unsupported persist option '{persist}'. Valid values are 'disk' or None."
+            )
+
+        # Support passing the params via function decorator, e.g.
+        # @st.memo(persist=True, show_spinner=False)
+        if func is None:
+            return lambda f: create_cache_wrapper(
+                MemoizedFunction(
+                    func=f,
+                    persist=persist,
+                    show_spinner=show_spinner,
+                    suppress_st_warning=suppress_st_warning,
+                    max_entries=max_entries,
+                    ttl=ttl,
+                )
+            )
+
+        return create_cache_wrapper(
             MemoizedFunction(
-                func=f,
+                func=cast(types.FunctionType, func),
                 persist=persist,
                 show_spinner=show_spinner,
                 suppress_st_warning=suppress_st_warning,
@@ -333,16 +348,10 @@ def memo(
             )
         )
 
-    return create_cache_wrapper(
-        MemoizedFunction(
-            func=cast(types.FunctionType, func),
-            persist=persist,
-            show_spinner=show_spinner,
-            suppress_st_warning=suppress_st_warning,
-            max_entries=max_entries,
-            ttl=ttl,
-        )
-    )
+    @staticmethod
+    def clear() -> None:
+        """Clear all in-memory and on-disk memo caches."""
+        _memo_caches.clear_all()
 
 
 class MemoCache(Cache):

--- a/lib/streamlit/caching/singleton_decorator.py
+++ b/lib/streamlit/caching/singleton_decorator.py
@@ -111,123 +111,133 @@ class SingletonFunction(CachedFunction):
         )
 
 
-# Type-annotate the decorator.
-# (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-# Bare decorator usage
-@overload
-def singleton(func: F) -> F:
-    ...
-
-
-# Decorator with arguments
-@overload
-def singleton(
-    *,
-    show_spinner: bool = True,
-    suppress_st_warning=False,
-) -> Callable[[F], F]:
-    ...
-
-
-def singleton(
-    func: Optional[F] = None,
-    *,
-    show_spinner: bool = True,
-    suppress_st_warning=False,
-):
-    """Function decorator to store singleton objects.
-
-    Each singleton object is shared across all users connected to the app.
-    Singleton objects *must* be thread-safe, because they can be accessed from
-    multiple threads concurrently.
-
-    (If thread-safety is an issue, consider using ``st.session_state`` to
-    store per-session singleton objects instead.)
-
-    You can clear a memoized function's cache with f.clear().
-
-    Parameters
-    ----------
-    func : callable
-        The function that creates the singleton. Streamlit hashes the
-        function's source code.
-
-    show_spinner : boolean
-        Enable the spinner. Default is True to show a spinner when there is
-        a "cache miss" and the singleton is being created.
-
-    suppress_st_warning : boolean
-        Suppress warnings about calling Streamlit functions from within
-        the singleton function.
-
-    Example
-    -------
-    >>> @st.experimental_singleton
-    ... def get_database_session(url):
-    ...     # Create a database session object that points to the URL.
-    ...     return session
-    ...
-    >>> s1 = get_database_session(SESSION_URL_1)
-    >>> # Actually executes the function, since this is the first time it was
-    >>> # encountered.
-    >>>
-    >>> s2 = get_database_session(SESSION_URL_1)
-    >>> # Does not execute the function. Instead, returns its previously computed
-    >>> # value. This means that now the connection object in s1 is the same as in s2.
-    >>>
-    >>> s3 = get_database_session(SESSION_URL_2)
-    >>> # This is a different URL, so the function executes.
-
-    By default, all parameters to a singleton function must be hashable.
-    Any parameter whose name begins with ``_`` will not be hashed. You can use
-    this as an "escape hatch" for parameters that are not hashable:
-
-    >>> @st.experimental_singleton
-    ... def get_database_session(_sessionmaker, url):
-    ...     # Create a database connection object that points to the URL.
-    ...     return connection
-    ...
-    >>> s1 = get_database_session(create_sessionmaker(), DATA_URL_1)
-    >>> # Actually executes the function, since this is the first time it was
-    >>> # encountered.
-    >>>
-    >>> s2 = get_database_session(create_sessionmaker(), DATA_URL_1)
-    >>> # Does not execute the function. Instead, returns its previously computed
-    >>> # value - even though the _sessionmaker parameter was different
-    >>> # in both calls.
-
-    A singleton function's cache can be procedurally cleared:
-
-    >>> @st.experimental_singleton
-    ... def get_database_session(_sessionmaker, url):
-    ...     # Create a database connection object that points to the URL.
-    ...     return connection
-    ...
-    >>> get_database_session.clear()
-    >>> # Clear all cached entries for this function.
-
+class SingletonAPI:
+    """Implements the public st.singleton API. (We have a single SingletonAPI
+    instance declared below.)
     """
-    # Support passing the params via function decorator, e.g.
-    # @st.singleton(show_spinner=False)
-    if func is None:
-        return lambda f: create_cache_wrapper(
+
+    # Type-annotate the decorator function.
+    # (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
+
+    F = TypeVar("F", bound=Callable[..., Any])
+
+    # Bare decorator usage
+    @overload
+    def __call__(self, func: F) -> F:
+        ...
+
+    # Decorator with arguments
+    @overload
+    def __call__(
+        self,
+        *,
+        show_spinner: bool = True,
+        suppress_st_warning=False,
+    ) -> Callable[[F], F]:
+        ...
+
+    def __call__(
+        self,
+        func: Optional[F] = None,
+        *,
+        show_spinner: bool = True,
+        suppress_st_warning=False,
+    ):
+        """Function decorator to store singleton objects.
+
+        Each singleton object is shared across all users connected to the app.
+        Singleton objects *must* be thread-safe, because they can be accessed from
+        multiple threads concurrently.
+
+        (If thread-safety is an issue, consider using ``st.session_state`` to
+        store per-session singleton objects instead.)
+
+        You can clear a memoized function's cache with f.clear().
+
+        Parameters
+        ----------
+        func : callable
+            The function that creates the singleton. Streamlit hashes the
+            function's source code.
+
+        show_spinner : boolean
+            Enable the spinner. Default is True to show a spinner when there is
+            a "cache miss" and the singleton is being created.
+
+        suppress_st_warning : boolean
+            Suppress warnings about calling Streamlit functions from within
+            the singleton function.
+
+        Example
+        -------
+        >>> @st.experimental_singleton
+        ... def get_database_session(url):
+        ...     # Create a database session object that points to the URL.
+        ...     return session
+        ...
+        >>> s1 = get_database_session(SESSION_URL_1)
+        >>> # Actually executes the function, since this is the first time it was
+        >>> # encountered.
+        >>>
+        >>> s2 = get_database_session(SESSION_URL_1)
+        >>> # Does not execute the function. Instead, returns its previously computed
+        >>> # value. This means that now the connection object in s1 is the same as in s2.
+        >>>
+        >>> s3 = get_database_session(SESSION_URL_2)
+        >>> # This is a different URL, so the function executes.
+
+        By default, all parameters to a singleton function must be hashable.
+        Any parameter whose name begins with ``_`` will not be hashed. You can use
+        this as an "escape hatch" for parameters that are not hashable:
+
+        >>> @st.experimental_singleton
+        ... def get_database_session(_sessionmaker, url):
+        ...     # Create a database connection object that points to the URL.
+        ...     return connection
+        ...
+        >>> s1 = get_database_session(create_sessionmaker(), DATA_URL_1)
+        >>> # Actually executes the function, since this is the first time it was
+        >>> # encountered.
+        >>>
+        >>> s2 = get_database_session(create_sessionmaker(), DATA_URL_1)
+        >>> # Does not execute the function. Instead, returns its previously computed
+        >>> # value - even though the _sessionmaker parameter was different
+        >>> # in both calls.
+
+        A singleton function's cache can be procedurally cleared:
+
+        >>> @st.experimental_singleton
+        ... def get_database_session(_sessionmaker, url):
+        ...     # Create a database connection object that points to the URL.
+        ...     return connection
+        ...
+        >>> get_database_session.clear()
+        >>> # Clear all cached entries for this function.
+
+        """
+        # Support passing the params via function decorator, e.g.
+        # @st.singleton(show_spinner=False)
+        if func is None:
+            return lambda f: create_cache_wrapper(
+                SingletonFunction(
+                    func=f,
+                    show_spinner=show_spinner,
+                    suppress_st_warning=suppress_st_warning,
+                )
+            )
+
+        return create_cache_wrapper(
             SingletonFunction(
-                func=f,
+                func=cast(types.FunctionType, func),
                 show_spinner=show_spinner,
                 suppress_st_warning=suppress_st_warning,
             )
         )
 
-    return create_cache_wrapper(
-        SingletonFunction(
-            func=cast(types.FunctionType, func),
-            show_spinner=show_spinner,
-            suppress_st_warning=suppress_st_warning,
-        )
-    )
+    @staticmethod
+    def clear() -> None:
+        """Clear all singleton caches."""
+        _singleton_caches.clear_all()
 
 
 class SingletonCache(Cache):

--- a/lib/streamlit/caching/singleton_decorator.py
+++ b/lib/streamlit/caching/singleton_decorator.py
@@ -123,21 +123,22 @@ class SingletonAPI:
 
     # Bare decorator usage
     @overload
-    def __call__(self, func: F) -> F:
+    @staticmethod
+    def __call__(func: F) -> F:
         ...
 
     # Decorator with arguments
     @overload
+    @staticmethod
     def __call__(
-        self,
         *,
         show_spinner: bool = True,
         suppress_st_warning=False,
     ) -> Callable[[F], F]:
         ...
 
+    @staticmethod
     def __call__(
-        self,
         func: Optional[F] = None,
         *,
         show_spinner: bool = True,

--- a/lib/streamlit/caching/singleton_decorator.py
+++ b/lib/streamlit/caching/singleton_decorator.py
@@ -112,8 +112,8 @@ class SingletonFunction(CachedFunction):
 
 
 class SingletonAPI:
-    """Implements the public st.singleton API. (We have a single SingletonAPI
-    instance declared below.)
+    """Implements the public st.singleton API: the @st.singleton decorator,
+    and st.singleton.clear().
     """
 
     # Type-annotate the decorator function.

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -240,8 +240,8 @@ def cache_clear():
     else:
         print("Nothing to clear at %s." % cache_path)
 
-    streamlit.caching.clear_memo_cache()
-    streamlit.caching.clear_singleton_cache()
+    streamlit.caching.memo.clear()
+    streamlit.caching.singleton.clear()
 
 
 # SUBCOMMAND: config

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -166,8 +166,8 @@ class AppSessionTest(unittest.TestCase):
         self.assertTrue("foo" not in rs._session_state)
 
     @patch("streamlit.legacy_caching.clear_cache")
-    @patch("streamlit.caching.clear_memo_cache")
-    @patch("streamlit.caching.clear_singleton_cache")
+    @patch("streamlit.caching.memo.clear")
+    @patch("streamlit.caching.singleton.clear")
     def test_clear_cache_all_caches(
         self, clear_singleton_cache, clear_memo_cache, clear_legacy_cache
     ):

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -15,7 +15,6 @@
 """Tests that are common to both st.memo and st.singleton"""
 
 import threading
-import unittest
 from unittest.mock import patch
 
 from parameterized import parameterized
@@ -25,8 +24,6 @@ from streamlit import script_run_context
 from streamlit.caching import (
     MEMO_CALL_STACK,
     SINGLETON_CALL_STACK,
-    clear_memo_cache,
-    clear_singleton_cache,
 )
 from tests.testutil import DeltaGeneratorTestCase
 
@@ -44,8 +41,8 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         SINGLETON_CALL_STACK._suppress_st_function_warning = 0
 
         # Clear caches
-        clear_memo_cache()
-        clear_singleton_cache()
+        st.experimental_memo.clear()
+        st.experimental_singleton.clear()
 
         # And some tests create widgets, and can result in DuplicateWidgetID
         # errors on subsequent runs.
@@ -268,8 +265,8 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            ("memo", memo, clear_memo_cache),
-            ("singleton", singleton, clear_singleton_cache),
+            ("memo", memo, memo.clear),
+            ("singleton", singleton, singleton.clear),
         ]
     )
     def test_clear_all_caches(self, _, cache_decorator, clear_cache_func):

--- a/lib/tests/streamlit/caching/memo_test.py
+++ b/lib/tests/streamlit/caching/memo_test.py
@@ -20,7 +20,7 @@ from unittest.mock import patch, mock_open, MagicMock, Mock
 
 import streamlit as st
 from streamlit import StreamlitAPIException, file_util
-from streamlit.caching import memo_decorator, clear_memo_cache
+from streamlit.caching import memo_decorator
 from streamlit.caching.cache_errors import CacheError
 from streamlit.caching.memo_decorator import get_cache_path, get_memo_stats_provider
 from streamlit.stats import CacheStat
@@ -32,7 +32,7 @@ class MemoTest(unittest.TestCase):
         # Reset default values on teardown.
         memo_decorator.MEMO_CALL_STACK._cached_func_stack = []
         memo_decorator.MEMO_CALL_STACK._suppress_st_function_warning = 0
-        clear_memo_cache()
+        st.experimental_memo.clear()
 
     @patch.object(st, "exception")
     def test_mutate_return(self, exception):
@@ -116,7 +116,7 @@ class MemoPersistTest(unittest.TestCase):
     """st.memo disk persistence tests"""
 
     def tearDown(self) -> None:
-        clear_memo_cache()
+        st.experimental_memo.clear()
 
     @patch("streamlit.caching.memo_decorator.streamlit_write")
     def test_dont_persist_by_default(self, mock_write):
@@ -201,14 +201,14 @@ class MemoPersistTest(unittest.TestCase):
 
         # If the cache dir exists, we should delete it.
         with patch("os.path.isdir", MagicMock(return_value=True)):
-            clear_memo_cache()
+            st.experimental_memo.clear()
             mock_rmtree.assert_called_once_with(get_cache_path())
 
         mock_rmtree.reset_mock()
 
         # If the cache dir does not exist, we shouldn't try to delete it.
         with patch("os.path.isdir", MagicMock(return_value=False)):
-            clear_memo_cache()
+            st.experimental_memo.clear()
             mock_rmtree.assert_not_called()
 
     @patch("streamlit.file_util.os.stat", MagicMock())
@@ -259,10 +259,10 @@ class MemoStatsProviderTest(unittest.TestCase):
     def setUp(self):
         # Guard against external tests not properly cache-clearing
         # in their teardowns.
-        clear_memo_cache()
+        st.experimental_memo.clear()
 
     def tearDown(self):
-        clear_memo_cache()
+        st.experimental_memo.clear()
 
     def test_no_stats(self):
         self.assertEqual([], get_memo_stats_provider().get_stats())

--- a/lib/tests/streamlit/caching/singleton_test.py
+++ b/lib/tests/streamlit/caching/singleton_test.py
@@ -24,14 +24,13 @@ import streamlit as st
 from streamlit.caching import (
     singleton_decorator,
     get_singleton_stats_provider,
-    clear_singleton_cache,
 )
 from streamlit.stats import CacheStat
 
 
 class SingletonTest(unittest.TestCase):
     def tearDown(self):
-        clear_singleton_cache()
+        st.experimental_singleton.clear()
         # Some of these tests reach directly into _cache_info and twiddle it.
         # Reset default values on teardown.
         singleton_decorator.SINGLETON_CALL_STACK._cached_func_stack = []
@@ -62,10 +61,10 @@ class SingletonStatsProviderTest(unittest.TestCase):
     def setUp(self):
         # Guard against external tests not properly cache-clearing
         # in their teardowns.
-        clear_singleton_cache()
+        st.experimental_singleton.clear()
 
     def tearDown(self):
-        clear_singleton_cache()
+        st.experimental_singleton.clear()
 
     def test_no_stats(self):
         self.assertEqual([], get_singleton_stats_provider().get_stats())

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -348,8 +348,8 @@ class CliTest(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     @patch("streamlit.legacy_caching.clear_cache")
-    @patch("streamlit.caching.clear_memo_cache")
-    @patch("streamlit.caching.clear_singleton_cache")
+    @patch("streamlit.caching.memo.clear")
+    @patch("streamlit.caching.singleton.clear")
     def test_cache_clear_all_caches(
         self, clear_singleton_cache, clear_memo_cache, clear_legacy_cache
     ):


### PR DESCRIPTION
Exposes `st.memo.clear` and `st.singleton.clear` to the public Streamlit API.

(These functions were previously named `clear_singleton_cache` and `clear_memo_cache`, and were not part of the public Streamlit API.)

To implement this pattern, `st.memo` and `st.singleton` are now callable objects rather than functions - that is, `@st.memo` is now implemented as a `__call__` function within a singleton `MemoAPI` object, rather than as a standalone function:

```python
# old implementation:
def memo(f): ...

# new implementation
class MemoAPI:
  def __call__(f): ...
  def clear(): ...

memo = MemoAPI()
```

The existing public API and implementation remains the same. (The bulk of this PR is just indenting the old singleton/memo functions inside their respective API classes.)

There are no new tests here, because our existing cache-clearing tests - which previously used the aforementioned private APIs - now use these public functions.