### PR TITLE
Import Final from typing or typing_extensions depending on the Python version

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -13,24 +13,29 @@
 # limitations under the License.
 
 import io
-from streamlit.scriptrunner import ScriptRunContext, get_script_run_ctx
-
-from streamlit.type_util import Key, to_key
+import sys
 from typing import cast, Optional, Union, BinaryIO, TextIO
-from typing_extensions import Final
 from textwrap import dedent
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.in_memory_file_manager import in_memory_file_manager
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
+from streamlit.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.state import (
     register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.type_util import Key, to_key
+
 from .form import current_form_id, is_in_form
 from .utils import check_callback_rules, check_session_state_rules
 


### PR DESCRIPTION
## 📚 Context

I noticed that trying to run streamlit in a fresh wheel running on Python >= 3.8 explodes
since we conditionally install the `typing_extensions` module, and #4657 imports `Final`
from `typing_extensions` unconditionally. This PR fixes this.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change
