### PR TITLE
Fix st.metric return value

### DIFF
--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -46,7 +46,7 @@ class MetricMixin:
         value: Value,
         delta: Delta = None,
         delta_color: DeltaColor = "normal",
-    ) -> str:
+    ) -> "DeltaGenerator":
         """Display a metric in big bold font, with an optional indicator of how the metric changed.
 
         Tip: If you want to display a large number, it may be a good idea to
@@ -116,7 +116,7 @@ class MetricMixin:
         metric_proto.color = color_and_direction.color
         metric_proto.direction = color_and_direction.direction
 
-        return str(self.dg._enqueue("metric", metric_proto))
+        return cast("DeltaGenerator", self.dg._enqueue("metric", metric_proto))
 
     @staticmethod
     def parse_label(label: str) -> str:


### PR DESCRIPTION
## 📚 Context

Currently, `st.metric` returns a string-serialized `DeltaGenerator` object instead of the `DeltaGenerator`
itself like every non-widget element.

I highly doubt we intended to return a string-serialized `DeltaGenerator` to the user as I can't see how
a user would possibly have any use for it, so this PR changes `st.metric` to be consistent with other elements
that don't interactively return a value from the app.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Other, please describe: type annotation improvements

## 🧠 Description of Changes

- Fix `st.metric` return value to be a `DeltaGenerator` like other non-widget elements

  - [x] This is a breaking API change -- _technically_, but I can't see how anyone would possibly ever rely on the current behavior of returning the `DeltaGenerator` serialized to a string
  - [x] This is a visible (user-facing) change
