### PR TITLE
Detect being installed in `__pypackages__`

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -263,6 +263,7 @@ def _global_development_mode() -> bool:
         not env_util.is_pex()
         and "site-packages" not in __file__
         and "dist-packages" not in __file__
+        and "__pypackages__" not in __file__
     )
 
 


### PR DESCRIPTION
The install location won't have site-packages or dist-packages in it, so
check for `__pypackages__` as well. 

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Check for being installed in `__pypackages__` (PEP582 install location)

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #3132 
