### PR TITLE
session_data cleanup (types, fstrings)

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -253,7 +253,7 @@ class AppSession:
         self._on_source_file_changed()
 
     def _clear_queue(self) -> None:
-        self._session_data.clear()
+        self._session_data.clear_browser_queue()
 
     def _on_scriptrunner_event(
         self,

--- a/lib/streamlit/session_data.py
+++ b/lib/streamlit/session_data.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import List
 
 import attr
@@ -44,11 +45,9 @@ def get_url(host_ip: str) -> str:
     if base_path:
         base_path = "/" + base_path
 
-    return "http://%(host_ip)s:%(port)s%(base_path)s" % {
-        "host_ip": host_ip.strip("/"),
-        "port": port,
-        "base_path": base_path,
-    }
+    host_ip = host_ip.strip("/")
+
+    return f"http://{host_ip}:{port}{base_path}"
 
 
 @attr.s(auto_attribs=True, slots=True, init=False)
@@ -89,14 +88,15 @@ class SessionData:
 
         self.command_line = command_line
 
-    def enqueue(self, msg):
+    def enqueue(self, msg: ForwardMsg) -> None:
         self._browser_queue.enqueue(msg)
 
-    def clear(self):
+    def clear_browser_queue(self) -> None:
+        """Clear all pending ForwardMsgs from our browser queue."""
         self._browser_queue.clear()
 
     def flush_browser_queue(self) -> List[ForwardMsg]:
-        """Clears our browser queue and returns the messages it contained.
+        """Clear our browser queue and return the messages it contained.
 
         The Server calls this periodically to deliver new messages
         to the browser associated with this session.
@@ -111,7 +111,7 @@ class SessionData:
         return self._browser_queue.flush()
 
 
-def _get_browser_address_bar_port():
+def _get_browser_address_bar_port() -> int:
     """Get the app URL that will be shown in the browser's address bar.
 
     That is, this is the port where static assets will be served from. In dev,
@@ -121,4 +121,4 @@ def _get_browser_address_bar_port():
     """
     if config.get_option("global.developmentMode"):
         return 3000
-    return config.get_option("browser.serverPort")
+    return int(config.get_option("browser.serverPort"))


### PR DESCRIPTION
A few drive-by cleanups in `session_data.py`:

- type annotations
- `SessionData.clear` is confusing - rename to `clear_browser_queue`, which is what it does