### PR TITLE
Teach the StaticFileHandler how to deal with page names

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -616,8 +616,6 @@ def _populate_user_info_msg(msg: UserInfo) -> None:
         msg.email = ""
 
 
-# TODO(vdonato): Eventually, rework this to listen for pages being added/removed
-# instead of repeatedly scanning the pages dir every time this function is called.
 def _populate_app_pages(msg: NewSession, main_script_path: str) -> None:
     for page in source_util.get_pages(main_script_path):
         page_proto = msg.app_pages.add()

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -360,15 +360,11 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
-            # TODO(vdonato): We'll eventually want to do a few things here:
-            # 1. Don't scan the `pages` directory for each script run. We'll
-            #    instead want to add a listener to only update our page info
-            #    when a page is added or removed.
-            # 2. Add proper 404 handling. Right now, we just run the main
-            #    script if we can't find a script corresponding to the given
-            #    page_name. We still want to do this in the final version of
-            #    the feature, but we also want to pop a modal telling the user
-            #    that the page they're looking for doesn't exist.
+            # TODO(vdonato): We'll eventually want to add proper 404 handling.
+            # Right now, we just run the main script if we can't find a script
+            # corresponding to the given page_name. We still want to do this in
+            # the final version of the feature, but we also want to pop a modal
+            # telling the user that the page they're looking for doesn't exist.
             script_path = None
 
             # NOTE: It may seem weird that we're passing the page_name around

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -42,6 +42,11 @@ def allow_cross_origin_requests():
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
+    def initialize(self, path, default_filename, get_page_names):
+        self._page_names = get_page_names()
+
+        super().initialize(path=path, default_filename=default_filename)
+
     def set_extra_headers(self, path):
         """Disable cache for HTML files.
 
@@ -54,6 +59,17 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             self.set_header("Cache-Control", "no-cache")
         else:
             self.set_header("Cache-Control", "public")
+
+    def parse_url_path(self, url_path: str) -> str:
+        url_parts = url_path.split("/")
+
+        # TODO(vdonato): Maybe clean this up if we decide to tweak the spec so
+        # that there's a separator between the baseUrlPath and page name.
+        maybe_page_name = url_parts[0]
+        if maybe_page_name in self._page_names:
+            url_path = "/".join(url_parts[1:])
+
+        return super().parse_url_path(url_path)
 
 
 class AssetsFileHandler(tornado.web.StaticFileHandler):

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -78,6 +78,8 @@ def page_name(script_path: Path) -> str:
     return str(name)
 
 
+# TODO(vdonato): Eventually, have this function cache its return value and
+# avoid re-scanning the file system unless a page has been added/removed.
 def get_pages(main_script_path: str) -> List[Dict[str, str]]:
     main_script_path = Path(main_script_path)
     main_page_name = page_name(main_script_path)


### PR DESCRIPTION
## 📚 Context

In the multipage apps world, we may get a request for `page1/index.html` (or some other
static asset) and want to serve the normal `index.html` page (since our `index.html` page
really only sends over the react app, which is then dynamically populated by the output of
a script run). This PR makes some small method overrides to the default tornado `StaticFileHandler`
to make this possible.

- What kind of change does this PR introduce?

  - [x] Feature(-ish)

## 🧠 Description of Changes

- Teach the StaticFileHandler how to deal with page names
- Move some TODOs around (since a few of them can be consolidated)

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/358
