### PR TITLE
[STLT-26] 🔄 (CircleCI RC Pipeline) Fix CLI regression test deadlock and run before release; add version for Node and ensure version is only incremented once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,14 +276,15 @@ jobs:
       - run:
           name: Set desired version from branch name
           command: echo 'export DESIRED_VERSION=$(echo $CIRCLE_BRANCH | tr -d "release/")' >> $BASH_ENV
+
       - run:
-          name: Set final version with pre-release
-          command: echo 'export STREAMLIT_RELEASE_VERSION=$(python scripts/get_prerelease_version.py $DESIRED_VERSION)' >> $BASH_ENV
-      - run:
-          name: Update streamlit version
+          name: Set final versions for pre-release and update version
           command: |
-            echo "Release version ${STREAMLIT_RELEASE_VERSION}"
-            python scripts/update_version.py $STREAMLIT_RELEASE_VERSION
+            export STREAMLIT_RELEASE_SEMVER=$(python scripts/get_prerelease_version.py $DESIRED_VERSION)
+            echo 'export STREAMLIT_RELEASE_SEMVER=$(python scripts/get_prerelease_version.py $DESIRED_VERSION)' >> $BASH_ENV
+            echo 'export STREAMLIT_RELEASE_VERSION=$(echo $STREAMLIT_RELEASE_SEMVER | sed s/\-rc\./rc/)' >> $BASH_ENV
+            python scripts/update_version.py $STREAMLIT_RELEASE_SEMVER
+
       - run:
           name: Commit version updates
           command: |
@@ -326,8 +327,8 @@ jobs:
             make distribute
 
       - slack/status:
-          success_message: ":rocket: RC version ${STREAMLIT_RELEASE_VERSION} was successful!"
-          failure_message: ":blobonfire: RC version ${STREAMLIT_RELEASE_VERSION} failed to release"
+          success_message: ":rocket: RC version ${STREAMLIT_RELEASE_SEMVER} was successful!"
+          failure_message: ":blobonfire: RC version ${STREAMLIT_RELEASE_SEMVER} failed to release"
 
   python-max-version: &job-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,11 +312,9 @@ jobs:
             ${SUDO} apt-get install rsync
             make package
 
-      # TODO: need to fix this - it doesn't seem to run with the correct build/version
-      # - run:
-      #     name: Run CLI regression tests with full build
-      #     command: |
-      #       make cli-regression-tests
+      - run:
+          name: Run CLI regression tests
+          command: make cli-regression-tests
 
       - store_artifacts:
           path: ./lib/dist

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ eggs/
 .eggs/
 *.egg-info/
 *.egg
+.prerelease-version
 
 # Preloaded, minified js (downloaded via script due to dependencies having
 # issues with babel transpilation).

--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import signal
 import subprocess
 import time
 from typing import Optional
@@ -84,37 +85,47 @@ class TestCLIRegressions:
     def parameterize(self, params):
         return params.split(" ")
 
+    def read_process_output(self, proc, num_lines_to_read):
+        num_lines_read = 0
+        output = ""
+
+        while num_lines_read < num_lines_to_read:
+            output += proc.stdout.readline().decode("UTF-8")
+            num_lines_read += 1
+
+        return output
+
     def run_command(self, command):
         return subprocess.check_output(self.parameterize(command)).decode("UTF-8")
 
-    def run_single_proc(self, command, wait_in_seconds=2):
+    def run_single_proc(self, command, num_lines_to_read=4):
         proc = subprocess.Popen(
             command,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            preexec_fn=os.setpgrp,
         )
 
-        # Sleep to allow commands to run
-        time.sleep(wait_in_seconds)
-
-        # Kill both processes, as output is accessible afterwards
-        proc.terminate()
+        output = self.read_process_output(proc, num_lines_to_read)
 
         try:
