### PR TITLE
Add support for column sorting on header click

### DIFF
--- a/e2e/specs/st_data_grid_canvas_rendering.spec.js
+++ b/e2e/specs/st_data_grid_canvas_rendering.spec.js
@@ -21,7 +21,7 @@ describe("Data Grid canvas rendering", () => {
   });
 
   it("shows widget correctly", () => {
-    cy.get(".stDataGrid").should("have.length", 13);
+    cy.get(".stDataGrid").should("have.length", 15);
 
     /** Since glide-data-grid uses HTML canvas for rendering the table we
     cannot run any tests based on the HTML DOM. Therefore, we only use snapshot

--- a/frontend/src/components/widgets/DataGrid/DataGrid.test.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.test.tsx
@@ -19,6 +19,7 @@ import React from "react"
 import {
   DataEditor as GlideDataEditor,
   SizedGridColumn,
+  NumberCell,
 } from "@glideapps/glide-data-grid"
 import { renderHook, act } from "@testing-library/react-hooks"
 
@@ -26,7 +27,7 @@ import { TEN_BY_TEN } from "src/lib/mocks/arrow"
 import { mount } from "src/lib/test_util"
 import { Quiver } from "src/lib/Quiver"
 
-import DataGrid, { DataGridProps, useDataLoader } from "./DataGrid"
+import DataGrid, { DataGridProps, useDataLoader, getColumns } from "./DataGrid"
 import { ResizableContainer } from "./DataGridContainer"
 
 const getProps = (data: Quiver): DataGridProps => ({
@@ -82,6 +83,50 @@ describe("DataGrid widget", () => {
     expect((result.current.columns[0] as SizedGridColumn).width).toBe(321)
   })
 
-  // TODO(lukasmasuch): Unit tests for a few methods, such as fillCellTemplate, getColumn, useDataLoader, getCellTemplate, etc.
-  //                    will be added in a later PR once support for different data types is added.
+  it("should correctly sort the table descending order", () => {
+    // TODO(lukasmasuch): Add additional sort tests for other example quiver tables
+    const tableColumns = getColumns(new Quiver({ data: TEN_BY_TEN }))
+
+    // Add descending sort for first column
+    const { result } = renderHook(() =>
+      useDataLoader(new Quiver({ data: TEN_BY_TEN }), {
+        column: tableColumns[0],
+        mode: "smart",
+        direction: "desc",
+      })
+    )
+
+    let sortedData = []
+
+    for (let i = 0; i < result.current.numRows; i++) {
+      sortedData.push(
+        (result.current.getCellContent([0, i]) as NumberCell).data
+      )
+    }
+
+    expect(sortedData).toBe(sortedData.sort().reverse())
+  })
+
+  it("should correctly sort the table ascending order", () => {
+    const tableColumns = getColumns(new Quiver({ data: TEN_BY_TEN }))
+
+    // Add descending sort for first column
+    const { result } = renderHook(() =>
+      useDataLoader(new Quiver({ data: TEN_BY_TEN }), {
+        column: tableColumns[0],
+        mode: "smart",
+        direction: "asc",
+      })
+    )
+
+    let sortedData = []
+
+    for (let i = 0; i < result.current.numRows; i++) {
+      sortedData.push(
+        (result.current.getCellContent([0, i]) as NumberCell).data
+      )
+    }
+
+    expect(sortedData).toBe(sortedData.sort())
+  })
 })

--- a/frontend/src/components/widgets/DataGrid/DataGrid.test.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.test.tsx
@@ -96,7 +96,7 @@ describe("DataGrid widget", () => {
       })
     )
 
-    let sortedData = []
+    const sortedData = []
 
     for (let i = 0; i < result.current.numRows; i++) {
       sortedData.push(
@@ -119,7 +119,7 @@ describe("DataGrid widget", () => {
       })
     )
 
-    let sortedData = []
+    const sortedData = []
 
     for (let i = 0; i < result.current.numRows; i++) {
       sortedData.push(

--- a/frontend/src/components/widgets/DataGrid/DataGrid.test.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.test.tsx
@@ -104,7 +104,11 @@ describe("DataGrid widget", () => {
       )
     }
 
-    expect(sortedData).toBe(sortedData.sort().reverse())
+    expect(Array.from(sortedData)).toEqual(
+      Array.from(sortedData)
+        .sort()
+        .reverse()
+    )
   })
 
   it("should correctly sort the table ascending order", () => {
@@ -127,6 +131,6 @@ describe("DataGrid widget", () => {
       )
     }
 
-    expect(sortedData).toBe(sortedData.sort())
+    expect(Array.from(sortedData)).toEqual(Array.from(sortedData).sort())
   })
 })

--- a/frontend/src/components/widgets/DataGrid/DataGrid.tsx
+++ b/frontend/src/components/widgets/DataGrid/DataGrid.tsx
@@ -47,7 +47,7 @@ type GridColumnWithCellTemplate = GridColumn & {
 /**
  * Returns a list of glide-data-grid compatible columns based on a Quiver instance.
  */
-function getColumns(element: Quiver): GridColumnWithCellTemplate[] {
+export function getColumns(element: Quiver): GridColumnWithCellTemplate[] {
   const columns: GridColumnWithCellTemplate[] = []
 
   const numIndices = element.types?.index?.length ?? 0
@@ -135,7 +135,7 @@ type DataLoaderReturn = { numRows: number; numIndices: number } & Pick<
  */
 export function useDataLoader(
   element: Quiver,
-  sort: ColumnSortConfig | undefined
+  sort?: ColumnSortConfig | undefined
 ): DataLoaderReturn {
   // The columns with the corresponding empty template for every type:
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## 📚 Context

Add support for sorting columns by clicking on the column header.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add the column sorting hook and activate sorting by clicking on a column header.
 
## 🧪 Testing Done

- [x] Added/Updated unit tests

Interactive features involving HTML Canvas interactions are a lot more complicated to test end2end compared to HTML DOM based components and would have considerable overhead. Since glide-data-grid already has some basic tests for interactive features, we decided to only test custom build interactive features. Column sorting is something implemented and tested within the glide-data-grid library.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
