### PR TITLE
Update Streamlit markdown to be more flexible with links

### DIFF
--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -52,9 +52,21 @@ describe("createAnchorFromText", () => {
 
 describe("linkReference", () => {
   it("renders a link with _blank target", () => {
+    const source =
+      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>"
+    const wrapper = mount(
+      <StreamlitMarkdown source={source} allowHTML={true} />
+    )
+
+    expect(wrapper.find("a").prop("href")).toEqual(
+      "//0.0.0.0:8501/?p=some_page"
+    )
+    expect(wrapper.find("a").prop("target")).toEqual("_self")
+  })
+
+  it("renders a link when passed in", () => {
     const body = "Some random URL like [Streamlit](https://streamlit.io/)"
     const wrapper = mount(getMarkdownElement(body))
-
     expect(wrapper.find("a").prop("href")).toEqual("https://streamlit.io/")
     expect(wrapper.find("a").prop("target")).toEqual("_blank")
   })

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -52,19 +52,6 @@ describe("createAnchorFromText", () => {
 
 describe("linkReference", () => {
   it("renders a link with _blank target", () => {
-    const source =
-      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>"
-    const wrapper = mount(
-      <StreamlitMarkdown source={source} allowHTML={true} />
-    )
-
-    expect(wrapper.find("a").prop("href")).toEqual(
-      "//0.0.0.0:8501/?p=some_page"
-    )
-    expect(wrapper.find("a").prop("target")).toEqual("_self")
-  })
-
-  it("renders a link when passed in", () => {
     const body = "Some random URL like [Streamlit](https://streamlit.io/)"
     const wrapper = mount(getMarkdownElement(body))
     expect(wrapper.find("a").prop("href")).toEqual("https://streamlit.io/")
@@ -122,6 +109,19 @@ describe("StreamlitMarkdown", () => {
       </IsSidebarContext.Provider>
     )
     expect(wrapper.find(StyledLinkIconContainer).exists()).toBeTruthy()
+  })
+
+  it("passes props properly", () => {
+    const source =
+      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>"
+    const wrapper = mount(
+      <StreamlitMarkdown source={source} allowHTML={true} />
+    )
+
+    expect(wrapper.find("a").prop("href")).toEqual(
+      "//0.0.0.0:8501/?p=some_page"
+    )
+    expect(wrapper.find("a").prop("target")).toEqual("_self")
   })
 
   it("doesn't render header anchors when isSidebar is true", () => {

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -212,6 +212,7 @@ class StreamlitMarkdown extends PureComponent<Props> {
         remarkPlugins={plugins}
         rehypePlugins={rehypePlugins}
         components={renderers}
+        transformLinkUri={transformLinkUri}
       >
         {source}
       </ReactMarkdown>
@@ -230,11 +231,20 @@ class StreamlitMarkdown extends PureComponent<Props> {
   }
 }
 
+// Note: React markdown limits hrefs to specific protocols ('http', 'https',
+// 'mailto', 'tel') We are essentially allowing any URL (a data URL). It can
+// be considered a security flaw, but developers can choose to expose it.
+export function transformLinkUri(href: string): string {
+  return href
+}
+
 interface LinkProps {
   node: any
   children: ReactNode[]
   href?: string
   title?: string
+  target?: string
+  rel?: string
 }
 
 // Using target="_blank" without rel="noopener noreferrer" is a security risk:
@@ -247,9 +257,15 @@ export function LinkWithTargetBlank(props: LinkProps): ReactElement {
     return <a {...rest}>{children}</a>
   }
 
-  const { title, children } = props
+  const { title, children, node, target, rel, ...rest } = props
   return (
-    <a href={href} title={title} target="_blank" rel="noopener noreferrer">
+    <a
+      href={href}
+      title={title}
+      target={target || "_blank"}
+      rel={rel || "noopener noreferrer"}
+      {...rest}
+    >
       {children}
     </a>
   )

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -75,6 +75,13 @@ export function createAnchorFromText(text: string | null): string {
   return newAnchor || ""
 }
 
+// Note: React markdown limits hrefs to specific protocols ('http', 'https',
+// 'mailto', 'tel') We are essentially allowing any URL (a data URL). It can
+// be considered a security flaw, but developers can choose to expose it.
+function transformLinkUri(href: string): string {
+  return href
+}
+
 // wrapping in `once` ensures we only scroll once
 const scrollNodeIntoView = once((node: HTMLElement): void => {
   node.scrollIntoView(true)
@@ -229,13 +236,6 @@ class StreamlitMarkdown extends PureComponent<Props> {
       </StyledStreamlitMarkdown>
     )
   }
-}
-
-// Note: React markdown limits hrefs to specific protocols ('http', 'https',
-// 'mailto', 'tel') We are essentially allowing any URL (a data URL). It can
-// be considered a security flaw, but developers can choose to expose it.
-export function transformLinkUri(href: string): string {
-  return href
 }
 
 interface LinkProps {


### PR DESCRIPTION
## 📚 Context

This PR is a duplicate of https://github.com/streamlit/streamlit/pull/4362 because it's on ken's fork so I can't actually make changes so I have to make a new branch with the added changes. 

1.5.0 broke markdown functionality specifically around generating links. This change handles those fixes

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Allow links to override the `target` and `rel` attributes as well as add any others.
- Allow any links to pass through. Previous 1.5.0 prevents any links that do not start with http, https, mailto, or tel

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit/issues/4332, https://github.com/streamlit/streamlit/issues/4346, and https://github.com/streamlit/streamlit/issues/4350

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
