### PR TITLE
Ability to clear selectbox 

### DIFF
--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -133,8 +133,8 @@ class Selectbox extends React.PureComponent<Props, State> {
   public render = (): React.ReactNode => {
     const style = { width: this.props.width }
     const { label, help } = this.props
-    let { disabled, clearable, options } = this.props
-
+    let { disabled, options } = this.props
+    const { clearable } = this.props
     let value = [
       {
         label:

--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -92,6 +92,9 @@ class Selectbox extends React.PureComponent<Props, State> {
   private onChange = (params: OnChangeParams): void => {
     if (params.value.length === 0) {
       logWarning("No value selected!")
+      if (params.type === "clear") {
+        this.setState({ isEmpty: true })
+      }
       return
     }
 

--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -30,6 +30,7 @@ import {
 
 export interface Props {
   disabled: boolean
+  clearable: boolean
   width?: number
   value: number
   onChange: (value: number) => void
@@ -132,7 +133,7 @@ class Selectbox extends React.PureComponent<Props, State> {
   public render = (): React.ReactNode => {
     const style = { width: this.props.width }
     const { label, help } = this.props
-    let { disabled, options } = this.props
+    let { disabled, clearable, options } = this.props
 
     let value = [
       {
@@ -170,7 +171,7 @@ class Selectbox extends React.PureComponent<Props, State> {
           )}
         </WidgetLabel>
         <UISelect
-          clearable={false}
+          clearable={clearable}
           disabled={disabled}
           labelKey="label"
           onChange={this.onChange}

--- a/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -33,6 +33,7 @@ const getProps = (elementProps: Partial<SelectboxProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
+  clearable: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -106,8 +106,8 @@ class Selectbox extends React.PureComponent<Props, State> {
   }
 
   public render = (): React.ReactNode => {
-    const { options, help, label, formId } = this.props.element
-    const { disabled, clearable, widgetMgr } = this.props
+    const { options, help, label, formId, clearable } = this.props.element
+    const { disabled, widgetMgr } = this.props
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -23,6 +23,7 @@ import UISelectbox from "src/components/shared/Dropdown"
 
 export interface Props {
   disabled: boolean
+  clearable: boolean
   element: SelectboxProto
   widgetMgr: WidgetStateManager
   width: number
@@ -106,7 +107,7 @@ class Selectbox extends React.PureComponent<Props, State> {
 
   public render = (): React.ReactNode => {
     const { options, help, label, formId } = this.props.element
-    const { disabled, widgetMgr } = this.props
+    const { disabled, clearable, widgetMgr } = this.props
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
@@ -120,6 +121,7 @@ class Selectbox extends React.PureComponent<Props, State> {
         label={label}
         options={options}
         disabled={disabled}
+        clearable={clearable}        
         width={this.props.width}
         onChange={this.onChange}
         value={this.state.value}

--- a/frontend/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.tsx
@@ -121,7 +121,7 @@ class Selectbox extends React.PureComponent<Props, State> {
         label={label}
         options={options}
         disabled={disabled}
-        clearable={clearable}        
+        clearable={clearable}
         width={this.props.width}
         onChange={this.onChange}
         value={this.state.value}

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -45,6 +45,7 @@ class SelectboxMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
+        clearable: bool = False,
     ) -> Any:
         """Display a select widget.
 
@@ -76,7 +77,9 @@ class SelectboxMixin:
         disabled : bool
             An optional boolean, which disables the selectbox if set to True.
             The default is False. This argument can only be supplied by keyword.
-
+        clearable : bool
+            An optional boolean, which adds a clear button to the selectbox if set to True.
+            The default is False. This argument can only be supplied by keyword.
         Returns
         -------
         any
@@ -107,6 +110,7 @@ class SelectboxMixin:
             args=args,
             kwargs=kwargs,
             disabled=disabled,
+            clearable=clearable,
             ctx=ctx,
         )
 
@@ -123,6 +127,7 @@ class SelectboxMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
+        clearable: bool = False,        
         ctx: Optional[ScriptRunContext] = None,
     ) -> Any:
         key = to_key(key)
@@ -147,6 +152,7 @@ class SelectboxMixin:
         selectbox_proto.options[:] = [str(format_func(option)) for option in opt]
         selectbox_proto.form_id = current_form_id(self.dg)
         selectbox_proto.disabled = disabled
+        selectbox_proto.clearable = clearable
         if help is not None:
             selectbox_proto.help = dedent(help)
 

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -127,7 +127,7 @@ class SelectboxMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
-        clearable: bool = False,        
+        clearable: bool = False,
         ctx: Optional[ScriptRunContext] = None,
     ) -> Any:
         key = to_key(key)

--- a/lib/tests/streamlit/selectbox_test.py
+++ b/lib/tests/streamlit/selectbox_test.py
@@ -43,6 +43,13 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.selectbox
         self.assertEqual(c.disabled, True)
 
+    def test_just_clearable(self):
+        """Test that it can be called with clearable param."""
+        st.selectbox("the label", ("m", "f"), clearable=True)
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        self.assertEqual(c.clearable, True)
+
     def test_valid_value(self):
         """Test that valid value is an int."""
         st.selectbox("the label", ("m", "f"), 1)

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -26,4 +26,5 @@ message Selectbox {
   int32 value = 7;
   bool set_value = 8;
   bool disabled = 9;
+  bool clearable = 10;
 }


### PR DESCRIPTION
This PR is related to #4440.

It adds a clearable parameter to selectbox widget, to enable users to clear existing input, especially for cases when a selectbox has a huge list of options.