### PR TITLE
Fix `st.bokeh_chart` long description in docstring

### DIFF
--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -33,6 +33,9 @@ class BokehMixin:
         closely follow the ones for Bokeh's `show` function. You can find
         more about Bokeh at https://bokeh.pydata.org.
 
+        To show Bokeh charts in Streamlit, call `st.bokeh_chart`
+        wherever you would call Bokeh's `show`.
+
         Parameters
         ----------
         figure : bokeh.plotting.figure.Figure
@@ -41,9 +44,6 @@ class BokehMixin:
         use_container_width : bool
             If True, set the chart width to the column width. This takes
             precedence over Bokeh's native `width` value.
-
-        To show Bokeh charts in Streamlit, call `st.bokeh_chart`
-        wherever you would call Bokeh's `show`.
 
         Example
         -------


### PR DESCRIPTION
## 📚 Context

Part of the long/extended description in the `st.bokeh_chart` docstring deviates from the numpydoc convention. Part of the long description is erroneously in the Parameters section. It should instead be above the Parameters section. This error causes the docstring to incorrectly render in our docs.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

Moves paragraph text (part of the extended description) above the Parameters section of the `st.bokeh_chart` docstring.

  - [x] This is a visible (user-facing) change

**Revised:**
![image](https://user-images.githubusercontent.com/20672874/161006992-ad17f824-f4af-43d6-9fb1-69990228f50e.png)
![image](https://user-images.githubusercontent.com/20672874/161008260-3071a4a1-8b5c-4d49-b22f-d3fcdb33addc.png)

**Current:**
![image](https://user-images.githubusercontent.com/20672874/161007124-38d780af-e147-476c-b00f-8dca224d2758.png)
![image](https://user-images.githubusercontent.com/20672874/161008368-bf813393-fdd0-48e0-8b31-ad8f66940c8e.png)

## 🧪 Testing Done

- [x] Screenshots included

## 🌐 References

[_Does this depend on other work, documents, or tickets?_](https://www.notion.so/streamlit/Website-please-update-table-on-st-bokeh_chart-page-104d9c158e694353a5ffe87dda3690d8)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
