### PR TITLE
Add (very) rough skeleton of the SidebarNav component

### DIFF
--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -23,6 +23,7 @@ import { PageConfig } from "src/autogen/proto"
 import { mount } from "src/lib/test_util"
 import { spacing } from "src/theme/primitives/spacing"
 import Sidebar, { SidebarProps } from "./Sidebar"
+import SidebarNav from "./SidebarNav"
 
 expect.extend(matchers)
 
@@ -107,5 +108,15 @@ describe("Sidebar Component", () => {
       "top",
       "50px"
     )
+  })
+
+  it("renders SidebarNav component", () => {
+    const wrapper = renderSideBar({
+      appPages: [
+        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      ],
+    })
+
+    expect(wrapper.find(SidebarNav).exists()).toBe(true)
   })
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
   StyledSidebarContent,
 } from "./styled-components"
 import IsSidebarContext from "./IsSidebarContext"
+import SidebarNav from "./SidebarNav"
 
 export interface SidebarProps {
   chevronDownshift: number
@@ -148,7 +149,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
 
   public render = (): ReactElement => {
     const { collapsedSidebar } = this.state
-    const { chevronDownshift, children } = this.props
+    const { appPages, chevronDownshift, children, hasElements } = this.props
 
     // The tabindex is required to support scrolling by arrow keys.
     return (
@@ -163,6 +164,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               <Icon content={X} />
             </Button>
           </StyledSidebarCloseButton>
+          <SidebarNav appPages={appPages} sidebarHasElements={hasElements} />
           {children}
         </StyledSidebarContent>
         <StyledSidebarCollapsedControl

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -20,7 +20,10 @@ import React from "react"
 import { shallow } from "src/lib/test_util"
 
 import SidebarNav, { Props } from "./SidebarNav"
-import { StyledSidebarNavSeparator } from "./styled-components"
+import {
+  StyledSidebarNavItems,
+  StyledSidebarNavSeparator,
+} from "./styled-components"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   appPages: [
@@ -66,5 +69,22 @@ describe("SidebarNav", () => {
       <SidebarNav {...getProps({ sidebarHasElements: true })} />
     )
     expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(true)
+  })
+
+  // NOTE: Ideally we'd want to test that the maxHeight of the element here is
+  // actually 25vh (and 75vh in the test below), but for whatever reason the
+  // emotion `toHaveStyleRule` matcher doesn't seem to work with maxHeight or
+  // max-height :(
+  it("is unexpanded by default", () => {
+    const wrapper = shallow(<SidebarNav {...getProps()} />)
+    expect(wrapper.find(StyledSidebarNavItems).prop("expanded")).toBe(false)
+  })
+
+  it("toggles to expanded when the separator is clicked", () => {
+    const wrapper = shallow(
+      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+    )
+    wrapper.find(StyledSidebarNavSeparator).simulate("click")
+    expect(wrapper.find(StyledSidebarNavItems).prop("expanded")).toBe(true)
   })
 })

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { shallow } from "src/lib/test_util"
+
+import SidebarNav, { Props } from "./SidebarNav"
+import { StyledSidebarNavSeparator } from "./styled-components"
+
+const getProps = (props: Partial<Props> = {}): Props => ({
+  appPages: [
+    { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+    { pageName: "my_other_page", scriptPath: "my_other_page.py" },
+  ],
+  ...props,
+})
+
+describe("SidebarNav", () => {
+  it("returns null if 0 appPages (may be true before the first script run)", () => {
+    const wrapper = shallow(<SidebarNav {...getProps({ appPages: [] })} />)
+    expect(wrapper.getElement()).toBeNull()
+  })
+
+  it("returns null if 1 appPage", () => {
+    const wrapper = shallow(
+      <SidebarNav
+        {...getProps({ appPages: [{ pageName: "streamlit_app" }] })}
+      />
+    )
+    expect(wrapper.getElement()).toBeNull()
+  })
+
+  it("replaces underscores with spaces in pageName", () => {
+    const wrapper = shallow(<SidebarNav {...getProps()} />)
+
+    const listElems = wrapper.find("li")
+
+    expect(listElems.at(0).text()).toBe("streamlit app")
+    expect(listElems.at(1).text()).toBe("my other page")
+  })
+
+  it("does not add separator below if there are no sidebar elements", () => {
+    const wrapper = shallow(
+      <SidebarNav {...getProps({ sidebarHasElements: false })} />
+    )
+    expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(false)
+  })
+
+  it("adds separator below if the sidebar also has elements", () => {
+    const wrapper = shallow(
+      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+    )
+    expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement } from "react"
+
+import { AppPage } from "src/autogen/proto"
+
+import {
+  StyledSidebarNavContainer,
+  StyledSidebarNavLinkContainer,
+  StyledSidebarNavLink,
+  StyledSidebarNavSeparator,
+} from "./styled-components"
+
+export interface Props {
+  pages: AppPage[]
+  sidebarHasElements: boolean
+}
+
+// TODO(vdonato): somehow indicate the current page and make it unclickable
+// TODO(vdonato): make the full container for each link clickable
+// TODO(vdonato): set links correctly
+// TODO(vdonato): actually add an onClick handler
+// TODO(vdonato): Toggle between expanded and collapsed page selector state
+//                based on separator click
+// TODO(vdonato): Toggle between expanded and collapsed page selector state
+//                based on mouse over / out (stretch goal).
+const SidebarNav = ({
+  appPages,
+  sidebarHasElements,
+}: Props): ReactElement | null => {
+  if (appPages.length < 2) {
+    return null
+  }
+
+  return (
+    <StyledSidebarNavContainer>
+      <ul>
+        {appPages.map(({ pageName }: AppPage) => (
+          <li key={pageName}>
+            <StyledSidebarNavLinkContainer>
+              <StyledSidebarNavLink href={"http://example.com"}>
+                {pageName.replace(/_/g, " ")}
+              </StyledSidebarNavLink>
+            </StyledSidebarNavLinkContainer>
+          </li>
+        ))}
+      </ul>
+      {sidebarHasElements && <StyledSidebarNavSeparator />}
+    </StyledSidebarNavContainer>
+  )
+}
+
+export default SidebarNav

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { ReactElement, useState } from "react"
 
 import { AppPage } from "src/autogen/proto"
 
 import {
   StyledSidebarNavContainer,
+  StyledSidebarNavItems,
   StyledSidebarNavLinkContainer,
   StyledSidebarNavLink,
   StyledSidebarNavSeparator,
@@ -32,13 +33,10 @@ export interface Props {
 }
 
 // TODO(vdonato): somehow indicate the current page and make it unclickable
-// TODO(vdonato): make the full container for each link clickable
 // TODO(vdonato): set links correctly
 // TODO(vdonato): actually add an onClick handler
-// TODO(vdonato): Toggle between expanded and collapsed page selector state
-//                based on separator click
-// TODO(vdonato): Toggle between expanded and collapsed page selector state
-//                based on mouse over / out (stretch goal).
+// TODO(vdonato): (Maybe) toggle between expanded and collapsed page selector
+//                state based on mouse over / out (stretch goal).
 const SidebarNav = ({
   appPages,
   sidebarHasElements,
@@ -47,9 +45,11 @@ const SidebarNav = ({
     return null
   }
 
+  const [expanded, setExpanded] = useState(false)
+
   return (
     <StyledSidebarNavContainer>
-      <ul>
+      <StyledSidebarNavItems expanded={expanded}>
         {appPages.map(({ pageName }: AppPage) => (
           <li key={pageName}>
             <StyledSidebarNavLinkContainer>
@@ -59,8 +59,15 @@ const SidebarNav = ({
             </StyledSidebarNavLinkContainer>
           </li>
         ))}
-      </ul>
-      {sidebarHasElements && <StyledSidebarNavSeparator />}
+      </StyledSidebarNavItems>
+
+      {sidebarHasElements && (
+        <StyledSidebarNavSeparator
+          onClick={() => {
+            setExpanded(!expanded)
+          }}
+        />
+      )}
     </StyledSidebarNavContainer>
   )
 }

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -51,27 +51,41 @@ export const StyledSidebar = styled.section(({ theme }) => ({
   },
 }))
 
-export interface StyledSidebarContentProps {
-  isCollapsed: boolean
-}
-
-export const StyledSidebarNavContainer = styled.div(({ theme }) => ({
-  maxHeight: "25vh",
-  overflow: "auto",
+export const StyledSidebarNavContainer = styled.div(({ expanded, theme }) => ({
   // TODO(vdonato): FIXME (add proper styling)
 }))
 
+export interface StyledSidebarNavItemsProps {
+  expanded: boolean
+}
+
+export const StyledSidebarNavItems = styled.ul<StyledSidebarNavItemsProps>(
+  ({ expanded, theme }) => ({
+    listStyle: "none",
+    maxHeight: expanded ? "75vh" : "25vh",
+    overflow: "auto",
+    // TODO(vdonato): FIXME (add proper styling)
+  })
+)
+
 export const StyledSidebarNavSeparator = styled.hr(({ theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling)
+  // TODO(vdonato): FIXME
+  // * add proper styling
+  // * increase clickable area for the separator
+  // * add dynamic styling behavior for mouse hover
 }))
 
 export const StyledSidebarNavLinkContainer = styled.div(({ theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling)
+  // TODO(vdonato): FIXME (add proper styling and make the full container clickable)
 }))
 
 export const StyledSidebarNavLink = styled.a(({ theme }) => ({
   // TODO(vdonato): FIXME (add proper styling)
 }))
+
+export interface StyledSidebarContentProps {
+  isCollapsed: boolean
+}
 
 export const StyledSidebarContent = styled.div<StyledSidebarContentProps>(
   ({ isCollapsed, theme }) => ({

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -55,6 +55,24 @@ export interface StyledSidebarContentProps {
   isCollapsed: boolean
 }
 
+export const StyledSidebarNavContainer = styled.div(({ theme }) => ({
+  maxHeight: "25vh",
+  overflow: "auto",
+  // TODO(vdonato): FIXME (add proper styling)
+}))
+
+export const StyledSidebarNavSeparator = styled.hr(({ theme }) => ({
+  // TODO(vdonato): FIXME (add proper styling)
+}))
+
+export const StyledSidebarNavLinkContainer = styled.div(({ theme }) => ({
+  // TODO(vdonato): FIXME (add proper styling)
+}))
+
+export const StyledSidebarNavLink = styled.a(({ theme }) => ({
+  // TODO(vdonato): FIXME (add proper styling)
+}))
+
 export const StyledSidebarContent = styled.div<StyledSidebarContentProps>(
   ({ isCollapsed, theme }) => ({
     backgroundColor: theme.colors.bgColor,


### PR DESCRIPTION
## 📚 Context

This PR adds a (very) rough skeleton of the `SidebarNav` component. It's missing a
ton of stuff:
* things are essentially completely unstyled. `styled-components` were added so that
   the structure is already there, though, and only CSS work needs to be done for styling
   (more or less)
* each of the page links points to http://example.com for now since not enough of the rest
   of the multipage apps code has been built for things to work end-to-end

Even with all this missing, I still think it makes sense to get this PR in now since it's going
into a feature branch anyway, and it'll be much easier to review a bunch of small PRs
incrementally adding each of these things than a gigantic one adding them simultaneously.

Note that the tasks left are listed as TODOs in inline comments.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Render an unstyled list of an app's pages in the sidebar if an app has >1 page
- Also render a separator between the page nav and sidebar content if an app has both

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests
