### PR TITLE
Include raw options in protos of widgets that support format_func

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -175,6 +175,7 @@ class MultiSelectMixin:
         default_value = [] if indices is None else indices
         multiselect_proto.default[:] = default_value
         multiselect_proto.options[:] = [str(format_func(option)) for option in opt]
+        multiselect_proto.raw_options[:] = [str(option) for option in opt]
         multiselect_proto.form_id = current_form_id(self.dg)
         multiselect_proto.disabled = disabled
         if help is not None:

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -151,6 +151,7 @@ class RadioMixin:
         radio_proto.label = label
         radio_proto.default = index
         radio_proto.options[:] = [str(format_func(option)) for option in opt]
+        radio_proto.raw_options[:] = [str(option) for option in opt]
         radio_proto.form_id = current_form_id(self.dg)
         radio_proto.disabled = disabled
         if help is not None:

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -188,6 +188,7 @@ class SelectSliderMixin:
         slider_proto.step = 1  # default for index changes
         slider_proto.data_type = SliderProto.INT
         slider_proto.options[:] = [str(format_func(option)) for option in opt]
+        slider_proto.raw_options[:] = [str(option) for option in opt]
         slider_proto.form_id = current_form_id(self.dg)
         slider_proto.disabled = disabled
         if help is not None:

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -145,6 +145,7 @@ class SelectboxMixin:
         selectbox_proto.label = label
         selectbox_proto.default = index
         selectbox_proto.options[:] = [str(format_func(option)) for option in opt]
+        selectbox_proto.raw_options[:] = [str(option) for option in opt]
         selectbox_proto.form_id = current_form_id(self.dg)
         selectbox_proto.disabled = disabled
         if help is not None:

--- a/lib/tests/streamlit/multiselect_test.py
+++ b/lib/tests/streamlit/multiselect_test.py
@@ -241,3 +241,12 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         self.assertEqual(multiselect_proto.label, "foo")
         self.assertEqual(multiselect_proto.options, ["bar", "baz"])
         self.assertEqual(multiselect_proto.default, [])
+
+    def test_different_raw_options_have_different_ids(self):
+        st.multiselect("foo", ["Alice", "Bob"], format_func=lambda x: x[0])
+        st.multiselect("foo", ["Amy", "Barry"], format_func=lambda x: x[0])
+
+        multiselect1 = self.get_delta_from_queue(0).new_element.multiselect
+        multiselect2 = self.get_delta_from_queue(1).new_element.multiselect
+
+        self.assertNotEqual(multiselect1.id, multiselect2.id)

--- a/lib/tests/streamlit/radio_test.py
+++ b/lib/tests/streamlit/radio_test.py
@@ -164,3 +164,12 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(radio_proto.label, "foo")
         self.assertEqual(radio_proto.options, ["bar", "baz"])
         self.assertEqual(radio_proto.default, 0)
+
+    def test_different_raw_options_have_different_ids(self):
+        st.radio("foo", ["Alice", "Bob"], format_func=lambda x: x[0])
+        st.radio("foo", ["Amy", "Barry"], format_func=lambda x: x[0])
+
+        radio1 = self.get_delta_from_queue(0).new_element.radio
+        radio2 = self.get_delta_from_queue(1).new_element.radio
+
+        self.assertNotEqual(radio1.id, radio2.id)

--- a/lib/tests/streamlit/select_slider_test.py
+++ b/lib/tests/streamlit/select_slider_test.py
@@ -228,3 +228,12 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         form_proto = self.get_delta_from_queue(0).add_block
         select_slider_proto = self.get_delta_from_queue(1).new_element.slider
         self.assertEqual(select_slider_proto.form_id, form_proto.form.form_id)
+
+    def test_different_raw_options_have_different_ids(self):
+        st.select_slider("foo", ["Alice", "Bob"], format_func=lambda x: x[0])
+        st.select_slider("foo", ["Amy", "Barry"], format_func=lambda x: x[0])
+
+        select_slider1 = self.get_delta_from_queue(0).new_element.slider
+        select_slider2 = self.get_delta_from_queue(1).new_element.slider
+
+        self.assertNotEqual(select_slider1.id, select_slider2.id)

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -151,3 +151,12 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
         form_proto = self.get_delta_from_queue(0).add_block
         selectbox_proto = self.get_delta_from_queue(1).new_element.selectbox
         self.assertEqual(selectbox_proto.form_id, form_proto.form.form_id)
+
+    def test_different_raw_options_have_different_ids(self):
+        st.selectbox("foo", ("Alice", "Bob"), format_func=lambda x: x[0])
+        st.selectbox("foo", ("Amy", "Barry"), format_func=lambda x: x[0])
+
+        selectbox1 = self.get_delta_from_queue(0).new_element.selectbox
+        selectbox2 = self.get_delta_from_queue(1).new_element.selectbox
+
+        self.assertNotEqual(selectbox1.id, selectbox2.id)

--- a/proto/streamlit/proto/MultiSelect.proto
+++ b/proto/streamlit/proto/MultiSelect.proto
@@ -26,4 +26,10 @@ message MultiSelect {
   repeated int32 value = 7;
   bool set_value = 8;
   bool disabled = 9;
+
+  // This field saves the options used to create this widget before they are
+  // transformed via the widget's `format_func`. Doing this allows us to
+  // differentiate widgets that have `format_func`s that collapse distinct raw
+  // options into having the same label.
+  repeated string raw_options = 10;
 }

--- a/proto/streamlit/proto/Radio.proto
+++ b/proto/streamlit/proto/Radio.proto
@@ -26,4 +26,10 @@ message Radio {
   int32 value = 7;
   bool set_value = 8;
   bool disabled = 9;
+
+  // This field saves the options used to create this widget before they are
+  // transformed via the widget's `format_func`. Doing this allows us to
+  // differentiate widgets that have `format_func`s that collapse distinct raw
+  // options into having the same label.
+  repeated string raw_options = 10;
 }

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -26,4 +26,10 @@ message Selectbox {
   int32 value = 7;
   bool set_value = 8;
   bool disabled = 9;
+
+  // This field saves the options used to create this widget before they are
+  // transformed via the widget's `format_func`. Doing this allows us to
+  // differentiate widgets that have `format_func`s that collapse distinct raw
+  // options into having the same label.
+  repeated string raw_options = 10;
 }

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -44,4 +44,10 @@ message Slider {
   repeated string options = 13;
   string help = 14;
   bool disabled = 15;
+
+  // This field saves the options used to create this widget before they are
+  // transformed via the widget's `format_func`. Doing this allows us to
+  // differentiate widgets that have `format_func`s that collapse distinct raw
+  // options into having the same label.
+  repeated string raw_options = 16;
 }


### PR DESCRIPTION
## 📚 Context

See https://github.com/streamlit/streamlit/issues/4264#issuecomment-1010524604 for a description of the root cause of the bug that this
PR fixes.

I'm a bit uncertain about this change as there may be some unintended
consequences with using non-primitive types as widget options. I think things
are okay, though, since we generally don't support non-primitives being returned
as widget values very well to begin with (as we check for equality to detect widget
value changes for callbacks), which means that any of the use-cases this would
affect already aren't supported.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Copy raw options into the protos of the following widgets

  - multiselect
  - radio
  - select_slider
  - selectbox

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4264
