### PR TITLE
Clear the screen when switching between pages of an app

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -810,6 +810,7 @@ describe("App.sendRerunBackMsg", () => {
     const instance = wrapper.instance() as App
     instance.sendBackMsg = jest.fn()
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
+    instance.clearAppState = jest.fn()
 
     // Set the value of document.location.pathname to '/foo/bar/page1'
     window.history.pushState({}, "", "/foo/bar/page1")
@@ -819,6 +820,7 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
+    expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
   it("switches pages correctly when sendRerunbackMsg is given a pageName", () => {
@@ -826,6 +828,7 @@ describe("App.sendRerunBackMsg", () => {
     const instance = wrapper.instance() as App
     instance.sendBackMsg = jest.fn()
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+    instance.clearAppState = jest.fn()
 
     instance.sendRerunBackMsg(undefined, "page1")
 
@@ -833,6 +836,7 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
+    expect(instance.clearAppState).toHaveBeenCalled()
   })
 
   it("also switches pages correctly when a baseUrlPath is set", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1000,6 +1000,9 @@ export class App extends PureComponent<Props, State> {
         .replace(`/${basePath}`, "")
         .replace(new RegExp("^/?"), "")
     } else {
+      const { appHash, scriptRunId, scriptName } = this.state
+      this.clearAppState(appHash, scriptRunId, scriptName)
+
       const qs = queryString ? `?${queryString}` : ""
       const basePathPrefix = basePath ? `/${basePath}` : ""
 


### PR DESCRIPTION
## 📚 Context

When a script run takes a long time to complete, we currently fade out elements
from the previous script run instead of removing them entirely as doing so normally
provides a less jumpy user experience (more often than not, we'll redraw updated
versions of the same elements to the screen once a long-running computation
completes).

This is behavior that we do *not* want when switching between pages since it's unlikely
that we'll redraw updated versions of the same elements when navigating between
pages.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Clear all elements in the app when switching between pages

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/449