-            # Retrieve and return outputs
-            out_one, _ = proc.communicate(timeout=1)
+            os.kill(os.getpgid(proc.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            # The process may have exited already. If so, we don't need to do anything
+            pass
 
-            return out_one.decode("utf-8")
-        except subprocess.TimeoutExpired:
-            assert False, "Subprocess timed out"
+        return output
 
-    def run_double_proc(self, command_one, command_two, wait_in_seconds=2):
+    def run_double_proc(
+        self, command_one, command_two, wait_in_seconds=2, num_lines_to_read=4
+    ):
         proc_one = subprocess.Popen(
             command_one,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            preexec_fn=os.setpgrp,
         )
 
         # Quick sleep to ensure that proc_one gets started first
@@ -125,27 +136,24 @@ class TestCLIRegressions:
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            preexec_fn=os.setpgrp,
         )
 
-        # Sleep to allow commands to run
-        time.sleep(wait_in_seconds)
-
-        # Kill both processes, as output is accessible afterwards
-        proc_one.terminate()
-        proc_two.terminate()
+        output_one = self.read_process_output(proc_one, num_lines_to_read)
+        output_two = self.read_process_output(proc_two, num_lines_to_read)
 
         try:
-            # Retrieve and return outputs
-            out_one, _ = proc_one.communicate(timeout=1)
-            out_two, _ = proc_two.communicate(timeout=1)
+            os.killpg(os.getpgid(proc_one.pid), signal.SIGKILL)
+            os.killpg(os.getpgid(proc_two.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            # The process may have exited already. If so, we don't need to do anything
+            pass
 
-            return out_one.decode("utf-8"), out_two.decode("utf-8")
-        except subprocess.TimeoutExpired:
-            assert False, "Subprocess timed out"
+        return output_one, output_two
 
     def test_streamlit_version(self):
         assert (
-            STREAMLIT_RELEASE_VERSION != ""
+            STREAMLIT_RELEASE_VERSION != None and STREAMLIT_RELEASE_VERSION != ""
         ), "You must set the $STREAMLIT_RELEASE_VERSION env variable"
         assert STREAMLIT_RELEASE_VERSION in self.run_command(
             "streamlit version"

--- a/scripts/get_prerelease_version.py
+++ b/scripts/get_prerelease_version.py
@@ -13,22 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Calculate the next appropriate pre-release based on the target version.
+"""Calculate the next pre-release semver based on the target version and store in a version file.
 
+This has a small hack to get the pipeline on CircleCI to work properly. The command may run
+multiple times, so this file is idempotent for each release build. To accomplish this, we store the
+version into a file on the first run. Any subsequent calls will return the file contents if the file
+exists instead of recalculating the release version.
+
+- If a version exists in the version file, return the file contents.
 - If the current version is the same as the target version, increment the pre-release only
 - If the current version is less than the target version, first update the version to match, then
 increment the pre-release version
 
 A few examples:
 
-- Target: 1.6.0
-  Current: 1.5.1
-  Output: 1.6.0-rc1
+- Target:   1.6.0
+  Current:  1.5.1
+  Output:   1.6.0-rc1
 
-- Target: 1.6.0
-  Current:1.6.0-rc1
-  Output: 1.6.0-rc2
-
+- Target:   1.6.0
+  Current:  1.6.0-rc1
+  Output:   1.6.0-rc2
 """
 
 import fileinput
@@ -39,6 +44,7 @@ import sys
 import semver
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+VERSION_FILE = ".prerelease-version"
 
 
 def get_current_version():
@@ -56,18 +62,30 @@ def get_current_version():
 
 
 def main():
+    if os.path.exists(VERSION_FILE):
+        with open(VERSION_FILE) as f:
+            print(f.read())
+            return
+
     if len(sys.argv) != 2:
         raise Exception(
             'Specify target version as an argument: "%s 1.2.3"' % sys.argv[0]
         )
 
     target_version = semver.VersionInfo.parse(sys.argv[1])
-    current_version = semver.VersionInfo.parse(get_current_version())
+    # Ensure that current version is semver-compliant (it's stored as PEP440-compliant in setup.py)
+    current_version = semver.VersionInfo.parse(
+        get_current_version().replace("rc", "-rc.")
+    )
 
     if current_version.finalize_version() < target_version:
         current_version = target_version
 
-    print(str(current_version.bump_prerelease()))
+    new_version = str(current_version.bump_prerelease())
+    with open(VERSION_FILE, "w") as f:
+        f.write(new_version)
+
+    print(new_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📚 Context

- What kind of change does this PR introduce?

  - [X] Other, please describe: Fixes/updates from RC test run

## 🧠 Description of Changes

  - Refactor CLI regression tests to avoid deadlocks in CircleCI; run CLI regression tests before releasing
  - Update package.json with semver version
  - Ensure that version calculation is idempotent per release build

## 🧪 Testing Done

- [X] Ran partial RC run in Cuttlesoft's CircleCI - essentially a full build minus the Streamlit specific things (committing and pushing back to GH, releasing to PyPI). See: https://app.circleci.com/pipelines/github/cuttlesoft/streamlit/101/workflows/5abd4bdb-d903-4e1e-ab19-74d7a0de9b71/jobs/340

## 🌐 References

N/A