### PR TITLE
SessionState: no longer a MutableMapping

### DIFF
--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -328,10 +328,6 @@ class SessionState(MutableMapping[str, Any]):
         self._key_id_mapping.clear()
 
     @property
-    def _merged_state(self) -> Dict[str, Any]:
-        return {k: self[k] for k in self}
-
-    @property
     def filtered_state(self) -> Dict[str, Any]:
         """The combined session and widget state, excluding keyless widgets."""
 
@@ -382,9 +378,6 @@ class SessionState(MutableMapping[str, Any]):
 
     def __len__(self) -> int:
         return len(self.keys())
-
-    def __str__(self) -> str:
-        return str(self._merged_state)
 
     def __getitem__(self, key: str) -> Any:
         wid_key_map = self.reverse_key_wid_map

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -359,7 +359,7 @@ class SessionState:
         wid_key_map = {v: k for k, v in self._key_id_mapping.items()}
         return wid_key_map
 
-    def keys(self) -> Set[str]:  # type: ignore
+    def keys(self) -> Set[str]:
         """All keys active in Session State, with widget keys converted
         to widget ids when one is known."""
         old_keys = {self._get_widget_id(k) for k in self._old_state.keys()}

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -327,23 +327,6 @@ class SessionState(MutableMapping[str, Any]):
         self._new_widget_state.clear()
         self._key_id_mapping.clear()
 
-    def _safe_widget_state(self) -> Dict[str, Any]:
-        """Return widget states for all widgets with deserializers registered.
-
-        On a browser tab reconnect, it's possible for widgets in
-        self._new_widget_state to not have deserializers registered, which will
-        result in trying to access them raising a KeyError. This results in
-        things exploding if we try to naively use the splat operator on
-        self._new_widget_state in _merged_state below.
-        """
-        wstate = {}
-        for k in self._new_widget_state.keys():
-            try:
-                wstate[k] = self._new_widget_state[k]
-            except KeyError:
-                pass
-        return wstate
-
     @property
     def _merged_state(self) -> Dict[str, Any]:
         return {k: self[k] for k in self}

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -331,7 +331,7 @@ class SessionState(MutableMapping[str, Any]):
     def filtered_state(self) -> Dict[str, Any]:
         """The combined session and widget state, excluding keyless widgets."""
 
-        wid_key_map = self.reverse_key_wid_map
+        wid_key_map = self._reverse_key_wid_map
 
         state: Dict[str, Any] = {}
 
@@ -354,7 +354,7 @@ class SessionState(MutableMapping[str, Any]):
         return state
 
     @property
-    def reverse_key_wid_map(self) -> Dict[str, str]:
+    def _reverse_key_wid_map(self) -> Dict[str, str]:
         """Return a mapping of widget_id : widget_key."""
         wid_key_map = {v: k for k, v in self._key_id_mapping.items()}
         return wid_key_map
@@ -380,7 +380,7 @@ class SessionState(MutableMapping[str, Any]):
         return len(self.keys())
 
     def __getitem__(self, key: str) -> Any:
-        wid_key_map = self.reverse_key_wid_map
+        wid_key_map = self._reverse_key_wid_map
         widget_id = self._get_widget_id(key)
 
         if widget_id in wid_key_map and widget_id == key:

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -374,9 +374,13 @@ class SessionState:
         return user_key in self._new_session_state
 
     def __iter__(self) -> Iterator[Any]:
+        """Return an iterator over the keys of the SessionState.
+        This is a shortcut for `iter(self.keys())`
+        """
         return iter(self.keys())
 
     def __len__(self) -> int:
+        """Return the number of items in SessionState."""
         return len(self.keys())
 
     def __getitem__(self, key: str) -> Any:
@@ -437,7 +441,7 @@ class SessionState:
         """Set the value of the session_state entry with the given user_key.
 
         If the key corresponds to a widget or form that's been instantiated
-        during the current script run, raise an Exception instead.
+        during the current script run, raise a StreamlitAPIException instead.
         """
         from streamlit.scriptrunner import get_script_run_ctx
 

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -279,7 +279,7 @@ def _missing_key_error_message(key: str) -> str:
 
 
 @attr.s(auto_attribs=True, slots=True)
