### PR TITLE
Remove some remaining usage of the term "report"

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -409,32 +409,11 @@ export class App extends PureComponent<Props, State> {
           this.handleGitInfoChanged(gitInfo),
         scriptFinished: (status: ForwardMsg.ScriptFinishedStatus) =>
           this.handleScriptFinished(status),
-        uploadReportProgress: (progress: number) =>
-          this.handleUploadReportProgress(progress),
-        reportUploaded: (url: string) => this.handleReportUploaded(url),
       })
     } catch (err) {
       logError(err)
       this.showError("Bad message format", err.message)
     }
-  }
-
-  handleUploadReportProgress = (progress: number): void => {
-    const newDialog: DialogProps = {
-      type: DialogType.UPLOAD_PROGRESS,
-      progress,
-      onClose: () => {},
-    }
-    this.openDialog(newDialog)
-  }
-
-  handleReportUploaded = (url: string): void => {
-    const newDialog: DialogProps = {
-      type: DialogType.UPLOADED,
-      url,
-      onClose: () => {},
-    }
-    this.openDialog(newDialog)
   }
 
   handlePageConfigChanged = (pageConfig: PageConfig): void => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -483,11 +483,11 @@ export class App extends PureComponent<Props, State> {
         stateChangeProto.scriptIsRunning &&
         prevState.scriptRunState !== ScriptRunState.STOP_REQUESTED
       ) {
-        // If the report is running, we change our ScriptRunState only
+        // If the script is running, we change our ScriptRunState only
         // if we don't have a pending stop request
         scriptRunState = ScriptRunState.RUNNING
 
-        // If the scriptCompileError dialog is open and the report starts
+        // If the scriptCompileError dialog is open and the script starts
         // running, close it.
         if (
           dialog != null &&
@@ -500,7 +500,7 @@ export class App extends PureComponent<Props, State> {
         prevState.scriptRunState !== ScriptRunState.RERUN_REQUESTED &&
         prevState.scriptRunState !== ScriptRunState.COMPILATION_ERROR
       ) {
-        // If the report is not running, we change our ScriptRunState only
+        // If the script is not running, we change our ScriptRunState only
         // if we don't have a pending rerun request, and we don't have
         // a script compilation failure
         scriptRunState = ScriptRunState.NOT_RUNNING
@@ -705,7 +705,7 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Handler for ForwardMsg.scriptFinished messages
-   * @param status the ScriptFinishedStatus that the report finished with
+   * @param status the ScriptFinishedStatus that the script finished with
    */
   handleScriptFinished(status: ForwardMsg.ScriptFinishedStatus): void {
     if (status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY) {
@@ -821,7 +821,7 @@ export class App extends PureComponent<Props, State> {
       this.pendingElementsTimerRunning = true
 
       // (BUG #685) When user presses stop, stop adding elements to
-      // report immediately to avoid race condition.
+      // the app immediately to avoid race condition.
       const scriptIsRunning =
         this.state.scriptRunState === ScriptRunState.RUNNING
 
@@ -850,7 +850,7 @@ export class App extends PureComponent<Props, State> {
    *
    * @param alwaysRunOnSave a boolean. If true, UserSettings.runOnSave
    * will be set to true, which will result in a request to the Server
-   * to enable runOnSave for this report.
+   * to enable runOnSave for this session.
    */
   rerunScript = (alwaysRunOnSave = false): void => {
     this.closeDialog()
@@ -916,7 +916,7 @@ export class App extends PureComponent<Props, State> {
     )
   }
 
-  /** Requests that the server stop running the report */
+  /** Requests that the server stop running the script */
   stopScript = (): void => {
     if (!this.isServerConnected()) {
       logError("Cannot stop app when disconnected from server.")
@@ -992,7 +992,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Updates the report body when there's a connection error.
+   * Updates the app body when there's a connection error.
    */
   handleConnectionError = (errNode: ReactNode): void => {
     this.showError("Connection error", errNode)

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -34,7 +34,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
 
   return {
     elements: AppRoot.empty(),
-    scriptRunId: "report 123",
+    scriptRunId: "script run 123",
     scriptRunState: ScriptRunState.NOT_RUNNING,
     showStaleElementIndicator: true,
     widgetMgr: new WidgetStateManager({
@@ -72,7 +72,7 @@ describe("AppView element", () => {
     const sidebarElement = new ElementNode(
       makeElementWithInfoText("sidebar!"),
       ForwardMsgMetadata.create({}),
-      "no report id"
+      "no script run id"
     )
 
     const sidebar = new BlockNode(

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -38,16 +38,14 @@ import {
 export interface AppViewProps {
   elements: AppRoot
 
-  // The unique ID for the most recent run of the report.
+  // The unique ID for the most recent script run.
   scriptRunId: string
 
   scriptRunState: ScriptRunState
 
   /**
    * If true, "stale" elements (that is, elements that were created during a previous
-   * run of a currently-running report) will be faded out.
-   *
-   * (When we're viewing a shared report, this is set to false.)
+   * run of a currently-running script) will be faded out.
    */
   showStaleElementIndicator: boolean
 
@@ -64,7 +62,7 @@ export interface AppViewProps {
 }
 
 /**
- * Renders a Streamlit report. Reports consist of 0 or more elements.
+ * Renders a Streamlit app.
  */
 function AppView(props: AppViewProps): ReactElement {
   const {

--- a/frontend/src/components/core/Block/Block.test.tsx
+++ b/frontend/src/components/core/Block/Block.test.tsx
@@ -49,7 +49,7 @@ describe("Vertical Block Component", () => {
     const wrapper = mount(
       <VerticalBlock
         node={block}
-        reportId={""}
+        scriptRunId={""}
         scriptRunState={ScriptRunState.NOT_RUNNING}
         showStaleElementIndicator={false}
         widgetsDisabled={false}

--- a/frontend/src/components/core/Block/styled-components.ts
+++ b/frontend/src/components/core/Block/styled-components.ts
@@ -39,7 +39,7 @@ export interface StyledElementContainerProps {
 export const StyledElementContainer = styled.div<StyledElementContainerProps>(
   ({ theme, isStale, width, elementType }) => ({
     width,
-    // Allows to have absolutely-positioned nodes inside report elements, like
+    // Allows to have absolutely-positioned nodes inside app elements, like
     // floating buttons.
     position: "relative",
 

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -76,7 +76,7 @@ export interface Props {
   /** True if we're connected to the Streamlit server. */
   isServerConnected: boolean
 
-  /** Rerun the report. */
+  /** Rerun the current script. */
   quickRerunCallback: () => void
 
   /** Reload git information message */

--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -177,7 +177,7 @@ describe("Tooltip element", () => {
     expect(stopScript).toBeCalled()
   })
 
-  it("shows the rerun button when report changes", () => {
+  it("shows the rerun button when script changes", () => {
     const sessionEventDispatcher = new SessionEventDispatcher()
     const rerunScript = jest.fn()
 
@@ -196,7 +196,7 @@ describe("Tooltip element", () => {
     sessionEventDispatcher.handleSessionEventMsg(
       new SessionEvent({
         scriptChangedOnDisk: true,
-        reportWasManuallyStopped: null,
+        scriptWasManuallyStopped: null,
         scriptCompilationException: null,
       })
     )
@@ -210,7 +210,7 @@ describe("Tooltip element", () => {
     expect(rerunScript).toBeCalledWith(false)
   })
 
-  it("shows the always rerun button when report changes", () => {
+  it("shows the always rerun button when script changes", () => {
     const sessionEventDispatcher = new SessionEventDispatcher()
     const rerunScript = jest.fn()
 
@@ -229,7 +229,7 @@ describe("Tooltip element", () => {
     sessionEventDispatcher.handleSessionEventMsg(
       new SessionEvent({
         scriptChangedOnDisk: true,
-        reportWasManuallyStopped: null,
+        scriptWasManuallyStopped: null,
         scriptCompilationException: null,
       })
     )
@@ -243,7 +243,7 @@ describe("Tooltip element", () => {
     expect(rerunScript).toBeCalledWith(true)
   })
 
-  it("does not show the always rerun button when report changes", () => {
+  it("does not show the always rerun button when script changes", () => {
     const sessionEventDispatcher = new SessionEventDispatcher()
     const rerunScript = jest.fn()
 
@@ -263,7 +263,7 @@ describe("Tooltip element", () => {
     sessionEventDispatcher.handleSessionEventMsg(
       new SessionEvent({
         scriptChangedOnDisk: true,
-        reportWasManuallyStopped: null,
+        scriptWasManuallyStopped: null,
         scriptCompilationException: null,
       })
     )

--- a/frontend/src/components/core/StatusWidget/StatusWidget.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.tsx
@@ -58,17 +58,19 @@ export interface StatusWidgetProps {
   /** Dispatches transient SessionEvents received from the server. */
   sessionEventDispatcher: SessionEventDispatcher
 
-  /** Report's current runstate */
+  /** script's current runstate */
   scriptRunState: ScriptRunState
 
   /**
-   * Function called when the user chooses to re-run the report
-   * in response to its source file changing.
-   * @param alwaysRerun if true, also change the run-on-save setting for this report
+   * Function called when the user chooses to re-run a script in response to
+   * its source file changing.
+   *
+   * @param alwaysRerun if true, also change the run-on-save setting for this
+   * session
    */
   rerunScript: (alwaysRerun: boolean) => void
 
-  /** Function called when the user chooses to stop the running report. */
+  /** Function called when the user chooses to stop the running script. */
   stopScript: () => void
 
   /** Allows users to change user settings to allow rerun on save */
@@ -86,20 +88,20 @@ interface State {
   statusMinimized: boolean
 
   /**
-   * If true, the server has told us that the report has changed and is
+   * If true, the server has told us that a script has changed and is
    * not being automatically re-run; we'll prompt the user to manually
    * re-run when this happens.
    *
-   * This is reverted to false in getDerivedStateFromProps when the report
+   * This is reverted to false in getDerivedStateFromProps when the script
    * begins running again.
    */
   scriptChangedOnDisk: boolean
 
-  /** True if our Report Changed prompt should be minimized. */
+  /** True if our Script Changed prompt should be minimized. */
   promptMinimized: boolean
 
   /**
-   * True if our Report Changed prompt is being hovered. Hovered prompts are always
+   * True if our Script Changed prompt is being hovered. Hovered prompts are always
    * shown, even if they'd otherwise be minimized.
    */
   promptHovered: boolean
@@ -111,17 +113,16 @@ interface ConnectionStateUI {
   tooltip: string
 }
 
-// Amount of time to display the "Report Changed. Rerun?" prompt when it first appears.
+// Amount of time to display the "Script Changed. Rerun?" prompt when it first appears.
 const PROMPT_DISPLAY_INITIAL_TIMEOUT_MS = 15 * 1000
 
-// Amount of time to display the Report Changed prompt after the user has hovered
+// Amount of time to display the Script Changed prompt after the user has hovered
 // and then unhovered on it.
 const PROMPT_DISPLAY_HOVER_TIMEOUT_MS = 1.0 * 1000
 
 /**
- * Displays various report- and connection-related info: our WebSocket
- * connection status, the run-state of our report, and transient report-related
- * events.
+ * Displays various script- and connection-related info: our WebSocket
+ * connection status, the run-state of our script, and other transient events.
  */
 class StatusWidget extends PureComponent<StatusWidgetProps, State> {
   /** onSessionEvent signal connection */
@@ -262,15 +263,15 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
         this.props.scriptRunState === ScriptRunState.RUNNING ||
         this.props.scriptRunState === ScriptRunState.RERUN_REQUESTED
       ) {
-        // Show scriptIsRunning when the report is actually running,
+        // Show scriptIsRunning when the script is actually running,
         // but also when the user has just requested a re-run.
         // In the latter case, the server should get around to actually
-        // re-running the report in a second or two, but we can appear
+        // re-running the script in a second or two, but we can appear
         // more responsive by claiming it's started immemdiately.
         return this.renderScriptIsRunning()
       }
       if (!RERUN_PROMPT_MODAL_DIALOG && this.state.scriptChangedOnDisk) {
-        return this.renderRerunReportPrompt()
+        return this.renderRerunScriptPrompt()
       }
     }
 
@@ -306,7 +307,7 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
     const stopButton = StatusWidget.promptButton(
       stopRequested ? "Stopping..." : "Stop",
       stopRequested,
-      this.handleStopReportClick,
+      this.handleStopScriptClick,
       minimized
     )
 
@@ -341,7 +342,7 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
    * "Source file changed. [Rerun] [Always Rerun]"
    * (This is only shown when the RERUN_PROMPT_MODAL_DIALOG feature flag is false)
    */
-  private renderRerunReportPrompt(): ReactNode {
+  private renderRerunScriptPrompt(): ReactNode {
     const rerunRequested =
       this.props.scriptRunState === ScriptRunState.RERUN_REQUESTED
     const minimized = this.state.promptMinimized && !this.state.promptHovered
@@ -390,7 +391,7 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
     this.minimizePromptAfterTimeout(PROMPT_DISPLAY_HOVER_TIMEOUT_MS)
   }
 
-  private handleStopReportClick = (): void => {
+  private handleStopScriptClick = (): void => {
     this.props.stopScript()
   }
 

--- a/frontend/src/components/core/StatusWidget/styled-components.ts
+++ b/frontend/src/components/core/StatusWidget/styled-components.ts
@@ -56,7 +56,7 @@ export const StyledConnectionStatusLabel = styled.label<
 }))
 
 /*
-  "AppStatus" styles are for report-related statuses:
+  "AppStatus" styles are for app-related statuses:
   whether it's running, if the source file has changed on disk,
   etc.
 */

--- a/frontend/src/components/core/StreamlitDialog/ScriptChangedDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ScriptChangedDialog.tsx
@@ -27,12 +27,14 @@ import { Kind } from "src/components/shared/Button"
 import { StyledShortcutLabel } from "./styled-components"
 
 export interface Props {
-  /** Called to close the dialog without rerunning the report. */
+  /** Called to close the dialog without rerunning the script. */
   onClose: () => void
 
   /**
-   * Called when the user chooses to re-run the report in response to its source file changing.
-   * @param alwaysRerun if true, also change the run-on-save setting for this report
+   * Called when the user chooses to re-run the current script in response to
+   * its source file changing.
+   * @param alwaysRerun if true, also change the run-on-save setting for this
+   * session.
    */
   onRerun: (alwaysRerun: boolean) => void
   allowRunOnSave: boolean

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-import copy from "copy-to-clipboard"
 import React, { ReactElement, ReactNode, CSSProperties } from "react"
-import ProgressBar from "src/components/shared/ProgressBar"
 import { Kind } from "src/components/shared/Button"
 import Modal, {
   ModalHeader,

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -41,10 +41,8 @@ import ThemeCreatorDialog, {
 } from "./ThemeCreatorDialog"
 
 import {
-  StyledUploadFirstLine,
   StyledRerunHeader,
   StyledCommandLine,
-  StyledUploadUrl,
   StyledDeployErrorContent,
   StyledAboutInfo,
 } from "./styled-components"
@@ -71,8 +69,6 @@ export type DialogProps =
   | ScriptChangedProps
   | ScriptCompileErrorProps
   | ThemeCreatorProps
-  | UploadProgressProps
-  | UploadedProps
   | WarningProps
   | DeployErrorProps
 
@@ -84,8 +80,6 @@ export enum DialogType {
   SCRIPT_CHANGED = "scriptChanged",
   SCRIPT_COMPILE_ERROR = "scriptCompileError",
   THEME_CREATOR = "themeCreator",
-  UPLOAD_PROGRESS = "uploadProgress",
-  UPLOADED = "uploaded",
   WARNING = "warning",
   DEPLOY_ERROR = "deployError",
 }
@@ -106,10 +100,6 @@ export function StreamlitDialog(dialogProps: DialogProps): ReactNode {
       return scriptCompileErrorDialog(dialogProps)
     case DialogType.THEME_CREATOR:
       return <ThemeCreatorDialog {...dialogProps} />
-    case DialogType.UPLOAD_PROGRESS:
-      return uploadProgressDialog(dialogProps)
-    case DialogType.UPLOADED:
-      return uploadedDialog(dialogProps)
     case DialogType.WARNING:
       return warningDialog(dialogProps)
     case DialogType.DEPLOY_ERROR:
@@ -343,77 +333,6 @@ function scriptCompileErrorDialog(
  */
 function settingsDialog(props: SettingsProps): ReactElement {
   return <SettingsDialog {...props} />
-}
-
-interface UploadProgressProps {
-  type: DialogType.UPLOAD_PROGRESS
-  progress?: number
-  onClose: PlainEventHandler
-}
-
-/**
- * Shows the progress of an upload in progress.
- */
-function uploadProgressDialog(props: UploadProgressProps): ReactElement {
-  return (
-    <Modal isOpen onClose={props.onClose}>
-      <ModalBody>
-        <StyledUploadFirstLine>Saving app snapshot...</StyledUploadFirstLine>
-        <div>
-          <ProgressBar value={props.progress || 0} />
-        </div>
-      </ModalBody>
-    </Modal>
-  )
-}
-
-interface UploadedProps {
-  type: DialogType.UPLOADED
-  url: string
-  onClose: PlainEventHandler
-}
-
-/**
- * Shows the URL after something has been uploaded.
- */
-function uploadedDialog(props: UploadedProps): ReactElement {
-  const handleClick: () => void = () => {
-    copy(props.url)
-    props.onClose()
-  }
-
-  return (
-    <Modal isOpen onClose={props.onClose}>
-      <ModalBody>
-        <div className="streamlit-upload-first-line">
-          App snapshot saved to:
-        </div>
-        {/* We make this an id instead of a class to enable clipboard copy */}
-        <StyledUploadUrl id="streamlit-upload-url">
-          <a href={props.url} target="_blank" rel="noopener noreferrer">
-            {props.url}
-          </a>
-        </StyledUploadUrl>
-      </ModalBody>
-      <ModalFooter>
-        <ModalButton kind={Kind.SECONDARY} onClick={handleClick}>
-          Copy to clipboard
-        </ModalButton>
-        <ModalButton
-          kind={Kind.SECONDARY}
-          onClick={() => {
-            window.open(props.url, "_blank")
-            props.onClose()
-          }}
-        >
-          Open
-        </ModalButton>
-        <ModalButton kind={Kind.PRIMARY} onClick={props.onClose}>
-          Done
-        </ModalButton>
-      </ModalFooter>
-    </Modal>
-  )
 }
 
 interface WarningProps {

--- a/frontend/src/components/core/StreamlitDialog/UserSettings.ts
+++ b/frontend/src/components/core/StreamlitDialog/UserSettings.ts
@@ -17,13 +17,13 @@
 
 export interface UserSettings {
   /**
-   * If true, the report will be rendered with a wider column size
+   * If true, the app will be rendered with a wider column size
    */
   wideMode: boolean
 
   /**
-   * Flag indicating whether the server should re-run the report automatically
-   * when its source file is modified on disk.
+   * Flag indicating whether the server should re-run an app's scripts automatically
+   * when their source files are modified on disk.
    *
    * The server passes the initial runOnSave value in its 'NewConnection'
    * forward message. If the value is modified via {@link App.saveSettings},

--- a/frontend/src/components/core/StreamlitDialog/styled-components.ts
+++ b/frontend/src/components/core/StreamlitDialog/styled-components.ts
@@ -19,10 +19,6 @@ import styled from "@emotion/styled"
 import { ChevronLeft } from "react-feather"
 import { Small } from "src/components/shared/TextElements"
 
-export const StyledUploadFirstLine = styled.div(({ theme }) => ({
-  marginBottom: theme.spacing.sm,
-}))
-
 export const StyledRerunHeader = styled.div(({ theme }) => ({
   marginBottom: theme.spacing.sm,
 }))
@@ -32,13 +28,6 @@ export const StyledCommandLine = styled.textarea(({ theme }) => ({
   fontFamily: theme.genericFonts.codeFont,
   fontSize: theme.fontSizes.sm,
   height: "6rem",
-}))
-
-export const StyledUploadUrl = styled.pre(({ theme }) => ({
-  fontFamily: theme.genericFonts.codeFont,
-  fontSize: theme.fontSizes.sm,
-  whiteSpace: "normal",
-  wordWrap: "break-word",
 }))
 
 export const StyledShortcutLabel = styled.span(({ theme }) => ({

--- a/frontend/src/components/elements/IFrame/IFrame.test.tsx
+++ b/frontend/src/components/elements/IFrame/IFrame.test.tsx
@@ -117,7 +117,7 @@ describe("st.iframe", () => {
       expect(wrapper.find("iframe").prop("width")).toBe(200)
     })
 
-    it("should set report width", () => {
+    it("should set app width", () => {
       const props = getProps({})
       const wrapper = shallow(<IFrame {...props} />)
       expect(wrapper.find("iframe").prop("width")).toBe(100)

--- a/frontend/src/components/shared/ErrorElement/ErrorElement.tsx
+++ b/frontend/src/components/shared/ErrorElement/ErrorElement.tsx
@@ -29,7 +29,7 @@ export interface ErrorElementProps {
 /**
  * A component that draws an error on the screen. This is for internal use
  * only. That is, this should not be an element that a user purposefully places
- * in a Streamlit report. For that, see st.exception / Exception.tsx or
+ * in a Streamlit app. For that, see st.exception / Exception.tsx or
  * st.error / Text.tsx.
  */
 function ErrorElement(props: ErrorElementProps): ReactElement {

--- a/frontend/src/components/widgets/Form/Form.tsx
+++ b/frontend/src/components/widgets/Form/Form.tsx
@@ -60,7 +60,7 @@ export function Form(props: Props): ReactElement {
   // Determine if we need to show the "missing submit button" warning.
   // If we have a submit button, we don't show the warning, of course.
   // If we *don't* have a submit button, then we only mutate the showWarning
-  // flag when our scriptRunState is NOT_RUNNING. (If the report is still
+  // flag when our scriptRunState is NOT_RUNNING. (If the script is still
   // running, there might be an incoming SubmitButton delta that we just
   // haven't seen yet.)
   const [showWarning, setShowWarning] = useState(false)

--- a/frontend/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.tsx
@@ -141,7 +141,7 @@ class TextArea extends React.PureComponent<Props, State> {
 
     // If TextArea *is* part of a form, we immediately update its widgetValue
     // on text changes. The widgetValue won't be passed to the Python
-    // script until the form is submitted, so this won't cause the report
+    // script until the form is submitted, so this won't cause the script
     // to re-run. (This also means that we won't show the "Press Enter
     // to Apply" prompt because the TextArea will never be "dirty").
     this.setState({ dirty: false, value }, () =>

--- a/frontend/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.tsx
@@ -141,7 +141,7 @@ class TextInput extends React.PureComponent<Props, State> {
 
     // If TextInput *is* part of a form, we immediately update its widgetValue
     // on text changes. The widgetValue won't be passed to the Python
-    // script until the form is submitted, so this won't cause the report
+    // script until the form is submitted, so this won't cause the script
     // to re-run. (This also means that we won't show the "Press Enter
     // to Apply" prompt because the TextInput will never be "dirty").
     this.setState({ dirty: false, value }, () =>

--- a/frontend/src/lib/AppNode.test.ts
+++ b/frontend/src/lib/AppNode.test.ts
@@ -835,7 +835,7 @@ describe("AppRoot.applyDelta", () => {
     const newNode = newRoot.main.getIn([1, 1]) as ElementNode
     expect(newNode).toBeTextNode("newElement!")
 
-    // Check that our new reportID has been set only on the touched nodes
+    // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
@@ -855,7 +855,7 @@ describe("AppRoot.applyDelta", () => {
     const newNode = newRoot.main.getIn([1, 1]) as BlockNode
     expect(newNode).toBeDefined()
 
-    // Check that our new reportID has been set only on the touched nodes
+    // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
@@ -866,7 +866,7 @@ describe("AppRoot.applyDelta", () => {
 
   const addRowsTypes = ["dataFrame", "table", "vegaLiteChart"]
   it.each(addRowsTypes)("handles 'addRows' for %s", elementType => {
-    // Create a report with a dataframe node
+    // Create an app with a dataframe node
     const root = AppRoot.empty().applyDelta(
       "preAddRows",
       makeProto(DeltaProto, {

--- a/frontend/src/lib/AppNode.ts
+++ b/frontend/src/lib/AppNode.ts
@@ -46,7 +46,7 @@ import {
 const NO_SCRIPT_RUN_ID = "NO_SCRIPT_RUN_ID"
 
 /**
- * An immutable node of the "Report Data Tree".
+ * An immutable node of the "App Data Tree".
  *
  * Trees are composed of `ElementNode` leaves, which contain data about
  * a single visual element, and `BlockNode` branches, which determine the

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -47,7 +47,6 @@ function createForwardMsg(hash: string, cacheable = true): ForwardMsg {
   return ForwardMsg.fromObject({
     hash,
     metadata: { cacheable, deltaId: 0 },
-    reportUploaded: hash,
   })
 }
 

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -62,14 +62,14 @@ export class MetricsManager {
   private pendingEvents: Event[] = []
 
   /**
-   * Object used to count the number of delta types seen in a given report.
+   * Object used to count the number of delta types seen in a given script run.
    * Maps type of delta (string) to count (number).
    */
   private pendingDeltaCounter: DeltaCounter = {}
 
   /**
-   * Object used to count the number of custom instance names seen in a given report.
-   * Maps type of custom instance name (string) to count (number).
+   * Object used to count the number of custom instance names seen in a given
+   * script run. Maps type of custom instance name (string) to count (number).
    */
   private pendingCustomComponentCounter: CustomComponentCounter = {}
 

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -451,7 +451,7 @@ export class WebsocketConnection {
   }
 
   /**
-   * Called when our report has finished running. Calls through
+   * Called when our script has finished running. Calls through
    * to the ForwardMsgCache, to handle cached entry expiry.
    */
   public incrementMessageCacheRunCount(maxMessageAge: number): void {

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -512,7 +512,7 @@ export class WidgetStateManager {
 
   /**
    * Remove the state of widgets that are not contained in `activeIds`.
-   * This is called when a report finishes running, so that we don't retain
+   * This is called when a script finishes running, so that we don't retain
    * data for widgets that have been removed from the app.
    */
   public removeInactive(activeIds: Set<string>): void {

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -368,7 +368,7 @@ class AppSession:
         self.enqueue(msg)
 
     def _enqueue_file_change_message(self):
-        LOGGER.debug("Enqueuing report_changed message (id=%s)", self.id)
+        LOGGER.debug("Enqueuing script_changed message (id=%s)", self.id)
         msg = ForwardMsg()
         msg.session_event.script_changed_on_disk = True
         self.enqueue(msg)
@@ -386,7 +386,7 @@ class AppSession:
         _populate_config_msg(msg.new_session.config)
         _populate_theme_msg(msg.new_session.custom_theme)
 
-        # Immutable session data. We send this every time a new report is
+        # Immutable session data. We send this every time a new session is
         # started, to avoid having to track whether the client has already
         # received it. It does not change from run to run; it's up to the
         # to perform one-time initialization only once.

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -297,7 +297,7 @@ class ButtonMixin:
         # for the "Form Submitter" button that's automatically created in
         # every form). We throw an error to warn the user about this.
         # We omit this check for scripts running outside streamlit, because
-        # they will have no report_ctx.
+        # they will have no script_run_ctx.
         if streamlit._is_running_with_streamlit:
             if is_in_form(self.dg) and not is_form_submitter:
                 raise StreamlitAPIException(

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -34,7 +34,7 @@ class IframeMixin:
         src : str
             The URL of the page to embed.
         width : int
-            The width of the frame in CSS pixels. Defaults to the report's
+            The width of the frame in CSS pixels. Defaults to the app's
             default element width.
         height : int
             The height of the frame in CSS pixels. Defaults to 150.
@@ -67,7 +67,7 @@ class IframeMixin:
         html : str
             The HTML string to embed in the iframe.
         width : int
-            The width of the frame in CSS pixels. Defaults to the report's
+            The width of the frame in CSS pixels. Defaults to the app's
             default element width.
         height : int
             The height of the frame in CSS pixels. Defaults to 150.
@@ -115,7 +115,7 @@ def marshall(
     srcdoc : str
         Inline HTML to embed. Overrides src.
     width : int
-        The width of the frame in CSS pixels. Defaults to the report's
+        The width of the frame in CSS pixels. Defaults to the app's
         default element width.
     height : int
         The height of the frame in CSS pixels. Defaults to 150.

--- a/lib/streamlit/forward_msg_queue.py
+++ b/lib/streamlit/forward_msg_queue.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-A queue of ForwardMsg associated with a particular report.
+A queue of ForwardMsg associated with a particular session.
 Whenever possible, message deltas are combined.
 """
 
@@ -32,7 +32,7 @@ LOGGER = get_logger(__name__)
 
 @attr.s(auto_attribs=True, slots=True)
 class ForwardMsgQueue:
-    """Thread-safe queue that smartly accumulates the report's messages."""
+    """Thread-safe queue that smartly accumulates the session's messages."""
 
     _lock: threading.Lock = attr.Factory(threading.Lock)
     _queue: List[ForwardMsg] = attr.Factory(list)
@@ -72,7 +72,7 @@ class ForwardMsgQueue:
 
             # If there's a Delta message with the same delta_path already in
             # the queue - meaning that it refers to the same location in
-            # the report - we attempt to combine this new Delta into the old
+            # the app - we attempt to combine this new Delta into the old
             # one. This is an optimization that prevents redundant Deltas
             # from being sent to the frontend.
             delta_key = tuple(msg.metadata.delta_path)

--- a/lib/streamlit/in_memory_file_manager.py
+++ b/lib/streamlit/in_memory_file_manager.py
@@ -156,7 +156,7 @@ class InMemoryFileManager(CacheStatsProvider):
     - Which files are being used by which AppSession (by ID). This is
       important so we can remove files from memory when no more sessions need
       them.
-    - The exact location in the report where each file is being used (i.e. the
+    - The exact location in the app where each file is being used (i.e. the
       file's "coordinates"). This is is important so we can mark a file as "not
       being used by a certain session" if it gets replaced by another file at
       the same coordinates. For example, when doing an animation where the same

--- a/lib/streamlit/legacy_caching/hashing.py
+++ b/lib/streamlit/legacy_caching/hashing.py
@@ -716,7 +716,7 @@ class _CodeHasher:
         import __main__
         import os
 
-        # This works because we set __main__.__file__ to the report
+        # This works because we set __main__.__file__ to the
         # script path in ScriptRunner.
         main_path = __main__.__file__
         return str(os.path.dirname(main_path))

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -119,7 +119,7 @@ class SessionInfo:
     """Type stored in our _session_info_by_id dict.
 
     For each AppSession, the server tracks that session's
-    report_run_count. This is used to track the age of messages in
+    script_run_count. This is used to track the age of messages in
     the ForwardMsgCache.
     """
 
@@ -131,11 +131,11 @@ class SessionInfo:
         session : AppSession
             The AppSession object.
         ws : _BrowserWebSocketHandler
-            The websocket that owns this report.
+            The websocket corresponding to this session.
         """
         self.session = session
         self.ws = ws
-        self.report_run_count = 0
+        self.script_run_count = 0
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -590,7 +590,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             populate_hash_if_needed(msg)
 
             if self._message_cache.has_message_reference(
-                msg, session_info.session, session_info.report_run_count
+                msg, session_info.session, session_info.script_run_count
             ):
                 # This session has probably cached this message. Send
                 # a reference instead.
@@ -602,24 +602,24 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             # age.
             LOGGER.debug("Caching message (hash=%s)" % msg.hash)
             self._message_cache.add_message(
-                msg, session_info.session, session_info.report_run_count
+                msg, session_info.session, session_info.script_run_count
             )
 
         # If this was a `script_finished` message, we increment the
-        # report_run_count for this session, and update the cache
+        # script_run_count for this session, and update the cache
         if (
             msg.WhichOneof("type") == "script_finished"
             and msg.script_finished == ForwardMsg.FINISHED_SUCCESSFULLY
         ):
             LOGGER.debug(
-                "Report finished successfully; "
+                "Script run finished successfully; "
                 "removing expired entries from MessageCache "
                 "(max_age=%s)",
                 config.get_option("global.maxCachedMessageAge"),
             )
-            session_info.report_run_count += 1
+            session_info.script_run_count += 1
             self._message_cache.remove_expired_session_entries(
-                session_info.session, session_info.report_run_count
+                session_info.session, session_info.script_run_count
             )
 
         # Ship it off!

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -619,7 +619,7 @@ def get_session_state() -> SessionState:
 
     ctx = get_script_run_ctx()
 
-    # If there is no report context because the script is run bare, have
+    # If there is no script run context because the script is run bare, have
     # session state act as an always empty dictionary, and print a warning.
     if ctx is None:
         if not _state_use_warning_already_displayed:

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -133,9 +133,8 @@ def register_widget(
     element_proto.id = widget_id
 
     if ctx is None:
-        # Early-out if we're not running inside a ReportThread (which
-        # probably means we're running as a "bare" Python script, and
-        # not via `streamlit run`).
+        # Early-out if we don't have a script run context (which probably means
+        # we're running as a "bare" Python script, and not via `streamlit run`).
         return (deserializer(None, ""), False)
 
     # Register the widget, and ensure another widget with the same id hasn't

--- a/lib/streamlit/uploaded_file_manager.py
+++ b/lib/streamlit/uploaded_file_manager.py
@@ -100,9 +100,9 @@ class UploadedFileManager(CacheStatsProvider):
         Parameters
         ----------
         session_id
-            The session ID of the report that owns the files.
+            The ID of the session that owns the file.
         widget_id
-            The widget ID of the FileUploader that created the files.
+            The widget ID of the FileUploader that created the file.
         file
             The file to add.
 
@@ -135,9 +135,9 @@ class UploadedFileManager(CacheStatsProvider):
         Parameters
         ----------
         session_id
-            The session ID of the report that owns the file.
+            The ID of the session that owns the files.
         widget_id
-            The widget ID of the FileUploader that created the file.
+            The widget ID of the FileUploader that created the files.
         """
         file_list_id = (session_id, widget_id)
         with self._files_lock:
@@ -151,9 +151,9 @@ class UploadedFileManager(CacheStatsProvider):
         Parameters
         ----------
         session_id
-            The session ID of the report that owns the file.
+            The ID of the session that owns the files.
         widget_id
-            The widget ID of the FileUploader that created the file.
+            The widget ID of the FileUploader that created the files.
         file_ids
             List of file IDs. Only files whose IDs are in this list will be
             returned.
@@ -257,20 +257,20 @@ class UploadedFileManager(CacheStatsProvider):
         Parameters
         ----------
         session_id : str
-            The session ID of the report that owns the file.
+            The ID of the session that owns the files.
         widget_id : str
-            The widget ID of the FileUploader that created the file.
+            The widget ID of the FileUploader that created the files.
         """
         self._remove_files(session_id, widget_id)
         self.on_files_updated.send(session_id)
 
     def remove_session_files(self, session_id: str) -> None:
-        """Remove all files that belong to the given report.
+        """Remove all files that belong to the given session.
 
         Parameters
         ----------
         session_id : str
-            The session ID of the report whose files we're removing.
+            The ID of the session whose files we're removing.
 
         """
         # Copy the keys into a list, because we'll be mutating the dictionary.


### PR DESCRIPTION
## 📚 Context

NOTE: This PR is probably most easily reviewed commit-wise.

I noticed some usage of the term "report" (mostly in docstrings, etc) that
managed to slip by in the recently merged report refactor. This PR attempts to
wrap up removing the last few stragglers.

I also reworded some of the script-related comments so that they'll continue to
make sense after we implement multipage apps (which may have multiple scripts).

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: report refactor cleanup

## 🧠 Description of Changes

(These are just copied from my commit titles)

- Clean up a few more bits of dead code related to report sharing
- s/report/script in the forward message cache
- s/report/"script run" in MetricsManager.ts
- s/report/session in upload_file_manager.py
- Replace references to report in forward_msg_queue.py
- Remove/replace "report" usage in the rest of the streamlit server
- Remove/replace remaining mentions of report in the frontend dir
