### PR TITLE
Snowflake demo prototype

### DIFF
--- a/lib/snowflake_test.py
+++ b/lib/snowflake_test.py
@@ -1,0 +1,37 @@
+from streamlit import snowflake_demo
+from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.snowflake_demo import SnowflakeConfig, SnowflakeSessionCtx, SnowflakeSessionMessageQueue
+
+SCRIPT_PATH = "snowflake_test_script.py"
+
+
+class ExampleMessageQueue(SnowflakeSessionMessageQueue):
+    """Example MessageQueue implementation. The Snowflake implementation
+    should write each ForwardMsg to the session's websocket.
+    """
+    def push_forward_msg(self, msg: ForwardMsg) -> None:
+        print(msg)
+
+
+def create_rerun_msg() -> BackMsg:
+    msg = BackMsg()
+    msg.rerun_script.query_string = ""
+    return msg
+
+
+# Start Streamlit
+config = SnowflakeConfig(script_path=SCRIPT_PATH)
+snowflake_demo.start(config)
+
+# Add a session
+ctx = SnowflakeSessionCtx(queue=ExampleMessageQueue())
+snowflake_demo.session_created(ctx)
+
+# Send a BackMsg (these will arrive from the frontend - you shouldn't
+# need to construct them manually, just pass them on to the appropriate
+# session)
+snowflake_demo.handle_backmsg(ctx, create_rerun_msg())
+
+# Close the session
+snowflake_demo.session_closed(ctx)

--- a/lib/snowflake_test.py
+++ b/lib/snowflake_test.py
@@ -13,7 +13,7 @@ class ExampleMessageQueue(SnowflakeSessionMessageQueue):
     should write each ForwardMsg to the session's websocket.
     """
     def write_forward_msg(self, msg: ForwardMsg) -> None:
-        print(msg)
+        print(f"Got ForwardMsg: {msg.WhichOneof('type')}")
 
 
 def create_rerun_msg() -> BackMsg:
@@ -36,10 +36,10 @@ demo.session_created(ctx)
 # session)
 demo.handle_backmsg(ctx, create_rerun_msg())
 
+time.sleep(10)
+
 # Close the session
 demo.session_closed(ctx)
-
-time.sleep(10)
 
 print("stopping...")
 demo.stop()

--- a/lib/snowflake_test.py
+++ b/lib/snowflake_test.py
@@ -1,7 +1,9 @@
-from streamlit import snowflake_demo
+import time
+
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.snowflake_demo import SnowflakeConfig, SnowflakeSessionCtx, SnowflakeSessionMessageQueue
+from streamlit.snowflake_demo import SnowflakeConfig, SnowflakeSessionCtx, \
+    SnowflakeSessionMessageQueue, SnowflakeDemo
 
 SCRIPT_PATH = "snowflake_test_script.py"
 
@@ -22,16 +24,22 @@ def create_rerun_msg() -> BackMsg:
 
 # Start Streamlit
 config = SnowflakeConfig(script_path=SCRIPT_PATH)
-snowflake_demo.start(config)
+demo = SnowflakeDemo(config)
+demo.start()
 
 # Add a session
 ctx = SnowflakeSessionCtx(queue=ExampleMessageQueue())
-snowflake_demo.session_created(ctx)
+demo.session_created(ctx)
 
 # Send a BackMsg (these will arrive from the frontend - you shouldn't
 # need to construct them manually, just pass them on to the appropriate
 # session)
-snowflake_demo.handle_backmsg(ctx, create_rerun_msg())
+demo.handle_backmsg(ctx, create_rerun_msg())
 
 # Close the session
-snowflake_demo.session_closed(ctx)
+demo.session_closed(ctx)
+
+time.sleep(10)
+
+print("stopping...")
+demo.stop()

--- a/lib/snowflake_test.py
+++ b/lib/snowflake_test.py
@@ -12,7 +12,7 @@ class ExampleMessageQueue(SnowflakeSessionMessageQueue):
     """Example MessageQueue implementation. The Snowflake implementation
     should write each ForwardMsg to the session's websocket.
     """
-    def push_forward_msg(self, msg: ForwardMsg) -> None:
+    def write_forward_msg(self, msg: ForwardMsg) -> None:
         print(msg)
 
 

--- a/lib/snowflake_test_script.py
+++ b/lib/snowflake_test_script.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+
+def increment_num_clicks():
+    num_clicks = st.session_state.get("num_clicks", 0)
+    st.session_state["num_clicks"] = num_clicks + 1
+
+
+st.write(f"Hello, Snowflake!")
+st.write(f"You've clicked {st.session_state.get('num_clicks', 0)} times.")
+st.button("Click Me!", on_click=increment_num_clicks)

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -357,9 +357,11 @@ class AppSession:
 
         """
 
