### PR TITLE
Pandas 1.4 styler fix

### DIFF
--- a/lib/streamlit/elements/legacy_data_frame.py
+++ b/lib/streamlit/elements/legacy_data_frame.py
@@ -253,7 +253,7 @@ def _get_css_styles(translated_style):
             match = cell_selector_regex.match(cell_selector)
             if not match:
                 raise RuntimeError(
-                    'Failed to parse cellstyle selector "%s"' % cell_selector
+                    f'Failed to parse cellstyle selector "{cell_selector}"'
                 )
             row = int(match.group(1))
             col = int(match.group(2))
@@ -261,7 +261,7 @@ def _get_css_styles(translated_style):
             props = cell_style["props"]
             for prop in props:
                 if not isinstance(prop, (tuple, list)) or len(prop) != 2:
-                    raise RuntimeError('Unexpected cellstyle props "%s"' % prop)
+                    raise RuntimeError(f'Unexpected cellstyle props "{prop}"')
                 name = str(prop[0]).strip()
                 value = str(prop[1]).strip()
                 if name and value:

--- a/lib/streamlit/elements/legacy_data_frame.py
+++ b/lib/streamlit/elements/legacy_data_frame.py
@@ -17,15 +17,20 @@
 import datetime
 import re
 from collections import namedtuple
-from typing import cast
+from typing import cast, Dict, Any, Optional
 
 import pyarrow as pa
 import tzlocal
+from pandas import DataFrame
+from pandas.io.formats.style import Styler
 
 import streamlit
 from streamlit import errors, type_util
 from streamlit.logger import get_logger
-from streamlit.proto.DataFrame_pb2 import DataFrame as DataFrameProto
+from streamlit.proto.DataFrame_pb2 import (
+    DataFrame as DataFrameProto,
+    TableStyle as TableStyleProto,
+)
 
 LOGGER = get_logger(__name__)
 
@@ -127,7 +132,7 @@ class LegacyDataFrameMixin:
         return cast("streamlit.delta_generator.DeltaGenerator", self)
 
 
-def marshall_data_frame(data, proto_df):
+def marshall_data_frame(data: Any, proto_df: DataFrameProto) -> None:
     """Convert a pandas.DataFrame into a proto.DataFrame.
 
     Parameters
@@ -160,7 +165,9 @@ To be able to use pyarrow tables, please enable pyarrow by changing the config s
     _marshall_styles(proto_df.style, df, styler)
 
 
-def _marshall_styles(proto_table_style, df, styler=None):
+def _marshall_styles(
+    proto_table_style: TableStyleProto, df: DataFrame, styler: Optional[Styler] = None
+) -> None:
     """Adds pandas.Styler styling data to a proto.DataFrame
 
     Parameters
@@ -284,7 +291,7 @@ def _get_custom_display_values(df, translated_style):
 
     default_formatter = df.style._display_funcs[(0, 0)]
 
-    def has_custom_display_value(cell):
+    def has_custom_display_value(cell: Dict[Any, Any]) -> bool:
         value = cell["value"]
         display_value = cell["display_value"]
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -242,7 +242,7 @@ def is_pydeck(obj):
     return is_type(obj, "pydeck.bindings.deck.Deck")
 
 
