### PR TITLE
Replace static apps with live Cloud apps

### DIFF
--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -63,8 +63,8 @@ class BokehMixin:
         >>> st.bokeh_chart(p, use_container_width=True)
 
         .. output::
-           https://static.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp
-           height: 600px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.bokeh_chart.py
+           height: 700px
 
         """
         import bokeh

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -91,6 +91,11 @@ class ButtonMixin:
         ...     st.write('Why hello there')
         ... else:
         ...     st.write('Goodbye')
+
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.button.py
+           height: 220px
+
         """
         key = to_key(key)
         ctx = get_script_run_ctx()
@@ -208,6 +213,11 @@ class ButtonMixin:
         ...             file_name="flower.png",
         ...             mime="image/png"
         ...           )
+
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.download_button.py
+           height: 335px
+
         """
         ctx = get_script_run_ctx()
         return self._download_button(

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -80,6 +80,10 @@ class CheckboxMixin:
         >>> if agree:
         ...     st.write('Great!')
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.checkbox.py
+           height: 220px
+
         """
         ctx = get_script_run_ctx()
         return self._checkbox(

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -82,6 +82,10 @@ class ColorPickerMixin:
         >>> color = st.color_picker('Pick A Color', '#00f900')
         >>> st.write('The current color is', color)
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.color_picker.py
+           height: 335px
+
         """
         ctx = get_script_run_ctx()
         return self._color_picker(

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -62,8 +62,8 @@ class DataFrameSelectorMixin:
         >>> st.dataframe(df)  # Same as st.write(df)
 
         .. output::
-           https://static.streamlit.io/1.2.0-2FAcu/index.html?id=C2AE4xf85jDddBCaY1ugvt
-           height: 365px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.dataframe.py
+           height: 410px
 
         >>> st.dataframe(df, 200, 100)
 
@@ -77,8 +77,8 @@ class DataFrameSelectorMixin:
         >>> st.dataframe(df.style.highlight_max(axis=0))
 
         .. output::
-           https://static.streamlit.io/1.2.0-2FAcu/index.html?id=AgoA9PCNWzoJuwJL7J9ybD
-           height: 375px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.dataframe1.py
+           height: 410px
 
         """
         if _use_arrow():
@@ -110,7 +110,7 @@ class DataFrameSelectorMixin:
         >>> st.table(df)
 
         .. output::
-           https://static.streamlit.io/1.2.0-2FAcu/index.html?id=VQdtFSFvML7uMB8P7JMfT5
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.table.py
            height: 480px
 
         """
@@ -158,8 +158,8 @@ class DataFrameSelectorMixin:
         >>> st.line_chart(chart_data)
 
         .. output::
-           https://static.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8
-           height: 220px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.line_chart.py
+           height: 400px
 
         """
         if _use_arrow():
@@ -206,8 +206,8 @@ class DataFrameSelectorMixin:
         >>> st.area_chart(chart_data)
 
         .. output::
-           https://static.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt
-           height: 220px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.area_chart.py
+           height: 400px
 
         """
         if _use_arrow():
@@ -254,8 +254,8 @@ class DataFrameSelectorMixin:
         >>> st.bar_chart(chart_data)
 
         .. output::
-           https://static.streamlit.io/0.66.0-2BLtg/index.html?id=GaYDn6vxskvBUkBwsGVEaL
-           height: 220px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.bar_chart.py
+           height: 400px
 
         """
 
@@ -296,8 +296,8 @@ class DataFrameSelectorMixin:
         https://altair-viz.github.io/gallery/.
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
-           height: 200px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.vega_lite_chart.py
+           height: 300px
 
         """
 
@@ -358,8 +358,8 @@ class DataFrameSelectorMixin:
         ... })
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
-           height: 200px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.vega_lite_chart.py
+           height: 300px
 
         Examples of Vega-Lite usage without Streamlit can be found at
         https://vega.github.io/vega-lite/examples/. Most of those can be easily

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -234,6 +234,11 @@ class FileUploaderMixin:
         ...     bytes_data = uploaded_file.read()
         ...     st.write("filename:", uploaded_file.name)
         ...     st.write(bytes_data)
+
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.file_uploader.py
+           height: 375px
+
         """
         ctx = get_script_run_ctx()
         return self._file_uploader(

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -85,8 +85,8 @@ class GraphvizMixin:
         ''')
 
         .. output::
-           https://static.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL
-           height: 400px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.graphviz_chart.py
+           height: 600px
 
         """
         # Generate element ID from delta path

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -101,8 +101,8 @@ class ImageMixin:
         >>> st.image(image, caption='Sunrise by the mountains')
 
         .. output::
-           https://static.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk
-           height: 630px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.image.py
+           height: 710px
 
         """
 

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -45,8 +45,8 @@ class JsonMixin:
         ... })
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS
-           height: 280px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.json.py
+           height: 385px
 
         """
         import streamlit as st

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -49,8 +49,8 @@ class LayoutsMixin:
         >>> st.write("This is outside the container")
 
         .. output ::
-            https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux
-            height: 420px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.container1.py
+            height: 520px
 
         Inserting elements out of order:
 
@@ -62,7 +62,8 @@ class LayoutsMixin:
         >>> container.write("This is inside too")
 
         .. output ::
-            https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.container2.py
+            height: 480px
         """
         return self.dg._block()
 
@@ -121,8 +122,8 @@ class LayoutsMixin:
         ...    st.image("https://static.streamlit.io/examples/owl.jpg")
 
         .. output ::
-            https://static.streamlit.io/0.66.0-Wnid/index.html?id=VW45Va5XmSKed2ayzf7vYa
-            height: 550px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.columns1.py
+            height: 620px
 
         Or you can just call methods directly in the returned objects:
 
@@ -136,8 +137,8 @@ class LayoutsMixin:
         >>> col2.write(data)
 
         .. output ::
-            https://static.streamlit.io/0.66.0-Wnid/index.html?id=XSQ6VkonfGcT2AyNYMZN83
-            height: 400px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.columns2.py
+            height: 550px
 
         """
         weights = spec
@@ -204,7 +205,7 @@ class LayoutsMixin:
         ...     st.image("https://static.streamlit.io/examples/dice.jpg")
 
         .. output ::
-            https://static.streamlit.io/0.66.0-2BLtg/index.html?id=7v2tgefVbW278gemvYrRny
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
             height: 750px
 
         """

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -66,8 +66,8 @@ class MapMixin:
         >>> st.map(df)
 
         .. output::
-           https://static.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH
-           height: 600px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.map.py
+           height: 650px
 
         """
         map_proto = DeckGlJsonChartProto()

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -66,10 +66,6 @@ class MarkdownMixin:
         -------
         >>> st.markdown('Streamlit is **_really_ cool**.')
 
-        .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS
-           height: 50px
-
         """
         markdown_proto = MarkdownProto()
 
@@ -93,10 +89,6 @@ class MarkdownMixin:
         Example
         -------
         >>> st.header('This is a header')
-
-        .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj
-           height: 100px
 
         """
         header_proto = MarkdownProto()
@@ -122,10 +114,6 @@ class MarkdownMixin:
         Example
         -------
         >>> st.subheader('This is a subheader')
-
-        .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ
-           height: 100px
 
         """
         subheader_proto = MarkdownProto()
@@ -157,10 +145,6 @@ class MarkdownMixin:
         ...     print("Hello, Streamlit!")'''
         >>> st.code(code, language='python')
 
-        .. output::
-           https://static.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2
-           height: 100px
-
         """
         code_proto = MarkdownProto()
         markdown = "```%(language)s\n%(body)s\n```" % {
@@ -188,10 +172,6 @@ class MarkdownMixin:
         Example
         -------
         >>> st.title('This is a title')
-
-        .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj
-           height: 100px
 
         """
         title_proto = MarkdownProto()
@@ -238,10 +218,6 @@ class MarkdownMixin:
         -------
         >>> st.caption('This is a string that explains something above.')
 
-        .. output::
-           https://static.streamlit.io/1.1.0-eQCi/index.html?id=SVQb16b2UDZX4W8VLkEJLJ
-           height: 175px
-
         """
         caption_proto = MarkdownProto()
         caption_proto.body = clean_text(body)
@@ -272,10 +248,6 @@ class MarkdownMixin:
         ...     \sum_{k=0}^{n-1} ar^k =
         ...     a \left(\frac{1-r^{n}}{1-r}\right)
         ...     ''')
-
-        .. output::
-           https://static.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4
-           height: 75px
 
         """
         if type_util.is_sympy_expession(body):

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -50,8 +50,8 @@ class MediaMixin:
         >>> st.audio(audio_bytes, format='audio/ogg')
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb
-           height: 400px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.audio.py
+           height: 465px
 
         """
         audio_proto = AudioProto()
@@ -84,8 +84,8 @@ class MediaMixin:
         >>> st.video(video_bytes)
 
         .. output::
-           https://static.streamlit.io/0.66.0-2BLtg/index.html?id=DzAouvizGRAyuLjkPpR894
-           height: 600px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.video.py
+           height: 700px
 
         .. note::
            Some videos may not display if they are encoded using MP4V (which is an export option in OpenCV), as this codec is

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -62,8 +62,8 @@ class MetricMixin:
         >>> st.metric(label="Temperature", value="70 °F", delta="1.2 °F")
 
         .. output::
-            https://static.streamlit.io/0.86.0-mT2t/index.html?id=1TxwRhgBgFg62p2AXqJdM
-            height: 175px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/metric.example1.py
+            height: 210px
 
         ``st.metric`` looks especially nice in combination with ``st.columns``:
 
@@ -73,8 +73,8 @@ class MetricMixin:
         >>> col3.metric("Humidity", "86%", "4%")
 
         .. output::
-            https://static.streamlit.io/0.86.0-mT2t/index.html?id=4K9bKXhiPAxBNhktd8cxbg
-            height: 175px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/metric.example2.py
+            height: 210px
 
         The delta indicator color can also be inverted or turned off:
 
@@ -85,8 +85,8 @@ class MetricMixin:
         ...     delta_color="off")
 
         .. output::
-            https://static.streamlit.io/0.86.0-mT2t/index.html?id=UTtQvbBQFaPtCmPcQ23wpP
-            height: 275px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/metric.example3.py
+            height: 320px
 
         """
         metric_proto = MetricProto()

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -95,6 +95,10 @@ class MultiSelectMixin:
         >>>
         >>> st.write('You selected:', options)
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.multiselect.py
+           height: 420px
+
         .. note::
            User experience can be degraded for large lists of `options` (100+), as this widget
            is not designed to handle arbitrary text search efficiently. See this

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -102,6 +102,11 @@ class NumberInputMixin:
         -------
         >>> number = st.number_input('Insert a number')
         >>> st.write('The current number is ', number)
+
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.number_input.py
+           height: 260px
+
         """
         ctx = get_script_run_ctx()
         return self._number_input(

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -103,7 +103,7 @@ class PlotlyMixin:
         >>> st.plotly_chart(fig, use_container_width=True)
 
         .. output::
-           https://static.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.plotly_chart.py
            height: 400px
 
         """

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -63,8 +63,8 @@ class PyplotMixin:
         >>> st.pyplot(fig)
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB
-           height: 530px
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.pyplot.py
+           height: 630px
 
         Notes
         -----

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -107,6 +107,11 @@ class SelectSliderMixin:
         ...     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'],
         ...     value=('red', 'blue'))
         >>> st.write('You selected wavelengths between', start_color, 'and', end_color)
+
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.select_slider.py
+           height: 450px
+
         """
         ctx = get_script_run_ctx()
         return self._select_slider(

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -90,6 +90,10 @@ class SelectboxMixin:
         >>>
         >>> st.write('You selected:', option)
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.selectbox.py
+           height: 320px
+
         """
         ctx = get_script_run_ctx()
         return self._selectbox(

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -143,6 +143,10 @@ class SliderMixin:
         ...     format="MM/DD/YY - hh:mm")
         >>> st.write("Start time:", start_time)
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.slider.py
+           height: 300px
+
         """
         ctx = get_script_run_ctx()
         return self._slider(

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -32,10 +32,6 @@ class TextMixin:
         -------
         >>> st.text('This is some text.')
 
-        .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1
-           height: 50px
-
         """
         text_proto = TextProto()
         text_proto.body = clean_text(body)

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -99,6 +99,10 @@ class TextWidgetsMixin:
         >>> title = st.text_input('Movie title', 'Life of Brian')
         >>> st.write('The current movie title is', title)
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.text_input.py
+           height: 260px
+
         """
         ctx = get_script_run_ctx()
         return self._text_input(

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -83,6 +83,10 @@ class TimeWidgetsMixin:
         >>> t = st.time_input('Set an alarm for', datetime.time(8, 45))
         >>> st.write('Alarm is set for', t)
 
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.time_input.py
+           height: 260px
+
         """
         ctx = get_script_run_ctx()
         return self._time_input(
@@ -225,6 +229,10 @@ class TimeWidgetsMixin:
         ...     "When\'s your birthday",
         ...     datetime.date(2019, 7, 6))
         >>> st.write('Your birthday is:', d)
+
+        .. output::
+           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.date_input.py
+           height: 260px
 
         """
         ctx = get_script_run_ctx()

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -104,8 +104,8 @@ class WriteMixin:
         >>> write('Hello, *World!* :sunglasses:')
 
         ..  output::
-            https://static.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE
-            height: 50px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/text.write1.py
+            height: 150px
 
         As mentioned earlier, `st.write()` also accepts other data formats, such as
         numbers, data frames, styled data frames, and assorted objects:
@@ -117,8 +117,8 @@ class WriteMixin:
         ... }))
 
         ..  output::
-            https://static.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD
-            height: 250px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/text.write2.py
+            height: 350px
 
         Finally, you can pass in multiple arguments to do things like:
 
@@ -126,8 +126,8 @@ class WriteMixin:
         >>> st.write('Below is a DataFrame:', data_frame, 'Above is a dataframe.')
 
         ..  output::
-            https://static.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1
-            height: 300px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/text.write3.py
+            height: 410px
 
         Oh, one more thing: `st.write` accepts chart objects too! For example:
 
@@ -145,8 +145,8 @@ class WriteMixin:
         >>> st.write(c)
 
         ..  output::
-            https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5
-            height: 200px
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.vega_lite_chart.py
+            height: 300px
 
         """
         string_buffer = []  # type: List[str]


### PR DESCRIPTION
## 📚 Context

Everything related to report sharing was removed in #4124, as it was only pertinent to the docs site where we display static embedded apps. As of this PR, we move away from static embedded apps entirely and replace them by live, Streamlit Cloud apps, just like #4170.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Replaces all static embedded app URLs in element docstrings with live Cloud apps URLs
- Adds live Cloud apps URLs to widget docstrings
- Removes static embedded app URLs from text elements (to be replaced by images in the docs repo as apps are unnecessary for static elements)

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- #4124 and #4170 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
