### PR TITLE
Saner "execution control request" handling

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -189,19 +189,6 @@ class AppSession:
         if not config.get_option("client.displayEnabled"):
             return
 
-        # Avoid having two maybe_handle_execution_control_request running on
-        # top of each other when tracer is installed. This leads to a lock
-        # contention.
-        if not config.get_option("runner.installTracer"):
-            # If we have an active ScriptRunner, signal that it can handle an
-            # execution control request. (Copy the scriptrunner reference to
-            # avoid it being unset from underneath us, as this function can be
-            # called outside the main thread.)
-            scriptrunner = self._scriptrunner
-
-            if scriptrunner is not None:
-                scriptrunner.maybe_handle_execution_control_request()
-
         self._session_data.enqueue(msg)
         if self._message_enqueued_callback:
             self._message_enqueued_callback()

--- a/lib/streamlit/script_run_context.py
+++ b/lib/streamlit/script_run_context.py
@@ -65,6 +65,7 @@ class ScriptRunContext:
         self._has_script_started = True
 
     def enqueue(self, msg: ForwardMsg) -> None:
+        """Enqueue a ForwardMsg for this context's session."""
         if msg.HasField("page_config_changed") and not self._set_page_config_allowed:
             raise StreamlitAPIException(
                 "`set_page_config()` can only be called once per app, "
@@ -81,6 +82,7 @@ class ScriptRunContext:
         ):
             self._set_page_config_allowed = False
 
+        # Pass the message up to our associated ScriptRunner.
         self._enqueue(msg)
 
 

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -171,7 +171,7 @@ class ScriptRunner:
             raise Exception("ScriptRunner was already started")
 
         self._script_thread = threading.Thread(
-            target=self._process_request_queue,
+            target=self._run_script_thread,
             name="ScriptRunner.scriptThread",
         )
 
@@ -211,11 +211,14 @@ class ScriptRunner:
             )
         return ctx
 
-    def _process_request_queue(self) -> None:
-        """Process the ScriptRequestQueue and then exits.
+    def _run_script_thread(self) -> None:
+        """The entry point for the script thread.
 
-        This is run in the script thread.
+        Processes the ScriptRequestQueue, which will at least contain the RERUN
+        request that will trigger the first script-run.
 
+        When the ScriptRequestQueue is empty, or when a SHUTDOWN request is
+        dequeued, this function will exit and its thread will terminate.
         """
         LOGGER.debug("Beginning script thread")
 

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -101,6 +101,11 @@ class ScriptRunner:
         session_data : SessionData
             The AppSession's session data.
 
+        enqueue_forward_msg : Callable
+            Function to call to send a ForwardMsg to the frontend.
+            (When not running a unit test, this will be the enqueue function
+            of the AppSession instance that created this ScriptRunner.)
+
         client_state : ClientState
             The current state from the client (widgets and query params).
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -83,7 +83,7 @@ class AppSessionTest(unittest.TestCase):
         """Make sure there is no lock contention when tracer is on.
 
         When the tracer is set up, we want