-def convert_anything_to_df(df):
+def convert_anything_to_df(df: Any) -> DataFrame:
     """Try to convert different formats to a Pandas Dataframe.
 
     Parameters

--- a/lib/tests/streamlit/legacy_dataframe_styling_test.py
+++ b/lib/tests/streamlit/legacy_dataframe_styling_test.py
@@ -46,9 +46,9 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
         for row in range(rows):
             for col in range(cols):
                 style = get_cell_style(proto_df, col, row)
-                self.assertEqual(style.display_value, "")
-                self.assertEqual(style.has_display_value, False)
-                self.assertEqual(len(style.css), 0)
+                self.assertEqual(False, style.has_display_value)
+                self.assertEqual("", style.display_value)
+                self.assertEqual(0, len(style.css))
 
     @parameterized.expand(
         [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]

--- a/lib/tests/streamlit/legacy_dataframe_styling_test.py
+++ b/lib/tests/streamlit/legacy_dataframe_styling_test.py
@@ -19,9 +19,18 @@ import pandas as pd
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.proto.DataFrame_pb2 import CellStyle
+from streamlit.proto.DataFrame_pb2 import CellStyle, DataFrame, Table
 from streamlit.proto.DataFrame_pb2 import CSSStyle
+from streamlit.proto.Element_pb2 import Element
 from tests import testutil
+
+
+def _get_df_proto(element: Element) -> DataFrame:
+    return element.data_frame
+
+
+def _get_table_proto(element: Element) -> Table:
+    return element.table
 
 
 class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
@@ -30,9 +39,9 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
     """
 
     @parameterized.expand(
-        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
+        [(st._legacy_dataframe, _get_df_proto), (st._legacy_table, _get_table_proto)]
     )
-    def test_unstyled_has_no_style(self, st_element, proto):
+    def test_unstyled_has_no_style(self, st_element, get_proto):
         """A DataFrame with an unmodified Styler should result in a protobuf
         with no styling data
         """
@@ -40,7 +49,7 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
         df = pd.DataFrame({"A": [1, 2, 3, 4, 5]})
 
         st_element(df.style)
-        proto_df = getattr(self._get_element(), proto)
+        proto_df = get_proto(self._get_element())
 
         rows, cols = df.shape
         for row in range(rows):
@@ -51,9 +60,9 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
                 self.assertEqual(0, len(style.css))
 
     @parameterized.expand(
-        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
+        [(st._legacy_dataframe, _get_df_proto), (st._legacy_table, _get_table_proto)]
     )
-    def test_format(self, st_element, proto):
+    def test_format(self, st_element, get_proto):
         """Tests DataFrame.style.format()"""
         values = [0.1, 0.2, 0.3352, np.nan]
         display_values = ["10.00%", "20.00%", "33.52%", "nan%"]
@@ -62,13 +71,13 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
 
         st_element(df.style.format("{:.2%}"))
 
-        proto_df = getattr(self._get_element(), proto)
+        proto_df = get_proto(self._get_element())
         self._assert_column_display_values(proto_df, 0, display_values)
 
     @parameterized.expand(
-        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
+        [(st._legacy_dataframe, _get_df_proto), (st._legacy_table, _get_table_proto)]
     )
-    def test_css_styling(self, st_element, proto):
+    def test_css_styling(self, st_element, get_proto):
         """Tests DataFrame.style css styling"""
 
         values = [-1, 1]
@@ -85,13 +94,13 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
             )
         )
 
-        proto_df = getattr(self._get_element(), proto)
+        proto_df = get_proto(self._get_element())
         self._assert_column_css_styles(proto_df, 0, css_values)
 
     @parameterized.expand(
-        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
+        [(st._legacy_dataframe, _get_df_proto), (st._legacy_table, _get_table_proto)]
     )
-    def test_add_styled_rows(self, st_element, proto):
+    def test_add_styled_rows(self, st_element, get_proto):
         """Add rows should preserve existing styles and append new styles"""
         df1 = pd.DataFrame([5, 6])
         df2 = pd.DataFrame([7, 8])
@@ -107,13 +116,13 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
 
         x._legacy_add_rows(df2.style.applymap(lambda val: "color: black"))
 
-        proto_df = getattr(self._get_element(), proto)
+        proto_df = get_proto(self._get_element())
         self._assert_column_css_styles(proto_df, 0, css_values)
 
     @parameterized.expand(
-        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
+        [(st._legacy_dataframe, _get_df_proto), (st._legacy_table, _get_table_proto)]
     )
