### PR TITLE
Add and use new cy.loadApp command

### DIFF
--- a/e2e/specs/app_hotkeys.spec.js
+++ b/e2e/specs/app_hotkeys.spec.js
@@ -22,7 +22,7 @@
  */
 describe("app hotkeys", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
     // Wait for an element to exist
     cy.get(".stTextInput").should("exist");
   });

--- a/e2e/specs/component_template.spec.js
+++ b/e2e/specs/component_template.spec.js
@@ -35,7 +35,7 @@ function getIframeBody(index) {
 // the other is pure Typescript, but both should produce identical results.
 describe("Component template", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/components_declare_component.spec.js
+++ b/e2e/specs/components_declare_component.spec.js
@@ -17,7 +17,7 @@
 
 describe("components.declare_component", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("sets `src` correctly", () => {

--- a/e2e/specs/components_html.spec.js
+++ b/e2e/specs/components_html.spec.js
@@ -17,7 +17,7 @@
 
 describe("components.html", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("sets `srcDoc` correctly", () => {

--- a/e2e/specs/components_iframe.spec.js
+++ b/e2e/specs/components_iframe.spec.js
@@ -17,7 +17,7 @@
 
 describe("components.iframe", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("sets src correctly", () => {

--- a/e2e/specs/empty_labels.spec.js
+++ b/e2e/specs/empty_labels.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.error and friends", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("matches the snapshot", () => {

--- a/e2e/specs/form_multiple_buttons.spec.js
+++ b/e2e/specs/form_multiple_buttons.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.form", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays both buttons", () => {

--- a/e2e/specs/linked_sliders.spec.js
+++ b/e2e/specs/linked_sliders.spec.js
@@ -18,7 +18,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.slider", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("has correct initial values", () => {

--- a/e2e/specs/redisplayed_widgets.spec.js
+++ b/e2e/specs/redisplayed_widgets.spec.js
@@ -18,7 +18,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("redisplayed widgets", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("does not save widget state when widget is removed and redisplayed", () => {

--- a/e2e/specs/session_state_frontend_sync.spec.js
+++ b/e2e/specs/session_state_frontend_sync.spec.js
@@ -21,7 +21,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("checkbox state update regression", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("checking one disables the other", () => {

--- a/e2e/specs/st_alert.spec.js
+++ b/e2e/specs/st_alert.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.error and friends", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for the "Please, wait" alert to disappear.
     cy.get(

--- a/e2e/specs/st_arrow_add_rows.spec.js
+++ b/e2e/specs/st_arrow_add_rows.spec.js
@@ -22,7 +22,7 @@ describe("st._arrow_add_rows", () => {
     // dataframes, tables, and charts to be rendered.
     Cypress.config("defaultCommandTimeout", 30000);
 
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for 'data-stale' attr to go away, so the snapshot looks right.
     cy.get(".element-container")

--- a/e2e/specs/st_arrow_altair_chart.spec.js
+++ b/e2e/specs/st_arrow_altair_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_altair_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_arrow_area_chart.spec.js
+++ b/e2e/specs/st_arrow_area_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_area_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_arrow_bar_chart.spec.js
+++ b/e2e/specs/st_arrow_bar_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_bar_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a bar chart", () => {

--- a/e2e/specs/st_arrow_chart_utc_time.spec.js
+++ b/e2e/specs/st_arrow_chart_utc_time.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_area_chart, st._arrow_bar_chart, st._arrow_line_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_arrow_dataframe.spec.js
+++ b/e2e/specs/st_arrow_dataframe.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_dataframe", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get(".element-container .stDataFrame")
       .find(".ReactVirtualized__Grid__innerScrollContainer")

--- a/e2e/specs/st_arrow_dataframe_dimension_spec.spec.js
+++ b/e2e/specs/st_arrow_dataframe_dimension_spec.spec.js
@@ -25,7 +25,7 @@ describe("Arrow Dataframes with different sizes", () => {
   ];
 
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("should show as expected", () => {

--- a/e2e/specs/st_arrow_dataframe_format.spec.js
+++ b/e2e/specs/st_arrow_dataframe_format.spec.js
@@ -17,7 +17,7 @@
 
 describe("Arrow Dataframe format", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_arrow_dataframe_sizes.spec.js
+++ b/e2e/specs/st_arrow_dataframe_sizes.spec.js
@@ -21,7 +21,7 @@ describe("Arrow Dataframes and Tables snapshots", () => {
     // dataframes and tables to be rendered.
     Cypress.config("defaultCommandTimeout", 30000);
 
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_arrow_dataframe_sort_column.spec.js
+++ b/e2e/specs/st_arrow_dataframe_sort_column.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_dataframe - sort by column", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get(".element-container .stDataFrame")
       .find("[data-testid='StyledDataFrameColHeaderCell']")

--- a/e2e/specs/st_arrow_datetimes_dataframe.spec.js
+++ b/e2e/specs/st_arrow_datetimes_dataframe.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st._arrow_dataframe", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
     cy.get(".element-container .stDataFrame")
       .find(".ReactVirtualized__Grid__innerScrollContainer")
       .find("[data-testid='StyledDataFrameDataCell']")

--- a/e2e/specs/st_arrow_empty_charts.spec.js
+++ b/e2e/specs/st_arrow_empty_charts.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("handles arrow empty charts", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for the site to be fully loaded
     cy.get(".element-container").should($els => {

--- a/e2e/specs/st_arrow_empty_dataframes.spec.js
+++ b/e2e/specs/st_arrow_empty_dataframes.spec.js
@@ -23,7 +23,7 @@ describe("Arrow Dataframes", () => {
 
   before(() => {
     // http://gs.statcounter.com/screen-resolution-stats/desktop/worldwide
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the decoration line disappear
     // This prevents us from occasionally getting the little multi-colored

--- a/e2e/specs/st_arrow_line_chart.spec.js
+++ b/e2e/specs/st_arrow_line_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_line_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a line chart", () => {

--- a/e2e/specs/st_arrow_line_chart_add_rows_special.spec.js
+++ b/e2e/specs/st_arrow_line_chart_add_rows_special.spec.js
@@ -24,9 +24,6 @@ describe("st._arrow_line_chart_add_rows_special", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Wait until we're not running
-    cy.get("[data-testid='stStatusWidget']").should("not.exist");
-
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
   });

--- a/e2e/specs/st_arrow_line_chart_add_rows_special.spec.js
+++ b/e2e/specs/st_arrow_line_chart_add_rows_special.spec.js
@@ -22,7 +22,7 @@ describe("st._arrow_line_chart_add_rows_special", () => {
 
   // Doesn't have to run before each, since these tests are stateless.
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait until we're not running
     cy.get("[data-testid='stStatusWidget']").should("not.exist");

--- a/e2e/specs/st_arrow_new_features.spec.js
+++ b/e2e/specs/st_arrow_new_features.spec.js
@@ -17,7 +17,7 @@
 
 describe("st_arrow_new_feautres", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear.
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_arrow_table.spec.js
+++ b/e2e/specs/st_arrow_table.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._arrow_table", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear.
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_arrow_table_styling.spec.js
+++ b/e2e/specs/st_arrow_table_styling.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st._arrow_table styling", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get("[data-testid='stTable']").should("have.length", 3);
 

--- a/e2e/specs/st_arrow_vega_lite_chart.spec.js
+++ b/e2e/specs/st_arrow_vega_lite_chart.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st._arrow_vega_lite_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Force our header to scroll with the page, rather than
     // remaining fixed. This prevents us from occasionally getting

--- a/e2e/specs/st_audio.spec.js
+++ b/e2e/specs/st_audio.spec.js
@@ -19,7 +19,7 @@ describe("st.audio", () => {
   before(() => {
     // Increasing timeout since we're requesting an external audio file
     Cypress.config("defaultCommandTimeout", 10000);
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays an audio player", () => {

--- a/e2e/specs/st_balloons.spec.js
+++ b/e2e/specs/st_balloons.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.balloons", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("uses negative bottom margin styling", () => {

--- a/e2e/specs/st_bokeh_chart.spec.js
+++ b/e2e/specs/st_bokeh_chart.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.bokeh_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_button.spec.js
+++ b/e2e/specs/st_button.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.button", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -22,7 +22,7 @@ describe("st.camera_input", () => {
     Cypress.Cookies.defaults({
       preserve: ["_xsrf"]
     });
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_caption.spec.js
+++ b/e2e/specs/st_caption.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.caption", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_checkbox.spec.js
+++ b/e2e/specs/st_checkbox.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.checkbox", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_code.spec.js
+++ b/e2e/specs/st_code.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.code", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a code block", () => {

--- a/e2e/specs/st_color_picker.spec.js
+++ b/e2e/specs/st_color_picker.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.color_picker", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("shows the widget correctly", () => {

--- a/e2e/specs/st_columns.spec.js
+++ b/e2e/specs/st_columns.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.column", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("creates 2 equal-width columns", () => {

--- a/e2e/specs/st_columns_layout.spec.js
+++ b/e2e/specs/st_columns_layout.spec.js
@@ -20,7 +20,7 @@ import { cyGetIndexed } from "./spec_utils";
 describe("st.columns layout", () => {
   it("shows columns horizontally when viewport > 640", () => {
     cy.viewport(641, 800);
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get("[data-testid='stHorizontalBlock']")
       .first()
@@ -29,7 +29,7 @@ describe("st.columns layout", () => {
 
   it("stacks columns vertically when viewport <= 640", () => {
     cy.viewport(640, 800);
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cyGetIndexed("[data-testid='stHorizontalBlock']", 0).matchImageSnapshot(
       "columns-layout-vertical"

--- a/e2e/specs/st_container.spec.js
+++ b/e2e/specs/st_container.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.container", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("permits multiple out-of-order elements", () => {

--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.date_input", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("shows labels", () => {

--- a/e2e/specs/st_disabled.spec.js
+++ b/e2e/specs/st_disabled.spec.js
@@ -21,7 +21,7 @@
  */
 describe("disable widgets", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_disconnect.spec.js
+++ b/e2e/specs/st_disconnect.spec.js
@@ -17,7 +17,7 @@
 
 describe("kill server", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_download_button.spec.js
+++ b/e2e/specs/st_download_button.spec.js
@@ -20,7 +20,7 @@ const path = require("path");
 
 describe("st.download_button", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_echo.spec.js
+++ b/e2e/specs/st_echo.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.echo", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("echos a code", () => {

--- a/e2e/specs/st_empty.spec.js
+++ b/e2e/specs/st_empty.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.empty", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_error.spec.js
+++ b/e2e/specs/st_error.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.error", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays an error message", () => {

--- a/e2e/specs/st_exception.spec.js
+++ b/e2e/specs/st_exception.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.exception", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays an exception message", () => {

--- a/e2e/specs/st_expander.spec.js
+++ b/e2e/specs/st_expander.spec.js
@@ -21,7 +21,7 @@ const expanderHeaderIdentifier = ".streamlit-expanderHeader";
 
 describe("st.expander", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays expander + regular containers properly", () => {

--- a/e2e/specs/st_experimental_get_query_params.spec.js
+++ b/e2e/specs/st_experimental_get_query_params.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.experimental_get_query_string", () => {
   beforeEach(() => {
-    cy.visit(
+    cy.loadApp(
       "http://localhost:3000/?" +
         "show_map=True&number_of_countries=2&selected=asia&selected=america"
     );

--- a/e2e/specs/st_experimental_rerun.spec.js
+++ b/e2e/specs/st_experimental_rerun.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.experimental_rerun", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("restarts the session when invoked", () => {

--- a/e2e/specs/st_experimental_set_query_params.spec.js
+++ b/e2e/specs/st_experimental_set_query_params.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.experimental_query_string", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -25,7 +25,7 @@ describe("st.file_uploader", () => {
     cy.server();
     cy.route("POST", "**/upload_file").as("uploadFile");
 
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_form.spec.js
+++ b/e2e/specs/st_form.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.form", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Just adding an alias to markdown containers that are below the form.
     cy.get(

--- a/e2e/specs/st_form_column_association.spec.js
+++ b/e2e/specs/st_form_column_association.spec.js
@@ -36,7 +36,7 @@ const checkboxInsideForm = {
 
 describe("Form/column association", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   Object.entries(checkboxInsideForm).forEach(

--- a/e2e/specs/st_graphviz_chart.spec.js
+++ b/e2e/specs/st_graphviz_chart.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.graphviz_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_header.spec.js
+++ b/e2e/specs/st_header.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.header", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_hello.spec.js
+++ b/e2e/specs/st_hello.spec.js
@@ -19,7 +19,7 @@ describe("hello", () => {
   before(() => {
     // Increasing timeout since we're waiting for the animation and map to load.
     Cypress.config("defaultCommandTimeout", 30000);
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays the welcome message", () => {

--- a/e2e/specs/st_help.spec.js
+++ b/e2e/specs/st_help.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.help", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("matches the snapshot", () => {

--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.image", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays an image", () => {

--- a/e2e/specs/st_in_cache_warning.spec.js
+++ b/e2e/specs/st_in_cache_warning.spec.js
@@ -17,7 +17,7 @@
 
 describe("st calls within cached functions", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays expected results", () => {

--- a/e2e/specs/st_info.spec.js
+++ b/e2e/specs/st_info.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.info", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays an info message", () => {

--- a/e2e/specs/st_json.spec.js
+++ b/e2e/specs/st_json.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.json", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a json", () => {

--- a/e2e/specs/st_latex.spec.js
+++ b/e2e/specs/st_latex.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.latex", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays LaTeX symbol", () => {

--- a/e2e/specs/st_legacy_add_rows.spec.js
+++ b/e2e/specs/st_legacy_add_rows.spec.js
@@ -22,7 +22,7 @@ describe("st._legacy_add_rows", () => {
     // dataframes, tables, and charts to be rendered.
     Cypress.config("defaultCommandTimeout", 30000);
 
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Rerun the script because we want to test that JS-side coalescing works.
     cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {

--- a/e2e/specs/st_legacy_altair_chart.spec.js
+++ b/e2e/specs/st_legacy_altair_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_altair_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_legacy_area_chart.spec.js
+++ b/e2e/specs/st_legacy_area_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_area_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_legacy_bar_chart.spec.js
+++ b/e2e/specs/st_legacy_bar_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_bar_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a bar chart", () => {

--- a/e2e/specs/st_legacy_chart_utc_time.spec.js
+++ b/e2e/specs/st_legacy_chart_utc_time.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_area, legacy_bar, and legacy_line charts", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_legacy_dataframe.spec.js
+++ b/e2e/specs/st_legacy_dataframe.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_dataframe", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get(".element-container .stDataFrame")
       .find(".ReactVirtualized__Grid__innerScrollContainer")

--- a/e2e/specs/st_legacy_dataframe_dimension_spec.spec.js
+++ b/e2e/specs/st_legacy_dataframe_dimension_spec.spec.js
@@ -25,7 +25,7 @@ describe("Legacy Dataframes with different sizes", () => {
   ];
 
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("should show as expected", () => {

--- a/e2e/specs/st_legacy_dataframe_format.spec.js
+++ b/e2e/specs/st_legacy_dataframe_format.spec.js
@@ -17,7 +17,7 @@
 
 describe("Legacy Dataframe format", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_legacy_dataframe_sizes.spec.js
+++ b/e2e/specs/st_legacy_dataframe_sizes.spec.js
@@ -21,7 +21,7 @@ describe("Legacy Dataframes and Tables snapshots", () => {
     // dataframes and tables to be rendered.
     Cypress.config("defaultCommandTimeout", 30000);
 
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_legacy_dataframe_sort_column.spec.js
+++ b/e2e/specs/st_legacy_dataframe_sort_column.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_dataframe - sort by column", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get(".element-container .stDataFrame")
       .find("[data-testid='StyledDataFrameRowHeaderCell']")

--- a/e2e/specs/st_legacy_datetimes_dataframe.spec.js
+++ b/e2e/specs/st_legacy_datetimes_dataframe.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st._legacy_dataframe", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
     cy.get(".element-container .stDataFrame")
       .find(".ReactVirtualized__Grid__innerScrollContainer")
       .find("[data-testid='StyledDataFrameDataCell']")

--- a/e2e/specs/st_legacy_empty_charts.spec.js
+++ b/e2e/specs/st_legacy_empty_charts.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("handles legacy empty charts", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for the site to be fully loaded
     cy.get(".element-container").should($els => {

--- a/e2e/specs/st_legacy_empty_dataframes.spec.js
+++ b/e2e/specs/st_legacy_empty_dataframes.spec.js
@@ -23,7 +23,7 @@ describe("Legacy Dataframes", () => {
 
   before(() => {
     // http://gs.statcounter.com/screen-resolution-stats/desktop/worldwide
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the decoration line disappear
     // This prevents us from occasionally getting the little multi-colored

--- a/e2e/specs/st_legacy_line_chart.spec.js
+++ b/e2e/specs/st_legacy_line_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_line_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a line chart", () => {

--- a/e2e/specs/st_legacy_table.spec.js
+++ b/e2e/specs/st_legacy_table.spec.js
@@ -17,7 +17,7 @@
 
 describe("st._legacy_table", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get(".element-container [data-testid='stTable'] tbody tr").as("rows");
     cy.get(".element-container [data-testid='stTable'] tbody td").as("cells");

--- a/e2e/specs/st_legacy_table_styling.spec.js
+++ b/e2e/specs/st_legacy_table_styling.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st._legacy_table styling", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     cy.get("[data-testid='stTable']").should("have.length", 4);
 

--- a/e2e/specs/st_legacy_vega_lite_chart.spec.js
+++ b/e2e/specs/st_legacy_vega_lite_chart.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st._legacy_vega_lite_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Force our header to scroll with the page, rather than
     // remaining fixed. This prevents us from occasionally getting

--- a/e2e/specs/st_magic.spec.js
+++ b/e2e/specs/st_magic.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("streamlit magic", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays expected text", () => {

--- a/e2e/specs/st_main_menu.spec.js
+++ b/e2e/specs/st_main_menu.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("main menu", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_map.spec.js
+++ b/e2e/specs/st_map.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.map", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays 3 maps", () => {

--- a/e2e/specs/st_markdown.spec.js
+++ b/e2e/specs/st_markdown.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.markdown", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_markdown_in_alert_box.spec.js
+++ b/e2e/specs/st_markdown_in_alert_box.spec.js
@@ -17,7 +17,7 @@
 
 describe("info/success/warning/error boxes", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_message_deduping.spec.js
+++ b/e2e/specs/st_message_deduping.spec.js
@@ -17,7 +17,7 @@
 
 describe("message_deduping", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays two dataframes", () => {

--- a/e2e/specs/st_metric.spec.js
+++ b/e2e/specs/st_metric.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.metric", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   describe("Test first metric", () => {

--- a/e2e/specs/st_multiselect.spec.js
+++ b/e2e/specs/st_multiselect.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.multiselect", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_number_input.spec.js
+++ b/e2e/specs/st_number_input.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.number_input", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_plotly_chart.spec.js
+++ b/e2e/specs/st_plotly_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.plotly_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_progress.spec.js
+++ b/e2e/specs/st_progress.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.progress", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a progress bar", () => {

--- a/e2e/specs/st_pydeck_chart.spec.js
+++ b/e2e/specs/st_pydeck_chart.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.pydeck_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays 2 maps", () => {

--- a/e2e/specs/st_pydeck_geo_layers.spec.js
+++ b/e2e/specs/st_pydeck_geo_layers.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.pydeck_chart geo layers", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays H3 hexagon layer", () => {

--- a/e2e/specs/st_pyplot.spec.js
+++ b/e2e/specs/st_pyplot.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.pyplot", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a pyplot figure", () => {

--- a/e2e/specs/st_pyplot_kwargs.spec.js
+++ b/e2e/specs/st_pyplot_kwargs.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.pyplot with kwargs", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for the site to be fully loaded
     cy.contains("Done!", { timeout: 100000 }).should($els => {

--- a/e2e/specs/st_radio.spec.js
+++ b/e2e/specs/st_radio.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.radio", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_reuse_label.spec.js
+++ b/e2e/specs/st_reuse_label.spec.js
@@ -17,7 +17,7 @@
 
 describe("reuse widget label", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("reuses a widget label for different widget types", () => {

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.select_slider", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_selectbox.spec.js
+++ b/e2e/specs/st_selectbox.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.selectbox", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_session_state.spec.js
+++ b/e2e/specs/st_session_state.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.session_state", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_set_page_config.spec.js
+++ b/e2e/specs/st_set_page_config.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.set_page_config", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("sets the page favicon", () => {

--- a/e2e/specs/st_sidebar.spec.js
+++ b/e2e/specs/st_sidebar.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.sidebar", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.slider", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("looks right", () => {

--- a/e2e/specs/st_spinner.spec.js
+++ b/e2e/specs/st_spinner.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.spinner", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a message", () => {

--- a/e2e/specs/st_stop.spec.js
+++ b/e2e/specs/st_stop.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.stop", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays only one piece of text", () => {

--- a/e2e/specs/st_subheader.spec.js
+++ b/e2e/specs/st_subheader.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.subheader", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_success.spec.js
+++ b/e2e/specs/st_success.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.success", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a success message", () => {

--- a/e2e/specs/st_text.spec.js
+++ b/e2e/specs/st_text.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.text", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a text", () => {

--- a/e2e/specs/st_text_area.spec.js
+++ b/e2e/specs/st_text_area.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.text_area", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_text_input.spec.js
+++ b/e2e/specs/st_text_input.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.text_input", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e/specs/st_time_input.spec.js
+++ b/e2e/specs/st_time_input.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.time_input", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("shows labels", () => {

--- a/e2e/specs/st_title.spec.js
+++ b/e2e/specs/st_title.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.title", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_tooltips.spec.js
+++ b/e2e/specs/st_tooltips.spec.js
@@ -34,7 +34,7 @@ const tooltipTextBlock2 = `thisisatooltipwithnoindents. It has some spaces but\
 
 describe("tooltips on widgets", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays tooltips on textinput", () => {
@@ -100,7 +100,7 @@ describe("tooltips on widgets", () => {
 
 describe("tooltip text with dedent on widgets", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("Display text properly on tooltips on text input", () => {

--- a/e2e/specs/st_video.spec.js
+++ b/e2e/specs/st_video.spec.js
@@ -19,7 +19,7 @@ describe("st.video", () => {
   before(() => {
     // Increasing timeout since we're requesting an external video file
     Cypress.config("defaultCommandTimeout", 10000);
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a video player", () => {

--- a/e2e/specs/st_warning.spec.js
+++ b/e2e/specs/st_warning.spec.js
@@ -17,7 +17,7 @@
 
 describe("st.warning", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a warning message", () => {

--- a/e2e/specs/st_write.spec.js
+++ b/e2e/specs/st_write.spec.js
@@ -19,7 +19,7 @@ import { cyGetIndexed } from "./spec_utils";
 
 describe("st.write", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   beforeEach(() => {

--- a/e2e/specs/typography.spec.js
+++ b/e2e/specs/typography.spec.js
@@ -18,7 +18,7 @@
 describe("app typography", () => {
   // Doesn't have to run before each, since these tests are stateless.
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for 'data-stale' attr to go away, so the snapshot looks right.
     cy.get(".element-container")

--- a/e2e_flaky/specs/st_bokeh_chart.spec.ts
+++ b/e2e_flaky/specs/st_bokeh_chart.spec.ts
@@ -19,7 +19,7 @@
 
 describe("st.bokeh_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
   });
 
   it("displays a bokeh chart", () => {

--- a/e2e_flaky/specs/st_empty.spec.ts
+++ b/e2e_flaky/specs/st_empty.spec.ts
@@ -19,7 +19,7 @@
 
 describe("st.empty", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e_flaky/specs/st_graphviz_chart.spec.ts
+++ b/e2e_flaky/specs/st_graphviz_chart.spec.ts
@@ -19,7 +19,7 @@
 
 describe("st.graphviz_chart", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Make the ribbon decoration line disappear
     cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");

--- a/e2e_flaky/specs/st_legacy_add_rows.spec.ts
+++ b/e2e_flaky/specs/st_legacy_add_rows.spec.ts
@@ -24,7 +24,7 @@ describe("st._legacy_add_rows", () => {
     // dataframes, tables, and charts to be rendered.
     Cypress.config("defaultCommandTimeout", 30000);
 
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Rerun the script because we want to test that JS-side coalescing works.
     cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {

--- a/e2e_flaky/specs/st_pyplot_kwargs.spec.ts
+++ b/e2e_flaky/specs/st_pyplot_kwargs.spec.ts
@@ -19,7 +19,7 @@
 
 describe("st.pyplot with kwargs", () => {
   before(() => {
-    cy.visit("http://localhost:3000/");
+    cy.loadApp("http://localhost:3000/");
 
     // Wait for the site to be fully loaded
     cy.contains("Done!", { timeout: 100000 }).should($els => {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -114,3 +114,20 @@ Cypress.Commands.overwrite(
     return originalFn(subject, name, options)
   }
 )
+
+Cypress.Commands.add("loadApp", appUrl => {
+  cy.visit(appUrl)
+
+  // Wait until we know the script has started. We have to do this
+  // because the status widget is initially hidden (so that it doesn't quickly
+  // appear and disappear if the user has it configured to be hidden). Without
+  // waiting here, it's possible to pass the status widget check below before
+  // it initially renders.
+  cy.get("[data-testid='stAppViewContainer']").should(
+    "not.contain",
+    "Please wait..."
+  )
+
+  // Wait until the script is no longer running.
+  cy.get("[data-testid='stStatusWidget']").should("not.exist")
+})


### PR DESCRIPTION
## 📚 Context

NOTE: Most of this PR is a big search and replace. The only file changes worth reviewing
carefully are those made to `frontend/cypress/support/commands.js`

Working on #4259 uncovered some ways that our e2e tests are currently flaky that are
masked by the soon-to-be-removed preheat script run optimization.

Notably, calls to `cy.visit()` that appear frequently in our e2e tests wait for the page to
initially load, but they don't wait for the script run to complete, which means we may begin
running test cases before the script has fully rendered to the page. Most of the time this is
fine since the test cases themselves wait for some conditions to be true, but occasionally
this results in flaky test failures (most often when tests do nothing but take snapshots of
elements that may not have actually rendered yet).

This was less of a problem in the past because the preheated script run cut down on load
times just enough to dodge most potential flakiness, but the race conditions currently
present in the code became quite obvious while working on #4259.

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: test improvements

## 🧠 Description of Changes

- Added a new `cy.loadApp` command that navigates to the given URL and waits
  for the script to run to completion before proceeding
- Ran `find e2e/specs -type f -name "*.spec.js" | xargs sed -i '' "s/cy.visit/cy.loadApp/g"`
   to swap out current usage of `cy.visit` with `cy.loadApp`

## 🧪 Testing Done

- [x] Added/Updated e2e tests
