### PR TITLE
Disable Websocket compression by default

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -625,9 +625,9 @@ def _server_max_message_size() -> int:
 def _server_enable_websocket_compression() -> bool:
     """Enables support for websocket compression.
 
-    Default: true
+    Default: false
     """
-    return True
+    return False
 
 
 # Config Section: Browser #


### PR DESCRIPTION
WS compression saves a fair bit of network data, but compressing large
dataframes takes a very long time (6.5s for a random 150MB DF), which
destroys the responsiveness of apps using them. For slower network
connections it is unclear if this is worthwhile, but for fast ones it
appears much better to have compression off by default.

Using smarter heuristics for when to enable compression is worth
exploring in the future.


## 📚 Context

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
  Performance improvement by changing configuration default

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests
