### PR TITLE
Hide the MPA sidebar nav by default

### DIFF
--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -96,9 +96,6 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").prop("currentPageName")).toBe(
       "streamlit_app"
     )
-    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
-      "function"
-    )
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
@@ -111,9 +108,6 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(false)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
-    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
-      "function"
-    )
   })
 
   it("renders a sidebar when there are elements and multiple pages", () => {
@@ -143,9 +137,20 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
-    expect(typeof wrapper.find("ThemedSidebar").prop("onPageChange")).toBe(
-      "function"
-    )
+  })
+
+  it("does not render the sidebar if there are no elements, multiple pages but hideSidebarNav is true", () => {
+    const appPages = [
+      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
+      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+    ]
+    const props = getProps({
+      appPages,
+      hideSidebarNav: true,
+    })
+    const wrapper = shallow(<AppView {...props} />)
+
+    expect(wrapper.find("ThemedSidebar").exists()).toBe(false)
   })
 
   it("does not render the wide class", () => {

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -118,7 +118,8 @@ function AppView(props: AppViewProps): ReactElement {
 
   const layout = wideMode ? "wide" : "narrow"
   const hasSidebarElements = !elements.sidebar.isEmpty
-  const showSidebar = hasSidebarElements || appPages.length > 1
+  const showSidebar =
+    hasSidebarElements || (!hideSidebarNav && appPages.length > 1)
 
   // The tabindex is required to support scrolling by arrow keys.
   return (

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -709,8 +709,15 @@ _create_option(
 
 _create_option(
     "ui.hideSidebarNav",
-    description="""Flag to hide the sidebar page navigation component.""",
-    default_val=False,
+    description="""
+    Flag to hide the sidebar page navigation component.
+
+    We have this default to True for now so that we can "soft-launch" the
+    multipage apps feature and merge the feature branch into develop earlier.
+    Once we're ready to have multipage apps enabled by default, we'll flip the
+    default to False.
+    """,
+    default_val=True,
     type_=bool,
     visibility="hidden",
 )


### PR DESCRIPTION
## 📚 Context

We want to go ahead and merge the multipage apps feature branch into develop as it's
getting more and more expensive to maintain as it grows. To allow us to do this earlier, we
use the `ui.hideSidebarNav` config option as a "feature flag" by temporarily setting its
default value to `True`, which makes it so that it's nearly impossible to hit the new MPA-
related code paths through normal usage.
