### PR TITLE
AppSession: process script events on main thread

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import sys
+import threading
 import uuid
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Optional, List, Any, cast
+from typing import TYPE_CHECKING, Callable, Optional, List, Any
 
 from streamlit.uploaded_file_manager import UploadedFileManager
 
@@ -264,8 +265,26 @@ class AppSession:
     ) -> None:
         """Called when our ScriptRunner emits an event.
 
-        This is called from the sender ScriptRunner's script thread;
-        it is *not* called on the main thread.
+        This is generally called from the sender ScriptRunner's script thread.
+        We forward the event on to _handle_scriptrunner_event_on_main_thread,
+        which will be called on the main thread.
+        """
+        self._ioloop.spawn_callback(
+            lambda: self._handle_scriptrunner_event_on_main_thread(
+                sender, event, exception, client_state
+            )
+        )
+
+    def _handle_scriptrunner_event_on_main_thread(
+        self,
+        sender: Optional[ScriptRunner],
+        event: ScriptRunnerEvent,
+        exception: Optional[BaseException] = None,
+        client_state: Optional[ClientState] = None,
+    ) -> None:
+        """Handle a ScriptRunner event.
+
+        This function must only be called on the main thread.
 
         Parameters
         ----------
@@ -285,7 +304,10 @@ class AppSession:
             SHUTDOWN event.
 
         """
-        LOGGER.debug("OnScriptRunnerEvent: %s", event)
+
+        assert (
+            threading.main_thread() == threading.current_thread()
+        ), "This function must only be called on the main thread"
 
         prev_state = self._state
 
@@ -342,18 +364,14 @@ class AppSession:
                 # session is actually shutting down.
                 in_memory_file_manager.clear_session_files(self.id)
 
-            def on_shutdown():
-                # We assert above that this is non-null
-                self._client_state = cast(ClientState, client_state)
+            self._client_state = client_state
+            self._scriptrunner = None
 
-                self._scriptrunner = None
-                # Because a new ScriptEvent could have been enqueued while the
-                # scriptrunner was shutting down, we check to see if we should
-                # create a new one. (Otherwise, a newly-enqueued ScriptEvent
-                # won't be processed until another event is enqueued.)
-                self._maybe_create_scriptrunner()
-
-            self._ioloop.spawn_callback(on_shutdown)
+            # Because a new ScriptEvent could have been enqueued while the
+            # scriptrunner was shutting down, we check to see if we should
+            # create a new one. (Otherwise, a newly-enqueued ScriptEvent
+            # won't be processed until another event is enqueued.)
+            self._maybe_create_scriptrunner()
 
         # Send a message if our run state changed
         app_was_running = prev_state == AppSessionState.APP_IS_RUNNING

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -15,7 +15,7 @@
 import sys
 import uuid
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Optional, List, Any
+from typing import TYPE_CHECKING, Callable, Optional, List, Any, cast
 
 from streamlit.uploaded_file_manager import UploadedFileManager
 

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -781,7 +781,7 @@ class _BrowserWebSocketHandler(WebSocketHandler):
 
         except BaseException as e:
             LOGGER.error(e)
-            self._session.enqueue_exception(e)
+            self._session.handle_backmsg_exception(e)
 
 
 def _set_tornado_log_levels() -> None:

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -152,7 +152,7 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
         )
 
         # Create a AppSession with some mocked bits