-    def test_add_styled_rows_to_unstyled_rows(self, st_element, proto):
+    def test_add_styled_rows_to_unstyled_rows(self, st_element, get_proto):
         """Adding styled rows to unstyled rows should work"""
         df1 = pd.DataFrame([5, 6])
         df2 = pd.DataFrame([7, 8])
@@ -128,13 +137,13 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
         x = st_element(df1)
         x._legacy_add_rows(df2.style.applymap(lambda val: "color: black"))
 
-        proto_df = getattr(self._get_element(), proto)
+        proto_df = get_proto(self._get_element())
         self._assert_column_css_styles(proto_df, 0, css_values)
 
     @parameterized.expand(
-        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
+        [(st._legacy_dataframe, _get_df_proto), (st._legacy_table, _get_table_proto)]
     )
-    def test_add_unstyled_rows_to_styled_rows(self, st_element, proto):
+    def test_add_unstyled_rows_to_styled_rows(self, st_element, get_proto):
         """Adding unstyled rows to styled rows should work"""
         df1 = pd.DataFrame([5, 6])
         df2 = pd.DataFrame([7, 8])
@@ -150,14 +159,14 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
 
         x._legacy_add_rows(df2)
 
-        proto_df = getattr(self._get_element(), proto)
+        proto_df = get_proto(self._get_element())
         self._assert_column_css_styles(proto_df, 0, css_values)
 
-    def _get_element(self):
+    def _get_element(self) -> Element:
         """Returns the most recent element in the DeltaGenerator queue"""
         return self.get_delta_from_queue().new_element
 
-    def _assert_column_display_values(self, proto_df, col, display_values):
+    def _assert_column_display_values(self, proto_df, col, display_values) -> None:
         """Asserts that cells in a column have the given display_values"""
         for row in range(len(display_values)):
             style = get_cell_style(proto_df, col, row)

