### PR TITLE
Return a dict from source_util.get_pages

### DIFF
--- a/lib/streamlit/scriptrunner/script_runner.py
+++ b/lib/streamlit/scriptrunner/script_runner.py
@@ -413,16 +413,12 @@ class ScriptRunner:
             # serve a request to run a non-main page before we've had a chance
             # to send page info to the frontend.
             if rerun_data.page_name:
-                current_page = next(
-                    filter(
-                        lambda p: p["page_name"] == rerun_data.page_name,
-                        source_util.get_pages(self._session_data.main_script_path),
-                    ),
-                    None,
-                )
+                page_info = source_util.get_pages(
+                    self._session_data.main_script_path
+                ).get(rerun_data.page_name, None)
 
-                if current_page:
-                    script_path = current_page["script_path"]
+                if page_info:
+                    script_path = page_info["script_path"]
                 else:
                     msg = ForwardMsg()
                     msg.page_not_found.page_name = rerun_data.page_name

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -42,8 +42,8 @@ def allow_cross_origin_requests():
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
-    def initialize(self, path, default_filename, get_page_names):
-        self._page_names = get_page_names()
+    def initialize(self, path, default_filename, get_pages):
+        self._pages = get_pages()
 
         super().initialize(path=path, default_filename=default_filename)
 
@@ -66,7 +66,7 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
         # TODO(vdonato): Maybe clean this up if we decide to tweak the spec so
         # that there's a separator between the baseUrlPath and page name.
         maybe_page_name = url_parts[0]
-        if maybe_page_name in self._page_names:
+        if maybe_page_name in self._pages:
             url_path = "/".join(url_parts[1:])
 
         return super().parse_url_path(url_path)

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -294,9 +294,6 @@ class Server:
     def main_script_path(self) -> str:
         return self._main_script_path
 
-    def get_page_names(self) -> Set[str]:
-        return {p["page_name"] for p in source_util.get_pages(self.main_script_path)}
-
     def get_session_by_id(self, session_id: str) -> Optional[AppSession]:
         """Return the AppSession corresponding to the given id, or None if
         no such session exists."""
