### PR TITLE
streamlit.state package cleanup

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -191,7 +191,7 @@ from streamlit.commands.page_config import set_page_config
 
 # Session State
 
-from streamlit.state.session_state import AutoSessionState
+from streamlit.state import AutoSessionState
 
 session_state = AutoSessionState()
 

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -39,7 +39,7 @@ from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 
 LOGGER = get_logger(__name__)
 if TYPE_CHECKING:
-    from streamlit.state.session_state import SessionState
+    from streamlit.state import SessionState
 
 
 class AppSessionState(Enum):
@@ -127,7 +127,7 @@ class AppSession:
         self._scriptrunner: Optional[ScriptRunner] = None
 
         # This needs to be lazily imported to avoid a dependency cycle.
-        from streamlit.state.session_state import SessionState
+        from streamlit.state import SessionState
 
         self._session_state = SessionState()
 

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -30,7 +30,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Components_pb2 import SpecialArg, ArrowTable as ArrowTableProto
 from streamlit.proto.Element_pb2 import Element
-from streamlit.state.widgets import NoValue, register_widget
+from streamlit.state import NoValue, register_widget
 from streamlit.type_util import to_bytes
 
 LOGGER = get_logger(__name__)

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -64,7 +64,7 @@ from streamlit.elements.pyplot import PyplotMixin
 from streamlit.elements.write import WriteMixin
 from streamlit.elements.layouts import LayoutsMixin
 from streamlit.elements.form import FormMixin, FormData, current_form_id
