### PR TITLE
SessionState widget registration refactor

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -583,44 +583,10 @@ class SessionState(MutableMapping[str, Any]):
             if (k in widget_ids or not _is_widget_id(k))
         }
 
-    def _set_metadata(self, widget_metadata: WidgetMetadata) -> None:
+    def _set_widget_metadata(self, widget_metadata: WidgetMetadata) -> None:
         """Set a widget's metadata."""
         widget_id = widget_metadata.id
         self._new_widget_state.widget_metadata[widget_id] = widget_metadata
-
-    def _maybe_set_new_widget_value(
-        self, widget_id: str, user_key: Optional[str] = None
-    ) -> None:
-        """Add the value of a new widget to session state."""
-        widget_metadata = self._new_widget_state.widget_metadata[widget_id]
-        deserializer = widget_metadata.deserializer
-        initial_widget_value = deepcopy(deserializer(None, widget_metadata.id))
-
-        if widget_id not in self and (user_key is None or user_key not in self):
-            # This is the first time this widget is being registered, so we save
-            # its value in widget state.
-            self._new_widget_state.set_from_value(widget_id, initial_widget_value)
-
-    def should_set_frontend_state_value(
-        self, widget_id: str, user_key: Optional[str]
-    ) -> bool:
-        """Keep widget_state and session_state in sync when a widget is registered.
-
-        This method returns whether the frontend needs to be updated with the
-        new value of this widget.
-        """
-        if user_key is None:
-            return False
-
-        return self.is_new_state_value(user_key)
-
-    def get_value_for_registration(self, widget_id: str) -> Any:
-        """Get the value of a widget, for use as its return value.
-
-        Returns a copy, so reference types can't be accidentally mutated by user code.
-        """
-        value = self[widget_id]
-        return deepcopy(value)
 
     def as_widget_states(self) -> List[WidgetStateProto]:
         return self._new_widget_state.as_widget_states()
@@ -638,20 +604,42 @@ class SessionState(MutableMapping[str, Any]):
         """Return a deep copy of self."""
         return deepcopy(self)
 
-    def set_keyed_widget_metadata(
-        self, metadata: WidgetMetadata, widget_id: str, user_key: str
-    ) -> None:
-        """Set the metadata for the widget with the given id and user_key."""
-        self._set_metadata(metadata)
-        self.set_key_widget_mapping(widget_id, user_key)
-        self._maybe_set_new_widget_value(widget_id, user_key)
+    def register_widget(
+        self, metadata: WidgetMetadata, widget_id: str, user_key: Optional[str]
+    ) -> Tuple[Any, bool]:
+        """Register a widget with the SessionState.
 
-    def set_unkeyed_widget_metadata(
-        self, metadata: WidgetMetadata, widget_id: str
-    ) -> None:
-        """Set the metadata for the widget with the given id."""
-        self._set_metadata(metadata)
-        self._maybe_set_new_widget_value(widget_id)
+        Returns
+        -------
+        Tuple[Any, bool]
+            The widget's current value, and a bool that will be True if the
+            frontend needs to be updated with the current value.
+        """
+        self._set_widget_metadata(metadata)
+        if user_key is not None:
+            # If the widget has a user_key, update its user_key:widget_id mapping
+            self.set_key_widget_mapping(widget_id, user_key)
+
+        if widget_id not in self and (user_key is None or user_key not in self):
+            # This is the first time the widget is registered, so we save its
+            # value in widget state.
+            deserializer = metadata.deserializer
+            initial_widget_value = deepcopy(deserializer(None, metadata.id))
+            self._new_widget_state.set_from_value(widget_id, initial_widget_value)
+
+        # Get the current value of the widget for use as its return value.
+        # We return a copy, so that reference types can't be accidentally
+        # mutated by user code.
+        widget_value = self[widget_id]
+        widget_value = deepcopy(widget_value)
+
+        # widget_value_changed indicates to the caller that the widget's
+        # current value is different from what is in the frontend.
+        widget_value_changed = user_key is not None and self.is_new_state_value(
+            user_key
+        )
+
+        return widget_value, widget_value_changed
 
     def get_stats(self) -> List[CacheStat]:
         stat = CacheStat("st_session_state", "", asizeof(self))

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -653,11 +653,6 @@ class SessionState(MutableMapping[str, Any]):
         self._set_metadata(metadata)
         self._maybe_set_new_widget_value(widget_id)
 
-    def get_widget_metadata_by_key(self, user_key: str) -> WidgetMetadata:
-        """Return the WidgetMetadata for the widget with the given user_key."""
-        widget_id = self._key_id_mapping[user_key]
-        return self._new_widget_state.widget_metadata[widget_id]
-
     def get_stats(self) -> List[CacheStat]:
         stat = CacheStat("st_session_state", "", asizeof(self))
         return [stat]

