### PR TITLE
[STLT-22] 🔄 (CircleCI Release Pipeline) Add release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,16 @@ workflows:
           filters:
             branches:
               only: /^release\/([0-9]+\.){2}([0-9]+)/
+      - build-deploy-release:
+          requires:
+            - python-min-version
+            - python-max-version
+            - cypress
+          filters:
+            tags:
+              only: /^([0-9]+\.){2}([0-9]+)/
+            branches:
+              ignore: /.*/
 
       # Uncomment to get a button that runs flaky tests on CircleCI:
       # - cypress-flaky-approval:
@@ -328,6 +338,78 @@ jobs:
       - slack/status:
           success_message: ":rocket: RC version ${STREAMLIT_RELEASE_VERSION} was successful!"
           failure_message: ":blobonfire: RC version ${STREAMLIT_RELEASE_VERSION} failed to release"
+
+  build-deploy-release:
+    resource_class: large
+    docker:
+      - image: circleci/python:3.9.7
+    working_directory: ~/repo
+    steps:
+      - checkout:
+          name: Checkout Streamlit code
+
+      - configure-build-env
+
+      - run:
+          name: Set release version from tag name
+          command: echo 'export STREAMLIT_RELEASE_VERSION=$(echo $CIRCLE_TAG)' >> $BASH_ENV
+
+      - run:
+          name: Update version
+          command: python scripts/update_version.py $STREAMLIT_RELEASE_VERSION
+
+      - run:
+          name: Commit version updates
+          command: |
+            git config user.email "core+streamlitbot-github@streamlit.io"
+            git config user.name "Streamlit Bot"
+
+            git commit -am "Up version to $STREAMLIT_RELEASE_VERSION [skip ci]" && git push origin release/$CIRCLE_TAG || echo "No changes to commit"
+
+      # Password added to circleci environment
+      # https://ui.circleci.com/settings/project/github/streamlit/streamlit/environment-variables
+      - run:
+          name: init .pypirc
+          command: |
+            cd lib
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = streamlit" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+
+      - run:
+          name: Make package
+          no_output_timeout: 2h
+          command: |
+            echo "working directory = $(pwd)"
+            chmod +x ./frontend/scripts/preload-bokeh.sh
+            ${SUDO} apt-get install rsync
+            make package
+
+      - run:
+          name: Run CLI regression tests
+          command: make cli-regression-tests
+
+      - store_artifacts:
+          path: ./lib/dist
+
+      - run:
+          name: upload to pypi
+          command: |
+            make distribute
+
+      - run:
+          name: Mark GH release as official, upload artifacts
+          command: |
+            echo "TODO: Updating GH release..."
+
+      - run:
+          name: Merge branch
+          command: |
+            echo "TODO: Merging branch..."
+
+      - slack/status:
+          success_message: ":rocket: RC version ${STREAMLIT_RELEASE_SEMVER} was successful!"
+          failure_message: ":blobonfire: RC version ${STREAMLIT_RELEASE_SEMVER} failed to release"
 
   python-max-version: &job-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
           path: ./lib/dist
 
       - run:
-          name: upload to pypi
+          name: Upload to pypi
           command: |
             make distribute
 
@@ -347,6 +347,34 @@ jobs:
     steps:
       - checkout:
           name: Checkout Streamlit code
+
+      - run:
+          name: Install GitHub CLI tool and related dependencies
+          command: |
+            sudo apt-get install jq
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            brew install gh
+
+      - run:
+          name: Configure GitHub CLI Settings
+          command: echo 'export GH_REPO=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
+
+      - run:
+          name: Look up the related GitHub PR number and branch name
+          command: |
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            echo "export GH_PR_NUMBER=$(gh api repos/${GH_REPO}/commits/${CIRCLE_SHA1}/pulls | jq '.[0] | .number')" >> $BASH_ENV
+            echo "export GH_PR_BRANCH=$(gh api repos/${GH_REPO}/commits/${CIRCLE_SHA1}/pulls | jq '.[0] | .head.ref')" >> $BASH_ENV
+
+      - run:
+          name: Ensure that version tag matches branch version
+          command: |
+            if [ "$(echo $GH_PR_BRANCH | tr -d "release/")" != "$CIRCLE_TAG" ]
+            then
+              echo "ERROR: Version number from tag does not match the version number from the branch name."
+              exit 1
+            fi
 
       - configure-build-env
 
@@ -393,23 +421,20 @@ jobs:
           path: ./lib/dist
 
       - run:
-          name: upload to pypi
+          name: Upload to pypi
           command: |
             make distribute
 
       - run:
-          name: Mark GH release as official, upload artifacts
+          name: Create GitHub Release and merge PR
           command: |
-            echo "TODO: Updating GH release..."
-
-      - run:
-          name: Merge branch
-          command: |
-            echo "TODO: Merging branch..."
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            gh release create $CIRCLE_TAG -n "" -t $CIRCLE_TAG
+            gh pr merge $GH_PR_NUMBER -m
 
       - slack/status:
-          success_message: ":rocket: RC version ${STREAMLIT_RELEASE_SEMVER} was successful!"
-          failure_message: ":blobonfire: RC version ${STREAMLIT_RELEASE_SEMVER} failed to release"
+          success_message: ":rocket: Version ${STREAMLIT_RELEASE_VERSION} was successful!"
+          failure_message: ":blobonfire: Version ${STREAMLIT_RELEASE_VERSION} failed to release"
 
   python-max-version: &job-template
     docker:


### PR DESCRIPTION
## 📚 Context

- What kind of change does this PR introduce?

  - [X] Other, please describe: Add release pipeline

## 🧠 Description of Changes

- Add release pipeline. This is very similar to the rc pipeline with the following differences:
  - Use version directly from tag and validate against corresponding PR branch name; do not use pre-release version
  - Install gh cli-tool and related dependencies, including jq for parsing API responses
  - After the release is successful, create the GH release and merge the PR

**Note: this requires a new environment variable in CircleCI to create the release and merge the branch. It should be added as `GITHUB_TOKEN` in order to have the cli tool automatically pick up credentials.**

## 🧪 Testing Done

- [X] Ran through "release" in Cuttlesoft's fork, sans Streamlit-specific things (e.g. PyPI release, commit version back to repo). I was able to test the full GH lookup, release and merge 🙌🏻

## 🌐 References

N/A