### PR TITLE
Wrap Markdown text when there's no word break

### DIFF
--- a/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-yu1mjb-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-1o5mqjl-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;
+exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-yu1mjb-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-8npnmo-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;

--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -35,6 +35,10 @@ export const StyledStreamlitMarkdown = styled.div<
     color: theme.colors.linkText,
   },
 
+  p: {
+    wordWrap: "break-word",
+  },
+
   li: {
     margin: "0.2em 0 0.2em 1.2em",
     padding: "0 0 0 0.6em",


### PR DESCRIPTION
## 📚 Context

When a long string with no break words is passed to `st.write` & `st.markdown`, the rendered text overflows the bounds of the container in the x-direction. This happens because the elements break words only at allowed break points by default. i.e. The value of the CSS property `wordWrap` for `<p>` is the default `normal`.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- This PR sets the value of the CSS property `wordWrap` for `<p>` to `break-word` in `StyledStreamlitMarkdown`, so that unbreakable words can be broken and wrapped to fit the container width.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/167083821-fec2b150-dc34-4902-be03-fd6e6a6151ff.png)

```python
import streamlit as st

with st.expander("Expand me!"):
    st.write(
        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
    )

```

**Current:**

![image](https://user-images.githubusercontent.com/20672874/167084007-4bfa3374-1c22-4aa2-ae87-e230cdca1941.png)

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
