### PR TITLE
Update CI jobs to current-gen docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
   build-deploy-rc:
     resource_class: large
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9.7
     working_directory: ~/repo
     steps:
       - checkout:
@@ -358,7 +358,7 @@ jobs:
   build-deploy-release:
     resource_class: large
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9.7
     working_directory: ~/repo
     steps:
       - checkout:
@@ -449,7 +449,7 @@ jobs:
 
   python-max-version: &job-template
     docker:
-      - image: circleci/python:3.10.0
+      - image: cimg/python:3.10.0
 
     working_directory: ~/repo
 
@@ -553,11 +553,11 @@ jobs:
   python-min-version:
     <<: *job-template
     docker:
-      - image: circleci/python:3.7.12
+      - image: cimg/python:3.7.12
 
   create-tag:
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9.7
 
     working_directory: ~/repo
 
@@ -604,7 +604,7 @@ jobs:
 
   nightly-release:
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9.7
 
     resource_class: large
 
@@ -650,7 +650,7 @@ jobs:
 
   pr-preview:
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9.7
 
     resource_class: large
 
@@ -735,7 +735,7 @@ jobs:
 
   cypress:
     docker:
-      - image: circleci/python:3.7.11
+      - image: cimg/python:3.7.11
     parallelism: 20
 
     resource_class: xlarge
@@ -844,7 +844,7 @@ jobs:
   cli-regression-test:
     resource_class: large
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.9.7
     working_directory: ~/repo
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,15 @@ commands:
             ${SUDO} apt-get install -y unixodbc-dev
 
       - run:
+          name: Install libpython dependencies
+          command: |
+            if [ "${CIRCLE_JOB}" != "python-min-version" ] ; then
+              echo "libpython3.7 only needs to be installed for testing 3.7"
+            else
+              ${SUDO} apt-get install -y libpython3.7
+            fi
+
+      - run:
           name: Install graphviz dependencies
           command: |
             ${SUDO} apt update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ commands:
       - run:
           name: Install pyodbc dependencies
           command: |
+            ${SUDO} apt-get update
             ${SUDO} apt-get install -y unixodbc-dev
 
       - run:


### PR DESCRIPTION
There is now a deprecation notice in circleci, so this seems worth doing
to stay up to date and get whatever improvements these have.

## 📚 Context

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
CI image update

## 🧠 Description of Changes

- Update all circleci docker images to latest generation

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests
