### PR TITLE
Makefile: add build commands for Snowflake-compatible package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,14 @@ conda-distribution:
 	rm -rfv lib/conda-recipe/dist
 	cd lib/conda-recipe ; mkdir dist ; conda build . --output-folder dist
 
+.PHONY: conda-hash
+# Get the sha256 hash of the conda distribution
+conda-hash:
+	@# `conda build --output` will tell us where the output file lives.
+	@# `sha256sum` outputs hash + filename - we just print the hash here.
+	sha256sum $$(conda build lib/conda-recipe --output --output-folder lib/conda-recipe/dist) | cut -d " " -f 1
+
+
 .PHONY: conda-package
 # Build lib and frontend, and then run 'conda-distribution'
 conda-package: mini-devel frontend install conda-distribution

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,8 @@ conda-distribution:
 conda-hash:
 	@# `conda build --output` will tell us where the output file lives.
 	@# `sha256sum` outputs hash + filename - we just print the hash here.
-	sha256sum $$(conda build lib/conda-recipe --output --output-folder lib/conda-recipe/dist) | cut -d " " -f 1
+	# (NB: on Mac, do `brew install coreutils` to get the `sha256sum` command.)
+	sha256sum lib/conda-recipe/dist/noarch/streamlit*.tar.bz2 | cut -d " " -f 1
 
 
 .PHONY: conda-package

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,11 @@ distribution:
 # Build lib and frontend, and then run 'distribution'.
 package: mini-devel frontend install distribution
 
+.PHONY: conda-distribution
+conda-distribution:
+	rm -rfv lib/conda-recipe/dist
+	cd lib/conda-recipe ; mkdir dist ; conda build . --output-folder dist
+
 
 .PHONY: clean
 # Remove all generated files.

--- a/Makefile
+++ b/Makefile
@@ -179,10 +179,11 @@ package: mini-devel frontend install distribution
 
 .PHONY: conda-distribution
 # Create conda distribution files in lib/conda-recipe/dist.
-# This can take many minutes to complete! (Dependency solving is slow.)
 conda-distribution:
-	rm -rfv lib/conda-recipe/dist
-	cd lib/conda-recipe ; mkdir dist ; conda build . --channel conda-forge --output-folder dist
+	rm -rf lib/conda-recipe/dist
+	mkdir lib/conda-recipe/dist
+	# This can take upwards of 20 minutes to complete in a fresh conda installation! (Dependency solving is slow.)
+	conda build lib/conda-recipe --channel conda-forge --output-folder lib/conda-recipe/dist
 
 .PHONY: conda-hash
 # Get the sha256 hash of the conda distribution

--- a/Makefile
+++ b/Makefile
@@ -178,15 +178,20 @@ distribution:
 package: mini-devel frontend install distribution
 
 .PHONY: conda-distribution
+# Create conda distribution files in lib/conda-recipe/dist
 conda-distribution:
 	rm -rfv lib/conda-recipe/dist
 	cd lib/conda-recipe ; mkdir dist ; conda build . --output-folder dist
+
+.PHONY: conda-package
+# Build lib and frontend, and then run 'conda-distribution'
+conda-package: mini-devel frontend install conda-distribution
 
 
 .PHONY: clean
 # Remove all generated files.
 clean:
-	cd lib; rm -rf build dist  .eggs *.egg-info
+	cd lib/conda-recipe ; rm -rf
 	find . -name '*.pyc' -type f -delete || true
 	find . -name __pycache__ -type d -delete || true
 	find . -name .pytest_cache -exec rm -rfv {} \; || true
@@ -201,6 +206,7 @@ clean:
 	rm -rf frontend/public/reports
 	find . -name .streamlit -type d -exec rm -rfv {} \; || true
 	cd lib; rm -rf .coverage .coverage\.*
+	rm -rfv lib/conda-recipe/dist
 
 .PHONY: protobuf
 # Recompile Protobufs for Python and the frontend.

--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,11 @@ distribution:
 package: mini-devel frontend install distribution
 
 .PHONY: conda-distribution
