### PR TITLE
Set widget proto disabled attr *after* registering widget

### DIFF
--- a/e2e/scripts/st_download_button.py
+++ b/e2e/scripts/st_download_button.py
@@ -21,7 +21,11 @@ st.download_button(
 )
 
 st.download_button(
-    "Download button label", data="Hello world!", file_name="hello.txt", disabled=True
+    "Download button label",
+    data="Hello world!",
+    file_name="hello.txt",
+    key="disabled_dl_button",
+    disabled=True,
 )
 
 st.download_button(

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -261,7 +261,6 @@ class ButtonMixin:
 
         download_button_proto.label = label
         download_button_proto.default = False
-        download_button_proto.disabled = disabled
         marshall_file(
             self.dg._get_delta_path_str(), data, download_button_proto, mime, file_name
         )
@@ -283,6 +282,11 @@ class ButtonMixin:
             serializer=bool,
             ctx=ctx,
         )
+
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        download_button_proto.disabled = disabled
+
         self.dg._enqueue("download_button", download_button_proto)
         return cast(bool, current_value)
 
@@ -323,7 +327,6 @@ class ButtonMixin:
         button_proto.default = False
         button_proto.is_form_submitter = is_form_submitter
         button_proto.form_id = current_form_id(self.dg)
-        button_proto.disabled = disabled
         if help is not None:
             button_proto.help = dedent(help)
 
@@ -341,6 +344,11 @@ class ButtonMixin:
             serializer=bool,
             ctx=ctx,
         )
+
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        button_proto.disabled = disabled
+
         self.dg._enqueue("button", button_proto)
         return cast(bool, current_value)
 

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -132,7 +132,6 @@ class CameraInputMixin:
         camera_input_proto = CameraInputProto()
         camera_input_proto.label = label
         camera_input_proto.form_id = current_form_id(self.dg)
-        camera_input_proto.disabled = disabled
 
         if help is not None:
             camera_input_proto.help = dedent(help)
@@ -183,6 +182,10 @@ class CameraInputMixin:
             serializer=serialize_camera_image_input,
             ctx=ctx,
         )
+
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        camera_input_proto.disabled = disabled
 
         ctx = get_script_run_ctx()
         camera_image_input_state = serialize_camera_image_input(widget_value)

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -121,7 +121,6 @@ class CheckboxMixin:
         checkbox_proto.label = label
         checkbox_proto.default = bool(value)
         checkbox_proto.form_id = current_form_id(self.dg)
-        checkbox_proto.disabled = disabled
         if help is not None:
             checkbox_proto.help = dedent(help)
 
@@ -140,6 +139,9 @@ class CheckboxMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        checkbox_proto.disabled = disabled
         if set_frontend_value:
             checkbox_proto.value = current_value
             checkbox_proto.set_value = True

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -147,7 +147,6 @@ class ColorPickerMixin:
         color_picker_proto.label = label
         color_picker_proto.default = str(value)
         color_picker_proto.form_id = current_form_id(self.dg)
-        color_picker_proto.disabled = disabled
         if help is not None:
             color_picker_proto.help = dedent(help)
 
@@ -168,6 +167,9 @@ class ColorPickerMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        color_picker_proto.disabled = disabled
         if set_frontend_value:
             color_picker_proto.value = current_value
             color_picker_proto.set_value = True

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -291,7 +291,6 @@ class FileUploaderMixin:
         )
         file_uploader_proto.multiple_files = accept_multiple_files
         file_uploader_proto.form_id = current_form_id(self.dg)
-        file_uploader_proto.disabled = disabled
         if help is not None:
             file_uploader_proto.help = dedent(help)
 
@@ -347,6 +346,10 @@ class FileUploaderMixin:
             serializer=serialize_file_uploader,
             ctx=ctx,
         )
+
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        file_uploader_proto.disabled = disabled
 
         file_uploader_state = serialize_file_uploader(widget_value)
         uploaded_file_info = file_uploader_state.uploaded_file_info

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -176,7 +176,6 @@ class MultiSelectMixin:
         multiselect_proto.default[:] = default_value
         multiselect_proto.options[:] = [str(format_func(option)) for option in opt]
         multiselect_proto.form_id = current_form_id(self.dg)
-        multiselect_proto.disabled = disabled
         if help is not None:
             multiselect_proto.help = dedent(help)
 
