### PR TITLE
Add mechanisms to hide the sidebar page nav

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -57,13 +57,14 @@ jest.mock("src/lib/ConnectionManager")
 const getS4ACommunicationState = (
   extend?: Partial<S4ACommunicationState>
 ): S4ACommunicationState => ({
-  queryParams: "",
-  menuItems: [],
-  toolbarItems: [],
   forcedModalClose: false,
+  hideSidebarNav: false,
   isOwner: true,
+  menuItems: [],
+  queryParams: "",
   sidebarChevronDownshift: 0,
   streamlitShareMetadata: {},
+  toolbarItems: [],
   ...extend,
 })
 
@@ -695,15 +696,29 @@ describe("App.handleNewSession", () => {
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
   })
 
-  it("plumbs hideSidebarNav to AppView", () => {
+  it("sets hideSidebarNav based on the server config option and s4a setting", () => {
     const wrapper = shallow(<App {...getProps()} />)
+
+    // hideSidebarNav initializes to true.
+    expect(wrapper.find("AppView").prop("hideSidebarNav")).toEqual(true)
+
+    // Simulate the server ui.hideSidebarNav config option being false.
     const instance = wrapper.instance() as App
-
     instance.handleNewSession(new NewSession(NEW_SESSION_JSON))
-
-    // hideSidebarNav is initialized to true, so if it's false below, it must
-    // have been changed as expected.
     expect(wrapper.find("AppView").prop("hideSidebarNav")).toEqual(false)
+
+    // Have s4a override the server config option.
+    wrapper.setProps(
+      getProps({
+        s4aCommunication: getS4ACommunicationProp({
+          currentState: getS4ACommunicationState({
+            hideSidebarNav: true,
+          }),
+        }),
+      })
+    )
+
+    expect(wrapper.find("AppView").prop("hideSidebarNav")).toEqual(true)
   })
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -388,6 +388,7 @@ describe("App.handleNewSession", () => {
       maxCachedMessageAge: 0,
       mapboxToken: "mapboxToken",
       allowRunOnSave: false,
+      hideSidebarNav: false,
     },
     customTheme: {
       primaryColor: "red",
@@ -692,6 +693,17 @@ describe("App.handleNewSession", () => {
     // @ts-ignore
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
+  })
+
+  it("plumbs hideSidebarNav to AppView", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+
+    instance.handleNewSession(new NewSession(NEW_SESSION_JSON))
+
+    // hideSidebarNav is initialized to true, so if it's false below, it must
+    // have been changed as expected.
+    expect(wrapper.find("AppView").prop("hideSidebarNav")).toEqual(false)
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -141,6 +141,7 @@ interface State {
   gitInfo: IGitInfo | null
   formsData: FormsData
   hideTopBar: boolean
+  hideSidebarNav: boolean
   appPages: IAppPage[]
   currentPageName: string
 }
@@ -209,13 +210,16 @@ export class App extends PureComponent<Props, State> {
       themeHash: null,
       gitInfo: null,
       formsData: createFormsData(),
-      // We set this to true by default because this information isn't
-      // available on page load (we get it when the script begins to run), so
-      // the user would see top bar elements for a few ms if this defaulted to
-      // false.
-      hideTopBar: true,
       appPages: [],
       currentPageName: "",
+      // We set hideTopBar to true by default because this information isn't
+      // available on page load (we get it when the script begins to run), so
+      // the user would see top bar elements for a few ms if this defaulted to
+      // false. hideSidebarNav doesn't have this issue (app pages and the value
+      // of the config option are received simultaneously), but we set it to
+      // true as well for consistency.
+      hideTopBar: true,
+      hideSidebarNav: true,
     }
 
     this.sessionEventDispatcher = new SessionEventDispatcher()
@@ -617,6 +621,7 @@ export class App extends PureComponent<Props, State> {
     this.setState({
       allowRunOnSave: config.allowRunOnSave,
       hideTopBar: config.hideTopBar,
+      hideSidebarNav: config.hideSidebarNav,
       appPages: newSessionProto.appPages,
     })
 
@@ -1165,6 +1170,7 @@ export class App extends PureComponent<Props, State> {
       userSettings,
       gitInfo,
       hideTopBar,
+      hideSidebarNav,
       currentPageName,
     } = this.state
 
@@ -1268,6 +1274,7 @@ export class App extends PureComponent<Props, State> {
               appPages={this.state.appPages}
               onPageChange={this.onPageChange}
               currentPageName={currentPageName}
+              hideSidebarNav={hideSidebarNav}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1174,6 +1174,10 @@ export class App extends PureComponent<Props, State> {
       currentPageName,
     } = this.state
 
+    const {
+      hideSidebarNav: s4AHideSidebarNav,
+    } = this.props.s4aCommunication.currentState
+
     const outerDivClass = classNames("stApp", {
       "streamlit-embedded": isEmbeddedInIFrame(),
       "streamlit-wide": userSettings.wideMode,
@@ -1274,7 +1278,7 @@ export class App extends PureComponent<Props, State> {
               appPages={this.state.appPages}
               onPageChange={this.onPageChange}
               currentPageName={currentPageName}
-              hideSidebarNav={hideSidebarNav}
+              hideSidebarNav={hideSidebarNav || s4AHideSidebarNav}
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -51,6 +51,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
     onPageChange: jest.fn(),
     currentPageName: "streamlit_app",
+    hideSidebarNav: false,
     ...props,
   }
 }

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -61,6 +61,8 @@ export interface AppViewProps {
   onPageChange: (pageName: string) => void
 
   currentPageName: string
+
+  hideSidebarNav: boolean
 }
 
 /**
@@ -79,6 +81,7 @@ function AppView(props: AppViewProps): ReactElement {
     appPages,
     onPageChange,
     currentPageName,
+    hideSidebarNav,
   } = props
 
   React.useEffect(() => {
@@ -131,6 +134,7 @@ function AppView(props: AppViewProps): ReactElement {
           hasElements={hasSidebarElements}
           onPageChange={onPageChange}
           currentPageName={currentPageName}
+          hideSidebarNav={hideSidebarNav}
         >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -37,6 +37,7 @@ function renderSideBar(props: Partial<SidebarProps> = {}): ReactWrapper {
       onPageChange={jest.fn()}
       currentPageName={""}
       hasElements
+      hideSidebarNav={false}
       {...props}
     />
   )
@@ -164,6 +165,7 @@ describe("Sidebar Component", () => {
   it("renders SidebarNav component", () => {
     const appPages = [
       { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
     ]
     const wrapper = renderSideBar({ appPages })
 
@@ -172,5 +174,21 @@ describe("Sidebar Component", () => {
     expect(typeof wrapper.find(SidebarNav).prop("onPageChange")).toBe(
       "function"
     )
+    expect(
+      wrapper.find("StyledSidebarUserContent").prop("hasPageNavAbove")
+    ).toBe(true)
+  })
+
+  it("can hide SidebarNav with the hideSidebarNav option", () => {
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+    ]
+    const wrapper = renderSideBar({ appPages, hideSidebarNav: true })
+
+    expect(wrapper.find(SidebarNav).exists()).toBe(false)
+    expect(
+      wrapper.find("StyledSidebarUserContent").prop("hasPageNavAbove")
+    ).toBe(false)
   })
 })

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -43,6 +43,7 @@ export interface SidebarProps {
   appPages: IAppPage[]
   onPageChange: (pageName: string) => void
   currentPageName: string
+  hideSidebarNav: boolean
 }
 
 interface State {
@@ -169,7 +170,10 @@ class Sidebar extends PureComponent<SidebarProps, State> {
       hasElements,
       onPageChange,
       currentPageName,
+      hideSidebarNav,
     } = this.props
+
+    const hasPageNavAbove = appPages.length > 1 && !hideSidebarNav
 
     // The tabindex is required to support scrolling by arrow keys.
     return (
@@ -187,14 +191,16 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               <Icon content={Close} size="lg" />
             </Button>
           </StyledSidebarCloseButton>
-          <SidebarNav
-            appPages={appPages}
-            hasSidebarElements={hasElements}
-            onPageChange={onPageChange}
-            hideParentScrollbar={this.hideScrollbar}
-            currentPageName={currentPageName}
-          />
-          <StyledSidebarUserContent hasPageNavAbove={appPages.length > 1}>
+          {!hideSidebarNav && (
+            <SidebarNav
+              appPages={appPages}
+              hasSidebarElements={hasElements}
+              onPageChange={onPageChange}
+              hideParentScrollbar={this.hideScrollbar}
+              currentPageName={currentPageName}
+            />
+          )}
+          <StyledSidebarUserContent hasPageNavAbove={hasPageNavAbove}>
             {children}
           </StyledSidebarUserContent>
         </StyledSidebarContent>

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -29,6 +29,7 @@ function getProps(
     onPageChange: jest.fn(),
     currentPageName: "streamlit_app",
     hasElements: true,
+    hideSidebarNav: false,
     ...props,
   }
 }

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -29,6 +29,7 @@ export type StreamlitShareMetadata = {
 
 export interface S4ACommunicationState {
   forcedModalClose: boolean
+  hideSidebarNav: boolean
   isOwner: boolean
   menuItems: IMenuItem[]
   queryParams: string
@@ -75,6 +76,10 @@ export type IHostToGuestMessage = {
   | {
       type: "SET_SIDEBAR_CHEVRON_DOWNSHIFT"
       sidebarChevronDownshift: number
+    }
+  | {
+      type: "SET_SIDEBAR_NAV_VISIBILITY"
+      hidden: boolean
     }
   | {
       type: "SET_TOOLBAR_ITEMS"

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -160,6 +160,30 @@ describe("withS4ACommunication HOC", () => {
     expect(props.currentState.sidebarChevronDownshift).toBe(50)
   })
 
+  it("can process a received SET_SIDEBAR_NAV_VISIBILITY message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "SET_SIDEBAR_NAV_VISIBILITY",
+            hidden: true,
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+
+    wrapper.update()
+
+    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    expect(props.currentState.hideSidebarNav).toBe(true)
+  })
+
   describe("Test different origins", () => {
     it("exact pattern", () => {
       const dispatchEvent = mockEventListeners()

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -55,13 +55,14 @@ function withS4ACommunication(
   function ComponentWithS4ACommunication(props: any): ReactElement {
     // TODO(vdonato): Refactor this to use useReducer to make this less
     // unwieldy.
+    const [forcedModalClose, setForcedModalClose] = useState(false)
+    const [hideSidebarNav, setHideSidebarNav] = useState(false)
+    const [isOwner, setIsOwner] = useState(false)
     const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
-    const [forcedModalClose, setForcedModalClose] = useState(false)
-    const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
-    const [isOwner, setIsOwner] = useState(false)
-    const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
     const [sidebarChevronDownshift, setSidebarChevronDownshift] = useState(0)
+    const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
+    const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
@@ -104,6 +105,10 @@ function withS4ACommunication(
           setSidebarChevronDownshift(message.sidebarChevronDownshift)
         }
 
+        if (message.type === "SET_SIDEBAR_NAV_VISIBILITY") {
+          setHideSidebarNav(message.hidden)
+        }
+
         if (message.type === "SET_TOOLBAR_ITEMS") {
           setToolbarItems(message.items)
         }
@@ -130,6 +135,7 @@ function withS4ACommunication(
           {
             currentState: {
               forcedModalClose,
+              hideSidebarNav,
               isOwner,
               menuItems,
               queryParams,

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -640,6 +640,7 @@ def _populate_config_msg(msg: Config) -> None:
     msg.mapbox_token = config.get_option("mapbox.token")
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
     msg.hide_top_bar = config.get_option("ui.hideTopBar")
+    msg.hide_sidebar_nav = config.get_option("ui.hideSidebarNav")
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -707,6 +707,14 @@ _create_option(
     visibility="hidden",
 )
 
+_create_option(
+    "ui.hideSidebarNav",
+    description="""Flag to hide the sidebar page navigation component.""",
+    default_val=False,
+    type_=bool,
+    visibility="hidden",
+)
+
 
 # Config Section: Mapbox #
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -334,6 +334,7 @@ class ConfigTest(unittest.TestCase):
                 "server.maxUploadSize",
                 "server.maxMessageSize",
                 "ui.hideTopBar",
+                "ui.hideSidebarNav",
             ]
         )
         keys = sorted(config._config_options.keys())

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -92,6 +92,9 @@ message Config {
   // See config option "ui.hideTopBar".
   bool hide_top_bar = 6;
 
+  // See config option "ui.hideSidebarNav".
+  bool hide_sidebar_nav = 7;
+
   reserved 1;
 }
 


### PR DESCRIPTION
## 📚 Context

In the future, we may build a page navigation component directly into Streamlit Cloud.
If we do this, then we'll want to hide the one that lives in the streamlit app as it'll be
redundant. This PR allows us to do this in two ways:

* via the `ui.hideSidebarNav` config option -- we expect this to be the primary way we hide the
   `SidebarNav` component
* via a message that can be sent to the `withS4ACommunication` hoc. We doubt we'll have to be
   able to show and hide the nav component as dynamically as this allows us to, but we add this
   now to futureproof.


- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Add a config option to hide the sidebar page nav
- Add message allowing the withS4ACommunication hoc to hide the SidebarNav

## 🧪 Testing Done

- [x] Added/Updated unit tests