### PR TITLE
Add opt-in port proxying via jupyter-server-proxy

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -564,6 +564,15 @@ def _server_port() -> int:
     return 8501
 
 
+@_create_option("server.portProxy", type_=bool)
+def _server_port_proxy() -> int:
+    """Use jupyter_server_proxy to proxy local ports.
+
+    Default: False
+    """
+    return False
+
+
 _create_option(
     "server.scriptHealthCheckEnabled",
     visibility="hidden",

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -424,14 +424,12 @@ class Server:
             try:
                 from jupyter_server_proxy.handlers import LocalProxyHandler
             except ModuleNotFoundError:
-                LOGGER.error("jupyter_server_proxy is not installed. Cannot use `server.portProxy`")
+                LOGGER.error(
+                    "jupyter_server_proxy is not installed. Cannot use `server.portProxy`"
+                )
             else:
                 routes.extend(
-                    [
-                        (
-                            make_url_path_regex(base, r"proxy/(\d+)(.*)"), LocalProxyHandler
-                        )
-                    ]
+                    [(make_url_path_regex(base, r"proxy/(\d+)(.*)"), LocalProxyHandler)]
                 )
 
         return tornado.web.Application(

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -420,6 +420,20 @@ class Server:
                 ]
             )
 
+        if config.get_option("server.portProxy"):
+            try:
+                from jupyter_server_proxy.handlers import LocalProxyHandler
+            except ModuleNotFoundError:
+                LOGGER.error("jupyter_server_proxy is not installed. Cannot use `server.portProxy`")
+            else:
+                routes.extend(
+                    [
+                        (
+                            make_url_path_regex(base, r"proxy/(\d+)(.*)"), LocalProxyHandler
+                        )
+                    ]
+                )
+
         return tornado.web.Application(
             routes,
             cookie_secret=config.get_option("server.cookieSecret"),


### PR DESCRIPTION
## 📚 Context

This addresses https://github.com/streamlit/streamlit/issues/439#issuecomment-1116651595 and my issues described in https://discuss.streamlit.io/t/streamlit-cloud-port-proxying-on-streamlit-io/24748/4 by using `jupyter_server_proxy`'s `LocalProxyHandler` to proxy requests through the web app to any locally hosted server.


cc @giswqs


- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

These changes make it so that a user can specify `portProxy` in their config and have `jupyter-server-proxy` installed to proxy any port on the localhost through the streamlit web app:

```
[server]
portProxy = true
```

Locally, this allows you to do the following where you can launch a web server in a background thread and access it through the streamlit web server:

```py
import requests
import streamlit as st
from werkzeug import Request, Response
from server_thread import ServerThread


@Request.application
def app(request):
    return Response(f"howdy: {request.args}", 200)


# Launch app in a background thread
# This could be a tornado or flask or django or whatever app
server = ServerThread(app)

# Perform requests against the server without blocking
url = f"http://localhost:8501/proxy/{server.port}/?foo=bar"
st.write(url)
r = requests.get(url)
st.write(r.content)
```

![Screen Shot 2022-05-03 at 4 54 52 PM](https://user-images.githubusercontent.com/22067021/166586100-3774f5da-3472-4f5a-8585-124d19213340.png)


As cool as it is to have a web server running on a different port say *Howdy*, this enables a whole bunch of additional cool things you could do with streamlit like the following with my [`localtileserver`](https://github.com/banesullivan/localtileserver) package

In `localtileserver`, I use `server-thread` much like the example above but to spin up a geospatial image tile server on a randomly chosen port on the host machine. I then need to proxy requests from the browser using mapping frameworks like Leaflet via `streamlit-folium` through the streamlit server to the tile server.

I have included a demo that leverages this in: https://github.com/banesullivan/streamlit-localtileserver/pull/1/files

Which looks a little something like:

![Screen Shot 2022-05-03 at 4 50 09 PM](https://user-images.githubusercontent.com/22067021/166586544-393bebf9-aa1a-497e-b1f0-393a99360d50.png)

and you can see that the image tile requests in the browser coming from Leaflet are going through the proxied URL:

![Screen Shot 2022-05-03 at 4 50 49 PM](https://user-images.githubusercontent.com/22067021/166586589-1fe7abd4-2f60-4c8b-a82e-58e00c8f2169.png)


### Things I'm unsure about

- [ ] Testing... should I add `jupyter-server-proxy` as a test dependency and test this feature?
- [ ] Will this work on streamlit cloud? Because I really *need* it to

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

This depends on [`jupyter-server-proxy`](https://github.com/jupyterhub/jupyter-server-proxy) where they have done a lot of the leg work for implementing a `RequestHandler` that can proxy requests. IMO, this feature should be opt-in and until someone is able to implement a request handler for proxying like this directly in streamlit, then this try import/except clause is pretty acceptable.

- **Issue**: Addresses #439 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.