--- a/lib/streamlit/state/widgets.py
+++ b/lib/streamlit/state/widgets.py
@@ -137,8 +137,7 @@ def register_widget(
         # we're running as a "bare" Python script, and not via `streamlit run`).
         return (deserializer(None, ""), False)
 
-    # Register the widget, and ensure another widget with the same id hasn't
-    # already been registered.
+    # Ensure another widget with the same id hasn't already been registered.
     new_widget = widget_id not in ctx.widget_ids_this_run
     if new_widget:
         ctx.widget_ids_this_run.add(widget_id)
@@ -150,8 +149,7 @@ def register_widget(
             )
         )
 
-    session_state = ctx.session_state
-
+    # Create the widget's updated metadata, and register it with session_state.
     metadata = WidgetMetadata(
         widget_id,
         deserializer,
@@ -161,16 +159,7 @@ def register_widget(
         callback_args=args,
         callback_kwargs=kwargs,
     )
-    # TODO: should these be merged into a more generic call so this code doesn't need to know about keyed vs unkeyed?
-    if user_key is not None:
-        session_state.set_keyed_widget_metadata(metadata, widget_id, user_key)
-    else:
-        session_state.set_unkeyed_widget_metadata(metadata, widget_id)
-    value_changed = session_state.should_set_frontend_state_value(widget_id, user_key)
-
-    val = session_state.get_value_for_registration(widget_id)
-
-    return (val, value_changed)
+    return ctx.session_state.register_widget(metadata, widget_id, user_key)
 
 
 # NOTE: We use this table to start with a best-effort guess for the value_type

--- a/lib/tests/streamlit/script_request_queue_test.py
+++ b/lib/tests/streamlit/script_request_queue_test.py
@@ -90,10 +90,10 @@ class ScriptRequestQueueTest(unittest.TestCase):
         _create_widget("trigger", states).trigger_value = False
         _create_widget("int", states).int_value = 456
 
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
             WidgetMetadata("trigger", lambda x, s: x, None, "trigger_value")
         )
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
             WidgetMetadata("int", lambda x, s: x, lambda x: x, "int_value")
         )
 

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -716,7 +716,7 @@ def test_mapping_laws(m):
 
 @given(
     m=stst.session_state(),
-    key=stst.user_key,
+    key=stst.USER_KEY,
     value1=hst.integers(),
     value2=hst.integers(),
 )
@@ -728,7 +728,7 @@ def test_map_set_set(m, key, value1, value2):
     assert len(m) == l1
 
 
-@given(m=stst.session_state(), key=stst.user_key, value1=hst.integers())
+@given(m=stst.session_state(), key=stst.USER_KEY, value1=hst.integers())
 def test_map_set_del(m, key, value1):
     m[key] = value1
     l1 = len(m)

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -577,23 +577,21 @@ class SessionStateMethodTests(unittest.TestCase):
         wstates = WStates()
         self.session_state._new_widget_state = wstates
 
+        WIDGET_VALUE = 123
+
         metadata = WidgetMetadata(
             id=f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1",
-            deserializer=lambda _, __: 0,
+            deserializer=lambda _, __: WIDGET_VALUE,
             serializer=identity,
             value_type="int_value",
         )