@@ -201,6 +200,9 @@ class MultiSelectMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        multiselect_proto.disabled = disabled
         if set_frontend_value:
             multiselect_proto.value[:] = _check_and_convert_to_indices(
                 opt, current_value

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -258,7 +258,6 @@ class NumberInputMixin:
         number_input_proto.label = label
         number_input_proto.default = value
         number_input_proto.form_id = current_form_id(self.dg)
-        number_input_proto.disabled = disabled
         if help is not None:
             number_input_proto.help = dedent(help)
 
@@ -291,6 +290,9 @@ class NumberInputMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        number_input_proto.disabled = disabled
         if set_frontend_value:
             number_input_proto.value = current_value
             number_input_proto.set_value = True

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -152,7 +152,6 @@ class RadioMixin:
         radio_proto.default = index
         radio_proto.options[:] = [str(format_func(option)) for option in opt]
         radio_proto.form_id = current_form_id(self.dg)
-        radio_proto.disabled = disabled
         if help is not None:
             radio_proto.help = dedent(help)
 
@@ -178,6 +177,9 @@ class RadioMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        radio_proto.disabled = disabled
         if set_frontend_value:
             radio_proto.value = serialize_radio(current_value)
             radio_proto.set_value = True

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -189,7 +189,6 @@ class SelectSliderMixin:
         slider_proto.data_type = SliderProto.INT
         slider_proto.options[:] = [str(format_func(option)) for option in opt]
         slider_proto.form_id = current_form_id(self.dg)
-        slider_proto.disabled = disabled
         if help is not None:
             slider_proto.help = dedent(help)
 
@@ -219,6 +218,9 @@ class SelectSliderMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        slider_proto.disabled = disabled
         if set_frontend_value:
             slider_proto.value[:] = serialize_select_slider(current_value)
             slider_proto.set_value = True

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -146,7 +146,6 @@ class SelectboxMixin:
         selectbox_proto.default = index
         selectbox_proto.options[:] = [str(format_func(option)) for option in opt]
         selectbox_proto.form_id = current_form_id(self.dg)
-        selectbox_proto.disabled = disabled
         if help is not None:
             selectbox_proto.help = dedent(help)
 
@@ -172,6 +171,9 @@ class SelectboxMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        selectbox_proto.disabled = disabled
         if set_frontend_value:
             selectbox_proto.value = serialize_select_box(current_value)
             selectbox_proto.set_value = True

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -445,7 +445,6 @@ class SliderMixin:
         slider_proto.data_type = data_type
         slider_proto.options[:] = []
         slider_proto.form_id = current_form_id(self.dg)
-        slider_proto.disabled = disabled
         if help is not None:
             slider_proto.help = dedent(help)
 
@@ -493,6 +492,9 @@ class SliderMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        slider_proto.disabled = disabled
         if set_frontend_value:
             slider_proto.value[:] = serialize_slider(current_value)
             slider_proto.set_value = True

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -146,7 +146,6 @@ class TextWidgetsMixin:
         text_input_proto.label = label
         text_input_proto.default = str(value)
         text_input_proto.form_id = current_form_id(self.dg)
-        text_input_proto.disabled = disabled
 
         if help is not None:
             text_input_proto.help = dedent(help)
@@ -188,6 +187,9 @@ class TextWidgetsMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        text_input_proto.disabled = disabled
         if set_frontend_value:
             text_input_proto.value = current_value
             text_input_proto.set_value = True
@@ -301,7 +303,6 @@ class TextWidgetsMixin:
         text_area_proto.label = label
         text_area_proto.default = str(value)
         text_area_proto.form_id = current_form_id(self.dg)
-        text_area_proto.disabled = disabled
 
         if help is not None:
             text_area_proto.help = dedent(help)
@@ -330,6 +331,9 @@ class TextWidgetsMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        text_area_proto.disabled = disabled
         if set_frontend_value:
             text_area_proto.value = current_value
             text_area_proto.set_value = True

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -136,7 +136,6 @@ class TimeWidgetsMixin:
         time_input_proto.label = label
         time_input_proto.default = time.strftime(value, "%H:%M")
         time_input_proto.form_id = current_form_id(self.dg)
-        time_input_proto.disabled = disabled
         if help is not None:
             time_input_proto.help = dedent(help)
 
@@ -164,6 +163,9 @@ class TimeWidgetsMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        time_input_proto.disabled = disabled
         if set_frontend_value:
             time_input_proto.value = serialize_time_input(current_value)
             time_input_proto.set_value = True
@@ -324,7 +326,6 @@ class TimeWidgetsMixin:
         date_input_proto.max = date.strftime(max_value, "%Y/%m/%d")
 
         date_input_proto.form_id = current_form_id(self.dg)
-        date_input_proto.disabled = disabled
 
         def deserialize_date_input(ui_value, widget_id=""):
             if ui_value is not None:
@@ -353,6 +354,9 @@ class TimeWidgetsMixin:
             ctx=ctx,
         )
 
+        # This needs to be done after register_widget because we don't want
+        # the following proto fields to affect a widget's ID.
+        date_input_proto.disabled = disabled
         if set_frontend_value:
             date_input_proto.value[:] = serialize_date_input(current_value)
             date_input_proto.set_value = True


### PR DESCRIPTION
## 📚 Context

For the vast majority of widget arguments, we want changing the argument to
reset the widget. This is because changing the arguments to a widget function
most likely changes the set of values a widget can have, so resetting the
widget's value back to its default tends to be intuitive behavior.

The `disabled` arg is special because it's unlikely that a user will want
changing the value of the argument to also reset the widget. This was the case
when the feature was originally released as we did not consider the implication
of the `disabled` arg's value changing on a widget's ID. We fix this issue in
this PR by setting the `disabled` proto field _after_ calling `register_widget`,
which is where a widget's ID gets computed.

There were other ways of fixing this bug that we considered, such as making the
`_get_widget_id` function aware of which widget arguments we don't want affecting
a widget's ID. We chose the approach in this PR because the `value` and `set_value`
proto fields are already intentionally set after `register_widget` for the same
reason that `disabled` is being moved there, so there's already some precedent
for doing things this way.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Move setting `<widget_proto>.disabled` to after the call to `register_widget`
- Add an explanatory comment above setting proto fields that shouldn't affect a
  widget's ID

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes #4318
