### PR TITLE
Update Streamlit markdown to be more flexible with links

### DIFF
--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -212,6 +212,7 @@ class StreamlitMarkdown extends PureComponent<Props> {
         remarkPlugins={plugins}
         rehypePlugins={rehypePlugins}
         components={renderers}
+        transformLinkUri={transformLinkUri}
       >
         {source}
       </ReactMarkdown>
@@ -230,11 +231,20 @@ class StreamlitMarkdown extends PureComponent<Props> {
   }
 }
 
+// Note: React markdown limits hrefs to specific protocols ('http', 'https',
+// 'mailto', 'tel') We are essentially allowing any URL (a data URL). It can
+// be considered a security flaw, but developers can choose to expose it.
+export function transformLinkUri(href: string): string {
+  return href
+}
+
 interface LinkProps {
   node: any
   children: ReactNode[]
   href?: string
   title?: string
+  target?: string
+  rel?: string
 }
 
 // Using target="_blank" without rel="noopener noreferrer" is a security risk:
@@ -247,9 +257,15 @@ export function LinkWithTargetBlank(props: LinkProps): ReactElement {
     return <a {...rest}>{children}</a>
   }
 
-  const { title, children } = props
+  const { title, children, node, target, rel, ...rest } = props
   return (
-    <a href={href} title={title} target="_blank" rel="noopener noreferrer">
+    <a
+      href={href}
+      title={title}
+      target={target || "_blank"}
+      rel={rel || "noopener noreferrer"}
+      {...rest}
+    >
       {children}
     </a>
   )


### PR DESCRIPTION
## 📚 Context

1.5.0 broke markdown functionality specifically around generating links. This change handles those fixes

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Allow links to override the `target` and `rel` attributes as well as add any others.
- Allow any links to pass through. Previous 1.5.0 prevents any links that do not start with http, https, mailto, or tel

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit/issues/4332, https://github.com/streamlit/streamlit/issues/4346, and https://github.com/streamlit/streamlit/issues/4350

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
