### PR TITLE
Only run black in commit hook when there are python file changes

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -22,5 +22,8 @@ yarn --cwd "frontend" pretty-quick --staged
 # "--diff-filter=ACMR" only lists files that are [A]dded, [C]opied, [M]odified,
 # or [R]enamed; we don't want to try to format files that have been deleted.
 if command -v "black" > /dev/null; then
-  git diff --diff-filter=ACMR --name-only --cached | grep -E "\.pyi?$" | xargs black
+  changed_files=git diff --diff-filter=ACMR --name-only --cached | grep -E "\.pyi?$"
+  if [ -n changed_files ]; then
+    xargs black $changed_files
+  fi
 fi


### PR DESCRIPTION
Otherwise `black` will return an error, blocking commit. This doesn't
happen for versions of xargs which violate the POSIX requirement to
always run the command at least once, but does happen for current GNU
xargs.

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

