### PR TITLE
Implement page not found behavior

### DIFF
--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -360,11 +360,6 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
-            # TODO(vdonato): We'll eventually want to add proper 404 handling.
-            # Right now, we just run the main script if we can't find a script
-            # corresponding to the given page_name. We still want to do this in
-            # the final version of the feature, but we also want to pop a modal
-            # telling the user that the page they're looking for doesn't exist.
             script_path = None
 
             # NOTE: It may seem weird that we're passing the page_name around
@@ -383,6 +378,10 @@ class ScriptRunner:
 
                 if current_page:
                     script_path = current_page["script_path"]
+                else:
+                    msg = ForwardMsg()
+                    msg.page_not_found.page_name = rerun_data.page_name
+                    ctx.enqueue(msg)
 
             if not script_path:
                 script_path = self._session_data.main_script_path

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -689,6 +689,10 @@ class ScriptRunnerTest(AsyncTestCase):
             ],
         )
         self._assert_text_deltas(scriptrunner, [text_utf])
+
+        page_not_found_msg = scriptrunner.forward_msg_queue._queue[0].page_not_found
+        self.assertEqual(page_not_found_msg.page_name, "page3")
+
         self.assertEqual(
             scriptrunner._session_data.main_script_path,
             sys.modules["__main__"].__file__,

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -17,12 +17,13 @@
 syntax = "proto3";
 
 import "streamlit/proto/Delta.proto";
+import "streamlit/proto/GitInfo.proto";
 import "streamlit/proto/NewSession.proto";
 import "streamlit/proto/PageConfig.proto";
 import "streamlit/proto/PageInfo.proto";
+import "streamlit/proto/PageNotFound.proto";
 import "streamlit/proto/SessionEvent.proto";
 import "streamlit/proto/SessionState.proto";
-import "streamlit/proto/GitInfo.proto";
 
 // A message sent from Proxy to the browser
 message ForwardMsg {
@@ -44,7 +45,6 @@ message ForwardMsg {
 
   oneof type {
     // App lifecycle messages.
-
     NewSession new_session = 4;
     Delta delta = 5;
     PageInfo page_info_changed = 12;
@@ -52,17 +52,12 @@ message ForwardMsg {
     ScriptFinishedStatus script_finished = 6;
     GitInfo git_info_changed = 14;
 
-    // Upload progress messages.
-
     // State change and event messages.
-
-    // AppSession state changed. This is the new state.
     SessionState session_state_changed = 9;
-
-    // A SessionEvent was emitted.
     SessionEvent session_event = 10;
 
     // Other messages.
+    PageNotFound page_not_found = 15;
 
     // A reference to a ForwardMsg that has already been delivered.
     // The client should substitute the message with the given hash
@@ -72,7 +67,7 @@ message ForwardMsg {
   }
 
   reserved 7, 8;
-  // Next: 15
+  // Next: 16
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)

--- a/proto/streamlit/proto/PageNotFound.proto
+++ b/proto/streamlit/proto/PageNotFound.proto
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+syntax = "proto3";
+
+// Message used to tell the client that the requested page does not exist.
+message PageNotFound {
+  string page_name = 1;
+}


### PR DESCRIPTION
## 📚 Context

When the user tries to navigate to a page that doesn't exist (which should only be
possible when they directly type in an invalid page URL as a nonexistent page can't
possibly end up in the Nav UI), we want to display an error modal while redirecting
to the app's main page. This PR implements this behavior.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add a new `PageNotFound` type
- Sent a `ForwardMessage` of the new type to the client if we can't find a
   page on script run (and run the main script)
- Display an error modal upon receiving the `PageNotFound` message 
- Remove some unnecessary test setup/teardown code

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- Closes https://github.com/streamlit/streamlit-issues/issues/361