-from streamlit.state.widgets import NoValue
+from streamlit.state import NoValue
 
 # DataFrame elements come in two flavors: "Legacy" and "Arrow".
 # We select between them with the DataFrameElementSelectorMixin.

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -24,12 +24,12 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.in_memory_file_manager import in_memory_file_manager
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 from .form import current_form_id, is_in_form
 from .utils import check_callback_rules, check_session_state_rules
 

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -25,11 +25,11 @@ from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.in_memory_file_manager import in_memory_file_manager
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state import register_widget
 from .form import current_form_id, is_in_form
 from .utils import check_callback_rules, check_session_state_rules
 

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -22,8 +22,8 @@ from streamlit.proto.CameraInput_pb2 import (
 )
 
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state.widgets import register_widget
-from streamlit.state.session_state import (
+from streamlit.state import register_widget
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -22,8 +22,8 @@ from streamlit.proto.CameraInput_pb2 import (
 )
 
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state import register_widget
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -19,8 +19,8 @@ from typing import cast, Optional
 
 import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
-from streamlit.state.widgets import register_widget
-from streamlit.state.session_state import (
+from streamlit.state import register_widget
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -19,8 +19,8 @@ from typing import cast, Optional
 
 import streamlit
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
-from streamlit.state import register_widget
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -21,8 +21,8 @@ from typing import Optional, cast
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
-from streamlit.state.widgets import register_widget
-from streamlit.state.session_state import (
+from streamlit.state import register_widget
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -28,8 +28,8 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state.widgets import register_widget
-from streamlit.state.session_state import (
+from streamlit.state import register_widget
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -28,8 +28,8 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state import register_widget
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -17,7 +17,7 @@ from typing import cast
 
 import streamlit
 from streamlit.proto.Json_pb2 import Json as JsonProto
-from streamlit.state.session_state import AutoSessionState
+from streamlit.state import AutoSessionState
 
 
 class JsonMixin:

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -19,10 +19,10 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, is_type, to_key
 
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -19,10 +19,10 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, is_type, to_key
 
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -22,8 +22,8 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber, JSNumberBoundsException
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
-from streamlit.state.widgets import register_widget, NoValue
-from streamlit.state.session_state import (
+from streamlit.state import register_widget, NoValue
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -22,8 +22,9 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber, JSNumberBoundsException
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
-from streamlit.state import register_widget, NoValue
 from streamlit.state import (
+    register_widget,
+    NoValue,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -19,8 +19,8 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state.widgets import register_widget
-from streamlit.state.session_state import (
+from streamlit.state import register_widget
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -19,8 +19,8 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state import register_widget
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -19,12 +19,12 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -20,11 +20,11 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -20,11 +20,11 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -19,12 +19,12 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.script_run_context import ScriptRunContext, get_script_run_ctx
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -24,11 +24,11 @@ from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state import register_widget
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -23,12 +23,12 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -22,11 +22,11 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state import register_widget
 
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -21,12 +21,12 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -24,12 +24,12 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
-from streamlit.state.session_state import (
+from streamlit.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state.widgets import register_widget
+from streamlit.state import register_widget
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -25,11 +25,11 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
 from streamlit.state import (
+    register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.state import register_widget
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -19,8 +19,7 @@ import streamlit
 from streamlit import type_util
 from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException
-from streamlit.state.session_state import get_session_state
-from streamlit.state.session_state import WidgetCallback
+from streamlit.state import get_session_state, WidgetCallback
 
 
 if TYPE_CHECKING:

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -22,7 +22,7 @@ import numpy as np
 import streamlit
 from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
-from streamlit.state.session_state import AutoSessionState
+from streamlit.state import AutoSessionState
 
 # Special methods:
 

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -20,7 +20,7 @@ from typing import Any, Optional, Tuple, Deque, Iterable, Callable, TypeVar
 import attr
 
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
-from streamlit.state.widgets import coalesce_widget_states
+from streamlit.state import coalesce_widget_states
 
 
 class ScriptRequest(Enum):

--- a/lib/streamlit/script_run_context.py
+++ b/lib/streamlit/script_run_context.py
@@ -20,7 +20,7 @@ import attr
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.state.session_state import SessionState
+from streamlit.state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
 
 LOGGER = get_logger(__name__)

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -33,7 +33,7 @@ from streamlit.script_run_context import ScriptRunContext, add_script_run_ctx
 from streamlit.script_run_context import get_script_run_ctx
 from streamlit.script_request_queue import ScriptRequest, ScriptRequestQueue, RerunData
 from streamlit.session_data import SessionData
-from streamlit.state.session_state import (
+from streamlit.state import (
     SessionState,
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
 )

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -68,7 +68,7 @@ from streamlit.server.upload_file_request_handler import (
 )
 
 from streamlit.session_data import SessionData
-from streamlit.state.session_state import (
+from streamlit.state import (
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
     SessionStateStatProvider,
 )

--- a/lib/streamlit/state/__init__.py
+++ b/lib/streamlit/state/__init__.py
@@ -11,3 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Explicitly re-export public symbols
+from .session_state import (
+    SessionState as SessionState,
+    WidgetCallback as WidgetCallback,
+)
+
+from .auto_session_state import (
+    AutoSessionState as AutoSessionState,
+    get_session_state as get_session_state,
+)

--- a/lib/streamlit/state/__init__.py
+++ b/lib/streamlit/state/__init__.py
@@ -16,9 +16,19 @@
 from .session_state import (
     SessionState as SessionState,
     WidgetCallback as WidgetCallback,
+    WidgetArgs as WidgetArgs,
+    WidgetKwargs as WidgetKwargs,
+    SessionStateStatProvider as SessionStateStatProvider,
+    SCRIPT_RUN_WITHOUT_ERRORS_KEY as SCRIPT_RUN_WITHOUT_ERRORS_KEY,
 )
 
 from .auto_session_state import (
     AutoSessionState as AutoSessionState,
     get_session_state as get_session_state,
+)
+
+from .widgets import (
+    coalesce_widget_states as coalesce_widget_states,
+    register_widget as register_widget,
+    NoValue as NoValue,
 )

--- a/lib/streamlit/state/auto_session_state.py
+++ b/lib/streamlit/state/auto_session_state.py
@@ -1,0 +1,127 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    MutableMapping,
+)
+
+import streamlit as st
+from streamlit import logger as _logger
+from streamlit.type_util import Key
+from .session_state import SessionState, validate_key
+
+logger = _logger.get_logger(__name__)
+
+
+_state_use_warning_already_displayed = False
+
+
+def get_session_state() -> SessionState:
+    """Get the SessionState object for the current session.
+
+    Note that in streamlit scripts, this function should not be called
+    directly. Instead, SessionState objects should be accessed via
+    st.session_state.
+    """
+    global _state_use_warning_already_displayed
+    from streamlit.script_run_context import get_script_run_ctx
+
+    ctx = get_script_run_ctx()
+
+    # If there is no script run context because the script is run bare, have
+    # session state act as an always empty dictionary, and print a warning.
+    if ctx is None:
+        if not _state_use_warning_already_displayed:
+            _state_use_warning_already_displayed = True
+            if not st._is_running_with_streamlit:
+                logger.warning(
+                    "Session state does not function when running a script without `streamlit run`"
+                )
+        return SessionState()
+    return ctx.session_state
+
+
+class AutoSessionState(MutableMapping[str, Any]):
+    """A SessionState interface that acts as a wrapper around the
+    current script thread's SessionState instance.
+
+    When a user script uses `st.session_state`, it's interacting with
+    the singleton AutoSessionState instance, which delegates to the
+    SessionState for the active AppSession.
+
+    (This will only be used within an app script, when an AppSession is
+    guaranteed to exist.)
+    """
+
+    def __iter__(self) -> Iterator[Any]:
+        state = get_session_state()
+        return iter(state.filtered_state)
+
+    def __len__(self) -> int:
+        state = get_session_state()
+        return len(state.filtered_state)
+
+    def __str__(self) -> str:
+        state = get_session_state()
+        return str(state.filtered_state)
+
+    def __getitem__(self, key: Key) -> Any:
+        key = str(key)
+        validate_key(key)
+        state = get_session_state()
+        return state[key]
+
+    def __setitem__(self, key: Key, value: Any) -> None:
+        key = str(key)
+        validate_key(key)
+        state = get_session_state()
+        state[key] = value
+
+    def __delitem__(self, key: Key) -> None:
+        key = str(key)
+        validate_key(key)
+        state = get_session_state()
+        del state[key]
+
+    def __getattr__(self, key: str) -> Any:
+        validate_key(key)
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(_missing_attr_error_message(key))
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        validate_key(key)
+        self[key] = value
+
+    def __delattr__(self, key: str) -> None:
+        validate_key(key)
+        try:
+            del self[key]
+        except KeyError:
+            raise AttributeError(_missing_attr_error_message(key))
+
+    def to_dict(self) -> Dict[str, Any]:
+        state = get_session_state()
+        return state.filtered_state
+
+
+def _missing_attr_error_message(attr_name: str) -> str:
+    return (
+        f'st.session_state has no attribute "{attr_name}". Did you forget to initialize it? '
+        f"More info: https://docs.streamlit.io/library/advanced-features/session-state#initialization"
+    )

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -15,7 +15,6 @@
 from copy import deepcopy
 import json
 from streamlit.stats import CacheStat, CacheStatsProvider
-from streamlit.type_util import Key
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -275,13 +274,6 @@ class WStates(MutableMapping[str, Any]):
 def _missing_key_error_message(key: str) -> str:
     return (
         f'st.session_state has no key "{key}". Did you forget to initialize it? '
-        f"More info: https://docs.streamlit.io/library/advanced-features/session-state#initialization"
-    )
-
-
-def _missing_attr_error_message(attr_name: str) -> str:
-    return (
-        f'st.session_state has no attribute "{attr_name}". Did you forget to initialize it? '
         f"More info: https://docs.streamlit.io/library/advanced-features/session-state#initialization"
     )
 
@@ -676,105 +668,12 @@ def _is_internal_key(key: str) -> bool:
     return key.startswith(STREAMLIT_INTERNAL_KEY_PREFIX)
 
 
-_state_use_warning_already_displayed = False
-
-
-def get_session_state() -> SessionState:
-    """Get the SessionState object for the current session.
-
-    Note that in streamlit scripts, this function should not be called
-    directly. Instead, SessionState objects should be accessed via
-    st.session_state.
-    """
-    global _state_use_warning_already_displayed
-    from streamlit.script_run_context import get_script_run_ctx
-
-    ctx = get_script_run_ctx()
-
-    # If there is no script run context because the script is run bare, have
-    # session state act as an always empty dictionary, and print a warning.
-    if ctx is None:
-        if not _state_use_warning_already_displayed:
-            _state_use_warning_already_displayed = True
-            if not st._is_running_with_streamlit:
-                logger.warning(
-                    "Session state does not function when running a script without `streamlit run`"
-                )
-        return SessionState()
-    return ctx.session_state
-
-
-class AutoSessionState(MutableMapping[str, Any]):
-    """A SessionState interface that acts as a wrapper around the
-    current script thread's SessionState instance.
-
-    When a user script uses `st.session_state`, it's interacting with
-    the singleton AutoSessionState instance, which delegates to the
-    SessionState for the active AppSession.
-
-    (This will only be used within an app script, when an AppSession is
-    guaranteed to exist.)
-    """
-
-    @staticmethod
-    def _validate_key(key: str) -> None:
-        """Raise an Exception if the given value key is invalid."""
-        if _is_widget_id(key):
-            raise StreamlitAPIException(
-                f"Keys beginning with {GENERATED_WIDGET_KEY_PREFIX} are reserved."
-            )
-
-    def __iter__(self) -> Iterator[Any]:
-        state = get_session_state()
-        return iter(state.filtered_state)
-
-    def __len__(self) -> int:
-        state = get_session_state()
-        return len(state.filtered_state)
-
-    def __str__(self) -> str:
-        state = get_session_state()
-        return str(state.filtered_state)
-
-    def __getitem__(self, key: Key) -> Any:
-        key = str(key)
-        self._validate_key(key)
-        state = get_session_state()
-        return state[key]
-
-    def __setitem__(self, key: Key, value: Any) -> None:
-        key = str(key)
-        self._validate_key(key)
-        state = get_session_state()
-        state[key] = value
-
-    def __delitem__(self, key: Key) -> None:
-        key = str(key)
-        self._validate_key(key)
-        state = get_session_state()
-        del state[key]
-
-    def __getattr__(self, key: str) -> Any:
-        self._validate_key(key)
-        try:
-            return self[key]
-        except KeyError:
-            raise AttributeError(_missing_attr_error_message(key))
-
-    def __setattr__(self, key: str, value: Any) -> None:
-        self._validate_key(key)
-        self[key] = value
-
-    def __delattr__(self, key: str) -> None:
-        self._validate_key(key)
-        try:
-            del self[key]
-        except KeyError:
-            raise AttributeError(_missing_attr_error_message(key))
-
-    def to_dict(self) -> Dict[str, Any]:
-        state = get_session_state()
-        return state.filtered_state
+def validate_key(key: str) -> None:
+    """Raise an Exception if the given value key is invalid."""
+    if _is_widget_id(key):
+        raise StreamlitAPIException(
+            f"Keys beginning with {GENERATED_WIDGET_KEY_PREFIX} are reserved."
+        )
 
 
 @attr.s(auto_attribs=True, slots=True)

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -14,10 +14,8 @@
 
 import hashlib
 import textwrap
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
 
-
-from streamlit.script_run_context import ScriptRunContext
 from streamlit.errors import DuplicateWidgetID
 from streamlit.proto.Button_pb2 import Button
 from streamlit.proto.Checkbox_pb2 import Checkbox
@@ -45,6 +43,9 @@ from .session_state import (
     WidgetDeserializer,
     WidgetKwargs,
 )
+
+if TYPE_CHECKING:
+    from streamlit.script_run_context import ScriptRunContext
 
 # Protobuf types for all widgets.
 WidgetProto = Union[
@@ -81,7 +82,7 @@ def register_widget(
     element_proto: WidgetProto,
     deserializer: WidgetDeserializer,
     serializer: WidgetSerializer,
-    ctx: Optional[ScriptRunContext],
+    ctx: Optional["ScriptRunContext"],
     user_key: Optional[str] = None,
     widget_func_name: Optional[str] = None,
     on_change_handler: Optional[WidgetCallback] = None,

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -36,7 +36,7 @@ from streamlit.proto.TextArea_pb2 import TextArea
 from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.proto.TimeInput_pb2 import TimeInput
 from streamlit.proto.WidgetStates_pb2 import WidgetStates, WidgetState
-from streamlit.state.session_state import (
+from .session_state import (
     GENERATED_WIDGET_KEY_PREFIX,
     WidgetMetadata,
     WidgetSerializer,

--- a/lib/tests/streamlit/state/auto_session_state_test.py
+++ b/lib/tests/streamlit/state/auto_session_state_test.py
@@ -1,0 +1,124 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AutoSessionState unit tests."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from streamlit.errors import StreamlitAPIException
+from streamlit.state.auto_session_state import AutoSessionState
+from streamlit.state.session_state import (
+    GENERATED_WIDGET_KEY_PREFIX,
+    SessionState,
+    validate_key,
+)
+
+
+@patch(
+    "streamlit.state.auto_session_state.get_session_state",
+    return_value=MagicMock(filtered_state={"foo": "bar"}),
+)
+class AutoSessionStateTests(unittest.TestCase):
+    reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
+
+    def setUp(self):
+        self.auto_session_state = AutoSessionState()
+
+    def test_iter(self, _):
+        state_iter = iter(self.auto_session_state)
+        assert next(state_iter) == "foo"
+        with pytest.raises(StopIteration):
+            next(state_iter)
+
+    def test_len(self, _):
+        assert len(self.auto_session_state) == 1
+
+    def test_validate_key(self, _):
+        with pytest.raises(StreamlitAPIException) as e:
+            validate_key(self.reserved_key)
+        assert "are reserved" in str(e.value)
+
+    def test_to_dict(self, _):
+        assert self.auto_session_state.to_dict() == {"foo": "bar"}
+
+    # NOTE: We only test the error cases of {get, set, del}{item, attr} below
+    # since the others are tested in another test class.
+    def test_getitem_reserved_key(self, _):
+        with pytest.raises(StreamlitAPIException):
+            self.auto_session_state[self.reserved_key]
+
+    def test_setitem_reserved_key(self, _):
+        with pytest.raises(StreamlitAPIException):
+            self.auto_session_state[self.reserved_key] = "foo"
+
+    def test_delitem_reserved_key(self, _):
+        with pytest.raises(StreamlitAPIException):
+            del self.auto_session_state[self.reserved_key]
+
+    def test_getattr_reserved_key(self, _):
+        with pytest.raises(StreamlitAPIException):
+            getattr(self.auto_session_state, self.reserved_key)
+
+    def test_setattr_reserved_key(self, _):
+        with pytest.raises(StreamlitAPIException):
+            setattr(self.auto_session_state, self.reserved_key, "foo")
+
+    def test_delattr_reserved_key(self, _):
+        with pytest.raises(StreamlitAPIException):
+            delattr(self.auto_session_state, self.reserved_key)
+
+
+class AutoSessionStateAttributeTests(unittest.TestCase):
+    """Tests of AutoSessionState attribute methods.
+
+    Separate from the others to change patching. Test methods are individually
+    patched to avoid issues with mutability.
+    """
+
+    def setUp(self):
+        self.auto_session_state = AutoSessionState()
+
+    @patch(
+        "streamlit.state.auto_session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_delattr(self, _):
+        del self.auto_session_state.foo
+        assert "foo" not in self.auto_session_state
+
+    @patch(
+        "streamlit.state.auto_session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_getattr(self, _):
+        assert self.auto_session_state.foo == "bar"
+
+    @patch(
+        "streamlit.state.auto_session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_getattr_error(self, _):
+        with pytest.raises(AttributeError):
+            del self.auto_session_state.nonexistent
+
+    @patch(
+        "streamlit.state.auto_session_state.get_session_state",
+        return_value=SessionState(new_session_state={"foo": "bar"}),
+    )
+    def test_setattr(self, _):
+        self.auto_session_state.corge = "grault2"
+        assert self.auto_session_state.corge == "grault2"

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -26,7 +26,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.script_run_context import get_script_run_ctx
-from streamlit.state.auto_session_state import get_session_state, AutoSessionState
+from streamlit.state.auto_session_state import get_session_state
 from streamlit.state.session_state import (
     GENERATED_WIDGET_KEY_PREFIX,
     SessionState,
@@ -593,102 +593,6 @@ class SessionStateMethodTests(unittest.TestCase):
             == False
         )
         assert self.session_state["widget_id_1"] == 0
-
-
-@patch(
-    "streamlit.state.session_state.get_session_state",
-    return_value=MagicMock(filtered_state={"foo": "bar"}),
-)
-class AutoSessionStateTests(unittest.TestCase):
-    reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
-
-    def setUp(self):
-        self.auto_session_state = AutoSessionState()
-
-    def test_iter(self, _):
-        state_iter = iter(self.auto_session_state)
-        assert next(state_iter) == "foo"
-        with pytest.raises(StopIteration):
-            next(state_iter)
-
-    def test_len(self, _):
-        assert len(self.auto_session_state) == 1
-
-    def test_validate_key(self, _):
-        with pytest.raises(StreamlitAPIException) as e:
-            self.auto_session_state.validate_key(self.reserved_key)
-        assert "are reserved" in str(e.value)
-
-    def test_to_dict(self, _):
-        assert self.auto_session_state.to_dict() == {"foo": "bar"}
-
-    # NOTE: We only test the error cases of {get, set, del}{item, attr} below
-    # since the others are tested in another test class.
-    def test_getitem_reserved_key(self, _):
-        with pytest.raises(StreamlitAPIException):
-            self.auto_session_state[self.reserved_key]
-
-    def test_setitem_reserved_key(self, _):
-        with pytest.raises(StreamlitAPIException):
-            self.auto_session_state[self.reserved_key] = "foo"
-
-    def test_delitem_reserved_key(self, _):
-        with pytest.raises(StreamlitAPIException):
-            del self.auto_session_state[self.reserved_key]
-
-    def test_getattr_reserved_key(self, _):
-        with pytest.raises(StreamlitAPIException):
-            getattr(self.auto_session_state, self.reserved_key)
-
-    def test_setattr_reserved_key(self, _):
-        with pytest.raises(StreamlitAPIException):
-            setattr(self.auto_session_state, self.reserved_key, "foo")
-
-    def test_delattr_reserved_key(self, _):
-        with pytest.raises(StreamlitAPIException):
-            delattr(self.auto_session_state, self.reserved_key)
-
-
-class AutoSessionStateAttributeTests(unittest.TestCase):
-    """Tests of AutoSessionState attribute methods.
-
-    Separate from the others to change patching. Test methods are individually
-    patched to avoid issues with mutability.
-    """
-
-    def setUp(self):
-        self.auto_session_state = AutoSessionState()
-
-    @patch(
-        "streamlit.state.session_state.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
-    )
-    def test_delattr(self, _):
-        del self.auto_session_state.foo
-        assert "foo" not in self.auto_session_state
-
-    @patch(
-        "streamlit.state.session_state.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
-    )
-    def test_getattr(self, _):
-        assert self.auto_session_state.foo == "bar"
-
-    @patch(
-        "streamlit.state.session_state.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
-    )
-    def test_getattr_error(self, _):
-        with pytest.raises(AttributeError):
-            del self.auto_session_state.nonexistent
-
-    @patch(
-        "streamlit.state.session_state.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
-    )
-    def test_setattr(self, _):
-        self.auto_session_state.corge = "grault2"
-        assert self.auto_session_state.corge == "grault2"
 
 
 @given(state=stst.session_state())

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -26,10 +26,9 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.script_run_context import get_script_run_ctx
+from streamlit.state.auto_session_state import get_session_state, AutoSessionState
 from streamlit.state.session_state import (
     GENERATED_WIDGET_KEY_PREFIX,
-    get_session_state,
-    AutoSessionState,
     SessionState,
     Serialized,
     Value,

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -617,7 +617,7 @@ class AutoSessionStateTests(unittest.TestCase):
 
     def test_validate_key(self, _):
         with pytest.raises(StreamlitAPIException) as e:
-            self.auto_session_state._validate_key(self.reserved_key)
+            self.auto_session_state.validate_key(self.reserved_key)
         assert "are reserved" in str(e.value)
 
     def test_to_dict(self, _):

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -27,7 +27,7 @@ import streamlit as st
 from streamlit import type_util
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIException
-from streamlit.state.session_state import AutoSessionState
+from streamlit.state import AutoSessionState
 
 
 class StreamlitWriteTest(unittest.TestCase):


### PR DESCRIPTION
A minor reorg of the `streamlit.state` package. No new functionality.

- `AutoSessionState` now has its own module (because `session_state.py` is huuuuge)
- public session_state and widgets symbols are now exported from the package's `__init__.py`

(This is in service of upcoming changes in the `feature/faster-reruns` branch)