### PR TITLE
session_state docstrings (+ minor housekeeping)

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -191,9 +191,9 @@ from streamlit.commands.page_config import set_page_config
 
 # Session State
 
-from streamlit.state.session_state import LazySessionState
+from streamlit.state.session_state import AutoSessionState
 
-session_state = LazySessionState()
+session_state = AutoSessionState()
 
 
 # Beta APIs

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -17,7 +17,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Json_pb2 import Json as JsonProto
-from streamlit.state.session_state import LazySessionState
+from streamlit.state.session_state import AutoSessionState
 
 
 class JsonMixin:
@@ -51,7 +51,7 @@ class JsonMixin:
         """
         import streamlit as st
 
-        if isinstance(body, LazySessionState):
+        if isinstance(body, AutoSessionState):
             body = body.to_dict()
 
         if not isinstance(body, str):

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -22,7 +22,7 @@ import numpy as np
 import streamlit
 from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
-from streamlit.state.session_state import LazySessionState
+from streamlit.state.session_state import AutoSessionState
 
 # Special methods:
 
@@ -211,7 +211,7 @@ class WriteMixin:
                 flush_buffer()
                 dot = vis_utils.model_to_dot(arg)
                 self.dg.graphviz_chart(dot.to_string())
-            elif isinstance(arg, (dict, list, LazySessionState)):
+            elif isinstance(arg, (dict, list, AutoSessionState)):
                 flush_buffer()
                 self.dg.json(arg)
             elif type_util.is_namedtuple(arg):

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -703,14 +703,16 @@ def get_session_state() -> SessionState:
     return ctx.session_state
 
 
-class LazySessionState(MutableMapping[str, Any]):
-    """A lazy wrapper around SessionState.
+class AutoSessionState(MutableMapping[str, Any]):
+    """A SessionState interface that acts as a wrapper around the
+    current script thread's SessionState instance.
 
-    SessionState can't be instantiated normally in lib/streamlit/__init__.py
-    because there may not be a AppSession yet. Instead we have this wrapper,
-    which delegates to the SessionState for the active AppSession. This will
-    only be interacted within an app script, that is, when a AppSession is
-    guaranteed to exist.
+    When a user script uses `st.session_state`, it's interacting with
+    the singleton AutoSessionState instance, which delegates to the
+    SessionState for the active AppSession.
+
+    (This will only be used within an app script, when an AppSession is
+    guaranteed to exist.)
     """
 
     @staticmethod

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -634,20 +634,26 @@ class SessionState(MutableMapping[str, Any]):
         self._key_id_mapping[user_key] = widget_id
 
     def copy(self) -> "SessionState":
+        """Return a deep copy of self."""
         return deepcopy(self)
 
