### PR TITLE
Prune some Python dependencies

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -34,7 +34,6 @@ types-typed-ast = "*"
 # IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
 # And if you do add one, make the required version as general as possible.
 altair = ">=3.2.0"
-astor = "*"
 attrs = "*"
 base58 = "*"
 blinker = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -35,7 +35,6 @@ types-typed-ast = "*"
 # And if you do add one, make the required version as general as possible.
 altair = ">=3.2.0"
 attrs = "*"
-base58 = "*"
 blinker = "*"
 cachetools = ">=4.0"
 click = ">=7.0"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -6,8 +6,6 @@ verify_ssl = true
 [dev-packages]
 # black 21.7b0 and higher pull in an incompatible version of typing-extensions
 black = "==21.6b0"
-boto3 = "*"
-botocore = ">=1.13.44"
 hypothesis = ">=6.17.4"
 mypy = ">=0.930"
 mypy-protobuf = ">=3.2"


### PR DESCRIPTION
- Remove boto3 + botocore (these were part of the static sharing feature that's now gone)
- Remove "astor" (it's used for AST manipulation - but `magic.py` (which is our only AST-manipulating source file) does not actually use astor)
- Remove "base58" (was formerly used for random ID generation, but we don't use it anymore)