### PR TITLE
Add example to camera_input docstring

### DIFF
--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -95,11 +95,9 @@ class CameraInputMixin:
         -------
         >>> import streamlit as st
         >>>
-        >>> x = st.camera_input("Take a picture")
+        >>> picture = st.camera_input("Take a picture")
         >>>
-        >>> if x:
-        ...     # To read camera input as bytes:
-        ...     picture = x.read()
+        >>> if picture:
         ...     st.image(picture)
 
         """

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -91,6 +91,17 @@ class CameraInputMixin:
             it is "file-like". This means you can pass them anywhere where
             a file is expected.
 
+        Examples
+        -------
+        >>> import streamlit as st
+        >>>
+        >>> x = st.camera_input("Take a picture")
+        >>>
+        >>> if x:
+        ...     # To read camera input as bytes:
+        ...     picture = x.read()
+        ...     st.image(picture)
+
         """
         key = to_key(key)
         check_callback_rules(self.dg, on_change)


### PR DESCRIPTION
## 📚 Context

The `st.camera_input` docstring does not demonstrate example usage.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Docs improvement request.

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change.
  - [x] Adds an `Examples` section to the widget docstring, demonstrating example usage. 
 
Post 1.4.0 release, a follow up PR will add an embedded, live Cloud app to the docstring. 

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/148904944-d12dd357-2da6-4a0e-96f6-c2935be26a6a.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/148905095-858966a2-62aa-4170-83c4-0e97c25704b1.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
