### PR TITLE
Don't redirect when navigating directly to a page

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -915,8 +915,9 @@ describe("App.sendRerunBackMsg", () => {
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
 
-    // Set the value of document.location.pathname to '/page1'
-    window.history.pushState({}, "", "/page1")
+    // Set the value of document.location.pathname to '/page1/' (with leading
+    // and trailing slashes to test that they get stripped)
+    window.history.pushState({}, "", "/page1/")
 
     instance.sendRerunBackMsg()
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -999,6 +999,7 @@ export class App extends PureComponent<Props, State> {
       pageName = document.location.pathname
         .replace(`/${basePath}`, "")
         .replace(new RegExp("^/?"), "")
+        .replace(new RegExp("/$"), "")
     } else {
       const { appHash, scriptRunId, scriptName } = this.state
       this.clearAppState(appHash as string, scriptRunId, scriptName)

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -63,10 +63,22 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
     def parse_url_path(self, url_path: str) -> str:
         url_parts = url_path.split("/")
 
-        # TODO(vdonato): Maybe clean this up if we decide to tweak the spec so
-        # that there's a separator between the baseUrlPath and page name.
         maybe_page_name = url_parts[0]
         if maybe_page_name in self._pages:
+            # If we're trying to navigate to a page, we return "index.html"
+            # directly here instead of defering to the superclass below after
+            # modifying the url_path. The reason why is that tornado handles
+            # requests to "directories" (which is what navigating to a page
+            # looks like) by appending a trailing '/' if there is none and
+            # redirecting.
+            #
+            # This would work, but it
+            #   * adds an unnecessary redirect+roundtrip
+            #   * adds a trailing '/' to the URL appearing in the browser, which
+            #     looks bad
+            if len(url_parts) == 1:
+                return "index.html"
+
             url_path = "/".join(url_parts[1:])
 
         return super().parse_url_path(url_path)


### PR DESCRIPTION
## 📚 Context

This PR fixes some weirdness that occurs when you navigate directly to a page to see
that tornado has appended a trailing slash to the URL shown in your browser.

One of the inline code comments in this PR describes why this happens pretty well,
so I just duplicate it below.

```
# If we're trying to navigate to a page, we return "index.html"
# directly here instead of defering to the superclass below after
# modifying the url_path. The reason why is that tornado handles
# requests to "directories" (which is what navigating to a page
# looks like) by appending a trailing '/' if there is none and
# redirecting.
#
# This would work, but it
#   * adds an unnecessary redirect+roundtrip
#   * adds a trailing '/' to the URL appearing in the browser, which
#     looks bad
```

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Feature

## 🧠 Description of Changes

- Remove trailing slashes when calculating the page name (if present)
- Avoid redirecting when navigating directly to a page 

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests
