### PR TITLE
png as default favicon to allow alpha transparency

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -104,7 +104,7 @@ def set_page_config(
             width=-1,  # Always use full width for favicons
             clamp=False,
             channels="RGB",
-            output_format="JPEG",
+            output_format="PNG",
             image_id="favicon",
             allow_emoji=True,
         )

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -104,7 +104,7 @@ def set_page_config(
             width=-1,  # Always use full width for favicons
             clamp=False,
             channels="RGB",
-            output_format="PNG",
+            output_format="auto",
             image_id="favicon",
             allow_emoji=True,
         )


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

I wanted to have my custom logo as the favicon for my streamlit app, and it loaded in but the transparent parts were filled with a random color. This change makes the default type PNG, a type that allows for alpha transparency and is supported by common browsers (https://caniuse.com/link-icon-png).

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Changed type to PNG from JPEG for custom, non-emoji favicons

  - [x] This is a visible (user-facing) change

**Revised:**
Pretty transparent favicon!

<img width="203" alt="Screen Shot 2022-01-12 at 2 58 34 PM" src="https://user-images.githubusercontent.com/10490006/149212615-045ae177-4c6b-4a68-973f-c05438c1c99c.png">


**Current:**
Favicon with extra blue stuff around it (alpha filled from common color)
<img width="178" alt="Screen Shot 2022-01-12 at 2 59 48 PM" src="https://user-images.githubusercontent.com/10490006/149212879-05ba5a48-0140-4db5-b27e-57f920ad85e1.png">


## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [x] Added/Updated e2e tests

## 🌐 References

This PR has no dependencies.

- **Issue**: Closes #4214

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
