### PR TITLE
Enable more maintainable frontend styling hacks

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -160,7 +160,11 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
         const propsWithNewWidth = { ...props, ...{ width } }
 
         return (
-          <StyledVerticalBlock width={width} data-testid="stVerticalBlock">
+          <StyledVerticalBlock
+            width={width}
+            data-testid="stVerticalBlock"
+            className={props.node.deltaBlock.cssClasses.join(" ")}
+          >
             <ChildRenderer {...propsWithNewWidth} />
           </StyledVerticalBlock>
         )

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, List, Sequence, TYPE_CHECKING, Union
+from typing import cast, Sequence, TYPE_CHECKING, Union, List, Optional
 
 from streamlit.beta_util import function_beta_warning
 from streamlit.errors import StreamlitAPIException
@@ -25,7 +25,7 @@ SpecType = Union[int, Sequence[Union[int, float]]]
 
 
 class LayoutsMixin:
-    def container(self) -> "DeltaGenerator":
+    def container(self, css_classes: Optional[List[str]] = None) -> "DeltaGenerator":
         """Insert a multi-element container.
 
         Inserts an invisible container into your app that can be used to hold
@@ -35,6 +35,17 @@ class LayoutsMixin:
         To add elements to the returned container, you can use "with" notation
         (preferred) or just call methods directly on the returned object. See
         examples below.
+
+        Parameters
+        ----------
+        css_classes : list of strings
+            Optional list of CSS class names that are attached to the resulting
+            HTML element. Should be used sparingly and only when existing
+            styling and layout options are exhausted.
+
+            Note: There is no guarantee of the HTML structure inside or outside
+            this element. The CSS that targets this element _will_ be fragile
+            and potentially tied to specific Streamlit versions.
 
         Examples
         --------
@@ -66,7 +77,8 @@ class LayoutsMixin:
             https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.container2.py
             height: 480px
         """
-        return self.dg._block()
+
+        return self.dg._block(BlockProto(css_classes=css_classes))
 
     # TODO: Enforce that columns are not nested or in Sidebar
     def columns(self, spec: SpecType) -> List["DeltaGenerator"]:

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -26,6 +26,7 @@ message Block {
   }
 
   bool allow_empty = 6;
+  repeated string css_classes = 7;
 
   message Vertical {
   }
@@ -47,5 +48,5 @@ message Block {
     bool clear_on_submit = 2;
   }
 
-  // Next ID: 7
+  // Next ID: 8
 }


### PR DESCRIPTION
## 📚 Context

This PRs enables **better and cleaner hacks™** by allowing the developer to pass-through additional CSS class names on `st.container`.

A quick browse of StackOverflow and the Streamlit forums reveals many developers utilizing crazy, unmaintainable hacks to tweak and manipulate style and behavior in the frontend.

My favorite being this monstrosity from SO trying to layout buttons next to each other:

```python
css_code_tree_button_side_by_side= '''
<style>
#root > div:nth-child(1) > div > div > div > div > section > div > div:nth-child(1) > div > div:nth-child(2) > div{
    display: -webkit-inline-box;
    width: 180px;
}
#root > div:nth-child(1) > div > div > div > div > section > div > div:nth-child(1) > div > div:nth-child(2) > div > div:nth-child(-n+3){
    width: 50px!important;
}
#root > div:nth-child(1) > div > div > div > div > section > div > div:nth-child(1) > div > div:nth-child(2) > div > div:nth-child(-n+3) > div{
    width: 50px!important;
}
#root > div:nth-child(1) > div > div > div > div > section > div > div:nth-child(1) > div > div:nth-child(2) > div > div:nth-child(-n+3) > div > button{
    width: fit-content;
}
</style>
'''
st.markdown(css_code_tree_button_side_by_side, unsafe_allow_html=True)

with st.container():
    if st.button('a'):
        pass
    if st.button('b'):
        pass
    if st.button('c'):
        pass
```

:scream: :scream: :scream:

Being guilty of similar (though less egregious) hacks, I realized the many of them come down to not being able to target specific instances of components from a CSS selector.

Simply being able to identify a component by ID or class would be sufficient to "solve" (where "solve" is still a hack, but done a more maintainable way) many issues.

This PR simply tweaks the `Block` protobuf message to add a `css_classes` field. This enables simple code like:

```python
with st.container(css_classes=["big", "red"]):
    st.text("We don't talk about B***o")
```

Which results in:

```html
<div width="..." data-testid="stVerticalBlock" class="big red css-1n76uvr">
```
Which is now easy find and style.

Is this the right thing to do? No.
Will this result in more tweaks and tight coupling to specific Streamlit versions? Yes.
Is everyone going to continue to develop and deploy tightly coupled hacks anyway? **Yes**.

Other possible approaches/options:
* Allow setting an element ID -- would also work, but classnames are more reusable
* Expose option on _every_ component -- possible, but adds additional API surface. `st.container` can be used to explicitly wrap any other component and apply classnames
* With :snowflake: :moneybag: hire 1000 devs to cater to the every whim of data-scientists turned UX developers...

Source code from screen shot below here: https://gist.github.com/kung-foo/61ba8bff2e4b48c86596c1f423e7fb38

Showing silly colors, two different FontAwesome integrations and some side-by-side button layout tweaks.

---

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

![Screenshot from 2022-04-07 23-47-47](https://user-images.githubusercontent.com/1357571/162325470-7b81e072-041f-4c2a-8323-37eb4b7c049a.png)

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [X] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
