### PR TITLE
Don't send rerun notifications if a page we're not viewing is changed

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -252,8 +252,33 @@ class AppSession:
     def session_state(self) -> "SessionState":
         return self._session_state
 
-    def _on_source_file_changed(self) -> None:
+    def _should_rerun_on_file_change(self, filepath: str) -> bool:
+        main_script_path = self._session_data.main_script_path
+
+        page_for_file = next(
+            filter(
+                lambda p: p["script_path"] == filepath,
+                source_util.get_pages(main_script_path),
+            ),
+            None,
+        )
+
+        if page_for_file:
+            is_main_page = page_for_file["script_path"] == main_script_path
+            changed_page_name = page_for_file["page_name"]
+            current_page_name = self._client_state.page_name
+
+            return (is_main_page and current_page_name == "") or (
+                current_page_name == changed_page_name
+            )
+
+        return True
+
+    def _on_source_file_changed(self, filepath: Optional[str] = None) -> None:
         """One of our source files changed. Schedule a rerun if appropriate."""
+        if filepath is not None and not self._should_rerun_on_file_change(filepath):
+            return
+
         if self._run_on_save:
             self.request_rerun(self._client_state)
         else:

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -42,7 +42,7 @@ FileWatcher = None
 class LocalSourcesWatcher:
     def __init__(self, session_data: SessionData):
         self._session_data = session_data
-        self._on_file_changed: List[Callable[[], None]] = []
+        self._on_file_changed: List[Callable[[str], None]] = []
         self._is_closed = False
 
         # Blacklist for folders that should not be watched
@@ -58,7 +58,7 @@ class LocalSourcesWatcher:
                 module_name=None,  # Only root scripts have their modules set to None
             )
 
-    def register_file_change_callback(self, cb: Callable[[], None]) -> None:
+    def register_file_change_callback(self, cb: Callable[[str], None]) -> None:
         self._on_file_changed.append(cb)
 
     def on_file_changed(self, filepath):
@@ -83,7 +83,7 @@ class LocalSourcesWatcher:
                 del sys.modules[wm.module_name]
 
         for cb in self._on_file_changed:
-            cb()
+            cb(filepath)
 
     def close(self):
         for wm in self._watched_modules.values():

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -47,7 +47,7 @@ def _create_test_session() -> AppSession:
     """Create an AppSession instance with some default mocked data."""
     return AppSession(
         ioloop=MagicMock(),
-        session_data=SessionData("/fake/script_path", "fake_command_line"),
+        session_data=SessionData("/fake/script_path.py", "fake_command_line"),
         uploaded_file_manager=MagicMock(),
         message_enqueued_callback=lambda: None,
         local_sources_watcher=MagicMock(),
@@ -119,6 +119,18 @@ class AppSessionTest(unittest.TestCase):
         session._on_source_file_changed()
 
         session.request_rerun.assert_called_once_with(session._client_state)
+
+    @patch(
+        "streamlit.app_session.AppSession._should_rerun_on_file_change",
+        MagicMock(return_value=False),
+    )
+    def test_does_not_rerun_if_not_current_page(self):
+        session = _create_test_session()
+        session._run_on_save = True
+        session.request_rerun = MagicMock()
+        session._on_source_file_changed("/fake/script_path.py")
+
+        self.assertEqual(session.request_rerun.called, False)
 
 
 def _mock_get_options_for_section(overrides=None) -> Callable[..., Any]:
@@ -434,10 +446,53 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
             " Allowed values include ['sans serif', 'serif', 'monospace']. Setting theme.font to \"sans serif\"."
         )
 
-    def test_passes_client_state_on_run_on_save(self):
-        session = _create_test_session()
-        session._run_on_save = True
-        session.request_rerun = MagicMock()
-        session._on_source_file_changed()
 
-        session.request_rerun.assert_called_once_with(session._client_state)
+@patch(
+    "streamlit.app_session.source_util.get_pages",
+    MagicMock(
+        return_value=[
+            {"page_name": "script_path", "script_path": "/fake/script_path.py"},
+            {"page_name": "page2", "script_path": "/fake/pages/page2.py"},
+        ]
+    ),
+)
+class ShouldRerunOnFileChangeTest(unittest.TestCase):
+    def test_true_if_main_page_and_empty_page_name(self):
+        session = _create_test_session()
+        session._client_state.page_name = ""
+
+        self.assertEqual(
+            session._should_rerun_on_file_change("/fake/script_path.py"), True
+        )
+
+    def test_true_if_main_page_changed_and_on_main_page(self):
+        session = _create_test_session()
+        session._client_state.page_name = "script_path"
+
+        self.assertEqual(
+            session._should_rerun_on_file_change("/fake/script_path.py"), True
+        )
+
+    def test_true_if_changed_page_is_current_page(self):
+        session = _create_test_session()
+        session._client_state.page_name = "page2"
+
+        self.assertEqual(
+            session._should_rerun_on_file_change("/fake/pages/page2.py"), True
+        )
+
+    def test_true_if_file_is_not_page(self):
+        session = _create_test_session()
+        session._client_state.page_name = "script_path"
+
+        self.assertEqual(
+            session._should_rerun_on_file_change("/fake/some_other_file.py"), True
+        )
+
+    def test_false_if_page_but_not_current_page(self):
+        session = _create_test_session()
+        session._client_state.page_name = "script_path"
+
+        self.assertEqual(
+            session._should_rerun_on_file_change("/fake/pages/page2.py"), False
+        )

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -39,7 +39,7 @@ DUMMY_MODULE_2_FILE = os.path.abspath(DUMMY_MODULE_2.__file__)
 NESTED_MODULE_CHILD_FILE = os.path.abspath(NESTED_MODULE_CHILD.__file__)
 
 
-def NOOP_CALLBACK():
+def NOOP_CALLBACK(_filepath):
     pass
 
 
@@ -309,6 +309,23 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         assert args1[0] == "streamlit_app.py"
         assert args2[0] == "streamlit_app2.py"
+
+    @patch("streamlit.watcher.local_sources_watcher.FileWatcher")
+    def test_passes_filepath_to_callback(self, fob, _):
+        saved_filepath = None
+
+        def callback(filepath):
+            nonlocal saved_filepath
+
+            saved_filepath = filepath
+
+        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso.register_file_change_callback(callback)
+
+        # Simulate a change to the report script
+        lso.on_file_changed(REPORT_PATH)
+
+        self.assertEqual(saved_filepath, REPORT_PATH)
 
 
 def test_get_module_paths_outputs_abs_paths():


### PR DESCRIPTION
## 📚 Context

In the multipage apps world, it can be a bit weird if you get a "source file changed" notification
when you're viewing `pageA` but editing `pageB`. This PR (mostly) handles this case by only sending
these notifications (or auto-rerunning) if the edited page is the page currently being viewed. Note that
we don't solve this "perfectly" by building the full dependency graph and avoiding notifications
and reruns if the edited file doesn't affect the currently viewed page. Doing so would be a bit nicer
but doesn't seem to be worth the implementation effort (for now, we may decide to do this later).
Instead, we accept some false positives and send a notification or do an auto-rerun if any page's
dependencies change.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add an optional `filename` parameter to `AppSession`'s `_on_source_file_changed` method
- Do not send notifications / auto-rerun if the page being changed isn't the one being viewed

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/357