-class SessionState(MutableMapping[str, Any]):
+class SessionState:
     """SessionState allows users to store values that persist between app
     reruns.
 
@@ -476,12 +476,6 @@ class SessionState(MutableMapping[str, Any]):
 
         if widget_id in self._old_state:
             del self._old_state[widget_id]
-
-    def update(self, other: "SessionState") -> None:  # type: ignore
-        self._new_session_state.update(other._new_session_state)
-        self._new_widget_state.update(other._new_widget_state)
-        self._old_state.update(other._old_state)
-        self._key_id_mapping.update(other._key_id_mapping)
 
     def set_widgets_from_proto(self, widget_states: WidgetStatesProto) -> None:
         """Set the value of all widgets represented in the given WidgetStatesProto."""

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -581,10 +581,6 @@ class SessionState:
     def _set_key_widget_mapping(self, widget_id: str, user_key: str) -> None:
         self._key_id_mapping[user_key] = widget_id
 
-    def copy(self) -> "SessionState":
-        """Return a deep copy of self."""
-        return deepcopy(self)
-
     def register_widget(
         self, metadata: WidgetMetadata, user_key: Optional[str]
     ) -> Tuple[Any, bool]:

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -604,7 +604,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # At this point, scriptrunner should have finished running, detected
         # that our widget_id wasn't in the list of widgets found this run, and
         # culled it. Ensure widget cache no longer holds our widget ID.
-        self.assertIsNone(scriptrunner._session_state.get(widget_id, None))
+        self.assertRaises(KeyError, lambda: scriptrunner._session_state[widget_id])
 
     # TODO re-enable after flakyness is fixed
     def off_test_multiple_scriptrunners(self):

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -473,16 +473,15 @@ class SessionStateMethodTests(unittest.TestCase):
         assert self.session_state._new_widget_state == WStates()
 
     def test_clear_state(self):
-        self.session_state.clear_state()
-        assert self.session_state._merged_state == {}
+        # Sanity test
+        keys = {"foo", "baz", "corge", f"{GENERATED_WIDGET_KEY_PREFIX}-foo-None"}
+        self.assertEqual(keys, self.session_state.keys())
 
-    def test_merged_state(self):
-        assert self.session_state._merged_state == {
-            "foo": "bar2",
-            "baz": "qux2",
-            "corge": "grault",
-            f"{GENERATED_WIDGET_KEY_PREFIX}-foo-None": "bar",
-        }
+        # Clear state
+        self.session_state.clear_state()
+
+        # Keys should be empty
+        self.assertEqual(set(), self.session_state.keys())
 
     def test_filtered_state(self):
         assert self.session_state.filtered_state == {
@@ -495,7 +494,7 @@ class SessionStateMethodTests(unittest.TestCase):
         old_state = {"foo": "bar", "corge": "grault"}
         new_session_state = {}
         new_widget_state = WStates(
-            {f"{GENERATED_WIDGET_KEY_PREFIX}-baz": Serialized(None)},
+            {f"{GENERATED_WIDGET_KEY_PREFIX}-baz": Serialized(WidgetStateProto())},
         )
         self.session_state = SessionState(
             old_state, new_session_state, new_widget_state

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -476,16 +476,6 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state.clear_state()
         assert self.session_state._merged_state == {}
 
-    def test_safe_widget_state(self):
-        new_session_state = MagicMock()
-
-        wstate = {"foo": "bar"}
-        new_session_state.__getitem__.side_effect = wstate.__getitem__
-        new_session_state.keys = lambda: {"foo", "baz"}
-        self.session_state = SessionState({}, {}, new_session_state)
-
-        assert self.session_state._safe_widget_state() == wstate
-
     def test_merged_state(self):
         assert self.session_state._merged_state == {
             "foo": "bar2",

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Session state unit tests."""
-
+from copy import deepcopy
 from typing import Any, List, Tuple
 import unittest
 from unittest.mock import patch, MagicMock
@@ -442,7 +442,7 @@ class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
 
 def _compact_copy(state: SessionState) -> SessionState:
     """Return a compacted copy of the given SessionState."""
-    state_copy = state.copy()
+    state_copy = deepcopy(state)
     state_copy._compact_state()
     return state_copy
 

--- a/lib/tests/streamlit/state/strategies.py
+++ b/lib/tests/streamlit/state/strategies.py
@@ -79,6 +79,14 @@ def _session_state(draw) -> SessionState:
     return state
 
 
+def _merge_states(a: SessionState, b: SessionState) -> None:
+    """Merge 'b' into 'a'."""
+    a._new_session_state.update(b._new_session_state)
+    a._new_widget_state.update(b._new_widget_state)
+    a._old_state.update(b._old_state)
+    a._key_id_mapping.update(b._key_id_mapping)
+
+
 # TODO: don't generate states where there is a k-wid mapping where the key exists but the widget doesn't
 @hst.composite
 def session_state(draw) -> SessionState:
