### PR TITLE
Fixed issue #4000

### DIFF
--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -38,7 +38,7 @@ export const StyledStreamlitMarkdown = styled.div<
   li: {
     margin: "0.2em 0 0.2em 1.2em",
     padding: "0 0 0 0.6em",
-    fontSize: theme.fontSizes.md,
+    fontSize: theme.fontSizes.sm,
   },
 
   tr: {

--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -38,7 +38,7 @@ export const StyledStreamlitMarkdown = styled.div<
   li: {
     margin: "0.2em 0 0.2em 1.2em",
     padding: "0 0 0 0.6em",
-    fontSize: theme.fontSizes.sm,
+    fontSize: theme.fontSizes.md,
   },
 
   tr: {

--- a/frontend/src/components/shared/Tooltip/styled-components.tsx
+++ b/frontend/src/components/shared/Tooltip/styled-components.tsx
@@ -49,6 +49,8 @@ export const StyledTooltipContentWrapper = styled.div(({ theme }) => ({
     background: transparentize(theme.colors.darkenedBgMix60, 0.8),
   },
   "*": {
-    fontSize: theme.fontSizes.sm,
+    // Regular markdown is medium font-size.
+    // Special markdown styles (like for the li element) would overwrite this, if it wasn't set to !important
+    fontSize: `${theme.fontSizes.sm} !important`,
   },
 }))


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Fixing the styling of li elements in mardown popups

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Set the li font size from md to sm
  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4000

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
