### PR TITLE
Relax assertions around streamlit program name

### DIFF
--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -111,7 +111,7 @@ def help(ctx):
     # Pretend user typed 'streamlit --help' instead of 'streamlit help'.
     import sys
 
-    # We use _get_command_line_as_string to run some assertions but don't do
+    # We use _get_command_line_as_string to run some error checks but don't do
     # anything with its return value.
     _get_command_line_as_string()
 
@@ -127,7 +127,7 @@ def main_version(ctx):
     # Pretend user typed 'streamlit --version' instead of 'streamlit version'
     import sys
 
-    # We use _get_command_line_as_string to run some assertions but don't do
+    # We use _get_command_line_as_string to run some error checks but don't do
     # anything with its return value.
     _get_command_line_as_string()
 
@@ -215,10 +215,6 @@ def _get_command_line_as_string() -> Optional[str]:
             " unsupported. Please use `python -m streamlit <command>` instead."
         )
 
-    # Assert that the program name we see here is `streamlit`, even if we ran
-    # streamlit some other way than `streamlit run`.
-    assert parent.command_path == "streamlit"
-
     cmd_line_as_list = [parent.command_path]
     cmd_line_as_list.extend(click.get_os_args())
     return subprocess.list2cmdline(cmd_line_as_list)
@@ -301,6 +297,36 @@ def activate(ctx):
 def activate_reset():
     """Reset Activation Credentials."""
     Credentials.get_current().reset()
+
+
+# SUBCOMMAND: test
+
+
+@main.group("test", hidden=True)
+def test():
+    """Internal-only commands used for testing.
+
+    These commands are not included in the output of `streamlit help`.
+    """
+    pass
+
+
+@test.command("prog_name")
+def test_prog_name():
+    """Assert that the program name is set to `streamlit test`.
+
+    This is used by our cli-smoke-tests to verify that the program name is set
+    to `streamlit ...` whether the streamlit binary is invoked directly or via
+    `python -m streamlit ...`.
+    """
+    # We use _get_command_line_as_string to run some error checks but don't do
+    # anything with its return value.
+    _get_command_line_as_string()
+
+    parent = click.get_current_context().parent
+
+    assert parent is not None
+    assert parent.command_path == "streamlit test"
 
 
 if __name__ == "__main__":

--- a/scripts/cli_smoke_tests.py
+++ b/scripts/cli_smoke_tests.py
@@ -20,29 +20,29 @@ import click
 
 
 def main():
-    standard_cli = ["streamlit", "help"]
-    if not _can_run_streamlit_help(standard_cli):
-        sys.exit("Failed to run `streamlit help`")
+    standard_cli = ["streamlit", "test", "prog_name"]
+    if not _can_run_streamlit(standard_cli):
+        sys.exit("Failed to run `streamlit test prog_name`")
 
     # When calling from module, the called argv[0] is updated by
     # __main__.py to be "streamlit" instead of "__main__.py".
     # If this doesn't occur, an assert stops execution of the program.
-    module_cli = ["python", "-m", "streamlit", "help"]
-    if not _can_run_streamlit_help(module_cli):
-        sys.exit("Failed to run `python -m streamlit help`")
+    module_cli = ["python", "-m", "streamlit", "test", "prog_name"]
+    if not _can_run_streamlit(module_cli):
+        sys.exit("Failed to run `python -m streamlit test prog_name`")
 
     # Invoking streamlit via `python -m streamlit.cli <command>` is a method
     # that we previously accidentally supported, but we decided that we should
     # only keep official support for the similar `python -m streamlit <command>`
     # invocation.
-    unsupported_module_cli = ["python", "-m", "streamlit.cli", "help"]
-    if _can_run_streamlit_help(unsupported_module_cli):
-        sys.exit("`python -m streamlit.cli help` should not run")
+    unsupported_module_cli = ["python", "-m", "streamlit.cli", "test", "prog_name"]
+    if _can_run_streamlit(unsupported_module_cli):
+        sys.exit("`python -m streamlit.cli test prog_name` should not run")
 
     click.secho("CLI smoke tests succeeded!", fg="green", bold=True)
 
 
-def _can_run_streamlit_help(command_list):
+def _can_run_streamlit(command_list):
     result = subprocess.run(command_list, stdout=subprocess.DEVNULL)
     return result.returncode == 0
 


### PR DESCRIPTION
## 📚 Context

Something about the way that the VSCode debugger works causes the streamlit
program name to still appear as `python -m streamlit`, which fails the assertion
that is checked when grabbing the command used to run streamlit.

Because of this (and because I'm worried that there are other obscure ways of
invoking streamlit that may run into similar issues), I don't think it's worth
keeping the assertion around for testing purposes, so I reworked things to
instead

- remove the assertion so that any unexpected ways of invoking streamlit as a
  module no longer break going forward
- add a new, hidden `streamlit test` cli command group to use in the
  `cli-smoke-tests`

* What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

(See the context section above)

- [x] This is a visible (user-facing) change

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [x] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4371
