### PR TITLE
Add rich library to dependencies

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -64,3 +64,4 @@ watchdog = {version = "*", markers = "platform_system != 'Darwin'"}
 gitpython = "!=3.1.19"
 typing-extensions = "*"
 semver = "*"
+rich = "*"


### PR DESCRIPTION
## 📚 Context

The rich library is required for better exception logging in S4T. We first planned to have that as an optional dependency which is only installed in S4T, but we decided to move this dependency directly to streamlit dependencies because of stability concerns on installing this library independently from Streamlit installation into every virtual environment. Rich is MIT licensed and pretty lightweight.

The PR that added support for rich: https://github.com/streamlit/streamlit/pull/4294 
 
## 🧠 Description of Changes

- Add rich library to dependencies.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
