### PR TITLE
[STLT-17] ✨ (Release Pipeline) Add full regression suite via pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,11 @@ integration-tests:
 cli-smoke-tests:
 	python scripts/cli_smoke_tests.py
 
+.PHONY: cli-regression-tests
+# Verify that CLI boots as expected when called with `python -m streamlit`
+cli-regression-tests:
+	pytest scripts/cli_regression_tests.py
+
 .PHONY: install
 # Install Streamlit into your Python environment.
 install:

--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import threading
+import time
+
+import pytest
+
+# Before running, ensure that you have:
+# - An isolated environment with Streamlit installed in production mode (not development) as well
+#   pytest. This can include the current version, nightly, or local build/wheel, like one of the
+#   following:
+#         pip install streamlit-nightly=[nightly tag]
+#         pip install lib/dist/<WHEEL_FILE>
+#         pip install streamlit
+# - The STREAMLIT_RELEASE_VERSION environment variable must be set, such as:
+#        export STREAMLIT_RELEASE_VERSION=1.5.1
+#
+# You can then run the tests from the root of the Streamlit repository using one of the following:
+#         pytest scripts/cli_regression_tests.py
+#         make cli-regression-tests
+
+
+class TestCLIRegressions:
+    @pytest.fixture(scope="module", autouse=True)
+    def setup(self):
+        # ---- Initialization
+        global CONFIG_FILE_PATH
+        CONFIG_FILE_PATH = os.path.expanduser("~/.streamlit/config.toml")
+
+        global CREDENTIALS_FILE_PATH
+        CREDENTIALS_FILE_PATH = os.path.expanduser("~/.streamlit/credentials.toml")
+
+        global REPO_ROOT
+        REPO_ROOT = os.getcwd()
+
+        global STREAMLIT_RELEASE_VERSION
+        STREAMLIT_RELEASE_VERSION = os.environ.get("STREAMLIT_RELEASE_VERSION", None)
+
+        # Ensure that there aren't any previously stored credentials
+        if os.path.exists(CREDENTIALS_FILE_PATH):
+            os.remove(CREDENTIALS_FILE_PATH)
+
+        yield  # Run tests
+
+        # ---- Tear Down
+        # Remove testing credentials
+        if os.path.exists(CREDENTIALS_FILE_PATH):
+            os.remove(CREDENTIALS_FILE_PATH)
+
+        if os.path.exists(CONFIG_FILE_PATH):
+            os.remove(CONFIG_FILE_PATH)
+
+        self.run_command("streamlit cache clear")
+
+    def parameterize(self, params):
+        return params.split(" ")
+
+    def run_command(self, command):
+        return subprocess.check_output(self.parameterize(command)).decode("UTF-8")
+
+    def test_streamlit_version(self):
+        assert (
+            STREAMLIT_RELEASE_VERSION != None
+        ), "You must set the $STREAMLIT_RELEASE_VERSION env variable"
+        assert STREAMLIT_RELEASE_VERSION in self.run_command("streamlit version")
+
+    def test_streamlit_activate(self):
+        process = subprocess.Popen(
+            "streamlit activate", stdin=subprocess.PIPE, shell=True
+        )
+        process.stdin.write(b"regressiontest@streamlit.io\n")
+        process.stdin.flush()
+        process.communicate()
+
+        with open(CREDENTIALS_FILE_PATH) as f:
+            assert "regressiontest@streamlit.io" in f.read()
+
+    # ---------------------------------------------------------------------------------------------
+    def run_single_proc(self, command, wait_in_seconds=2):
+        proc = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        # Sleep to allow commands to run
+        time.sleep(wait_in_seconds)
+
+        # Kill both processes, as output is accessible afterwards
+        proc.terminate()
+
+        try:
+            # Retrieve and return outputs
+            out_one, _ = proc.communicate(timeout=1)
+
+            return out_one.decode("utf-8")
+        except subprocess.TimeoutExpired:
+            assert False, "Subprocess timed out"
+
+    def run_double_proc(self, command_one, command_two, wait_in_seconds=2):
+        proc_one = subprocess.Popen(
+            command_one,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        # Quick sleep to ensure that proc_one gets started first
+        time.sleep(0.1)
+
+        proc_two = subprocess.Popen(
+            command_two,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        # Sleep to allow commands to run
+        time.sleep(wait_in_seconds)
+
+        # Kill both processes, as output is accessible afterwards
+        proc_one.terminate()
+        proc_two.terminate()
+
+        try:
+            # Retrieve and return outputs
+            out_one, _ = proc_one.communicate(timeout=1)
+            out_two, _ = proc_two.communicate(timeout=1)
+
+            return out_one.decode("utf-8"), out_two.decode("utf-8")
+        except subprocess.TimeoutExpired:
+            assert False, "Subprocess timed out"
+
+    def test_port_reassigned(self):
+        """When starting a new Streamlit session, it will run on port 8501 by default. If 8501 is
+        not available, it will use the next available port.
+        """
+
+        out_one, out_two = self.run_double_proc(
+            f"streamlit run --server.headless=true {REPO_ROOT}/examples/file_uploader.py",
+            f"streamlit run --server.headless=true {REPO_ROOT}/examples/file_uploader.py",
+        )
+
+        assert ":8501" in out_one, out_one
+        assert ":8502" in out_two, out_two
+
+    def test_conflicting_port(self):
+        out_one, out_two = self.run_double_proc(
+            f"streamlit run --server.headless=true {REPO_ROOT}/examples/file_uploader.py",
+            f"streamlit run --server.headless=true --server.port=8501 {REPO_ROOT}/examples/file_uploader.py",
+        )
+
+        assert ":8501" in out_one, out_one
+        assert "Port 8501 is already in use" in out_two, out_two
+
+    def test_cli_defined_port(self):
+        out = self.run_single_proc(
+            f"streamlit run --server.headless=true --server.port=9999 {REPO_ROOT}/examples/file_uploader.py",
+        )
+
+        assert ":9999" in out, out
+
+    def test_config_toml_defined_port(self):
+        with open(CONFIG_FILE_PATH, "w") as file:
+            file.write("[server]\n  port=8888")
+
+        out = self.run_single_proc(
+            f"streamlit run --server.headless=true {REPO_ROOT}/examples/file_uploader.py",
+        )
+
+        assert ":8888" in out, out

--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -89,7 +89,10 @@ class TestCLIRegressions:
 
     def run_single_proc(self, command, wait_in_seconds=2):
         proc = subprocess.Popen(
-            command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
 
         # Sleep to allow commands to run
@@ -108,14 +111,20 @@ class TestCLIRegressions:
 
     def run_double_proc(self, command_one, command_two, wait_in_seconds=2):
         proc_one = subprocess.Popen(
-            command_one, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            command_one,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
 
         # Quick sleep to ensure that proc_one gets started first
         time.sleep(0.1)
 
         proc_two = subprocess.Popen(
-            command_two, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            command_two,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
 
         # Sleep to allow commands to run
@@ -143,9 +152,11 @@ class TestCLIRegressions:
         ), f"Package version does not match the desired version of {STREAMLIT_RELEASE_VERSION}"
 
     def test_streamlit_activate(self):
-        process = subprocess.Popen("streamlit activate", stdin=subprocess.PIPE, shell=True)
-        process.stdin.write(b"regressiontest@streamlit.io\n")
-        process.stdin.flush()
+        process = subprocess.Popen(
+            "streamlit activate", stdin=subprocess.PIPE, shell=True
+        )
+        process.stdin.write(b"regressiontest@streamlit.io\n")  # type: ignore
+        process.stdin.flush()  # type: ignore
         process.communicate()
 
         with open(CREDENTIALS_FILE_PATH) as f:

--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -15,10 +15,16 @@
 
 import os
 import subprocess
-import threading
 import time
+from typing import Optional
 
 import pytest
+
+
+CONFIG_FILE_PATH: str
+CREDENTIALS_FILE_PATH: str
+REPO_ROOT: str
+STREAMLIT_RELEASE_VERSION: Optional[str]
 
 
 class TestCLIRegressions:
@@ -83,10 +89,7 @@ class TestCLIRegressions:
 
     def run_single_proc(self, command, wait_in_seconds=2):
         proc = subprocess.Popen(
-            command,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         )
 
         # Sleep to allow commands to run
@@ -105,20 +108,14 @@ class TestCLIRegressions:
 
     def run_double_proc(self, command_one, command_two, wait_in_seconds=2):
         proc_one = subprocess.Popen(
-            command_one,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            command_one, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         )
 
         # Quick sleep to ensure that proc_one gets started first
         time.sleep(0.1)
 
         proc_two = subprocess.Popen(
-            command_two,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            command_two, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         )
 
         # Sleep to allow commands to run
@@ -139,16 +136,14 @@ class TestCLIRegressions:
 
     def test_streamlit_version(self):
         assert (
-            STREAMLIT_RELEASE_VERSION != None
+            STREAMLIT_RELEASE_VERSION != ""
         ), "You must set the $STREAMLIT_RELEASE_VERSION env variable"
         assert STREAMLIT_RELEASE_VERSION in self.run_command(
             "streamlit version"
         ), f"Package version does not match the desired version of {STREAMLIT_RELEASE_VERSION}"
 
     def test_streamlit_activate(self):
-        process = subprocess.Popen(
-            "streamlit activate", stdin=subprocess.PIPE, shell=True
-        )
+        process = subprocess.Popen("streamlit activate", stdin=subprocess.PIPE, shell=True)
         process.stdin.write(b"regressiontest@streamlit.io\n")
         process.stdin.flush()
         process.communicate()

--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -20,22 +20,30 @@ import time
 
 import pytest
 
-# Before running, ensure that you have:
-# - An isolated environment with Streamlit installed in production mode (not development) as well
-#   pytest. This can include the current version, nightly, or local build/wheel, like one of the
-#   following:
-#         pip install streamlit-nightly=[nightly tag]
-#         pip install lib/dist/<WHEEL_FILE>
-#         pip install streamlit
-# - The STREAMLIT_RELEASE_VERSION environment variable must be set, such as:
-#        export STREAMLIT_RELEASE_VERSION=1.5.1
-#
-# You can then run the tests from the root of the Streamlit repository using one of the following:
-#         pytest scripts/cli_regression_tests.py
-#         make cli-regression-tests
-
 
 class TestCLIRegressions:
+    """Suite of CLI regression tests to be run against a release build of the Streamlit library.
+
+    Before running, ensure that you have:
+        - An isolated environment with Streamlit installed in production mode (not development) as
+          well as pytest. This can include the current version, nightly, or local build/wheel, like
+          one of the following:
+                pip install streamlit-nightly=[nightly tag]
+                pip install lib/dist/<WHEEL_FILE>
+                pip install streamlit
+        - The STREAMLIT_RELEASE_VERSION environment variable must be set, such as:
+                export STREAMLIT_RELEASE_VERSION=1.5.1
+
+    You can then run the tests from the root of the Streamlit repository using one of the following:
+            pytest scripts/cli_regression_tests.py
+            make cli-regression-tests
+
+    This test suite makes use of Python's built-in assert statement. Note that assertions in the
+    form of `assert <expression>` use Pytest's assertion introspection. In some cases, a more clear
+    error message is specified manually by using `assert <expression>, <message>`. See
+    https://docs.pytest.org/en/7.0.x/how-to/assert.html#assert-details for more details.
+    """
+
     @pytest.fixture(scope="module", autouse=True)
     def setup(self):
         # ---- Initialization
@@ -73,24 +81,6 @@ class TestCLIRegressions:
     def run_command(self, command):
         return subprocess.check_output(self.parameterize(command)).decode("UTF-8")
 
-    def test_streamlit_version(self):
-        assert (
-            STREAMLIT_RELEASE_VERSION != None
-        ), "You must set the $STREAMLIT_RELEASE_VERSION env variable"
-        assert STREAMLIT_RELEASE_VERSION in self.run_command("streamlit version")
-
-    def test_streamlit_activate(self):
-        process = subprocess.Popen(
-            "streamlit activate", stdin=subprocess.PIPE, shell=True
-        )
-        process.stdin.write(b"regressiontest@streamlit.io\n")
-        process.stdin.flush()
-        process.communicate()
-
-        with open(CREDENTIALS_FILE_PATH) as f:
-            assert "regressiontest@streamlit.io" in f.read()
-
-    # ---------------------------------------------------------------------------------------------
     def run_single_proc(self, command, wait_in_seconds=2):
         proc = subprocess.Popen(
             command,
@@ -147,6 +137,27 @@ class TestCLIRegressions:
         except subprocess.TimeoutExpired:
             assert False, "Subprocess timed out"
 
+    def test_streamlit_version(self):
+        assert (
+            STREAMLIT_RELEASE_VERSION != None
+        ), "You must set the $STREAMLIT_RELEASE_VERSION env variable"
+        assert STREAMLIT_RELEASE_VERSION in self.run_command(
+            "streamlit version"
+        ), f"Package version does not match the desired version of {STREAMLIT_RELEASE_VERSION}"
+
+    def test_streamlit_activate(self):
+        process = subprocess.Popen(
+            "streamlit activate", stdin=subprocess.PIPE, shell=True
+        )
+        process.stdin.write(b"regressiontest@streamlit.io\n")
+        process.stdin.flush()
+        process.communicate()
+
+        with open(CREDENTIALS_FILE_PATH) as f:
+            assert (
+                "regressiontest@streamlit.io" in f.read()
+            ), "Email address was not found in the credentials file"
+
     def test_port_reassigned(self):
         """When starting a new Streamlit session, it will run on port 8501 by default. If 8501 is
         not available, it will use the next available port.
@@ -157,8 +168,8 @@ class TestCLIRegressions:
             f"streamlit run --server.headless=true {REPO_ROOT}/examples/file_uploader.py",
         )
 
-        assert ":8501" in out_one, out_one
-        assert ":8502" in out_two, out_two
+        assert ":8501" in out_one, f"Incorrect port. See output:\n{out_one}"
+        assert ":8502" in out_two, f"Incorrect port. See output:\n{out_two}"
 
     def test_conflicting_port(self):
         out_one, out_two = self.run_double_proc(
@@ -166,15 +177,17 @@ class TestCLIRegressions:
             f"streamlit run --server.headless=true --server.port=8501 {REPO_ROOT}/examples/file_uploader.py",
         )
 
-        assert ":8501" in out_one, out_one
-        assert "Port 8501 is already in use" in out_two, out_two
+        assert ":8501" in out_one, f"Incorrect port. See output:\n{out_one}"
+        assert (
+            "Port 8501 is already in use" in out_two
+        ), f"Incorrect conflict. See output:\n{out_one}"
 
     def test_cli_defined_port(self):
         out = self.run_single_proc(
             f"streamlit run --server.headless=true --server.port=9999 {REPO_ROOT}/examples/file_uploader.py",
         )
 
-        assert ":9999" in out, out
+        assert ":9999" in out, f"Incorrect port. See output:\n{out}"
 
     def test_config_toml_defined_port(self):
         with open(CONFIG_FILE_PATH, "w") as file:
@@ -184,4 +197,4 @@ class TestCLIRegressions:
             f"streamlit run --server.headless=true {REPO_ROOT}/examples/file_uploader.py",
         )
 
-        assert ":8888" in out, out
+        assert ":8888" in out, f"Incorrect port. See output:\n{out}"


### PR DESCRIPTION
## 📚 Context

- What kind of change does this PR introduce?

  - [X] Other, please describe: Automate CLI regressions tests for release process

## 🧠 Description of Changes

- Add regression test using `pytest` to automate the manual CLI-based testing as part of the release process. A follow up PR will integrate this process into CI.

## 🧪 Testing Done

- [X] Testing was completed using an isolated environment with the desired Streamlit library and pytest installed. Note that this does not work on development builds, a prod build must be used in order to use some features such as the `server.port` arg. After having issues with flaky tests (and false positives), I refactored the subprocess flow to be much more stable. The test suite can be run from the root of the repository with either `pytest scripts/cli_regression_tests.py` or `make cli-regression-tests`. You must also set the `STREAMLIT_RELEASE_VERSION` env var. See https://github.com/streamlit/streamlit/pull/4397/files#diff-9aed1d25a71096c8a9104faa5a1edc1e0384915621212990b0874c236b61bb48R23 for full instructions.

## 🌐 References

- Regression Suite Notes: https://www.notion.so/streamlit/Streamlit-Pipeline-Documentation-a01c0469549043c58e709fb6e0a7e11a