### PR TITLE
Reduce JS WebSocket message handling latency

### DIFF
--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -340,6 +340,7 @@ export class WebsocketConnection {
 
     logMessage(LOG, "creating WebSocket")
     this.websocket = new WebSocket(uri)
+    this.websocket.binaryType = "arraybuffer"
 
     this.setConnectionTimeout(uri)
 
@@ -458,19 +459,12 @@ export class WebsocketConnection {
     this.cache.incrementRunCount(maxMessageAge)
   }
 
-  private async handleMessage(data: any): Promise<void> {
+  private async handleMessage(data: ArrayBuffer): Promise<void> {
     // Assign this message an index.
     const messageIndex = this.nextMessageIndex
     this.nextMessageIndex += 1
 
-    // Read in the message data.
-    const result = await readFileAsync(data)
-    if (result == null || typeof result === "string") {
-      throw new Error(`Unexpected result from FileReader: ${result}.`)
-    }
-
-    const resultArray = new Uint8Array(result)
-    const msg = ForwardMsg.decode(resultArray)
+    const msg = ForwardMsg.decode(new Uint8Array(data))
     this.messageQueue[messageIndex] = await this.cache.processMessagePayload(
       msg
     )
@@ -621,16 +615,4 @@ export function doHealthPing(
   connect()
 
   return resolver.promise
-}
-
-/**
- * Wrap FileReader.readAsArrayBuffer in a Promise.
- */
-function readFileAsync(data: any): Promise<string | ArrayBuffer | null> {
-  return new Promise<any>((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result)
-    reader.onerror = reject
-    reader.readAsArrayBuffer(data)
-  })
 }


### PR DESCRIPTION
By default, a JavaScript websocket delivers its data in the `Blob` format, and we need to use a FileReader to asynchronously convert to an `ArrayBuffer`. But we can just ask for ArrayBuffer data up front, and skip this FileReader step. On my Mac, running an internal Streamlit dashboard app, this saves us ~5-50 milliseconds of latency per websocket message.