@@ -89,6 +97,6 @@ def session_state(draw) -> SessionState:
 
     state2 = draw(_session_state())
 
-    state.update(state2)
+    _merge_states(state, state2)
 
     return state

--- a/lib/tests/streamlit/state/widgets_test.py
+++ b/lib/tests/streamlit/state/widgets_test.py
@@ -65,15 +65,15 @@ class WidgetManagerTests(unittest.TestCase):
         session_state._set_widget_metadata(create_metadata("int", "int_value"))
         session_state._set_widget_metadata(create_metadata("string", "string_value"))
 
-        self.assertEqual(True, session_state.get("trigger"))
-        self.assertEqual(True, session_state.get("bool"))
-        self.assertAlmostEqual(0.5, session_state.get("float"))
-        self.assertEqual(123, session_state.get("int"))
-        self.assertEqual("howdy!", session_state.get("string"))
+        self.assertEqual(True, session_state["trigger"])
+        self.assertEqual(True, session_state["bool"])
+        self.assertAlmostEqual(0.5, session_state["float"])
+        self.assertEqual(123, session_state["int"])
+        self.assertEqual("howdy!", session_state["string"])
 
     def test_get_nonexistent(self):
         session_state = SessionState()
-        self.assertIsNone(session_state.get("fake_widget_id"))
+        self.assertRaises(KeyError, lambda: session_state["fake_widget_id"])
 
     @pytest.mark.skip
     def test_get_keyed_widget_values(self):
@@ -93,7 +93,7 @@ class WidgetManagerTests(unittest.TestCase):
 
     def test_get_prev_widget_value_nonexistent(self):
         session_state = SessionState()
-        self.assertIsNone(session_state.get("fake_widget_id"))
+        self.assertRaises(KeyError, lambda: session_state["fake_widget_id"])
 
     def test_set_widget_attrs_nonexistent(self):
         session_state = SessionState()
@@ -193,13 +193,13 @@ class WidgetManagerTests(unittest.TestCase):
             WidgetMetadata("int", lambda x, s: x, None, "int_value")
         )
 
-        self.assertTrue(session_state.get("trigger"))
-        self.assertEqual(123, session_state.get("int"))
+        self.assertTrue(session_state["trigger"])
+        self.assertEqual(123, session_state["int"])
 
         session_state._reset_triggers()
 
-        self.assertFalse(session_state.get("trigger"))
-        self.assertEqual(123, session_state.get("int"))
+        self.assertFalse(session_state["trigger"])
+        self.assertEqual(123, session_state["int"])
 
     def test_coalesce_widget_states(self):
         session_state = SessionState()
@@ -242,16 +242,16 @@ class WidgetManagerTests(unittest.TestCase):
             coalesce_widget_states(old_states, new_states)
         )
 
-        self.assertIsNone(session_state.get("old_unset_trigger"))
-        self.assertIsNone(session_state.get("missing_in_new"))
+        self.assertRaises(KeyError, lambda: session_state["old_unset_trigger"])
+        self.assertRaises(KeyError, lambda: session_state["missing_in_new"])
 
-        self.assertEqual(True, session_state.get("old_set_trigger"))
-        self.assertEqual(True, session_state.get("new_set_trigger"))
-        self.assertEqual(456, session_state.get("added_in_new"))
+        self.assertEqual(True, session_state["old_set_trigger"])
+        self.assertEqual(True, session_state["new_set_trigger"])
+        self.assertEqual(456, session_state["added_in_new"])
 
         # Widgets that were triggers before, but no longer are, will *not*
         # be coalesced
-        self.assertEqual(3, session_state.get("shape_changing_trigger"))
+        self.assertEqual(3, session_state["shape_changing_trigger"])
 
 
 class WidgetHelperTests(unittest.TestCase):


### PR DESCRIPTION
Further reduces the surface area of the internal SessionState API:

- `SessionState` no longer extends `MutableMapping` (`AutoSessionState`, which is the public interface to SessionState, still does - so this doesn't change the public API at all)
- Removed unused functions: `SessionState. _safe_widget_state`, `SessionState.update`, `SessionState.copy`, `SessionState._merged_state`
- `SessionState. _reverse_key_wid_map` is now private

SessionState is accessed through wrapper classes (`AutoSessionState` - and, in the upcoming faster-reruns feature, a new thread-safe wrapper called `SafeSessionState`). These changes make those wrappers easier to understand + maintain.