### PR TITLE
Add helpers to compute hashes for directories

### DIFF
--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -21,6 +21,7 @@ functions that use streamlit.config can go here to avoid a dependency cycle.
 import hashlib
 import time
 import os
+from pathlib import Path
 
 
 # How many times to try to grab the MD5 hash.
@@ -30,28 +31,21 @@ _MAX_RETRIES = 5
 _RETRY_WAIT_SECS = 0.1
 
 
-def calc_md5_with_blocking_retries(file_path):
-    """Calculate the MD5 checksum of a given file_path
+def calc_md5_with_blocking_retries(path: str) -> str:
+    """Calculate the MD5 checksum of a given path.
+
+    For a file, this means calculating the md5 of the file's contents. For a
+    directory, we concatenate the directory's path with the names of all the
+    files in it and calculate the md5 of that.
 
     IMPORTANT: This method calls time.sleep(), which blocks execution. So you
     should only use this outside the main thread.
-
-    Parameters
-    ----------
-    file_path : str
-        The path of the file to check.
-
-    Returns
-    -------
-    str
-        The MD5 checksum.
-
     """
 
-    if os.path.isdir(file_path):
-        content = file_path.encode("UTF8")
+    if os.path.isdir(path):
+        content = _stable_dir_identifier(path).encode("UTF-8")
     else:
-        content = _get_file_content_with_blocking_retries(file_path)
+        content = _get_file_content_with_blocking_retries(path)
 
     md5 = hashlib.md5()
     md5.update(content)
@@ -60,7 +54,7 @@ def calc_md5_with_blocking_retries(file_path):
     return md5.hexdigest()
 
 
-def _get_file_content_with_blocking_retries(file_path):
+def _get_file_content_with_blocking_retries(file_path: str) -> bytes:
     content = b""
     # There's a race condition where sometimes file_path no longer exists when
     # we try to read it (since the file is in the process of being written).
@@ -75,3 +69,48 @@ def _get_file_content_with_blocking_retries(file_path):
                 raise e
             time.sleep(_RETRY_WAIT_SECS)
     return content
+
+
+def _dirfiles(dir_path: str, glob_pattern: str) -> str:
+    p = Path(dir_path)
+    filenames = sorted(
+        [f.name for f in p.glob(glob_pattern) if not f.name.startswith(".")]
+    )
+    return "+".join(filenames)
+
+
+def _stable_dir_identifier(dir_path: str, glob_pattern: str = "*") -> str:
+    """Wait for the files in a directory to look stable-ish before returning an id.
+
+    We do this to deal with problems that would otherwise arise from many tools
+    (e.g. git) and editors (e.g. vim) "editing" files (from the user's
+    perspective) by doing some combination of deleting, creating, and moving
+    various files under the hood.
+
+    Because of this, we're unable to rely on FileSystemEvents that we receive
+    from watchdog to determine when a file has been added to or removed from a
+    directory.
+
+    This is a bit of an unfortunate situation, but the approach we take here is
+    most likely fine as:
+      * The worst thing that can happen taking this approach is a false
+        positive page added/removed notification, which isn't too disastrous
+        and can just be ignored.
+      * It is impossible (that is, I'm fairly certain that the problem is
+        undecidable) to know whether a file created/deleted/moved event
+        corresponds to a legitimate file creation/deletion/move or is part of
+        some sequence of events that results in what the user sees as a file
+        "edit".
+    """
+    dirfiles = _dirfiles(dir_path, glob_pattern)
+
+    for _ in range(_MAX_RETRIES):
+        time.sleep(_RETRY_WAIT_SECS)
+
+        new_dirfiles = _dirfiles(dir_path, glob_pattern)
+        if dirfiles == new_dirfiles:
+            break
+
+        dirfiles = new_dirfiles
+
+    return f"{dir_path}+{dirfiles}"

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, MagicMock, mock_open
+import tempfile
 import unittest
 
 from streamlit.watcher import util
@@ -24,6 +25,15 @@ class UtilTest(unittest.TestCase):
             md5 = util.calc_md5_with_blocking_retries("foo")
             self.assertEqual(md5, "5d41402abc4b2a76b9719d911017c592")
 
+    @patch("os.path.isdir", MagicMock(return_value=True))
+    @patch(
+        "streamlit.watcher.util._stable_dir_identifier",
+        MagicMock(return_value="hello"),
+    )
+    def test_md5_calculation_succeeds_with_dir_input(self):
+        md5 = util.calc_md5_with_blocking_retries("foo")
+        self.assertEqual(md5, "5d41402abc4b2a76b9719d911017c592")
+
     def test_md5_calculation_opens_file_with_rb(self):
         # This tests implementation :( . But since the issue this is addressing
         # could easily come back to bite us if a distracted coder tweaks the
@@ -31,3 +41,44 @@ class UtilTest(unittest.TestCase):
         with patch("streamlit.watcher.util.open", mock_open(read_data=b"hello")) as m:
             md5 = util.calc_md5_with_blocking_retries("foo")
             m.assert_called_once_with("foo", "rb")
+
+
+class DirHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._test_dir = tempfile.TemporaryDirectory()
+
+        create_file = lambda prefix, suffix: tempfile.NamedTemporaryFile(
+            dir=self._test_dir.name,
+            prefix=prefix,
+            suffix=suffix,
+            delete=False,
+        )
+
+        create_file("01", ".py")
+        create_file("02", ".py")
+        create_file("03", ".py")
+        create_file("04", ".rs")
+        create_file(".05", ".py")
+
+    def tearDown(self) -> None:
+        self._test_dir.cleanup()
+
+    def test_dirfiles_sorts_files_and_ignores_hidden(self):
+        dirfiles = util._dirfiles(self._test_dir.name, "*")
+        filename_prefixes = [f[:2] for f in dirfiles.split("+")]
+        assert filename_prefixes == ["01", "02", "03", "04"]
+
+    def test_dirfiles_glob_pattern(self):
+        dirfiles = util._dirfiles(self._test_dir.name, "*.py")
+        filename_prefixes = [f[:2] for f in dirfiles.split("+")]
+        assert filename_prefixes == ["01", "02", "03"]
+
+    @patch("streamlit.watcher.util._dirfiles", MagicMock(side_effect=["foo", "foo"]))
+    def test_stable_dir(self):
+        assert util._stable_dir_identifier("my_dir") == "my_dir+foo"
+
+    @patch(
+        "streamlit.watcher.util._dirfiles", MagicMock(side_effect=["foo", "bar", "bar"])
+    )
+    def test_stable_dir_files_change(self):
+        assert util._stable_dir_identifier("my_dir") == "my_dir+bar"


### PR DESCRIPTION
## 📚 Context

NOTE: This PR builds off work done in https://github.com/streamlit/streamlit/pull/4604, which should be reviewed first.

See the PR description of #4604 for a description of the feature this work is building toward.
In this PR, we teach the `calc_md5_with_blocking_retries` functions to generate hashes for
directories that change when files (optionally filtered by a given extension) are added or removed
from a directory. The reason that we need to do this to support watchers on the `pages/` directory
of an app with multiple pages is described in the docstring of a helper function that I added, so I've
pasted the function signature+docstring below.

```python
def _stable_dir_identifier(dir_path: str, glob_pattern: str = "*") -> str:
    """Wait for the files in a directory to look stable-ish before returning an id.

    We do this to deal with problems that would otherwise arise from many tools
    (e.g. git) and editors (e.g. vim) "editing" files (from the user's
    perspective) by doing some combination of deleting, creating, and moving
    various files under the hood.

    Because of this, we're unable to rely on FileSystemEvents that we receive
    from watchdog to determine when a file has been added to or removed from a
    directory.

    This is a bit of an unfortunate situation, but the approach we take here is
    most likely fine as:
      * The worst thing that can happen taking this approach is a false
        positive page added/removed notification, which isn't too disastrous
        and can just be ignored.
      * It is impossible (that is, I'm fairly certain that the problem is
        undecidable) to know whether a file created/deleted/moved event
        corresponds to a legitimate file creation/deletion/move or is part of
        some sequence of events that results in what the user sees as a file
        "edit".
    """
```
- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Teach `calc_md5_with_blocking_retries` how to generate hashes for directories
   that can be used to tell when files with a given extension have been added or removed.

## 🧪 Testing Done

- [x] Added/Updated unit tests
