### PR TITLE
Revert "Remove pydeck as a dependency (#4560)"

### DIFF
--- a/e2e/specs/st_hello.spec.js
+++ b/e2e/specs/st_hello.spec.js
@@ -81,11 +81,35 @@ describe("hello", () => {
       });
   });
 
-  it("displays dataframe demo", () => {
+  it("displays mapping demo", () => {
     cy.get(".element-container .stSelectbox")
       .click()
       .then(() => {
         cy.get("ul li:nth-child(4)")
+          .click()
+          .then(() => {
+            cy.get(".element-container .stMarkdown h1").should(
+              "contain",
+              "Mapping Demo"
+            );
+
+            cy.get(".element-container .stDeckGlJsonChart")
+              .find("canvas")
+              .should("have.css", "height", "500px");
+
+            // Wait for Mapbox to build the canvas.
+            cy.wait(5000);
+
+            cy.get(".appview-container").matchThemedSnapshots("mapping-demo");
+          });
+      });
+  });
+
+  it("displays dataframe demo", () => {
+    cy.get(".element-container .stSelectbox")
+      .click()
+      .then(() => {
+        cy.get("ul li:nth-child(5)")
           .click()
           .then(() => {
             cy.get(".element-container .stMarkdown h1").should(

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -49,6 +49,7 @@ pillow = ">=6.2.0"
 # protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
 protobuf = ">=3.6.0, !=3.11"
 pyarrow = "*"
+pydeck = ">=0.1.dev5"
 pympler = ">=0.9"
 python-dateutil = "*"
 requests = "*"

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -31,10 +31,6 @@ class PydeckMixin:
         - DeckGL docs: https://github.com/uber/deck.gl/tree/master/docs
         - DeckGL JSON docs: https://github.com/uber/deck.gl/tree/master/modules/json
 
-        PyDeck is not installed automatically as part of Streamlit, so to use
-        this element, you must first install it with `pip install --user pydeck`
-        or add it to your package dependency file.
-
         When using this command, we advise all users to use a personal Mapbox
         token. This ensures the map tiles used in this chart are more
         robust. You can do this with the mapbox.token config option.

--- a/lib/streamlit/hello/demos.py
+++ b/lib/streamlit/hello/demos.py
@@ -48,6 +48,86 @@ def intro():
 # Turn off black formatting for this function to present the user with more
 # compact code.
 # fmt: off
+def mapping_demo():
+    import streamlit as st
+    import pandas as pd
+    import pydeck as pdk
+
+    from urllib.error import URLError
+
+    @st.cache
+    def from_data_file(filename):
+        url = (
+            "http://raw.githubusercontent.com/streamlit/"
+            "example-data/master/hello/v1/%s" % filename)
+        return pd.read_json(url)
+
+    try:
+        ALL_LAYERS = {
+            "Bike Rentals": pdk.Layer(
+                "HexagonLayer",
+                data=from_data_file("bike_rental_stats.json"),
+                get_position=["lon", "lat"],
+                radius=200,
+                elevation_scale=4,
+                elevation_range=[0, 1000],
+                extruded=True,
+            ),
+            "Bart Stop Exits": pdk.Layer(
+                "ScatterplotLayer",
+                data=from_data_file("bart_stop_stats.json"),
+                get_position=["lon", "lat"],
+                get_color=[200, 30, 0, 160],
+                get_radius="[exits]",
+                radius_scale=0.05,
+            ),
+            "Bart Stop Names": pdk.Layer(
+                "TextLayer",
+                data=from_data_file("bart_stop_stats.json"),
+                get_position=["lon", "lat"],
+                get_text="name",
+                get_color=[0, 0, 0, 200],
+                get_size=15,
+                get_alignment_baseline="'bottom'",
+            ),
+            "Outbound Flow": pdk.Layer(
+                "ArcLayer",
+                data=from_data_file("bart_path_stats.json"),
+                get_source_position=["lon", "lat"],
+                get_target_position=["lon2", "lat2"],
+                get_source_color=[200, 30, 0, 160],
+                get_target_color=[200, 30, 0, 160],
+                auto_highlight=True,
+                width_scale=0.0001,
+                get_width="outbound",
+                width_min_pixels=3,
+                width_max_pixels=30,
+            ),
+        }
+        st.sidebar.markdown('### Map Layers')
+        selected_layers = [
+            layer for layer_name, layer in ALL_LAYERS.items()
+            if st.sidebar.checkbox(layer_name, True)]
+        if selected_layers:
+            st.pydeck_chart(pdk.Deck(
+                map_style="mapbox://styles/mapbox/light-v9",
+                initial_view_state={"latitude": 37.76,
+                                    "longitude": -122.4, "zoom": 11, "pitch": 50},
+                layers=selected_layers,
+            ))
+        else:
+            st.error("Please choose at least one layer above.")
+    except URLError as e:
+        st.error("""
+            **This demo requires internet access.**
+
+            Connection error: %s
+        """ % e.reason)
+# fmt: on
+
+# Turn off black formatting for this function to present the user with more
+# compact code.
+# fmt: off
 
 
 def fractal_demo():

--- a/lib/streamlit/hello/hello.py
+++ b/lib/streamlit/hello/hello.py
@@ -50,6 +50,17 @@ Streamlit. We're generating a bunch of random numbers in a loop for around
             ),
         ),
         (
+            "Mapping Demo",
+            (
+                demos.mapping_demo,
+                """
+This demo shows how to use
+[`st.pydeck_chart`](https://docs.streamlit.io/library/api-reference/charts/st.pydeck_chart)
+to display geospatial data.
+""",
+            ),
+        ),
+        (
             "DataFrame Demo",
             (
                 demos.data_frame_demo,

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -12,7 +12,6 @@ mysqlclient>=2.0.3
 opencv-python>=4.5.3
 plotly>=5.3.1
 psycopg2-binary>=2.9.1
-pydeck>=0.1.dev5
 pydot>=1.4.2
 pyodbc>=4.0.32
 seaborn>=0.11.2


### PR DESCRIPTION
This reverts commit 6d3c914c3d9298e02ee6feef7186991f338cb210.

Thiago doesn't want it to go out without a replacement demo, so we have to revert this for now.