### PR TITLE
Fix docstring formatting issues

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -257,7 +257,6 @@ def experimental_show(*args):
 
     Example
     -------
-
     >>> dataframe = pd.DataFrame({
     ...     'first column': [1, 2, 3, 4],
     ...     'second column': [10, 20, 30, 40],
@@ -266,13 +265,12 @@ def experimental_show(*args):
 
     Notes
     -----
-
     This is an experimental feature with usage limitations:
 
     - The method must be called with the name `show`.
     - Must be called in one line of code, and only once per line.
     - When passing multiple arguments the inclusion of `,` or `)` in a string
-    argument may cause an error.
+        argument may cause an error.
 
     """
     if not args:
@@ -323,7 +321,6 @@ def experimental_get_query_params():
 
     Example
     -------
-
     Let's say the user's web browser is at
     `http://localhost:8501/?show_map=True&selected=asia&selected=america`.
     Then, you can get the query parameters using the following:

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -92,7 +92,7 @@ class CameraInputMixin:
             a file is expected.
 
         Examples
-        -------
+        --------
         >>> import streamlit as st
         >>>
         >>> picture = st.camera_input("Take a picture")


### PR DESCRIPTION
## 📚 Context
Improperly formatted docstrings (deviating from the [numpydoc convention](https://numpydoc.readthedocs.io/en/latest/format.html)) cause rendering issues on the docs site.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Docs improvement request

## 🧠 Description of Changes

- This small PR fixes indents and line breaks in docstrings.

  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/150122576-253c0c20-7075-4f98-9cb8-f752ea91c460.png)
![image](https://user-images.githubusercontent.com/20672874/150122744-ca902b50-106a-4369-8c91-b2e24166a9d6.png)


**Current:**
![image](https://user-images.githubusercontent.com/20672874/150122988-c99ca294-1adf-4a39-8808-684f5be544bb.png)
![image](https://user-images.githubusercontent.com/20672874/150123132-1d5e7901-d953-45dd-8a9e-c1803b019577.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
