### PR TITLE
Actually use the MPA Nav UI to switch pages

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -778,7 +778,7 @@ describe("App.sendRerunBackMsg", () => {
   })
 
   const mockGetBaseUriParts = basePath => () => ({
-    basePath: basePath ? basePath : "",
+    basePath: basePath || "",
   })
 
   it("figures out pageName when sendRerunBackMsg isn't given one (case 1: main page)", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -759,6 +759,50 @@ describe("App.handlePageInfoChanged", () => {
   })
 })
 
+describe("App.sendRerunBackMsg", () => {
+  it("switches pages correctly when sendRerunbackMsg is given a pageName", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.sendBackMsg = jest.fn()
+
+    instance.sendRerunBackMsg(undefined, "page1")
+
+    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/page1")
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: { pageName: "page1", queryString: "" },
+    })
+  })
+
+  it("handles a page change correctly if there is also a query string", () => {
+    const wrapper = shallow(
+      <App
+        {...getProps({
+          s4aCommunication: {
+            connect: jest.fn(),
+            sendMessage: jest.fn(),
+            currentState: {
+              queryParams: "?foo=bar",
+            },
+          },
+        })}
+      />
+    )
+    const instance = wrapper.instance() as App
+    instance.sendBackMsg = jest.fn()
+
+    instance.sendRerunBackMsg(undefined, "page1")
+
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      {},
+      "",
+      "/page1?foo=bar"
+    )
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: { pageName: "page1", queryString: "foo=bar" },
+    })
+  })
+})
+
 describe("Test Main Menu shortcut functionality", () => {
   beforeEach(() => {
     delete window.location

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -678,9 +678,10 @@ describe("App.handlePageInfoChanged", () => {
   let wrapper: ShallowWrapper<App>
   let app: App
   let pushStateSpy: any
+  let originalPathName
 
   beforeEach(() => {
-    // Reset the value of document.location.pathname.
+    originalPathName = document.location.pathname
     window.history.pushState({}, "", "/")
 
     // Setup wrapper and app and spy on window.history.pushState.
@@ -693,9 +694,10 @@ describe("App.handlePageInfoChanged", () => {
     )
   })
 
-  afterAll(() => {
+  afterEach(() => {
     // Reset the value of document.location.pathname.
     window.history.pushState({}, "", "/")
+    document.location.pathname = originalPathName
   })
 
   it("does not override the pathname when setting query params", () => {
@@ -760,14 +762,99 @@ describe("App.handlePageInfoChanged", () => {
 })
 
 describe("App.sendRerunBackMsg", () => {
+  let originalPathName
+
+  beforeEach(() => {
+    jest.spyOn(
+      window.history,
+      // @ts-ignore
+      "pushState"
+    )
+    originalPathName = document.location.pathname
+  })
+
+  afterEach(() => {
+    document.location.pathname = originalPathName
+  })
+
+  const mockGetBaseUriParts = basePath => () => ({
+    basePath: basePath ? basePath : "",
+  })
+
+  it("figures out pageName when sendRerunBackMsg isn't given one (case 1: main page)", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.sendBackMsg = jest.fn()
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+
+    instance.sendRerunBackMsg()
+
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: { pageName: "", queryString: "" },
+    })
+  })
+
+  it("figures out pageName when sendRerunBackMsg isn't given one (case 2: non-main page)", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.sendBackMsg = jest.fn()
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+
+    // Set the value of document.location.pathname to '/page1'
+    window.history.pushState({}, "", "/page1")
+
+    instance.sendRerunBackMsg()
+
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: { pageName: "page1", queryString: "" },
+    })
+  })
+
+  it("figures out pageName when sendRerunBackMsg isn't given one and a baseUrlPath is set", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.sendBackMsg = jest.fn()
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
+
+    // Set the value of document.location.pathname to '/foo/bar/page1'
+    window.history.pushState({}, "", "/foo/bar/page1")
+
+    instance.sendRerunBackMsg()
+
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: { pageName: "page1", queryString: "" },
+    })
+  })
+
   it("switches pages correctly when sendRerunbackMsg is given a pageName", () => {
     const wrapper = shallow(<App {...getProps()} />)
     const instance = wrapper.instance() as App
     instance.sendBackMsg = jest.fn()
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
 
     instance.sendRerunBackMsg(undefined, "page1")
 
     expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/page1")
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: { pageName: "page1", queryString: "" },
+    })
+  })
+
+  it("also switches pages correctly when a baseUrlPath is set", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.sendBackMsg = jest.fn()
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
+
+    instance.sendRerunBackMsg(undefined, "page1")
+
+    // Note that, below, the URL should be set to "/foo/bar/page1", but the
+    // pageName passed back to the server is "page1".
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      {},
+      "",
+      "/foo/bar/page1"
+    )
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
@@ -789,6 +876,7 @@ describe("App.sendRerunBackMsg", () => {
     )
     const instance = wrapper.instance() as App
     instance.sendBackMsg = jest.fn()
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
 
     instance.sendRerunBackMsg(undefined, "page1")
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -904,7 +904,16 @@ export class App extends PureComponent<Props, State> {
     )
   }
 
-  sendRerunBackMsg = (widgetStates?: WidgetStates | undefined): void => {
+  onPageChange = (pageName: string): void => {
+    // TODO(vdonato): Verify that sending an empty widgetStates object back
+    // when switching pages is correct (I'm fairly certain it is).
+    this.sendRerunBackMsg(undefined, pageName)
+  }
+
+  sendRerunBackMsg = (
+    widgetStates?: WidgetStates,
+    pageName?: string
+  ): void => {
     const { queryParams } = this.props.s4aCommunication.currentState
 
     let queryString =
@@ -916,9 +925,23 @@ export class App extends PureComponent<Props, State> {
       queryString = queryString.substring(1)
     }
 
+    // TODO(vdonato): Ensure that both cases below account for non-default
+    // `baseUrlPath`s once handling for that is fixed.
+
+    // NOTE: We specifically check for `undefined` instead of making a falsy
+    //       check below because navigating to "" can be used to navigate to
+    //       the main page of an app.
+    if (pageName === undefined) {
+      // If pageName is undefined, we're not switching pages, so we should
+      // use the current URL to determine the pageName.
+    } else {
+      const qs = queryString ? `?${queryString}` : ""
+      window.history.pushState({}, "", `/${pageName}${qs}`)
+    }
+
     this.sendBackMsg(
       new BackMsg({
-        rerunScript: { queryString, widgetStates },
+        rerunScript: { queryString, widgetStates, pageName },
       })
     )
   }
@@ -1180,6 +1203,7 @@ export class App extends PureComponent<Props, State> {
               componentRegistry={this.componentRegistry}
               formsData={this.state.formsData}
               appPages={this.state.appPages}
+              onPageChange={this.onPageChange}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -50,6 +50,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     componentRegistry: new ComponentRegistry(() => undefined),
     formsData,
     appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
+    onPageChange: jest.fn(),
     ...props,
   }
 }
@@ -91,6 +92,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
+    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
@@ -103,6 +107,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(false)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 
   it("renders a sidebar when there are elements and multiple pages", () => {
@@ -132,6 +139,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 
   it("does not render the wide class", () => {

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -63,6 +63,8 @@ export interface AppViewProps {
   formsData: FormsData
 
   appPages: AppPage[]
+
+  onPageChange: (pageName: string) => void
 }
 
 /**
@@ -80,6 +82,7 @@ function AppView(props: AppViewProps): ReactElement {
     componentRegistry,
     formsData,
     appPages,
+    onPageChange,
   } = props
 
   React.useEffect(() => {
@@ -132,6 +135,7 @@ function AppView(props: AppViewProps): ReactElement {
           initialSidebarState={initialSidebarState}
           appPages={appPages}
           hasElements={hasElements}
+          onPageChange={onPageChange}
         >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -30,6 +30,7 @@ expect.extend(matchers)
 function renderSideBar(props: Partial<SidebarProps>): ReactWrapper {
   props = {
     appPages: [],
+    onPageChange: jest.fn(),
     ...props,
   }
   return mount(<Sidebar {...props} />)
@@ -111,12 +112,15 @@ describe("Sidebar Component", () => {
   })
 
   it("renders SidebarNav component", () => {
-    const wrapper = renderSideBar({
-      appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      ],
-    })
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+    ]
+    const wrapper = renderSideBar({ appPages })
 
     expect(wrapper.find(SidebarNav).exists()).toBe(true)
+    expect(wrapper.find(SidebarNav).prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find(SidebarNav).prop("onPageChange")).toBe(
+      "function"
+    )
   })
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -38,6 +38,7 @@ export interface SidebarProps {
   theme: Theme
   hasElements?: boolean
   appPages: AppPage[]
+  onPageChange: (pageName: string) => void
 }
 
 interface State {
@@ -149,7 +150,13 @@ class Sidebar extends PureComponent<SidebarProps, State> {
 
   public render = (): ReactElement => {
     const { collapsedSidebar } = this.state
-    const { appPages, chevronDownshift, children, hasElements } = this.props
+    const {
+      appPages,
+      chevronDownshift,
+      children,
+      hasElements,
+      onPageChange,
+    } = this.props
 
     // The tabindex is required to support scrolling by arrow keys.
     return (
@@ -164,7 +171,11 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               <Icon content={X} />
             </Button>
           </StyledSidebarCloseButton>
-          <SidebarNav appPages={appPages} sidebarHasElements={hasElements} />
+          <SidebarNav
+            appPages={appPages}
+            hasSidebarElements={hasElements}
+            onPageChange={onPageChange}
+          />
           {children}
         </StyledSidebarContent>
         <StyledSidebarCollapsedControl

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -23,6 +23,7 @@ import SidebarNav, { Props } from "./SidebarNav"
 import {
   StyledSidebarNavItems,
   StyledSidebarNavSeparator,
+  StyledSidebarNavLink,
 } from "./styled-components"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
@@ -30,6 +31,8 @@ const getProps = (props: Partial<Props> = {}): Props => ({
     { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
     { pageName: "my_other_page", scriptPath: "my_other_page.py" },
   ],
+  hasSidebarElements: false,
+  onPageChange: jest.fn(),
   ...props,
 })
 
@@ -51,22 +54,22 @@ describe("SidebarNav", () => {
   it("replaces underscores with spaces in pageName", () => {
     const wrapper = shallow(<SidebarNav {...getProps()} />)
 
-    const listElems = wrapper.find("li")
+    const links = wrapper.find(StyledSidebarNavLink)
 
-    expect(listElems.at(0).text()).toBe("streamlit app")
-    expect(listElems.at(1).text()).toBe("my other page")
+    expect(links.at(0).text()).toBe("streamlit app")
+    expect(links.at(1).text()).toBe("my other page")
   })
 
   it("does not add separator below if there are no sidebar elements", () => {
     const wrapper = shallow(
-      <SidebarNav {...getProps({ sidebarHasElements: false })} />
+      <SidebarNav {...getProps({ hasSidebarElements: false })} />
     )
     expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(false)
   })
 
   it("adds separator below if the sidebar also has elements", () => {
     const wrapper = shallow(
-      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+      <SidebarNav {...getProps({ hasSidebarElements: true })} />
     )
     expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(true)
   })
@@ -82,9 +85,33 @@ describe("SidebarNav", () => {
 
   it("toggles to expanded when the separator is clicked", () => {
     const wrapper = shallow(
-      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+      <SidebarNav {...getProps({ hasSidebarElements: true })} />
     )
     wrapper.find(StyledSidebarNavSeparator).simulate("click")
     expect(wrapper.find(StyledSidebarNavItems).prop("expanded")).toBe(true)
+  })
+
+  it("passes the empty string to onPageChange if the main page link is clicked", () => {
+    const props = getProps()
+    const wrapper = shallow(<SidebarNav {...props} />)
+
+    const preventDefault = jest.fn()
+    const links = wrapper.find(StyledSidebarNavLink)
+    links.at(0).simulate("click", { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(props.onPageChange).toHaveBeenCalledWith("")
+  })
+
+  it("passes the page name to onPageChange if any other link is clicked", () => {
+    const props = getProps()
+    const wrapper = shallow(<SidebarNav {...props} />)
+
+    const preventDefault = jest.fn()
+    const links = wrapper.find(StyledSidebarNavLink)
+    links.at(1).simulate("click", { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(props.onPageChange).toHaveBeenCalledWith("my_other_page")
   })
 })

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -29,17 +29,16 @@ import {
 
 export interface Props {
   pages: AppPage[]
-  sidebarHasElements: boolean
+  hasSidebarElements: boolean
+  onPageChange: (pageName: string) => void
 }
 
-// TODO(vdonato): somehow indicate the current page and make it unclickable
-// TODO(vdonato): set links correctly
-// TODO(vdonato): actually add an onClick handler
-// TODO(vdonato): (Maybe) toggle between expanded and collapsed page selector
-//                state based on mouse over / out (stretch goal).
+// TODO(vdonato): indicate the current page and make it unclickable
+// TODO(vdonato): set links correctly (requires baseUrlPath handling to be done)
 const SidebarNav = ({
   appPages,
-  sidebarHasElements,
+  hasSidebarElements,
+  onPageChange,
 }: Props): ReactElement | null => {
   if (appPages.length < 2) {
     return null
@@ -50,10 +49,17 @@ const SidebarNav = ({
   return (
     <StyledSidebarNavContainer>
       <StyledSidebarNavItems expanded={expanded}>
-        {appPages.map(({ pageName }: AppPage) => (
+        {appPages.map(({ pageName }: AppPage, pageIndex: number) => (
           <li key={pageName}>
             <StyledSidebarNavLinkContainer>
-              <StyledSidebarNavLink href={"http://example.com"}>
+              <StyledSidebarNavLink
+                href={"http://example.com"}
+                onClick={e => {
+                  e.preventDefault()
+                  const navigateTo = pageIndex === 0 ? "" : pageName
+                  onPageChange(navigateTo)
+                }}
+              >
                 {pageName.replace(/_/g, " ")}
               </StyledSidebarNavLink>
             </StyledSidebarNavLinkContainer>
@@ -61,7 +67,7 @@ const SidebarNav = ({
         ))}
       </StyledSidebarNavItems>
 
-      {sidebarHasElements && (
+      {hasSidebarElements && (
         <StyledSidebarNavSeparator
           onClick={() => {
             setExpanded(!expanded)

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -25,6 +25,7 @@ function getProps(props: Partial<SidebarProps> = {}): SidebarProps {
   return {
     chevronDownshift: 0,
     appPages: [],
+    onPageChange: jest.fn(),
     ...props,
   }
 }
@@ -47,12 +48,15 @@ describe("ThemedSidebar Component", () => {
     expect(updatedTheme.inSidebar).toBe(true)
   })
 
-  it("plumbs appPages to main Sidebar component", () => {
+  it("plumbs appPages and onPageChange to main Sidebar component", () => {
     const appPages = [
       { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
     ]
     const wrapper = mount(<ThemedSidebar {...getProps({ appPages })} />)
 
     expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find("Sidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 })

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -51,8 +51,10 @@ export const StyledSidebar = styled.section(({ theme }) => ({
   },
 }))
 
-export const StyledSidebarNavContainer = styled.div(({ expanded, theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling)
+export const StyledSidebarNavContainer = styled.div(({ theme }) => ({
+  // TODO(vdonato): styling
+  // * width of this component is 100% of the sidebar (probably needs
+  //   adjustments to StyledSidebarContent)
 }))
 
 export interface StyledSidebarNavItemsProps {
@@ -64,24 +66,54 @@ export const StyledSidebarNavItems = styled.ul<StyledSidebarNavItemsProps>(
     listStyle: "none",
     maxHeight: expanded ? "75vh" : "25vh",
     overflow: "auto",
-    // TODO(vdonato): FIXME (add proper styling)
+    // TODO(vdonato): styling
+    // * Fade in/out at the top/bottom if there is scrollable content in that
+    //   direction
   })
 )
 
 export const StyledSidebarNavSeparator = styled.hr(({ theme }) => ({
-  // TODO(vdonato): FIXME
-  // * add proper styling
-  // * increase clickable area for the separator
-  // * add dynamic styling behavior for mouse hover
+  // TODO(vdonato): styling
+  // * disable hover behavior when nav items list is not overflowing
+  // * add small second line underneath the separator
+  paddingTop: "3px",
+
+  "&:hover": {
+    cursor: "pointer",
+    backgroundColor: theme.colors.transparentDarkenedBgMix60,
+  },
 }))
 
 export const StyledSidebarNavLinkContainer = styled.div(({ theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling and make the full container clickable)
+  // TODO(vdonato): styling
+  // * adjust bgcolor/fontWeight for the currently selected page
+  //   (dependent on some other work to be finished first)
 }))
 
-export const StyledSidebarNavLink = styled.a(({ theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling)
-}))
+export const StyledSidebarNavLink = styled.a<StyledSidebarNavLinkProps>(
+  ({ theme }) => {
+    const defaultPageLinkStyles = {
+      textDecoration: "none",
+      color: theme.colors.bodyText,
+    }
+
+    return {
+      ...defaultPageLinkStyles,
+
+      // NOTE: This hover behavior needs to be redone (in particular, we
+      //       probably want to change the background of the link being hovered
+      //       over). It's set this way for now as it requires very little
+      //       effort and works reasonably well considering that.
+      "&:hover": {
+        fontWeight: "bold",
+      },
+
+      "&:active,&:visited,&:hover": {
+        ...defaultPageLinkStyles,
+      },
+    }
+  }
+)
 
 export interface StyledSidebarContentProps {
   isCollapsed: boolean


### PR DESCRIPTION
## 📚 Context

Until now, many of our PRs into the multipage apps feature branch have said
something like "this doesn't actually work end-to-end yet". This PR finally
ties everything together so that clicking on a link actually changes the page
displayed on an app! There's still a ton of stuff to do (see an incomplete list below),
but this PR will mark the first point where the production version of the feature
works end to end.

Some of the notable things that are left to do include:
* style the Nav UI properly (minimal work has been done on this so far)
* have the links in the MPA Nav UI be real links to the app's pages
* handle `baseUrlPath`s that aren't the default correctly
* add watchers on the `pages/` directory for added/removed pages
* fix 404 behavior for pages (we want to display a 404 modal when the
   user somehow hits a nonexistent page)


- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add a parameter to `sendRerunBackMsg` allowing a page name to be specified
   - If the `pageName` param is set, it's passed back to the server in the backMsg
   - Also, the page's URL history is edited to reflect the page change
- Plumb the parameter to the `SidebarNav` component
- Pass the right parameter into `sendRerunBackMsg` when a nav UI link gets clicked

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**:
  - Closes https://github.com/streamlit/streamlit-issues/issues/421
  - Closes https://github.com/streamlit/streamlit-issues/issues/363
