### PR TITLE
ScriptRunner.on_event: include 'sender' param

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -15,7 +15,7 @@
 import sys
 import uuid
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Optional, List, Any
+from typing import TYPE_CHECKING, Callable, Optional, List, Any, cast
 
 from streamlit.uploaded_file_manager import UploadedFileManager
 

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -781,7 +781,7 @@ class _BrowserWebSocketHandler(WebSocketHandler):
 
         except BaseException as e:
             LOGGER.error(e)
-            self._session.enqueue_exception(e)
+            self._session.handle_backmsg_exception(e)
 
 
 def _set_tornado_log_levels() -> None:

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -152,7 +152,7 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
         )
 
         # Create a AppSession with some mocked bits
-        rs = AppSession(
+        session = AppSession(
             self.io_loop,
             SessionData("mock_report.py", ""),
             UploadedFileManager(),
@@ -162,14 +162,20 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
 
         orig_ctx = get_script_run_ctx()
         ctx = ScriptRunContext(
-            "TestSessionID", rs._session_data.enqueue, "", None, None
+            session_id="TestSessionID",
+            enqueue=session._session_data.enqueue,
+            query_string="",
+            session_state=MagicMock(),
+            uploaded_file_mgr=MagicMock(),
         )
         add_script_run_ctx(ctx=ctx)
 
-        rs._on_scriptrunner_event(ScriptRunnerEvent.SCRIPT_STARTED)
+        session._on_scriptrunner_event(
+            sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED
+        )
 
-        sent_messages = rs._session_data._browser_queue._queue
-        self.assertEqual(len(sent_messages), 2)  # NewApp and SessionState messages
+        sent_messages = session._session_data._browser_queue._queue
+        self.assertEqual(2, len(sent_messages))  # NewApp and SessionState messages
 
         # Note that we're purposefully not very thoroughly testing new_session
         # fields below to avoid getting to the point where we're just

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -17,7 +17,7 @@
 import os
 import sys
 import time
-from typing import List, Any
+from typing import List, Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,9 +30,9 @@ from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
+from streamlit.script_request_queue import ScriptRequestQueue, ScriptRequest, RerunData
 from streamlit.session_data import SessionData
 from streamlit.forward_msg_queue import ForwardMsgQueue
-from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
@@ -706,7 +706,14 @@ class TestScriptRunner(ScriptRunner):
         self.events: List[ScriptRunnerEvent] = []
         self.event_data: List[Any] = []
 
-        def record_event(event, **kwargs):
+        def record_event(
+            sender: Optional[ScriptRunner], event: ScriptRunnerEvent, **kwargs
+        ):
+            # Assert that we're not getting unexpected `sender` params
+            # from ScriptRunner.on_event
+            assert (
+                sender is None or sender == self
+            ), "Unexpected ScriptRunnerEvent sender!"
             self.events.append(event)
             self.event_data.append(kwargs)
 


### PR DESCRIPTION
Modify `ScriptRunner.on_event` to include the sender of the event in the call. (This is actually the way that signals are intended to be used - we'd been sending the event data in the signal's "sender" param.)

This will become important when there can be multiple ScriptRunners executing inside a single AppSession.