### PR TITLE
[Pure design change] Make checkbox/radio only show focus when tabbing, not when clicked.

### DIFF
--- a/frontend/src/components/shared/Radio/Radio.tsx
+++ b/frontend/src/components/shared/Radio/Radio.tsx
@@ -99,13 +99,17 @@ class Radio extends React.PureComponent<Props, State> {
               value={index.toString()}
               overrides={{
                 Root: {
-                  style: ({ $isFocused }: { $isFocused: boolean }) => ({
+                  style: ({
+                    $isFocusVisible,
+                  }: {
+                    $isFocusVisible: boolean
+                  }) => ({
                     marginBottom: 0,
                     marginTop: 0,
                     // Make left and right padding look the same visually.
                     paddingLeft: 0,
                     paddingRight: "2px",
-                    backgroundColor: $isFocused
+                    backgroundColor: $isFocusVisible
                       ? colors.transparentDarkenedBgMix60
                       : "",
                     borderTopLeftRadius: radii.md,

--- a/frontend/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.tsx
@@ -141,11 +141,11 @@ class Checkbox extends React.PureComponent<Props, State> {
           onChange={this.onChange}
           overrides={{
             Root: {
-              style: ({ $isFocused }: { $isFocused: boolean }) => ({
+              style: ({ $isFocusVisible }: { $isFocusVisible: boolean }) => ({
                 marginBottom: 0,
                 marginTop: 0,
                 paddingRight: spacing.twoThirdsSmFont,
-                backgroundColor: $isFocused
+                backgroundColor: $isFocusVisible
                   ? colors.transparentDarkenedBgMix60
                   : "",
                 borderTopLeftRadius: radii.md,


### PR DESCRIPTION
## 📚 Context

Focus queues are often confusing for mouse-based users (why is there
sometimes a box around this element?). To help with this, in this PR I
replace the "focus" state with the "focus-visible" state, which tries to
be smart about when to draw focus queues around an element.

Here's a nice little write-up about "focus-visible":
https://matthiasott.com/notes/focus-visible-is-here

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: visual updates


## 🧠 Description of Changes

- Make checkbox and radio focus use "focus-visible" rather than "focus"

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

No existing tests are impacted by this change, and I felt the cost/benefit ratio of writing of new tests just for this would be too high (high cost, low benefit). LMK if you think otherwise!  

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

No. This is a very minor change, not connected to any existing issue.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
