### PR TITLE
Set st.number_input initial value correctly for both ints and doubles

### DIFF
--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -206,6 +206,14 @@ describe("NumberInput widget", () => {
       expect(props.widgetMgr.setDoubleValue).toHaveBeenCalled()
       expect(wrapper.state("dirty")).toBe(false)
     })
+
+    it("sets initialValue from widgetMgr", () => {
+      const props = getFloatProps({ default: 10.0 })
+      props.widgetMgr.getDoubleValue = jest.fn(() => 15.0)
+
+      const wrapper = shallow(<NumberInput {...props} />)
+      expect(wrapper.state().value).toBe(15.0)
+    })
   })
 
   describe("IntData", () => {
@@ -266,6 +274,14 @@ describe("NumberInput widget", () => {
 
       expect(props.widgetMgr.setIntValue).toHaveBeenCalled()
       expect(wrapper.state("dirty")).toBe(false)
+    })
+
+    it("sets initialValue from widgetMgr", () => {
+      const props = getIntProps({ default: 10 })
+      props.widgetMgr.getIntValue = jest.fn(() => 15)
+
+      const wrapper = shallow(<NumberInput {...props} />)
+      expect(wrapper.state().value).toBe(15)
     })
   })
 

--- a/frontend/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.tsx
@@ -82,7 +82,10 @@ class NumberInput extends React.PureComponent<Props, State> {
   get initialValue(): number {
     // If WidgetStateManager knew a value for this widget, initialize to that.
     // Otherwise, use the default value from the widget protobuf
-    const storedValue = this.props.widgetMgr.getIntValue(this.props.element)
+    const storedValue = this.isIntData()
+      ? this.props.widgetMgr.getIntValue(this.props.element)
+      : this.props.widgetMgr.getDoubleValue(this.props.element)
+
     return storedValue !== undefined ? storedValue : this.props.element.default
   }
 


### PR DESCRIPTION
## 📚 Context

Currently, if you put an `st.number_input` widget in an expander, it correctly
retains its state when the expander is closed and reopened if the type of the
`st.number_input` value is `int`, but it breaks for type `float`.

The reason this happens is because we simply don't handle initialization correctly
in the `float` case, so the fix ended up being a one-liner.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Set number_input initial value correctly for both ints and floats

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes #2378
