### PR TITLE
Get version using importlib-metadata instead of pkg_resources

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -42,6 +42,8 @@ base58 = "*"
 blinker = "*"
 cachetools = ">=4.0"
 click = ">=7.0"
+# 1.4 introduced the functionality found in python 3.8's importlib.metadata module
+importlib-metadata = ">=1.4"
 numpy = "*"
 packaging = "*"
 pandas = ">=0.21.0"

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -51,13 +51,11 @@ from streamlit.secrets import Secrets, SECRETS_FILE_LOC
 _LOGGER = _logger.get_logger("root")
 
 # Give the package a version.
-import pkg_resources as _pkg_resources
+from importlib_metadata import version as _version
+
+__version__ = _version("streamlit")
+
 from typing import NoReturn
-
-# This used to be pkg_resources.require('streamlit') but it would cause
-# pex files to fail. See #394 for more details.
-__version__ = _pkg_resources.get_distribution("streamlit").version
-
 import contextlib as _contextlib
 import sys as _sys
 import threading as _threading

--- a/lib/streamlit/version.py
+++ b/lib/streamlit/version.py
@@ -16,9 +16,9 @@
 import random
 
 import packaging.version
-import pkg_resources
 import requests
 
+import streamlit as st
 from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -44,7 +44,7 @@ def _get_installed_streamlit_version():
         The version string specified in setup.py.
 
     """
-    version_str = pkg_resources.get_distribution("streamlit").version
+    version_str = st.__version__
     return _version_str_to_obj(version_str)
 
 

--- a/scripts/update_name.py
+++ b/scripts/update_name.py
@@ -28,8 +28,7 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # but the project name so we can throw any string in there
 PYTHON = {
     "lib/setup.py": r"(?P<pre>.*NAME = \").*(?P<post>\")",
-    "lib/streamlit/__init__.py": r"(?P<pre>.*get_distribution\(\").*(?P<post>\"\)\.version$)",
-    "lib/streamlit/version.py": r"(?P<pre>.*get_distribution\(\").*(?P<post>\"\)\.version$)",
+    "lib/streamlit/__init__.py": r"(?P<pre>.*_version\(\").*(?P<post>\"\)$)",
 }
 
 


### PR DESCRIPTION
`pkg_resources` is pretty slow, adding up to .75s to our startup time 
(probably .5s without profiling overhead). Importlib is much faster, and 
the `version` function from`importlib.metadata` gives us exactly what 
we want.

We still support 3.7, so we have to use the separate package that
provides a backport, because the `metadata` module wasn't added to
stdlib importlib until 3.8.
