### PR TITLE
[STLT-16] 🔄 (CircleCI Release Pipeline) Commit and push version changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,16 +234,16 @@ workflows:
                 - develop
     jobs:
       - create-tag
-  manual-release-pipeline:
+  release-pipeline:
     when: << pipeline.parameters.release-version >>
     jobs:
-      - manualpipeline:
+      - create-release:
           filters:
             branches:
-              only: /^([0-9]+\.){3}dev[0-9]+/
+              only: /^release\/([0-9]+\.){2}([0-9]+)/
 
 jobs:
-  manualpipeline:
+  create-release:
     resource_class: large
     docker:
       - image: circleci/python:3.9.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,6 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2.1
-parameters:
-  release-version:
-    type: string
-    default: ""
 orbs:
   slack: circleci/slack@3.4.2
 commands:
@@ -235,7 +231,6 @@ workflows:
     jobs:
       - create-tag
   release-pipeline:
-    when: << pipeline.parameters.release-version >>
     jobs:
       - create-release:
           filters:
@@ -247,15 +242,13 @@ jobs:
     resource_class: large
     docker:
       - image: circleci/python:3.9.7
-
-    environment:
-      STREAMLIT_RELEASE_VERSION: << pipeline.parameters.release-version >>
-      PR_BRANCH: << pipeline.git.branch >>
-
     working_directory: ~/repo
     steps:
       - checkout:
           name: Checkout Streamlit code
+      - run:
+          name: Set version from branch name
+          command: echo 'export STREAMLIT_RELEASE_VERSION=$(echo $CIRCLE_BRANCH | tr -d "release/")' >> $BASH_ENV
       - run:
           name: Update streamlit version
           command: |
@@ -267,8 +260,7 @@ jobs:
             git config user.email "core+streamlitbot-github@streamlit.io"
             git config user.name "Streamlit Bot"
 
-            git commit -am "Up version to $STREAMLIT_RELEASE_VERSION"
-            git push origin $PR_BRANCH
+            git commit -am "Up version to $STREAMLIT_RELEASE_VERSION [skip ci]" && git push origin $CIRCLE_BRANCH || echo "No changes to commit"
       - update-submodules
       - pre-cache
       - restore-from-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ workflows:
     jobs:
       - manualpipeline:
           filters:
-            tags:
+            branches:
               only: /^([0-9]+\.){3}dev[0-9]+/
 
 jobs:
@@ -250,17 +250,25 @@ jobs:
 
     environment:
       STREAMLIT_RELEASE_VERSION: << pipeline.parameters.release-version >>
+      PR_BRANCH: << pipeline.git.branch >>
 
     working_directory: ~/repo
     steps:
       - checkout:
           name: Checkout Streamlit code
-      - run: echo "Done with checkout"
       - run:
           name: Update streamlit version
           command: |
             echo "Release version ${STREAMLIT_RELEASE_VERSION}"
             python scripts/update_version.py $STREAMLIT_RELEASE_VERSION
+      - run:
+          name: Commit version updates
+          command: |
+            git config user.email "core+streamlitbot-github@streamlit.io"
+            git config user.name "Streamlit Bot"
+
+            git commit -am "Up version to $STREAMLIT_RELEASE_VERSION"
+            git push origin $PR_BRANCH
       - update-submodules
       - pre-cache
       - restore-from-cache


### PR DESCRIPTION
## 📚 Context

- What kind of change does this PR introduce?

  - [X] Other, please describe: Improvement to CircleCI Release Pipeline

## 🧠 Description of Changes

- The release pipeline now runs only on `release/*` branches instead of needing to be triggered manually
	- The `STREAMLIT_VERSION` is now retrieved from the branch name
- Commit version changes and push back to the PR branch

## 🧪 Testing Done

  - [X] Tested committing back to my branch and retrieving the version from a demo branch in my fork
  - [x] Test edge case: re-committing to a branch that already has an updated version. This should result in no changes when updating the version and should gracefully skip the commit step
  - [x] I'd love to have someone with write access test this on a release branch to make sure everything works properly with the final branch settings

## 🌐 References

None