### PR TITLE
Comment out config options in `streamlit config show` unless explicitly set

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -355,7 +355,7 @@ def _logger_message_format() -> str:
     [Python's documentation](https://docs.python.org/2.6/library/logging.html#formatter-objects)
     for available attributes.
 
-    Default: None
+    Default: "%(asctime)s %(message)s"
     """
     if get_option("global.developmentMode"):
         from streamlit.logger import DEFAULT_LOG_MESSAGE

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -114,7 +114,9 @@ def show_config(
             toml_setting = toml.dumps({key: option.value})
 
             if len(toml_setting) == 0:
-                toml_setting = "#%s =\n" % key
+                toml_setting = f"# {key} =\n"
+            elif not option_is_manually_set:
+                toml_setting = f"# {toml_setting}"
 
             append_setting(toml_setting)
 


### PR DESCRIPTION
## 📚 Context

https://github.com/streamlit/streamlit/issues/2953 describes some edge-case scenarios where populating a config file using 
`streamlit config show > ~/.streamlit/config.toml` can result in confusing behavior.

One fix for this is to comment out any config options not explicitly set by the
user when running `streamlit config show`. Doing so prevents the weird edge cases
from coming up while not reducing the usefulness of the command.

Note that we always uncomment out the config options if they are explicitly set,
even if they are explicitly set to the default option.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Comment out config options in `streamlit config show` if they aren't explicitly set

  - [x] This is a visible (user-facing) change

**Revised:**

<img width="974" alt="Screen Shot 2022-02-23 at 17 15 51" src="https://user-images.githubusercontent.com/3144420/155439773-f3c11121-af29-4833-b78b-db2c844d4489.png">

**Current:**

<img width="974" alt="Screen Shot 2022-02-23 at 17 14 51" src="https://user-images.githubusercontent.com/3144420/155439796-0f3658c3-e4d1-4c05-bfce-da560f566f1a.png">

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #2953