-    def set_keyed_widget(
+    def set_keyed_widget_metadata(
         self, metadata: WidgetMetadata, widget_id: str, user_key: str
     ) -> None:
+        """Set the metadata for the widget with the given id and user_key."""
         self._set_metadata(metadata)
         self.set_key_widget_mapping(widget_id, user_key)
         self._maybe_set_new_widget_value(widget_id, user_key)
 
-    def set_unkeyed_widget(self, metadata: WidgetMetadata, widget_id: str) -> None:
+    def set_unkeyed_widget_metadata(
+        self, metadata: WidgetMetadata, widget_id: str
+    ) -> None:
+        """Set the metadata for the widget with the given id."""
         self._set_metadata(metadata)
         self._maybe_set_new_widget_value(widget_id)
 
-    def get_metadata_by_key(self, user_key: str) -> WidgetMetadata:
+    def get_widget_metadata_by_key(self, user_key: str) -> WidgetMetadata:
+        """Return the WidgetMetadata for the widget with the given user_key."""
         widget_id = self._key_id_mapping[user_key]
         return self._new_widget_state.widget_metadata[widget_id]
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -30,7 +30,6 @@ from typing import (
     Callable,
     Set,
     List,
-    NamedTuple,
 )
 
 import attr
@@ -56,13 +55,15 @@ SCRIPT_RUN_WITHOUT_ERRORS_KEY = (
 )
 
 
-class Serialized(NamedTuple):
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class Serialized:
     """A widget value that's serialized to a protobuf. Immutable."""
 
     value: WidgetStateProto
 
 
-class Value(NamedTuple):
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class Value:
     """A widget value that's not serialized. Immutable."""
 
     value: Any

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -410,10 +410,6 @@ class SessionState(MutableMapping[str, Any]):
         """True if a value with the given key is in the current session state."""
         return user_key in self._new_session_state
 
-    def is_new_widget_value(self, widget_id: str) -> bool:
-        """True a widget with the given ID is in the current widget state."""
-        return widget_id in self._new_widget_state
-
     def __iter__(self) -> Iterator[Any]:
         return iter(self.keys())
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -713,7 +713,9 @@ class LazySessionState(MutableMapping[str, Any]):
     guaranteed to exist.
     """
 
-    def _validate_key(self, key) -> None:
+    @staticmethod
+    def _validate_key(key: str) -> None:
+        """Raise an Exception if the given value key is invalid."""
         if _is_widget_id(key):
             raise StreamlitAPIException(
                 f"Keys beginning with {GENERATED_WIDGET_KEY_PREFIX} are reserved."

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -30,6 +30,7 @@ from typing import (
     Callable,
     Set,
     List,
+    NamedTuple,
 )
 
 import attr
@@ -55,13 +56,15 @@ SCRIPT_RUN_WITHOUT_ERRORS_KEY = (
 )
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
-class Serialized:
+class Serialized(NamedTuple):
+    """A widget value that's serialized to a protobuf. Immutable."""
+
     value: WidgetStateProto
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
-class Value:
+class Value(NamedTuple):
+    """A widget value that's not serialized. Immutable."""
+
     value: Any
 
 

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -163,9 +163,9 @@ def register_widget(
     )
     # TODO: should these be merged into a more generic call so this code doesn't need to know about keyed vs unkeyed?
     if user_key is not None:
-        session_state.set_keyed_widget(metadata, widget_id, user_key)
+        session_state.set_keyed_widget_metadata(metadata, widget_id, user_key)
     else:
-        session_state.set_unkeyed_widget(metadata, widget_id)
+        session_state.set_unkeyed_widget_metadata(metadata, widget_id)
     value_changed = session_state.should_set_frontend_state_value(widget_id, user_key)
 
     val = session_state.get_value_for_registration(widget_id)

--- a/lib/tests/streamlit/script_request_queue_test.py
+++ b/lib/tests/streamlit/script_request_queue_test.py
@@ -90,10 +90,10 @@ class ScriptRequestQueueTest(unittest.TestCase):
         _create_widget("trigger", states).trigger_value = False
         _create_widget("int", states).int_value = 456
 
-        session_state.set_metadata(
+        session_state._set_metadata(
             WidgetMetadata("trigger", lambda x, s: x, None, "trigger_value")
         )
-        session_state.set_metadata(
+        session_state._set_metadata(
             WidgetMetadata("int", lambda x, s: x, lambda x: x, "int_value")
         )
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -29,7 +29,7 @@ from streamlit.script_run_context import get_script_run_ctx
 from streamlit.state.session_state import (
     GENERATED_WIDGET_KEY_PREFIX,
     get_session_state,
-    LazySessionState,
+    AutoSessionState,
     SessionState,
     Serialized,
     Value,
@@ -600,80 +600,80 @@ class SessionStateMethodTests(unittest.TestCase):
     "streamlit.state.session_state.get_session_state",
     return_value=MagicMock(filtered_state={"foo": "bar"}),
 )
-class LazySessionStateTests(unittest.TestCase):
+class AutoSessionStateTests(unittest.TestCase):
     reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
 
     def setUp(self):
-        self.lazy_session_state = LazySessionState()
+        self.auto_session_state = AutoSessionState()
 
     def test_iter(self, _):
-        state_iter = iter(self.lazy_session_state)
+        state_iter = iter(self.auto_session_state)
         assert next(state_iter) == "foo"
         with pytest.raises(StopIteration):
             next(state_iter)
 
     def test_len(self, _):
-        assert len(self.lazy_session_state) == 1
+        assert len(self.auto_session_state) == 1
 
     def test_validate_key(self, _):
         with pytest.raises(StreamlitAPIException) as e:
-            self.lazy_session_state._validate_key(self.reserved_key)
+            self.auto_session_state._validate_key(self.reserved_key)
         assert "are reserved" in str(e.value)
 
     def test_to_dict(self, _):
-        assert self.lazy_session_state.to_dict() == {"foo": "bar"}
+        assert self.auto_session_state.to_dict() == {"foo": "bar"}
 
     # NOTE: We only test the error cases of {get, set, del}{item, attr} below
     # since the others are tested in another test class.
     def test_getitem_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
-            self.lazy_session_state[self.reserved_key]
+            self.auto_session_state[self.reserved_key]
 
     def test_setitem_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
-            self.lazy_session_state[self.reserved_key] = "foo"
+            self.auto_session_state[self.reserved_key] = "foo"
 
     def test_delitem_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
-            del self.lazy_session_state[self.reserved_key]
+            del self.auto_session_state[self.reserved_key]
 
     def test_getattr_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
-            getattr(self.lazy_session_state, self.reserved_key)
+            getattr(self.auto_session_state, self.reserved_key)
 
     def test_setattr_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
-            setattr(self.lazy_session_state, self.reserved_key, "foo")
+            setattr(self.auto_session_state, self.reserved_key, "foo")
 
     def test_delattr_reserved_key(self, _):
         with pytest.raises(StreamlitAPIException):
-            delattr(self.lazy_session_state, self.reserved_key)
+            delattr(self.auto_session_state, self.reserved_key)
 
 
-class LazySessionStateAttributeTests(unittest.TestCase):
-    """Tests of LazySessionState attribute methods.
+class AutoSessionStateAttributeTests(unittest.TestCase):
+    """Tests of AutoSessionState attribute methods.
 
     Separate from the others to change patching. Test methods are individually
     patched to avoid issues with mutability.
     """
 
     def setUp(self):
-        self.lazy_session_state = LazySessionState()
+        self.auto_session_state = AutoSessionState()
 
     @patch(
         "streamlit.state.session_state.get_session_state",
         return_value=SessionState(new_session_state={"foo": "bar"}),
     )
     def test_delattr(self, _):
-        del self.lazy_session_state.foo
-        assert "foo" not in self.lazy_session_state
+        del self.auto_session_state.foo
+        assert "foo" not in self.auto_session_state
 
     @patch(
         "streamlit.state.session_state.get_session_state",
         return_value=SessionState(new_session_state={"foo": "bar"}),
     )
     def test_getattr(self, _):
-        assert self.lazy_session_state.foo == "bar"
+        assert self.auto_session_state.foo == "bar"
 
     @patch(
         "streamlit.state.session_state.get_session_state",
@@ -681,15 +681,15 @@ class LazySessionStateAttributeTests(unittest.TestCase):
     )
     def test_getattr_error(self, _):
         with pytest.raises(AttributeError):
-            del self.lazy_session_state.nonexistent
+            del self.auto_session_state.nonexistent
 
     @patch(
         "streamlit.state.session_state.get_session_state",
         return_value=SessionState(new_session_state={"foo": "bar"}),
     )
     def test_setattr(self, _):
-        self.lazy_session_state.corge = "grault2"
-        assert self.lazy_session_state.corge == "grault2"
+        self.auto_session_state.corge = "grault2"
+        assert self.auto_session_state.corge == "grault2"
 
 
 @given(state=stst.session_state())

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -583,7 +583,7 @@ class SessionStateMethodTests(unittest.TestCase):
             serializer=identity,
             value_type="int_value",
         )
-        self.session_state.set_keyed_widget(
+        self.session_state.set_keyed_widget_metadata(
             metadata, f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1", "widget_id_1"
         )
         assert (
@@ -756,12 +756,12 @@ def test_map_set_del_3837_regression():
     )
     m = SessionState()
     m["0"] = 0
-    m.set_unkeyed_widget(
+    m.set_unkeyed_widget_metadata(
         meta1, "$$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None"
     )
     m.compact_state()
 
-    m.set_keyed_widget(
+    m.set_keyed_widget_metadata(
         meta2, "$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", "0"
     )
     key = "0"

--- a/lib/tests/streamlit/state/strategies.py
+++ b/lib/tests/streamlit/state/strategies.py
@@ -40,7 +40,7 @@ def _session_state(draw):
         hst.dictionaries(keys=unkeyed_widget_ids, values=hst.integers())
     )
     for wid, v in unkeyed_widgets.items():
-        state.set_unkeyed_widget(mock_metadata(wid, v), wid)
+        state.set_unkeyed_widget_metadata(mock_metadata(wid, v), wid)
 
     widget_key_val_triple = draw(
         hst.lists(hst.tuples(hst.uuids(), user_key, hst.integers()))
@@ -50,7 +50,7 @@ def _session_state(draw):
         for wid, key, val in widget_key_val_triple
     }
     for key, (wid, val) in k_wids.items():
-        state.set_keyed_widget(mock_metadata(wid, val), wid, key)
+        state.set_keyed_widget_metadata(mock_metadata(wid, val), wid, key)
 
     if k_wids:
         session_state_widget_entries = draw(

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -54,11 +54,11 @@ class WidgetManagerTests(unittest.TestCase):
         session_state = SessionState()
         session_state.set_widgets_from_proto(states)
 
-        session_state.set_metadata(create_metadata("trigger", "trigger_value"))
-        session_state.set_metadata(create_metadata("bool", "bool_value"))
-        session_state.set_metadata(create_metadata("float", "double_value"))
-        session_state.set_metadata(create_metadata("int", "int_value"))
-        session_state.set_metadata(create_metadata("string", "string_value"))
+        session_state._set_metadata(create_metadata("trigger", "trigger_value"))
+        session_state._set_metadata(create_metadata("bool", "bool_value"))
+        session_state._set_metadata(create_metadata("float", "double_value"))
+        session_state._set_metadata(create_metadata("int", "int_value"))
+        session_state._set_metadata(create_metadata("string", "string_value"))
 
         self.assertEqual(True, session_state.get("trigger"))
         self.assertEqual(True, session_state.get("bool"))
@@ -79,8 +79,8 @@ class WidgetManagerTests(unittest.TestCase):
         session_state = SessionState()
         session_state.set_widgets_from_proto(states)
 
-        session_state.set_metadata(create_metadata("trigger", "trigger_value", True))
-        session_state.set_metadata(create_metadata("trigger2", "trigger_value"))
+        session_state._set_metadata(create_metadata("trigger", "trigger_value", True))
+        session_state._set_metadata(create_metadata("trigger2", "trigger_value"))
 
         self.assertEqual(dict(session_state.values()), {"trigger": True})
 
@@ -90,7 +90,7 @@ class WidgetManagerTests(unittest.TestCase):
 
     def test_set_widget_attrs_nonexistent(self):
         session_state = SessionState()
-        session_state.set_metadata(create_metadata("fake_widget_id", ""))
+        session_state._set_metadata(create_metadata("fake_widget_id", ""))
 
         self.assertTrue(
             isinstance(
@@ -133,7 +133,7 @@ class WidgetManagerTests(unittest.TestCase):
             ("string", "string_value", mock_callback, (1,), {"x": 2}),
         ]
         for widget_id, value_type, callback, args, kwargs in callback_cases:
-            session_state.set_metadata(
+            session_state._set_metadata(
                 WidgetMetadata(
                     widget_id,
                     deserializer,
@@ -166,7 +166,7 @@ class WidgetManagerTests(unittest.TestCase):
 
         session_state = SessionState()
         session_state.set_widgets_from_proto(widget_states)
-        session_state.set_metadata(
+        session_state._set_metadata(
             WidgetMetadata("other_widget", lambda x, s: x, None, "trigger_value", True)
         )
 
@@ -182,10 +182,10 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("trigger", states).trigger_value = True
         _create_widget("int", states).int_value = 123
         session_state.set_widgets_from_proto(states)
-        session_state.set_metadata(
+        session_state._set_metadata(
             WidgetMetadata("trigger", lambda x, s: x, None, "trigger_value")
         )
-        session_state.set_metadata(
+        session_state._set_metadata(
             WidgetMetadata("int", lambda x, s: x, None, "int_value")
         )
 
@@ -207,12 +207,12 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("missing_in_new", old_states).int_value = 123
         _create_widget("shape_changing_trigger", old_states).trigger_value = True
 
-        session_state.set_metadata(create_metadata("old_set_trigger", "trigger_value"))
-        session_state.set_metadata(
+        session_state._set_metadata(create_metadata("old_set_trigger", "trigger_value"))
+        session_state._set_metadata(
             create_metadata("old_unset_trigger", "trigger_value")
         )
-        session_state.set_metadata(create_metadata("missing_in_new", "int_value"))
-        session_state.set_metadata(
+        session_state._set_metadata(create_metadata("missing_in_new", "int_value"))
+        session_state._set_metadata(
             create_metadata("shape changing trigger", "trigger_value")
         )
 
@@ -222,9 +222,9 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("new_set_trigger", new_states).trigger_value = True
         _create_widget("added_in_new", new_states).int_value = 456
         _create_widget("shape_changing_trigger", new_states).int_value = 3
-        session_state.set_metadata(create_metadata("new_set_trigger", "trigger_value"))
-        session_state.set_metadata(create_metadata("added_in_new", "int_value"))
-        session_state.set_metadata(
+        session_state._set_metadata(create_metadata("new_set_trigger", "trigger_value"))
+        session_state._set_metadata(create_metadata("added_in_new", "int_value"))
+        session_state._set_metadata(
             create_metadata("shape_changing_trigger", "int_value")
         )
 

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -27,7 +27,7 @@ import streamlit as st
 from streamlit import type_util
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIException
-from streamlit.state.session_state import LazySessionState
+from streamlit.state.session_state import AutoSessionState
 
 
 class StreamlitWriteTest(unittest.TestCase):
@@ -171,7 +171,7 @@ class StreamlitWriteTest(unittest.TestCase):
     def test_session_state(self):
         """Test st.write with st.session_state."""
         with patch("streamlit.delta_generator.DeltaGenerator.json") as p:
-            st.write(LazySessionState())
+            st.write(AutoSessionState())
 
             p.assert_called_once()
 


### PR DESCRIPTION
Some housekeeping to the session_state module as I was working through understanding it better

- Adds docstrings to many session_state methods (especially the ones that were non-obvious to me)
- Simplifies a couple of methods with some deeply-nested clauses
- Adds underscores to a few private-seeming methods that aren't called outside of the module
- Adds a handful of missing type annotations
- Renames `LazySessionState` -> `AutoSessionState` ("Lazy" generally means "lazily-instantiated", but this class is not instantiating a SessionState; it's redirecting to whatever the current thread's SessionState is.)
