### PR TITLE
[STLT-13] 🚑 (Scripts - Update Version) Allow PEP-440 version to be used as the version arg as well as semver

### DIFF
--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -115,10 +115,19 @@ def main():
         raise (e)
 
     # We need two flavors of the version - one that's semver-compliant for Node, one that's
-    # PEP440-compliant for Python. We expect the incoming version to be semver-compliant; `verify_pep440`
-    # will convert it to PEP440-compliant.
+    # PEP440-compliant for Python. We allow for the incoming version to be either semver-compliant
+    # PEP440-compliant.
+    # - `verify_pep440` automatically converts semver to PEP440-compliant
     pep440_version = verify_pep440(sys.argv[1])
-    semver_version = verify_semver(sys.argv[1])
+
+    # - Attempt to convert to semver-compliant. If a failure occurs, manually attempt to convert.
+    semver_version = None
+    try:
+        semver_version = verify_semver(sys.argv[1])
+    except ValueError:
+        semver_version = verify_semver(
+            sys.argv[1].replace("rc", "-rc.").replace(".dev", "-dev")
+        )
 
     update_files(PYTHON, pep440_version)
     update_files(NODE, semver_version)


### PR DESCRIPTION
## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [X] Bugfix

## 🧠 Description of Changes

- Allow PEP-440 version to be supplied as the argument to `scripts/update_version.py` as well as semver. Essentially, you can now run either `python scripts/update_version.py 1.6.1.dev20220224` or `python scripts/update_version.py 1.6.1-rc1` successfully.

## 🧪 Testing Done

- [X] Tested running the `update_version.py` script locally with all required versions


## 🌐 References

N/A
