### PR TITLE
Add more type annotations

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -206,7 +206,7 @@ beta_expander = _main.beta_expander
 beta_columns = _main.beta_columns
 
 
-def set_option(key, value):
+def set_option(key: str, value) -> None:
     """Set config option.
 
     Currently, only the following config options can be set within the script itself:
@@ -372,7 +372,7 @@ def experimental_set_query_params(**query_params):
 
 
 @_contextlib.contextmanager
-def spinner(text="In progress..."):
+def spinner(text: str = "In progress..."):
     """Temporarily displays a message while executing a block of code.
 
     Parameters
@@ -446,7 +446,7 @@ def _transparent_write(*args):
 _use_warning_has_been_displayed = False
 
 
-def _maybe_print_use_warning():
+def _maybe_print_use_warning() -> None:
     """Print a warning if Streamlit is imported but not being run with `streamlit run`.
     The warning is printed only once.
     """
@@ -492,7 +492,7 @@ def stop() -> NoReturn:
     raise StopException()
 
 
-def experimental_rerun():
+def experimental_rerun() -> NoReturn:
     """Rerun the script immediately.
 
     When `st.experimental_rerun()` is called, the script is halted - no

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from .utils import clean_text

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 from typing import cast
+from typing import TYPE_CHECKING
 
-import streamlit
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from .utils import clean_text
 
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
 
 class AlertMixin:
-    def error(self, body):
+    def error(self, body: str) -> "DeltaGenerator":
         """Display error message.
 
         Parameters
@@ -36,9 +39,10 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.ERROR
-        return self.dg._enqueue("alert", alert_proto)
+        dg = self.dg._enqueue("alert", alert_proto)
+        return cast("DeltaGenerator", dg)
 
-    def warning(self, body):
+    def warning(self, body: str) -> "DeltaGenerator":
         """Display warning message.
 
         Parameters
@@ -54,9 +58,10 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.WARNING
-        return self.dg._enqueue("alert", alert_proto)
+        dg = self.dg._enqueue("alert", alert_proto)
+        return cast("DeltaGenerator", dg)
 
-    def info(self, body):
+    def info(self, body: str) -> "DeltaGenerator":
         """Display an informational message.
 
         Parameters
@@ -72,9 +77,10 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.INFO
-        return self.dg._enqueue("alert", alert_proto)
+        dg = self.dg._enqueue("alert", alert_proto)
+        return cast("DeltaGenerator", dg)
 
-    def success(self, body):
+    def success(self, body: str) -> "DeltaGenerator":
         """Display a success message.
 
         Parameters
@@ -90,9 +96,10 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.SUCCESS
-        return self.dg._enqueue("alert", alert_proto)
+        dg = self.dg._enqueue("alert", alert_proto)
+        return cast("DeltaGenerator", dg)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -16,7 +16,8 @@ import io
 from streamlit.scriptrunner import ScriptRunContext, get_script_run_ctx
 
 from streamlit.type_util import Key, to_key
-from typing import cast, Final, Optional, Union, BinaryIO, TextIO
+from typing import cast, Optional, Union, BinaryIO, TextIO
+from typing_extensions import Final
 from textwrap import dedent
 
 import streamlit

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -16,7 +16,7 @@ import io
 from streamlit.scriptrunner import ScriptRunContext, get_script_run_ctx
 
 from streamlit.type_util import Key, to_key
-from typing import cast, Optional, Union, BinaryIO, TextIO
+from typing import cast, Final, Optional, Union, BinaryIO, TextIO
 from textwrap import dedent
 
 import streamlit
@@ -34,7 +34,7 @@ from .form import current_form_id, is_in_form
 from .utils import check_callback_rules, check_session_state_rules
 
 
-FORM_DOCS_INFO = """
+FORM_DOCS_INFO: Final = """
 
 For more information, refer to the
 [documentation for forms](https://docs.streamlit.io/library/api-reference/control-flow/st.form).

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import cast
+from typing import Optional
 from typing import TYPE_CHECKING
 
 import streamlit
@@ -131,7 +132,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", subheader_proto)
 
-    def code(self, body: str, language: str = "python") -> DeltaGenerator:
+    def code(self, body: str, language: Optional[str] = "python") -> DeltaGenerator:
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -268,4 +269,4 @@ class MarkdownMixin:
     @property
     def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -17,7 +17,6 @@ from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Union
 
-import streamlit
 from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from .utils import clean_text
@@ -233,7 +232,7 @@ class MarkdownMixin:
         caption_proto.is_caption = True
         return self.dg._enqueue("markdown", caption_proto)
 
-    def latex(self, body: Union[str, sympy.Expr]) -> "DeltaGenerator":
+    def latex(self, body: Union[str, "sympy.Expr"]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.
         r"""Display mathematical expressions formatted as LaTeX.

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -24,7 +24,7 @@ from .utils import clean_text
 
 if TYPE_CHECKING:
     import sympy
