### PR TITLE
Remove ConnectionState.STATIC and associated code

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1167,9 +1167,6 @@ export class App extends PureComponent<Props, State> {
               elements={elements}
               scriptRunId={scriptRunId}
               scriptRunState={scriptRunState}
-              showStaleElementIndicator={
-                connectionState !== ConnectionState.STATIC
-              }
               widgetMgr={this.widgetMgr}
               widgetsDisabled={connectionState !== ConnectionState.CONNECTED}
               uploadClient={this.uploadClient}

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -36,7 +36,6 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     elements: AppRoot.empty(),
     scriptRunId: "script run 123",
     scriptRunState: ScriptRunState.NOT_RUNNING,
-    showStaleElementIndicator: true,
     widgetMgr: new WidgetStateManager({
       sendRerunBackMsg: jest.fn(),
       formsDataChanged: jest.fn(),

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -43,12 +43,6 @@ export interface AppViewProps {
 
   scriptRunState: ScriptRunState
 
-  /**
-   * If true, "stale" elements (that is, elements that were created during a previous
-   * run of a currently-running script) will be faded out.
-   */
-  showStaleElementIndicator: boolean
-
   widgetMgr: WidgetStateManager
 
   uploadClient: FileUploadClient
@@ -69,7 +63,6 @@ function AppView(props: AppViewProps): ReactElement {
     elements,
     scriptRunId,
     scriptRunState,
-    showStaleElementIndicator,
     widgetMgr,
     widgetsDisabled,
     uploadClient,
@@ -100,7 +93,6 @@ function AppView(props: AppViewProps): ReactElement {
         node={node}
         scriptRunId={scriptRunId}
         scriptRunState={scriptRunState}
-        showStaleElementIndicator={showStaleElementIndicator}
         widgetMgr={widgetMgr}
         widgetsDisabled={widgetsDisabled}
         uploadClient={uploadClient}

--- a/frontend/src/components/core/Block/Block.test.tsx
+++ b/frontend/src/components/core/Block/Block.test.tsx
@@ -51,7 +51,6 @@ describe("Vertical Block Component", () => {
         node={block}
         scriptRunId={""}
         scriptRunState={ScriptRunState.NOT_RUNNING}
-        showStaleElementIndicator={false}
         widgetsDisabled={false}
         // @ts-ignore
         widgetMgr={undefined}

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -62,7 +62,6 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const isStale = isComponentStale(
     enable,
     node,
-    props.showStaleElementIndicator,
     props.scriptRunState,
     props.scriptRunId
   )

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -596,7 +596,6 @@ const ElementNodeRenderer = (
   const isStale = isComponentStale(
     enable,
     node,
-    props.showStaleElementIndicator,
     props.scriptRunState,
     props.scriptRunId
   )

--- a/frontend/src/components/core/Block/utils.ts
+++ b/frontend/src/components/core/Block/utils.ts
@@ -47,21 +47,15 @@ export function isElementStale(
 export function isComponentStale(
   enable: boolean,
   node: AppNode,
-  showStaleElementIndicator: boolean,
   scriptRunState: ScriptRunState,
   scriptRunId: string
 ): boolean {
-  return (
-    !enable ||
-    (showStaleElementIndicator &&
-      isElementStale(node, scriptRunState, scriptRunId))
-  )
+  return !enable || isElementStale(node, scriptRunState, scriptRunId)
 }
 
 export interface BaseBlockProps {
   scriptRunId: string
   scriptRunState: ScriptRunState
-  showStaleElementIndicator: boolean
   widgetMgr: WidgetStateManager
   uploadClient: FileUploadClient
   widgetsDisabled: boolean

--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -111,16 +111,6 @@ describe("Tooltip element", () => {
     expect(wrapper.find("Tooltip").exists()).toBeFalsy()
   })
 
-  it("does not render its tooltip when static", () => {
-    const wrapper = shallow(
-      <StatusWidget
-        {...getProps({ connectionState: ConnectionState.STATIC })}
-      />
-    )
-
-    expect(wrapper.find("Tooltip").exists()).toBeFalsy()
-  })
-
   it("renders running img correctly with lightTheme", () => {
     const wrapper = mount(<StatusWidget {...getProps()} />)
     expect(wrapper).toMatchSnapshot()

--- a/frontend/src/components/core/StatusWidget/StatusWidget.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.tsx
@@ -440,7 +440,6 @@ class StatusWidget extends PureComponent<StatusWidgetProps, State> {
         }
 
       case ConnectionState.CONNECTED:
-      case ConnectionState.STATIC:
         return undefined
 
       case ConnectionState.DISCONNECTED_FOREVER:

--- a/frontend/src/lib/ConnectionState.ts
+++ b/frontend/src/lib/ConnectionState.ts
@@ -21,5 +21,4 @@ export enum ConnectionState {
   INITIAL = "INITIAL",
   PINGING_SERVER = "PINGING_SERVER",
   CONNECTING = "CONNECTING",
-  STATIC = "STATIC",
 }


### PR DESCRIPTION
## 📚 Context

This PR removes a bit more essentially-dead code left behind from the static
sharing feature. The first thing that we remove is `ConnectionState.STATIC` itself,
and we also get rid of the `showStaleElementIndicator` prop since it's no
longer useful -- ConnectionState.STATIC is no longer used, so the value of the
prop is always `true`.

- What kind of change does this PR introduce?

  - [x] Refactoring

## 🧠 Description of Changes

- remove `ConnectionState.STATIC`
- remove the `showStaleElementIndicator` prop

## 🧪 Testing Done

- [x] Added/Updated unit tests
