### PR TITLE
Send an app's page info to the frontend

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -22,7 +22,7 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 import tornado.ioloop
 
 import streamlit.elements.exception as exception_utils
-from streamlit import __version__, caching, config, legacy_caching, secrets
+from streamlit import __version__, caching, config, legacy_caching, secrets, source_util
 from streamlit.case_converters import to_snake_case
 from streamlit.credentials import Credentials
 from streamlit.in_memory_file_manager import in_memory_file_manager
@@ -31,7 +31,12 @@ from streamlit.metrics_util import Installation
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.GitInfo_pb2 import GitInfo
-from streamlit.proto.NewSession_pb2 import Config, CustomThemeConfig, UserInfo
+from streamlit.proto.NewSession_pb2 import (
+    Config,
+    CustomThemeConfig,
+    NewSession,
+    UserInfo,
+)
 from streamlit.session_data import SessionData
 from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
@@ -375,6 +380,7 @@ class AppSession:
         msg.new_session.name = self._session_data.name
         msg.new_session.main_script_path = self._session_data.main_script_path
 
+        _populate_app_pages(msg.new_session, self._session_data.main_script_path)
         _populate_config_msg(msg.new_session.config)
         _populate_theme_msg(msg.new_session.custom_theme)
 
@@ -599,3 +605,12 @@ def _populate_user_info_msg(msg: UserInfo) -> None:
         msg.email = Credentials.get_current().activation.email
     else:
         msg.email = ""
+
+
+# TODO(vdonato): Eventually, rework this to listen for pages being added/removed
+# instead of repeatedly scanning the pages dir every time this function is called.
+def _populate_app_pages(msg: NewSession, main_script_path: str) -> None:
+    for page in source_util.get_pages(main_script_path):
+        page_proto = msg.app_pages.add()
+        page_proto.script_path = page["script_path"]
+        page_proto.page_name = page["page_name"]

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -59,8 +59,8 @@ def page_name(script_path: Path) -> str:
     This is *almost* the page name displayed in the nav UI, but it has
     underscores instead of spaces. The reason we do this is because having
     spaces in URLs both looks bad and is hard to deal with due to the need to
-    URL-encode them. To solve this, we only swap spaces for underscores right
-    before we render page names.
+    URL-encode them. To solve this, we only swap the underscores for spaces
+    right before we render page names.
     """
     extraction = re.search(PAGE_FILENAME_REGEX, script_path.name)
     if extraction is None:

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+from pathlib import Path
+from typing import Any, cast, Dict, List, Tuple
+
 
 def open_python_file(filename):
     """Open a read-only Python file taking proper care of its encoding.
@@ -29,3 +33,67 @@ def open_python_file(filename):
         return tokenize.open(filename)
     else:
         return open(filename, "r", encoding="utf-8")
+
+
+PAGE_FILENAME_REGEX = re.compile(r"([0-9]*)[_ -]*(.*)\.py")
+
+
+def page_sort_key(script_path: Path) -> Tuple[float, str]:
+    matches = re.findall(PAGE_FILENAME_REGEX, script_path.name)
+
+    # Failing this assert should only be possible if script_path isn't a Python
+    # file, which should never happen.
+    assert len(matches) > 0, f"{script_path} is not a Python file"
+
+    [(number, label)] = matches
+
+    if number == "":
+        return (float("inf"), label)
+
+    return (float(number), label)
+
+
+def page_name(script_path: Path) -> str:
+    """Compute the name of a page from its script path.
+
+    This is *almost* the page name displayed in the nav UI, but it has
+    underscores instead of spaces. The reason we do this is because having
+    spaces in URLs both looks bad and is hard to deal with due to the need to
+    URL-encode them. To solve this, we only swap spaces for underscores right
+    before we render page names.
+    """
+    extraction = re.search(PAGE_FILENAME_REGEX, script_path.name)
+    if extraction is None:
+        return ""
+
+    # This cast to Any+type annotation weirdness is done because
+    # cast(re.Match[str], ...) explodes at runtime since Python interprets it
+    # as an attempt to index into re.Match instead of as a type annotation.
+    extraction: re.Match[str] = cast(Any, extraction)
+
+    name = re.sub(r"[_ ]+", "_", extraction.group(2)).strip()
+    if not name:
+        name = extraction.group(1)
+
+    return str(name)
+
+
+def get_pages(main_script_path: str) -> List[Dict[str, str]]:
+    main_script_path = Path(main_script_path)
+    main_page_name = page_name(main_script_path)
+
+    used_page_names = {main_page_name}
+    pages = [{"page_name": main_page_name, "script_path": str(main_script_path)}]
+
+    pages_dir = main_script_path.parent / "pages"
+    page_scripts = sorted(pages_dir.glob("*.py"), key=page_sort_key)
+
+    for script_path in page_scripts:
+        pn = page_name(script_path)
+        if pn in used_page_names:
+            continue
+
+        used_page_names.add(pn)
+        pages.append({"page_name": pn, "script_path": str(script_path)})
+
+    return pages

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -74,6 +74,7 @@ class PageHelperFunctionTests(unittest.TestCase):
             ("12 monkeys.py", "monkeys"),
             ("_12 monkeys.py", "12_monkeys"),
             ("123.py", "123"),
