### PR TITLE
Set package name correctly in nightly

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -82,7 +82,10 @@ def _download_remote(script_path, url_path):
 
 @click.group(context_settings={"auto_envvar_prefix": "STREAMLIT"})
 @click.option("--log_level", show_default=True, type=click.Choice(LOG_LEVELS))
-@click.version_option(prog_name="Streamlit")
+@click.version_option(
+    prog_name="Streamlit",
+    package_name="streamlit",
+)
 @click.pass_context
 def main(ctx, log_level="info"):
     """Try out a demo with:

--- a/scripts/update_name.py
+++ b/scripts/update_name.py
@@ -29,6 +29,7 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 PYTHON = {
     "lib/setup.py": r"(?P<pre>.*NAME = \").*(?P<post>\")",
     "lib/streamlit/__init__.py": r"(?P<pre>.*get_distribution\(\").*(?P<post>\"\)\.version$)",
+    "lib/streamlit/cli.py": r"(?P<pre>.*package_name=\").*(?P<post>\")",
     "lib/streamlit/version.py": r"(?P<pre>.*get_distribution\(\").*(?P<post>\"\)\.version$)",
 }
 


### PR DESCRIPTION
## 📚 Context

Merging #4259 broke the nightly build, which was.. confusing. It turns out the
reason this happened was that running `streamlit version` has not worked in the
nightly for awhile, and #4259 simply uncovered this by running
`streamlit version` in the cli smoke tests.

The reason the `version` command didn't work is because `click` uses the
program/package names to look up what version a package is when adding a
`--version` flag with the `@click.version_option` decorator. This proves
problematic in the `streamlit-nightly` package, where the package name doesn't
match the `streamlit` binary name.

The fix for this is to manually specify `package_name` in the
`@click.version_option` decorator. The package name is normally `streamlit`, but
it's now changed to `streamlit-nightly` in the script that does all the related
package renaming used by the nightly build job.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Other, please describe: Fix the build :(

## 🧠 Description of Changes

- Add a `package_name` field to the click version decorator
- Set the newly added field in the `update_name.py` script (used by the nightly
  build job)
