### PR TITLE
Make easy proto changes for passing pages to the frontend

### DIFF
--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -22,4 +22,5 @@ import "streamlit/proto/WidgetStates.proto";
 message ClientState {
   string query_string = 1;
   WidgetStates widget_states = 2;
+  string page_name = 3;
 }

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -48,6 +48,9 @@ message NewSession {
   // Theme configuration options defined in the .streamlit/config.toml file.
   // See the "theme" config section.
   CustomThemeConfig custom_theme = 7;
+
+  // A list of all of this app's pages, in order and including the main page.
+  repeated AppPage app_pages = 8;
 }
 
 // Contains the session state that existed at the time the user connected.
@@ -132,4 +135,11 @@ message UserInfo {
 message EnvironmentInfo {
   string streamlit_version = 1;
   string python_version = 2;
+}
+
+// A page in the app. Includes both the name of the page as well as the full
+// path to the corresponding script file.
+message AppPage {
+  string page_name = 1;
+  string script_path = 2;
 }


### PR DESCRIPTION
## 📚 Context

In the multipage apps world, we need to send the list of an app's pages to the client
so that links to each page can be rendered by the page nav UI.

Note that we don't actually use any of these protos yet. That will come in a future commit
(and it's not a big deal that we're checking in dead code as it's going into a feature branch).

- What kind of change does this PR introduce?

  - [x] Feature - ..kinda. These changes will eventually be used to build a feature
 
## 🧠 Description of Changes

- Add new page-related proto fields and message types