### PR TITLE
Small refactor: session_data no longer stores "script_run_id"

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -16,6 +16,7 @@ import sys
 import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Optional, List, Any, cast
+
 from streamlit.uploaded_file_manager import UploadedFileManager
 
 import tornado.ioloop
@@ -32,7 +33,6 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.GitInfo_pb2 import GitInfo
 from streamlit.proto.NewSession_pb2 import Config, CustomThemeConfig, UserInfo
 from streamlit.session_data import SessionData
-from streamlit.session_data import generate_new_id
 from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
@@ -46,6 +46,11 @@ class AppSessionState(Enum):
     APP_NOT_RUNNING = "APP_NOT_RUNNING"
     APP_IS_RUNNING = "APP_IS_RUNNING"
     SHUTDOWN_REQUESTED = "SHUTDOWN_REQUESTED"
+
+
+def _generate_scriptrun_id() -> str:
+    """Randomly generate a unique ID for a script execution."""
+    return str(uuid.uuid4())
 
 
 class AppSession:
@@ -377,12 +382,11 @@ class AppSession:
         self.enqueue(msg)
 
     def _enqueue_new_session_message(self) -> None:
-        new_id = generate_new_id()
-        self._session_data.script_run_id = new_id
+        new_id = _generate_scriptrun_id()
 
         msg = ForwardMsg()
 
-        msg.new_session.script_run_id = self._session_data.script_run_id
+        msg.new_session.script_run_id = new_id
         msg.new_session.name = self._session_data.name
         msg.new_session.script_path = self._session_data.script_path
 

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -382,11 +382,9 @@ class AppSession:
         self.enqueue(msg)
 
     def _enqueue_new_session_message(self) -> None:
-        new_id = _generate_scriptrun_id()
-
         msg = ForwardMsg()
 
-        msg.new_session.script_run_id = new_id
+        msg.new_session.script_run_id = _generate_scriptrun_id()
         msg.new_session.name = self._session_data.name
         msg.new_session.script_path = self._session_data.script_path
 

--- a/lib/streamlit/session_data.py
+++ b/lib/streamlit/session_data.py
@@ -14,9 +14,7 @@
 from typing import List
 
 import attr
-import base58
 import os
-import uuid
 
 from streamlit import config
 from streamlit.forward_msg_queue import ForwardMsgQueue
@@ -25,11 +23,6 @@ from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 LOGGER = get_logger(__name__)
-
-
-def generate_new_id() -> str:
-    """Randomly generate an ID representing this session's execution."""
-    return base58.b58encode(uuid.uuid4().bytes).decode()
 
 
 def get_url(host_ip: str) -> str:
@@ -69,7 +62,6 @@ class SessionData:
     script_folder: str
     name: str
     command_line: str
-    script_run_id: str
     _browser_queue: ForwardMsgQueue
 
     def __init__(self, script_path: str, command_line: str):
@@ -94,8 +86,6 @@ class SessionData:
         # delivered to the browser. Periodically, the server flushes
         # this queue and delivers its contents to the browser.
         self._browser_queue = ForwardMsgQueue()
-
-        self.script_run_id = generate_new_id()
 
         self.command_line = command_line
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -16,7 +16,6 @@ import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-import tornado.gen
 import tornado.testing
 
 import streamlit.app_session as app_session
@@ -213,6 +212,10 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
     @patch("streamlit.app_session.LocalSourcesWatcher")
     @patch("streamlit.util.os.makedirs")
     @patch("streamlit.metrics_util.os.path.exists", MagicMock(return_value=False))
+    @patch(
+        "streamlit.app_session._generate_scriptrun_id",
+        MagicMock(return_value="mock_scriptrun_id"),
+    )
     @patch("streamlit.file_util.open", mock_open(read_data=""))
     @tornado.testing.gen_test
     def test_enqueue_new_session_message(self, _1, _2, patched_config):
@@ -236,7 +239,6 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
             lambda: None,
             MagicMock(),
         )
-        rs._session_data.script_run_id = "testing _enqueue_new_session"
 
         orig_ctx = get_script_run_ctx()
         ctx = ScriptRunContext(
@@ -253,7 +255,7 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
         # fields below to avoid getting to the point where we're just
         # duplicating code in tests.
         new_session_msg = sent_messages[0].new_session
-        self.assertEqual(new_session_msg.script_run_id, rs._session_data.script_run_id)
+        self.assertEqual("mock_scriptrun_id", new_session_msg.script_run_id)
 
         self.assertEqual(new_session_msg.HasField("config"), True)
         self.assertEqual(


### PR DESCRIPTION
`SessionData` is intended to store session-wide data, but it also currently holds `script_run_id`: a random ID that's regenerated every time a new script run starts.

This doesn't make tons of sense, especially because the ID is only used in a single place: the function where it's regenerated. It'll also be problematic if we move to a world where a single session can have multiple active ScriptRunners.

This PR just fixes this!