-        rs = AppSession(
+        session = AppSession(
             self.io_loop,
             SessionData("mock_report.py", ""),
             UploadedFileManager(),
@@ -162,14 +162,20 @@ class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
 
         orig_ctx = get_script_run_ctx()
         ctx = ScriptRunContext(
-            "TestSessionID", rs._session_data.enqueue, "", None, None
+            session_id="TestSessionID",
+            enqueue=session._session_data.enqueue,
+            query_string="",
+            session_state=MagicMock(),
+            uploaded_file_mgr=MagicMock(),
         )
         add_script_run_ctx(ctx=ctx)
 
-        rs._on_scriptrunner_event(ScriptRunnerEvent.SCRIPT_STARTED)
+        session._on_scriptrunner_event(
+            sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED
+        )
 
-        sent_messages = rs._session_data._browser_queue._queue
-        self.assertEqual(len(sent_messages), 2)  # NewApp and SessionState messages
+        sent_messages = session._session_data._browser_queue._queue
+        self.assertEqual(2, len(sent_messages))  # NewApp and SessionState messages
 
         # Note that we're purposefully not very thoroughly testing new_session
         # fields below to avoid getting to the point where we're just

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import tornado.testing
@@ -129,16 +129,12 @@ def _mock_get_options_for_section(overrides=None):
 
 class AppSessionNewSessionDataTest(tornado.testing.AsyncTestCase):
     @patch("streamlit.app_session.config")
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    @patch("streamlit.util.os.makedirs")
-    @patch("streamlit.metrics_util.os.path.exists", MagicMock(return_value=False))
     @patch(
         "streamlit.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
     )
-    @patch("streamlit.file_util.open", mock_open(read_data=""))
     @tornado.testing.gen_test
-    def test_enqueue_new_session_message(self, _1, _2, patched_config):
+    def test_enqueue_new_session_message(self, patched_config):
         def get_option(name):
             if name == "server.runOnSave":
                 # Just to avoid starting the watcher for no reason.

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -38,13 +38,13 @@ def del_path(monkeypatch):
     monkeypatch.setenv("PATH", "")
 
 
+@patch("streamlit.app_session.LocalSourcesWatcher", MagicMock())
 class AppSessionTest(unittest.TestCase):
     @patch("streamlit.app_session.secrets._file_change_listener.disconnect")
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_shutdown(self, _, patched_disconnect):
+    def test_shutdown(self, patched_disconnect):
         """Test that AppSession.shutdown behaves sanely."""
         file_mgr = MagicMock(spec=UploadedFileManager)
-        rs = AppSession(None, SessionData("", ""), file_mgr, None, MagicMock())
+        rs = AppSession(MagicMock(), SessionData("", ""), file_mgr, None, MagicMock())
 
         rs.shutdown()
         self.assertEqual(AppSessionState.SHUTDOWN_REQUESTED, rs._state)
@@ -56,8 +56,7 @@ class AppSessionTest(unittest.TestCase):
         self.assertEqual(AppSessionState.SHUTDOWN_REQUESTED, rs._state)
         file_mgr.remove_session_files.assert_called_once_with(rs.id)
 
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_unique_id(self, _1):
+    def test_unique_id(self):
         """Each AppSession should have a unique ID"""
         file_mgr = MagicMock(spec=UploadedFileManager)
         lsw = MagicMock()
@@ -65,15 +64,13 @@ class AppSessionTest(unittest.TestCase):
         rs2 = AppSession(None, SessionData("", ""), file_mgr, None, lsw)
         self.assertNotEqual(rs1.id, rs2.id)
 
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_creates_session_state_on_init(self, _):
+    def test_creates_session_state_on_init(self):
         rs = AppSession(
             None, SessionData("", ""), UploadedFileManager(), None, MagicMock()
         )
         self.assertTrue(isinstance(rs.session_state, SessionState))
 
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_clear_cache_resets_session_state(self, _1):
+    def test_clear_cache_resets_session_state(self):
         rs = AppSession(
             None, SessionData("", ""), UploadedFileManager(), None, MagicMock()
         )
@@ -289,8 +286,8 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
             " Allowed values include ['sans serif', 'serif', 'monospace']. Setting theme.font to \"sans serif\"."
         )
 
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_passes_client_state_on_run_on_save(self, _):
+    @patch("streamlit.app_session.LocalSourcesWatcher", MagicMock())
+    def test_passes_client_state_on_run_on_save(self):
         rs = AppSession(
             None, SessionData("", ""), UploadedFileManager(), None, MagicMock()
         )

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -134,6 +134,7 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_enqueue_new_session_message(self, patched_config):
         """The SCRIPT_STARTED event should enqueue a 'new_session' message."""
+
         def get_option(name):
             if name == "server.runOnSave":
                 # Just to avoid starting the watcher for no reason.
@@ -218,7 +219,11 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
         session._handle_scriptrunner_event_on_main_thread = mock_handle_event
 
         # Send a ScriptRunner event from another thread
-        thread = threading.Thread(target=lambda: session._on_scriptrunner_event(sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED))
+        thread = threading.Thread(
+            target=lambda: session._on_scriptrunner_event(
+                sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED
+            )
+        )
         thread.start()
         thread.join()
 

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -17,7 +17,7 @@
 import os
 import sys
 import time
-from typing import List, Any
+from typing import List, Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,9 +30,9 @@ from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
+from streamlit.script_request_queue import ScriptRequestQueue, ScriptRequest, RerunData
 from streamlit.session_data import SessionData
 from streamlit.forward_msg_queue import ForwardMsgQueue
-from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
@@ -706,7 +706,14 @@ class TestScriptRunner(ScriptRunner):
         self.events: List[ScriptRunnerEvent] = []
         self.event_data: List[Any] = []
 
-        def record_event(event, **kwargs):
+        def record_event(
+            sender: Optional[ScriptRunner], event: ScriptRunnerEvent, **kwargs
+        ):
+            # Assert that we're not getting unexpected `sender` params
+            # from ScriptRunner.on_event
+            assert (
+                sender is None or sender == self
+            ), "Unexpected ScriptRunnerEvent sender!"
             self.events.append(event)
             self.event_data.append(kwargs)
 


### PR DESCRIPTION
(This builds on #4436, so that PR should be reviewed and merged first)

Simplifies AppSession's ScriptRunnerEvent handling to happen *only* on the main thread.

Currently, AppSession handles only the "SHUTDOWN" ScriptRunner event on the main thread, and all other events are handled in the thread that dispatched the event. 

With this PR, AppSession handles all events on the main thread, and is no longer mutating any state from other threads.

The PR also includes a small amount of drive-by cleanup of `app_session_test.py` (mostly just removing unnecessary patches).