--- a/lib/tests/streamlit/legacy_dataframe_styling_test.py
+++ b/lib/tests/streamlit/legacy_dataframe_styling_test.py
@@ -30,16 +30,16 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
     """
 
     @parameterized.expand(
-        [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]
+        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
     )
-    def test_unstyled_has_no_style(self, element, proto):
+    def test_unstyled_has_no_style(self, st_element, proto):
         """A DataFrame with an unmodified Styler should result in a protobuf
         with no styling data
         """
 
         df = pd.DataFrame({"A": [1, 2, 3, 4, 5]})
 
-        getattr(st, element)(df.style)
+        st_element(df.style)
         proto_df = getattr(self._get_element(), proto)
 
         rows, cols = df.shape
@@ -51,25 +51,24 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
                 self.assertEqual(0, len(style.css))
 
     @parameterized.expand(
-        [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]
+        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
     )
-    def test_format(self, element, proto):
+    def test_format(self, st_element, proto):
         """Tests DataFrame.style.format()"""
         values = [0.1, 0.2, 0.3352, np.nan]
         display_values = ["10.00%", "20.00%", "33.52%", "nan%"]
 
         df = pd.DataFrame({"A": values})
 
-        get_delta = getattr(st, element)
-        get_delta(df.style.format("{:.2%}"))
+        st_element(df.style.format("{:.2%}"))
 
         proto_df = getattr(self._get_element(), proto)
         self._assert_column_display_values(proto_df, 0, display_values)
 
     @parameterized.expand(
-        [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]
+        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
     )
-    def test_css_styling(self, element, proto):
+    def test_css_styling(self, st_element, proto):
         """Tests DataFrame.style css styling"""
 
         values = [-1, 1]
@@ -80,8 +79,7 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
 
         df = pd.DataFrame({"A": values})
 
-        get_delta = getattr(st, element)
-        get_delta(
+        st_element(
             df.style.highlight_max(color="yellow").applymap(
                 lambda val: "color: red" if val < 0 else "color: black"
             )
@@ -91,9 +89,9 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
         self._assert_column_css_styles(proto_df, 0, css_values)
 
     @parameterized.expand(
-        [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]
+        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
     )
-    def test_add_styled_rows(self, element, proto):
+    def test_add_styled_rows(self, st_element, proto):
         """Add rows should preserve existing styles and append new styles"""
         df1 = pd.DataFrame([5, 6])
         df2 = pd.DataFrame([7, 8])
@@ -105,8 +103,7 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
             {css_s("color", "black")},
         ]
 
-        get_delta = getattr(st, element)
-        x = get_delta(df1.style.applymap(lambda val: "color: red"))
+        x = st_element(df1.style.applymap(lambda val: "color: red"))
 
         x._legacy_add_rows(df2.style.applymap(lambda val: "color: black"))
 
@@ -114,9 +111,9 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
         self._assert_column_css_styles(proto_df, 0, css_values)
 
     @parameterized.expand(
-        [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]
+        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
     )
-    def test_add_styled_rows_to_unstyled_rows(self, element, proto):
+    def test_add_styled_rows_to_unstyled_rows(self, st_element, proto):
         """Adding styled rows to unstyled rows should work"""
         df1 = pd.DataFrame([5, 6])
         df2 = pd.DataFrame([7, 8])
@@ -128,16 +125,16 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
             {css_s("color", "black")},
         ]
 
-        x = getattr(st, element)(df1)
+        x = st_element(df1)
         x._legacy_add_rows(df2.style.applymap(lambda val: "color: black"))
 
         proto_df = getattr(self._get_element(), proto)
         self._assert_column_css_styles(proto_df, 0, css_values)
 
     @parameterized.expand(
-        [("_legacy_dataframe", "data_frame"), ("_legacy_table", "table")]
+        [(st._legacy_dataframe, "data_frame"), (st._legacy_table, "table")]
     )
-    def test_add_unstyled_rows_to_styled_rows(self, element, proto):
+    def test_add_unstyled_rows_to_styled_rows(self, st_element, proto):
         """Adding unstyled rows to styled rows should work"""
         df1 = pd.DataFrame([5, 6])
         df2 = pd.DataFrame([7, 8])
@@ -149,8 +146,7 @@ class LegacyDataFrameStylingTest(testutil.DeltaGeneratorTestCase):
             set(),
         ]
 
-        get_delta = getattr(st, element)
-        x = get_delta(df1.style.applymap(lambda val: "color: black"))
+        x = st_element(df1.style.applymap(lambda val: "color: black"))
 
         x._legacy_add_rows(df2)
 


### PR DESCRIPTION
Change the way we detect custom styling in a DataFrame, to account for changes in Pandas 1.4.

Our DataFrame styling support is based on internal Pandas APIs, so they're always subject to change out from underneath us. In general, we'd prefer to only pass `display_value` data to the frontend when a DataFrame cell has been custom-formatted by the user, to save on bandwidth. However, Panda's Styler's internals are private, and it doesn't give us a consistent way of testing whether a cell has a custom `display_value` or not. 

Prior to Pandas 1.4, we could test whether a cell's `display_value` differed from its `value`, and only stick the `display_value` in the protobuf when that was the case. In 1.4, an unmodified Styler will contain `display_value` strings for all cells, regardless of whether any formatting has been applied to that cell, so we no longer have this ability (or at least I couldn't figure out a reasonable way to test for this). 

So instead, as of this PR, calling `st._legacy_dataframe(df.styler)` will *always* result in `display_value` strings being written to the dataframe protobuf (even though there isn't any custom formatting). This means that styled DataFrames may result in more data being sent to the frontend now than was the case before. In practice, I don't think this is a big deal - only the legacy DataFrame code has styling support; and often, if you're styling a DataFrame, you're customizing the formatting on most or all of its cells anyway.

I also made a number of small type-safety changes as I was working with the dataframe code, and those are all in the PR as well. (I've left a PR comment under the actual logic changes.)