-        assert (
-            threading.main_thread() == threading.current_thread()
-        ), "This function must only be called on the main thread"
+        # TSC: commented out for SnowflakeDemo (which runs the server
+        # on another thread.)
+        # assert (
+        #     threading.main_thread() == threading.current_thread()
+        # ), "This function must only be called on the main thread"
 
         if sender is not self._scriptrunner:
             # This event was sent by a non-current ScriptRunner; ignore it.

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import sys
-import threading
 import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Optional, List
 
+from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.uploaded_file_manager import UploadedFileManager
 
 import tornado.ioloop
@@ -147,6 +147,28 @@ class AppSession:
 
         """
         return self._session_data.flush_browser_queue()
+
+    def handle_backmsg(self, msg: BackMsg) -> None:
+        try:
+            msg_type = msg.WhichOneof("type")
+
+            LOGGER.debug("Received the following back message:\n%s", msg)
+
+            if msg_type == "rerun_script":
+                self.handle_rerun_script_request(msg.rerun_script)
+            elif msg_type == "load_git_info":
+                self.handle_git_information_request()
+            elif msg_type == "clear_cache":
+                self.handle_clear_cache_request()
+            elif msg_type == "set_run_on_save":
+                self.handle_set_run_on_save_request(msg.set_run_on_save)
+            elif msg_type == "stop_script":
+                self.handle_stop_script_request()
+            else:
+                LOGGER.warning('No handler for "%s"', msg_type)
+        except BaseException as e:
+            LOGGER.error(e)
+            self.handle_backmsg_exception(e)
 
     def shutdown(self) -> None:
         """Shut down the AppSession.

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -124,7 +124,9 @@ class SessionInfo:
     the ForwardMsgCache.
     """
 
-    def __init__(self, write_forward_msg: Callable[[ForwardMsg], None], session: AppSession):
+    def __init__(
+        self, write_forward_msg: Callable[[ForwardMsg], None], session: AppSession
+    ):
         """Initialize a SessionInfo instance.
 
         Parameters
@@ -229,7 +231,6 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
             f"Cannot start Streamlit server. Port {port} is already in use, and "
             f"Streamlit was unable to find a free port after {MAX_PORT_SEARCH_RETRIES} attempts.",
         )
-
 
 
 class Server:
@@ -649,7 +650,9 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         """
         self._ioloop.stop()
 
-    def create_demo_app_session(self, write_forward_msg: Callable[[ForwardMsg], None]) -> AppSession:
+    def create_demo_app_session(
+        self, write_forward_msg: Callable[[ForwardMsg], None]
+    ) -> AppSession:
         return self._create_app_session(write_forward_msg)
 
     def _create_websocket_app_session(self, ws: WebSocketHandler) -> AppSession:
@@ -678,7 +681,9 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 
         return session
 
-    def _create_app_session(self, write_forward_msg: Callable[[ForwardMsg], None]) -> AppSession:
+    def _create_app_session(
+        self, write_forward_msg: Callable[[ForwardMsg], None]
+    ) -> AppSession:
         session_data = SessionData(self._main_script_path, self._command_line)
         local_sources_watcher = LocalSourcesWatcher(session_data)
         session = AppSession(

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -20,6 +20,7 @@ import sys
 import errno
 import time
 import traceback
+
 import click
 from enum import Enum
 from typing import (

--- a/lib/streamlit/snowflake_demo.py
+++ b/lib/streamlit/snowflake_demo.py
@@ -47,6 +47,10 @@ class SnowflakeSessionMessageQueue:
     """
 
     def push_forward_msg(self, msg: ForwardMsg) -> None:
+        """Add a new ForwardMsg to the queue.
+        Note that this will be called on the Streamlit server thread,
+        not the main thread!
+        """
         raise NotImplementedError
 
 

--- a/lib/streamlit/snowflake_demo.py
+++ b/lib/streamlit/snowflake_demo.py
@@ -27,9 +27,16 @@ import tornado
 import tornado.ioloop
 
 import streamlit
-from streamlit.bootstrap import _fix_sys_path, _fix_matplotlib_crash, \
-    _fix_tornado_crash, _fix_sys_argv, _fix_pydeck_mapbox_api_warning, \
-    _install_config_watchers, _set_up_signal_handler, _on_server_start
+from streamlit.bootstrap import (
+    _fix_sys_path,
+    _fix_matplotlib_crash,
+    _fix_tornado_crash,
+    _fix_sys_argv,
+    _fix_pydeck_mapbox_api_warning,
+    _install_config_watchers,
+    _set_up_signal_handler,
+    _on_server_start,
+)
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.server.server import Server
@@ -105,10 +112,7 @@ def start(config: SnowflakeConfig) -> None:
         ioloop.start()
 
     # Start the Streamlit thread
