### PR TITLE
Support new keyword-only `expanded` flag in `st.json`

### DIFF
--- a/e2e/scripts/st_json.py
+++ b/e2e/scripts/st_json.py
@@ -16,4 +16,4 @@ import streamlit as st
 
 data = {"foo": "bar"}
 st.json(data)
-st.json(data, collapsed=True)
+st.json(data, expanded=False)

--- a/e2e/scripts/st_json.py
+++ b/e2e/scripts/st_json.py
@@ -16,3 +16,4 @@ import streamlit as st
 
 data = {"foo": "bar"}
 st.json(data)
+st.json(data, collapsed=True)

--- a/e2e/specs/st_json.spec.js
+++ b/e2e/specs/st_json.spec.js
@@ -20,9 +20,13 @@ describe("st.json", () => {
     cy.loadApp("http://localhost:3000/");
   });
 
-  it("displays a json", () => {
-    cy.get("[data-testid='stJson']")
+  it("displays expanded json", () => {
+    cy.getIndexed("[data-testid='stJson']", 0)
       .should("contain", "foo")
       .and("contain", "bar");
+  });
+
+  it("displays collapsed json", () => {
+    cy.getIndexed("[data-testid='stJson']", 1).should("contain", "...");
   });
 });

--- a/frontend/src/components/elements/Json/Json.tsx
+++ b/frontend/src/components/elements/Json/Json.tsx
@@ -61,6 +61,7 @@ export default function Json({ width, element }: JsonProps): ReactElement {
     <div data-testid="stJson" style={styleProp}>
       <ReactJson
         src={bodyObject}
+        collapsed={element.collapsed}
         displayDataTypes={false}
         displayObjectSize={false}
         name={false}

--- a/frontend/src/components/elements/Json/Json.tsx
+++ b/frontend/src/components/elements/Json/Json.tsx
@@ -61,7 +61,7 @@ export default function Json({ width, element }: JsonProps): ReactElement {
     <div data-testid="stJson" style={styleProp}>
       <ReactJson
         src={bodyObject}
-        collapsed={element.collapsed}
+        collapsed={!element.expanded}
         displayDataTypes={false}
         displayObjectSize={false}
         name={false}

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -36,6 +36,11 @@ class JsonMixin:
             serializable to JSON as well. If object is a string, we assume it
             contains serialized JSON.
 
+        collapsed : bool
+            An optional boolean that allows the user to set the initial state
+            of this json element to be collapsed. Defaults to False. This
+            argument can only be supplied by keyword.
+
         Example
         -------
         >>> st.json({

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -25,7 +25,7 @@ class JsonMixin:
         self,
         body,
         *,  # keyword-only arguments:
-        collapsed=False,
+        expanded=True,
     ):
         """Display object or string as a pretty-printed JSON string.
 
@@ -36,10 +36,10 @@ class JsonMixin:
             serializable to JSON as well. If object is a string, we assume it
             contains serialized JSON.
 
-        collapsed : bool
-            An optional boolean that allows the user to set the initial state
-            of this json element to be collapsed. Defaults to False. This
-            argument can only be supplied by keyword.
+        expanded : bool
+            An optional boolean that allows the user to set whether the initial
+            state of this json element should be expanded. Defaults to True.
+            This argument can only be supplied by keyword.
 
         Example
         -------
@@ -76,7 +76,7 @@ class JsonMixin:
 
         json_proto = JsonProto()
         json_proto.body = body
-        json_proto.collapsed = collapsed
+        json_proto.expanded = expanded
         return self.dg._enqueue("json", json_proto)
 
     @property

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -21,7 +21,12 @@ from streamlit.state import AutoSessionState
 
 
 class JsonMixin:
-    def json(self, body):
+    def json(
+        self,
+        body,
+        *,  # keyword-only arguments:
+        collapsed=False,
+    ):
         """Display object or string as a pretty-printed JSON string.
 
         Parameters
@@ -66,6 +71,7 @@ class JsonMixin:
 
         json_proto = JsonProto()
         json_proto.body = body
+        json_proto.collapsed = collapsed
         return self.dg._enqueue("json", json_proto)
 
     @property

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -377,6 +377,7 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
 
         element = self.get_delta_from_queue().new_element
         self.assertEqual(json_string, element.json.body)
+        self.assertEqual(False, element.json.collapsed)
 
     def test_json_string(self):
         """Test Text.JSON string."""
@@ -399,6 +400,19 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
 
         # validate a substring since repr for a module may contain an installation-specific path
         self.assertTrue(element.json.body.startswith("\"<module 'json'"))
+
+    def test_json_collapsed_arg(self):
+        """Test st.json collapsed arg."""
+        json_data = {"key": "value"}
+
+        # Testing python object
+        st.json(json_data, collapsed=True)
+
+        json_string = json.dumps(json_data)
+
+        element = self.get_delta_from_queue().new_element
+        self.assertEqual(json_string, element.json.body)
+        self.assertEqual(True, element.json.collapsed)
 
     def test_markdown(self):
         """Test Markdown element."""

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -377,7 +377,7 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
 
         element = self.get_delta_from_queue().new_element
         self.assertEqual(json_string, element.json.body)
-        self.assertEqual(False, element.json.collapsed)
+        self.assertEqual(True, element.json.expanded)
 
     def test_json_string(self):
         """Test Text.JSON string."""
@@ -401,18 +401,18 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
         # validate a substring since repr for a module may contain an installation-specific path
         self.assertTrue(element.json.body.startswith("\"<module 'json'"))
 
-    def test_json_collapsed_arg(self):
-        """Test st.json collapsed arg."""
+    def test_json_not_expanded_arg(self):
+        """Test st.json expanded arg."""
         json_data = {"key": "value"}
 
         # Testing python object
-        st.json(json_data, collapsed=True)
+        st.json(json_data, expanded=False)
 
         json_string = json.dumps(json_data)
 
         element = self.get_delta_from_queue().new_element
         self.assertEqual(json_string, element.json.body)
-        self.assertEqual(True, element.json.collapsed)
+        self.assertEqual(False, element.json.expanded)
 
     def test_markdown(self):
         """Test Markdown element."""

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -19,4 +19,6 @@ syntax = "proto3";
 message Json {
   // Content to display.
   string body = 1;
+
+  bool collapsed = 2;
 }

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -20,5 +20,5 @@ message Json {
   // Content to display.
   string body = 1;
 
-  bool collapsed = 2;
+  bool expanded = 2;
 }


### PR DESCRIPTION
## 📚 Context

This PR adds a new `expanded` keyword-only flag to `st.json` that allows a
developer to specify whether the rendered `st.json` element should be expanded
by default. The default value for the flag is `True` so that `st.json` with the flag
unspecified behaves as it does today.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
- [x] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #3807
