### PR TITLE
config.fastReruns + multiple ScriptRunners

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -244,13 +244,25 @@ class AppSession:
         else:
             rerun_data = RerunData()
 
-        if self._scriptrunner is None or not self._scriptrunner.request_rerun(
-            rerun_data
-        ):
-            # If we are here, then either we have no ScriptRunner, or our
-            # current ScriptRunner is shutting down and cannot handle a rerun
-            # request - so we'll create and start a new ScriptRunner.
-            self._create_scriptrunner(rerun_data)
+        if self._scriptrunner is not None:
+            if bool(config.get_option("runner.fastReruns")):
+                # If fastReruns is enabled, we don't send rerun requests to our
+                # existing ScriptRunner. Instead, we tell it to shut down. We'll
+                # then spin up a new ScriptRunner, below, to handle the rerun
+                # immediately.
+                self._scriptrunner.request_stop()
+                self._scriptrunner = None
+            else:
+                # fastReruns is not enabled. Send our ScriptRunner a rerun
+                # request. If the request is successful, we're done.
+                success = self._scriptrunner.request_rerun(rerun_data)
+                if success:
+                    return
+
+        # If we are here, then either we have no ScriptRunner, or our
+        # current ScriptRunner is shutting down and cannot handle a rerun
+        # request - so we'll create and start a new ScriptRunner.
+        self._create_scriptrunner(rerun_data)
 
     def _create_scriptrunner(self, initial_rerun_data: RerunData) -> None:
         """Create and run a new ScriptRunner with the given RerunData."""

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -254,7 +254,7 @@ class AppSession:
                 self._scriptrunner = None
             else:
                 # fastReruns is not enabled. Send our ScriptRunner a rerun
-                # request. If the request is successful, we're done.
+                # request. If the request is accepted, we're done.
                 success = self._scriptrunner.request_rerun(rerun_data)
                 if success:
                     return

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -448,6 +448,19 @@ _create_option(
     type_=bool,
 )
 
+_create_option(
+    "runner.fastReruns",
+    description="""
+        Handle script rerun requests immediately, rather than waiting for
+        script execution to reach a yield point. Enabling this will
+        make Streamlit much more responsive to user interaction, but it can
+        lead to race conditions in apps that mutate session_state data outside
+        of explicit session_state assignment statements.
+    """,
+    default_val=True,
+    type_=bool,
+)
+
 # Config Section: Server #
 
 _create_section("server", "Settings for the Streamlit server")

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -38,7 +38,7 @@ from streamlit.session_data import SessionData
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
-from testutil import patch_config_options
+from tests.testutil import patch_config_options
 
 
 @pytest.fixture

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -37,6 +37,8 @@ from streamlit.scriptrunner import ScriptRunnerEvent
 from streamlit.session_data import SessionData
 from streamlit.state.session_state import SessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
+from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
+from testutil import patch_config_options
 
 
 @pytest.fixture
@@ -58,7 +60,7 @@ def _create_test_session(ioloop: Optional[IOLoop] = None) -> AppSession:
     )
 
 
-@patch("streamlit.app_session.LocalSourcesWatcher", MagicMock())
+@patch("streamlit.app_session.LocalSourcesWatcher", MagicMock(spec=LocalSourcesWatcher))
 class AppSessionTest(unittest.TestCase):
     @patch("streamlit.app_session.secrets._file_change_listener.disconnect")
     def test_shutdown(self, patched_disconnect):
@@ -127,6 +129,7 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         patched_connect.assert_called_once_with(session._on_secrets_file_changed)
 
+    @patch_config_options({"runner.fastReruns": False})
     @patch("streamlit.app_session.AppSession._create_scriptrunner")
     def test_rerun_with_no_scriptrunner(self, mock_create_scriptrunner: MagicMock):
         """If we don't have a ScriptRunner, a rerun request will result in
@@ -135,6 +138,7 @@ class AppSessionTest(unittest.TestCase):
         session.request_rerun(None)
         mock_create_scriptrunner.assert_called_once_with(RerunData())
 
+    @patch_config_options({"runner.fastReruns": False})
     @patch("streamlit.app_session.AppSession._create_scriptrunner")
     def test_rerun_with_active_scriptrunner(self, mock_create_scriptrunner: MagicMock):
         """If we have an active ScriptRunner, it receives rerun requests."""
@@ -152,6 +156,7 @@ class AppSessionTest(unittest.TestCase):
         # So _create_scriptrunner should not be called.
         mock_create_scriptrunner.assert_not_called()
 
+    @patch_config_options({"runner.fastReruns": False})
     @patch("streamlit.app_session.AppSession._create_scriptrunner")
     def test_rerun_with_stopped_scriptrunner(self, mock_create_scriptrunner: MagicMock):
         """If have a ScriptRunner but it's shutting down and cannot handle
@@ -169,6 +174,26 @@ class AppSessionTest(unittest.TestCase):
 
         # So we'll create a new ScriptRunner.
         mock_create_scriptrunner.assert_called_once_with(RerunData())
+
+    @patch_config_options({"runner.fastReruns": True})
+    @patch("streamlit.app_session.AppSession._create_scriptrunner")
+    def test_fast_rerun(self, mock_create_scriptrunner: MagicMock):
+        """If runner.fastReruns is enabled, a rerun request will stop the
+        existing ScriptRunner and immediately create a new one.
+        """
+        session = _create_test_session()
+
+        mock_active_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_active_scriptrunner
+
+        session.request_rerun(None)
+
+        # The active ScriptRunner should be shut down.
+        mock_active_scriptrunner.request_rerun.assert_not_called()
+        mock_active_scriptrunner.request_stop.assert_called_once()
+
+        # And a new ScriptRunner should be created.
+        mock_create_scriptrunner.assert_called_once()
 
     @patch("streamlit.app_session.ScriptRunner")
     def test_create_scriptrunner(self, mock_scriptrunner: MagicMock):

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -316,6 +316,7 @@ class ConfigTest(unittest.TestCase):
                 "runner.installTracer",
                 "runner.fixMatplotlib",
                 "runner.postScriptGC",
+                "runner.fastReruns",
                 "mapbox.token",
                 "server.baseUrlPath",
                 "server.enableCORS",


### PR DESCRIPTION
(Finally) implement opt-in fast reruns

- "config.fastReruns" is the new config option for controlling this feature. It's defaulted to `True` in this feature branch, but I think we'll probably default it to `False`  when this is merged to develop?
- When the option is enabled, a rerun request will cause an existing ScriptRunner to shutdown, and immediately spin up a new one to handle the rerun.