### PR TITLE
Don't retain state across distinct-but-similar expanders

### DIFF
--- a/e2e/scripts/expander_state.py
+++ b/e2e/scripts/expander_state.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+b0 = st.button("b0")
+b1 = st.button("b1")
+
+if b0:
+    with st.expander("b0_expander", expanded=False):
+        st.write("b0_write")
+
+if b1:
+    with st.expander("b1_expander", expanded=False):
+        st.write("b1_write")

--- a/e2e/specs/expander_state.spec.js
+++ b/e2e/specs/expander_state.spec.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("expandable state", () => {
+  before(() => {
+    cy.loadApp("http://localhost:3000/");
+  });
+
+  it("does not retain expander state for a distinct expander", () => {
+    cy.getIndexed(".stButton button", 0).click();
+    cy.get("[data-testid='stExpander']").click();
+
+    cy.get("[data-testid='stExpander']").should("contain.text", "b0_write");
+
+    cy.getIndexed(".stButton button", 1).click();
+
+    cy.get("[data-testid='stExpander']").should(
+      "not.contain.text",
+      "b0_write"
+    );
+    cy.get("[data-testid='stExpander']").should(
+      "not.contain.text",
+      "b1_write"
+    );
+  });
+});

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -48,12 +48,12 @@ function withExpandable(
       ...componentProps
     } = props
 
-    const [expanded, toggleExpanded] = useState<boolean>(initialExpanded)
+    const [expanded, setExpanded] = useState<boolean>(initialExpanded)
     useEffect(() => {
-      toggleExpanded(initialExpanded)
-    }, [initialExpanded])
+      setExpanded(initialExpanded)
+    }, [label, initialExpanded])
 
-    const toggle = (): void => toggleExpanded(!expanded)
+    const toggle = (): void => setExpanded(!expanded)
     const { colors, radii, spacing, fontSizes } = useTheme<Theme>()
 
     return (

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -51,6 +51,14 @@ function withExpandable(
     const [expanded, setExpanded] = useState<boolean>(initialExpanded)
     useEffect(() => {
       setExpanded(initialExpanded)
+      // Having `label` in the dependency array here is necessary because
+      // sometimes two distinct expanders look so similar that even the react
+      // diffing algorithm decides that they're the same element with updated
+      // props (this happens when something in the app removes one expander and
+      // replaces it with another in the same position).
+      //
+      // By adding `label` as a dependency, we ensure that we reset the
+      // expander's `expanded` state in this edge case.
     }, [label, initialExpanded])
 
     const toggle = (): void => setExpanded(!expanded)


### PR DESCRIPTION
## 📚 Context

It turns out that #4258 is caused by what seems to be a _really_ fun bug --
distinct expanders sometimes look so similar that react's diffing algorithm
decides that the two elements are the same (but with different props), and so
the state of the `useState` hook is retained across two distinct expanders 🤯

The fix for this is to simply add a `useEffect` dependency on the hook currently 
watching for default expanded state changes so that the expander's state is also
reset when its `label` changes.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Fix expander state being incorrectly retained for distinct expanders by
  adding a `useEffect` dependency
- Added an e2e test for this behavior

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #4258
