### PR TITLE
Hide `ui.hideTopBar` and the entire `ui` section

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -676,6 +676,10 @@ def _browser_server_port() -> int:
 
 # Config Section: UI #
 
+# NOTE: We currently hide the ui config section in the `streamlit config show`
+# output as all of its options are hidden. If a non-hidden option is eventually
+# added, the section should be unhidden by removing it from the `SKIP_SECTIONS`
+# set in config_util.show_config.
 _create_section("ui", "Configuration of UI elements displayed in the browser.")
 
 _create_option(
@@ -687,6 +691,7 @@ _create_option(
     """,
     default_val=False,
     type_=bool,
+    visibility="hidden",
 )
 
 

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -28,7 +28,7 @@ def show_config(
     config_options: Dict[str, ConfigOption],
 ) -> None:
     """Print the given config sections/options to the terminal."""
-    SKIP_SECTIONS = ("_test",)
+    SKIP_SECTIONS = {"_test", "ui"}
 
     out = []
     out.append(

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -87,6 +87,20 @@ class ConfigUtilTest(unittest.TestCase):
         assert 'address = "example.com"' in lines
         assert "port = 8501" in lines
 
+    @patch("streamlit.config_util.click.echo")
+    def test_ui_section_hidden(self, patched_echo):
+        config_options = create_config_options({})
+
+        config_util.show_config(CONFIG_SECTION_DESCRIPTIONS, config_options)
+
+        [(args, _)] = patched_echo.call_args_list
+        # Remove the ascii escape sequences used to color terminal output.
+        output = re.compile(r"\x1b[^m]*m").sub("", args[0])
+        lines = set(output.split("\n"))
+
+        assert "[ui]" not in lines
+        assert "# hideTopBar = false" not in lines
+
     @parameterized.expand(
         [
             # Nothing changed.


### PR DESCRIPTION
## 📚 Context

We accidentally left the (currently unused and just for future-proofing)
`ui.hideTopBar` config option visible. This PR changes it to hidden, and it also
hides the entire `ui` config section for now since there are no visible options
in the section.

- What kind of change does this PR introduce?

  - [x] "Bugfix"
  - [x] Other, please describe: hide accidentally-displayed config option

## 🧠 Description of Changes

- Switch the visibility of `ui.hideTopBar` to "hidden"
- Hide the entire `ui` section in `streamlit config show`

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/405
