### PR TITLE
Use `sys.argv` instead of the removed `click.get_os_args`

### DIFF
--- a/examples/caching.py
+++ b/examples/caching.py
@@ -28,7 +28,7 @@ def check_if_cached():
 
 @st.cache
 def my_func(arg1, arg2=None, *args, **kwargs):
-    return random.randint(0, 2 ** 32)
+    return random.randint(0, 2**32)
 
 
 check_if_cached()
@@ -87,7 +87,7 @@ else:
     # config option from when it was declared.
     @st.cache
     def my_func(arg1, arg2=None, *args, **kwargs):
-        return random.randint(0, 2 ** 32)
+        return random.randint(0, 2**32)
 
     u = my_func(1, 2, dont_care=10)
     v = my_func(1, 2, dont_care=10)

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -37,9 +37,7 @@ altair = ">=3.2.0"
 attrs = "*"
 blinker = "*"
 cachetools = ">=4.0"
-# 8.1.0 removes `get_os_args` and is incompatible with our pinned black version,
-# so it must be pinned until those are sorted out
-click = ">=7.0, <8.1"
+click = ">=7.0"
 # 1.4 introduced the functionality found in python 3.8's importlib.metadata module
 importlib-metadata = ">=1.4"
 numpy = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -4,8 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-# black 21.7b0 and higher pull in an incompatible version of typing-extensions
-black = "==21.6b0"
+# Minimum version compatible with click>=8.1
+black = ">=22.3.0"
 hypothesis = ">=6.17.4"
 mypy = ">=0.930"
 mypy-protobuf = ">=3.2"

--- a/lib/streamlit/cli.py
+++ b/lib/streamlit/cli.py
@@ -14,6 +14,7 @@
 
 """This is a script which is run when the Streamlit package is executed."""
 
+import sys
 from streamlit import config as _config
 
 import os
@@ -218,7 +219,7 @@ def _get_command_line_as_string() -> Optional[str]:
         )
 
     cmd_line_as_list = [parent.command_path]
-    cmd_line_as_list.extend(click.get_os_args())
+    cmd_line_as_list.extend(sys.argv[1:])
     return subprocess.list2cmdline(cmd_line_as_list)
 
 

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -274,14 +274,10 @@ class SliderMixin:
             max_value = DEFAULTS[data_type]["max_value"]
         if step is None:
             step = DEFAULTS[data_type]["step"]
-            if (
-                data_type
-                in (
-                    SliderProto.DATETIME,
-                    SliderProto.DATE,
-                )
-                and max_value - min_value < timedelta(days=1)
-            ):
+            if data_type in (
+                SliderProto.DATETIME,
+                SliderProto.DATE,
+            ) and max_value - min_value < timedelta(days=1):
                 step = timedelta(minutes=15)
         if format is None:
             format = DEFAULTS[data_type]["format"]

--- a/lib/tests/streamlit/caching/hashing_test.py
+++ b/lib/tests/streamlit/caching/hashing_test.py
@@ -69,8 +69,8 @@ class HashTest(unittest.TestCase):
         self.assertEqual(get_hash(145757624235), get_hash(145757624235))
         self.assertNotEqual(get_hash(10), get_hash(11))
         self.assertNotEqual(get_hash(-1), get_hash(1))
-        self.assertNotEqual(get_hash(2 ** 7), get_hash(2 ** 7 - 1))
-        self.assertNotEqual(get_hash(2 ** 7), get_hash(2 ** 7 + 1))
+        self.assertNotEqual(get_hash(2**7), get_hash(2**7 - 1))
+        self.assertNotEqual(get_hash(2**7), get_hash(2**7 + 1))
 
     def test_mocks_do_not_result_in_infinite_recursion(self):
         try:

--- a/lib/tests/streamlit/cli_test.py
+++ b/lib/tests/streamlit/cli_test.py
@@ -172,7 +172,7 @@ class CliTest(unittest.TestCase):
         mock_context = MagicMock()
         mock_context.parent.command_path = "streamlit"
         with patch("click.get_current_context", return_value=mock_context):
-            with patch("click.get_os_args", return_value=["os_arg1", "os_arg2"]):
+            with patch.object(sys, "argv", ["", "os_arg1", "os_arg2"]):
                 result = cli._get_command_line_as_string()
                 self.assertEqual("streamlit os_arg1 os_arg2", result)
 

--- a/lib/tests/streamlit/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/legacy_caching/hashing_test.py
@@ -82,8 +82,8 @@ class HashTest(unittest.TestCase):
         self.assertEqual(get_hash(145757624235), get_hash(145757624235))
         self.assertNotEqual(get_hash(10), get_hash(11))
         self.assertNotEqual(get_hash(-1), get_hash(1))
-        self.assertNotEqual(get_hash(2 ** 7), get_hash(2 ** 7 - 1))
-        self.assertNotEqual(get_hash(2 ** 7), get_hash(2 ** 7 + 1))
+        self.assertNotEqual(get_hash(2**7), get_hash(2**7 - 1))
+        self.assertNotEqual(get_hash(2**7), get_hash(2**7 + 1))
 
     def test_mocks_do_not_result_in_infinite_recursion(self):
         try:
@@ -1059,7 +1059,7 @@ class CodeHashTest(unittest.TestCase):
 
         def f(x):
             def func(v):
-                return v ** x
+                return v**x
 
             return func
 
@@ -1071,7 +1071,7 @@ class CodeHashTest(unittest.TestCase):
 
         def h(x):
             def func(v):
-                return v ** x
+                return v**x
 
             return func
 


### PR DESCRIPTION
## 📚 Context

We were pinning click to exclude the breaking change in 8.1; this PR replaces our use of the removed function so we can unpin click.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Replace use of `click.get_os_args()` with direct access of `sys.argv`

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

