### PR TITLE
Run help instead of version in the CLI smoke tests (to fix the nightly)

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -111,6 +111,10 @@ def help(ctx):
     # Pretend user typed 'streamlit --help' instead of 'streamlit help'.
     import sys
 
+    # We use _get_command_line_as_string to run some assertions but don't do
+    # anything with its return value.
+    _get_command_line_as_string()
+
     assert len(sys.argv) == 2  # This is always true, but let's assert anyway.
     sys.argv[1] = "--help"
     main(prog_name="streamlit")

--- a/scripts/cli_smoke_tests.py
+++ b/scripts/cli_smoke_tests.py
@@ -20,21 +20,21 @@ import click
 
 
 def main():
-    standard_cli = ["streamlit", "version"]
-    if not _can_run_streamlit_version(standard_cli):
-        sys.exit("Failed to run `streamlit version`")
+    standard_cli = ["streamlit", "help"]
+    if not _can_run_streamlit_help(standard_cli):
+        sys.exit("Failed to run `streamlit help`")
 
     # When calling from module, the called argv[0] is updated by
     # __main__.py to be "streamlit" instead of "__main__.py".
     # If this doesn't occur, an assert stops execution of the program.
-    module_cli = ["python", "-m", "streamlit", "version"]
-    if not _can_run_streamlit_version(module_cli):
-        sys.exit("Failed to run `python -m streamlit version`")
+    module_cli = ["python", "-m", "streamlit", "help"]
+    if not _can_run_streamlit_help(module_cli):
+        sys.exit("Failed to run `python -m streamlit help`")
 
     click.secho("CLI smoke tests succeeded!", fg="green", bold=True)
 
 
-def _can_run_streamlit_version(command_list):
+def _can_run_streamlit_help(command_list):
     result = subprocess.run(command_list, stdout=subprocess.DEVNULL)
     return result.returncode == 0
 


### PR DESCRIPTION
## 📚 Context

#4259 broke the nightly for reasons described in the PR description of #4301.
While a totally correct fix as built in #4301 would be preferable, this proves
to be problematic because we support both click 7 and click 8, and the decorator
kwarg that fixes the problem only exists in click 8.

We'll probably want to figure out a way to properly fix this eventually (not being
able to run `streamlit version` in the nightly releases is pretty inconsequential but
also a bit sad), but for now we can get the nightly working again by simply running
the test with `streamlit help` instead of `streamlit version`

- What kind of change does this PR introduce?

  - [x] Other, please describe: Fix the nightly 😞 

## 🧠 Description of Changes

- Run `streamlit help` instead of `streamlit version` in the CLI smoke tests
