### PR TITLE
Fixed sliders default range value initialization (Issue #4538) 

### DIFF
--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -189,7 +189,7 @@ class SliderMixin:
         # Set value default.
         if value is None:
             session_state = get_session_state()
-            if key in session_state:
+            if key is not None and key in session_state:
                 value = session_state[key]
             else:
                 value = min_value if min_value is not None else 0

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -30,7 +30,7 @@ from streamlit.state import (
     WidgetKwargs,
 )
 from .form import current_form_id
-from .utils import check_callback_rules, check_session_state_rules
+from .utils import check_callback_rules, check_session_state_rules, get_session_state
 
 
 class SliderMixin:
@@ -188,7 +188,11 @@ class SliderMixin:
 
         # Set value default.
         if value is None:
-            value = min_value if min_value is not None else 0
+            session_state = get_session_state()
+            if key in session_state:
+                value = session_state[key]
+            else:
+                value = min_value if min_value is not None else 0
 
         SUPPORTED_TYPES = {
             int: SliderProto.INT,


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Slider with default range-value set using the "sessionstate" pattern loses its range value when it is clicked and becomes single-value.

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/79311899/165233005-a20f316c-3c3d-476a-8e07-4dc083e89ba9.png)

**Current:**
We get this right after clicking the slider X. It becomes single-value with a dangling end.
![image](https://user-images.githubusercontent.com/79311899/165232704-76599af6-6379-452d-8c11-29738edc5082.png)

## 🧪 Testing Done

- [X] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4538

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