-    
+
     from streamlit.delta_generator import DeltaGenerator
 
 

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -13,15 +13,21 @@
 # limitations under the License.
 
 from typing import cast
+from typing import TYPE_CHECKING
 
 import streamlit
 from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from .utils import clean_text
 
+if TYPE_CHECKING:
+    import sympy
+    
+    from streamlit.delta_generator import DeltaGenerator
+
 
 class MarkdownMixin:
-    def markdown(self, body, unsafe_allow_html=False):
+    def markdown(self, body: str, unsafe_allow_html: bool = False) -> DeltaGenerator:
         """Display string formatted as Markdown.
 
         Parameters
@@ -74,7 +80,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
-    def header(self, body, anchor=None):
+    def header(self, body: str, anchor: Optional[str] = None) -> DeltaGenerator:
         """Display text in header formatting.
 
         Parameters
@@ -99,7 +105,7 @@ class MarkdownMixin:
             header_proto.allow_html = True
         return self.dg._enqueue("markdown", header_proto)
 
-    def subheader(self, body, anchor=None):
+    def subheader(self, body: str, anchor: Optional[str] = None) -> DeltaGenerator:
         """Display text in subheader formatting.
 
         Parameters
@@ -125,7 +131,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", subheader_proto)
 
-    def code(self, body, language="python"):
+    def code(self, body: str, language: str = "python") -> DeltaGenerator:
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -154,7 +160,7 @@ class MarkdownMixin:
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
-    def title(self, body, anchor=None):
+    def title(self, body: str, anchor: Optional[str] = None) -> DeltaGenerator:
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not
@@ -182,7 +188,7 @@ class MarkdownMixin:
             title_proto.allow_html = True
         return self.dg._enqueue("markdown", title_proto)
 
-    def caption(self, body, unsafe_allow_html=False):
+    def caption(self, body: str, unsafe_allow_html: bool = False) -> DeltaGenerator:
         """Display text in small font.
 
         This should be used for captions, asides, footnotes, sidenotes, and
@@ -225,7 +231,7 @@ class MarkdownMixin:
         caption_proto.is_caption = True
         return self.dg._enqueue("markdown", caption_proto)
 
-    def latex(self, body):
+    def latex(self, body: Union[str, sympy.Expr]) -> DeltaGenerator:
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.
         r"""Display mathematical expressions formatted as LaTeX.
@@ -260,6 +266,6 @@ class MarkdownMixin:
         return self.dg._enqueue("markdown", latex_proto)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
         return cast("streamlit.delta_generator.DeltaGenerator", self)

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -15,6 +15,7 @@
 from typing import cast
 from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Union
 
 import streamlit
 from streamlit import type_util
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
 
 
 class MarkdownMixin:
-    def markdown(self, body: str, unsafe_allow_html: bool = False) -> DeltaGenerator:
+    def markdown(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
         """Display string formatted as Markdown.
 
         Parameters
