### PR TITLE
Plumb page_name around and save it after a script run completes

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -229,7 +229,9 @@ class AppSession:
         """
         if client_state:
             rerun_data = RerunData(
-                client_state.query_string, client_state.widget_states
+                client_state.query_string,
+                client_state.widget_states,
+                client_state.page_name,
             )
         else:
             rerun_data = RerunData()

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -38,6 +38,7 @@ class RerunData:
 
     query_string: str = ""
     widget_states: Optional[WidgetStates] = None
+    page_name: str = ""
 
 
 class ScriptRequestQueue:
@@ -100,6 +101,7 @@ class ScriptRequestQueue:
                             RerunData(
                                 query_string=data.query_string,
                                 widget_states=data.widget_states,
+                                page_name=data.page_name,
                             ),
                         )
                         return
@@ -115,6 +117,7 @@ class ScriptRequestQueue:
                             RerunData(
                                 query_string=data.query_string,
                                 widget_states=coalesced_states,
+                                page_name=data.page_name,
                             ),
                         )
                         return

--- a/lib/streamlit/script_run_context.py
+++ b/lib/streamlit/script_run_context.py
@@ -44,6 +44,7 @@ class ScriptRunContext:
     query_string: str
     session_state: SessionState
     uploaded_file_mgr: UploadedFileManager
+    page_name: str
 
     _set_page_config_allowed: bool = True
     _has_script_started: bool = False
@@ -52,11 +53,12 @@ class ScriptRunContext:
     cursors: Dict[int, "streamlit.cursor.RunningCursor"] = attr.Factory(dict)
     dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = attr.Factory(list)
 
-    def reset(self, query_string: str = "") -> None:
+    def reset(self, query_string: str = "", page_name: str = "") -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
         self.form_ids_this_run = set()
         self.query_string = query_string
+        self.page_name = page_name
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -222,6 +222,7 @@ class ScriptRunner:
             query_string=self._client_state.query_string,
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,
+            page_name=self._client_state.page_name,
         )
         add_script_run_ctx(threading.current_thread(), ctx)
 
@@ -243,6 +244,7 @@ class ScriptRunner:
         # created.
         client_state = ClientState()
         client_state.query_string = ctx.query_string
+        client_state.page_name = ctx.page_name
         widget_states = self._session_state.as_widget_states()
         client_state.widget_states.widgets.extend(widget_states)
         self.on_event.send(ScriptRunnerEvent.SHUTDOWN, client_state=client_state)
@@ -344,7 +346,7 @@ class ScriptRunner:
         in_memory_file_manager.clear_session_files()
 
         ctx = self._get_script_run_ctx()
-        ctx.reset(query_string=rerun_data.query_string)
+        ctx.reset(query_string=rerun_data.query_string, page_name=rerun_data.page_name)
 
         self.on_event.send(ScriptRunnerEvent.SCRIPT_STARTED)
 
@@ -353,6 +355,9 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
+            # TODO(vdonato): Find the appropriate script_path given
+            # rerun_data.page_name
+
             with source_util.open_python_file(self._session_data.main_script_path) as f:
                 filebody = f.read()
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -181,7 +181,12 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
 
         orig_ctx = get_script_run_ctx()
         ctx = ScriptRunContext(
-            "TestSessionID", rs._session_data.enqueue, "", None, None
+            session_id="TestSessionID",
+            enqueue=rs._session_data.enqueue,
+            query_string="",
+            session_state=None,
+            uploaded_file_mgr=None,
+            page_name="",
         )
         add_script_run_ctx(ctx=ctx)
 

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -178,6 +178,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
                 query_string="",
                 session_state=SessionState(),
                 uploaded_file_mgr=None,
+                page_name="",
             ),
         )
         with patch.object(call_stack, "_show_cached_st_function_warning") as warning:

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -27,11 +27,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         msg = ForwardMsg()
@@ -47,11 +48,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         ctx.on_script_start()
@@ -71,11 +73,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         ctx.on_script_start()
@@ -94,11 +97,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         ctx.on_script_start()

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -443,9 +443,9 @@ class ScriptRunnerTest(AsyncTestCase):
         scriptrunner.join()
         self._assert_no_exceptions(scriptrunner)
 
-    def test_query_string_saved(self):
+    def test_query_string_and_page_name_saved(self):
         scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.enqueue_rerun(query_string="foo=bar")
+        scriptrunner.enqueue_rerun(query_string="foo=bar", page_name="baz")
         scriptrunner.start()
         scriptrunner.join()
 
@@ -461,6 +461,7 @@ class ScriptRunnerTest(AsyncTestCase):
 
         shutdown_data = scriptrunner.event_data[-1]
         self.assertEqual(shutdown_data["client_state"].query_string, "foo=bar")
+        self.assertEqual(shutdown_data["client_state"].page_name, "baz")
 
     def test_coalesce_rerun(self):
         """Tests that multiple pending rerun requests get coalesced."""
@@ -712,10 +713,16 @@ class TestScriptRunner(ScriptRunner):
 
         self.on_event.connect(record_event, weak=False)
 
-    def enqueue_rerun(self, argv=None, widget_states=None, query_string=""):
+    def enqueue_rerun(
+        self, argv=None, widget_states=None, query_string="", page_name=""
+    ):
         self.script_request_queue.enqueue(
             ScriptRequest.RERUN,
-            RerunData(widget_states=widget_states, query_string=query_string),
+            RerunData(
+                widget_states=widget_states,
+                query_string=query_string,
+                page_name=page_name,
+            ),
         )
 
     def enqueue_stop(self):

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -88,6 +88,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             query_string="",
             session_state=SessionState(),
             uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         if self.override_root:


### PR DESCRIPTION
## 📚 Context

This PR implements lots of the server/app session/script runner internals of
plumbing a `page_name` that we get from the client around and saving it
between script runs.

Note that most of these changes are effectively no-ops for now as we don't
actually send the page the user is currently viewing back to the server.

- What kind of change does this PR introduce?

  - [x] Feature(-ish)

## 🧠 Description of Changes

- Add a new `page_name` attribute to `RerunData` and `ScriptRunContext`
- Plumb `page_name` around where the classes mentioned above are used
- Set a `ScriptRunContext`'s `page_name` correctly at the beginning of a script run
- Adjust all relevant tests as needed, and also use kwargs in tests for clarity)

## 🧪 Testing Done

- [x] Added/Updated unit tests
