### PR TITLE
Add a prepForElementSnapshots cypress command and use it

### DIFF
--- a/e2e/specs/component_template.spec.js
+++ b/e2e/specs/component_template.spec.js
@@ -37,8 +37,7 @@ describe("Component template", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("is rendered correctly", () => {

--- a/e2e/specs/st_arrow_add_rows.spec.js
+++ b/e2e/specs/st_arrow_add_rows.spec.js
@@ -29,8 +29,7 @@ describe("st._arrow_add_rows", () => {
       .should("have.attr", "data-stale", "false")
       .invoke("css", "opacity", "1");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_arrow_altair_chart.spec.js
+++ b/e2e/specs/st_arrow_altair_chart.spec.js
@@ -19,8 +19,7 @@ describe("st._arrow_altair_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays an altair chart", () => {

--- a/e2e/specs/st_arrow_area_chart.spec.js
+++ b/e2e/specs/st_arrow_area_chart.spec.js
@@ -19,8 +19,7 @@ describe("st._arrow_area_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays an area chart", () => {

--- a/e2e/specs/st_arrow_chart_utc_time.spec.js
+++ b/e2e/specs/st_arrow_chart_utc_time.spec.js
@@ -19,8 +19,7 @@ describe("st._arrow_area_chart, st._arrow_bar_chart, st._arrow_line_chart", () =
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("display times in UTC", () => {

--- a/e2e/specs/st_arrow_dataframe_sizes.spec.js
+++ b/e2e/specs/st_arrow_dataframe_sizes.spec.js
@@ -23,8 +23,7 @@ describe("Arrow Dataframes and Tables snapshots", () => {
 
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     // HACK: Add `overflow: auto` to all tables to prevent Cypress
     // from throwing [RangeError: The value of "offset" is out of range.]

--- a/e2e/specs/st_arrow_empty_charts.spec.js
+++ b/e2e/specs/st_arrow_empty_charts.spec.js
@@ -24,8 +24,7 @@ describe("handles arrow empty charts", () => {
       expect($els).to.have.length.of.at.least(10);
     });
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("gracefully handles no data", () => {

--- a/e2e/specs/st_arrow_empty_dataframes.spec.js
+++ b/e2e/specs/st_arrow_empty_dataframes.spec.js
@@ -23,10 +23,7 @@ describe("Arrow Dataframes", () => {
     // http://gs.statcounter.com/screen-resolution-stats/desktop/worldwide
     cy.loadApp("http://localhost:3000/");
 
-    // Make the decoration line disappear
-    // This prevents us from occasionally getting the little multi-colored
-    // ribbon at the top of our screenshots.
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     // Wait for the site to be fully loaded
     cy.get(".element-container").should($els => {

--- a/e2e/specs/st_arrow_line_chart_add_rows_special.spec.js
+++ b/e2e/specs/st_arrow_line_chart_add_rows_special.spec.js
@@ -24,8 +24,7 @@ describe("st._arrow_line_chart_add_rows_special", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("correctly adds rows to a line chart", () => {

--- a/e2e/specs/st_arrow_new_features.spec.js
+++ b/e2e/specs/st_arrow_new_features.spec.js
@@ -19,8 +19,7 @@ describe("st_arrow_new_feautres", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear.
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     // Wait for all the tables to be loaded.
     cy.get("[data-testid='stTable']").should("have.length", 7);

--- a/e2e/specs/st_arrow_table.spec.js
+++ b/e2e/specs/st_arrow_table.spec.js
@@ -19,8 +19,7 @@ describe("st._arrow_table", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear.
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     // Wait for all the tables to be loaded.
     cy.get("[data-testid='stTable']").should("have.length", 10);

--- a/e2e/specs/st_arrow_table_styling.spec.js
+++ b/e2e/specs/st_arrow_table_styling.spec.js
@@ -21,8 +21,7 @@ describe("st._arrow_table styling", () => {
 
     cy.get("[data-testid='stTable']").should("have.length", 3);
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays unstyled table", () => {

--- a/e2e/specs/st_arrow_vega_lite_chart.spec.js
+++ b/e2e/specs/st_arrow_vega_lite_chart.spec.js
@@ -19,13 +19,7 @@ describe("st._arrow_vega_lite_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Force our header to scroll with the page, rather than
-    // remaining fixed. This prevents us from occasionally getting
-    // the little multi-colored ribbon at the top of our screenshots.
-    cy.get(".stApp > header").invoke("css", "position", "absolute");
-
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays charts on the DOM", () => {

--- a/e2e/specs/st_button.spec.js
+++ b/e2e/specs/st_button.spec.js
@@ -19,8 +19,7 @@ describe("st.button", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_checkbox.spec.js
+++ b/e2e/specs/st_checkbox.spec.js
@@ -19,8 +19,7 @@ describe("st.checkbox", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_disabled.spec.js
+++ b/e2e/specs/st_disabled.spec.js
@@ -23,8 +23,7 @@ describe("disable widgets", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("disconnects the client and disables widgets", () => {

--- a/e2e/specs/st_disconnect.spec.js
+++ b/e2e/specs/st_disconnect.spec.js
@@ -19,8 +19,7 @@ describe("kill server", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("disconnects the client", () => {

--- a/e2e/specs/st_download_button.spec.js
+++ b/e2e/specs/st_download_button.spec.js
@@ -21,8 +21,7 @@ describe("st.download_button", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_empty.spec.js
+++ b/e2e/specs/st_empty.spec.js
@@ -19,8 +19,7 @@ describe("st.empty", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("uses display none styling", () => {

--- a/e2e/specs/st_experimental_get_query_params.spec.js
+++ b/e2e/specs/st_experimental_get_query_params.spec.js
@@ -21,8 +21,8 @@ describe("st.experimental_get_query_string", () => {
       "http://localhost:3000/?" +
         "show_map=True&number_of_countries=2&selected=asia&selected=america"
     );
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+
+    cy.prepForElementSnapshots();
   });
 
   it("shows query string correctly", () => {

--- a/e2e/specs/st_experimental_set_query_params.spec.js
+++ b/e2e/specs/st_experimental_set_query_params.spec.js
@@ -19,8 +19,7 @@ describe("st.experimental_query_string", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows button correctly", () => {

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -25,8 +25,7 @@ describe("st.file_uploader", () => {
 
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_graphviz_chart.spec.js
+++ b/e2e/specs/st_graphviz_chart.spec.js
@@ -19,8 +19,7 @@ describe("st.graphviz_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_legacy_add_rows.spec.js
+++ b/e2e/specs/st_legacy_add_rows.spec.js
@@ -25,7 +25,7 @@ describe("st._legacy_add_rows", () => {
     cy.loadApp("http://localhost:3000/");
 
     // Rerun the script because we want to test that JS-side coalescing works.
-    cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {
+    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
       keyCode: 82, // "r"
       which: 82, // "r"
       force: true
@@ -36,8 +36,7 @@ describe("st._legacy_add_rows", () => {
       .should("have.attr", "data-stale", "false")
       .invoke("css", "opacity", "1");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   beforeEach(() => {

--- a/e2e/specs/st_legacy_add_rows.spec.js
+++ b/e2e/specs/st_legacy_add_rows.spec.js
@@ -24,12 +24,7 @@ describe("st._legacy_add_rows", () => {
 
     cy.loadApp("http://localhost:3000/");
 
-    // Rerun the script because we want to test that JS-side coalescing works.
-    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
-      keyCode: 82, // "r"
-      which: 82, // "r"
-      force: true
-    });
+    cy.rerunScript();
 
     // Wait for 'data-stale' attr to go away, so the snapshot looks right.
     cy.get(".element-container")

--- a/e2e/specs/st_legacy_altair_chart.spec.js
+++ b/e2e/specs/st_legacy_altair_chart.spec.js
@@ -19,8 +19,7 @@ describe("st._legacy_altair_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays an altair chart", () => {

--- a/e2e/specs/st_legacy_area_chart.spec.js
+++ b/e2e/specs/st_legacy_area_chart.spec.js
@@ -19,8 +19,7 @@ describe("st._legacy_area_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays an area chart", () => {

--- a/e2e/specs/st_legacy_chart_utc_time.spec.js
+++ b/e2e/specs/st_legacy_chart_utc_time.spec.js
@@ -19,8 +19,7 @@ describe("st._legacy_area, legacy_bar, and legacy_line charts", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("display times in UTC", () => {

--- a/e2e/specs/st_legacy_dataframe_sizes.spec.js
+++ b/e2e/specs/st_legacy_dataframe_sizes.spec.js
@@ -23,8 +23,7 @@ describe("Legacy Dataframes and Tables snapshots", () => {
 
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     // HACK: Add `overflow: auto` to all tables to prevent Cypress
     // from throwing [RangeError: The value of "offset" is out of range.]

--- a/e2e/specs/st_legacy_empty_charts.spec.js
+++ b/e2e/specs/st_legacy_empty_charts.spec.js
@@ -24,8 +24,7 @@ describe("handles legacy empty charts", () => {
       expect($els).to.have.length.of.at.least(10);
     });
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("gracefully handles no data", () => {

--- a/e2e/specs/st_legacy_empty_dataframes.spec.js
+++ b/e2e/specs/st_legacy_empty_dataframes.spec.js
@@ -23,10 +23,7 @@ describe("Legacy Dataframes", () => {
     // http://gs.statcounter.com/screen-resolution-stats/desktop/worldwide
     cy.loadApp("http://localhost:3000/");
 
-    // Make the decoration line disappear
-    // This prevents us from occasionally getting the little multi-colored
-    // ribbon at the top of our screenshots.
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     // Wait for the site to be fully loaded
     cy.get(".element-container").should($els => {

--- a/e2e/specs/st_legacy_table_styling.spec.js
+++ b/e2e/specs/st_legacy_table_styling.spec.js
@@ -21,8 +21,7 @@ describe("st._legacy_table styling", () => {
 
     cy.get("[data-testid='stTable']").should("have.length", 4);
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays unstyled table", () => {

--- a/e2e/specs/st_legacy_vega_lite_chart.spec.js
+++ b/e2e/specs/st_legacy_vega_lite_chart.spec.js
@@ -19,13 +19,7 @@ describe("st._legacy_vega_lite_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Force our header to scroll with the page, rather than
-    // remaining fixed. This prevents us from occasionally getting
-    // the little multi-colored ribbon at the top of our screenshots.
-    cy.get(".stApp > header").invoke("css", "position", "absolute");
-
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays charts on the DOM", () => {

--- a/e2e/specs/st_main_menu.spec.js
+++ b/e2e/specs/st_main_menu.spec.js
@@ -19,8 +19,7 @@ describe("main menu", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays light main menu and about section properly", () => {

--- a/e2e/specs/st_markdown.spec.js
+++ b/e2e/specs/st_markdown.spec.js
@@ -19,8 +19,7 @@ describe("st.markdown", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("displays correct number of elements", () => {

--- a/e2e/specs/st_markdown_in_alert_box.spec.js
+++ b/e2e/specs/st_markdown_in_alert_box.spec.js
@@ -19,8 +19,7 @@ describe("info/success/warning/error boxes", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("show complex markdown beautifully", () => {

--- a/e2e/specs/st_multiselect.spec.js
+++ b/e2e/specs/st_multiselect.spec.js
@@ -19,8 +19,7 @@ describe("st.multiselect", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   describe("when first loaded", () => {

--- a/e2e/specs/st_number_input.spec.js
+++ b/e2e/specs/st_number_input.spec.js
@@ -19,8 +19,7 @@ describe("st.number_input", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_pyplot.spec.js
+++ b/e2e/specs/st_pyplot.spec.js
@@ -27,11 +27,7 @@ describe("st.pyplot", () => {
   });
 
   it("clears the figure on rerun", () => {
-    // Rerun the script
-    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
-      keyCode: 82, // "r"
-      which: 82 // "r"
-    });
+    cy.rerunScript();
 
     // Wait for 'data-stale' attr to go away, so the snapshot looks right.
     cy.get(".element-container")

--- a/e2e/specs/st_pyplot.spec.js
+++ b/e2e/specs/st_pyplot.spec.js
@@ -28,7 +28,7 @@ describe("st.pyplot", () => {
 
   it("clears the figure on rerun", () => {
     // Rerun the script
-    cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {
+    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
       keyCode: 82, // "r"
       which: 82 // "r"
     });
@@ -38,8 +38,7 @@ describe("st.pyplot", () => {
       .should("have.attr", "data-stale", "false")
       .invoke("css", "opacity", "1");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
 
     cy.get("[data-testid='stImage'] > img")
       .first()

--- a/e2e/specs/st_pyplot_kwargs.spec.js
+++ b/e2e/specs/st_pyplot_kwargs.spec.js
@@ -24,7 +24,6 @@ describe("st.pyplot with kwargs", () => {
       expect($els).to.have.length.of.at.least(1);
     });
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 });

--- a/e2e/specs/st_radio.spec.js
+++ b/e2e/specs/st_radio.spec.js
@@ -19,8 +19,7 @@ describe("st.radio", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -134,11 +134,7 @@ describe("st.select_slider", () => {
       .click()
       .type("{leftarrow}", { force: true });
 
-    // Rerun the script.
-    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
-      keyCode: 82, // "r"
-      which: 82 // "r"
-    });
+    cy.rerunScript();
 
     cy.getIndexed(".stMarkdown", 0).should(
       "have.text",

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -135,7 +135,7 @@ describe("st.select_slider", () => {
       .type("{leftarrow}", { force: true });
 
     // Rerun the script.
-    cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {
+    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
       keyCode: 82, // "r"
       which: 82 // "r"
     });

--- a/e2e/specs/st_selectbox.spec.js
+++ b/e2e/specs/st_selectbox.spec.js
@@ -19,8 +19,7 @@ describe("st.selectbox", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_session_state.spec.js
+++ b/e2e/specs/st_session_state.spec.js
@@ -19,8 +19,7 @@ describe("st.session_state", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("has correct starting values", () => {

--- a/e2e/specs/st_sidebar.spec.js
+++ b/e2e/specs/st_sidebar.spec.js
@@ -19,8 +19,7 @@ describe("st.sidebar", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("handles z-index of date input popover", () => {

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -101,11 +101,7 @@ describe("st.slider", () => {
       .click()
       .type("{leftarrow}", { force: true });
 
-    // Rerun the script.
-    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
-      keyCode: 82, // "r"
-      which: 82 // "r"
-    });
+    cy.rerunScript();
 
     cy.getIndexed(".stMarkdown", 2).should("have.text", "Value 1: 24");
   });

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -18,12 +18,11 @@
 describe("st.slider", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
+
+    cy.prepForElementSnapshots();
   });
 
   it("looks right", () => {
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
-
     cy.getIndexed(".stSlider", 2).matchThemedSnapshots("slider");
   });
 
@@ -73,9 +72,6 @@ describe("st.slider", () => {
   });
 
   it("handles value changes", () => {
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
-
     // trigger click in the center of the slider
     cy.getIndexed('.stSlider [role="slider"]', 2)
       .parent()
@@ -106,7 +102,7 @@ describe("st.slider", () => {
       .type("{leftarrow}", { force: true });
 
     // Rerun the script.
-    cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {
+    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
       keyCode: 82, // "r"
       which: 82 // "r"
     });

--- a/e2e/specs/st_text_area.spec.js
+++ b/e2e/specs/st_text_area.spec.js
@@ -19,8 +19,7 @@ describe("st.text_area", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e/specs/st_text_input.spec.js
+++ b/e2e/specs/st_text_input.spec.js
@@ -19,8 +19,7 @@ describe("st.text_input", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("shows widget correctly", () => {

--- a/e2e_flaky/specs/st_empty.spec.ts
+++ b/e2e_flaky/specs/st_empty.spec.ts
@@ -21,8 +21,7 @@ describe("st.empty", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("matches the snapshot", () => {

--- a/e2e_flaky/specs/st_graphviz_chart.spec.ts
+++ b/e2e_flaky/specs/st_graphviz_chart.spec.ts
@@ -21,8 +21,7 @@ describe("st.graphviz_chart", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   beforeEach(() => {

--- a/e2e_flaky/specs/st_legacy_add_rows.spec.ts
+++ b/e2e_flaky/specs/st_legacy_add_rows.spec.ts
@@ -27,7 +27,7 @@ describe("st._legacy_add_rows", () => {
     cy.loadApp("http://localhost:3000/");
 
     // Rerun the script because we want to test that JS-side coalescing works.
-    cy.get(".stApp [data-testid='stDecoration']").trigger("keypress", {
+    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
       keyCode: 82, // "r"
       which: 82 // "r"
     });
@@ -37,8 +37,7 @@ describe("st._legacy_add_rows", () => {
       .should("have.attr", "data-stale", "false")
       .invoke("css", "opacity", "1");
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   beforeEach(() => {

--- a/e2e_flaky/specs/st_legacy_add_rows.spec.ts
+++ b/e2e_flaky/specs/st_legacy_add_rows.spec.ts
@@ -26,11 +26,7 @@ describe("st._legacy_add_rows", () => {
 
     cy.loadApp("http://localhost:3000/");
 
-    // Rerun the script because we want to test that JS-side coalescing works.
-    cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
-      keyCode: 82, // "r"
-      which: 82 // "r"
-    });
+    cy.rerunScript();
 
     // Wait for 'data-stale' attr to go away, so the snapshot looks right.
     cy.get(".element-container")

--- a/e2e_flaky/specs/st_pyplot_kwargs.spec.ts
+++ b/e2e_flaky/specs/st_pyplot_kwargs.spec.ts
@@ -26,8 +26,7 @@ describe("st.pyplot with kwargs", () => {
       expect($els).to.have.length.of.at.least(1);
     });
 
-    // Make the ribbon decoration line disappear
-    cy.get("[data-testid='stDecoration']").invoke("css", "display", "none");
+    cy.prepForElementSnapshots();
   });
 
   it("draws long text strings correctly", () => {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -154,3 +154,12 @@ Cypress.Commands.add("prepForElementSnapshots", () => {
   // caught when a snapshot is taken.
   cy.get("[data-testid='stDecoration']").invoke("css", "display", "none")
 })
+
+// Rerun the script by simulating the user pressing the 'r' key.
+Cypress.Commands.add("rerunScript", () => {
+  cy.get(".stApp [data-testid='stHeader']").trigger("keypress", {
+    keyCode: 82, // "r"
+    which: 82, // "r"
+    force: true,
+  })
+})

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -145,3 +145,12 @@ Cypress.Commands.add("getIndexed", (selector, index) =>
     .should("have.length.at.least", index + 1)
     .eq(index)
 )
+
+// The header at the top of the page can sometimes interfere when we are
+// attempting to take snapshots. This command removes the problematic parts to
+// avoid this issue.
+Cypress.Commands.add("prepForElementSnapshots", () => {
+  // Make the ribbon decoration line disappear as it can occasionally get
+  // caught when a snapshot is taken.
+  cy.get("[data-testid='stDecoration']").invoke("css", "display", "none")
+})

--- a/frontend/src/components/core/Header/Header.tsx
+++ b/frontend/src/components/core/Header/Header.tsx
@@ -38,6 +38,7 @@ function Header({ isStale, children }: HeaderProps): ReactElement {
       // The tabindex below is required for testing.
       tabIndex={-1}
       isStale={isStale}
+      data-testid="stHeader"
     >
       <StyledHeaderDecoration data-testid="stDecoration" />
       <StyledHeaderToolbar data-testid="stToolbar">


### PR DESCRIPTION
## 📚 Context

In https://github.com/streamlit/streamlit/pull/4496, we saw a bunch of seemingly unrelated snapshot tests fail. It turns out the cause of
the test failures was that the gradient being added to the bottom of the header was being picked
up when taking snapshots of larger elements.

We've seen something similar happen before with the ribbon decorator occasionally appearing
in snapshots, so a reasonable solution is to factor out the code removing the ribbon decorator
into a new `cy.prepForElementSnapshots` command that will also be used to remove the gradient
and blur at the bottom of the header so that none of these things interfere with taking snapshots.
We'll handle actually removing the gradient/blur in #4496.

- What kind of change does this PR introduce?

  - [x] Refactoring

## 🧠 Description of Changes

- Add a new `cy.prepForElementSnapshots` command
- Use this command throughout our e2e tests
- Also add a new `cy.rerunScript` command to remove some duplication

## 🧪 Testing Done

- [x] Added/Updated e2e tests

## 🌐 References

Prerequisite for finishing https://github.com/streamlit/streamlit/pull/4496