+            # Test the default case for non-Python files.
             ("not_a_python_script.rs", ""),
         ]
 

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -1,0 +1,126 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from pathlib import Path
+
+import pytest
+
+import streamlit.source_util as source_util
+
+
+# NOTE: Using @pytest.mark.parametrize throughout this test suite would be
+# nice, but it doesn't play nicely with unittest.TestCase, so we just manually
+# write out the loops for tests instead :(
+class PageHelperFunctionTests(unittest.TestCase):
+    def test_page_sort_key(self):
+        test_cases = [
+            # Test that the page number is treated as the first sort key.
+            ("/foo/01_bar.py", (1.0, "bar")),
+            ("/foo/02-bar.py", (2.0, "bar")),
+            ("/foo/03 bar.py", (3.0, "bar")),
+            ("/foo/04 bar baz.py", (4.0, "bar baz")),
+            ("/foo/05 -_- bar.py", (5.0, "bar")),
+            # Test that the first sort key is float("inf") if there is no page
+            # number.
+            ("/foo/bar.py", (float("inf"), "bar")),
+            ("/foo/bar baz.py", (float("inf"), "bar baz")),
+        ]
+
+        for path_str, expected in test_cases:
+            assert source_util.page_sort_key(Path(path_str)) == expected
+
+    def test_page_sort_key_error(self):
+        with pytest.raises(AssertionError) as e:
+            source_util.page_sort_key(Path("/foo/bar/baz.rs"))
+
+        assert str(e.value) == "/foo/bar/baz.rs is not a Python file"
+
+    def test_page_name(self):
+        test_cases = [
+            # Test that the page number is removed as expected.
+            ("/foo/01_bar.py", "bar"),
+            ("/foo/02-bar.py", "bar"),
+            ("/foo/03 bar.py", "bar"),
+            ("/foo/04 bar baz.py", "bar_baz"),
+            ("/foo/05 -_- bar.py", "bar"),
+            # Test cases with no page number.
+            ("/foo/bar.py", "bar"),
+            ("/foo/bar baz.py", "bar_baz"),
+            # Test that separator characters in the page name are removed as
+            # as expected.
+            ("/foo/1 - first page.py", "first_page"),
+            ("/foo/123_hairy_koala.py", "hairy_koala"),
+            (
+                "/foo/123 wow_this_has a _lot_ _of  _ ___ separators.py",
+                "wow_this_has_a_lot_of_separators",
+            ),
+            (
+                "/foo/1-dashes in page-name stay.py",
+                "dashes_in_page-name_stay",
+            ),
+            # Test other weirdness that might happen with numbers.
+            ("12 monkeys.py", "monkeys"),
+            ("_12 monkeys.py", "12_monkeys"),
+            ("123.py", "123"),
+            ("not_a_python_script.rs", ""),
+        ]
+
+        for path_str, expected in test_cases:
+            assert source_util.page_name(Path(path_str)) == expected
+
+
+# NOTE: We write this test function using pytest conventions (as opposed to
+# using unittest.TestCase like in the rest of the codebase) because the tmpdir
+# pytest fixture is so useful for writing this test it's worth having the
+# slight inconsistency.
+def test_get_pages(tmpdir):
+    # Write an empty string to create a file.
+    tmpdir.join("streamlit_app.py").write("")
+
+    pages_dir = tmpdir.mkdir("pages")
+    pages = [
+        # These pages are out of order so that we can check that they're sorted
+        # in the assert below.
+        "03_other_page.py",
+        "last page.py",
+        "01-page.py",
+        # The next two pages have duplicate names so shouldn't appear.
+        "page.py",
+        "streamlit_app.py",
+        # This shouldn't appear because it's not a Python file.
+        "not_a_page.rs",
+    ]
+    for p in pages:
+        pages_dir.join(p).write("")
+
+    main_script_path = str(tmpdir / "streamlit_app.py")
+    assert source_util.get_pages(main_script_path) == [
+        {
+            "page_name": "streamlit_app",
+            "script_path": main_script_path,
+        },
+        {
+            "page_name": "page",
+            "script_path": str(pages_dir / "01-page.py"),
+        },
+        {
+            "page_name": "other_page",
+            "script_path": str(pages_dir / "03_other_page.py"),
+        },
+        {
+            "page_name": "last_page",
+            "script_path": str(pages_dir / "last page.py"),
+        },
+    ]

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -16,16 +16,14 @@ import unittest
 from pathlib import Path
 
 import pytest
+from parameterized import parameterized
 
 import streamlit.source_util as source_util
 
 
-# NOTE: Using @pytest.mark.parametrize throughout this test suite would be
-# nice, but it doesn't play nicely with unittest.TestCase, so we just manually
-# write out the loops for tests instead :(
 class PageHelperFunctionTests(unittest.TestCase):
-    def test_page_sort_key(self):
-        test_cases = [
+    @parameterized.expand(
+        [
             # Test that the page number is treated as the first sort key.
             ("/foo/01_bar.py", (1.0, "bar")),
             ("/foo/02-bar.py", (2.0, "bar")),
@@ -37,9 +35,9 @@ class PageHelperFunctionTests(unittest.TestCase):
             ("/foo/bar.py", (float("inf"), "bar")),
             ("/foo/bar baz.py", (float("inf"), "bar baz")),
         ]
-
-        for path_str, expected in test_cases:
-            assert source_util.page_sort_key(Path(path_str)) == expected
+    )
+    def test_page_sort_key(self, path_str, expected):
+        assert source_util.page_sort_key(Path(path_str)) == expected
 
     def test_page_sort_key_error(self):
         with pytest.raises(AssertionError) as e:
@@ -47,8 +45,8 @@ class PageHelperFunctionTests(unittest.TestCase):
 
         assert str(e.value) == "/foo/bar/baz.rs is not a Python file"
 
-    def test_page_name(self):
-        test_cases = [
+    @parameterized.expand(
+        [
             # Test that the page number is removed as expected.
             ("/foo/01_bar.py", "bar"),
             ("/foo/02-bar.py", "bar"),
@@ -77,9 +75,9 @@ class PageHelperFunctionTests(unittest.TestCase):
             # Test the default case for non-Python files.
             ("not_a_python_script.rs", ""),
         ]
-
-        for path_str, expected in test_cases:
-            assert source_util.page_name(Path(path_str)) == expected
+    )
+    def test_page_name(self, path_str, expected):
+        assert source_util.page_name(Path(path_str)) == expected
 
 
 # NOTE: We write this test function using pytest conventions (as opposed to


### PR DESCRIPTION
## 📚 Context

This PR adds some helper functions that will soon be needed by the multipage apps
feature to look in the `pages` directory for a given main script, find all `.py` files, and
massage the file names into more user-friendly page names.

It also sends this page info over to the frontend, but it doesn't do anything with it past
that.

- What kind of change does this PR introduce?

  - [x] Feature(-ish)

## 🧪 Testing Done

- [x] Added/Updated unit tests