### PR TITLE
Add @jroes as a codeowner for new dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, that is.
 * @streamlit/core
+frontend/package.json @jroes
+lib/Pipfile @jroes


### PR DESCRIPTION
## 📚 Context

We want to ensure that streamlit/streamlit depends only on projects that are compatible with our preferred licensing model.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: New policy/process

## 🧠 Description of Changes

With this change I'm making myself the codeowner for our dependency files to ensure we only introduce dependencies that meet our standards.

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
