### PR TITLE
Fix the build

### DIFF
--- a/scripts/mypy
+++ b/scripts/mypy
@@ -102,7 +102,7 @@ def main(report: bool = False) -> None:
         else:
             paths.append(path)
 
-    args = ["--config-file=lib/mypy.ini"]
+    args = ["--config-file=lib/mypy.ini", "--namespace-packages"]
     if report:
         tempdir = tempfile.TemporaryDirectory()
         args.append("--lineprecision-report=%s" % tempdir.name)


### PR DESCRIPTION
## 📚 Context

It seems like our nightly build CI failures were caused by an accidental breaking change in
`types-protobuf` (see https://github.com/python/typeshed/issues/7519). The breaking change has already been
reverted, but builds will continue to fail due to our CI dependency cache, and I'm not sure if the
cache key will be updated so that this works again by the time the nightly build job runs. 

This PR fixes the issue by running `mypy` with the `--namespace-packages` flag, which
seems like a reasonable solution because this will apparently be made default behavior in
the near future, anyway.

Alternatively, we could bust the dependency cache to pick up the newest version of
`types-protobuf` that has the breaking changes reverted, but doing this would be annoying
as the only way to do this in CircleCI is to [make a change to the cache key](https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-dependency-cache), which feels
not ideal since the build failures will already resolve themself after some time passes

- What kind of change does this PR introduce?

  - [x] Other, please describe: unbreak CI

## 🧠 Description of Changes

- Run mypy with the `--namespace-packages` flag, which will apparently be default behavior soon