-# Create conda distribution files in lib/conda-recipe/dist
+# Create conda distribution files in lib/conda-recipe/dist.
+# This can take many minutes to complete! (Dependency solving is slow.)
 conda-distribution:
 	rm -rfv lib/conda-recipe/dist
-	cd lib/conda-recipe ; mkdir dist ; conda build . --output-folder dist
+	cd lib/conda-recipe ; mkdir dist ; conda build . --channel conda-forge --output-folder dist
 
 .PHONY: conda-hash
 # Get the sha256 hash of the conda distribution

--- a/lib/conda-recipe/LICENSE
+++ b/lib/conda-recipe/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/conda-recipe/README.md
+++ b/lib/conda-recipe/README.md
@@ -7,6 +7,7 @@ Install `conda` and `conda-build`:
 ```
 $ brew install miniconda
 $ conda install conda-build
+$ conda config --add channels conda-forge  # Make conda-forge available to conda
 ```
 
 ## Building

--- a/lib/conda-recipe/README.md
+++ b/lib/conda-recipe/README.md
@@ -1,0 +1,27 @@
+# Streamlit conda-build recipe (5/10/2022)
+
+## Prereqs
+
+Install `conda` and `conda-build`:
+
+```
+$ brew install conda
+$ conda install conda-build
+```
+
+## Building
+
+1. Build the streamlit frontend first: `$ cd streamlit && make frontend`
+
+2. Build this conda recipe
+
+```
+$ cd streamlit/lib/conda-recipe  # (this directory)
+$ conda build .    # build the streamlit recipe
+```
+
+3. If this is successful, you'll get a tar.bz2 conda file in your conda build directory. Run `conda build --output .` from this directory to find out where the output file ends up.
+
+## Troubleshooting
+
+- Do meta.yaml's "requirements" section need to be updated? (These requirements are not auto-generated - they must be manually specified.)

--- a/lib/conda-recipe/README.md
+++ b/lib/conda-recipe/README.md
@@ -17,7 +17,7 @@ $ conda install conda-build
 
 ```
 $ cd streamlit/lib/conda-recipe  # (this directory)
-$ conda build .    # build the streamlit recipe
+$ conda build .  # build the streamlit recipe
 ```
 
 3. If this is successful, you'll get a tar.bz2 conda file in your conda build directory. Run `conda build --output .` from this directory to find out where the output file ends up.

--- a/lib/conda-recipe/README.md
+++ b/lib/conda-recipe/README.md
@@ -5,7 +5,7 @@
 Install `conda` and `conda-build`:
 
 ```
-$ brew install conda
+$ brew install miniconda
 $ conda install conda-build
 ```
 

--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "streamlit" %}
+{% set version = "1.9.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - streamlit = streamlit.cli:main
+
+requirements:
+  host:
+    - pip
+    - python >=3.8
+    - pipenv
+  run:
+    - altair >=3.2.0
+    - astor
+    - attrs
+    - base58
+    - blinker
+    - boto3
+    - botocore >=1.13.44
+    - cachetools >=4.0
+    - click >=7.0, <8.1
+    - gitpython
+    - importlib-metadata >=1.4
+    - numpy
+    - packaging
+    - pandas >=0.21.0
+    - pillow >=6.2.0
+    - protobuf >=3.6.0, !=3.11
+    - pyarrow
+    - pydeck >=0.1.dev5
+    - pympler >=0.9
+    - python >=3.6
+    - python-dateutil
+    - requests
+    - semver
+    - toml
+    - tornado >=5.0
+    - tzlocal
+    - validators
+    - watchdog
+
+test:
+  imports:
+    - streamlit
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://streamlit.io
+  summary: The fastest way to build data apps in Python
+  license: Apache-2.0
+  license_file: LICENSE


### PR DESCRIPTION
Snowflake uses Anaconda for Python packages. This PR adds `make conda-distribution`, `make conda-package`, and `make conda-hash` (for generating the SHA256 hash of the package, which is required by conda).