### PR TITLE
Rename script_path to main_script_path

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -595,10 +595,10 @@ export class App extends PureComponent<Props, State> {
     })
 
     const { appHash } = this.state
-    const { scriptRunId, name: scriptName, scriptPath } = newSessionProto
+    const { scriptRunId, name: scriptName, mainScriptPath } = newSessionProto
 
     const newSessionHash = hashString(
-      SessionInfo.current.installationId + scriptPath
+      SessionInfo.current.installationId + mainScriptPath
     )
 
     // Set the title and favicon to their default values

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -76,7 +76,7 @@ export class MetricsManager {
   /**
    * App hash uniquely identifies "projects" so we can tell
    * how many projects are being created with Streamlit while still keeping
-   * possibly-sensitive info like the scriptPath outside of our metrics
+   * possibly-sensitive info like the mainScriptPath outside of our metrics
    * services.
    */
   private appHash = "Not initialized"

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -373,7 +373,7 @@ class AppSession:
 
         msg.new_session.script_run_id = _generate_scriptrun_id()
         msg.new_session.name = self._session_data.name
-        msg.new_session.script_path = self._session_data.script_path
+        msg.new_session.main_script_path = self._session_data.main_script_path
 
         _populate_config_msg(msg.new_session.config)
         _populate_theme_msg(msg.new_session.custom_theme)
@@ -413,7 +413,7 @@ class AppSession:
         try:
             from streamlit.git_util import GitRepo
 
-            repo = GitRepo(self._session_data.script_path)
+            repo = GitRepo(self._session_data.main_script_path)
 
             repo_info = repo.get_repo_info()
             if repo_info is None:

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -67,11 +67,11 @@ def configurator_options(func):
     return func
 
 
-# Fetch remote file at url_path to script_path
-def _download_remote(script_path, url_path):
+# Fetch remote file at url_path to main_script_path
+def _download_remote(main_script_path, url_path):
     import requests
 
-    with open(script_path, "wb") as fp:
+    with open(main_script_path, "wb") as fp:
         try:
             resp = requests.get(url_path)
             resp.raise_for_status()
@@ -191,11 +191,13 @@ def main_run(target, args=None, **kwargs):
             from streamlit import url_util
 
             path = urlparse(target).path
-            script_path = os.path.join(temp_dir, path.strip("/").rsplit("/", 1)[-1])
+            main_script_path = os.path.join(
+                temp_dir, path.strip("/").rsplit("/", 1)[-1]
+            )
             # if this is a GitHub/Gist blob url, convert to a raw URL first.
             target = url_util.process_gitblob_url(target)
-            _download_remote(script_path, target)
-            _main_run(script_path, args, flag_options=kwargs)
+            _download_remote(main_script_path, target)
+            _main_run(main_script_path, args, flag_options=kwargs)
     else:
         if not os.path.exists(target):
             raise click.BadParameter("File does not exist: {}".format(target))

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -353,16 +353,18 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
-            with source_util.open_python_file(self._session_data.script_path) as f:
+            with source_util.open_python_file(self._session_data.main_script_path) as f:
                 filebody = f.read()
 
             if config.get_option("runner.magicEnabled"):
-                filebody = magic.add_magic(filebody, self._session_data.script_path)
+                filebody = magic.add_magic(
+                    filebody, self._session_data.main_script_path
+                )
 
             code = compile(
                 filebody,
                 # Pass in the file path so it can show up in exceptions.
-                self._session_data.script_path,
+                self._session_data.main_script_path,
                 # We're compiling entire blocks of Python, so we need "exec"
                 # mode (as opposed to "eval" or "single").
                 mode="exec",
@@ -410,7 +412,7 @@ class ScriptRunner:
             # work correctly. The CodeHasher is scoped to
             # files contained in the directory of __main__.__file__, which we
             # assume is the main script directory.
-            module.__dict__["__file__"] = self._session_data.script_path
+            module.__dict__["__file__"] = self._session_data.main_script_path
 
             with modified_sys_path(self._session_data), self._set_execing_flag():
                 # Run callbacks for widgets whose values have changed.
@@ -533,14 +535,14 @@ class modified_sys_path:
         return util.repr_(self)
 
     def __enter__(self):
-        if self._session_data.script_path not in sys.path:
-            sys.path.insert(0, self._session_data.script_path)
+        if self._session_data.main_script_path not in sys.path:
+            sys.path.insert(0, self._session_data.main_script_path)
             self._added_path = True
 
     def __exit__(self, type, value, traceback):
         if self._added_path:
             try:
-                sys.path.remove(self._session_data.script_path)
+                sys.path.remove(self._session_data.main_script_path)
             except ValueError:
                 pass
 

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -246,7 +246,9 @@ class Server:
 
         return Server._singleton
 
-    def __init__(self, ioloop: IOLoop, script_path: str, command_line: Optional[str]):
+    def __init__(
+        self, ioloop: IOLoop, main_script_path: str, command_line: Optional[str]
+    ):
         """Create the server. It won't be started yet."""
         if Server._singleton is not None:
             raise RuntimeError("Server already initialized. Use .get_current() instead")
@@ -256,7 +258,7 @@ class Server:
         _set_tornado_log_levels()
 
         self._ioloop = ioloop
-        self._script_path = script_path
+        self._main_script_path = main_script_path
         self._command_line = command_line if command_line is not None else ""
 
         # Mapping of AppSession.id -> SessionInfo.
@@ -287,8 +289,8 @@ class Server:
         return util.repr_(self)
 
     @property
-    def script_path(self) -> str:
-        return self._script_path
+    def main_script_path(self) -> str:
+        return self._main_script_path
 
     def get_session_by_id(self, session_id: str) -> Optional[AppSession]:
         """Return the AppSession corresponding to the given id, or None if
@@ -446,7 +448,7 @@ class Server:
         (True, "ok") if the script completes without error, or (False, err_msg)
         if the script raises an exception.
         """
-        session_data = SessionData(self._script_path, self._command_line)
+        session_data = SessionData(self._main_script_path, self._command_line)
         local_sources_watcher = LocalSourcesWatcher(session_data)
         session = AppSession(
             ioloop=self._ioloop,
@@ -484,7 +486,7 @@ class Server:
     def is_running_hello(self) -> bool:
         from streamlit.hello import hello
 
-        return self._script_path == hello.__file__
+        return self._main_script_path == hello.__file__
 
     @tornado.gen.coroutine
     def _loop_coroutine(
@@ -659,7 +661,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             The newly-created AppSession for this browser connection.
 
         """
-        session_data = SessionData(self._script_path, self._command_line)
+        session_data = SessionData(self._main_script_path, self._command_line)
         local_sources_watcher = LocalSourcesWatcher(session_data)
         session = AppSession(
             ioloop=self._ioloop,

--- a/lib/streamlit/session_data.py
+++ b/lib/streamlit/session_data.py
@@ -58,28 +58,28 @@ class SessionData:
     the ForwardMsgQueue that is used to deliver messages to a connected browser.
     """
 
-    script_path: str
+    main_script_path: str
     script_folder: str
     name: str
     command_line: str
     _browser_queue: ForwardMsgQueue
 
-    def __init__(self, script_path: str, command_line: str):
+    def __init__(self, main_script_path: str, command_line: str):
         """Constructor.
 
         Parameters
         ----------
-        script_path : str
+        main_script_path : str
             Path of the Python file from which this app is generated.
 
         command_line : string
             Command line as input by the user
 
         """
-        basename = os.path.basename(script_path)
+        basename = os.path.basename(main_script_path)
 
-        self.script_path = os.path.abspath(script_path)
-        self.script_folder = os.path.dirname(self.script_path)
+        self.main_script_path = os.path.abspath(main_script_path)
+        self.script_folder = os.path.dirname(self.main_script_path)
         self.name = str(os.path.splitext(basename)[0])
 
         # The browser queue contains messages that haven't yet been

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -52,7 +52,7 @@ class LocalSourcesWatcher:
         self._watched_modules: Dict[str, WatchedModule] = {}
 
         self._register_watcher(
-            self._session_data.script_path,
+            self._session_data.main_script_path,
             module_name=None,  # Only the root script has None here.
         )
 
@@ -113,7 +113,7 @@ class LocalSourcesWatcher:
         if filepath not in self._watched_modules:
             return
 
-        if filepath == self._session_data.script_path:
+        if filepath == self._session_data.main_script_path:
             return
 
         wm = self._watched_modules[filepath]

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -284,7 +284,7 @@ class BootstrapPrintTest(unittest.TestCase):
         mock_git_repo.return_value.is_valid.return_value = False
         mock_git_repo.return_value.git_version = (1, 2, 3)
 
-        bootstrap._maybe_print_old_git_warning("script_path")
+        bootstrap._maybe_print_old_git_warning("main_script_path")
         out = sys.stdout.getvalue()
         self.assertTrue(
             "Streamlit requires Git 2.7.0 or later, but you have 1.2.3." in out

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -162,7 +162,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # files contained in the directory of __main__.__file__, which we
         # assume is the main script directory.
         self.assertEqual(
-            scriptrunner._session_data.script_path,
+            scriptrunner._session_data.main_script_path,
             sys.modules["__main__"].__file__,
             (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
@@ -685,11 +685,13 @@ class TestScriptRunner(ScriptRunner):
         self.forward_msg_queue = ForwardMsgQueue()
 
         self.script_request_queue = ScriptRequestQueue()
-        script_path = os.path.join(os.path.dirname(__file__), "test_data", script_name)
+        main_script_path = os.path.join(
+            os.path.dirname(__file__), "test_data", script_name
+        )
 
         super(TestScriptRunner, self).__init__(
             session_id="test session id",
-            session_data=SessionData(script_path, "test command line"),
+            session_data=SessionData(main_script_path, "test command line"),
             enqueue_forward_msg=self.forward_msg_queue.enqueue,
             client_state=ClientState(),
             session_state=SessionState(),

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -34,7 +34,7 @@ message NewSession {
 
   // The full path of the script that launched this app. Example:
   // '/foo/bar/foo.py'
-  string script_path = 4;
+  string main_script_path = 4;
 
   // DEPRECATED.
   // DeployParams deploy_params = 5;

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -322,11 +322,11 @@ def run_component_template_e2e_test(ctx: Context, template_dir: str, name: str) 
     # Start the template's dev server.
     with AsyncSubprocess(["yarn", "start"], cwd=frontend_dir) as webpack_proc:
         # Run the test!
-        script_path = join(template_dir, "__init__.py")
+        main_script_path = join(template_dir, "__init__.py")
         spec_path = join(ROOT_DIR, "e2e/specs/component_template.spec.js")
 
         ctx.cypress_env_vars["COMPONENT_TEMPLATE_TYPE"] = name
-        success = run_test(ctx, spec_path, ["streamlit", "run", script_path])
+        success = run_test(ctx, spec_path, ["streamlit", "run", main_script_path])
         del ctx.cypress_env_vars["COMPONENT_TEMPLATE_TYPE"]
 
         webpack_stdout = webpack_proc.terminate()


### PR DESCRIPTION
## 📚 Context

In the soon-to-come multipage apps world, the `script_path` name won't be ideal
as an app may have multiple scripts/pages. To account for this, we preemptively
rename `script_path` -> `main_script_path` in most places (although we keep it
the same in places where the script may be a general script as opposed to the
script specified in `streamlit run`).

Note that this is being merged straight into `develop` rather than
`feature/multipage-apps` since it's only a name change, and it's slightly nicer
to get this in earlier (to cut down on the size of the feature branch diff when
we eventually merge that).

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe:

## 🧠 Description of Changes

- replace `script_path` with `main_script_path` in most places