-        maybe_handle_execution_control_request to be executed only once. There
+        _maybe_handle_execution_control_request to be executed only once. There
         was a bug in the past where it was called twice: once from the tracer
         and once from the enqueue function. This caused a lock contention.
         """

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -27,7 +27,7 @@ from streamlit.script_run_context import (
     add_script_run_ctx,
     get_script_run_ctx,
 )
-from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
+from streamlit.script_runner import ScriptRunnerEvent
 from streamlit.session_data import SessionData
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
@@ -39,86 +39,6 @@ def del_path(monkeypatch):
 
 
 class AppSessionTest(unittest.TestCase):
-    @patch("streamlit.app_session.config")
-    @patch("streamlit.app_session.SessionData")
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_enqueue_without_tracer(self, _1, _2, patched_config):
-        """Make sure we try to handle execution control requests."""
-
-        def get_option(name):
-            if name == "server.runOnSave":
-                # Just to avoid starting the watcher for no reason.
-                return False
-            if name == "client.displayEnabled":
-                return True
-            if name == "runner.installTracer":
-                return False
-            raise RuntimeError("Unexpected argument to get_option: %s" % name)
-
-        patched_config.get_option.side_effect = get_option
-
-        send = MagicMock()
-        rs = AppSession(
-            None, SessionData("", ""), UploadedFileManager(), send, MagicMock()
-        )
-        mock_script_runner = MagicMock()
-        mock_script_runner._install_tracer = ScriptRunner._install_tracer
-        rs._scriptrunner = mock_script_runner
-
-        mock_msg = MagicMock()
-        rs.enqueue(mock_msg)
-
-        func = mock_script_runner.maybe_handle_execution_control_request
-
-        # Expect func and send to be called only once, inside enqueue().
-        func.assert_called_once()
-        send.assert_called_once()
-
-    @patch("streamlit.app_session.config")
-    @patch("streamlit.app_session.SessionData")
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    @patch("streamlit.util.os.makedirs")
-    @patch("streamlit.file_util.open", mock_open())
-    def test_enqueue_with_tracer(self, _1, _2, patched_config, _4):
-        """Make sure there is no lock contention when tracer is on.
-
-        When the tracer is set up, we want
-        _maybe_handle_execution_control_request to be executed only once. There
-        was a bug in the past where it was called twice: once from the tracer
-        and once from the enqueue function. This caused a lock contention.
-        """
-
-        def get_option(name):
-            if name == "server.runOnSave":
-                # Just to avoid starting the watcher for no reason.
-                return False
-            if name == "client.displayEnabled":
-                return True
-            if name == "runner.installTracer":
-                return True
-            raise RuntimeError("Unexpected argument to get_option: %s" % name)
-
-        patched_config.get_option.side_effect = get_option
-
-        rs = AppSession(
-            None, SessionData("", ""), UploadedFileManager(), lambda: None, MagicMock()
-        )
-        mock_script_runner = MagicMock()
-        rs._scriptrunner = mock_script_runner
-
-        mock_msg = MagicMock()
-        rs.enqueue(mock_msg)
-
-        func = mock_script_runner.maybe_handle_execution_control_request
-
-        # In reality, outside of a testing environment func should be called
-        # once. But in this test we're actually not installing a tracer here,
-        # since SessionData is mocked. So the correct behavior here is for func to
-        # never be called. If you ever see it being called once here it's
-        # likely because there's a bug in the enqueue function (which should
-        # skip func when installTracer is on).
-        func.assert_not_called()
-
     @patch("streamlit.app_session.secrets._file_change_listener.disconnect")
     @patch("streamlit.app_session.LocalSourcesWatcher")
     def test_shutdown(self, _, patched_disconnect):

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -625,7 +625,7 @@ class TestScriptRunner(ScriptRunner):
 
         def enqueue_fn(msg):
             self.forward_msg_queue.enqueue(msg)
-            self.maybe_handle_execution_control_request()
+            self._maybe_handle_execution_control_request()
 
         self.script_request_queue = ScriptRequestQueue()
         script_path = os.path.join(os.path.dirname(__file__), "test_data", script_name)

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -702,13 +702,13 @@ class TestScriptRunner(ScriptRunner):
 
     def _run_script_thread(self):
         try:
-            super(TestScriptRunner, self)._run_script_thread()
+            super()._run_script_thread()
         except BaseException as e:
             self.script_thread_exceptions.append(e)
 
     def _run_script(self, rerun_data):
         self.forward_msg_queue.clear()
-        super(TestScriptRunner, self)._run_script(rerun_data)
+        super()._run_script(rerun_data)
 
     def join(self):
         """Joins the run thread, if it was started"""

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -37,7 +37,6 @@ from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
 from tests import testutil
-from testutil import patch_config_options
 
 text_utf = "complete! 👨‍🎤"
 text_no_encoding = text_utf
@@ -76,7 +75,7 @@ class ScriptRunnerTest(AsyncTestCase):
         """Make sure we try to handle execution control requests whenever
         our _enqueue function is called, unless "runner.installTracer" is set.
         """
-        with patch_config_options({"runner.installTracer": install_tracer}):
+        with testutil.patch_config_options({"runner.installTracer": install_tracer}):
             # Create a TestScriptRunner. We won't actually be starting its
             # script thread - instead, we'll manually call _enqueue on it, and
             # pretend we're in the script thread.

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -17,8 +17,8 @@
 import os
 import sys
 import time
-from typing import List
-from unittest.mock import patch
+from typing import List, Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -37,6 +37,7 @@ from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
 from tests import testutil
+from testutil import patch_config_options
 
 text_utf = "complete! 👨‍🎤"
 text_no_encoding = text_utf
@@ -70,6 +71,50 @@ class ScriptRunnerTest(AsyncTestCase):
         self._assert_no_exceptions(scriptrunner)
         self._assert_events(scriptrunner, [ScriptRunnerEvent.SHUTDOWN])
         self._assert_text_deltas(scriptrunner, [])
+
+    @parameterized.expand(
+        [
+            ("installTracer=False", False),
+            ("installTracer=True", True),
+        ]
+    )
+    def test_enqueue(self, _, install_tracer):
+        """Make sure we try to handle execution control requests whenever
+        our _enqueue function is called, unless "runner.installTracer" is set.
+        """
+        with patch_config_options({"runner.installTracer": install_tracer}):
+            # Create a TestScriptRunner. We won't actually be starting its
+            # script thread - instead, we'll manually call _enqueue on it, and
+            # pretend we're in the script thread.
+            runner = TestScriptRunner("not_a_script.py")
+            runner._is_in_script_thread = MagicMock(return_value=True)
+
+            maybe_handle_execution_control_request_mock = MagicMock()
+            runner._maybe_handle_execution_control_request = (
+                maybe_handle_execution_control_request_mock
+            )
+
+            enqueue_forward_msg_mock = MagicMock()
+            runner._enqueue_forward_msg = enqueue_forward_msg_mock
+
+            # Enqueue a message on the runner
+            mock_msg = MagicMock()
+            runner._enqueue(mock_msg)
+
+            # The message should have been passed up to
+            enqueue_forward_msg_mock.assert_called_once_with(mock_msg)
+
+            # If "install_tracer" is true, maybe_handle_execution_control_request
+            # should not be called by the enqueue function. (In reality, it will
+            # still be called once in the tracing callback But in this test
+            # we're not actually installing a tracer - the script is not being
+            # run.) If "install_tracer" is false, the function should be called
+            # once.
+            expected_call_count = 0 if install_tracer else 1
+            self.assertEqual(
+                expected_call_count,
+                maybe_handle_execution_control_request_mock.call_count,
+            )
 
     @parameterized.expand(
         [
@@ -623,17 +668,13 @@ class TestScriptRunner(ScriptRunner):
         # DeltaGenerator deltas will be enqueued into self.forward_msg_queue.
         self.forward_msg_queue = ForwardMsgQueue()
 
-        def enqueue_fn(msg):
-            self.forward_msg_queue.enqueue(msg)
-            self._maybe_handle_execution_control_request()
-
         self.script_request_queue = ScriptRequestQueue()
         script_path = os.path.join(os.path.dirname(__file__), "test_data", script_name)
 
         super(TestScriptRunner, self).__init__(
             session_id="test session id",
             session_data=SessionData(script_path, "test command line"),
-            enqueue_forward_msg=enqueue_fn,
+            enqueue_forward_msg=self.forward_msg_queue.enqueue,
             client_state=ClientState(),
             session_state=SessionState(),
             request_queue=self.script_request_queue,
@@ -644,8 +685,8 @@ class TestScriptRunner(ScriptRunner):
         self.script_thread_exceptions = []
 
         # Accumulates all ScriptRunnerEvents emitted by us.
-        self.events = []
-        self.event_data = []
+        self.events: List[ScriptRunnerEvent] = []
+        self.event_data: List[Any] = []
 
         def record_event(event, **kwargs):
             self.events.append(event)

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -56,10 +56,10 @@ def _create_widget(id, states):
 
 class ScriptRunnerTest(AsyncTestCase):
     def setUp(self):
-        super(ScriptRunnerTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
-        super(ScriptRunnerTest, self).tearDown()
+        super().tearDown()
 
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -665,9 +665,9 @@ class TestScriptRunner(ScriptRunner):
     def enqueue_shutdown(self):
         self.script_request_queue.enqueue(ScriptRequest.SHUTDOWN)
 
-    def _process_request_queue(self):
+    def _run_script_thread(self):
         try:
-            super(TestScriptRunner, self)._process_request_queue()
+            super(TestScriptRunner, self)._run_script_thread()
         except BaseException as e:
             self.script_thread_exceptions.append(e)
 

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -56,12 +56,6 @@ def _create_widget(id, states):
 
 
 class ScriptRunnerTest(AsyncTestCase):
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""
         scriptrunner = TestScriptRunner("good_script.py")

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -94,7 +94,7 @@ class ScriptRunnerTest(AsyncTestCase):
             mock_msg = MagicMock()
             runner._enqueue(mock_msg)
 
-            # The message should have been passed up to
+            # Ensure the message was "bubbled up" to the enqueue callback.
             enqueue_forward_msg_mock.assert_called_once_with(mock_msg)
 
             # If "install_tracer" is true, maybe_handle_execution_control_request


### PR DESCRIPTION
### Background

Currently, a `ForwardMsg` enqueued from an `st.foo()` call results in a twisty path:

1. `st.foo()` retrieves the current `ScriptRunContext` and calls its `enqueue` function
1. `ScriptRunContext.enqueue` calls the `AppSession.enqueue` callback
2. `AppSession.enqueue` retrieves the current `ScriptRunner` and calls its `maybe_handle_execution_control_request` function
3. `ScriptRunner.maybe_handle_execution_control_request` optionally interrupts its own script's execution to respond to a STOP or RERUN request.

(In other words, the message results in this call chain: ScriptRunContext -> AppSession -> ScriptRunner.)

This is weird for a couple reasons:
1. `ScriptRunner.maybe_handle_execution_control_request` should be private. The circumstances in which it's legal to be called are very specific, and `AppSession.enqueue` currently has some ScriptRunner "business logic" inside it.
2. The call chain should really be ScriptRunContext -> ScriptRunner -> AppSession. (AppSession creates ScriptRunner which in turn creates ScriptRunContext. After creation, AppSession should ideally never have to communicate directly with its ScriptRunner - especially in a future where there may be multiple ScriptRunners attached to a single AppSession.)

### Resolution

With this PR, `maybe_handle_execution_control_request` is a private method, and an enqueued `ForwardMsg` now "bubbles up" from ScriptRunContext -> ScriptRunner -> AppSession. AppSession no longer knows about execution control requests; they are handled internally by ScriptRunner.

(The salient change is that ScriptRunner gets a new `_enqueue` function that is called by `ScriptRunContext.enqueue`, rather than `ScriptRunContext.enqueue` calling `AppSession.enqueue` directly. The execution control request handling happens inside this new `ScriptRunner.enqueue` function, which then calls up to `AppSession.enqueue`.)