### PR TITLE
Add automatic table width adjustment

### DIFF
--- a/frontend/src/components/widgets/DataGrid/DataGrid.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.tsx
@@ -185,7 +185,8 @@ function DataGrid({
   const dataEditorRef = React.useRef<DataEditorRef>(null)
 
   useLayoutEffect(() => {
-    // Without this timeout, the canvas does not reflect the actual size sometimes
+    // Without this timeout,the width calculation might fail in a few cases. The timeout ensures
+    // that the execution of this function is placed after the component render in the event loop.
     setTimeout(() => {
       // TODO(lukasmasuch): Support use_container_width parameter
 
@@ -208,12 +209,7 @@ function DataGrid({
           // TODO(lukasmasuch): Also adjust the table height?
           // const fullTableHeight = lastCell.y - firstCell.y + lastCell.height + 2
 
-          if (fullTableWidth < propWidth) {
-            adjustedTableWidth = fullTableWidth
-          } else {
-            // Use the max container width
-            adjustedTableWidth = propWidth
-          }
+          adjustedTableWidth = Math.min(fullTableWidth, propWidth)
         }
       }
 

--- a/frontend/src/components/widgets/DataGrid/DataGrid.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.tsx
@@ -180,9 +180,45 @@ function DataGrid({
     onColumnResized,
   } = useDataLoader(element)
 
-  const [tableWidth, setTableWidth] = useState(propWidth)
+  const [width, setWidth] = useState(propWidth)
 
   const dataEditorRef = React.useRef<DataEditorRef>(null)
+
+  useLayoutEffect(() => {
+    // Without this timeout, the canvas does not refelct the actual size sometimes
+    setTimeout(() => {
+      // TODO(lukasmasuch): Support use_container_width parameter
+
+      let adjustedTableWidth = Math.min(
+        columns.length * MIN_COLUMN_WIDTH,
+        MIN_COLUMN_WIDTH
+      )
+
+      if (numRows) {
+        const firstCell = dataEditorRef.current?.getBounds(0, 0)
+        const lastCell = dataEditorRef.current?.getBounds(
+          columns.length - 1,
+          numRows - 1
+        )
+
+        if (firstCell && lastCell) {
+          const fullTableWidth = lastCell.x - firstCell.x + lastCell.width + 2
+
+          // TODO(lukasmasuch): Also adjust the table height?
+          // const fullTableHeight = lastCell.y - firstCell.y + lastCell.height + 2
+
+          if (fullTableWidth < propWidth) {
+            adjustedTableWidth = fullTableWidth
+          } else {
+            // Use the max container width
+            adjustedTableWidth = propWidth
+          }
+        }
+      }
+
+      setWidth(adjustedTableWidth)
+    }, 0)
+  })
 
   // Automatic table height calculation: numRows +1 because of header, and +3 pixels for borders
   const height = propHeight || Math.min((numRows + 1) * ROW_HEIGHT + 3, 400)
@@ -192,7 +228,7 @@ function DataGrid({
 
   return (
     <ThemedDataGridContainer
-      width={tableWidth}
+      width={width}
       height={height}
       minHeight={minHeight}
     >

--- a/frontend/src/components/widgets/DataGrid/DataGrid.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.tsx
@@ -202,6 +202,7 @@ function DataGrid({
         )
 
         if (firstCell && lastCell) {
+          // Calculate the table width, the +2 corresponds to the table borders
           const fullTableWidth = lastCell.x - firstCell.x + lastCell.width + 2
 
           // TODO(lukasmasuch): Also adjust the table height?

--- a/frontend/src/components/widgets/DataGrid/DataGrid.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.tsx
@@ -185,7 +185,7 @@ function DataGrid({
   const dataEditorRef = React.useRef<DataEditorRef>(null)
 
   useLayoutEffect(() => {
-    // Without this timeout, the canvas does not refelct the actual size sometimes
+    // Without this timeout, the canvas does not reflect the actual size sometimes
     setTimeout(() => {
       // TODO(lukasmasuch): Support use_container_width parameter
 

--- a/frontend/src/lib/Quiver.test.ts
+++ b/frontend/src/lib/Quiver.test.ts
@@ -162,11 +162,13 @@ describe("Quiver", () => {
       })
 
       it("throws an exception if row index is out of range", () => {
-        expect(() => q.getCell(5, 0)).toThrow("Row index is out of range.")
+        expect(() => q.getCell(5, 0)).toThrow("Row index is out of range: 5")
       })
 
       it("throws an exception if column index is out of range", () => {
-        expect(() => q.getCell(0, 5)).toThrow("Column index is out of range.")
+        expect(() => q.getCell(0, 5)).toThrow(
+          "Column index is out of range: 5"
+        )
       })
     })
 


### PR DESCRIPTION
## 📚 Context

Adds a layout effect to adjust the table width based on the total size of the table canvas, so that only the minimum required width is used. The size of columns is already automatically determined based on the column content. This behavior is similar to how it's handled with the current `st.dataframe`. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

This is tested by existing e2e canvas snapshot tests. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