-        self.session_state.set_keyed_widget_metadata(
-            metadata, f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1", "widget_id_1"
+        _, widget_value_changed = self.session_state.register_widget(
+            metadata=metadata,
+            widget_id=f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1",
+            user_key="widget_id_1",
         )
-        assert (
-            self.session_state._should_set_frontend_state_value(
-                f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1",
-                "widget_id_1",
-            )
-            == False
-        )
-        assert self.session_state["widget_id_1"] == 0
+        assert not widget_value_changed
+        assert self.session_state["widget_id_1"] == WIDGET_VALUE
 
 
 @patch(
@@ -756,13 +754,17 @@ def test_map_set_del_3837_regression():
     )
     m = SessionState()
     m["0"] = 0
-    m.set_unkeyed_widget_metadata(
-        meta1, "$$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None"
+    m.register_widget(
+        metadata=meta1,
+        widget_id="$$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None",
+        user_key=None,
     )
     m.compact_state()
 
-    m.set_keyed_widget_metadata(
-        meta2, "$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", "0"
+    m.register_widget(
+        metadata=meta2,
+        widget_id="$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0",
+        user_key="0",
     )
     key = "0"
     value1 = 0

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -587,7 +587,7 @@ class SessionStateMethodTests(unittest.TestCase):
             metadata, f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1", "widget_id_1"
         )
         assert (
-            self.session_state.should_set_frontend_state_value(
+            self.session_state._should_set_frontend_state_value(
                 f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1",
                 "widget_id_1",
             )

--- a/lib/tests/streamlit/state/strategies.py
+++ b/lib/tests/streamlit/state/strategies.py
@@ -44,7 +44,7 @@ def mock_metadata(widget_id: str, default_value: int) -> WidgetMetadata:
 
 
 @hst.composite
-def _session_state(draw):
+def _session_state(draw) -> SessionState:
     state = SessionState()
     new_state = draw(NEW_SESSION_STATE)
     for k, v in new_state.items():
@@ -54,7 +54,7 @@ def _session_state(draw):
         hst.dictionaries(keys=UNKEYED_WIDGET_IDS, values=hst.integers())
     )
     for wid, v in unkeyed_widgets.items():
-        state.set_unkeyed_widget_metadata(mock_metadata(wid, v), wid)
+        state.register_widget(mock_metadata(wid, v), wid, user_key=None)
 
     widget_key_val_triple = draw(
         hst.lists(hst.tuples(hst.uuids(), USER_KEY, hst.integers()))
@@ -64,7 +64,7 @@ def _session_state(draw):
         for wid, key, val in widget_key_val_triple
     }
     for key, (wid, val) in k_wids.items():
-        state.set_keyed_widget_metadata(mock_metadata(wid, val), wid, key)
+        state.register_widget(mock_metadata(wid, val), wid, user_key=key)
 
     if k_wids:
         session_state_widget_entries = draw(
@@ -81,7 +81,7 @@ def _session_state(draw):
 
 # TODO: don't generate states where there is a k-wid mapping where the key exists but the widget doesn't
 @hst.composite
-def session_state(draw):
+def session_state(draw) -> SessionState:
     state = draw(_session_state())
 
     state.compact_state()

--- a/lib/tests/streamlit/state/strategies.py
+++ b/lib/tests/streamlit/state/strategies.py
@@ -1,3 +1,17 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from streamlit.state.session_state import (
     SessionState,
     GENERATED_WIDGET_KEY_PREFIX,

--- a/lib/tests/streamlit/state/strategies.py
+++ b/lib/tests/streamlit/state/strategies.py
@@ -19,13 +19,13 @@ from streamlit.state.session_state import (
 )
 from hypothesis import strategies as hst
 
-ascii = list("abcdefghijklmnopqrstuvwxyz0123456789_-")
+ASCII = list("abcdefghijklmnopqrstuvwxyz0123456789_-")
 
-user_key = hst.one_of(hst.text(alphabet=ascii, min_size=1), hst.integers().map(str))
+USER_KEY = hst.one_of(hst.text(alphabet=ASCII, min_size=1), hst.integers().map(str))
 
-new_session_state = hst.dictionaries(keys=user_key, values=hst.integers())
+NEW_SESSION_STATE = hst.dictionaries(keys=USER_KEY, values=hst.integers())
 
-unkeyed_widget_ids = hst.uuids().map(
+UNKEYED_WIDGET_IDS = hst.uuids().map(
     lambda s: f"{GENERATED_WIDGET_KEY_PREFIX}-{s}-None"
 )
 
@@ -46,18 +46,18 @@ def mock_metadata(widget_id: str, default_value: int) -> WidgetMetadata:
 @hst.composite
 def _session_state(draw):
     state = SessionState()
-    new_state = draw(new_session_state)
+    new_state = draw(NEW_SESSION_STATE)
     for k, v in new_state.items():
         state[k] = v
 
     unkeyed_widgets = draw(
-        hst.dictionaries(keys=unkeyed_widget_ids, values=hst.integers())
+        hst.dictionaries(keys=UNKEYED_WIDGET_IDS, values=hst.integers())
     )
     for wid, v in unkeyed_widgets.items():
         state.set_unkeyed_widget_metadata(mock_metadata(wid, v), wid)
 
     widget_key_val_triple = draw(
-        hst.lists(hst.tuples(hst.uuids(), user_key, hst.integers()))
+        hst.lists(hst.tuples(hst.uuids(), USER_KEY, hst.integers()))
     )
     k_wids = {
         key: (as_keyed_widget_id(wid, key), val)

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -54,11 +54,11 @@ class WidgetManagerTests(unittest.TestCase):
         session_state = SessionState()
         session_state.set_widgets_from_proto(states)
 
-        session_state._set_metadata(create_metadata("trigger", "trigger_value"))
-        session_state._set_metadata(create_metadata("bool", "bool_value"))
-        session_state._set_metadata(create_metadata("float", "double_value"))
-        session_state._set_metadata(create_metadata("int", "int_value"))
-        session_state._set_metadata(create_metadata("string", "string_value"))
+        session_state._set_widget_metadata(create_metadata("trigger", "trigger_value"))
+        session_state._set_widget_metadata(create_metadata("bool", "bool_value"))
+        session_state._set_widget_metadata(create_metadata("float", "double_value"))
+        session_state._set_widget_metadata(create_metadata("int", "int_value"))
+        session_state._set_widget_metadata(create_metadata("string", "string_value"))
 
         self.assertEqual(True, session_state.get("trigger"))
         self.assertEqual(True, session_state.get("bool"))
@@ -79,8 +79,10 @@ class WidgetManagerTests(unittest.TestCase):
         session_state = SessionState()
         session_state.set_widgets_from_proto(states)
 
-        session_state._set_metadata(create_metadata("trigger", "trigger_value", True))
-        session_state._set_metadata(create_metadata("trigger2", "trigger_value"))
+        session_state._set_widget_metadata(
+            create_metadata("trigger", "trigger_value", True)
+        )
+        session_state._set_widget_metadata(create_metadata("trigger2", "trigger_value"))
 
         self.assertEqual(dict(session_state.values()), {"trigger": True})
 
@@ -90,7 +92,7 @@ class WidgetManagerTests(unittest.TestCase):
 
     def test_set_widget_attrs_nonexistent(self):
         session_state = SessionState()
-        session_state._set_metadata(create_metadata("fake_widget_id", ""))
+        session_state._set_widget_metadata(create_metadata("fake_widget_id", ""))
 
         self.assertTrue(
             isinstance(
@@ -133,7 +135,7 @@ class WidgetManagerTests(unittest.TestCase):
             ("string", "string_value", mock_callback, (1,), {"x": 2}),
         ]
         for widget_id, value_type, callback, args, kwargs in callback_cases:
-            session_state._set_metadata(
+            session_state._set_widget_metadata(
                 WidgetMetadata(
                     widget_id,
                     deserializer,
@@ -166,7 +168,7 @@ class WidgetManagerTests(unittest.TestCase):
 
         session_state = SessionState()
         session_state.set_widgets_from_proto(widget_states)
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
             WidgetMetadata("other_widget", lambda x, s: x, None, "trigger_value", True)
         )
 
@@ -182,10 +184,10 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("trigger", states).trigger_value = True
         _create_widget("int", states).int_value = 123
         session_state.set_widgets_from_proto(states)
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
             WidgetMetadata("trigger", lambda x, s: x, None, "trigger_value")
         )
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
             WidgetMetadata("int", lambda x, s: x, None, "int_value")
         )
 
@@ -207,12 +209,16 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("missing_in_new", old_states).int_value = 123
         _create_widget("shape_changing_trigger", old_states).trigger_value = True
 
-        session_state._set_metadata(create_metadata("old_set_trigger", "trigger_value"))
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
+            create_metadata("old_set_trigger", "trigger_value")
+        )
+        session_state._set_widget_metadata(
             create_metadata("old_unset_trigger", "trigger_value")
         )
-        session_state._set_metadata(create_metadata("missing_in_new", "int_value"))
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
+            create_metadata("missing_in_new", "int_value")
+        )
+        session_state._set_widget_metadata(
             create_metadata("shape changing trigger", "trigger_value")
         )
 
@@ -222,9 +228,11 @@ class WidgetManagerTests(unittest.TestCase):
         _create_widget("new_set_trigger", new_states).trigger_value = True
         _create_widget("added_in_new", new_states).int_value = 456
         _create_widget("shape_changing_trigger", new_states).int_value = 3
-        session_state._set_metadata(create_metadata("new_set_trigger", "trigger_value"))
-        session_state._set_metadata(create_metadata("added_in_new", "int_value"))
-        session_state._set_metadata(
+        session_state._set_widget_metadata(
+            create_metadata("new_set_trigger", "trigger_value")
+        )
+        session_state._set_widget_metadata(create_metadata("added_in_new", "int_value"))
+        session_state._set_widget_metadata(
             create_metadata("shape_changing_trigger", "int_value")
         )
 


### PR DESCRIPTION
Widget registration currently involves calls to multiple SessionState functions:
- `set_keyed_widget_metadata`
- `set_unkeyed_widget_metadata`
- `should_set_frontend_state_value`
- `get_value_for_registration`

This PR collapses that down to a single public API, `SessionState.register_widget`. The idea is to reduce SessionState's public API surface area ahead of upcoming changes in the `feature/faster-reruns` branch.

There's a wee bit of other cleanup in here as well that is called out in comments below.