### PR TITLE
More cloud+multipage apps futureproofing

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -62,6 +62,7 @@ const getS4ACommunicationState = (
   isOwner: true,
   menuItems: [],
   queryParams: "",
+  requestedPageName: null,
   sidebarChevronDownshift: 0,
   streamlitShareMetadata: {},
   toolbarItems: [],
@@ -74,6 +75,7 @@ const getS4ACommunicationProp = (
   connect: jest.fn(),
   sendMessage: jest.fn(),
   onModalReset: jest.fn(),
+  onPageChanged: jest.fn(),
   currentState: getS4ACommunicationState({}),
   ...extend,
 })
@@ -385,6 +387,27 @@ describe("App", () => {
       type: "SET_APP_PAGES",
       appPages,
     })
+  })
+
+  it("responds to page change requests", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    const instance = wrapper.instance() as App
+    instance.onPageChange = jest.fn()
+
+    wrapper.setProps(
+      getProps({
+        s4aCommunication: getS4ACommunicationProp({
+          currentState: getS4ACommunicationState({
+            requestedPageName: "page1",
+          }),
+        }),
+      })
+    )
+    wrapper.update()
+
+    expect(instance.onPageChange).toHaveBeenCalledWith("page1")
+    expect(props.s4aCommunication.currentState.requestedPageName).toBeNull()
   })
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -860,7 +860,8 @@ describe("App.sendRerunBackMsg", () => {
   })
 
   it("figures out pageName when sendRerunBackMsg isn't given one (case 1: main page)", () => {
-    const wrapper = shallow(<App {...getProps()} />)
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
     const instance = wrapper.instance() as App
     // @ts-ignore
     instance.sendBackMsg = jest.fn()
@@ -875,10 +876,15 @@ describe("App.sendRerunBackMsg", () => {
     })
 
     expect(wrapper.find("AppView").prop("currentPageName")).toEqual("")
+    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+    })
   })
 
   it("figures out pageName when sendRerunBackMsg isn't given one (case 2: non-main page)", () => {
-    const wrapper = shallow(<App {...getProps()} />)
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
     const instance = wrapper.instance() as App
     // @ts-ignore
     instance.sendBackMsg = jest.fn()
@@ -895,6 +901,10 @@ describe("App.sendRerunBackMsg", () => {
       rerunScript: { pageName: "page1", queryString: "" },
     })
     expect(wrapper.find("AppView").prop("currentPageName")).toEqual("page1")
+    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "page1",
+    })
   })
 
   it("figures out pageName when sendRerunBackMsg isn't given one and a baseUrlPath is set", () => {
@@ -996,7 +1006,8 @@ describe("App.sendRerunBackMsg", () => {
 
 describe("App.handlePageNotFound", () => {
   it("displays an error modal", () => {
-    const wrapper = shallow(<App {...getProps()} />)
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
     const instance = wrapper.instance() as App
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
@@ -1011,6 +1022,10 @@ describe("App.handlePageNotFound", () => {
       "Page not found",
       `You have requested page /nonexistentPage, but no corresponding file was found in the app's pages/ directory.`
     )
+    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+    })
   })
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -373,12 +373,18 @@ describe("App", () => {
     const msg = new ForwardMsg()
     msg.pagesChanged = new PagesChanged({ appPages })
 
-    const wrapper = shallow(<App {...getProps()} />)
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
     expect(wrapper.find("AppView").prop("appPages")).toEqual([])
 
     const instance = wrapper.instance() as App
     instance.handleMessage(msg)
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
+
+    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "SET_APP_PAGES",
+      appPages,
+    })
   })
 })
 
@@ -672,7 +678,8 @@ describe("App.handleNewSession", () => {
   })
 
   it("plumbs appPages to the AppView component", () => {
-    const wrapper = shallow(<App {...getProps()} />)
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
 
     expect(wrapper.find("AppView").prop("appPages")).toEqual([])
 
@@ -694,6 +701,10 @@ describe("App.handleNewSession", () => {
     // @ts-ignore
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
+    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "SET_APP_PAGES",
+      appPages,
+    })
   })
 
   it("sets hideSidebarNav based on the server config option and s4a setting", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -61,6 +61,7 @@ const getS4ACommunicationState = (
   hideSidebarNav: false,
   isOwner: true,
   menuItems: [],
+  pageLinkBaseUrl: "",
   queryParams: "",
   requestedPageName: null,
   sidebarChevronDownshift: 0,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -495,7 +495,12 @@ export class App extends PureComponent<Props, State> {
 
   handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
     const { appPages } = pagesChangedMsg
-    this.setState({ appPages })
+    this.setState({ appPages }, () => {
+      this.props.s4aCommunication.sendMessage({
+        type: "SET_APP_PAGES",
+        appPages,
+      })
+    })
   }
 
   /**
@@ -618,12 +623,20 @@ export class App extends PureComponent<Props, State> {
     }
 
     this.processThemeInput(themeInput)
-    this.setState({
-      allowRunOnSave: config.allowRunOnSave,
-      hideTopBar: config.hideTopBar,
-      hideSidebarNav: config.hideSidebarNav,
-      appPages: newSessionProto.appPages,
-    })
+    this.setState(
+      {
+        allowRunOnSave: config.allowRunOnSave,
+        hideTopBar: config.hideTopBar,
+        hideSidebarNav: config.hideSidebarNav,
+        appPages: newSessionProto.appPages,
+      },
+      () => {
+        this.props.s4aCommunication.sendMessage({
+          type: "SET_APP_PAGES",
+          appPages: newSessionProto.appPages,
+        })
+      }
+    )
 
     const { appHash } = this.state
     const { scriptRunId, name: scriptName, mainScriptPath } = newSessionProto

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -304,6 +304,12 @@ export class App extends PureComponent<Props, State> {
     if (this.props.s4aCommunication.currentState.forcedModalClose) {
       this.closeDialog()
     }
+
+    const { requestedPageName } = this.props.s4aCommunication.currentState
+    if (requestedPageName !== null) {
+      this.onPageChange(requestedPageName)
+      this.props.s4aCommunication.onPageChanged()
+    }
   }
 
   showError(title: string, errorNode: ReactNode): void {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1309,6 +1309,9 @@ export class App extends PureComponent<Props, State> {
               onPageChange={this.onPageChange}
               currentPageName={currentPageName}
               hideSidebarNav={hideSidebarNav || s4AHideSidebarNav}
+              pageLinkBaseUrl={
+                this.props.s4aCommunication.currentState.pageLinkBaseUrl
+              }
             />
             {renderedDialog}
           </StyledApp>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -490,7 +490,13 @@ export class App extends PureComponent<Props, State> {
       `You have requested page /${pageName}, but no corresponding file was found in the app's pages/ directory.`
     )
 
-    this.setState({ currentPageName: "" })
+    const currentPageName = ""
+    this.setState({ currentPageName }, () => {
+      this.props.s4aCommunication.sendMessage({
+        type: "SET_CURRENT_PAGE_NAME",
+        currentPageName,
+      })
+    })
   }
 
   handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
@@ -998,7 +1004,12 @@ export class App extends PureComponent<Props, State> {
       window.history.pushState({}, "", pageUrl)
     }
 
-    this.setState({ currentPageName: pageName })
+    this.setState({ currentPageName: pageName }, () => {
+      this.props.s4aCommunication.sendMessage({
+        type: "SET_CURRENT_PAGE_NAME",
+        currentPageName: pageName as string,
+      })
+    })
 
     this.sendBackMsg(
       new BackMsg({

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -52,6 +52,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     onPageChange: jest.fn(),
     currentPageName: "streamlit_app",
     hideSidebarNav: false,
+    pageLinkBaseUrl: "",
     ...props,
   }
 }

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -63,6 +63,8 @@ export interface AppViewProps {
   currentPageName: string
 
   hideSidebarNav: boolean
+
+  pageLinkBaseUrl: string
 }
 
 /**
@@ -82,6 +84,7 @@ function AppView(props: AppViewProps): ReactElement {
     onPageChange,
     currentPageName,
     hideSidebarNav,
+    pageLinkBaseUrl,
   } = props
 
   React.useEffect(() => {
@@ -135,6 +138,7 @@ function AppView(props: AppViewProps): ReactElement {
           onPageChange={onPageChange}
           currentPageName={currentPageName}
           hideSidebarNav={hideSidebarNav}
+          pageLinkBaseUrl={pageLinkBaseUrl}
         >
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -37,6 +37,7 @@ function renderSideBar(props: Partial<SidebarProps> = {}): ReactWrapper {
       onPageChange={jest.fn()}
       currentPageName={""}
       hasElements
+      pageLinkBaseUrl={""}
       hideSidebarNav={false}
       {...props}
     />

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -44,6 +44,7 @@ export interface SidebarProps {
   onPageChange: (pageName: string) => void
   currentPageName: string
   hideSidebarNav: boolean
+  pageLinkBaseUrl: string
 }
 
 interface State {
@@ -171,6 +172,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
       onPageChange,
       currentPageName,
       hideSidebarNav,
+      pageLinkBaseUrl,
     } = this.props
 
     const hasPageNavAbove = appPages.length > 1 && !hideSidebarNav
@@ -198,6 +200,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               onPageChange={onPageChange}
               hideParentScrollbar={this.hideScrollbar}
               currentPageName={currentPageName}
+              pageLinkBaseUrl={pageLinkBaseUrl}
             />
           )}
           <StyledSidebarUserContent hasPageNavAbove={hasPageNavAbove}>

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -46,7 +46,6 @@ const mockUseIsOverflowing = useIsOverflowing as jest.MockedFunction<
   typeof useIsOverflowing
 >
 
-// @ts-ignore
 const getProps = (props: Partial<Props> = {}): Props => ({
   appPages: [
     { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
@@ -55,6 +54,8 @@ const getProps = (props: Partial<Props> = {}): Props => ({
   hasSidebarElements: false,
   onPageChange: jest.fn(),
   hideParentScrollbar: jest.fn(),
+  currentPageName: "",
+  pageLinkBaseUrl: "",
   ...props,
 })
 
@@ -166,6 +167,25 @@ describe("SidebarNav", () => {
       ])
 
       mockUseContext.mockRestore()
+    })
+
+    it("is built using the pageLinkBaseUrl if one is set", () => {
+      window.location.port = "3000"
+
+      const wrapper = shallow(
+        <SidebarNav
+          {...getProps({
+            pageLinkBaseUrl: "https://share.streamlit.io/vdonato/foo/bar",
+          })}
+        />
+      )
+
+      expect(
+        wrapper.find("StyledSidebarNavLink").map(node => node.props().href)
+      ).toEqual([
+        "https://share.streamlit.io/vdonato/foo/bar/",
+        "https://share.streamlit.io/vdonato/foo/bar/my_other_page",
+      ])
     })
   })
 

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -37,6 +37,7 @@ export interface Props {
   onPageChange: (pageName: string) => void
   hideParentScrollbar: (newValue: boolean) => void
   currentPageName: string
+  pageLinkBaseUrl: string
 }
 
 // TODO(vdonato): indicate the current page and make it unclickable
@@ -46,6 +47,7 @@ const SidebarNav = ({
   onPageChange,
   hideParentScrollbar,
   currentPageName,
+  pageLinkBaseUrl,
 }: Props): ReactElement | null => {
   if (appPages.length < 2) {
     return null
@@ -98,7 +100,9 @@ const SidebarNav = ({
             const navigateTo = pageIndex === 0 ? "" : pageName
             let pageUrl = ""
 
-            if (baseUriParts) {
+            if (pageLinkBaseUrl) {
+              pageUrl = `${pageLinkBaseUrl}/${navigateTo}`
+            } else if (baseUriParts) {
               const { basePath, host } = baseUriParts
               const portSection = port ? `:${port}` : ""
               const basePathSection = basePath ? `${basePath}/` : ""

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -30,6 +30,7 @@ function getProps(
     currentPageName: "streamlit_app",
     hasElements: true,
     hideSidebarNav: false,
+    pageLinkBaseUrl: "",
     ...props,
   }
 }

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -34,6 +34,7 @@ export interface S4ACommunicationState {
   isOwner: boolean
   menuItems: IMenuItem[]
   queryParams: string
+  requestedPageName: string
   sidebarChevronDownshift: number
   streamlitShareMetadata: StreamlitShareMetadata
   toolbarItems: IToolbarItem[]
@@ -61,6 +62,10 @@ export type IHostToGuestMessage = {
 } & (
   | {
       type: "CLOSE_MODALS"
+    }
+  | {
+      type: "REQUEST_PAGE_CHANGE"
+      pageName: string
     }
   | {
       type: "SET_IS_OWNER"

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -35,7 +35,7 @@ export interface S4ACommunicationState {
   menuItems: IMenuItem[]
   pageLinkBaseUrl: string
   queryParams: string
-  requestedPageName: string
+  requestedPageName: string | null
   sidebarChevronDownshift: number
   streamlitShareMetadata: StreamlitShareMetadata
   toolbarItems: IToolbarItem[]

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -113,6 +113,10 @@ export type IGuestToHostMessage =
       appPages: IAppPage[]
     }
   | {
+      type: "SET_CURRENT_PAGE_NAME"
+      currentPageName: string
+    }
+  | {
       type: "SET_PAGE_FAVICON"
       favicon: string
     }

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { IAppPage } from "src/autogen/proto"
 import { ExportedTheme } from "src/theme"
 
 export type StreamlitShareMetadata = {
@@ -106,6 +107,10 @@ export type IGuestToHostMessage =
   | {
       type: "TOOLBAR_ITEM_CALLBACK"
       key: string
+    }
+  | {
+      type: "SET_APP_PAGES"
+      appPages: IAppPage[]
     }
   | {
       type: "SET_PAGE_FAVICON"

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -33,6 +33,7 @@ export interface S4ACommunicationState {
   hideSidebarNav: boolean
   isOwner: boolean
   menuItems: IMenuItem[]
+  pageLinkBaseUrl: string
   queryParams: string
   requestedPageName: string
   sidebarChevronDownshift: number
@@ -78,6 +79,10 @@ export type IHostToGuestMessage = {
   | {
       type: "SET_METADATA"
       metadata: StreamlitShareMetadata
+    }
+  | {
+      type: "SET_PAGE_LINK_BASE_URL"
+      pageLinkBaseUrl: string
     }
   | {
       type: "SET_SIDEBAR_CHEVRON_DOWNSHIFT"

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -217,6 +217,32 @@ describe("withS4ACommunication HOC", () => {
     expect(props2.currentState.requestedPageName).toBe(null)
   })
 
+  it("can process a received SET_PAGE_LINK_BASE_URL message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "SET_PAGE_LINK_BASE_URL",
+            pageLinkBaseUrl: "https://share.streamlit.io/vdonato/foo/bar",
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+
+    wrapper.update()
+
+    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    expect(props.currentState.pageLinkBaseUrl).toBe(
+      "https://share.streamlit.io/vdonato/foo/bar"
+    )
+  })
+
   describe("Test different origins", () => {
     it("exact pattern", () => {
       const dispatchEvent = mockEventListeners()

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -184,6 +184,39 @@ describe("withS4ACommunication HOC", () => {
     expect(props.currentState.hideSidebarNav).toBe(true)
   })
 
+  it("can process a received REQUEST_PAGE_CHANGE message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: S4A_COMM_VERSION,
+            type: "REQUEST_PAGE_CHANGE",
+            pageName: "page1",
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+    wrapper.update()
+
+    const innerComponent = wrapper.find(TestComponentNaked)
+    const props = innerComponent.prop("s4aCommunication")
+    expect(props.currentState.requestedPageName).toBe("page1")
+
+    act(() => {
+      innerComponent.prop("s4aCommunication").onPageChanged()
+    })
+    wrapper.update()
+
+    const innerComponent2 = wrapper.find(TestComponentNaked)
+    const props2 = innerComponent2.prop("s4aCommunication")
+    expect(props2.currentState.requestedPageName).toBe(null)
+  })
+
   describe("Test different origins", () => {
     it("exact pattern", () => {
       const dispatchEvent = mockEventListeners()

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -35,6 +35,7 @@ export interface S4ACommunicationHOC {
   connect: () => void
   sendMessage: (message: IGuestToHostMessage) => void
   onModalReset: () => void
+  onPageChanged: () => void
 }
 
 export const S4A_COMM_VERSION = 1
@@ -60,6 +61,9 @@ function withS4ACommunication(
     const [isOwner, setIsOwner] = useState(false)
     const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
     const [queryParams, setQueryParams] = useState("")
+    const [requestedPageName, setRequestedPageName] = useState<string | null>(
+      null
+    )
     const [sidebarChevronDownshift, setSidebarChevronDownshift] = useState(0)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
     const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
@@ -87,6 +91,10 @@ function withS4ACommunication(
 
         if (message.type === "CLOSE_MODAL") {
           setForcedModalClose(true)
+        }
+
+        if (message.type === "REQUEST_PAGE_CHANGE") {
+          setRequestedPageName(message.pageName)
         }
 
         if (message.type === "SET_IS_OWNER") {
@@ -139,6 +147,7 @@ function withS4ACommunication(
               isOwner,
               menuItems,
               queryParams,
+              requestedPageName,
               sidebarChevronDownshift,
               streamlitShareMetadata,
               toolbarItems,
@@ -150,6 +159,9 @@ function withS4ACommunication(
             },
             onModalReset: () => {
               setForcedModalClose(false)
+            },
+            onPageChanged: () => {
+              setRequestedPageName(null)
             },
             sendMessage: sendS4AMessage,
           } as S4ACommunicationHOC

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -60,6 +60,7 @@ function withS4ACommunication(
     const [hideSidebarNav, setHideSidebarNav] = useState(false)
     const [isOwner, setIsOwner] = useState(false)
     const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
+    const [pageLinkBaseUrl, setPageLinkBaseUrl] = useState("")
     const [queryParams, setQueryParams] = useState("")
     const [requestedPageName, setRequestedPageName] = useState<string | null>(
       null
@@ -109,6 +110,10 @@ function withS4ACommunication(
           setStreamlitShareMetadata(message.metadata)
         }
 
+        if (message.type === "SET_PAGE_LINK_BASE_URL") {
+          setPageLinkBaseUrl(message.pageLinkBaseUrl)
+        }
+
         if (message.type === "SET_SIDEBAR_CHEVRON_DOWNSHIFT") {
           setSidebarChevronDownshift(message.sidebarChevronDownshift)
         }
@@ -146,6 +151,7 @@ function withS4ACommunication(
               hideSidebarNav,
               isOwner,
               menuItems,
+              pageLinkBaseUrl,
               queryParams,
               requestedPageName,
               sidebarChevronDownshift,


### PR DESCRIPTION
## 📚 Context

This PR does a bunch of things to futureproof for potential multipage apps
related features that we may have to build into Streamlit Cloud. Most of these
won't actually be used now / may never end up being used, but we add them
anyway just in case. The changes are listed in the section below.

Note that this PR is most easily reviewed commit-wise as each of the changes
listed below are written in their own commits.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- [Let Streamlit Cloud know when app pages change](https://github.com/streamlit/streamlit/commit/3c1570c56a3bb782502cda641d230e09e8828aab)
- [Let Streamlit Cloud know when the user has changed pages](https://github.com/streamlit/streamlit/commit/c60a6fcfdcb5d55aa65492efc05b09f7add3b673)
- [Provide a way for Streamlit Cloud to request for page changes](https://github.com/streamlit/streamlit/commit/a8ff8a411b33b166e4c63c27274e4e1c9dd4aff0)
- [Allow Streamlit Cloud to set a baseUrl to use for page links](https://github.com/streamlit/streamlit/commit/31eebdcc2a4eefc307dfe119d829e84589c18397)

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Closes https://github.com/streamlit/streamlit-issues/issues/364
