### PR TITLE
Figure out the app's baseUrlPath when initially loading a non-main page

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -787,6 +787,8 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "", queryString: "" },
     })
+
+    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("")
   })
 
   it("figures out pageName when sendRerunBackMsg isn't given one (case 2: non-main page)", () => {
@@ -803,6 +805,7 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
+    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("page1")
   })
 
   it("figures out pageName when sendRerunBackMsg isn't given one and a baseUrlPath is set", () => {
@@ -837,6 +840,7 @@ describe("App.sendRerunBackMsg", () => {
       rerunScript: { pageName: "page1", queryString: "" },
     })
     expect(instance.clearAppState).toHaveBeenCalled()
+    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("page1")
   })
 
   it("also switches pages correctly when a baseUrlPath is set", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import {
   notUndefined,
   getElementWidgetID,
 } from "src/lib/utils"
+import { BaseUriParts } from "src/lib/UriUtil"
 import {
   BackMsg,
   CustomThemeConfig,
@@ -138,6 +139,7 @@ interface State {
   formsData: FormsData
   hideTopBar: boolean
   appPages: AppPage[]
+  currentPageName: string
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -210,6 +212,7 @@ export class App extends PureComponent<Props, State> {
       // false.
       hideTopBar: true,
       appPages: [],
+      currentPageName: "",
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -221,11 +224,7 @@ export class App extends PureComponent<Props, State> {
     })
 
     this.uploadClient = new FileUploadClient({
-      getServerUri: () => {
-        return this.connectionManager
-          ? this.connectionManager.getBaseUriParts()
-          : undefined
-      },
+      getServerUri: this.getBaseUriParts,
       // A form cannot be submitted if it contains a FileUploader widget
       // that's currently uploading. We write that state here, in response
       // to a FileUploadClient callback. The FormSubmitButton element
@@ -235,11 +234,7 @@ export class App extends PureComponent<Props, State> {
       csrfEnabled: true,
     })
 
-    this.componentRegistry = new ComponentRegistry(() => {
-      return this.connectionManager
-        ? this.connectionManager.getBaseUriParts()
-        : undefined
-    })
+    this.componentRegistry = new ComponentRegistry(this.getBaseUriParts)
 
     this.pendingElementsTimerRunning = false
     this.pendingElementsBuffer = this.state.elements
@@ -443,7 +438,7 @@ export class App extends PureComponent<Props, State> {
     }
 
     if (favicon) {
-      handleFavicon(favicon)
+      handleFavicon(favicon, this.getBaseUriParts())
     }
 
     // Only change layout/sidebar when the page config has changed.
@@ -485,28 +480,13 @@ export class App extends PureComponent<Props, State> {
       `A page with the name ${pageName} does not exist. Redirecting to the app's main page.`
     )
 
-    // TODO(vdonato): Much of this code is duplicated from sendRerunBackMsg,
-    // but we leave both functions like this for now instead of creating a new
-    // abstraction around them since it's likely that we'll change the way the
-    // baseUrlPath is sent from server -> client. Once we're sure about what
-    // we're doing for baseUrlPath handling, we'll factor this code out into
-    // helper functions.
-    const { queryParams } = this.props.s4aCommunication.currentState
+    this.setState({ currentPageName: "" })
 
-    let queryString =
-      queryParams && queryParams.length > 0
-        ? queryParams
-        : document.location.search
-
-    if (queryString.startsWith("?")) {
-      queryString = queryString.substring(1)
-    }
-
-    const baseUriParts =
-      this.connectionManager && this.connectionManager.getBaseUriParts()
-
+    const baseUriParts = this.getBaseUriParts()
     if (baseUriParts) {
       const { basePath } = baseUriParts
+      const queryString = this.getQueryString()
+
       const qs = queryString ? `?${queryString}` : ""
 
       const pageUrl = `/${basePath}${qs}`
@@ -649,7 +629,10 @@ export class App extends PureComponent<Props, State> {
 
     // Set the title and favicon to their default values
     document.title = `${scriptName} · Streamlit`
-    handleFavicon(`${process.env.PUBLIC_URL}/favicon.png`)
+    handleFavicon(
+      `${process.env.PUBLIC_URL}/favicon.png`,
+      this.getBaseUriParts()
+    )
 
     MetricsManager.current.setMetadata(
       this.props.s4aCommunication.currentState.streamlitShareMetadata
@@ -944,8 +927,6 @@ export class App extends PureComponent<Props, State> {
   }
 
   onPageChange = (pageName: string): void => {
-    // TODO(vdonato): Verify that sending an empty widgetStates object back
-    // when switching pages is correct (I'm fairly certain it is).
     this.sendRerunBackMsg(undefined, pageName)
   }
 
@@ -953,29 +934,18 @@ export class App extends PureComponent<Props, State> {
     widgetStates?: WidgetStates,
     pageName?: string
   ): void => {
-    const { queryParams } = this.props.s4aCommunication.currentState
-
-    let queryString =
-      queryParams && queryParams.length > 0
-        ? queryParams
-        : document.location.search
-
-    if (queryString.startsWith("?")) {
-      queryString = queryString.substring(1)
-    }
-
-    // If we don't have a connectionManager or if it doesn't have an active
-    // websocket connection to the server (in which case
-    // connectionManager.getBaseUriParts() returns undefined), we can't send a
-    // rerun backMessage so just return early.
-    const baseUriParts =
-      this.connectionManager && this.connectionManager.getBaseUriParts()
+    const baseUriParts = this.getBaseUriParts()
     if (!baseUriParts) {
+      // If we don't have a connectionManager or if it doesn't have an active
+      // websocket connection to the server (in which case
+      // connectionManager.getBaseUriParts() returns undefined), we can't send a
+      // rerun backMessage so just return early.
       logError("Cannot send rerun backMessage when disconnected from server.")
       return
     }
 
     const { basePath } = baseUriParts
+    const queryString = this.getQueryString()
 
     // NOTE: We specifically check for `null` or `undefined` instead of making
     //       a falsy check below because navigating to "" can be used to
@@ -1009,6 +979,8 @@ export class App extends PureComponent<Props, State> {
       const pageUrl = `${basePathPrefix}/${pageName}${qs}`
       window.history.pushState({}, "", pageUrl)
     }
+
+    this.setState({ currentPageName: pageName })
 
     this.sendBackMsg(
       new BackMsg({
@@ -1157,6 +1129,22 @@ export class App extends PureComponent<Props, State> {
     })
   }
 
+  getBaseUriParts = (): BaseUriParts | undefined =>
+    this.connectionManager
+      ? this.connectionManager.getBaseUriParts()
+      : undefined
+
+  getQueryString = (): string => {
+    const { queryParams } = this.props.s4aCommunication.currentState
+
+    const queryString =
+      queryParams && queryParams.length > 0
+        ? queryParams
+        : document.location.search
+
+    return queryString.startsWith("?") ? queryString.substring(1) : queryString
+  }
+
   render(): JSX.Element {
     const {
       allowRunOnSave,
@@ -1172,6 +1160,7 @@ export class App extends PureComponent<Props, State> {
       userSettings,
       gitInfo,
       hideTopBar,
+      currentPageName,
     } = this.state
 
     const outerDivClass = classNames("stApp", {
@@ -1207,6 +1196,7 @@ export class App extends PureComponent<Props, State> {
           addThemes: this.props.theme.addThemes,
           sidebarChevronDownshift: this.props.s4aCommunication.currentState
             .sidebarChevronDownshift,
+          getBaseUriParts: this.getBaseUriParts,
         }}
       >
         <HotKeys
@@ -1272,6 +1262,7 @@ export class App extends PureComponent<Props, State> {
               formsData={this.state.formsData}
               appPages={this.state.appPages}
               onPageChange={this.onPageChange}
+              currentPageName={currentPageName}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/components/core/AppContext/index.tsx
+++ b/frontend/src/components/core/AppContext/index.tsx
@@ -16,8 +16,10 @@
  */
 
 import React from "react"
+
 import { PageConfig } from "src/autogen/proto"
 import { baseTheme, ThemeConfig } from "src/theme"
+import { BaseUriParts } from "src/lib/UriUtil"
 
 export interface Props {
   wideMode: boolean
@@ -33,6 +35,7 @@ export interface Props {
   availableThemes: ThemeConfig[]
   addThemes: (themes: ThemeConfig[]) => void
   sidebarChevronDownshift: number
+  getBaseUriParts: () => BaseUriParts | undefined
 }
 
 export default React.createContext<Props>({
@@ -49,4 +52,5 @@ export default React.createContext<Props>({
   availableThemes: [],
   addThemes: (themes: ThemeConfig[]) => {},
   sidebarChevronDownshift: 0,
+  getBaseUriParts: () => undefined,
 })

--- a/frontend/src/components/core/AppContext/index.tsx
+++ b/frontend/src/components/core/AppContext/index.tsx
@@ -19,7 +19,7 @@ import React from "react"
 
 import { PageConfig } from "src/autogen/proto"
 import { baseTheme, ThemeConfig } from "src/theme"
-import { BaseUriParts } from "src/lib/UriUtil"
+import { BaseUriParts, getWindowBaseUriParts } from "src/lib/UriUtil"
 
 export interface Props {
   wideMode: boolean
@@ -52,5 +52,5 @@ export default React.createContext<Props>({
   availableThemes: [],
   addThemes: (themes: ThemeConfig[]) => {},
   sidebarChevronDownshift: 0,
-  getBaseUriParts: () => undefined,
+  getBaseUriParts: getWindowBaseUriParts,
 })

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -50,6 +50,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     formsData,
     appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
     onPageChange: jest.fn(),
+    currentPageName: "streamlit_app",
     ...props,
   }
 }
@@ -91,6 +92,9 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
+    expect(wrapper.find("ThemedSidebar").prop("currentPageName")).toBe(
+      "streamlit_app"
+    )
     expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
       "function"
     )

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -59,6 +59,8 @@ export interface AppViewProps {
   appPages: AppPage[]
 
   onPageChange: (pageName: string) => void
+
+  currentPageName: string
 }
 
 /**
@@ -76,6 +78,7 @@ function AppView(props: AppViewProps): ReactElement {
     formsData,
     appPages,
     onPageChange,
+    currentPageName,
   } = props
 
   React.useEffect(() => {
@@ -127,6 +130,7 @@ function AppView(props: AppViewProps): ReactElement {
           appPages={appPages}
           hasElements={hasSidebarElements}
           onPageChange={onPageChange}
+          currentPageName={currentPageName}
         >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -42,6 +42,7 @@ export interface SidebarProps {
   hasElements?: boolean
   appPages: AppPage[]
   onPageChange: (pageName: string) => void
+  currentPageName: string
 }
 
 interface State {
@@ -167,6 +168,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
       children,
       hasElements,
       onPageChange,
+      currentPageName,
     } = this.props
 
     // The tabindex is required to support scrolling by arrow keys.
@@ -190,6 +192,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
             hasSidebarElements={hasElements}
             onPageChange={onPageChange}
             hideParentScrollbar={this.hideScrollbar}
+            currentPageName={currentPageName}
           />
           <StyledSidebarUserContent hasPageNavAbove={appPages.length > 1}>
             {children}

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -35,7 +35,7 @@ export interface Props {
   hasSidebarElements: boolean
   onPageChange: (pageName: string) => void
   hideParentScrollbar: (newValue: boolean) => void
-  // XXX Need some way to tell what's the current page
+  currentPageName: string
 }
 
 // TODO(vdonato): indicate the current page and make it unclickable
@@ -45,6 +45,7 @@ const SidebarNav = ({
   hasSidebarElements,
   onPageChange,
   hideParentScrollbar,
+  currentPageName,
 }: Props): ReactElement | null => {
   if (appPages.length < 2) {
     return null

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -26,6 +26,7 @@ function getProps(props: Partial<SidebarProps> = {}): SidebarProps {
     chevronDownshift: 0,
     appPages: [],
     onPageChange: jest.fn(),
+    currentPageName: "streamlit_app",
     ...props,
   }
 }
@@ -48,13 +49,16 @@ describe("ThemedSidebar Component", () => {
     expect(updatedTheme.inSidebar).toBe(true)
   })
 
-  it("plumbs appPages and onPageChange to main Sidebar component", () => {
+  it("plumbs appPages, currentPageName, and onPageChange to main Sidebar component", () => {
     const appPages = [
       { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
     ]
     const wrapper = mount(<ThemedSidebar {...getProps({ appPages })} />)
 
     expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
+    expect(wrapper.find("Sidebar").prop("currentPageName")).toBe(
+      "streamlit_app"
+    )
     expect(typeof wrapper.find("Sidebar").prop("onPageChange")).toBe(
       "function"
     )

--- a/frontend/src/components/elements/Audio/Audio.tsx
+++ b/frontend/src/components/elements/Audio/Audio.tsx
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useEffect, useRef } from "react"
+import React, { ReactElement, useContext, useEffect, useRef } from "react"
 import { Audio as AudioProto } from "src/autogen/proto"
+import AppContext from "src/components/core/AppContext"
 import { buildMediaUri } from "src/lib/UriUtil"
 
 export interface AudioProps {
@@ -26,6 +27,7 @@ export interface AudioProps {
 
 export default function Audio({ element, width }: AudioProps): ReactElement {
   const audioRef = useRef<HTMLAudioElement>(null)
+  const { getBaseUriParts } = useContext(AppContext)
 
   useEffect(() => {
     if (audioRef.current) {
@@ -33,7 +35,7 @@ export default function Audio({ element, width }: AudioProps): ReactElement {
     }
   }, [element.startTime])
 
-  const uri = buildMediaUri(element.url)
+  const uri = buildMediaUri(element.url, getBaseUriParts())
   return (
     <audio
       id="audio"

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -16,7 +16,7 @@
  */
 
 import nodeEmoji from "node-emoji"
-import { buildMediaUri } from "src/lib/UriUtil"
+import { BaseUriParts, buildMediaUri } from "src/lib/UriUtil"
 import { grabTheRightIcon } from "src/vendor/twemoji"
 import { sendS4AMessage } from "src/hocs/withS4ACommunication/withS4ACommunication"
 
@@ -26,7 +26,10 @@ import { sendS4AMessage } from "src/hocs/withS4ACommunication/withS4ACommunicati
  * @param {string} favicon may be an image url, or an emoji like 🍕 or :pizza:
  * @param {function} callback
  */
-export function handleFavicon(favicon: string): void {
+export function handleFavicon(
+  favicon: string,
+  baseUriParts?: BaseUriParts
+): void {
   const emoji = extractEmoji(favicon)
   let imageUrl
 
@@ -37,7 +40,7 @@ export function handleFavicon(favicon: string): void {
 
     imageUrl = emojiUrl
   } else {
-    imageUrl = buildMediaUri(favicon)
+    imageUrl = buildMediaUri(favicon, baseUriParts)
   }
 
   overwriteFavicon(imageUrl)

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -15,15 +15,18 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { useContext, ReactElement } from "react"
 import ReactHtmlParser from "react-html-parser"
-import withFullScreenWrapper from "src/hocs/withFullScreenWrapper"
-import { buildMediaUri, xssSanitizeSvg } from "src/lib/UriUtil"
+
 import {
   IImage,
   Image as ImageProto,
   ImageList as ImageListProto,
 } from "src/autogen/proto"
+import AppContext from "src/components/core/AppContext"
+import withFullScreenWrapper from "src/hocs/withFullScreenWrapper"
+import { buildMediaUri, xssSanitizeSvg } from "src/lib/UriUtil"
+
 import {
   StyledCaption,
   StyledImageContainer,
@@ -52,6 +55,8 @@ export function ImageList({
   element,
   height,
 }: ImageListProps): ReactElement {
+  const { getBaseUriParts } = useContext(AppContext)
+
   // The width field in the proto sets the image width, but has special
   // cases for -1, -2, and -3.
   let containerWidth: number | undefined
@@ -100,7 +105,7 @@ export function ImageList({
               ) : (
                 <img
                   style={imgStyle}
-                  src={buildMediaUri(image.url)}
+                  src={buildMediaUri(image.url, getBaseUriParts())}
                   alt={idx.toString()}
                 />
               )}

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useEffect, useRef } from "react"
+import React, { ReactElement, useContext, useEffect, useRef } from "react"
+import AppContext from "src/components/core/AppContext"
 import { Video as VideoProto } from "src/autogen/proto"
 import { buildMediaUri } from "src/lib/UriUtil"
 
@@ -26,6 +27,7 @@ export interface VideoProps {
 
 export default function Video({ element, width }: VideoProps): ReactElement {
   const videoRef = useRef<HTMLVideoElement>(null)
+  const { getBaseUriParts } = useContext(AppContext)
 
   /* Element may contain "url" or "data" property. */
 
@@ -82,7 +84,7 @@ export default function Video({ element, width }: VideoProps): ReactElement {
     <video
       ref={videoRef}
       controls
-      src={buildMediaUri(url)}
+      src={buildMediaUri(url, getBaseUriParts())}
       className="stVideo"
       style={{ width }}
     />

--- a/frontend/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { ReactElement, useContext } from "react"
 import { DownloadButton as DownloadButtonProto } from "src/autogen/proto"
+import AppContext from "src/components/core/AppContext"
 import UIButton, {
   ButtonTooltip,
   Kind,
@@ -35,15 +36,17 @@ export interface Props {
 function DownloadButton(props: Props): ReactElement {
   const { disabled, element, widgetMgr, width } = props
   const style = { width }
+  const { getBaseUriParts } = useContext(AppContext)
 
   const handleDownloadClick: () => void = () => {
     // Downloads are only done on links, so create a hidden one and click it
     // for the user.
     widgetMgr.setTriggerValue(element, { fromUi: true })
     const link = document.createElement("a")
-    const uri = `${buildMediaUri(element.url)}?title=${encodeURIComponent(
-      document.title
-    )}`
+    const uri = `${buildMediaUri(
+      element.url,
+      getBaseUriParts()
+    )}?title=${encodeURIComponent(document.title)}`
     link.setAttribute("href", uri)
     link.setAttribute("target", "_blank")
     link.click()

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -16,7 +16,7 @@
  */
 
 import { BackMsg, ForwardMsg } from "src/autogen/proto"
-import { BaseUriParts, getWindowBaseUriParts } from "src/lib/UriUtil"
+import { BaseUriParts, getPossibleBaseUris } from "src/lib/UriUtil"
 import { ReactNode } from "react"
 
 import { ConnectionState } from "./ConnectionState"
@@ -137,10 +137,10 @@ export class ConnectionManager {
   }
 
   private connectToRunningServer(): WebsocketConnection {
-    const baseUriParts = getWindowBaseUriParts()
+    const baseUriPartsList = getPossibleBaseUris()
 
     return new WebsocketConnection({
-      baseUriPartsList: [baseUriParts],
+      baseUriPartsList,
       onMessage: this.props.onMessage,
       onConnectionStateChange: this.setConnectionState,
       onRetry: this.showRetryError,

--- a/frontend/src/lib/UriUtil.test.ts
+++ b/frontend/src/lib/UriUtil.test.ts
@@ -22,6 +22,7 @@ import {
   buildMediaUri,
   xssSanitizeSvg,
   isValidURL,
+  getPossibleBaseUris,
 } from "./UriUtil"
 
 const location = {}
@@ -203,5 +204,50 @@ describe("isValidURL helper", () => {
 
   it("should return false if it doesn't match the pattern", () => {
     expect(isValidURL("*.b.com", "www.c.com")).toBeFalsy()
+  })
+})
+
+describe("getPossibleBaseUris", () => {
+  let originalPathName = ""
+
+  beforeEach(() => {
+    originalPathName = window.location.pathname
+  })
+
+  afterEach(() => {
+    window.location.pathname = originalPathName
+  })
+
+  const testCases = [
+    {
+      description: "empty pathnames",
+      pathname: "",
+      expectedBasePaths: [""],
+    },
+    {
+      description: "pathnames with a single part",
+      pathname: "foo",
+      expectedBasePaths: ["foo", ""],
+    },
+    {
+      description: "pathnames with two parts",
+      pathname: "foo/bar",
+      expectedBasePaths: ["foo/bar", "foo"],
+    },
+    {
+      description: "pathnames with more than two parts",
+      pathname: "foo/bar/baz/qux",
+      expectedBasePaths: ["foo/bar/baz/qux", "foo/bar/baz"],
+    },
+  ]
+
+  testCases.forEach(({ description, pathname, expectedBasePaths }) => {
+    it(`handles ${description}`, () => {
+      window.location.pathname = pathname
+
+      expect(getPossibleBaseUris(pathname).map(b => b.basePath)).toEqual(
+        expectedBasePaths
+      )
+    })
   })
 })


### PR DESCRIPTION
## 📚 Context

(The following description is copy-pasted from an inline-PR comment that more
or less exactly describes what's happening throughout the PR).

In the multipage apps world, there is some ambiguity around whether a
path like "foo/bar" means
   * the page "/" at baseUrlPath "foo/bar", or
   * the page "/bar" at baseUrlPath "foo".

To resolve this, we just try both possibilities for now, but this leads to
the unfortunate consequence of the initial page load when navigating directly
to a non-main page of an app being slower than navigating to the main page
(as the first attempt at connecting to the server fails the healthcheck).

We'll want to improve this situation in the near future, but figuring out
the best path forward may be tricky as I wasn't able to come up with an
easy solution covering every deployment scenario.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Figure out an app's `baseUrlPath` if a secondary page is loaded initially
- Handle `/media` URLs on secondary pages
- Make the `currentPageName` available to the `SidebarNav` component (but don't use it yet)
- Add actual links to the `SidebarNav` component now that we know what `baseUrlPath` is

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/356