### PR TITLE
Convert from page_name to script_path when rerunning a script

### DIFF
--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -355,21 +355,47 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
-            # TODO(vdonato): Find the appropriate script_path given
-            # rerun_data.page_name
+            # TODO(vdonato): We'll eventually want to do a few things here:
+            # 1. Don't scan the `pages` directory for each script run. We'll
+            #    instead want to add a listener to only update our page info
+            #    when a page is added or removed.
+            # 2. Add proper 404 handling. Right now, we just run the main
+            #    script if we can't find a script corresponding to the given
+            #    page_name. We still want to do this in the final version of
+            #    the feature, but we also want to pop a modal telling the user
+            #    that the page they're looking for doesn't exist.
+            script_path = None
 
-            with source_util.open_python_file(self._session_data.main_script_path) as f:
+            # NOTE: It may seem weird that we're passing the page_name around
+            # as opposed to the script_path, but this is necessary to handle
+            # the case where a user navigates directly to a page and we have to
+            # serve a request to run a non-main page before we've had a chance
+            # to send page info to the frontend.
+            if rerun_data.page_name:
+                current_page = next(
+                    filter(
+                        lambda p: p["page_name"] == rerun_data.page_name,
+                        source_util.get_pages(self._session_data.main_script_path),
+                    ),
+                    None,
+                )
+
+                if current_page:
+                    script_path = current_page["script_path"]
+
+            if not script_path:
+                script_path = self._session_data.main_script_path
+
+            with source_util.open_python_file(script_path) as f:
                 filebody = f.read()
 
             if config.get_option("runner.magicEnabled"):
-                filebody = magic.add_magic(
-                    filebody, self._session_data.main_script_path
-                )
+                filebody = magic.add_magic(filebody, script_path)
 
             code = compile(
                 filebody,
                 # Pass in the file path so it can show up in exceptions.
-                self._session_data.main_script_path,
+                script_path,
                 # We're compiling entire blocks of Python, so we need "exec"
                 # mode (as opposed to "eval" or "single").
                 mode="exec",
@@ -403,6 +429,14 @@ class ScriptRunner:
         try:
             # Create fake module. This gives us a name global namespace to
             # execute the code in.
+            # TODO(vdonato): Double-check that we're okay with naming the
+            # module for every page `__main__`. I'm pretty sure this is
+            # necessary given that people will likely often write
+            #     ```
+            #     if __name__ == "__main__":
+            #         ...
+            #     ```
+            # in their scripts.
             module = _new_module("__main__")
 
             # Install the fake module as the __main__ module. This allows
@@ -417,7 +451,7 @@ class ScriptRunner:
             # work correctly. The CodeHasher is scoped to
             # files contained in the directory of __main__.__file__, which we
             # assume is the main script directory.
-            module.__dict__["__file__"] = self._session_data.main_script_path
+            module.__dict__["__file__"] = script_path
 
             with modified_sys_path(self._session_data), self._set_execing_flag():
                 # Run callbacks for widgets whose values have changed.

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -39,6 +39,7 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 from tests import testutil
 
 text_utf = "complete! 👨‍🎤"
+text_utf2 = "complete2! 👨‍🎤"
 text_no_encoding = text_utf
 text_latin = "complete! ð\x9f\x91¨â\x80\x8dð\x9f\x8e¤"
 
@@ -627,6 +628,67 @@ class ScriptRunnerTest(AsyncTestCase):
             [
                 "cached_depending_on_not_yet_defined called",
             ],
+        )
+
+    @patch(
+        "streamlit.script_runner.source_util.get_pages",
+        return_value=[
+            {
+                "page_name": "page2",
+                "script_path": os.path.join(
+                    os.path.dirname(__file__), "test_data", "good_script2.py"
+                ),
+            },
+        ],
+    )
+    def test_page_name_to_script_path(self, _):
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.enqueue_rerun(page_name="page2")
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+        self._assert_text_deltas(scriptrunner, [text_utf2])
+        self.assertEqual(
+            os.path.join(os.path.dirname(__file__), "test_data", "good_script2.py"),
+            sys.modules["__main__"].__file__,
+            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
+        )
+
+    @patch(
+        "streamlit.script_runner.source_util.get_pages",
+        return_value=[
+            {"page_name": "page2", "script_path": "script2"},
+        ],
+    )
+    def test_page_name_to_script_path_404(self, _):
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.enqueue_rerun(page_name="page3")
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+        self._assert_text_deltas(scriptrunner, [text_utf])
+        self.assertEqual(
+            scriptrunner._session_data.main_script_path,
+            sys.modules["__main__"].__file__,
+            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
 
     def _assert_no_exceptions(self, scriptrunner):

--- a/lib/tests/streamlit/scriptrunner/test_data/good_script2.py
+++ b/lib/tests/streamlit/scriptrunner/test_data/good_script2.py
@@ -1,0 +1,19 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A test script for ScriptRunnerTest that enqueues a delta."""
+
+import streamlit as st
+
+st.text("complete2! 👨‍🎤")


### PR DESCRIPTION
## 📚 Context

When we get a rerun_script request from the frontend, we need to find the
script path corresponding to the page that the user wants to run and run that
script.

Note that there are a few things that we do sloppily for now for sake of time
(to unblock us from working on the Nav UI faster since product and design want
to be able to start tweaking the UI earlier rather than later).

* We don't open a "404" modal when the user tries to access a nonexistent page.
* We simply scan the `pages` dir every rerun request instead of adding a listener
   to only do so when a page gets added or removed.

- What kind of change does this PR introduce?

  - [x] Feature(-ish)

## 🧠 Description of Changes

- Convert from `page_name` to `script_path` on a script run
- Set a script's `__file__` global variable to the correct `script_path`

## 🧪 Testing Done

- [x] Added/Updated unit tests