### PR TITLE
Implement a new watch_dir function

### DIFF
--- a/lib/streamlit/watcher/__init__.py
+++ b/lib/streamlit/watcher/__init__.py
@@ -15,5 +15,6 @@
 from .local_sources_watcher import LocalSourcesWatcher as LocalSourcesWatcher
 from .path_watcher import (
     report_watchdog_availability as report_watchdog_availability,
+    watch_dir as watch_dir,
     watch_file as watch_file,
 )

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -262,7 +262,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                     glob_pattern=glob_pattern,
                     allow_nonexistent=allow_nonexistent,
                 )
-                modification_time = os.stat(path).st_mtime
+                modification_time = util.path_modification_time(path, allow_nonexistent)
                 watched_path = WatchedPath(
                     md5=md5,
                     modification_time=modification_time,
@@ -324,7 +324,9 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             )
             return
 
-        modification_time = os.stat(changed_path).st_mtime
+        modification_time = util.path_modification_time(
+            changed_path, changed_path_info.allow_nonexistent
+        )
         if modification_time == changed_path_info.modification_time:
             LOGGER.debug("File/dir timestamp did not change: %s", changed_path)
             return

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -60,12 +60,24 @@ class EventBasedPathWatcher:
         path_watcher.close()
         LOGGER.debug("Watcher closed")
 
-    def __init__(self, path: str, on_changed: Callable[[str], None]) -> None:
+    def __init__(
+        self,
+        path: str,
+        on_changed: Callable[[str], None],
+        *,  # keyword-only arguments:
+        glob_pattern: Optional[str] = None,
+        allow_nonexistent: bool = False,
+    ) -> None:
         self._path = os.path.abspath(path)
         self._on_changed = on_changed
 
         path_watcher = _MultiPathWatcher.get_singleton()
-        path_watcher.watch_path(self._path, on_changed)
+        path_watcher.watch_path(
+            self._path,
+            on_changed,
+            glob_pattern=glob_pattern,
+            allow_nonexistent=allow_nonexistent,
+        )
         LOGGER.debug("Watcher created for %s", self._path)
 
     def __repr__(self) -> str:
@@ -120,7 +132,14 @@ class _MultiPathWatcher(object):
     def __repr__(self) -> str:
         return repr_(self)
 
-    def watch_path(self, path: str, callback: Callable[[str], None]) -> None:
+    def watch_path(
+        self,
+        path: str,
+        callback: Callable[[str], None],
+        *,  # keyword-only arguments:
+        glob_pattern: Optional[str] = None,
+        allow_nonexistent: bool = False,
+    ) -> None:
         """Start watching a path."""
         folder_path = os.path.abspath(os.path.dirname(path))
 
@@ -135,7 +154,12 @@ class _MultiPathWatcher(object):
                     folder_handler, folder_path, recursive=True
                 )
 
-            folder_handler.add_path_change_listener(path, callback)
+            folder_handler.add_path_change_listener(
+                path,
+                callback,
+                glob_pattern=glob_pattern,
+                allow_nonexistent=allow_nonexistent,
+            )
 
     def stop_watching_path(self, path: str, callback: Callable[[str], None]) -> None:
         """Stop watching a path."""
@@ -181,9 +205,20 @@ class _MultiPathWatcher(object):
 class WatchedPath(object):
     """Emits notifications when a single path is modified."""
 
-    def __init__(self, md5, modification_time):
+    def __init__(
+        self,
+        md5,
+        modification_time,
+        *,  # keyword-only arguments:
+        glob_pattern: Optional[str] = None,
+        allow_nonexistent: bool = False,
+    ):
         self.md5 = md5
         self.modification_time = modification_time
+
+        self.glob_pattern = glob_pattern
+        self.allow_nonexistent = allow_nonexistent
+
         self.on_changed = Signal()
 
     def __repr__(self) -> str:
@@ -211,15 +246,29 @@ class _FolderEventHandler(events.FileSystemEventHandler):
         return repr_(self)
 
     def add_path_change_listener(
-        self, path: str, callback: Callable[[str], None]
+        self,
+        path: str,
+        callback: Callable[[str], None],
+        *,  # keyword-only arguments:
+        glob_pattern: Optional[str] = None,
+        allow_nonexistent: bool = False,
     ) -> None:
         """Add a path to this object's event filter."""
         with self._lock:
             watched_path = self._watched_paths.get(path, None)
             if watched_path is None:
-                md5 = util.calc_md5_with_blocking_retries(path)
+                md5 = util.calc_md5_with_blocking_retries(
+                    path,
+                    glob_pattern=glob_pattern,
+                    allow_nonexistent=allow_nonexistent,
+                )
                 modification_time = os.stat(path).st_mtime
-                watched_path = WatchedPath(md5=md5, modification_time=modification_time)
+                watched_path = WatchedPath(
+                    md5=md5,
+                    modification_time=modification_time,
+                    glob_pattern=glob_pattern,
+                    allow_nonexistent=allow_nonexistent,
+                )
                 self._watched_paths[path] = watched_path
 
             watched_path.on_changed.connect(callback, weak=False)
@@ -282,7 +331,11 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
         changed_path_info.modification_time = modification_time
 
-        new_md5 = util.calc_md5_with_blocking_retries(changed_path)
+        new_md5 = util.calc_md5_with_blocking_retries(
+            changed_path,
+            glob_pattern=changed_path_info.glob_pattern,
+            allow_nonexistent=changed_path_info.allow_nonexistent,
+        )
         if new_md5 == changed_path_info.md5:
             LOGGER.debug("File/dir MD5 did not change: %s", changed_path)
             return

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -68,6 +68,23 @@ class EventBasedPathWatcher:
         glob_pattern: Optional[str] = None,
         allow_nonexistent: bool = False,
     ) -> None:
+        """Constructor for EventBasedPathWatchers.
+
+        Parameters
+        ----------
+        path : str
+            The path to watch.
+        on_changed : Callable[[str], None]
+            Callback to call when the path changes.
+        glob_pattern : Optional[str]
+            A glob pattern to filter the files in a directory that should be
+            watched. Only relevant when creating an EventBasedPathWatcher on a
+            directory.
+        allow_nonexistent : bool
+            If True, the watcher will not raise an exception if the path does
+            not exist. This can be used to watch for the creation of a file or
+            directory at a given path.
+        """
         self._path = os.path.abspath(path)
         self._on_changed = on_changed
 
@@ -207,8 +224,8 @@ class WatchedPath(object):
 
     def __init__(
         self,
-        md5,
-        modification_time,
+        md5: str,
+        modification_time: float,
         *,  # keyword-only arguments:
         glob_pattern: Optional[str] = None,
         allow_nonexistent: bool = False,

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -46,7 +46,14 @@ except ImportError:
 # This forces us to define this stub class since the cached value equaling
 # None corresponds to case 1 above.
 class NoOpPathWatcher:
-    def __init__(self, _path_str, _on_changed):
+    def __init__(
+        self,
+        _path_str: str,
+        _on_changed: Callable[[str], None],
+        *,  # keyword-only arguments:
+        glob_pattern: Optional[str] = None,
+        allow_nonexistent: bool = False,
+    ):
         pass
 
 
@@ -78,12 +85,13 @@ def report_watchdog_availability():
             )
 
 
