### PR TITLE
Adding wildcards support for cloud communication whitelist

### DIFF
--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -159,4 +159,45 @@ describe("withS4ACommunication HOC", () => {
     const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
     expect(props.currentState.sidebarChevronDownshift).toBe(50)
   })
+
+  describe("Test different origins", () => {
+    it("exact pattern", () => {
+      const dispatchEvent = mockEventListeners()
+
+      mount(<TestComponent />)
+
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "UPDATE_HASH",
+            hash: "#somehash",
+          },
+          origin: "http://share.streamlit.io",
+        })
+      )
+
+      expect(window.location.hash).toEqual("#somehash")
+    })
+    it("wildcard pattern", () => {
+      const dispatchEvent = mockEventListeners()
+
+      mount(<TestComponent />)
+
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "UPDATE_HASH",
+            hash: "#somehash",
+          },
+          origin: "http://cool-cucumber-fa9ds9f.streamlitapp.com",
+        })
+      )
+
+      expect(window.location.hash).toEqual("#somehash")
+    })
+  })
 })

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -28,6 +28,7 @@ import {
   StreamlitShareMetadata,
   VersionedMessage,
 } from "./types"
+import { isValidURL } from "../../lib/UriUtil"
 
 interface State {
   forcedModalClose: boolean
@@ -74,7 +75,7 @@ function withS4ACommunication(
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
-        let origin
+        let origin: string
         const message: VersionedMessage<IHostToGuestMessage> | any = event.data
 
         try {
@@ -88,7 +89,7 @@ function withS4ACommunication(
         if (
           !origin ||
           message.stCommVersion !== S4A_COMM_VERSION ||
-          !CLOUD_COMM_WHITELIST.includes(origin)
+          !CLOUD_COMM_WHITELIST.find(el => isValidURL(el, origin))
         ) {
           return
         }

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -19,6 +19,7 @@ import React, { ComponentType, useState, useEffect, ReactElement } from "react"
 import hoistNonReactStatics from "hoist-non-react-statics"
 
 import { CLOUD_COMM_WHITELIST } from "src/urls"
+import { isValidURL } from "src/lib/UriUtil"
 
 import {
   IGuestToHostMessage,
@@ -28,7 +29,6 @@ import {
   StreamlitShareMetadata,
   VersionedMessage,
 } from "./types"
-import { isValidURL } from "../../lib/UriUtil"
 
 interface State {
   forcedModalClose: boolean

--- a/frontend/src/lib/UriUtil.test.ts
+++ b/frontend/src/lib/UriUtil.test.ts
@@ -21,6 +21,7 @@ import {
   getWindowBaseUriParts,
   buildMediaUri,
   xssSanitizeSvg,
+  isValidURL,
 } from "./UriUtil"
 
 const location = {}
@@ -176,4 +177,31 @@ test("sanitizes SVG uris", () => {
   )
 
   expect(uri).toBe(`<svg></svg>`)
+})
+
+describe("isValidURL helper", () => {
+  it("should return true when the pattern and url are the same", () => {
+    const isValid = isValidURL(
+      "http://devel.streamlit.io",
+      "http://devel.streamlit.io"
+    )
+
+    expect(isValid).toBeTruthy()
+  })
+
+  it("should return false if it has different form", () => {
+    const isValid = isValidURL("*.com", "test.test.com")
+
+    expect(isValid).toBeFalsy()
+  })
+
+  it("should return true if it matches the pattern", () => {
+    expect(isValidURL("*.com", "a.com")).toBeTruthy()
+    expect(isValidURL("*.a.com", "asd.a.com")).toBeTruthy()
+    expect(isValidURL("www.*.a.com", "www.asd.a.com")).toBeTruthy()
+  })
+
+  it("should return false if it doesn't match the pattern", () => {
+    expect(isValidURL("*.b.com", "www.c.com")).toBeFalsy()
+  })
 })

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -121,17 +121,18 @@ export function buildMediaUri(uri: string): string {
  * a wildcard.
  */
 export function isValidURL(pattern: string, hostname: string): boolean {
-  const splittedPattern = pattern.split(".")
-  const splittedHostname = hostname.split(".")
-
   if (pattern === hostname) return true
-  if (splittedPattern.length !== splittedHostname.length) return false
 
-  return splittedPattern.every((el, index) => {
+  const splitPattern = pattern.split(".")
+  const splitHostname = hostname.split(".")
+
+  if (splitPattern.length !== splitHostname.length) return false
+
+  return splitPattern.every((el, index) => {
     if (el === "*") {
       return true
     }
 
-    return el === splittedHostname[index]
+    return el === splitHostname[index]
   })
 }

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -115,3 +115,23 @@ export function buildMediaUri(uri: string): string {
     ? buildHttpUri(getWindowBaseUriParts(), uri)
     : uri
 }
+
+/**
+ * Check if the given url follows the url pattern which could include
+ * a wildcard.
+ */
+export function isValidURL(pattern: string, hostname: string): boolean {
+  const splittedPattern = pattern.split(".")
+  const splittedHostname = hostname.split(".")
+
+  if (pattern === hostname) return true
+  if (splittedPattern.length !== splittedHostname.length) return false
+
+  return splittedPattern.every((el, index) => {
+    if (el === "*") {
+      return true
+    }
+
+    return el === splittedHostname[index]
+  })
+}

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -33,4 +33,6 @@ export const CLOUD_COMM_WHITELIST = [
   "share-demo.streamlit.io",
   "share-head.streamlit.io",
   "share-staging.streamlit.io",
+  "*.streamlitapp.com",
+  "*.streamlit.run",
 ]


### PR DESCRIPTION

## 📚 Context

As we are starting the project of cloud unique subdomains, and they are gonna be dynamically generated we need a way to whitelist those also dynamically.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- CLOUD_WHITELIST now supports wildcards into each url
- New isValidURL helper that validates the URL against a wildcard pattern.

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes [@streamlit/cloud#2721](https://github.com/streamlit/s4t/issues/2721)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
