### PR TITLE
ForwardMsgQueue: no longer thread-safe

### DIFF
--- a/lib/streamlit/forward_msg_queue.py
+++ b/lib/streamlit/forward_msg_queue.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-A queue of ForwardMsg associated with a particular session.
-Whenever possible, message deltas are combined.
-"""
-
 from typing import Optional, List, Dict, Any, Tuple
 
 from streamlit.logger import get_logger
@@ -28,6 +23,7 @@ LOGGER = get_logger(__name__)
 
 class ForwardMsgQueue:
     """Accumulates a session's outgoing ForwardMsgs.
+
     Each AppSession adds messages to its queue, and the Server periodically
     flushes all session queues and delivers their messages to the appropriate
     clients.

--- a/lib/streamlit/forward_msg_queue.py
+++ b/lib/streamlit/forward_msg_queue.py
@@ -17,31 +17,33 @@ A queue of ForwardMsg associated with a particular session.
 Whenever possible, message deltas are combined.
 """
 
-import threading
-from typing import Optional, List, Dict, Any, Tuple, Iterator
-import attr
-
-from streamlit.proto.Delta_pb2 import Delta
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from typing import Optional, List, Dict, Any, Tuple
 
 from streamlit.logger import get_logger
+from streamlit.proto.Delta_pb2 import Delta
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 LOGGER = get_logger(__name__)
 
 
-@attr.s(auto_attribs=True, slots=True)
 class ForwardMsgQueue:
-    """Thread-safe queue that smartly accumulates the session's messages."""
+    """Accumulates a session's outgoing ForwardMsgs.
+    Each AppSession adds messages to its queue, and the Server periodically
+    flushes all session queues and delivers their messages to the appropriate
+    clients.
 
-    _lock: threading.Lock = attr.Factory(threading.Lock)
-    _queue: List[ForwardMsg] = attr.Factory(list)
+    ForwardMsgQueue is not thread-safe - a queue should only be used from
+    a single thread.
+    """
 
-    # A mapping of (delta_path -> _queue.indexof(msg)) for each
-    # Delta message in the queue. We use this for coalescing
-    # redundant outgoing Deltas (where a newer Delta supercedes
-    # an older Delta, with the same delta_path, that's still in the
-    # queue).
-    _delta_index_map: Dict[Tuple[int, ...], int] = attr.Factory(dict)
+    def __init__(self):
+        self._queue: List[ForwardMsg] = []
+        # A mapping of (delta_path -> _queue.indexof(msg)) for each
+        # Delta message in the queue. We use this for coalescing
+        # redundant outgoing Deltas (where a newer Delta supercedes
+        # an older Delta, with the same delta_path, that's still in the
+        # queue).
+        self._delta_index_map: Dict[Tuple[int, ...], int] = dict()
 
     def get_debug(self) -> Dict[str, Any]:
         from google.protobuf.json_format import MessageToDict
@@ -51,59 +53,47 @@ class ForwardMsgQueue:
             "ids": list(self._delta_index_map.keys()),
         }
 
-    def __iter__(self) -> Iterator[ForwardMsg]:
-        return iter(self._queue)
-
     def is_empty(self) -> bool:
         return len(self._queue) == 0
 
-    def get_initial_msg(self) -> Optional[ForwardMsg]:
-        if len(self._queue) > 0:
-            return self._queue[0]
-        return None
-
     def enqueue(self, msg: ForwardMsg) -> None:
         """Add message into queue, possibly composing it with another message."""
-        with self._lock:
-            if not _is_composable_message(msg):
-                self._queue.append(msg)
+        if not _is_composable_message(msg):
+            self._queue.append(msg)
+            return
+
+        # If there's a Delta message with the same delta_path already in
+        # the queue - meaning that it refers to the same location in
+        # the app - we attempt to combine this new Delta into the old
+        # one. This is an optimization that prevents redundant Deltas
+        # from being sent to the frontend.
+        delta_key = tuple(msg.metadata.delta_path)
+        if delta_key in self._delta_index_map:
+            index = self._delta_index_map[delta_key]
+            old_msg = self._queue[index]
+            composed_delta = _maybe_compose_deltas(old_msg.delta, msg.delta)
+            if composed_delta is not None:
+                new_msg = ForwardMsg()
+                new_msg.delta.CopyFrom(composed_delta)
+                new_msg.metadata.CopyFrom(msg.metadata)
+                self._queue[index] = new_msg
                 return
 
-            # If there's a Delta message with the same delta_path already in
-            # the queue - meaning that it refers to the same location in
-            # the app - we attempt to combine this new Delta into the old
-            # one. This is an optimization that prevents redundant Deltas
-            # from being sent to the frontend.
-            delta_key = tuple(msg.metadata.delta_path)
-            if delta_key in self._delta_index_map:
-                index = self._delta_index_map[delta_key]
-                old_msg = self._queue[index]
-                composed_delta = _maybe_compose_deltas(old_msg.delta, msg.delta)
-                if composed_delta is not None:
-                    new_msg = ForwardMsg()
-                    new_msg.delta.CopyFrom(composed_delta)
-                    new_msg.metadata.CopyFrom(msg.metadata)
-                    self._queue[index] = new_msg
-                    return
+        # No composition occured. Append this message to the queue, and
+        # store its index for potential future composition.
+        self._delta_index_map[delta_key] = len(self._queue)
+        self._queue.append(msg)
 
-            # No composition occured. Append this message to the queue, and
-            # store its index for potential future composition.
-            self._delta_index_map[delta_key] = len(self._queue)
-            self._queue.append(msg)
-
-    def _clear(self) -> None:
+    def clear(self) -> None:
+        """Clear the queue."""
         self._queue = []
         self._delta_index_map = dict()
 
-    def clear(self) -> None:
-        """Clear this queue."""
-        with self._lock:
-            self._clear()
-
     def flush(self) -> List[ForwardMsg]:
-        with self._lock:
-            queue = self._queue
-            self._clear()
+        """Clear the queue and return a list of the messages it contained
+        before being cleared."""
+        queue = self._queue
+        self.clear()
         return queue
 
 

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -119,7 +119,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
         ]
 
     def clear_queue(self) -> None:
-        self.forward_msg_queue._clear()
+        self.forward_msg_queue.clear()
 
 
 def normalize_md(txt: str) -> str:


### PR DESCRIPTION
ForwardMsgQueue is only written and read from the main thread, so there's no need for thread safety.