@@ -422,7 +419,9 @@ class Server:
                         {
                             "path": "%s/" % static_path,
                             "default_filename": "index.html",
-                            "get_page_names": self.get_page_names,
+                            "get_pages": lambda: source_util.get_pages(
+                                self.main_script_path
+                            ),
                         },
                     ),
                     (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -14,7 +14,7 @@
 
 import re
 from pathlib import Path
-from typing import Any, cast, Dict, List, Tuple
+from typing import Any, cast, Dict, Tuple
 
 
 def open_python_file(filename):
@@ -104,18 +104,17 @@ def page_name_and_icon(script_path: Path) -> Tuple[str, str]:
 
 # TODO(vdonato): Eventually, have this function cache its return value and
 # avoid re-scanning the file system unless a page has been added/removed.
-def get_pages(main_script_path: str) -> List[Dict[str, str]]:
+def get_pages(main_script_path: str) -> Dict[str, Dict[str, str]]:
     main_script_path = Path(main_script_path)
     main_page_name, main_page_icon = page_name_and_icon(main_script_path)
 
     used_page_names = {main_page_name}
-    pages = [
-        {
-            "page_name": main_page_name,
+    pages = {
+        main_page_name: {
             "icon": main_page_icon,
             "script_path": str(main_script_path),
         }
-    ]
+    }
 
     pages_dir = main_script_path.parent / "pages"
     page_scripts = sorted(
@@ -129,6 +128,9 @@ def get_pages(main_script_path: str) -> List[Dict[str, str]]:
             continue
 
         used_page_names.add(pn)
-        pages.append({"page_name": pn, "icon": pi, "script_path": str(script_path)})
+        pages[pn] = {
+            "icon": pi,
+            "script_path": str(script_path),
+        }
 
     return pages

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -53,7 +53,7 @@ class LocalSourcesWatcher:
 
         self._watched_modules: Dict[str, WatchedModule] = {}
 
-        for page_info in get_pages(self._session_data.main_script_path):
+        for page_info in get_pages(self._session_data.main_script_path).values():
             self._register_watcher(
                 page_info["script_path"],
                 module_name=None,  # Only root scripts have their modules set to None

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -305,10 +305,10 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
     @patch(
         "streamlit.app_session.source_util.get_pages",
         MagicMock(
-            return_value=[
-                {"page_name": "page1", "icon": "", "script_path": "script1"},
-                {"page_name": "page2", "icon": "🎉", "script_path": "script2"},
-            ]
+            return_value={
+                "page1": {"icon": "", "script_path": "script1"},
+                "page2": {"icon": "🎉", "script_path": "script2"},
+            }
         ),
     )
     @patch(
@@ -574,10 +574,10 @@ class PopulateCustomThemeMsgTest(unittest.TestCase):
 @patch(
     "streamlit.app_session.source_util.get_pages",
     MagicMock(
-        return_value=[
-            {"page_name": "script_path", "script_path": "/fake/script_path.py"},
-            {"page_name": "page2", "script_path": "/fake/pages/page2.py"},
-        ]
+        return_value={
+            "script_path": {"script_path": "/fake/script_path.py"},
+            "page2": {"script_path": "/fake/pages/page2.py"},
+        }
     ),
 )
 class ShouldRerunOnFileChangeTest(unittest.TestCase):

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -805,14 +805,13 @@ class ScriptRunnerTest(AsyncTestCase):
     @patch(
         "streamlit.source_util.get_pages",
         MagicMock(
-            return_value=[
-                {
-                    "page_name": "page2",
+            return_value={
+                "page2": {
                     "script_path": os.path.join(
                         os.path.dirname(__file__), "test_data", "good_script2.py"
                     ),
                 },
-            ],
+            },
         ),
     )
     def test_page_name_to_script_path(self):
@@ -841,9 +840,9 @@ class ScriptRunnerTest(AsyncTestCase):
     @patch(
         "streamlit.source_util.get_pages",
         MagicMock(
-            return_value=[
-                {"page_name": "page2", "script_path": "script2"},
-            ]
+            return_value={
+                "page2": {"script_path": "script2"},
+            }
         ),
     )
     def test_page_name_to_script_path_404(self):

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -759,8 +759,8 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self._tmpdir.cleanup()
 
-    def get_page_names(self):
-        return {"page1", "page2"}
+    def get_pages(self):
+        return {"page1": "page_info1", "page2": "page_info2"}
 
     def get_app(self):
         return tornado.web.Application(
@@ -771,7 +771,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     {
                         "path": self._tmpdir.name,
                         "default_filename": self._filename,
-                        "get_page_names": self.get_page_names,
+                        "get_pages": self.get_pages,
                     },
                 )
             ]

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -117,25 +117,21 @@ def test_get_pages(tmpdir):
         pages_dir.join(p).write("")
 
     main_script_path = str(tmpdir / "streamlit_app.py")
-    assert source_util.get_pages(main_script_path) == [
-        {
-            "page_name": "streamlit_app",
+    assert source_util.get_pages(main_script_path) == {
+        "streamlit_app": {
             "script_path": main_script_path,
             "icon": "",
         },
-        {
-            "page_name": "page",
+        "page": {
             "script_path": str(pages_dir / "01-page.py"),
             "icon": "",
         },
-        {
-            "page_name": "other_page",
+        "other_page": {
             "script_path": str(pages_dir / "03_other_page.py"),
             "icon": "",
         },
-        {
-            "page_name": "last_page",
+        "last_page": {
             "script_path": str(pages_dir / "last page.py"),
             "icon": "",
         },
-    ]
+    }

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -321,10 +321,10 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch(
         "streamlit.watcher.local_sources_watcher.get_pages",
         MagicMock(
-            return_value=[
-                {"page_name": "streamlit_app", "script_path": "streamlit_app.py"},
-                {"page_name": "streamlit_app2", "script_path": "streamlit_app2.py"},
-            ]
+            return_value={
+                "streamlit_app": {"script_path": "streamlit_app.py"},
+                "streamlit_app2": {"script_path": "streamlit_app2.py"},
+            }
         ),
     )
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")


### PR DESCRIPTION
## 📚 Context

Note: This PR is built on top of https://github.com/streamlit/streamlit/pull/4629, which should be reviewed first.

Initially, I wrote `source_util.get_pages` to return a `List` because pages have to
be ordered when they're rendered in the frontend. This resulted in a few places
where we're doing some sad linear-time searches for the right page when ideally
we'd want to do a constant-time lookup.

I recently randomly remembered that in Python 3.7+, we have a guarantee that
iterating over a dict will always be done in the same order as elements are inserted.
Due to this, we can return a dict from `get_pages` and get the constant-time lookups
we want in more places while also not having to worry about losing the order that
pages should be rendered on the frontend.

- What kind of change does this PR introduce?

  - [x] Refactoring+minor performance improvements

## 🧪 Testing Done

- [x] Added/Updated unit tests