### PR TITLE
Plumb appPages to the Sidebar and show the sidebar when there is >1 page

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -623,6 +623,31 @@ describe("App.handleNewSession", () => {
     expect(oneTimeInitialization).toHaveBeenCalledTimes(2)
     expect(SessionInfo.isSet()).toBe(true)
   })
+
+  it("plumbs appPages to the AppView component", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+
+    expect(wrapper.find("AppView").prop("appPages")).toEqual([])
+
+    const appPages = [
+      {
+        page_name: "page1",
+        script_path: "page1.py",
+      },
+      {
+        page_name: "page2",
+        script_path: "page2.py",
+      },
+    ]
+
+    const newSessionJson = cloneDeep(NEW_SESSION_JSON)
+    // @ts-ignore
+    newSessionJson.appPages = appPages
+
+    // @ts-ignore
+    wrapper.instance().handleNewSession(new NewSession(newSessionJson))
+    expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
+  })
 })
 
 describe("App.handlePageConfigChanged", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,6 +66,7 @@ import {
   Config,
   IGitInfo,
   GitInfo,
+  AppPage,
 } from "src/autogen/proto"
 import { without, concat } from "lodash"
 
@@ -135,6 +136,7 @@ interface State {
   gitInfo: IGitInfo | null
   formsData: FormsData
   hideTopBar: boolean
+  appPages: AppPage[]
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -206,6 +208,7 @@ export class App extends PureComponent<Props, State> {
       // the user would see top bar elements for a few ms if this defaulted to
       // false.
       hideTopBar: true,
+      appPages: [],
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -595,6 +598,7 @@ export class App extends PureComponent<Props, State> {
     this.setState({
       allowRunOnSave: config.allowRunOnSave,
       hideTopBar: config.hideTopBar,
+      appPages: newSessionProto.appPages,
     })
 
     const { appHash } = this.state
@@ -1175,6 +1179,7 @@ export class App extends PureComponent<Props, State> {
               uploadClient={this.uploadClient}
               componentRegistry={this.componentRegistry}
               formsData={this.state.formsData}
+              appPages={this.state.appPages}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -92,15 +92,14 @@ describe("AppView element", () => {
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
-    const props = getProps({
-      appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-        { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
-      ],
-    })
-    const wrapper = shallow(<AppView {...props} />)
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+    ]
+    const wrapper = shallow(<AppView {...getProps({ appPages })} />)
 
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
   })
 
   it("renders a sidebar when there are elements and multiple pages", () => {

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -89,6 +89,8 @@ describe("AppView element", () => {
     const wrapper = shallow(<AppView {...props} />)
 
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
@@ -99,6 +101,7 @@ describe("AppView element", () => {
     const wrapper = shallow(<AppView {...getProps({ appPages })} />)
 
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(false)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
   })
 
@@ -116,16 +119,19 @@ describe("AppView element", () => {
 
     const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
 
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+    ]
     const props = getProps({
       elements: new AppRoot(new BlockNode([main, sidebar])),
-      appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-        { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
-      ],
+      appPages,
     })
     const wrapper = shallow(<AppView {...props} />)
 
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
   })
 
   it("does not render the wide class", () => {

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -49,6 +49,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     widgetsDisabled: true,
     componentRegistry: new ComponentRegistry(() => undefined),
     formsData,
+    appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
     ...props,
   }
 }
@@ -61,14 +62,14 @@ describe("AppView element", () => {
     expect(wrapper).toBeDefined()
   })
 
-  it("does not render a sidebar when there are no elements", () => {
+  it("does not render a sidebar when there are no elements and only one page", () => {
     const props = getProps()
     const wrapper = shallow(<AppView {...props} />)
 
     expect(wrapper.find("[data-testid='stSidebar']").exists()).toBe(false)
   })
 
-  it("renders a sidebar when there are elements", () => {
+  it("renders a sidebar when there are elements and only one page", () => {
     const sidebarElement = new ElementNode(
       makeElementWithInfoText("sidebar!"),
       ForwardMsgMetadata.create({}),
@@ -84,6 +85,44 @@ describe("AppView element", () => {
 
     const props = getProps({
       elements: new AppRoot(new BlockNode([main, sidebar])),
+    })
+    const wrapper = shallow(<AppView {...props} />)
+
+    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+  })
+
+  it("renders a sidebar when there are no elements but multiple pages", () => {
+    const props = getProps({
+      appPages: [
+        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+        { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      ],
+    })
+    const wrapper = shallow(<AppView {...props} />)
+
+    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+  })
+
+  it("renders a sidebar when there are elements and multiple pages", () => {
+    const sidebarElement = new ElementNode(
+      makeElementWithInfoText("sidebar!"),
+      ForwardMsgMetadata.create({}),
+      "no script run id"
+    )
+
+    const sidebar = new BlockNode(
+      [sidebarElement],
+      new BlockProto({ allowEmpty: true })
+    )
+
+    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
+
+    const props = getProps({
+      elements: new AppRoot(new BlockNode([main, sidebar])),
+      appPages: [
+        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+        { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      ],
     })
     const wrapper = shallow(<AppView {...props} />)
 

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -126,7 +126,10 @@ function AppView(props: AppViewProps): ReactElement {
       data-layout={layout}
     >
       {showSidebar && (
-        <ThemedSidebar initialSidebarState={initialSidebarState}>
+        <ThemedSidebar
+          initialSidebarState={initialSidebarState}
+          appPages={appPages}
+        >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>
       )}

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -16,6 +16,8 @@
  */
 
 import React, { ReactElement } from "react"
+import { AppPage } from "src/autogen/proto"
+
 import VerticalBlock from "src/components/core/Block"
 import { ThemedSidebar } from "src/components/core/Sidebar"
 import { ScriptRunState } from "src/lib/ScriptRunState"
@@ -59,6 +61,8 @@ export interface AppViewProps {
   componentRegistry: ComponentRegistry
 
   formsData: FormsData
+
+  appPages: AppPage[]
 }
 
 /**
@@ -75,6 +79,7 @@ function AppView(props: AppViewProps): ReactElement {
     uploadClient,
     componentRegistry,
     formsData,
+    appPages,
   } = props
 
   React.useEffect(() => {
@@ -111,6 +116,8 @@ function AppView(props: AppViewProps): ReactElement {
   )
 
   const layout = wideMode ? "wide" : "narrow"
+  const showSidebar = !elements.sidebar.isEmpty || appPages.length > 1
+
   // The tabindex is required to support scrolling by arrow keys.
   return (
     <StyledAppViewContainer
@@ -118,7 +125,7 @@ function AppView(props: AppViewProps): ReactElement {
       data-testid="stAppViewContainer"
       data-layout={layout}
     >
-      {!elements.sidebar.isEmpty && (
+      {showSidebar && (
         <ThemedSidebar initialSidebarState={initialSidebarState}>
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -116,7 +116,9 @@ function AppView(props: AppViewProps): ReactElement {
   )
 
   const layout = wideMode ? "wide" : "narrow"
-  const showSidebar = !elements.sidebar.isEmpty || appPages.length > 1
+  // TODO(vdonato): Try coming up with a better name for `hasElements`.
+  const hasElements = !elements.sidebar.isEmpty
+  const showSidebar = hasElements || appPages.length > 1
 
   // The tabindex is required to support scrolling by arrow keys.
   return (
@@ -129,6 +131,7 @@ function AppView(props: AppViewProps): ReactElement {
         <ThemedSidebar
           initialSidebarState={initialSidebarState}
           appPages={appPages}
+          hasElements={hasElements}
         >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -27,6 +27,10 @@ import Sidebar, { SidebarProps } from "./Sidebar"
 expect.extend(matchers)
 
 function renderSideBar(props: Partial<SidebarProps>): ReactWrapper {
+  props = {
+    appPages: [],
+    ...props,
+  }
   return mount(<Sidebar {...props} />)
 }
 

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -19,7 +19,7 @@ import React, { PureComponent, ReactElement } from "react"
 import { ChevronRight, X } from "@emotion-icons/open-iconic"
 import Icon from "src/components/shared/Icon"
 import Button, { Kind } from "src/components/shared/Button"
-import { PageConfig } from "src/autogen/proto"
+import { AppPage, PageConfig } from "src/autogen/proto"
 import { withTheme } from "emotion-theming"
 import { Theme } from "src/theme"
 import {
@@ -35,6 +35,7 @@ export interface SidebarProps {
   children?: ReactElement
   initialSidebarState?: PageConfig.SidebarState
   theme: Theme
+  appPages: AppPage[]
 }
 
 interface State {

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -35,6 +35,7 @@ export interface SidebarProps {
   children?: ReactElement
   initialSidebarState?: PageConfig.SidebarState
   theme: Theme
+  hasElements?: boolean
   appPages: AppPage[]
 }
 

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -37,4 +37,13 @@ describe("ThemedSidebar Component", () => {
     // @ts-ignore
     expect(updatedTheme.inSidebar).toBe(true)
   })
+
+  it("plumbs appPages to main Sidebar component", () => {
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+    ]
+    const wrapper = mount(<ThemedSidebar appPages={appPages} />)
+
+    expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
+  })
 })

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -28,7 +28,7 @@ describe("ThemedSidebar Component", () => {
   })
 
   it("should switch bgColor and secondaryBgColor", () => {
-    const wrapper = mount(<ThemedSidebar theme={lightTheme} />)
+    const wrapper = mount(<ThemedSidebar />)
 
     const updatedTheme = wrapper.find("Sidebar").prop("theme")
 

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -18,17 +18,26 @@
 import React from "react"
 import { mount } from "src/lib/test_util"
 import lightTheme from "src/theme/lightTheme"
+import { SidebarProps } from "./Sidebar"
 import ThemedSidebar from "./ThemedSidebar"
+
+function getProps(props: Partial<SidebarProps> = {}): SidebarProps {
+  return {
+    chevronDownshift: 0,
+    appPages: [],
+    ...props,
+  }
+}
 
 describe("ThemedSidebar Component", () => {
   it("should render without crashing", () => {
-    const wrapper = mount(<ThemedSidebar />)
+    const wrapper = mount(<ThemedSidebar {...getProps()} />)
 
     expect(wrapper.find("Sidebar").exists()).toBe(true)
   })
 
   it("should switch bgColor and secondaryBgColor", () => {
-    const wrapper = mount(<ThemedSidebar />)
+    const wrapper = mount(<ThemedSidebar {...getProps()} />)
 
     const updatedTheme = wrapper.find("Sidebar").prop("theme")
 
@@ -42,7 +51,7 @@ describe("ThemedSidebar Component", () => {
     const appPages = [
       { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
     ]
-    const wrapper = mount(<ThemedSidebar appPages={appPages} />)
+    const wrapper = mount(<ThemedSidebar {...getProps({ appPages })} />)
 
     expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
   })

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
@@ -34,7 +34,6 @@ const createSidebarTheme = (theme: ThemeConfig): ThemeConfig =>
   )
 
 const ThemedSidebar = ({
-  theme,
   children,
   ...sidebarProps
 }: Partial<SidebarProps>): ReactElement => {


### PR DESCRIPTION
## 📚 Context

The first step of rendering our MPA app nav UI is to plumb app page data
to the Sidebar. This PR does this and also changes the logic to display the
sidebar to also do so if there's >1 page but no other sidebar content. We
intentionally don't do anything else with this data as we'll be building the
actual nav components in another PR.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Plumb the `appPages` we receive from a `NewSession` message to the sidebar
- Show the sidebar even if it is otherwise empty if there is >1 page in the app
- Get rid of an unused prop in `ThemedSidebar`

## 🧪 Testing Done

- [x] Added/Updated unit tests
