### PR TITLE
Watch all page scripts when installing local_source_watchers

### DIFF
--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -24,6 +24,7 @@ from streamlit.folder_black_list import FolderBlackList
 
 from streamlit.logger import get_logger
 from streamlit.session_data import SessionData
+from streamlit.source_util import get_pages
 from streamlit.watcher.file_watcher import (
     get_default_file_watcher_class,
     NoOpFileWatcher,
@@ -51,10 +52,11 @@ class LocalSourcesWatcher:
 
         self._watched_modules: Dict[str, WatchedModule] = {}
 
-        self._register_watcher(
-            self._session_data.main_script_path,
-            module_name=None,  # Only the root script has None here.
-        )
+        for page_info in get_pages(self._session_data.main_script_path):
+            self._register_watcher(
+                page_info["script_path"],
+                module_name=None,  # Only root scripts have their modules set to None
+            )
 
     def register_file_change_callback(self, cb: Callable[[], None]) -> None:
         self._on_file_changed.append(cb)

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -290,6 +290,26 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         del sys.modules["tests.streamlit.watcher.test_data.namespace_package"]
 
+    @patch(
+        "streamlit.watcher.local_sources_watcher.get_pages",
+        MagicMock(
+            return_value=[
+                {"page_name": "streamlit_app", "script_path": "streamlit_app.py"},
+                {"page_name": "streamlit_app2", "script_path": "streamlit_app2.py"},
+            ]
+        ),
+    )
+    @patch("streamlit.watcher.local_sources_watcher.FileWatcher")
+    def test_watches_all_page_scripts(self, fob, _):
+        lsw = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        args1, _ = fob.call_args_list[0]
+        args2, _ = fob.call_args_list[1]
+
+        assert args1[0] == "streamlit_app.py"
+        assert args2[0] == "streamlit_app2.py"
+
 
 def test_get_module_paths_outputs_abs_paths():
     mock_module = MagicMock()


### PR DESCRIPTION
## 📚 Context

In the multipage apps world, we will often have >1 "root" script to keep track of.
This PR simply changes `local_sources_watcher` to watch the script file for each
page returned by `get_pages`.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes (https://github.com/streamlit/streamlit-issues/issues/350)