-    streamlit_thread = threading.Thread(
-        target=run_streamlit,
-        name="StreamlitMain"
-    )
+    streamlit_thread = threading.Thread(target=run_streamlit, name="StreamlitMain")
     streamlit_thread.start()
 
     # Wait until Streamlit has been started before returning.
@@ -123,8 +127,7 @@ def session_created(ctx: SnowflakeSessionCtx) -> None:
 
 
 def handle_backmsg(ctx: SnowflakeSessionCtx, msg: BackMsg) -> None:
-    """Called when a BackMsg arrives for a given session.
-    """
+    """Called when a BackMsg arrives for a given session."""
     pass
 
 

--- a/lib/streamlit/snowflake_demo.py
+++ b/lib/streamlit/snowflake_demo.py
@@ -1,0 +1,104 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Snowflake/Streamlit hacky demo interface.
+
+This module is *not thread safe*. Functions here should be called only
+on a single thread.
+
+(Please don't release this into production :))
+"""
+
+from typing import NamedTuple
+
+import streamlit
+from streamlit import bootstrap
+from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+
+class SnowflakeConfig(NamedTuple):
+    """Passed to `start()`. Contains config options."""
+
+    script_path: str
+
+
+class SnowflakeSessionMessageQueue:
+    """A queue of ForwardMsgs for a single session.
+
+    When Streamlit has a ForwardMsg for a session, it will push it
+    to this queue.
+
+    (This is just an interface - Snowflake should create a concrete
+    implementation and pass it to Streamlit within SessionCtx.)
+    """
+
+    def push_forward_msg(self, msg: ForwardMsg) -> None:
+        raise NotImplementedError
+
+
+class SnowflakeSessionCtx(NamedTuple):
+    """Contains session-specific state. Create a new instance for
+    each session.
+    """
+
+    queue: SnowflakeSessionMessageQueue
+
+
+def start(config: SnowflakeConfig) -> None:
+    """Start the Streamlit server. Must be called once, before
+    any other functions are called.
+    """
+
+    command_line = f"streamlit run {config.script_path}"
+
+    # Set a global flag indicating that we're "within" streamlit.
+    streamlit._is_running_with_streamlit = True
+
+    # check_credentials()
+
+    bootstrap.run(
+        main_script_path=config.script_path,
+        command_line=command_line,
+        args=[],
+        flag_options={},
+    )
+
+
+def session_created(ctx: SnowflakeSessionCtx) -> None:
+    """Called when a new session starts. Streamlit will create
+    its own session machinery internally.
+
+    Must be called on the same thread as `start()`.
+    """
+    pass
+
+
+def handle_backmsg(ctx: SnowflakeSessionCtx, msg: BackMsg) -> None:
+    """Called when a BackMsg arrives for a given session.
+
+    Must be called on the same thread as `start()`.
+    """
+    pass
+
+
+def session_closed(ctx: SnowflakeSessionCtx) -> None:
+    """Called when a session has closed.
+
+    Streamlit will dispose of internal session-related resources here.
+
+    Must be called on the same thread as `start()`.
+    """
+    pass

--- a/lib/streamlit/snowflake_demo.py
+++ b/lib/streamlit/snowflake_demo.py
@@ -40,6 +40,7 @@ LOGGER = get_logger(__name__)
 class SnowflakeConfig(NamedTuple):
     """Passed to `start()`. Contains config options."""
 
+    # The path of the Streamlit script to run.
     script_path: str
 
 
@@ -55,8 +56,8 @@ class SnowflakeSessionMessageQueue:
 
     def write_forward_msg(self, msg: ForwardMsg) -> None:
         """Add a new ForwardMsg to the queue.
-        Note that this will be called on the Streamlit server thread,
-        not the main thread!
+        (Note that this will be called on the Streamlit server thread,
+        not the main thread!)
         """
         raise NotImplementedError
 
@@ -66,6 +67,9 @@ class SnowflakeSessionCtx(NamedTuple):
     each session.
     """
 
+    # A concrete SnowflakeSessionMessageQueue instance.
+    # The Streamlit server will send all ForwardMsgs for the session
+    # to this object.
     queue: SnowflakeSessionMessageQueue
 
 


### PR DESCRIPTION
A quick-and-dirty hack to get Streamlit running inside Snowflake.

- The public API is exposed in `snowflake_demo.py`
- The `SnowflakeDemo` class exposes a simple API for starting a Streamlit server on a separate thread, adding websocket-less sessions to it, and sending and receiving ForwardMsgs and BackMsgs.
- `snowflake_test.py` is a simple test app that demonstrates the public API. (Run the app directly from python: `python snowflake_test.py`)
- There are no tests! We'll never merge this into `develop`.