### PR TITLE
Make typing-extensions and unconditional dependency

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -62,5 +62,5 @@ validators = "*"
 # Without watchdog, we fallback to a polling file watcher to check for app changes.
 watchdog = {version = "*", markers = "platform_system != 'Darwin'"}
 gitpython = "!=3.1.19"
-typing-extensions = { version = "*", markers = "python_version < '3.8'" }
+typing-extensions = "*"
 semver = "*"


### PR DESCRIPTION
## 📚 Context

Currently, typing-extensions in only installed as a dependency for python versions <= 3.7.

This implies type annotations are pinned to the 3.8 standard, meaning we are blocked from using modern concepts, such as `TypeAlias`, `ParamSpec` and the like.

It also means that one has to use somewhat verbose branching imports, like:
```python
if sys.version_info >= (3, 8):
    from typing import Final
else:
    from typing_extensions import Final
```

- What kind of change does this PR introduce?
  - [X] Refactoring
  - [X] Other, please describe: Dependency addition

## 🧠 Description of Changes

- Add typing-extensions as an unconditional dependency.

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **PR**: Enables merging of #4684
- **PR**: Enables merging of #4688
- **PR**: Enables merging of #4691

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
