### PR TITLE
Improve error when streamlit is run via `python -m streamlit.cli`

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -209,6 +209,12 @@ def _get_command_line_as_string() -> Optional[str]:
     if parent is None:
         return None
 
+    if "streamlit.cli" in parent.command_path:
+        raise RuntimeError(
+            "Running streamlit via `python -m streamlit.cli <command>` is"
+            " unsupported. Please use `python -m streamlit <command>` instead."
+        )
+
     # Assert that the program name we see here is `streamlit`, even if we ran
     # streamlit some other way than `streamlit run`.
     assert parent.command_path == "streamlit"

--- a/scripts/cli_smoke_tests.py
+++ b/scripts/cli_smoke_tests.py
@@ -31,6 +31,14 @@ def main():
     if not _can_run_streamlit_help(module_cli):
         sys.exit("Failed to run `python -m streamlit help`")
 
+    # Invoking streamlit via `python -m streamlit.cli <command>` is a method
+    # that we previously accidentally supported, but we decided that we should
+    # only keep official support for the similar `python -m streamlit <command>`
+    # invocation.
+    unsupported_module_cli = ["python", "-m", "streamlit.cli", "help"]
+    if _can_run_streamlit_help(unsupported_module_cli):
+        sys.exit("`python -m streamlit.cli help` should not run")
+
     click.secho("CLI smoke tests succeeded!", fg="green", bold=True)
 
 


### PR DESCRIPTION
## 📚 Context

See [this forum comment](https://discuss.streamlit.io/t/run-streamlit-from-pycharm/21624/3?) for some context on this PR.

- What kind of change does this PR introduce?

  - [x] Other, please describe: error message improvement

## 🧠 Description of Changes

- Give a better error message for when streamlit is run via `python -m streamlit.cli <command>`

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated e2e tests