@@ -81,7 +82,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
-    def header(self, body: str, anchor: Optional[str] = None) -> DeltaGenerator:
+    def header(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in header formatting.
 
         Parameters
@@ -106,7 +107,7 @@ class MarkdownMixin:
             header_proto.allow_html = True
         return self.dg._enqueue("markdown", header_proto)
 
-    def subheader(self, body: str, anchor: Optional[str] = None) -> DeltaGenerator:
+    def subheader(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in subheader formatting.
 
         Parameters
@@ -132,7 +133,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", subheader_proto)
 
-    def code(self, body: str, language: Optional[str] = "python") -> DeltaGenerator:
+    def code(self, body: str, language: Optional[str] = "python") -> "DeltaGenerator":
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -161,7 +162,7 @@ class MarkdownMixin:
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
-    def title(self, body: str, anchor: Optional[str] = None) -> DeltaGenerator:
+    def title(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not
@@ -189,7 +190,7 @@ class MarkdownMixin:
             title_proto.allow_html = True
         return self.dg._enqueue("markdown", title_proto)
 
-    def caption(self, body: str, unsafe_allow_html: bool = False) -> DeltaGenerator:
+    def caption(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
         """Display text in small font.
 
         This should be used for captions, asides, footnotes, sidenotes, and
@@ -232,7 +233,7 @@ class MarkdownMixin:
         caption_proto.is_caption = True
         return self.dg._enqueue("markdown", caption_proto)
 
-    def latex(self, body: Union[str, sympy.Expr]) -> DeltaGenerator:
+    def latex(self, body: Union[str, sympy.Expr]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.
         r"""Display mathematical expressions formatted as LaTeX.
@@ -267,6 +268,6 @@ class MarkdownMixin:
         return self.dg._enqueue("markdown", latex_proto)
 
     @property
-    def dg(self) -> DeltaGenerator:
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
         return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -79,7 +79,8 @@ class MarkdownMixin:
         markdown_proto.body = clean_text(body)
         markdown_proto.allow_html = unsafe_allow_html
 
-        return self.dg._enqueue("markdown", markdown_proto)
+        dg = self.dg._enqueue("markdown", markdown_proto)
+        return cast("DeltaGenerator", dg)
 
     def header(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in header formatting.
@@ -104,7 +105,8 @@ class MarkdownMixin:
         else:
             header_proto.body = f'<h2 data-anchor="{anchor}">{clean_text(body)}</h2>'
             header_proto.allow_html = True
-        return self.dg._enqueue("markdown", header_proto)
+        dg = self.dg._enqueue("markdown", header_proto)
+        return cast("DeltaGenerator", dg)
 
     def subheader(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in subheader formatting.
@@ -130,7 +132,8 @@ class MarkdownMixin:
             subheader_proto.body = f'<h3 data-anchor="{anchor}">{clean_text(body)}</h3>'
             subheader_proto.allow_html = True
 
-        return self.dg._enqueue("markdown", subheader_proto)
+        dg = self.dg._enqueue("markdown", subheader_proto)
+        return cast("DeltaGenerator", dg)
 
     def code(self, body: str, language: Optional[str] = "python") -> "DeltaGenerator":
         """Display a code block with optional syntax highlighting.
@@ -159,7 +162,8 @@ class MarkdownMixin:
             "body": body,
         }
         code_proto.body = clean_text(markdown)
-        return self.dg._enqueue("markdown", code_proto)
+        dg = self.dg._enqueue("markdown", code_proto)
+        return cast("DeltaGenerator", dg)
 
     def title(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in title formatting.
@@ -187,7 +191,8 @@ class MarkdownMixin:
         else:
             title_proto.body = f'<h1 data-anchor="{anchor}">{clean_text(body)}</h1>'
             title_proto.allow_html = True
-        return self.dg._enqueue("markdown", title_proto)
+        dg = self.dg._enqueue("markdown", title_proto)
+        return cast("DeltaGenerator", dg)
 
     def caption(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
         """Display text in small font.
@@ -230,7 +235,8 @@ class MarkdownMixin:
         caption_proto.body = clean_text(body)
         caption_proto.allow_html = unsafe_allow_html
         caption_proto.is_caption = True
-        return self.dg._enqueue("markdown", caption_proto)
+        dg = self.dg._enqueue("markdown", caption_proto)
+        return cast("DeltaGenerator", dg)
 
     def latex(self, body: Union[str, "sympy.Expr"]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
@@ -264,7 +270,8 @@ class MarkdownMixin:
 
         latex_proto = MarkdownProto()
         latex_proto.body = "$$\n%s\n$$" % clean_text(body)
-        return self.dg._enqueue("markdown", latex_proto)
+        dg = self.dg._enqueue("markdown", latex_proto)
+        return cast("DeltaGenerator", dg)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
-from typing import Optional
-from typing import TYPE_CHECKING
-from typing import Union
+from typing import cast, Optional, TYPE_CHECKING, Union
 
 from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-from typing import cast
-from typing import TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 from streamlit.proto.Text_pb2 import Text as TextProto
 from .utils import clean_text

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -39,9 +39,10 @@ class TextMixin:
         """
         text_proto = TextProto()
         text_proto.body = clean_text(body)
-        return self.dg._enqueue("text", text_proto)
+        dg = self.dg._enqueue("text", text_proto)
+        return cast("DeltaGenerator", dg)
 
     @property
     def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast(DeltaGenerator, self)
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -13,14 +13,18 @@
 # limitations under the License.
 
 from typing import cast
+from typing import TYPE_CHECKING
 
 import streamlit
 from streamlit.proto.Text_pb2 import Text as TextProto
 from .utils import clean_text
 
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
 
 class TextMixin:
-    def text(self, body):
+    def text(self, body: str) -> DeltaGenerator:
         """Write fixed-width and preformatted text.
 
         Parameters
@@ -38,6 +42,6 @@ class TextMixin:
         return self.dg._enqueue("text", text_proto)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> DeltaGenerator:
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast(DeltaGenerator, self)

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
 
-import streamlit
 from streamlit.proto.Text_pb2 import Text as TextProto
 from .utils import clean_text
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class TextMixin:
-    def text(self, body: str) -> "DeltaGenerator":
+    def text(self, body: Any) -> "DeltaGenerator":
         """Write fixed-width and preformatted text.
 
         Parameters

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class TextMixin:
-    def text(self, body: str) -> DeltaGenerator:
+    def text(self, body: str) -> "DeltaGenerator":
         """Write fixed-width and preformatted text.
 
         Parameters
@@ -42,6 +42,6 @@ class TextMixin:
         return self.dg._enqueue("text", text_proto)
 
     @property
-    def dg(self) -> DeltaGenerator:
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
         return cast(DeltaGenerator, self)

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -419,7 +419,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        self.assertEqual(el.doc_string.signature, "(body, anchor=None)")
+        self.assertEqual(el.doc_string.signature, "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'")
 
     def test_st_image_PIL_image(self):
         """Test st.image with PIL image."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -420,8 +420,8 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        if sys.version_info[1] == 6:
-            # Python 3.6 represents the signature slightly differently
+        if sys.version_info[1] == 7:
+            # Python 3.7 represents the signature slightly differently
             self.assertEqual(
                 el.doc_string.signature,
                 "(body: str, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -419,7 +419,10 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        self.assertEqual(el.doc_string.signature, "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'")
+        self.assertEqual(
+            el.doc_string.signature,
+            "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'",
+        )
 
     def test_st_image_PIL_image(self):
         """Test st.image with PIL image."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -20,6 +20,7 @@ import json
 import os
 import io
 import re
+import sys
 import time
 import textwrap
 import unittest
@@ -419,10 +420,17 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        self.assertEqual(
-            el.doc_string.signature,
-            "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'",
-        )
+        if sys.version_info[1] == 6:
+            # Python 3.6 represents the signature slightly differently
+            self.assertEqual(
+                el.doc_string.signature,
+                "(body: str, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",
+            )
+        else:
+            self.assertEqual(
+                el.doc_string.signature,
+                "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'",
+            )
 
     def test_st_image_PIL_image(self):
         """Test st.image with PIL image."""


### PR DESCRIPTION
## 📚 Context

Add some low hanging type annotations to the code base.

I run `mypy` with fairly strict settings, including https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-disallow-untyped-calls

This results in a lot of errors for various parts of the Streamlit API. This PR adds type annotations to a few APIs I use heavily, in order to silence those errors.

- What kind of change does this PR introduce?
  - [x] Other, please describe: Type annotations

## 🧠 Description of Changes

- Add type annotations to various parts of the Streamlit API.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
