### PR TITLE
Tweak page "404" behavior to match spec

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -895,20 +895,7 @@ describe("App.sendRerunBackMsg", () => {
 })
 
 describe("App.handlePageNotFound", () => {
-  beforeEach(() => {
-    window.history.pushState({}, "", "/")
-    jest.spyOn(
-      window.history,
-      // @ts-ignore
-      "pushState"
-    )
-  })
-
-  afterEach(() => {
-    window.history.pushState({}, "", "/")
-  })
-
-  it("displays an error modal and navigates to the app main page", () => {
+  it("displays an error modal", () => {
     const wrapper = shallow(<App {...getProps()} />)
     const instance = wrapper.instance() as App
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
@@ -919,39 +906,8 @@ describe("App.handlePageNotFound", () => {
     expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
     expect(instance.showError).toHaveBeenCalledWith(
       "Page not found",
-      "A page with the name nonexistentPage does not exist. Redirecting to the app's main page."
+      `You have requested page /nonexistentPage, but no corresponding file was found in the app's pages/ directory.`
     )
-  })
-
-  it("retains the query string if there is one", () => {
-    const wrapper = shallow(
-      <App
-        {...getProps({
-          s4aCommunication: {
-            connect: jest.fn(),
-            sendMessage: jest.fn(),
-            currentState: {
-              queryParams: "?foo=bar",
-            },
-          },
-        })}
-      />
-    )
-    const instance = wrapper.instance() as App
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
-
-    instance.handlePageNotFound({ pageName: "nonexistentPage" })
-
-    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/?foo=bar")
-  })
-
-  it("works with a non-default baseUrlPath", () => {
-    const wrapper = shallow(<App {...getProps()} />)
-    const instance = wrapper.instance() as App
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("baz/qux")
-
-    instance.handlePageNotFound({ pageName: "nonexistentPage" })
-    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/baz/qux")
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -477,21 +477,10 @@ export class App extends PureComponent<Props, State> {
     const { pageName } = pageNotFound
     this.showError(
       "Page not found",
-      `A page with the name ${pageName} does not exist. Redirecting to the app's main page.`
+      `You have requested page /${pageName}, but no corresponding file was found in the app's pages/ directory.`
     )
 
     this.setState({ currentPageName: "" })
-
-    const baseUriParts = this.getBaseUriParts()
-    if (baseUriParts) {
-      const { basePath } = baseUriParts
-      const queryString = this.getQueryString()
-
-      const qs = queryString ? `?${queryString}` : ""
-
-      const pageUrl = `/${basePath}${qs}`
-      window.history.pushState({}, "", pageUrl)
-    }
   }
 
   /**


### PR DESCRIPTION
## 📚 Context

I somehow misremembered what was specified in the spec for handling multipage app "404"
behavior. This PR changes things from the behavior that I misremembered to what's actually
defined.

Note that I very slightly tweaked the error message to avoid specifying an actual corresponding
file name as it's possible for multiple files to map to the same label.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Fix "404" modal message to match that given in the MPA spec
- Don't change the page URL when navigating to a nonexistent page

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