-# TODO(vdonato): Add an internal `_watch_path` method, and use it to implement
-# `watch_file` and `watch_directory`.
-def watch_file(
+def _watch_path(
     path: str,
     on_file_changed: Callable[[str], None],
     watcher_type: Optional[str] = None,
+    *,  # keyword-only arguments:
+    glob_pattern: Optional[str] = None,
+    allow_nonexistent: bool = False,
 ) -> bool:
     """Create a PathWatcher for the given file if we have a viable
     PathWatcher class.
@@ -97,6 +105,13 @@ def watch_file(
     watcher_type
         Optional watcher_type string. If None, it will default to the
         'server.fileWatcherType` config option.
+    glob_pattern
+        Optional glob pattern to use when watching a directory. If set, only
+        files matching the pattern will be counted as being created/deleted
+        within the watched directory.
+    allow_nonexistent
+        If True, allow the file or directory at the given path to be
+        nonexistent.
 
     Returns
     -------
@@ -104,7 +119,6 @@ def watch_file(
         True if the file is being watched, or False if we have no
         PathWatcher class.
     """
-
     if watcher_type is None:
         watcher_type = config.get_option("server.fileWatcherType")
 
@@ -112,8 +126,38 @@ def watch_file(
     if watcher_class is NoOpPathWatcher:
         return False
 
-    watcher_class(path, on_file_changed)
+    watcher_class(
+        path,
+        on_file_changed,
+        glob_pattern=glob_pattern,
+        allow_nonexistent=allow_nonexistent,
+    )
     return True
+
+
+def watch_file(
+    path: str,
+    on_file_changed: Callable[[str], None],
+    watcher_type: Optional[str] = None,
+) -> bool:
+    return _watch_path(path, on_file_changed, watcher_type)
+
+
+def watch_dir(
+    path: str,
+    on_file_changed: Callable[[str], None],
+    watcher_type: Optional[str] = None,
+    *,  # keyword-only arguments:
+    glob_pattern: Optional[str] = None,
+    allow_nonexistent: bool = False,
+) -> bool:
+    return _watch_path(
+        path,
+        on_file_changed,
+        watcher_type,
+        glob_pattern=glob_pattern,
+        allow_nonexistent=allow_nonexistent,
+    )
 
 
 def get_default_path_watcher_class() -> PathWatcherType:

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -87,21 +87,21 @@ def report_watchdog_availability():
 
 def _watch_path(
     path: str,
-    on_file_changed: Callable[[str], None],
+    on_path_changed: Callable[[str], None],
     watcher_type: Optional[str] = None,
     *,  # keyword-only arguments:
     glob_pattern: Optional[str] = None,
     allow_nonexistent: bool = False,
 ) -> bool:
-    """Create a PathWatcher for the given file if we have a viable
+    """Create a PathWatcher for the given path if we have a viable
     PathWatcher class.
 
     Parameters
     ----------
     path
-        Path of the file to watch.
-    on_file_changed
-        Function that's called when the file changes.
+        Path to watch.
+    on_path_changed
+        Function that's called when the path changes.
     watcher_type
         Optional watcher_type string. If None, it will default to the
         'server.fileWatcherType` config option.
@@ -116,7 +116,7 @@ def _watch_path(
     Returns
     -------
     bool
-        True if the file is being watched, or False if we have no
+        True if the path is being watched, or False if we have no
         PathWatcher class.
     """
     if watcher_type is None:
@@ -128,7 +128,7 @@ def _watch_path(
 
     watcher_class(
         path,
-        on_file_changed,
+        on_path_changed,
         glob_pattern=glob_pattern,
         allow_nonexistent=allow_nonexistent,
     )
@@ -145,7 +145,7 @@ def watch_file(
 
 def watch_dir(
     path: str,
-    on_file_changed: Callable[[str], None],
+    on_dir_changed: Callable[[str], None],
     watcher_type: Optional[str] = None,
     *,  # keyword-only arguments:
     glob_pattern: Optional[str] = None,
@@ -153,7 +153,7 @@ def watch_dir(
 ) -> bool:
     return _watch_path(
         path,
-        on_file_changed,
+        on_dir_changed,
         watcher_type,
         glob_pattern=glob_pattern,
         allow_nonexistent=allow_nonexistent,

--- a/lib/streamlit/watcher/polling_path_watcher.py
+++ b/lib/streamlit/watcher/polling_path_watcher.py
@@ -67,7 +67,10 @@ class PollingPathWatcher:
         self._allow_nonexistent = allow_nonexistent
 
         self._active = True
-        self._modification_time = os.stat(self._path).st_mtime
+
+        self._modification_time = util.path_modification_time(
+            self._path, self._allow_nonexistent
+        )
         self._md5 = util.calc_md5_with_blocking_retries(
             self._path,
             glob_pattern=self._glob_pattern,
@@ -90,7 +93,9 @@ class PollingPathWatcher:
             # Don't call self._schedule()
             return
 
-        modification_time = os.stat(self._path).st_mtime
+        modification_time = util.path_modification_time(
+            self._path, self._allow_nonexistent
+        )
         if modification_time <= self._modification_time:
             self._schedule()
             return

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -22,6 +22,7 @@ import hashlib
 import time
 import os
 from pathlib import Path
+from typing import Optional
 
 
 # How many times to try to grab the MD5 hash.
@@ -31,7 +32,12 @@ _MAX_RETRIES = 5
 _RETRY_WAIT_SECS = 0.1
 
 
-def calc_md5_with_blocking_retries(path: str) -> str:
+def calc_md5_with_blocking_retries(
+    path: str,
+    *,  # keyword-only arguments:
+    glob_pattern: Optional[str] = None,
+    allow_nonexistent: bool = False,
+) -> str:
     """Calculate the MD5 checksum of a given path.
 
     For a file, this means calculating the md5 of the file's contents. For a
@@ -42,8 +48,11 @@ def calc_md5_with_blocking_retries(path: str) -> str:
     should only use this outside the main thread.
     """
 
-    if os.path.isdir(path):
-        content = _stable_dir_identifier(path).encode("UTF-8")
+    if allow_nonexistent and not os.path.exists(path):
+        content = path.encode("UTF-8")
+    elif os.path.isdir(path):
+        glob_pattern = glob_pattern or "*"
+        content = _stable_dir_identifier(path, glob_pattern).encode("UTF-8")
     else:
         content = _get_file_content_with_blocking_retries(path)
 
@@ -79,7 +88,7 @@ def _dirfiles(dir_path: str, glob_pattern: str) -> str:
     return "+".join(filenames)
 
 
-def _stable_dir_identifier(dir_path: str, glob_pattern: str = "*") -> str:
+def _stable_dir_identifier(dir_path: str, glob_pattern: str) -> str:
     """Wait for the files in a directory to look stable-ish before returning an id.
 
     We do this to deal with problems that would otherwise arise from many tools

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -64,6 +64,19 @@ def calc_md5_with_blocking_retries(
 
 
 def path_modification_time(path: str, allow_nonexistent: bool = False) -> float:
+    """Return the modification time of a path (file or directory).
+
+    If allow_nonexistent is True and the path does not exist, we return 0.0 to
+    guarantee that any file/dir later created at the path has a later
+    modification time than the last time returned by this function for that
+    path.
+
+    If allow_nonexistent is False and no file/dir exists at the path, a
+    FileNotFoundError is raised (by os.stat).
+
+    For any path that does correspond to an existing file/dir, we return its
+    modification time.
+    """
     if allow_nonexistent and not os.path.exists(path):
         return 0.0
     return os.stat(path).st_mtime

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -63,6 +63,12 @@ def calc_md5_with_blocking_retries(
     return md5.hexdigest()
 
 
+def path_modification_time(path: str, allow_nonexistent: bool = False) -> float:
+    if allow_nonexistent and not os.path.exists(path):
+        return 0.0
+    return os.stat(path).st_mtime
+
+
 def _get_file_content_with_blocking_retries(file_path: str) -> bytes:
     content = b""
     # There's a race condition where sometimes file_path no longer exists when

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -45,7 +45,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         """Test that when a file is modified, the callback is called."""
         cb = mock.Mock()
 
-        self.mock_util.path_modification_time = lambda _, __: 101
+        self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -57,7 +57,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_not_called()
 
-        self.mock_util.path_modification_time = lambda _, __: 102
+        self.mock_util.path_modification_time = lambda *args: 102.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
@@ -72,7 +72,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         """Test that when a directory is modified, the callback is called."""
         cb = mock.Mock()
 
-        self.mock_util.path_modification_time = lambda _, __: 101
+        self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/dir", cb)
@@ -84,7 +84,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_not_called()
 
-        self.mock_util.path_modification_time = lambda _, __: 102
+        self.mock_util.path_modification_time = lambda *args: 102.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/dir")
@@ -97,9 +97,18 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         ro.close()
 
     def test_kwargs_plumbed_to_calc_md5(self):
+        """Test that we pass the glob_pattern and allow_nonexistent kwargs to
+        calc_md5_with_blocking_retries.
+
+        `EventBasedPathWatcher`s can be created with optional kwargs allowing
+        the caller to specify what types of files to watch (when watching a
+        directory) and whether to allow watchers on paths with no files/dirs.
+        This test ensures that these optional parameters make it to our hash
+        calculation helpers across different on_changed events.
+        """
         cb = mock.Mock()
 
-        self.mock_util.path_modification_time = lambda _, __: 101
+        self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
 
         ro = event_based_path_watcher.EventBasedPathWatcher(
@@ -118,7 +127,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
         cb.assert_not_called()
 
-        self.mock_util.path_modification_time = lambda _, __: 102
+        self.mock_util.path_modification_time = lambda *args: 102.0
         self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="3")
 
         ev = events.FileSystemEvent("/this/is/my/dir")
@@ -136,7 +145,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         """Test that we ignore files with same mtime."""
         cb = mock.Mock()
 
-        self.mock_util.path_modification_time = lambda _, __: 101
+        self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -164,7 +173,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         """Test that we ignore files with same md5."""
         cb = mock.Mock()
 
-        self.mock_util.path_modification_time = lambda _, __: 101
+        self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -176,7 +185,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_not_called()
 
-        self.mock_util.path_modification_time = lambda _, __: 102
+        self.mock_util.path_modification_time = lambda *args: 102.0
         # Same MD5!
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
@@ -192,7 +201,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         """Test that we ignore created files."""
         cb = mock.Mock()
 
-        self.mock_util.path_modification_time = lambda _, __: 101
+        self.mock_util.path_modification_time = lambda *args: 101.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -204,7 +213,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_not_called()
 
-        self.mock_util.path_modification_time = lambda _, __: 102
+        self.mock_util.path_modification_time = lambda *args: 102.0
         self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
@@ -221,10 +230,10 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         filename = "/this/is/my/file.py"
 
-        mod_count = [0]
+        mod_count = [0.0]
 
         def modify_mock_file():
-            self.mock_util.path_modification_time = lambda _, __: mod_count[0]
+            self.mock_util.path_modification_time = lambda *args: mod_count[0]
             self.mock_util.calc_md5_with_blocking_retries = (
                 lambda _, **kwargs: "%d" % mod_count[0]
             )
@@ -233,7 +242,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
             ev.event_type = events.EVENT_TYPE_MODIFIED
             folder_handler.on_modified(ev)
 
-            mod_count[0] += 1
+            mod_count[0] += 1.0
 
         cb1 = mock.Mock()
         cb2 = mock.Mock()

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -64,7 +64,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         """Test that when a file is modified, the callback is called."""
         callback = mock.Mock()
 
-        self.util_mock.path_modification_time = lambda _, __: 101
+        self.util_mock.path_modification_time = lambda *args: 101.0
         self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         watcher = polling_path_watcher.PollingPathWatcher(
@@ -74,7 +74,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         self._run_executor_tasks()
         callback.assert_not_called()
 
-        self.util_mock.path_modification_time = lambda _, __: 102
+        self.util_mock.path_modification_time = lambda *args: 102.0
         self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
 
         self._run_executor_tasks()
@@ -86,7 +86,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         """Test that we ignore files with same mtime."""
         callback = mock.Mock()
 
-        self.util_mock.path_modification_time = lambda _, __: 101
+        self.util_mock.path_modification_time = lambda *args: 101.0
         self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         watcher = polling_path_watcher.PollingPathWatcher(
@@ -109,7 +109,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         """Test that we ignore files with same md5."""
         callback = mock.Mock()
 
-        self.util_mock.path_modification_time = lambda _, __: 101
+        self.util_mock.path_modification_time = lambda *args: 101.0
         self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
 
         watcher = polling_path_watcher.PollingPathWatcher(
@@ -119,7 +119,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         self._run_executor_tasks()
         callback.assert_not_called()
 
-        self.util_mock.path_modification_time = lambda _, __: 102
+        self.util_mock.path_modification_time = lambda *args: 102.0
         # Same MD5
 
         # This is the test:
@@ -129,9 +129,18 @@ class PollingPathWatcherTest(unittest.TestCase):
         watcher.close()
 
     def test_kwargs_plumbed_to_calc_md5(self):
+        """Test that we pass the glob_pattern and allow_nonexistent kwargs to
+        calc_md5_with_blocking_retries.
+
+        `PollingPathWatcher`s can be created with optional kwargs allowing
+        the caller to specify what types of files to watch (when watching a
+        directory) and whether to allow watchers on paths with no files/dirs.
+        This test ensures that these optional parameters make it to our hash
+        calculation helpers across different on_changed events.
+        """
         callback = mock.Mock()
 
-        self.util_mock.path_modification_time = lambda _, __: 101
+        self.util_mock.path_modification_time = lambda *args: 101.0
         self.util_mock.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
 
         watcher = polling_path_watcher.PollingPathWatcher(
@@ -146,7 +155,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
         assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
 
-        self.util_mock.path_modification_time = lambda _, __: 102
+        self.util_mock.path_modification_time = lambda *args: 102.0
         self.util_mock.calc_md5_with_blocking_retries = mock.Mock(return_value="2")
 
         self._run_executor_tasks()
@@ -160,15 +169,15 @@ class PollingPathWatcherTest(unittest.TestCase):
         """Test that we can have multiple watchers of the same file."""
         filename = "/this/is/my/file.py"
 
-        mod_count = [0]
+        mod_count = [0.0]
 
         def modify_mock_file():
-            self.util_mock.path_modification_time = lambda _, __: mod_count[0]
+            self.util_mock.path_modification_time = lambda *args: mod_count[0]
             self.util_mock.calc_md5_with_blocking_retries = (
                 lambda _, **kwargs: "%d" % mod_count[0]
             )
 
-            mod_count[0] += 1
+            mod_count[0] += 1.0
 
         modify_mock_file()
 

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -56,6 +56,29 @@ class UtilTest(unittest.TestCase):
             m.assert_called_once_with("foo", "rb")
 
 
+class FakeStat(object):
+    """Emulates the output of os.stat()."""
+
+    def __init__(self, mtime):
+        self.st_mtime = mtime
+
+
+class PathModificationTimeTests(unittest.TestCase):
+    @patch("streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101)))
+    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
+    def test_st_mtime_if_file_exists(self):
+        assert util.path_modification_time("foo") == 101
+
+    @patch("streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101)))
+    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
+    def test_st_mtime_if_file_exists_and_allow_nonexistent(self):
+        assert util.path_modification_time("foo", allow_nonexistent=True) == 101
+
+    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=False))
+    def test_zero_if_file_nonexistent_and_allow_nonexistent(self):
+        assert util.path_modification_time("foo", allow_nonexistent=True) == 0.0
+
+
 class DirHelperTests(unittest.TestCase):
     def setUp(self) -> None:
         self._test_dir = tempfile.TemporaryDirectory()

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -64,15 +64,19 @@ class FakeStat(object):
 
 
 class PathModificationTimeTests(unittest.TestCase):
-    @patch("streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101)))
+    @patch(
+        "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
+    )
     @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
     def test_st_mtime_if_file_exists(self):
-        assert util.path_modification_time("foo") == 101
+        assert util.path_modification_time("foo") == 101.0
 
-    @patch("streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101)))
+    @patch(
+        "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
+    )
     @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
     def test_st_mtime_if_file_exists_and_allow_nonexistent(self):
-        assert util.path_modification_time("foo", allow_nonexistent=True) == 101
+        assert util.path_modification_time("foo", allow_nonexistent=True) == 101.0
 
     @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=False))
     def test_zero_if_file_nonexistent_and_allow_nonexistent(self):

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -26,12 +26,25 @@ class UtilTest(unittest.TestCase):
             self.assertEqual(md5, "5d41402abc4b2a76b9719d911017c592")
 
     @patch("os.path.isdir", MagicMock(return_value=True))
-    @patch(
-        "streamlit.watcher.util._stable_dir_identifier",
-        MagicMock(return_value="hello"),
-    )
-    def test_md5_calculation_succeeds_with_dir_input(self):
+    @patch("streamlit.watcher.util._stable_dir_identifier")
+    def test_md5_calculation_succeeds_with_dir_input(self, mock_stable_dir_identifier):
+        mock_stable_dir_identifier.return_value = "hello"
+
         md5 = util.calc_md5_with_blocking_retries("foo")
+        self.assertEqual(md5, "5d41402abc4b2a76b9719d911017c592")
+        mock_stable_dir_identifier.assert_called_once_with("foo", "*")
+
+    @patch("os.path.isdir", MagicMock(return_value=True))
+    @patch("streamlit.watcher.util._stable_dir_identifier")
+    def test_md5_calculation_can_pass_glob(self, mock_stable_dir_identifier):
+        mock_stable_dir_identifier.return_value = "hello"
+
+        md5 = util.calc_md5_with_blocking_retries("foo", glob_pattern="*.py")
+        mock_stable_dir_identifier.assert_called_once_with("foo", "*.py")
+
+    @patch("os.path.exists", MagicMock(return_value=False))
+    def test_md5_calculation_allow_nonexistent(self):
+        md5 = util.calc_md5_with_blocking_retries("hello", allow_nonexistent=True)
         self.assertEqual(md5, "5d41402abc4b2a76b9719d911017c592")
 
     def test_md5_calculation_opens_file_with_rb(self):
@@ -75,10 +88,10 @@ class DirHelperTests(unittest.TestCase):
 
     @patch("streamlit.watcher.util._dirfiles", MagicMock(side_effect=["foo", "foo"]))
     def test_stable_dir(self):
-        assert util._stable_dir_identifier("my_dir") == "my_dir+foo"
+        assert util._stable_dir_identifier("my_dir", "*") == "my_dir+foo"
 
     @patch(
         "streamlit.watcher.util._dirfiles", MagicMock(side_effect=["foo", "bar", "bar"])
     )
     def test_stable_dir_files_change(self):
-        assert util._stable_dir_identifier("my_dir") == "my_dir+bar"
+        assert util._stable_dir_identifier("my_dir", "*") == "my_dir+bar"


### PR DESCRIPTION
## 📚 Context

NOTE: This PR builds on top of #4604, #4608, and #4609, which should all be
reviewed first.

Now that all of our `*PathWatcher` classes support watching directories, we need
a way of actually registering directory watchers.

This PR adds a new `watch_dir` function that is analogous to the existing `watch_file`
function. It differs in two ways:
* `watch_dir` can be given a `glob_pattern` to only watch the directory for file
   additions/removals matching the pattern. This will be used to only respond to
   changes for files with a given extension.
* `watch_dir` can also be passed the `allow_nonexistent` parameter, which allows
   the caller to watch for a directory that is currently nonexistent.


What kind of change does this PR introduce?
- [x] Feature

## 🧠 Description of Changes

- allow `calc_md5_with_blocking_retries` to handle nonexistent paths
- plumb `glob_pattern` and `allow_nonexistent` kwargs around our `*PathWatcher` classes
- refactor `watch_file` into `_watch_path`
- use `_watch_path` to implement `watch_file` and `watch_dir`

## 🧪 Testing Done

- [x] Added/Updated unit tests