### PR TITLE
Wait for first process to start up before running another process

### DIFF
--- a/scripts/cli_regression_tests.py
+++ b/scripts/cli_regression_tests.py
@@ -128,8 +128,8 @@ class TestCLIRegressions:
             preexec_fn=os.setpgrp,
         )
 
-        # Quick sleep to ensure that proc_one gets started first
-        time.sleep(0.1)
+        # Getting the output from process one ensures the process started first
+        output_one = self.read_process_output(proc_one, num_lines_to_read)
 
         proc_two = subprocess.Popen(
             command_two,
@@ -139,7 +139,6 @@ class TestCLIRegressions:
             preexec_fn=os.setpgrp,
         )
 
-        output_one = self.read_process_output(proc_one, num_lines_to_read)
         output_two = self.read_process_output(proc_two, num_lines_to_read)
 
         try:


### PR DESCRIPTION
## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Refactoring

## 🧠 Description of Changes

 CLI tests rely on starting up two processes. This change ensures the first process starts up first by waiting for a certain amount of output.

- It increases the length of each test, but I believe it's still far less then cypress and better than a flaky test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
