### PR TITLE
Extract the first character from the page name if it is an emoji

### DIFF
--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -83,8 +83,7 @@ const SidebarNav = ({
         onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}
       >
-        {/* XXX Need some way to tell what the icon is */}
-        {appPages.map(({ pageName }: AppPage, pageIndex: number) => {
+        {appPages.map(({ pageIcon, pageName }: AppPage, pageIndex: number) => {
           // NOTE: We use window.location to get the port instead of
           // getBaseUriParts() because the port may differ in dev mode (since
           // the frontend is served by the react dev server and not the

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -668,3 +668,4 @@ def _populate_app_pages(msg: NewSession, main_script_path: str) -> None:
         page_proto = msg.app_pages.add()
         page_proto.script_path = page["script_path"]
         page_proto.page_name = page["page_name"]
+        page_proto.icon = page["icon"]

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -281,8 +281,8 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
         "streamlit.app_session.source_util.get_pages",
         MagicMock(
             return_value=[
-                {"page_name": "page1", "script_path": "script1"},
-                {"page_name": "page2", "script_path": "script2"},
+                {"page_name": "page1", "icon": "", "script_path": "script1"},
+                {"page_name": "page2", "icon": "🎉", "script_path": "script2"},
             ]
         ),
     )
@@ -342,8 +342,8 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
         self.assertEqual(
             list(new_session_msg.app_pages),
             [
-                AppPage(page_name="page1", script_path="script1"),
-                AppPage(page_name="page2", script_path="script2"),
+                AppPage(page_name="page1", icon="", script_path="script1"),
+                AppPage(page_name="page2", icon="🎉", script_path="script2"),
             ],
         )
 

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -48,36 +48,46 @@ class PageHelperFunctionTests(unittest.TestCase):
     @parameterized.expand(
         [
             # Test that the page number is removed as expected.
-            ("/foo/01_bar.py", "bar"),
-            ("/foo/02-bar.py", "bar"),
-            ("/foo/03 bar.py", "bar"),
-            ("/foo/04 bar baz.py", "bar_baz"),
-            ("/foo/05 -_- bar.py", "bar"),
+            ("/foo/01_bar.py", ("bar", "")),
+            ("/foo/02-bar.py", ("bar", "")),
+            ("/foo/03 bar.py", ("bar", "")),
+            ("/foo/04 bar baz.py", ("bar_baz", "")),
+            ("/foo/05 -_- bar.py", ("bar", "")),
+            ("/foo/06 -_- 🎉bar.py", ("bar", "🎉")),
+            ("/foo/07 -_- 🎉-_bar.py", ("bar", "🎉")),
+            ("/foo/08 -_- 🎉 _ bar.py", ("bar", "🎉")),
             # Test cases with no page number.
-            ("/foo/bar.py", "bar"),
-            ("/foo/bar baz.py", "bar_baz"),
+            ("/foo/bar.py", ("bar", "")),
+            ("/foo/bar baz.py", ("bar_baz", "")),
+            ("/foo/😐bar baz.py", ("bar_baz", "😐")),
+            ("/foo/😐_bar baz.py", ("bar_baz", "😐")),
             # Test that separator characters in the page name are removed as
             # as expected.
-            ("/foo/1 - first page.py", "first_page"),
-            ("/foo/123_hairy_koala.py", "hairy_koala"),
+            ("/foo/1 - first page.py", ("first_page", "")),
+            ("/foo/123_hairy_koala.py", ("hairy_koala", "")),
             (
                 "/foo/123 wow_this_has a _lot_ _of  _ ___ separators.py",
-                "wow_this_has_a_lot_of_separators",
+                ("wow_this_has_a_lot_of_separators", ""),
             ),
             (
                 "/foo/1-dashes in page-name stay.py",
-                "dashes_in_page-name_stay",
+                ("dashes_in_page-name_stay", ""),
             ),
+            ("/foo/2 - 🙃second page.py", ("second_page", "🙃")),
             # Test other weirdness that might happen with numbers.
-            ("12 monkeys.py", "monkeys"),
-            ("_12 monkeys.py", "12_monkeys"),
-            ("123.py", "123"),
+            ("12 monkeys.py", ("monkeys", "")),
+            ("12 😰monkeys.py", ("monkeys", "😰")),
+            ("_12 monkeys.py", ("12_monkeys", "")),
+            ("_12 😰monkeys.py", ("12_😰monkeys", "")),
+            ("_😰12 monkeys.py", ("12_monkeys", "😰")),
+            ("123.py", ("123", "")),
+            ("😰123.py", ("123", "😰")),
             # Test the default case for non-Python files.
-            ("not_a_python_script.rs", ""),
+            ("not_a_python_script.rs", ("", "")),
         ]
     )
-    def test_page_name(self, path_str, expected):
-        assert source_util.page_name(Path(path_str)) == expected
+    def test_page_name_and_icon(self, path_str, expected):
+        assert source_util.page_name_and_icon(Path(path_str)) == expected
 
 
 # NOTE: We write this test function using pytest conventions (as opposed to
@@ -109,17 +119,21 @@ def test_get_pages(tmpdir):
         {
             "page_name": "streamlit_app",
             "script_path": main_script_path,
+            "icon": "",
         },
         {
             "page_name": "page",
             "script_path": str(pages_dir / "01-page.py"),
+            "icon": "",
         },
         {
             "page_name": "other_page",
             "script_path": str(pages_dir / "03_other_page.py"),
+            "icon": "",
         },
         {
             "page_name": "last_page",
             "script_path": str(pages_dir / "last page.py"),
+            "icon": "",
         },
     ]

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -142,4 +142,5 @@ message EnvironmentInfo {
 message AppPage {
   string page_name = 1;
   string script_path = 2;
+  string icon = 3;
 }


### PR DESCRIPTION
## 📚 Context

We want to support a lightweight way for users to be able to set page icons
that doesn't require edits to a separate config file. There are some drawbacks
to this approach, but we decided to initially do this by allowing a user to include
an emoji as part of the filename of a page.

This notably makes terminal-autocompleting a filename with an emoji in it get
pretty weird, but we expect people that make use of this to also explicitly sort
their pages using number prefixes, which mostly resolves the autocomplete issues.

We ideally want to be able to have the user set their page icon/emoji
using the favicon in `st.set_page_config`, but this seems to be a bit
too technically hairy to want to do in the first version of Multipage Apps
as it'll most likely require us to parse each page script's AST to pull out the
`st.set_page_config` calls (as well as restrict how `st.set_page_config` can
be called further to allow this to work).

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Extract an emoji from a page's name to use as the page icon if it is
   the first character

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit-issues/issues/481
