### PR TITLE
Watch the pages dir for changes and notify the client when they occur

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,6 +27,7 @@ import {
   PageConfig,
   PageInfo,
   PageNotFound,
+  PagesChanged,
 } from "src/autogen/proto"
 import { S4ACommunicationHOC } from "src/hocs/withS4ACommunication/withS4ACommunication"
 import {
@@ -360,6 +361,22 @@ describe("App", () => {
 
     expect(wrapper.find("WithTheme(StatusWidget)").exists()).toBe(true)
     expect(wrapper.find("ToolbarActions").exists()).toBe(true)
+  })
+
+  it("updates state.appPages when it receives a PagesChanged msg", () => {
+    const appPages = [
+      { icon: "", pageName: "bob", scriptPath: "bob.py" },
+      { icon: "", pageName: "carl", scriptPath: "carl.py" },
+    ]
+
+    const msg = new ForwardMsg()
+    msg.pagesChanged = { appPages }
+
+    const wrapper = shallow(<App {...getProps()} />)
+    expect(wrapper.find("AppView").prop("appPages")).toEqual([])
+
+    wrapper.instance().handleMessage(msg)
+    expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
   })
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -370,12 +370,13 @@ describe("App", () => {
     ]
 
     const msg = new ForwardMsg()
-    msg.pagesChanged = { appPages }
+    msg.pagesChanged = new PagesChanged({ appPages })
 
     const wrapper = shallow(<App {...getProps()} />)
     expect(wrapper.find("AppView").prop("appPages")).toEqual([])
 
-    wrapper.instance().handleMessage(msg)
+    const instance = wrapper.instance() as App
+    instance.handleMessage(msg)
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,7 @@ import {
   PageConfig,
   PageInfo,
   PageNotFound,
+  PagesChanged,
   SessionEvent,
   WidgetStates,
   SessionState,
@@ -406,6 +407,8 @@ export class App extends PureComponent<Props, State> {
           this.handlePageConfigChanged(pageConfig),
         pageInfoChanged: (pageInfo: PageInfo) =>
           this.handlePageInfoChanged(pageInfo),
+        pagesChanged: (pagesChangedMsg: PagesChanged) =>
+          this.handlePagesChanged(pagesChangedMsg),
         pageNotFound: (pageNotFound: PageNotFound) =>
           this.handlePageNotFound(pageNotFound),
         gitInfoChanged: (gitInfo: GitInfo) =>
@@ -484,6 +487,11 @@ export class App extends PureComponent<Props, State> {
     )
 
     this.setState({ currentPageName: "" })
+  }
+
+  handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
+    const { appPages } = pagesChangedMsg
+    this.setState({ appPages })
   }
 
   /**

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -328,11 +328,11 @@ def _install_config_watchers(flag_options: Dict[str, Any]) -> None:
             watch_file(filename, on_config_changed)
 
 
-def _install_pages_watcher(main_script_path: str) -> None:
+def _install_pages_watcher(main_script_path_str: str) -> None:
     def _on_pages_changed(_path: str) -> None:
         invalidate_pages_cache()
 
-    main_script_path = Path(main_script_path)
+    main_script_path = Path(main_script_path_str)
     pages_dir = main_script_path.parent / "pages"
 
     watch_dir(

--- a/lib/streamlit/bootstrap.py
+++ b/lib/streamlit/bootstrap.py
@@ -15,6 +15,7 @@
 import os
 import signal
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import click
@@ -33,7 +34,8 @@ from streamlit.config import CONFIG_FILENAMES
 from streamlit.logger import get_logger
 from streamlit.secrets import SECRETS_FILE_LOC
 from streamlit.server.server import Server, server_address_is_unix_socket
-from streamlit.watcher import report_watchdog_availability, watch_file
+from streamlit.source_util import invalidate_pages_cache
+from streamlit.watcher import report_watchdog_availability, watch_dir, watch_file
 
 LOGGER = get_logger(__name__)
 
@@ -326,6 +328,21 @@ def _install_config_watchers(flag_options: Dict[str, Any]) -> None:
             watch_file(filename, on_config_changed)
 
 
+def _install_pages_watcher(main_script_path: str) -> None:
+    def _on_pages_changed(_path: str) -> None:
+        invalidate_pages_cache()
+
+    main_script_path = Path(main_script_path)
+    pages_dir = main_script_path.parent / "pages"
+
+    watch_dir(
+        str(pages_dir),
+        _on_pages_changed,
+        glob_pattern="*.py",
+        allow_nonexistent=True,
+    )
+
+
 def run(
     main_script_path: str,
     command_line: Optional[str],
@@ -342,6 +359,7 @@ def run(
     _fix_sys_argv(main_script_path, args)
     _fix_pydeck_mapbox_api_warning()
     _install_config_watchers(flag_options)
+    _install_pages_watcher(main_script_path)
 
     # Install a signal handler that will shut down the ioloop
     # and close all our threads

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -15,7 +15,7 @@
 import re
 import threading
 from pathlib import Path
-from typing import Any, Callable, cast, Dict, List, Tuple
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
 from blinker import Signal
 
@@ -110,7 +110,7 @@ def page_name_and_icon(script_path: Path) -> Tuple[str, str]:
 
 
 _pages_cache_lock = threading.RLock()
-_cached_pages = None
+_cached_pages: Optional[List[Dict[str, str]]] = None
 _on_pages_changed = Signal(doc="Emitted when the pages directory is changed")
 
 
@@ -124,7 +124,7 @@ def invalidate_pages_cache():
     _on_pages_changed.send()
 
 
-def get_pages(main_script_path: str) -> Dict[str, Dict[str, str]]:
+def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
     global _cached_pages
 
     # Avoid taking the lock if the pages cache hasn't been invalidated.
@@ -138,7 +138,7 @@ def get_pages(main_script_path: str) -> Dict[str, Dict[str, str]]:
         if _cached_pages is not None:
             return _cached_pages
 
-        main_script_path = Path(main_script_path)
+        main_script_path = Path(main_script_path_str)
         main_page_name, main_page_icon = page_name_and_icon(main_script_path)
 
         used_page_names = {main_page_name}
@@ -169,7 +169,7 @@ def get_pages(main_script_path: str) -> Dict[str, Dict[str, str]]:
 
 
 def register_pages_changed_callback(
-    callback: Callable[[], None],
+    callback: Callable[[str], None],
 ):
     def disconnect():
         _on_pages_changed.disconnect(callback)

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -110,7 +110,7 @@ def page_name_and_icon(script_path: Path) -> Tuple[str, str]:
 
 
 _pages_cache_lock = threading.RLock()
-_cached_pages: Optional[List[Dict[str, str]]] = None
+_cached_pages: Optional[Dict[str, Dict[str, str]]] = None
 _on_pages_changed = Signal(doc="Emitted when the pages directory is changed")
 
 

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -41,8 +41,9 @@ with patch(
     # miss config options set via flag or environment variable.
     import streamlit as st
 
-    from streamlit import file_util
     from streamlit import config
+    from streamlit import file_util
+    from streamlit import source_util
 
     assert (
         not config._config_options
@@ -54,3 +55,10 @@ with patch(
     # Force a reparse of our config options with CONFIG_FILE_CONTENTS so the
     # result gets cached.
     config.get_config_options(force_reparse=True)
+
+    # Set source_util._cached_pages to the empty dict below so that
+    # source_util.get_pages behavior is deterministic and doesn't depend on the
+    # filesystem of the machine tests are being run on. Tests that need
+    # source_util.get_pages to depend on the filesystem can patch this value
+    # back to None.
+    source_util._cached_pages = {}

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -272,10 +272,10 @@ class AppSessionTest(unittest.TestCase):
     @patch(
         "streamlit.app_session.source_util.get_pages",
         MagicMock(
-            return_value=[
-                {"page_name": "page1", "icon": "", "script_path": "script1"},
-                {"page_name": "page2", "icon": "🎉", "script_path": "script2"},
-            ]
+            return_value={
+                "page1": {"icon": "", "script_path": "script1"},
+                "page2": {"icon": "🎉", "script_path": "script2"},
+            }
         ),
     )
     @patch("streamlit.app_session.AppSession._enqueue_forward_msg")

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -30,9 +30,10 @@ report = SessionData("the/path", "test command line")
 
 
 class BootstrapTest(unittest.TestCase):
-    @patch("streamlit.bootstrap.tornado.ioloop")
-    @patch("streamlit.bootstrap.Server")
-    def test_fix_matplotlib_crash(self, _1, _2):
+    @patch("streamlit.bootstrap.tornado.ioloop", Mock())
+    @patch("streamlit.bootstrap.Server", Mock())
+    @patch("streamlit.bootstrap._install_pages_watcher", Mock())
+    def test_fix_matplotlib_crash(self):
         """Test that bootstrap.run sets the matplotlib backend to
         "Agg" if config.runner.fixMatplotlib=True.
         """

--- a/lib/tests/streamlit/bootstrap_test.py
+++ b/lib/tests/streamlit/bootstrap_test.py
@@ -357,3 +357,23 @@ class BootstrapPrintTest(unittest.TestCase):
                 "server.port": 8502,
             },
         )
+
+    @patch("streamlit.bootstrap.invalidate_pages_cache")
+    @patch("streamlit.bootstrap.watch_dir")
+    def test_install_pages_watcher(
+        self, patched_watch_dir, patched_invalidate_pages_cache
+    ):
+        bootstrap._install_pages_watcher("/foo/bar/streamlit_app.py")
+
+        args, _ = patched_watch_dir.call_args_list[0]
+        on_pages_changed = args[1]
+
+        patched_watch_dir.assert_called_once_with(
+            "/foo/bar/pages",
+            on_pages_changed,
+            glob_pattern="*.py",
+            allow_nonexistent=True,
+        )
+
+        on_pages_changed("/foo/bar/pages")
+        patched_invalidate_pages_cache.assert_called_once()

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -74,6 +74,7 @@ def _is_control_event(event: ScriptRunnerEvent) -> bool:
     return event != ScriptRunnerEvent.ENQUEUE_FORWARD_MSG
 
 
+@patch("streamlit.source_util._cached_pages", new=None)
 class ScriptRunnerTest(AsyncTestCase):
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -14,6 +14,7 @@
 
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -89,11 +90,33 @@ class PageHelperFunctionTests(unittest.TestCase):
     def test_page_name_and_icon(self, path_str, expected):
         assert source_util.page_name_and_icon(Path(path_str)) == expected
 
+    @patch("streamlit.source_util._on_pages_changed", new=MagicMock())
+    @patch("streamlit.source_util._cached_pages", new="Some pages")
+    def test_invalidate_pages_cache(self):
+        source_util.invalidate_pages_cache()
+
+        assert source_util._cached_pages is None
+        source_util._on_pages_changed.send.assert_called_once()
+
+    @patch("streamlit.source_util._on_pages_changed", new=MagicMock())
+    def test_register_pages_changed_callback(self):
+        callback = lambda: None
+
+        disconnect = source_util.register_pages_changed_callback(callback)
+
+        source_util._on_pages_changed.connect.assert_called_once_with(
+            callback, weak=False
+        )
+
+        disconnect()
+        source_util._on_pages_changed.disconnect.assert_called_once_with(callback)
+
 
 # NOTE: We write this test function using pytest conventions (as opposed to
 # using unittest.TestCase like in the rest of the codebase) because the tmpdir
 # pytest fixture is so useful for writing this test it's worth having the
 # slight inconsistency.
+@patch("streamlit.source_util._cached_pages", new=None)
 def test_get_pages(tmpdir):
     # Write an empty string to create a file.
     tmpdir.join("streamlit_app.py").write("")
@@ -117,7 +140,9 @@ def test_get_pages(tmpdir):
         pages_dir.join(p).write("")
 
     main_script_path = str(tmpdir / "streamlit_app.py")
-    assert source_util.get_pages(main_script_path) == {
+
+    received_pages = source_util.get_pages(main_script_path)
+    assert received_pages == {
         "streamlit_app": {
             "script_path": main_script_path,
             "icon": "",
@@ -135,3 +160,7 @@ def test_get_pages(tmpdir):
             "icon": "",
         },
     }
+
+    # Assert address-equality to verify the cache is used the second time
+    # get_pages is called.
+    assert source_util.get_pages(main_script_path) is received_pages

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -43,6 +43,7 @@ def NOOP_CALLBACK(_filepath):
     pass
 
 
+@patch("streamlit.source_util._cached_pages", new=None)
 @patch("streamlit.file_util.file_in_pythonpath", return_value=False)
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):

--- a/proto/streamlit/proto/AppPage.proto
+++ b/proto/streamlit/proto/AppPage.proto
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+syntax = "proto3";
+
+// A page in the app. Includes both the name of the page as well as the full
+// path to the corresponding script file.
+message AppPage {
+  string page_name = 1;
+  string script_path = 2;
+  string icon = 3;
+}

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -22,6 +22,7 @@ import "streamlit/proto/NewSession.proto";
 import "streamlit/proto/PageConfig.proto";
 import "streamlit/proto/PageInfo.proto";
 import "streamlit/proto/PageNotFound.proto";
+import "streamlit/proto/PagesChanged.proto";
 import "streamlit/proto/SessionEvent.proto";
 import "streamlit/proto/SessionState.proto";
 
@@ -58,6 +59,7 @@ message ForwardMsg {
 
     // Other messages.
     PageNotFound page_not_found = 15;
+    PagesChanged pages_changed = 16;
 
     // A reference to a ForwardMsg that has already been delivered.
     // The client should substitute the message with the given hash
@@ -67,7 +69,7 @@ message ForwardMsg {
   }
 
   reserved 7, 8;
-  // Next: 16
+  // Next: 17
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -16,6 +16,7 @@
 
 syntax = "proto3";
 
+import "streamlit/proto/AppPage.proto";
 import "streamlit/proto/SessionState.proto";
 
 // This is the first message that is sent when a new session starts.
@@ -135,12 +136,4 @@ message UserInfo {
 message EnvironmentInfo {
   string streamlit_version = 1;
   string python_version = 2;
-}
-
-// A page in the app. Includes both the name of the page as well as the full
-// path to the corresponding script file.
-message AppPage {
-  string page_name = 1;
-  string script_path = 2;
-  string icon = 3;
 }

--- a/proto/streamlit/proto/PagesChanged.proto
+++ b/proto/streamlit/proto/PagesChanged.proto
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+syntax = "proto3";
+
+import "streamlit/proto/AppPage.proto";
+
+// Message used to tell the client that the app's pages have changed.
+message PagesChanged {
+  repeated AppPage app_pages = 1;
+}


### PR DESCRIPTION
## 📚 Context

Note: This PR is built on top of #4629, which should be reviewed first.

Now that we've improved our path watcher infrastructure to be able to watch
directories and not just files, we can finally install a watcher on an app's
`pages/` directory so that we can notify the client when a page gets added or
deleted. This PR does just that.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Cache the result of calls to `source_util.get_pages()` unless the pages dir changes
- Add functions to register pages changed callbacks
- Update the list of pages displayed on the frontend when page changes are detected.

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Closes https://github.com/streamlit/streamlit-issues/issues/359