### PR TITLE
Replace emoji.json link in markdown docstring with Streamlit app

### DIFF
--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -34,7 +34,7 @@ class MarkdownMixin:
 
             * Emoji shortcodes, such as `:+1:`  and `:sunglasses:`.
               For a list of all supported codes,
-              see https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json.
+              see https://share.streamlit.io/streamlit/emoji-shortcodes.
 
             * LaTeX expressions, by wrapping them in "$" or "$$" (the "$$"
               must be on their own lines). Supported LaTeX functions are listed


### PR DESCRIPTION
## 📚 Context

Thiago made an app to list our emoji shortcodes, instead of relying on an [ugly json file](https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json) like in the [st.markdown docstring](https://docs.streamlit.io/library/api-reference/text/st.markdown). This PR replaces the existing emoji.json link with the emoji shortcodes Streamlit app: https://share.streamlit.io/streamlit/emoji-shortcodes

- What kind of change does this PR introduce?
- [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Replaces https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json with @tvst's Streamlit app https://share.streamlit.io/streamlit/emoji-shortcodes in the `st.markdown` docstring.
- [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/153842711-c6cf8890-7132-4e30-b492-73700c1b428f.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/153842354-b12f1c19-0c91-49f4-9293-5995e8c80cd8.png)

## 🧪 Testing Done

- [x] Screenshots included

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
