### PR TITLE
ScriptRequestQueue cleanup

### DIFF
--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -15,7 +15,7 @@
 import threading
 from collections import deque
 from enum import Enum
-from typing import Any, Optional, Tuple, Deque, NamedTuple
+from typing import Any, Optional, Tuple, Deque, NamedTuple, Iterable, Callable, TypeVar
 
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.state.widgets import coalesce_widget_states
@@ -139,7 +139,10 @@ class ScriptRequestQueue:
                 return None, None
 
 
-def _index_if(collection, pred) -> int:
+T = TypeVar("T")
+
+
+def _index_if(collection: Iterable[T], pred: Callable[[T], bool]) -> int:
     """Find the index of the first item in a collection for which a predicate is true.
 
     Returns the index, or -1 if no such item exists.

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -15,7 +15,7 @@
 import threading
 from collections import deque
 from enum import Enum
-from typing import Any, Optional, Tuple, Deque
+from typing import Any, Optional, Tuple, Deque, NamedTuple
 
 import attr
 
@@ -32,9 +32,8 @@ class ScriptRequest(Enum):
     SHUTDOWN = "SHUTDOWN"
 
 
-@attr.s(auto_attribs=True, slots=True)
-class RerunData:
-    """Data attached to RERUN requests."""
+class RerunData(NamedTuple):
+    """Data attached to RERUN requests. Immutable."""
 
     query_string: str = ""
     widget_states: Optional[WidgetStates] = None

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -52,12 +52,12 @@ class ScriptRequestQueue:
     _queue: Deque[Tuple[ScriptRequest, Any]] = attr.Factory(deque)
 
     @property
-    def has_request(self):
+    def has_request(self) -> bool:
         """True if the queue has at least one element"""
         with self._lock:
             return len(self._queue) > 0
 
-    def enqueue(self, request, data=None):
+    def enqueue(self, request: ScriptRequest, data: Any = None) -> None:
         """Enqueue a new request to the end of the queue.
 
         This request may be coalesced with an existing request if appropriate.
@@ -121,7 +121,7 @@ class ScriptRequestQueue:
             else:
                 self._queue.append((request, data))
 
-    def dequeue(self):
+    def dequeue(self) -> Tuple[Optional[ScriptRequest], Any]:
         """Pops the front-most request from the queue and returns it.
 
         Returns (None, None) if the queue is empty.
@@ -137,7 +137,7 @@ class ScriptRequestQueue:
                 return None, None
 
 
-def _index_if(collection, pred):
+def _index_if(collection, pred) -> int:
     """Find the index of the first item in a collection for which a predicate is true.
 
     Returns the index, or -1 if no such item exists.

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -15,7 +15,9 @@
 import threading
 from collections import deque
 from enum import Enum
-from typing import Any, Optional, Tuple, Deque, NamedTuple, Iterable, Callable, TypeVar
+from typing import Any, Optional, Tuple, Deque, Iterable, Callable, TypeVar
+
+import attr
 
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.state.widgets import coalesce_widget_states
@@ -30,7 +32,8 @@ class ScriptRequest(Enum):
     SHUTDOWN = "SHUTDOWN"
 
 
-class RerunData(NamedTuple):
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class RerunData:
     """Data attached to RERUN requests. Immutable."""
 
     query_string: str = ""

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -17,8 +17,6 @@ from collections import deque
 from enum import Enum
 from typing import Any, Optional, Tuple, Deque, NamedTuple
 
-import attr
-
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.state.widgets import coalesce_widget_states
 
@@ -39,7 +37,6 @@ class RerunData(NamedTuple):
     widget_states: Optional[WidgetStates] = None
 
 
-@attr.s(auto_attribs=True, slots=True)
 class ScriptRequestQueue:
     """A thread-safe queue of ScriptRequests.
 
@@ -47,8 +44,9 @@ class ScriptRequestQueue:
 
     """
 
-    _lock: threading.Lock = attr.Factory(threading.Lock)
-    _queue: Deque[Tuple[ScriptRequest, Any]] = attr.Factory(deque)
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._queue: Deque[Tuple[ScriptRequest, Any]] = deque()
 
     @property
     def has_request(self) -> bool:


### PR DESCRIPTION
Some very minor ScriptRequestQueue work, in advance of the faster-reruns stuff

- `RerunData` is now immutable. (It was never modified before, but now it's explicit)
- `ScriptRequestQueue` no longer uses the `attrs` library (it's not a dataclass, so attrs was not buying us anything)
- Added missing type annotations
- Re-organized `ScriptRequestQueue` for clarity and added some clarifying comments