### PR TITLE
Remove branching imports and always import from typing_extensions

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -13,14 +13,9 @@
 # limitations under the License.
 
 import io
-import sys
 from typing import cast, Optional, Union, BinaryIO, TextIO
 from textwrap import dedent
-
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from typing_extensions import Final
 
 import streamlit
 from streamlit.errors import StreamlitAPIException

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -15,13 +15,7 @@
 from streamlit.type_util import Key, to_key
 from typing import cast, overload, List, Optional, Union
 from textwrap import dedent
-
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing_extensions import Literal
 
 import streamlit
 from streamlit import config


### PR DESCRIPTION
## 📚 Context

We recently decided that we might as well always have the `typing_extensions` module be a
dependency (vs before, where we conditionally installed it depending on the user's Python
version). See the comment thread in this PR for more context: https://github.com/streamlit/streamlit/pull/4657

Since we decided this, some of the weird branching import code that we currently have is now
unnecessary.

- What kind of change does this PR introduce?

  - [x] Refactoring