### PR TITLE
Clear the screen when switching between pages of an app

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -623,6 +623,31 @@ describe("App.handleNewSession", () => {
     expect(oneTimeInitialization).toHaveBeenCalledTimes(2)
     expect(SessionInfo.isSet()).toBe(true)
   })
+
+  it("plumbs appPages to the AppView component", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+
+    expect(wrapper.find("AppView").prop("appPages")).toEqual([])
+
+    const appPages = [
+      {
+        page_name: "page1",
+        script_path: "page1.py",
+      },
+      {
+        page_name: "page2",
+        script_path: "page2.py",
+      },
+    ]
+
+    const newSessionJson = cloneDeep(NEW_SESSION_JSON)
+    // @ts-ignore
+    newSessionJson.appPages = appPages
+
+    // @ts-ignore
+    wrapper.instance().handleNewSession(new NewSession(newSessionJson))
+    expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
+  })
 })
 
 describe("App.handlePageConfigChanged", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -810,6 +810,7 @@ describe("App.sendRerunBackMsg", () => {
     const instance = wrapper.instance() as App
     instance.sendBackMsg = jest.fn()
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
+    instance.clearAppState = jest.fn()
 
     // Set the value of document.location.pathname to '/foo/bar/page1'
     window.history.pushState({}, "", "/foo/bar/page1")
@@ -819,6 +820,7 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
+    expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
   it("switches pages correctly when sendRerunbackMsg is given a pageName", () => {
@@ -826,6 +828,7 @@ describe("App.sendRerunBackMsg", () => {
     const instance = wrapper.instance() as App
     instance.sendBackMsg = jest.fn()
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+    instance.clearAppState = jest.fn()
 
     instance.sendRerunBackMsg(undefined, "page1")
 
@@ -833,6 +836,7 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
+    expect(instance.clearAppState).toHaveBeenCalled()
   })
 
   it("also switches pages correctly when a baseUrlPath is set", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,6 +66,7 @@ import {
   Config,
   IGitInfo,
   GitInfo,
+  AppPage,
 } from "src/autogen/proto"
 import { without, concat } from "lodash"
 
@@ -135,6 +136,7 @@ interface State {
   gitInfo: IGitInfo | null
   formsData: FormsData
   hideTopBar: boolean
+  appPages: AppPage[]
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -206,6 +208,7 @@ export class App extends PureComponent<Props, State> {
       // the user would see top bar elements for a few ms if this defaulted to
       // false.
       hideTopBar: true,
+      appPages: [],
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -595,6 +598,7 @@ export class App extends PureComponent<Props, State> {
     this.setState({
       allowRunOnSave: config.allowRunOnSave,
       hideTopBar: config.hideTopBar,
+      appPages: newSessionProto.appPages,
     })
 
     const { appHash } = this.state
@@ -1175,6 +1179,7 @@ export class App extends PureComponent<Props, State> {
               uploadClient={this.uploadClient}
               componentRegistry={this.componentRegistry}
               formsData={this.state.formsData}
+              appPages={this.state.appPages}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1000,6 +1000,9 @@ export class App extends PureComponent<Props, State> {
         .replace(`/${basePath}`, "")
         .replace(new RegExp("^/?"), "")
     } else {
+      const { appHash, scriptRunId, scriptName } = this.state
+      this.clearAppState(appHash, scriptRunId, scriptName)
+
       const qs = queryString ? `?${queryString}` : ""
       const basePathPrefix = basePath ? `/${basePath}` : ""
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -904,7 +904,16 @@ export class App extends PureComponent<Props, State> {
     )
   }
 
-  sendRerunBackMsg = (widgetStates?: WidgetStates | undefined): void => {
+  onPageChange = (pageName: string): void => {
+    // TODO(vdonato): Verify that sending an empty widgetStates object back
+    // when switching pages is correct (I'm fairly certain it is).
+    this.sendRerunBackMsg(undefined, pageName)
+  }
+
+  sendRerunBackMsg = (
+    widgetStates?: WidgetStates,
+    pageName?: string
+  ): void => {
     const { queryParams } = this.props.s4aCommunication.currentState
 
     let queryString =
@@ -916,9 +925,52 @@ export class App extends PureComponent<Props, State> {
       queryString = queryString.substring(1)
     }
 
+    // If we don't have a connectionManager or if it doesn't have an active
+    // websocket connection to the server (in which case
+    // connectionManager.getBaseUriParts() returns undefined), we can't send a
+    // rerun backMessage so just return early.
+    const baseUriParts =
+      this.connectionManager && this.connectionManager.getBaseUriParts()
+    if (!baseUriParts) {
+      logError("Cannot send rerun backMessage when disconnected from server.")
+      return
+    }
+
+    const { basePath } = baseUriParts
+
+    // NOTE: We specifically check for `null` or `undefined` instead of making
+    //       a falsy check below because navigating to "" can be used to
+    //       navigate to the main page of an app.
+    if (pageName === undefined) {
+      // If pageName is undefined, we're not switching pages, so we should
+      // use the current URL to determine the pageName.
+      //
+      // Note also that we'd prefer to write something like
+      //
+      // ```
+      // replace(
+      //   new RegExp(`^/${basePath}/?`),
+      //   ""
+      // )
+      // ```
+      //
+      // below, but that doesn't work because basePath may contain unescaped
+      // regex special-characters. This is why we're stuck with the
+      // weird-looking double `replace()`.
+      pageName = document.location.pathname
+        .replace(`/${basePath}`, "")
+        .replace(new RegExp("^/?"), "")
+    } else {
+      const qs = queryString ? `?${queryString}` : ""
+      const basePathPrefix = basePath ? `/${basePath}` : ""
+
+      const pageUrl = `${basePathPrefix}/${pageName}${qs}`
+      window.history.pushState({}, "", pageUrl)
+    }
+
     this.sendBackMsg(
       new BackMsg({
-        rerunScript: { queryString, widgetStates },
+        rerunScript: { queryString, widgetStates, pageName },
       })
     )
   }
@@ -1180,6 +1232,7 @@ export class App extends PureComponent<Props, State> {
               componentRegistry={this.componentRegistry}
               formsData={this.state.formsData}
               appPages={this.state.appPages}
+              onPageChange={this.onPageChange}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -49,6 +49,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     widgetsDisabled: true,
     componentRegistry: new ComponentRegistry(() => undefined),
     formsData,
+    appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
     ...props,
   }
 }
@@ -61,14 +62,14 @@ describe("AppView element", () => {
     expect(wrapper).toBeDefined()
   })
 
-  it("does not render a sidebar when there are no elements", () => {
+  it("does not render a sidebar when there are no elements and only one page", () => {
     const props = getProps()
     const wrapper = shallow(<AppView {...props} />)
 
     expect(wrapper.find("[data-testid='stSidebar']").exists()).toBe(false)
   })
 
-  it("renders a sidebar when there are elements", () => {
+  it("renders a sidebar when there are elements and only one page", () => {
     const sidebarElement = new ElementNode(
       makeElementWithInfoText("sidebar!"),
       ForwardMsgMetadata.create({}),
@@ -88,6 +89,49 @@ describe("AppView element", () => {
     const wrapper = shallow(<AppView {...props} />)
 
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
+  })
+
+  it("renders a sidebar when there are no elements but multiple pages", () => {
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+    ]
+    const wrapper = shallow(<AppView {...getProps({ appPages })} />)
+
+    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(false)
+    expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+  })
+
+  it("renders a sidebar when there are elements and multiple pages", () => {
+    const sidebarElement = new ElementNode(
+      makeElementWithInfoText("sidebar!"),
+      ForwardMsgMetadata.create({}),
+      "no script run id"
+    )
+
+    const sidebar = new BlockNode(
+      [sidebarElement],
+      new BlockProto({ allowEmpty: true })
+    )
+
+    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
+
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+    ]
+    const props = getProps({
+      elements: new AppRoot(new BlockNode([main, sidebar])),
+      appPages,
+    })
+    const wrapper = shallow(<AppView {...props} />)
+
+    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
+    expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
   })
 
   it("does not render the wide class", () => {

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -50,6 +50,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     componentRegistry: new ComponentRegistry(() => undefined),
     formsData,
     appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
+    onPageChange: jest.fn(),
     ...props,
   }
 }
@@ -91,6 +92,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
+    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
@@ -103,6 +107,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(false)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 
   it("renders a sidebar when there are elements and multiple pages", () => {
@@ -132,6 +139,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 
   it("does not render the wide class", () => {

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -16,6 +16,8 @@
  */
 
 import React, { ReactElement } from "react"
+import { AppPage } from "src/autogen/proto"
+
 import VerticalBlock from "src/components/core/Block"
 import { ThemedSidebar } from "src/components/core/Sidebar"
 import { ScriptRunState } from "src/lib/ScriptRunState"
@@ -59,6 +61,8 @@ export interface AppViewProps {
   componentRegistry: ComponentRegistry
 
   formsData: FormsData
+
+  appPages: AppPage[]
 }
 
 /**
@@ -75,6 +79,7 @@ function AppView(props: AppViewProps): ReactElement {
     uploadClient,
     componentRegistry,
     formsData,
+    appPages,
   } = props
 
   React.useEffect(() => {
@@ -111,6 +116,10 @@ function AppView(props: AppViewProps): ReactElement {
   )
 
   const layout = wideMode ? "wide" : "narrow"
+  // TODO(vdonato): Try coming up with a better name for `hasElements`.
+  const hasElements = !elements.sidebar.isEmpty
+  const showSidebar = hasElements || appPages.length > 1
+
   // The tabindex is required to support scrolling by arrow keys.
   return (
     <StyledAppViewContainer
@@ -118,8 +127,12 @@ function AppView(props: AppViewProps): ReactElement {
       data-testid="stAppViewContainer"
       data-layout={layout}
     >
-      {!elements.sidebar.isEmpty && (
-        <ThemedSidebar initialSidebarState={initialSidebarState}>
+      {showSidebar && (
+        <ThemedSidebar
+          initialSidebarState={initialSidebarState}
+          appPages={appPages}
+          hasElements={hasElements}
+        >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>
       )}

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -63,6 +63,8 @@ export interface AppViewProps {
   formsData: FormsData
 
   appPages: AppPage[]
+
+  onPageChange: (pageName: string) => void
 }
 
 /**
@@ -80,6 +82,7 @@ function AppView(props: AppViewProps): ReactElement {
     componentRegistry,
     formsData,
     appPages,
+    onPageChange,
   } = props
 
   React.useEffect(() => {
@@ -132,6 +135,7 @@ function AppView(props: AppViewProps): ReactElement {
           initialSidebarState={initialSidebarState}
           appPages={appPages}
           hasElements={hasElements}
+          onPageChange={onPageChange}
         >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -23,6 +23,7 @@ import { PageConfig } from "src/autogen/proto"
 import { mount } from "src/lib/test_util"
 import { spacing } from "src/theme/primitives/spacing"
 import Sidebar, { SidebarProps } from "./Sidebar"
+import SidebarNav from "./SidebarNav"
 
 expect.extend(matchers)
 
@@ -107,5 +108,15 @@ describe("Sidebar Component", () => {
       "top",
       "50px"
     )
+  })
+
+  it("renders SidebarNav component", () => {
+    const wrapper = renderSideBar({
+      appPages: [
+        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      ],
+    })
+
+    expect(wrapper.find(SidebarNav).exists()).toBe(true)
   })
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -27,6 +27,10 @@ import Sidebar, { SidebarProps } from "./Sidebar"
 expect.extend(matchers)
 
 function renderSideBar(props: Partial<SidebarProps>): ReactWrapper {
+  props = {
+    appPages: [],
+    ...props,
+  }
   return mount(<Sidebar {...props} />)
 }
 

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -30,6 +30,7 @@ expect.extend(matchers)
 function renderSideBar(props: Partial<SidebarProps>): ReactWrapper {
   props = {
     appPages: [],
+    onPageChange: jest.fn(),
     ...props,
   }
   return mount(<Sidebar {...props} />)
@@ -111,12 +112,15 @@ describe("Sidebar Component", () => {
   })
 
   it("renders SidebarNav component", () => {
-    const wrapper = renderSideBar({
-      appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      ],
-    })
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+    ]
+    const wrapper = renderSideBar({ appPages })
 
     expect(wrapper.find(SidebarNav).exists()).toBe(true)
+    expect(wrapper.find(SidebarNav).prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find(SidebarNav).prop("onPageChange")).toBe(
+      "function"
+    )
   })
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -29,6 +29,7 @@ import {
   StyledSidebarContent,
 } from "./styled-components"
 import IsSidebarContext from "./IsSidebarContext"
+import SidebarNav from "./SidebarNav"
 
 export interface SidebarProps {
   chevronDownshift: number
@@ -148,7 +149,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
 
   public render = (): ReactElement => {
     const { collapsedSidebar } = this.state
-    const { chevronDownshift, children } = this.props
+    const { appPages, chevronDownshift, children, hasElements } = this.props
 
     // The tabindex is required to support scrolling by arrow keys.
     return (
@@ -163,6 +164,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               <Icon content={X} />
             </Button>
           </StyledSidebarCloseButton>
+          <SidebarNav appPages={appPages} sidebarHasElements={hasElements} />
           {children}
         </StyledSidebarContent>
         <StyledSidebarCollapsedControl

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -19,7 +19,7 @@ import React, { PureComponent, ReactElement } from "react"
 import { ChevronRight, X } from "@emotion-icons/open-iconic"
 import Icon from "src/components/shared/Icon"
 import Button, { Kind } from "src/components/shared/Button"
-import { PageConfig } from "src/autogen/proto"
+import { AppPage, PageConfig } from "src/autogen/proto"
 import { withTheme } from "emotion-theming"
 import { Theme } from "src/theme"
 import {
@@ -35,6 +35,8 @@ export interface SidebarProps {
   children?: ReactElement
   initialSidebarState?: PageConfig.SidebarState
   theme: Theme
+  hasElements?: boolean
+  appPages: AppPage[]
 }
 
 interface State {

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -38,6 +38,7 @@ export interface SidebarProps {
   theme: Theme
   hasElements?: boolean
   appPages: AppPage[]
+  onPageChange: (pageName: string) => void
 }
 
 interface State {
@@ -149,7 +150,13 @@ class Sidebar extends PureComponent<SidebarProps, State> {
 
   public render = (): ReactElement => {
     const { collapsedSidebar } = this.state
-    const { appPages, chevronDownshift, children, hasElements } = this.props
+    const {
+      appPages,
+      chevronDownshift,
+      children,
+      hasElements,
+      onPageChange,
+    } = this.props
 
     // The tabindex is required to support scrolling by arrow keys.
     return (
@@ -164,7 +171,11 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               <Icon content={X} />
             </Button>
           </StyledSidebarCloseButton>
-          <SidebarNav appPages={appPages} sidebarHasElements={hasElements} />
+          <SidebarNav
+            appPages={appPages}
+            hasSidebarElements={hasElements}
+            onPageChange={onPageChange}
+          />
           {children}
         </StyledSidebarContent>
         <StyledSidebarCollapsedControl

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import { shallow } from "src/lib/test_util"
+
+import SidebarNav, { Props } from "./SidebarNav"
+import {
+  StyledSidebarNavItems,
+  StyledSidebarNavSeparator,
+} from "./styled-components"
+
+const getProps = (props: Partial<Props> = {}): Props => ({
+  appPages: [
+    { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+    { pageName: "my_other_page", scriptPath: "my_other_page.py" },
+  ],
+  ...props,
+})
+
+describe("SidebarNav", () => {
+  it("returns null if 0 appPages (may be true before the first script run)", () => {
+    const wrapper = shallow(<SidebarNav {...getProps({ appPages: [] })} />)
+    expect(wrapper.getElement()).toBeNull()
+  })
+
+  it("returns null if 1 appPage", () => {
+    const wrapper = shallow(
+      <SidebarNav
+        {...getProps({ appPages: [{ pageName: "streamlit_app" }] })}
+      />
+    )
+    expect(wrapper.getElement()).toBeNull()
+  })
+
+  it("replaces underscores with spaces in pageName", () => {
+    const wrapper = shallow(<SidebarNav {...getProps()} />)
+
+    const listElems = wrapper.find("li")
+
+    expect(listElems.at(0).text()).toBe("streamlit app")
+    expect(listElems.at(1).text()).toBe("my other page")
+  })
+
+  it("does not add separator below if there are no sidebar elements", () => {
+    const wrapper = shallow(
+      <SidebarNav {...getProps({ sidebarHasElements: false })} />
+    )
+    expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(false)
+  })
+
+  it("adds separator below if the sidebar also has elements", () => {
+    const wrapper = shallow(
+      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+    )
+    expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(true)
+  })
+
+  // NOTE: Ideally we'd want to test that the maxHeight of the element here is
+  // actually 25vh (and 75vh in the test below), but for whatever reason the
+  // emotion `toHaveStyleRule` matcher doesn't seem to work with maxHeight or
+  // max-height :(
+  it("is unexpanded by default", () => {
+    const wrapper = shallow(<SidebarNav {...getProps()} />)
+    expect(wrapper.find(StyledSidebarNavItems).prop("expanded")).toBe(false)
+  })
+
+  it("toggles to expanded when the separator is clicked", () => {
+    const wrapper = shallow(
+      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+    )
+    wrapper.find(StyledSidebarNavSeparator).simulate("click")
+    expect(wrapper.find(StyledSidebarNavItems).prop("expanded")).toBe(true)
+  })
+})

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -23,6 +23,7 @@ import SidebarNav, { Props } from "./SidebarNav"
 import {
   StyledSidebarNavItems,
   StyledSidebarNavSeparator,
+  StyledSidebarNavLink,
 } from "./styled-components"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
@@ -30,6 +31,8 @@ const getProps = (props: Partial<Props> = {}): Props => ({
     { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
     { pageName: "my_other_page", scriptPath: "my_other_page.py" },
   ],
+  hasSidebarElements: false,
+  onPageChange: jest.fn(),
   ...props,
 })
 
@@ -51,22 +54,22 @@ describe("SidebarNav", () => {
   it("replaces underscores with spaces in pageName", () => {
     const wrapper = shallow(<SidebarNav {...getProps()} />)
 
-    const listElems = wrapper.find("li")
+    const links = wrapper.find(StyledSidebarNavLink)
 
-    expect(listElems.at(0).text()).toBe("streamlit app")
-    expect(listElems.at(1).text()).toBe("my other page")
+    expect(links.at(0).text()).toBe("streamlit app")
+    expect(links.at(1).text()).toBe("my other page")
   })
 
   it("does not add separator below if there are no sidebar elements", () => {
     const wrapper = shallow(
-      <SidebarNav {...getProps({ sidebarHasElements: false })} />
+      <SidebarNav {...getProps({ hasSidebarElements: false })} />
     )
     expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(false)
   })
 
   it("adds separator below if the sidebar also has elements", () => {
     const wrapper = shallow(
-      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+      <SidebarNav {...getProps({ hasSidebarElements: true })} />
     )
     expect(wrapper.find(StyledSidebarNavSeparator).exists()).toBe(true)
   })
@@ -82,9 +85,33 @@ describe("SidebarNav", () => {
 
   it("toggles to expanded when the separator is clicked", () => {
     const wrapper = shallow(
-      <SidebarNav {...getProps({ sidebarHasElements: true })} />
+      <SidebarNav {...getProps({ hasSidebarElements: true })} />
     )
     wrapper.find(StyledSidebarNavSeparator).simulate("click")
     expect(wrapper.find(StyledSidebarNavItems).prop("expanded")).toBe(true)
+  })
+
+  it("passes the empty string to onPageChange if the main page link is clicked", () => {
+    const props = getProps()
+    const wrapper = shallow(<SidebarNav {...props} />)
+
+    const preventDefault = jest.fn()
+    const links = wrapper.find(StyledSidebarNavLink)
+    links.at(0).simulate("click", { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(props.onPageChange).toHaveBeenCalledWith("")
+  })
+
+  it("passes the page name to onPageChange if any other link is clicked", () => {
+    const props = getProps()
+    const wrapper = shallow(<SidebarNav {...props} />)
+
+    const preventDefault = jest.fn()
+    const links = wrapper.find(StyledSidebarNavLink)
+    links.at(1).simulate("click", { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(props.onPageChange).toHaveBeenCalledWith("my_other_page")
   })
 })

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, useState } from "react"
+
+import { AppPage } from "src/autogen/proto"
+
+import {
+  StyledSidebarNavContainer,
+  StyledSidebarNavItems,
+  StyledSidebarNavLinkContainer,
+  StyledSidebarNavLink,
+  StyledSidebarNavSeparator,
+} from "./styled-components"
+
+export interface Props {
+  pages: AppPage[]
+  sidebarHasElements: boolean
+}
+
+// TODO(vdonato): somehow indicate the current page and make it unclickable
+// TODO(vdonato): set links correctly
+// TODO(vdonato): actually add an onClick handler
+// TODO(vdonato): (Maybe) toggle between expanded and collapsed page selector
+//                state based on mouse over / out (stretch goal).
+const SidebarNav = ({
+  appPages,
+  sidebarHasElements,
+}: Props): ReactElement | null => {
+  if (appPages.length < 2) {
+    return null
+  }
+
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <StyledSidebarNavContainer>
+      <StyledSidebarNavItems expanded={expanded}>
+        {appPages.map(({ pageName }: AppPage) => (
+          <li key={pageName}>
+            <StyledSidebarNavLinkContainer>
+              <StyledSidebarNavLink href={"http://example.com"}>
+                {pageName.replace(/_/g, " ")}
+              </StyledSidebarNavLink>
+            </StyledSidebarNavLinkContainer>
+          </li>
+        ))}
+      </StyledSidebarNavItems>
+
+      {sidebarHasElements && (
+        <StyledSidebarNavSeparator
+          onClick={() => {
+            setExpanded(!expanded)
+          }}
+        />
+      )}
+    </StyledSidebarNavContainer>
+  )
+}
+
+export default SidebarNav

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -29,17 +29,16 @@ import {
 
 export interface Props {
   pages: AppPage[]
-  sidebarHasElements: boolean
+  hasSidebarElements: boolean
+  onPageChange: (pageName: string) => void
 }
 
-// TODO(vdonato): somehow indicate the current page and make it unclickable
-// TODO(vdonato): set links correctly
-// TODO(vdonato): actually add an onClick handler
-// TODO(vdonato): (Maybe) toggle between expanded and collapsed page selector
-//                state based on mouse over / out (stretch goal).
+// TODO(vdonato): indicate the current page and make it unclickable
+// TODO(vdonato): set links correctly (requires baseUrlPath handling to be done)
 const SidebarNav = ({
   appPages,
-  sidebarHasElements,
+  hasSidebarElements,
+  onPageChange,
 }: Props): ReactElement | null => {
   if (appPages.length < 2) {
     return null
@@ -50,10 +49,17 @@ const SidebarNav = ({
   return (
     <StyledSidebarNavContainer>
       <StyledSidebarNavItems expanded={expanded}>
-        {appPages.map(({ pageName }: AppPage) => (
+        {appPages.map(({ pageName }: AppPage, pageIndex: number) => (
           <li key={pageName}>
             <StyledSidebarNavLinkContainer>
-              <StyledSidebarNavLink href={"http://example.com"}>
+              <StyledSidebarNavLink
+                href={"http://example.com"}
+                onClick={e => {
+                  e.preventDefault()
+                  const navigateTo = pageIndex === 0 ? "" : pageName
+                  onPageChange(navigateTo)
+                }}
+              >
                 {pageName.replace(/_/g, " ")}
               </StyledSidebarNavLink>
             </StyledSidebarNavLinkContainer>
@@ -61,7 +67,7 @@ const SidebarNav = ({
         ))}
       </StyledSidebarNavItems>
 
-      {sidebarHasElements && (
+      {hasSidebarElements && (
         <StyledSidebarNavSeparator
           onClick={() => {
             setExpanded(!expanded)

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -18,17 +18,26 @@
 import React from "react"
 import { mount } from "src/lib/test_util"
 import lightTheme from "src/theme/lightTheme"
+import { SidebarProps } from "./Sidebar"
 import ThemedSidebar from "./ThemedSidebar"
+
+function getProps(props: Partial<SidebarProps> = {}): SidebarProps {
+  return {
+    chevronDownshift: 0,
+    appPages: [],
+    ...props,
+  }
+}
 
 describe("ThemedSidebar Component", () => {
   it("should render without crashing", () => {
-    const wrapper = mount(<ThemedSidebar />)
+    const wrapper = mount(<ThemedSidebar {...getProps()} />)
 
     expect(wrapper.find("Sidebar").exists()).toBe(true)
   })
 
   it("should switch bgColor and secondaryBgColor", () => {
-    const wrapper = mount(<ThemedSidebar theme={lightTheme} />)
+    const wrapper = mount(<ThemedSidebar {...getProps()} />)
 
     const updatedTheme = wrapper.find("Sidebar").prop("theme")
 
@@ -36,5 +45,14 @@ describe("ThemedSidebar Component", () => {
     expect(updatedTheme.colors.bgColor).toBe(lightTheme.colors.secondaryBg)
     // @ts-ignore
     expect(updatedTheme.inSidebar).toBe(true)
+  })
+
+  it("plumbs appPages to main Sidebar component", () => {
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+    ]
+    const wrapper = mount(<ThemedSidebar {...getProps({ appPages })} />)
+
+    expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
   })
 })

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -25,6 +25,7 @@ function getProps(props: Partial<SidebarProps> = {}): SidebarProps {
   return {
     chevronDownshift: 0,
     appPages: [],
+    onPageChange: jest.fn(),
     ...props,
   }
 }
@@ -47,12 +48,15 @@ describe("ThemedSidebar Component", () => {
     expect(updatedTheme.inSidebar).toBe(true)
   })
 
-  it("plumbs appPages to main Sidebar component", () => {
+  it("plumbs appPages and onPageChange to main Sidebar component", () => {
     const appPages = [
       { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
     ]
     const wrapper = mount(<ThemedSidebar {...getProps({ appPages })} />)
 
     expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
+    expect(typeof wrapper.find("Sidebar").prop("onPageChange")).toBe(
+      "function"
+    )
   })
 })

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.tsx
@@ -34,7 +34,6 @@ const createSidebarTheme = (theme: ThemeConfig): ThemeConfig =>
   )
 
 const ThemedSidebar = ({
-  theme,
   children,
   ...sidebarProps
 }: Partial<SidebarProps>): ReactElement => {

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -51,6 +51,38 @@ export const StyledSidebar = styled.section(({ theme }) => ({
   },
 }))
 
+export const StyledSidebarNavContainer = styled.div(({ expanded, theme }) => ({
+  // TODO(vdonato): FIXME (add proper styling)
+}))
+
+export interface StyledSidebarNavItemsProps {
+  expanded: boolean
+}
+
+export const StyledSidebarNavItems = styled.ul<StyledSidebarNavItemsProps>(
+  ({ expanded, theme }) => ({
+    listStyle: "none",
+    maxHeight: expanded ? "75vh" : "25vh",
+    overflow: "auto",
+    // TODO(vdonato): FIXME (add proper styling)
+  })
+)
+
+export const StyledSidebarNavSeparator = styled.hr(({ theme }) => ({
+  // TODO(vdonato): FIXME
+  // * add proper styling
+  // * increase clickable area for the separator
+  // * add dynamic styling behavior for mouse hover
+}))
+
+export const StyledSidebarNavLinkContainer = styled.div(({ theme }) => ({
+  // TODO(vdonato): FIXME (add proper styling and make the full container clickable)
+}))
+
+export const StyledSidebarNavLink = styled.a(({ theme }) => ({
+  // TODO(vdonato): FIXME (add proper styling)
+}))
+
 export interface StyledSidebarContentProps {
   isCollapsed: boolean
 }

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -51,8 +51,10 @@ export const StyledSidebar = styled.section(({ theme }) => ({
   },
 }))
 
-export const StyledSidebarNavContainer = styled.div(({ expanded, theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling)
+export const StyledSidebarNavContainer = styled.div(({ theme }) => ({
+  // TODO(vdonato): styling
+  // * width of this component is 100% of the sidebar (probably needs
+  //   adjustments to StyledSidebarContent)
 }))
 
 export interface StyledSidebarNavItemsProps {
@@ -64,24 +66,54 @@ export const StyledSidebarNavItems = styled.ul<StyledSidebarNavItemsProps>(
     listStyle: "none",
     maxHeight: expanded ? "75vh" : "25vh",
     overflow: "auto",
-    // TODO(vdonato): FIXME (add proper styling)
+    // TODO(vdonato): styling
+    // * Fade in/out at the top/bottom if there is scrollable content in that
+    //   direction
   })
 )
 
 export const StyledSidebarNavSeparator = styled.hr(({ theme }) => ({
-  // TODO(vdonato): FIXME
-  // * add proper styling
-  // * increase clickable area for the separator
-  // * add dynamic styling behavior for mouse hover
+  // TODO(vdonato): styling
+  // * disable hover behavior when nav items list is not overflowing
+  // * add small second line underneath the separator
+  paddingTop: "3px",
+
+  "&:hover": {
+    cursor: "pointer",
+    backgroundColor: theme.colors.transparentDarkenedBgMix60,
+  },
 }))
 
 export const StyledSidebarNavLinkContainer = styled.div(({ theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling and make the full container clickable)
+  // TODO(vdonato): styling
+  // * adjust bgcolor/fontWeight for the currently selected page
+  //   (dependent on some other work to be finished first)
 }))
 
-export const StyledSidebarNavLink = styled.a(({ theme }) => ({
-  // TODO(vdonato): FIXME (add proper styling)
-}))
+export const StyledSidebarNavLink = styled.a<StyledSidebarNavLinkProps>(
+  ({ theme }) => {
+    const defaultPageLinkStyles = {
+      textDecoration: "none",
+      color: theme.colors.bodyText,
+    }
+
+    return {
+      ...defaultPageLinkStyles,
+
+      // NOTE: This hover behavior needs to be redone (in particular, we
+      //       probably want to change the background of the link being hovered
+      //       over). It's set this way for now as it requires very little
+      //       effort and works reasonably well considering that.
+      "&:hover": {
+        fontWeight: "bold",
+      },
+
+      "&:active,&:visited,&:hover": {
+        ...defaultPageLinkStyles,
+      },
+    }
+  }
+)
 
 export interface StyledSidebarContentProps {
   isCollapsed: boolean

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -229,7 +229,9 @@ class AppSession:
         """
         if client_state:
             rerun_data = RerunData(
-                client_state.query_string, client_state.widget_states
+                client_state.query_string,
+                client_state.widget_states,
+                client_state.page_name,
             )
         else:
             rerun_data = RerunData()

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -22,7 +22,7 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 import tornado.ioloop
 
 import streamlit.elements.exception as exception_utils
-from streamlit import __version__, caching, config, legacy_caching, secrets
+from streamlit import __version__, caching, config, legacy_caching, secrets, source_util
 from streamlit.case_converters import to_snake_case
 from streamlit.credentials import Credentials
 from streamlit.in_memory_file_manager import in_memory_file_manager
@@ -31,7 +31,12 @@ from streamlit.metrics_util import Installation
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.GitInfo_pb2 import GitInfo
-from streamlit.proto.NewSession_pb2 import Config, CustomThemeConfig, UserInfo
+from streamlit.proto.NewSession_pb2 import (
+    Config,
+    CustomThemeConfig,
+    NewSession,
+    UserInfo,
+)
 from streamlit.session_data import SessionData
 from streamlit.script_request_queue import RerunData, ScriptRequest, ScriptRequestQueue
 from streamlit.script_runner import ScriptRunner, ScriptRunnerEvent
@@ -385,6 +390,7 @@ class AppSession:
         msg.new_session.name = self._session_data.name
         msg.new_session.main_script_path = self._session_data.main_script_path
 
+        _populate_app_pages(msg.new_session, self._session_data.main_script_path)
         _populate_config_msg(msg.new_session.config)
         _populate_theme_msg(msg.new_session.custom_theme)
 
@@ -609,3 +615,12 @@ def _populate_user_info_msg(msg: UserInfo) -> None:
         msg.email = Credentials.get_current().activation.email
     else:
         msg.email = ""
+
+
+# TODO(vdonato): Eventually, rework this to listen for pages being added/removed
+# instead of repeatedly scanning the pages dir every time this function is called.
+def _populate_app_pages(msg: NewSession, main_script_path: str) -> None:
+    for page in source_util.get_pages(main_script_path):
+        page_proto = msg.app_pages.add()
+        page_proto.script_path = page["script_path"]
+        page_proto.page_name = page["page_name"]

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -619,8 +619,6 @@ def _populate_user_info_msg(msg: UserInfo) -> None:
         msg.email = ""
 
 
-# TODO(vdonato): Eventually, rework this to listen for pages being added/removed
-# instead of repeatedly scanning the pages dir every time this function is called.
 def _populate_app_pages(msg: NewSession, main_script_path: str) -> None:
     for page in source_util.get_pages(main_script_path):
         page_proto = msg.app_pages.add()

--- a/lib/streamlit/script_request_queue.py
+++ b/lib/streamlit/script_request_queue.py
@@ -38,6 +38,7 @@ class RerunData:
 
     query_string: str = ""
     widget_states: Optional[WidgetStates] = None
+    page_name: str = ""
 
 
 class ScriptRequestQueue:
@@ -100,6 +101,7 @@ class ScriptRequestQueue:
                             RerunData(
                                 query_string=data.query_string,
                                 widget_states=data.widget_states,
+                                page_name=data.page_name,
                             ),
                         )
                         return
@@ -115,6 +117,7 @@ class ScriptRequestQueue:
                             RerunData(
                                 query_string=data.query_string,
                                 widget_states=coalesced_states,
+                                page_name=data.page_name,
                             ),
                         )
                         return

--- a/lib/streamlit/script_run_context.py
+++ b/lib/streamlit/script_run_context.py
@@ -44,6 +44,7 @@ class ScriptRunContext:
     query_string: str
     session_state: SessionState
     uploaded_file_mgr: UploadedFileManager
+    page_name: str
 
     _set_page_config_allowed: bool = True
     _has_script_started: bool = False
@@ -52,11 +53,12 @@ class ScriptRunContext:
     cursors: Dict[int, "streamlit.cursor.RunningCursor"] = attr.Factory(dict)
     dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = attr.Factory(list)
 
-    def reset(self, query_string: str = "") -> None:
+    def reset(self, query_string: str = "", page_name: str = "") -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
         self.form_ids_this_run = set()
         self.query_string = query_string
+        self.page_name = page_name
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -360,15 +360,11 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
-            # TODO(vdonato): We'll eventually want to do a few things here:
-            # 1. Don't scan the `pages` directory for each script run. We'll
-            #    instead want to add a listener to only update our page info
-            #    when a page is added or removed.
-            # 2. Add proper 404 handling. Right now, we just run the main
-            #    script if we can't find a script corresponding to the given
-            #    page_name. We still want to do this in the final version of
-            #    the feature, but we also want to pop a modal telling the user
-            #    that the page they're looking for doesn't exist.
+            # TODO(vdonato): We'll eventually want to add proper 404 handling.
+            # Right now, we just run the main script if we can't find a script
+            # corresponding to the given page_name. We still want to do this in
+            # the final version of the feature, but we also want to pop a modal
+            # telling the user that the page they're looking for doesn't exist.
             script_path = None
 
             # NOTE: It may seem weird that we're passing the page_name around

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -225,6 +225,7 @@ class ScriptRunner:
             query_string=self._client_state.query_string,
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,
+            page_name=self._client_state.page_name,
         )
         add_script_run_ctx(threading.current_thread(), ctx)
 
@@ -246,6 +247,7 @@ class ScriptRunner:
         # created.
         client_state = ClientState()
         client_state.query_string = ctx.query_string
+        client_state.page_name = ctx.page_name
         widget_states = self._session_state.as_widget_states()
         client_state.widget_states.widgets.extend(widget_states)
         self.on_event.send(
@@ -349,7 +351,7 @@ class ScriptRunner:
         in_memory_file_manager.clear_session_files()
 
         ctx = self._get_script_run_ctx()
-        ctx.reset(query_string=rerun_data.query_string)
+        ctx.reset(query_string=rerun_data.query_string, page_name=rerun_data.page_name)
 
         self.on_event.send(self, event=ScriptRunnerEvent.SCRIPT_STARTED)
 
@@ -358,6 +360,9 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
+            # TODO(vdonato): Find the appropriate script_path given
+            # rerun_data.page_name
+
             with source_util.open_python_file(self._session_data.main_script_path) as f:
                 filebody = f.read()
 

--- a/lib/streamlit/script_runner.py
+++ b/lib/streamlit/script_runner.py
@@ -360,11 +360,6 @@ class ScriptRunner:
         # in their previous script elements disappearing.
 
         try:
-            # TODO(vdonato): We'll eventually want to add proper 404 handling.
-            # Right now, we just run the main script if we can't find a script
-            # corresponding to the given page_name. We still want to do this in
-            # the final version of the feature, but we also want to pop a modal
-            # telling the user that the page they're looking for doesn't exist.
             script_path = None
 
             # NOTE: It may seem weird that we're passing the page_name around
@@ -383,6 +378,10 @@ class ScriptRunner:
 
                 if current_page:
                     script_path = current_page["script_path"]
+                else:
+                    msg = ForwardMsg()
+                    msg.page_not_found.page_name = rerun_data.page_name
+                    ctx.enqueue(msg)
 
             if not script_path:
                 script_path = self._session_data.main_script_path

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -42,6 +42,11 @@ def allow_cross_origin_requests():
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
+    def initialize(self, path, default_filename, get_page_names):
+        self._page_names = get_page_names()
+
+        super().initialize(path=path, default_filename=default_filename)
+
     def set_extra_headers(self, path):
         """Disable cache for HTML files.
 
@@ -54,6 +59,17 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             self.set_header("Cache-Control", "no-cache")
         else:
             self.set_header("Cache-Control", "public")
+
+    def parse_url_path(self, url_path: str) -> str:
+        url_parts = url_path.split("/")
+
+        # TODO(vdonato): Maybe clean this up if we decide to tweak the spec so
+        # that there's a separator between the baseUrlPath and page name.
+        maybe_page_name = url_parts[0]
+        if maybe_page_name in self._page_names:
+            url_path = "/".join(url_parts[1:])
+
+        return super().parse_url_path(url_path)
 
 
 class AssetsFileHandler(tornado.web.StaticFileHandler):

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+from pathlib import Path
+from typing import Any, cast, Dict, List, Tuple
+
 
 def open_python_file(filename):
     """Open a read-only Python file taking proper care of its encoding.
@@ -29,3 +33,67 @@ def open_python_file(filename):
         return tokenize.open(filename)
     else:
         return open(filename, "r", encoding="utf-8")
+
+
+PAGE_FILENAME_REGEX = re.compile(r"([0-9]*)[_ -]*(.*)\.py")
+
+
+def page_sort_key(script_path: Path) -> Tuple[float, str]:
+    matches = re.findall(PAGE_FILENAME_REGEX, script_path.name)
+
+    # Failing this assert should only be possible if script_path isn't a Python
+    # file, which should never happen.
+    assert len(matches) > 0, f"{script_path} is not a Python file"
+
+    [(number, label)] = matches
+
+    if number == "":
+        return (float("inf"), label)
+
+    return (float(number), label)
+
+
+def page_name(script_path: Path) -> str:
+    """Compute the name of a page from its script path.
+
+    This is *almost* the page name displayed in the nav UI, but it has
+    underscores instead of spaces. The reason we do this is because having
+    spaces in URLs both looks bad and is hard to deal with due to the need to
+    URL-encode them. To solve this, we only swap the underscores for spaces
+    right before we render page names.
+    """
+    extraction = re.search(PAGE_FILENAME_REGEX, script_path.name)
+    if extraction is None:
+        return ""
+
+    # This cast to Any+type annotation weirdness is done because
+    # cast(re.Match[str], ...) explodes at runtime since Python interprets it
+    # as an attempt to index into re.Match instead of as a type annotation.
+    extraction: re.Match[str] = cast(Any, extraction)
+
+    name = re.sub(r"[_ ]+", "_", extraction.group(2)).strip()
+    if not name:
+        name = extraction.group(1)
+
+    return str(name)
+
+
+def get_pages(main_script_path: str) -> List[Dict[str, str]]:
+    main_script_path = Path(main_script_path)
+    main_page_name = page_name(main_script_path)
+
+    used_page_names = {main_page_name}
+    pages = [{"page_name": main_page_name, "script_path": str(main_script_path)}]
+
+    pages_dir = main_script_path.parent / "pages"
+    page_scripts = sorted(pages_dir.glob("*.py"), key=page_sort_key)
+
+    for script_path in page_scripts:
+        pn = page_name(script_path)
+        if pn in used_page_names:
+            continue
+
+        used_page_names.add(pn)
+        pages.append({"page_name": pn, "script_path": str(script_path)})
+
+    return pages

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -78,6 +78,8 @@ def page_name(script_path: Path) -> str:
     return str(name)
 
 
+# TODO(vdonato): Eventually, have this function cache its return value and
+# avoid re-scanning the file system unless a page has been added/removed.
 def get_pages(main_script_path: str) -> List[Dict[str, str]]:
     main_script_path = Path(main_script_path)
     main_page_name = page_name(main_script_path)

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -24,6 +24,7 @@ from streamlit.folder_black_list import FolderBlackList
 
 from streamlit.logger import get_logger
 from streamlit.session_data import SessionData
+from streamlit.source_util import get_pages
 from streamlit.watcher.file_watcher import (
     get_default_file_watcher_class,
     NoOpFileWatcher,
@@ -51,10 +52,11 @@ class LocalSourcesWatcher:
 
         self._watched_modules: Dict[str, WatchedModule] = {}
 
-        self._register_watcher(
-            self._session_data.main_script_path,
-            module_name=None,  # Only the root script has None here.
-        )
+        for page_info in get_pages(self._session_data.main_script_path):
+            self._register_watcher(
+                page_info["script_path"],
+                module_name=None,  # Only root scripts have their modules set to None
+            )
 
     def register_file_change_callback(self, cb: Callable[[], None]) -> None:
         self._on_file_changed.append(cb)

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -108,16 +108,13 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         patched_connect.assert_called_once_with(session._on_secrets_file_changed)
 
-    @patch("streamlit.app_session.LocalSourcesWatcher")
-    def test_passes_client_state_on_run_on_save(self, _):
-        rs = AppSession(
-            None, SessionData("", ""), UploadedFileManager(), None, MagicMock()
-        )
-        rs._run_on_save = True
-        rs.request_rerun = MagicMock()
-        rs._on_source_file_changed()
+    def test_passes_client_state_on_run_on_save(self):
+        session = _create_test_session()
+        session._run_on_save = True
+        session.request_rerun = MagicMock()
+        session._on_source_file_changed()
 
-        rs.request_rerun.assert_called_once_with(rs._client_state)
+        session.request_rerun.assert_called_once_with(session._client_state)
 
 
 def _mock_get_options_for_section(overrides=None):
@@ -147,10 +144,12 @@ def _mock_get_options_for_section(overrides=None):
 class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
     @patch(
         "streamlit.app_session.source_util.get_pages",
-        return_value=[
-            {"page_name": "page1", "script_path": "script1"},
-            {"page_name": "page2", "script_path": "script2"},
-        ],
+        MagicMock(
+            return_value=[
+                {"page_name": "page1", "script_path": "script1"},
+                {"page_name": "page2", "script_path": "script2"},
+            ]
+        ),
     )
     @patch("streamlit.app_session.config")
     @patch(
@@ -158,7 +157,7 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
         MagicMock(return_value="mock_scriptrun_id"),
     )
     @tornado.testing.gen_test
-    def test_enqueue_new_session_message(self, patched_config, _1):
+    def test_enqueue_new_session_message(self, patched_config):
         """The SCRIPT_STARTED event should enqueue a 'new_session' message."""
 
         def get_option(name):

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -189,6 +189,7 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
             query_string="",
             session_state=MagicMock(),
             uploaded_file_mgr=MagicMock(),
+            page_name="",
         )
         add_script_run_ctx(ctx=ctx)
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -21,6 +21,7 @@ import tornado.testing
 import streamlit.app_session as app_session
 from streamlit import config
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.proto.NewSession_pb2 import AppPage
 from streamlit.app_session import AppSession, AppSessionState
 from streamlit.script_run_context import (
     ScriptRunContext,
@@ -107,6 +108,17 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         patched_connect.assert_called_once_with(session._on_secrets_file_changed)
 
+    @patch("streamlit.app_session.LocalSourcesWatcher")
+    def test_passes_client_state_on_run_on_save(self, _):
+        rs = AppSession(
+            None, SessionData("", ""), UploadedFileManager(), None, MagicMock()
+        )
+        rs._run_on_save = True
+        rs.request_rerun = MagicMock()
+        rs._on_source_file_changed()
+
+        rs.request_rerun.assert_called_once_with(rs._client_state)
+
 
 def _mock_get_options_for_section(overrides=None):
     if not overrides:
@@ -133,13 +145,20 @@ def _mock_get_options_for_section(overrides=None):
 
 
 class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
+    @patch(
+        "streamlit.app_session.source_util.get_pages",
+        return_value=[
+            {"page_name": "page1", "script_path": "script1"},
+            {"page_name": "page2", "script_path": "script2"},
+        ],
+    )
     @patch("streamlit.app_session.config")
     @patch(
         "streamlit.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
     )
     @tornado.testing.gen_test
-    def test_enqueue_new_session_message(self, patched_config):
+    def test_enqueue_new_session_message(self, patched_config, _1):
         """The SCRIPT_STARTED event should enqueue a 'new_session' message."""
 
         def get_option(name):
@@ -198,6 +217,14 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
 
         init_msg = new_session_msg.initialize
         self.assertTrue(init_msg.HasField("user_info"))
+
+        self.assertEqual(
+            list(new_session_msg.app_pages),
+            [
+                AppPage(page_name="page1", script_path="script1"),
+                AppPage(page_name="page2", script_path="script2"),
+            ],
+        )
 
         add_script_run_ctx(ctx=orig_ctx)
 

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -178,6 +178,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
                 query_string="",
                 session_state=SessionState(),
                 uploaded_file_mgr=None,
+                page_name="",
             ),
         )
         with patch.object(call_stack, "_show_cached_st_function_warning") as warning:

--- a/lib/tests/streamlit/report_context_test.py
+++ b/lib/tests/streamlit/report_context_test.py
@@ -27,11 +27,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         msg = ForwardMsg()
@@ -47,11 +48,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         ctx.on_script_start()
@@ -71,11 +73,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         ctx.on_script_start()
@@ -94,11 +97,12 @@ class ScriptRunContextTest(unittest.TestCase):
 
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
-            "TestSessionID",
-            fake_enqueue,
-            "",
-            SessionState(),
-            UploadedFileManager(),
+            session_id="TestSessionID",
+            enqueue=fake_enqueue,
+            query_string="",
+            session_state=SessionState(),
+            uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         ctx.on_script_start()

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -632,16 +632,18 @@ class ScriptRunnerTest(AsyncTestCase):
 
     @patch(
         "streamlit.script_runner.source_util.get_pages",
-        return_value=[
-            {
-                "page_name": "page2",
-                "script_path": os.path.join(
-                    os.path.dirname(__file__), "test_data", "good_script2.py"
-                ),
-            },
-        ],
+        MagicMock(
+            return_value=[
+                {
+                    "page_name": "page2",
+                    "script_path": os.path.join(
+                        os.path.dirname(__file__), "test_data", "good_script2.py"
+                    ),
+                },
+            ],
+        ),
     )
-    def test_page_name_to_script_path(self, _):
+    def test_page_name_to_script_path(self):
         scriptrunner = TestScriptRunner("good_script.py")
         scriptrunner.enqueue_rerun(page_name="page2")
         scriptrunner.start()
@@ -665,11 +667,13 @@ class ScriptRunnerTest(AsyncTestCase):
 
     @patch(
         "streamlit.script_runner.source_util.get_pages",
-        return_value=[
-            {"page_name": "page2", "script_path": "script2"},
-        ],
+        MagicMock(
+            return_value=[
+                {"page_name": "page2", "script_path": "script2"},
+            ]
+        ),
     )
-    def test_page_name_to_script_path_404(self, _):
+    def test_page_name_to_script_path_404(self):
         scriptrunner = TestScriptRunner("good_script.py")
         scriptrunner.enqueue_rerun(page_name="page3")
         scriptrunner.start()

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -443,9 +443,9 @@ class ScriptRunnerTest(AsyncTestCase):
         scriptrunner.join()
         self._assert_no_exceptions(scriptrunner)
 
-    def test_query_string_saved(self):
+    def test_query_string_and_page_name_saved(self):
         scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.enqueue_rerun(query_string="foo=bar")
+        scriptrunner.enqueue_rerun(query_string="foo=bar", page_name="baz")
         scriptrunner.start()
         scriptrunner.join()
 
@@ -461,6 +461,7 @@ class ScriptRunnerTest(AsyncTestCase):
 
         shutdown_data = scriptrunner.event_data[-1]
         self.assertEqual(shutdown_data["client_state"].query_string, "foo=bar")
+        self.assertEqual(shutdown_data["client_state"].page_name, "baz")
 
     def test_coalesce_rerun(self):
         """Tests that multiple pending rerun requests get coalesced."""
@@ -719,10 +720,16 @@ class TestScriptRunner(ScriptRunner):
 
         self.on_event.connect(record_event, weak=False)
 
-    def enqueue_rerun(self, argv=None, widget_states=None, query_string=""):
+    def enqueue_rerun(
+        self, argv=None, widget_states=None, query_string="", page_name=""
+    ):
         self.script_request_queue.enqueue(
             ScriptRequest.RERUN,
-            RerunData(widget_states=widget_states, query_string=query_string),
+            RerunData(
+                widget_states=widget_states,
+                query_string=query_string,
+                page_name=page_name,
+            ),
         )
 
     def enqueue_stop(self):

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -39,6 +39,7 @@ from streamlit.uploaded_file_manager import UploadedFileManager
 from tests import testutil
 
 text_utf = "complete! 👨‍🎤"
+text_utf2 = "complete2! 👨‍🎤"
 text_no_encoding = text_utf
 text_latin = "complete! ð\x9f\x91¨â\x80\x8dð\x9f\x8e¤"
 
@@ -627,6 +628,67 @@ class ScriptRunnerTest(AsyncTestCase):
             [
                 "cached_depending_on_not_yet_defined called",
             ],
+        )
+
+    @patch(
+        "streamlit.script_runner.source_util.get_pages",
+        return_value=[
+            {
+                "page_name": "page2",
+                "script_path": os.path.join(
+                    os.path.dirname(__file__), "test_data", "good_script2.py"
+                ),
+            },
+        ],
+    )
+    def test_page_name_to_script_path(self, _):
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.enqueue_rerun(page_name="page2")
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+        self._assert_text_deltas(scriptrunner, [text_utf2])
+        self.assertEqual(
+            os.path.join(os.path.dirname(__file__), "test_data", "good_script2.py"),
+            sys.modules["__main__"].__file__,
+            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
+        )
+
+    @patch(
+        "streamlit.script_runner.source_util.get_pages",
+        return_value=[
+            {"page_name": "page2", "script_path": "script2"},
+        ],
+    )
+    def test_page_name_to_script_path_404(self, _):
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.enqueue_rerun(page_name="page3")
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+        self._assert_text_deltas(scriptrunner, [text_utf])
+        self.assertEqual(
+            scriptrunner._session_data.main_script_path,
+            sys.modules["__main__"].__file__,
+            (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
 
     def _assert_no_exceptions(self, scriptrunner):

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -689,6 +689,10 @@ class ScriptRunnerTest(AsyncTestCase):
             ],
         )
         self._assert_text_deltas(scriptrunner, [text_utf])
+
+        page_not_found_msg = scriptrunner.forward_msg_queue._queue[0].page_not_found
+        self.assertEqual(page_not_found_msg.page_name, "page3")
+
         self.assertEqual(
             scriptrunner._session_data.main_script_path,
             sys.modules["__main__"].__file__,

--- a/lib/tests/streamlit/scriptrunner/test_data/good_script2.py
+++ b/lib/tests/streamlit/scriptrunner/test_data/good_script2.py
@@ -1,0 +1,19 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A test script for ScriptRunnerTest that enqueues a delta."""
+
+import streamlit as st
+
+st.text("complete2! 👨‍🎤")

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -1,0 +1,125 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from pathlib import Path
+
+import pytest
+from parameterized import parameterized
+
+import streamlit.source_util as source_util
+
+
+class PageHelperFunctionTests(unittest.TestCase):
+    @parameterized.expand(
+        [
+            # Test that the page number is treated as the first sort key.
+            ("/foo/01_bar.py", (1.0, "bar")),
+            ("/foo/02-bar.py", (2.0, "bar")),
+            ("/foo/03 bar.py", (3.0, "bar")),
+            ("/foo/04 bar baz.py", (4.0, "bar baz")),
+            ("/foo/05 -_- bar.py", (5.0, "bar")),
+            # Test that the first sort key is float("inf") if there is no page
+            # number.
+            ("/foo/bar.py", (float("inf"), "bar")),
+            ("/foo/bar baz.py", (float("inf"), "bar baz")),
+        ]
+    )
+    def test_page_sort_key(self, path_str, expected):
+        assert source_util.page_sort_key(Path(path_str)) == expected
+
+    def test_page_sort_key_error(self):
+        with pytest.raises(AssertionError) as e:
+            source_util.page_sort_key(Path("/foo/bar/baz.rs"))
+
+        assert str(e.value) == "/foo/bar/baz.rs is not a Python file"
+
+    @parameterized.expand(
+        [
+            # Test that the page number is removed as expected.
+            ("/foo/01_bar.py", "bar"),
+            ("/foo/02-bar.py", "bar"),
+            ("/foo/03 bar.py", "bar"),
+            ("/foo/04 bar baz.py", "bar_baz"),
+            ("/foo/05 -_- bar.py", "bar"),
+            # Test cases with no page number.
+            ("/foo/bar.py", "bar"),
+            ("/foo/bar baz.py", "bar_baz"),
+            # Test that separator characters in the page name are removed as
+            # as expected.
+            ("/foo/1 - first page.py", "first_page"),
+            ("/foo/123_hairy_koala.py", "hairy_koala"),
+            (
+                "/foo/123 wow_this_has a _lot_ _of  _ ___ separators.py",
+                "wow_this_has_a_lot_of_separators",
+            ),
+            (
+                "/foo/1-dashes in page-name stay.py",
+                "dashes_in_page-name_stay",
+            ),
+            # Test other weirdness that might happen with numbers.
+            ("12 monkeys.py", "monkeys"),
+            ("_12 monkeys.py", "12_monkeys"),
+            ("123.py", "123"),
+            # Test the default case for non-Python files.
+            ("not_a_python_script.rs", ""),
+        ]
+    )
+    def test_page_name(self, path_str, expected):
+        assert source_util.page_name(Path(path_str)) == expected
+
+
+# NOTE: We write this test function using pytest conventions (as opposed to
+# using unittest.TestCase like in the rest of the codebase) because the tmpdir
+# pytest fixture is so useful for writing this test it's worth having the
+# slight inconsistency.
+def test_get_pages(tmpdir):
+    # Write an empty string to create a file.
+    tmpdir.join("streamlit_app.py").write("")
+
+    pages_dir = tmpdir.mkdir("pages")
+    pages = [
+        # These pages are out of order so that we can check that they're sorted
+        # in the assert below.
+        "03_other_page.py",
+        "last page.py",
+        "01-page.py",
+        # The next two pages have duplicate names so shouldn't appear.
+        "page.py",
+        "streamlit_app.py",
+        # This shouldn't appear because it's not a Python file.
+        "not_a_page.rs",
+    ]
+    for p in pages:
+        pages_dir.join(p).write("")
+
+    main_script_path = str(tmpdir / "streamlit_app.py")
+    assert source_util.get_pages(main_script_path) == [
+        {
+            "page_name": "streamlit_app",
+            "script_path": main_script_path,
+        },
+        {
+            "page_name": "page",
+            "script_path": str(pages_dir / "01-page.py"),
+        },
+        {
+            "page_name": "other_page",
+            "script_path": str(pages_dir / "03_other_page.py"),
+        },
+        {
+            "page_name": "last_page",
+            "script_path": str(pages_dir / "last page.py"),
+        },
+    ]

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -290,6 +290,26 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         del sys.modules["tests.streamlit.watcher.test_data.namespace_package"]
 
+    @patch(
+        "streamlit.watcher.local_sources_watcher.get_pages",
+        MagicMock(
+            return_value=[
+                {"page_name": "streamlit_app", "script_path": "streamlit_app.py"},
+                {"page_name": "streamlit_app2", "script_path": "streamlit_app2.py"},
+            ]
+        ),
+    )
+    @patch("streamlit.watcher.local_sources_watcher.FileWatcher")
+    def test_watches_all_page_scripts(self, fob, _):
+        lsw = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        args1, _ = fob.call_args_list[0]
+        args2, _ = fob.call_args_list[1]
+
+        assert args1[0] == "streamlit_app.py"
+        assert args2[0] == "streamlit_app2.py"
+
 
 def test_get_module_paths_outputs_abs_paths():
     mock_module = MagicMock()

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -90,6 +90,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             query_string="",
             session_state=SessionState(),
             uploaded_file_mgr=UploadedFileManager(),
+            page_name="",
         )
 
         if self.override_root:

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -22,4 +22,5 @@ import "streamlit/proto/WidgetStates.proto";
 message ClientState {
   string query_string = 1;
   WidgetStates widget_states = 2;
+  string page_name = 3;
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -17,12 +17,13 @@
 syntax = "proto3";
 
 import "streamlit/proto/Delta.proto";
+import "streamlit/proto/GitInfo.proto";
 import "streamlit/proto/NewSession.proto";
 import "streamlit/proto/PageConfig.proto";
 import "streamlit/proto/PageInfo.proto";
+import "streamlit/proto/PageNotFound.proto";
 import "streamlit/proto/SessionEvent.proto";
 import "streamlit/proto/SessionState.proto";
-import "streamlit/proto/GitInfo.proto";
 
 // A message sent from Proxy to the browser
 message ForwardMsg {
@@ -44,7 +45,6 @@ message ForwardMsg {
 
   oneof type {
     // App lifecycle messages.
-
     NewSession new_session = 4;
     Delta delta = 5;
     PageInfo page_info_changed = 12;
@@ -52,17 +52,12 @@ message ForwardMsg {
     ScriptFinishedStatus script_finished = 6;
     GitInfo git_info_changed = 14;
 
-    // Upload progress messages.
-
     // State change and event messages.
-
-    // AppSession state changed. This is the new state.
     SessionState session_state_changed = 9;
-
-    // A SessionEvent was emitted.
     SessionEvent session_event = 10;
 
     // Other messages.
+    PageNotFound page_not_found = 15;
 
     // A reference to a ForwardMsg that has already been delivered.
     // The client should substitute the message with the given hash
@@ -72,7 +67,7 @@ message ForwardMsg {
   }
 
   reserved 7, 8;
-  // Next: 15
+  // Next: 16
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -48,6 +48,9 @@ message NewSession {
   // Theme configuration options defined in the .streamlit/config.toml file.
   // See the "theme" config section.
   CustomThemeConfig custom_theme = 7;
+
+  // A list of all of this app's pages, in order and including the main page.
+  repeated AppPage app_pages = 8;
 }
 
 // Contains the session state that existed at the time the user connected.
@@ -132,4 +135,11 @@ message UserInfo {
 message EnvironmentInfo {
   string streamlit_version = 1;
   string python_version = 2;
+}
+
+// A page in the app. Includes both the name of the page as well as the full
+// path to the corresponding script file.
+message AppPage {
+  string page_name = 1;
+  string script_path = 2;
 }

--- a/proto/streamlit/proto/PageNotFound.proto
+++ b/proto/streamlit/proto/PageNotFound.proto
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+syntax = "proto3";
+
+// Message used to tell the client that the requested page does not exist.
+message PageNotFound {
+  string page_name = 1;
+}


### PR DESCRIPTION
## 📚 Context

When a script run takes a long time to complete, we currently fade out elements
from the previous script run instead of removing them entirely as doing so normally
provides a less jumpy user experience (more often than not, we'll redraw updated
versions of the same elements to the screen once a long-running computation
completes).

This is behavior that we do *not* want when switching between pages since it's unlikely
that we'll redraw updated versions of the same elements when navigating between
pages.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Clear all elements in the app when switching between pages

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/449
