### PR TITLE
Add object notation example to `st.expander` docstring

### DIFF
--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -194,9 +194,9 @@ class LayoutsMixin:
 
         Examples
         --------
-        
+
         You can use `with` notation to insert any element into an expander
-        
+
         >>> st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
         >>>
         >>> with st.expander("See explanation"):
@@ -210,9 +210,9 @@ class LayoutsMixin:
         .. output ::
             https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
             height: 750px
-        
+
         Or you can just call methods directly in the returned objects:
-        
+
         >>> st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
         >>>
         >>> expander = st.expander("See explanation")
@@ -222,7 +222,7 @@ class LayoutsMixin:
         ...     be random.
         ... \"\"\")
         >>> expander.image("https://static.streamlit.io/examples/dice.jpg")
-        
+
         .. output ::
             https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
             height: 750px

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -194,7 +194,10 @@ class LayoutsMixin:
 
         Examples
         --------
-        >>> st.line_chart({"data": [1, 5, 2, 6, 2, 1]})
+        
+        You can use `with` notation to insert any element into an expander
+        
+        >>> st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
         >>>
         >>> with st.expander("See explanation"):
         ...     st.write(\"\"\"
@@ -204,6 +207,22 @@ class LayoutsMixin:
         ...     \"\"\")
         ...     st.image("https://static.streamlit.io/examples/dice.jpg")
 
+        .. output ::
+            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
+            height: 750px
+        
+        Or you can just call methods directly in the returned objects:
+        
+        >>> st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
+        >>>
+        >>> expander = st.expander("See explanation")
+        >>> expander.write(\"\"\"
+        ...     The chart above shows some numbers I picked for you.
+        ...     I rolled actual dice for these, so they're *guaranteed* to
+        ...     be random.
+        ... \"\"\")
+        >>> expander.image("https://static.streamlit.io/examples/dice.jpg")
+        
         .. output ::
             https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
             height: 750px


### PR DESCRIPTION
## 📚 Context

The documentation for `st.expander` and containers should talk about both methods of adding items to containers:
- Object notation: `st.expander("Expander").foo`
- `With` notation:
   ```python
   with st.expander("Expander"):
       st.foo
   ```

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- In the `st.expander` docstring, provides an example of using object notation to add elements to an expander.
- Uses `st.bar_chart` instead of line chart in example, to correspond to [example app](https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py)

  - [x] This is a visible (user-facing) change

**Revised:**

<details>
  <summary>Revised code</summary>

 ![image](https://user-images.githubusercontent.com/20672874/160350600-2dc209c5-4bd0-42e0-ab81-2de4b502c881.png)
</details>

**Current:**

<details>
  <summary>Current code</summary>

![image](https://user-images.githubusercontent.com/20672874/160350467-13250ef3-20f6-4cae-be02-630f5c171746.png)
</details>

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- https://github.com/streamlit/docs/pull/350

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
