### PR TITLE
Add type annotations for DeltaGenerator and dataframe mixins

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -13,7 +13,24 @@
 # limitations under the License.
 
 """Allows us to create and absorb changes (aka Deltas) to elements."""
-from typing import Optional, Iterable
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Dict,
+    Hashable,
+    Optional,
+    overload,
+    Iterable,
+    NoReturn,
+    Tuple,
+    Type,
+    TypeVar,
+    TYPE_CHECKING,
+    Union,
+)
+
+from typing_extensions import Final, Literal
 
 import streamlit as st
 from streamlit import cursor, caching
@@ -77,21 +94,32 @@ from streamlit.elements.legacy_altair import LegacyAltairMixin
 from streamlit.elements.legacy_vega_lite import LegacyVegaLiteMixin
 from streamlit.elements.dataframe_selector import DataFrameSelectorMixin
 
-LOGGER = get_logger(__name__)
+if TYPE_CHECKING:
+    from numpy import typing as npt
+    from pandas import DataFrame, Series
+    from google.protobuf.message import Message
+    from streamlit.type_util import DataFrameCompatible
+    from streamlit.elements.arrow import Data
+
+
+LOGGER: Final = get_logger(__name__)
 
 # Save the type built-in for when we override the name "type".
 _type = type
 
-MAX_DELTA_BYTES = 14 * 1024 * 1024  # 14MB
+MAX_DELTA_BYTES: Final[int] = 14 * 1024 * 1024  # 14MB
 
 # List of Streamlit commands that perform a Pandas "melt" operation on
 # input dataframes.
-DELTA_TYPES_THAT_MELT_DATAFRAMES = ("line_chart", "area_chart", "bar_chart")
-ARROW_DELTA_TYPES_THAT_MELT_DATAFRAMES = (
+DELTA_TYPES_THAT_MELT_DATAFRAMES: Final = ("line_chart", "area_chart", "bar_chart")
+ARROW_DELTA_TYPES_THAT_MELT_DATAFRAMES: Final = (
     "arrow_line_chart",
     "arrow_area_chart",
     "arrow_bar_chart",
 )
+
+Value = TypeVar("Value")
+DG = TypeVar("DG", bound="DeltaGenerator")
 
 
 class DeltaGenerator(
@@ -176,7 +204,7 @@ class DeltaGenerator(
         cursor: Optional[Cursor] = None,
         parent: Optional["DeltaGenerator"] = None,
         block_type: Optional[str] = None,
-    ):
+    ) -> None:
         """Inserts or updates elements in Streamlit apps.
 
         As a user, you should never initialize this object by hand. Instead,
@@ -226,13 +254,18 @@ class DeltaGenerator(
     def __repr__(self) -> str:
         return util.repr_(self)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         # with block started
         ctx = get_script_run_ctx()
         if ctx:
             ctx.dg_stack.append(self)
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(
+        self,
+        type: Any,
+        value: Any,
+        traceback: Any,
+    ) -> Literal[False]:
         # with block ended
         ctx = get_script_run_ctx()
         if ctx is not None:
@@ -267,14 +300,14 @@ class DeltaGenerator(
         """
         return self._parent._main_dg if self._parent else self
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Callable[..., NoReturn]:
         import streamlit as st
 
         streamlit_methods = [
             method_name for method_name in dir(st) if callable(getattr(st, method_name))
         ]
 
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> NoReturn:
             if name in streamlit_methods:
                 if self._root_container == RootContainer.SIDEBAR:
                     message = (
@@ -336,15 +369,75 @@ class DeltaGenerator(
         dg = self._active_dg
         return str(dg._cursor.delta_path) if dg._cursor is not None else "[]"
 
+    @overload
+    def _enqueue(  # type: ignore[misc]
+        self,
+        delta_type: str,
+        element_proto: "Message",
+        return_value: None,
+        last_index: Optional[Hashable] = None,
+        element_width: Optional[int] = None,
+        element_height: Optional[int] = None,
+    ) -> "DeltaGenerator":
+        ...
+
+    @overload
+    def _enqueue(  # type: ignore[misc]
+        self,
+        delta_type: str,
+        element_proto: "Message",
+        return_value: Type[NoValue],
+        last_index: Optional[Hashable] = None,
+        element_width: Optional[int] = None,
+        element_height: Optional[int] = None,
+    ) -> None:
+        ...
+
+    @overload
+    def _enqueue(  # type: ignore[misc]
+        self,
+        delta_type: str,
+        element_proto: "Message",
+        return_value: Value,
+        last_index: Optional[Hashable] = None,
+        element_width: Optional[int] = None,
+        element_height: Optional[int] = None,
+    ) -> Value:
+        ...
+
+    @overload
     def _enqueue(
         self,
-        delta_type,
-        element_proto,
-        return_value=None,
-        last_index=None,
-        element_width=None,
-        element_height=None,
-    ):
+        delta_type: str,
+        element_proto: "Message",
+        return_value: None = None,
+        last_index: Optional[Hashable] = None,
+        element_width: Optional[int] = None,
+        element_height: Optional[int] = None,
+    ) -> "DeltaGenerator":
+        ...
+
+    @overload
+    def _enqueue(
+        self,
+        delta_type: str,
+        element_proto: "Message",
+        return_value: Union[None, Type[NoValue], Value] = None,
+        last_index: Optional[Hashable] = None,
+        element_width: Optional[int] = None,
+        element_height: Optional[int] = None,
+    ) -> Union["DeltaGenerator", None, Value]:
+        ...
+
+    def _enqueue(
+        self,
+        delta_type: str,
+        element_proto: "Message",
+        return_value: Union[None, Type[NoValue], Value] = None,
+        last_index: Optional[Hashable] = None,
+        element_width: Optional[int] = None,
+        element_height: Optional[int] = None,
+    ) -> Union["DeltaGenerator", None, Value]:
         """Create NewElement delta, fill it, and enqueue it.
 
         Parameters
@@ -432,7 +525,10 @@ class DeltaGenerator(
 
         return _value_or_dg(return_value, output_dg)
 
-    def _block(self, block_proto=Block_pb2.Block()) -> "DeltaGenerator":
+    def _block(
+        self,
+        block_proto: Block_pb2.Block = Block_pb2.Block(),
+    ) -> "DeltaGenerator":
         # Operate on the active DeltaGenerator, in case we're in a `with` block.
         dg = self._active_dg
 
@@ -479,7 +575,13 @@ class DeltaGenerator(
 
         return block_dg
 
-    def _legacy_add_rows(self, data=None, **kwargs):
+    def _legacy_add_rows(
+        self: DG,
+        data: "Data" = None,
+        **kwargs: Union[
+            "DataFrame", "npt.NDArray[Any]", Iterable[Any], Dict[Hashable, Any], None
+        ],
+    ) -> Optional[DG]:
         """Concatenate a dataframe to the bottom of the current one.
 
         Parameters
@@ -551,8 +653,8 @@ class DeltaGenerator(
             )
 
         # When doing _legacy_add_rows on an element that does not already have data
-        # (for example, st._legacy_ine_chart() without any args), call the original
-        # st._legacy_foo() element with new data instead of doing an _legacy_add_rows().
+        # (for example, st._legacy_line_chart() without any args), call the original
+        # st._legacy_foo() element with new data instead of doing a _legacy_add_rows().
         if (
             self._cursor.props["delta_type"] in DELTA_TYPES_THAT_MELT_DATAFRAMES
             and self._cursor.props["last_index"] is None
@@ -563,7 +665,7 @@ class DeltaGenerator(
             st_method_name = "_legacy_" + self._cursor.props["delta_type"]
             st_method = getattr(self, st_method_name)
             st_method(data, **kwargs)
-            return
+            return None
 
         data, self._cursor.props["last_index"] = _maybe_melt_data_for_add_rows(
             data, self._cursor.props["delta_type"], self._cursor.props["last_index"]
@@ -584,7 +686,13 @@ class DeltaGenerator(
 
         return self
 
-    def _arrow_add_rows(self, data=None, **kwargs):
+    def _arrow_add_rows(
+        self: DG,
+        data: "Data" = None,
+        **kwargs: Union[
+            "DataFrame", "npt.NDArray[Any]", Iterable[Any], Dict[Hashable, Any], None
+        ],
+    ) -> Optional[DG]:
         """Concatenate a dataframe to the bottom of the current one.
 
         Parameters
@@ -667,7 +775,7 @@ class DeltaGenerator(
             st_method_name = "_" + self._cursor.props["delta_type"]
             st_method = getattr(self, st_method_name)
             st_method(data, **kwargs)
-            return
+            return None
 
         data, self._cursor.props["last_index"] = _maybe_melt_data_for_add_rows(
             data, self._cursor.props["delta_type"], self._cursor.props["last_index"]
@@ -690,26 +798,26 @@ class DeltaGenerator(
         return self
 
 
-def _maybe_melt_data_for_add_rows(data, delta_type, last_index):
+DFT = TypeVar("DFT", bound="DataFrameCompatible")
+
+
+def _maybe_melt_data_for_add_rows(
+    data: "DataFrameCompatible",
+    delta_type: str,
+    last_index: Any,
+) -> Tuple[Union[DFT, "DataFrame"], Union[int, Any]]:
     import pandas as pd
 
-    # For some delta types we have to reshape the data structure
-    # otherwise the input data and the actual data used
-    # by vega_lite will be different and it will throw an error.
-    if (
-        delta_type in DELTA_TYPES_THAT_MELT_DATAFRAMES
-        or delta_type in ARROW_DELTA_TYPES_THAT_MELT_DATAFRAMES
-    ):
-        if not isinstance(data, pd.DataFrame):
-            data = type_util.convert_anything_to_df(data)
-
-        if type(data.index) is pd.RangeIndex:
-            old_step = _get_pandas_index_attr(data, "step")
+    def _melt_data(
+        df: "DataFrame", last_index: Any
+    ) -> Tuple["DataFrame", Union[int, Any]]:
+        if isinstance(df.index, pd.RangeIndex):
+            old_step = _get_pandas_index_attr(df, "step")
 
             # We have to drop the predefined index
-            data = data.reset_index(drop=True)
+            df = df.reset_index(drop=True)
 
-            old_stop = _get_pandas_index_attr(data, "stop")
+            old_stop = _get_pandas_index_attr(df, "stop")
 
             if old_step is None or old_stop is None:
                 raise StreamlitAPIException(
@@ -719,23 +827,68 @@ def _maybe_melt_data_for_add_rows(data, delta_type, last_index):
             start = last_index + old_step
             stop = last_index + old_step + old_stop
 
-            data.index = pd.RangeIndex(start=start, stop=stop, step=old_step)
+            df.index = pd.RangeIndex(start=start, stop=stop, step=old_step)
             last_index = stop - 1
 
-        index_name = data.index.name
+        index_name = df.index.name
         if index_name is None:
             index_name = "index"
 
-        data = pd.melt(data.reset_index(), id_vars=[index_name])
+        df = pd.melt(df.reset_index(), id_vars=[index_name])
+        return df, last_index
+
+    # For some delta types we have to reshape the data structure
+    # otherwise the input data and the actual data used
+    # by vega_lite will be different, and it will throw an error.
+    if (
+        delta_type in DELTA_TYPES_THAT_MELT_DATAFRAMES
+        or delta_type in ARROW_DELTA_TYPES_THAT_MELT_DATAFRAMES
+    ):
+        if not isinstance(data, pd.DataFrame):
+            return _melt_data(
+                df=type_util.convert_anything_to_df(data),
+                last_index=last_index,
+            )
+        else:
+            return _melt_data(df=data, last_index=last_index)
 
     return data, last_index
 
 
-def _get_pandas_index_attr(data, attr):
+def _get_pandas_index_attr(
+    data: "Union[DataFrame, Series]",
+    attr: str,
+) -> Optional[Any]:
     return getattr(data.index, attr, None)
 
 
-def _value_or_dg(value, dg):
+@overload
+def _value_or_dg(value: None, dg: DG) -> DG:
+    ...
+
+
+@overload
+def _value_or_dg(value: Type[NoValue], dg: DG) -> None:  # type: ignore[misc]
+    ...
+
+
+@overload
+def _value_or_dg(value: Value, dg: DG) -> Value:
+    # This overload definition technically overlaps with the one above (Value
+    # contains Type[NoValue]), and since the return types are conflicting,
+    # mypy complains. Hence, the ignore-comment above. But, in practice, since
+    # the overload above is more specific, and is matched first, there is no
+    # actual overlap. The `Value` type here is thus narrowed to the cases
+    # where value is neither None nor NoValue.
+
+    # The ignore-comment should thus be fine.
+    ...
+
+
+def _value_or_dg(
+    value: Union[None, Type[NoValue], Value],
+    dg: DG,
+) -> Union[DG, None, Value]:
     """Return either value, or None, or dg.
 
     This is needed because Widgets have meaningful return values. This is
@@ -751,10 +904,10 @@ def _value_or_dg(value, dg):
         return None
     if value is None:
         return dg
-    return value
+    return cast(Value, value)
 
 
-def _enqueue_message(msg):
+def _enqueue_message(msg: ForwardMsg_pb2.ForwardMsg) -> None:
     """Enqueues a ForwardMsg proto to send to the app."""
     ctx = get_script_run_ctx()
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -802,7 +802,7 @@ DFT = TypeVar("DFT", bound="DataFrameCompatible")
 
 
 def _maybe_melt_data_for_add_rows(
-    data: "DataFrameCompatible",
+    data: DFT,
     delta_type: str,
     last_index: Any,
 ) -> Tuple[Union[DFT, "DataFrame"], Union[int, Any]]:

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -38,8 +38,7 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.ERROR
-        dg = self.dg._enqueue("alert", alert_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("alert", alert_proto)
 
     def warning(self, body: str) -> "DeltaGenerator":
         """Display warning message.
@@ -57,8 +56,7 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.WARNING
-        dg = self.dg._enqueue("alert", alert_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("alert", alert_proto)
 
     def info(self, body: str) -> "DeltaGenerator":
         """Display an informational message.
@@ -76,8 +74,7 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.INFO
-        dg = self.dg._enqueue("alert", alert_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("alert", alert_proto)
 
     def success(self, body: str) -> "DeltaGenerator":
         """Display a success message.
@@ -95,8 +92,7 @@ class AlertMixin:
         alert_proto = AlertProto()
         alert_proto.body = clean_text(body)
         alert_proto.format = AlertProto.SUCCESS
-        dg = self.dg._enqueue("alert", alert_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("alert", alert_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/arrow_vega_lite.py
+++ b/lib/streamlit/elements/arrow_vega_lite.py
@@ -15,9 +15,9 @@
 """A Python wrapper around Vega-Lite."""
 
 import json
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional, cast, TYPE_CHECKING
+from typing_extensions import Final
 
-import streamlit
 import streamlit.elements.lib.dicttools as dicttools
 from streamlit.logger import get_logger
 from streamlit.proto.ArrowVegaLiteChart_pb2 import (
@@ -27,7 +27,11 @@ from streamlit.proto.ArrowVegaLiteChart_pb2 import (
 from . import arrow
 from .arrow import Data
 
-LOGGER = get_logger(__name__)
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+LOGGER: Final = get_logger(__name__)
 
 
 class ArrowVegaLiteMixin:
@@ -36,8 +40,8 @@ class ArrowVegaLiteMixin:
         data: Data = None,
         spec: Optional[Dict[str, Any]] = None,
         use_container_width: bool = False,
-        **kwargs,
-    ) -> "streamlit.delta_generator.DeltaGenerator":
+        **kwargs: Any,
+    ) -> "DeltaGenerator":
         """Display a chart using the Vega-Lite library.
 
         Parameters
@@ -91,15 +95,12 @@ class ArrowVegaLiteMixin:
             use_container_width=use_container_width,
             **kwargs,
         )
-        return cast(
-            "streamlit.delta_generator.DeltaGenerator",
-            self.dg._enqueue("arrow_vega_lite_chart", proto),
-        )
+        return self.dg._enqueue("arrow_vega_lite_chart", proto)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)
 
 
 def marshall(
@@ -175,33 +176,31 @@ def marshall(
 
 
 # See https://vega.github.io/vega-lite/docs/encoding.html
-_CHANNELS = set(
-    [
-        "x",
-        "y",
-        "x2",
-        "y2",
-        "xError",
-        "yError2",
-        "xError",
-        "yError2",
-        "longitude",
-        "latitude",
-        "color",
-        "opacity",
-        "fillOpacity",
-        "strokeOpacity",
-        "strokeWidth",
-        "size",
-        "shape",
-        "text",
-        "tooltip",
-        "href",
-        "key",
-        "order",
-        "detail",
-        "facet",
-        "row",
-        "column",
-    ]
-)
+_CHANNELS = {
+    "x",
+    "y",
+    "x2",
+    "y2",
+    "xError",
+    "yError2",
+    "xError",
+    "yError2",
+    "longitude",
+    "latitude",
+    "color",
+    "opacity",
+    "fillOpacity",
+    "strokeOpacity",
+    "strokeWidth",
+    "size",
+    "shape",
+    "text",
+    "tooltip",
+    "href",
+    "key",
+    "order",
+    "detail",
+    "facet",
+    "row",
+    "column",
+}

--- a/lib/streamlit/elements/balloons.py
+++ b/lib/streamlit/elements/balloons.py
@@ -33,8 +33,7 @@ class BalloonsMixin:
         """
         balloons_proto = BalloonsProto()
         balloons_proto.show = True
-        dg = self.dg._enqueue("balloons", balloons_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("balloons", balloons_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -14,11 +14,16 @@
 
 """Selects between our two DataFrame serialization methods ("legacy" and
 "arrow") based on a config option"""
+from typing import Any
+from typing import Dict
+from typing import cast, Optional, TYPE_CHECKING
 
-from typing import cast
-
-import streamlit
 from streamlit import config
+
+if TYPE_CHECKING:
+    from .arrow import Data
+    from streamlit.delta_generator import DeltaGenerator
+    from altair.vegalite.v4.api import Chart
 
 
 def _use_arrow() -> bool:
@@ -29,7 +34,12 @@ def _use_arrow() -> bool:
 
 
 class DataFrameSelectorMixin:
-    def dataframe(self, data=None, width=None, height=None):
+    def dataframe(
+        self,
+        data: "Data" = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> "DeltaGenerator":
         """Display a dataframe as an interactive table.
 
         Parameters
@@ -86,7 +96,7 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_dataframe(data, width, height)
 
-    def table(self, data=None):
+    def table(self, data: "Data" = None) -> "DeltaGenerator":
         """Display a static table.
 
         This differs from `st.dataframe` in that the table in this case is
@@ -119,7 +129,13 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_table(data)
 
-    def line_chart(self, data=None, width=0, height=0, use_container_width=True):
+    def line_chart(
+        self,
+        data: "Data" = None,
+        width: int = 0,
+        height: int = 0,
+        use_container_width: bool = True,
+    ) -> "DeltaGenerator":
         """Display a line chart.
 
         This is syntax-sugar around st.altair_chart. The main difference
@@ -167,7 +183,13 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_line_chart(data, width, height, use_container_width)
 
-    def area_chart(self, data=None, width=0, height=0, use_container_width=True):
+    def area_chart(
+        self,
+        data: "Data" = None,
+        width: int = 0,
+        height: int = 0,
+        use_container_width: bool = True,
+    ) -> "DeltaGenerator":
         """Display an area chart.
 
         This is just syntax-sugar around st.altair_chart. The main difference
@@ -215,7 +237,13 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_area_chart(data, width, height, use_container_width)
 
-    def bar_chart(self, data=None, width=0, height=0, use_container_width=True):
+    def bar_chart(
+        self,
+        data: "Data" = None,
+        width: int = 0,
+        height: int = 0,
+        use_container_width: bool = True,
+    ) -> "DeltaGenerator":
         """Display a bar chart.
 
         This is just syntax-sugar around st.altair_chart. The main difference
@@ -264,7 +292,11 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_bar_chart(data, width, height, use_container_width)
 
-    def altair_chart(self, altair_chart, use_container_width=False):
+    def altair_chart(
+        self,
+        altair_chart: "Chart",
+        use_container_width: bool = False,
+    ) -> "DeltaGenerator":
         """Display a chart using the Altair library.
 
         Parameters
@@ -308,11 +340,11 @@ class DataFrameSelectorMixin:
 
     def vega_lite_chart(
         self,
-        data=None,
-        spec=None,
-        use_container_width=False,
-        **kwargs,
-    ):
+        data: "Data" = None,
+        spec: Optional[Dict[str, Any]] = None,
+        use_container_width: bool = False,
+        **kwargs: Any,
+    ) -> "DeltaGenerator":
         """Display a chart using the Vega-Lite library.
 
         Parameters
@@ -375,7 +407,7 @@ class DataFrameSelectorMixin:
                 data, spec, use_container_width, **kwargs
             )
 
-    def add_rows(self, data=None, **kwargs):
+    def add_rows(self, data: "Data" = None, **kwargs) -> Optional["DeltaGenerator"]:
         """Concatenate a dataframe to the bottom of the current one.
 
         Parameters
@@ -436,6 +468,6 @@ class DataFrameSelectorMixin:
             return self.dg._legacy_add_rows(data, **kwargs)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -64,10 +64,7 @@ class HelpMixin:
         """
         doc_string_proto = DocStringProto()
         _marshall(doc_string_proto, obj)
-        return cast(
-            "DeltaGenerator",
-            self.dg._enqueue("doc_string", doc_string_proto),
-        )
+        return self.dg._enqueue("doc_string", doc_string_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/empty.py
+++ b/lib/streamlit/elements/empty.py
@@ -65,8 +65,7 @@ class EmptyMixin:
 
         """
         empty_proto = EmptyProto()
-        dg: "DeltaGenerator" = self.dg._enqueue("empty", empty_proto)
-        return dg
+        return self.dg._enqueue("empty", empty_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -59,8 +59,7 @@ class ExceptionMixin:
         """
         exception_proto = ExceptionProto()
         marshall(exception_proto, exception)
-        dg = self.dg._enqueue("exception", exception_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("exception", exception_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -140,10 +140,7 @@ class ImageMixin:
             channels,
             output_format,
         )
-        return cast(
-            "DeltaGenerator",
-            self.dg._enqueue("imgs", image_list_proto),
-        )
+        return self.dg._enqueue("imgs", image_list_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -80,7 +80,7 @@ class JsonMixin:
         json_proto = JsonProto()
         json_proto.body = body
         json_proto.expanded = expanded
-        return cast("DeltaGenerator", self.dg._enqueue("json", json_proto))
+        return self.dg._enqueue("json", json_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -159,7 +159,7 @@ class LayoutsMixin:
         if len(weights) == 0 or any(weight <= 0 for weight in weights):
             raise weights_exception
 
-        def column_proto(normalized_weight):
+        def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()
             col_proto.column.weight = normalized_weight
             col_proto.allow_empty = True

--- a/lib/streamlit/elements/legacy_data_frame.py
+++ b/lib/streamlit/elements/legacy_data_frame.py
@@ -16,29 +16,40 @@
 
 import datetime
 import re
-from collections import namedtuple
-from typing import cast, Dict, Any, Optional
+from typing import Any, cast, Dict, NamedTuple, Optional, TYPE_CHECKING
+from typing_extensions import Final
 
 import pyarrow as pa
 import tzlocal
 from pandas import DataFrame
 from pandas.io.formats.style import Styler
 
-import streamlit
 from streamlit import errors, type_util
+from streamlit.elements.arrow import Data
 from streamlit.logger import get_logger
 from streamlit.proto.DataFrame_pb2 import (
     DataFrame as DataFrameProto,
     TableStyle as TableStyleProto,
 )
 
-LOGGER = get_logger(__name__)
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
 
-CSSStyle = namedtuple("CSSStyle", ["property", "value"])
+LOGGER: Final = get_logger(__name__)
+
+
+class CSSStyle(NamedTuple):
+    property: Any
+    value: Any
 
 
 class LegacyDataFrameMixin:
-    def _legacy_dataframe(self, data=None, width=None, height=None):
+    def _legacy_dataframe(
+        self,
+        data: Data = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> "DeltaGenerator":
         """Display a dataframe as an interactive table.
 
         Parameters
@@ -97,7 +108,7 @@ class LegacyDataFrameMixin:
             element_height=height,
         )
 
-    def _legacy_table(self, data=None):
+    def _legacy_table(self, data: Data = None) -> "DeltaGenerator":
         """Display a static table.
 
         This differs from `st._legacy_dataframe` in that the table in this case is
@@ -127,12 +138,12 @@ class LegacyDataFrameMixin:
         return self.dg._enqueue("table", table_proto)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)
 
 
-def marshall_data_frame(data: Any, proto_df: DataFrameProto) -> None:
+def marshall_data_frame(data: Data, proto_df: DataFrameProto) -> None:
     """Convert a pandas.DataFrame into a proto.DataFrame.
 
     Parameters
@@ -338,7 +349,7 @@ def _get_custom_display_values(translated_style: Dict[Any, Any]) -> Dict[Any, An
     return display_values
 
 
-def _marshall_index(pandas_index, proto_index):
+def _marshall_index(pandas_index, proto_index) -> None:
     """Convert an pandas.Index into a proto.Index.
 
     pandas_index - Panda.Index or related (input)
@@ -385,7 +396,7 @@ def _marshall_index(pandas_index, proto_index):
         raise NotImplementedError("Can't handle %s yet." % type(pandas_index))
 
 
-def _marshall_table(pandas_table, proto_table):
+def _marshall_table(pandas_table, proto_table) -> None:
     """Convert a sequence of 1D arrays into proto.Table.
 
     pandas_table - Sequence of 1D arrays which are AnyArray compatible (input).
@@ -397,7 +408,7 @@ def _marshall_table(pandas_table, proto_table):
         _marshall_any_array(pandas_array, proto_table.cols.add())
 
 
-def _marshall_any_array(pandas_array, proto_array):
+def _marshall_any_array(pandas_array, proto_array) -> None:
     """Convert a 1D numpy.Array into a proto.AnyArray.
 
     pandas_array - 1D arrays which is AnyArray compatible (input).

--- a/lib/streamlit/elements/legacy_vega_lite.py
+++ b/lib/streamlit/elements/legacy_vega_lite.py
@@ -15,25 +15,29 @@
 """A Python wrapper around Vega-Lite."""
 
 import json
-from typing import cast
+from typing import Any, cast, Dict, Optional, TYPE_CHECKING
+from typing_extensions import Final
 
-import streamlit
 import streamlit.elements.legacy_data_frame as data_frame
 import streamlit.elements.lib.dicttools as dicttools
 from streamlit.logger import get_logger
 from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart as VegaLiteChartProto
 
-LOGGER = get_logger(__name__)
+if TYPE_CHECKING:
+    from .arrow import Data
+    from streamlit.delta_generator import DeltaGenerator
+
+LOGGER: Final = get_logger(__name__)
 
 
 class LegacyVegaLiteMixin:
     def _legacy_vega_lite_chart(
         self,
-        data=None,
-        spec=None,
-        use_container_width=False,
-        **kwargs,
-    ):
+        data: "Data" = None,
+        spec: Optional[Dict[str, Any]] = None,
+        use_container_width: bool = False,
+        **kwargs: Any,
+    ) -> "DeltaGenerator":
         """Display a chart using the Vega-Lite library.
 
         Parameters
@@ -95,12 +99,18 @@ class LegacyVegaLiteMixin:
         return self.dg._enqueue("vega_lite_chart", vega_lite_chart_proto)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)
 
 
-def marshall(proto, data=None, spec=None, use_container_width=False, **kwargs):
+def marshall(
+    proto: VegaLiteChartProto,
+    data: "Data" = None,
+    spec: Optional[Dict[str, Any]] = None,
+    use_container_width: bool = False,
+    **kwargs: Any,
+) -> None:
     """Construct a Vega-Lite chart object.
 
     See DeltaGenerator._legacy_vega_lite_chart for docs.
@@ -167,33 +177,31 @@ def marshall(proto, data=None, spec=None, use_container_width=False, **kwargs):
 
 
 # See https://vega.github.io/vega-lite/docs/encoding.html
-_CHANNELS = set(
-    [
-        "x",
-        "y",
-        "x2",
-        "y2",
-        "xError",
-        "yError2",
-        "xError",
-        "yError2",
-        "longitude",
-        "latitude",
-        "color",
-        "opacity",
-        "fillOpacity",
-        "strokeOpacity",
-        "strokeWidth",
-        "size",
-        "shape",
-        "text",
-        "tooltip",
-        "href",
-        "key",
-        "order",
-        "detail",
-        "facet",
-        "row",
-        "column",
-    ]
-)
+_CHANNELS: Final = {
+    "x",
+    "y",
+    "x2",
+    "y2",
+    "xError",
+    "yError2",
+    "xError",
+    "yError2",
+    "longitude",
+    "latitude",
+    "color",
+    "opacity",
+    "fillOpacity",
+    "strokeOpacity",
+    "strokeWidth",
+    "size",
+    "shape",
+    "text",
+    "tooltip",
+    "href",
+    "key",
+    "order",
+    "detail",
+    "facet",
+    "row",
+    "column",
+}

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -76,8 +76,7 @@ class MarkdownMixin:
         markdown_proto.body = clean_text(body)
         markdown_proto.allow_html = unsafe_allow_html
 
-        dg = self.dg._enqueue("markdown", markdown_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", markdown_proto)
 
     def header(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in header formatting.
@@ -102,8 +101,7 @@ class MarkdownMixin:
         else:
             header_proto.body = f'<h2 data-anchor="{anchor}">{clean_text(body)}</h2>'
             header_proto.allow_html = True
-        dg = self.dg._enqueue("markdown", header_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", header_proto)
 
     def subheader(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in subheader formatting.
@@ -129,8 +127,7 @@ class MarkdownMixin:
             subheader_proto.body = f'<h3 data-anchor="{anchor}">{clean_text(body)}</h3>'
             subheader_proto.allow_html = True
 
-        dg = self.dg._enqueue("markdown", subheader_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", subheader_proto)
 
     def code(self, body: str, language: Optional[str] = "python") -> "DeltaGenerator":
         """Display a code block with optional syntax highlighting.
@@ -159,8 +156,7 @@ class MarkdownMixin:
             "body": body,
         }
         code_proto.body = clean_text(markdown)
-        dg = self.dg._enqueue("markdown", code_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", code_proto)
 
     def title(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
         """Display text in title formatting.
@@ -188,8 +184,7 @@ class MarkdownMixin:
         else:
             title_proto.body = f'<h1 data-anchor="{anchor}">{clean_text(body)}</h1>'
             title_proto.allow_html = True
-        dg = self.dg._enqueue("markdown", title_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", title_proto)
 
     def caption(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
         """Display text in small font.
@@ -232,8 +227,7 @@ class MarkdownMixin:
         caption_proto.body = clean_text(body)
         caption_proto.allow_html = unsafe_allow_html
         caption_proto.is_caption = True
-        dg = self.dg._enqueue("markdown", caption_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", caption_proto)
 
     def latex(self, body: Union[str, "sympy.Expr"]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
@@ -267,8 +261,7 @@ class MarkdownMixin:
 
         latex_proto = MarkdownProto()
         latex_proto.body = "$$\n%s\n$$" % clean_text(body)
-        dg = self.dg._enqueue("markdown", latex_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("markdown", latex_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -74,7 +74,7 @@ class MediaMixin:
         audio_proto = AudioProto()
         coordinates = self.dg._get_delta_path_str()
         marshall_audio(coordinates, audio_proto, data, format, start_time)
-        return cast("DeltaGenerator", self.dg._enqueue("audio", audio_proto))
+        return self.dg._enqueue("audio", audio_proto)
 
     def video(
         self,
@@ -120,7 +120,7 @@ class MediaMixin:
         video_proto = VideoProto()
         coordinates = self.dg._get_delta_path_str()
         marshall_video(coordinates, video_proto, data, format, start_time)
-        return cast("DeltaGenerator", self.dg._enqueue("video", video_proto))
+        return self.dg._enqueue("video", video_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -116,7 +116,7 @@ class MetricMixin:
         metric_proto.color = color_and_direction.color
         metric_proto.direction = color_and_direction.direction
 
-        return cast("DeltaGenerator", self.dg._enqueue("metric", metric_proto))
+        return self.dg._enqueue("metric", metric_proto)
 
     @staticmethod
     def parse_label(label: str) -> str:

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -140,10 +140,7 @@ class PlotlyMixin:
         marshall(
             plotly_chart_proto, figure_or_data, use_container_width, sharing, **kwargs
         )
-        return cast(
-            "DeltaGenerator",
-            self.dg._enqueue("plotly_chart", plotly_chart_proto),
-        )
+        return self.dg._enqueue("plotly_chart", plotly_chart_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -74,10 +74,7 @@ class ProgressMixin:
                 "Progress Value has invalid type: %s" % type(value).__name__
             )
 
-        return cast(
-            "DeltaGenerator",
-            self.dg._enqueue("progress", progress_proto),
-        )
+        return self.dg._enqueue("progress", progress_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/snow.py
+++ b/lib/streamlit/elements/snow.py
@@ -33,7 +33,7 @@ class SnowMixin:
         """
         snow_proto = SnowProto()
         snow_proto.show = True
-        return cast("DeltaGenerator", self.dg._enqueue("snow", snow_proto))
+        return self.dg._enqueue("snow", snow_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -37,8 +37,7 @@ class TextMixin:
         """
         text_proto = TextProto()
         text_proto.body = clean_text(body)
-        dg = self.dg._enqueue("text", text_proto)
-        return cast("DeltaGenerator", dg)
+        return self.dg._enqueue("text", text_proto)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import textwrap
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, cast, Hashable, Optional, TYPE_CHECKING, Union
 
 import streamlit
 from streamlit import type_util
@@ -21,22 +21,24 @@ from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException
 from streamlit.state import get_session_state, WidgetCallback
 
-
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.type_util import DataFrameCompatible
 
 
-def clean_text(text: Any) -> str:
+def clean_text(text: object) -> str:
     """Convert an object to text, dedent it, and strip whitespace."""
     return textwrap.dedent(str(text)).strip()
 
 
-def last_index_for_melted_dataframes(data: Any) -> Any:
+def last_index_for_melted_dataframes(
+    data: Union["DataFrameCompatible", Any]
+) -> Optional[Hashable]:
     if type_util.is_dataframe_compatible(data):
         data = type_util.convert_anything_to_df(data)
 
         if data.index.size > 0:
-            return data.index[-1]
+            return cast(Hashable, data.index[-1])
 
     return None
 

--- a/lib/streamlit/scriptrunner/script_run_context.py
+++ b/lib/streamlit/scriptrunner/script_run_context.py
@@ -14,6 +14,7 @@
 
 import threading
 from typing import Dict, Optional, List, Callable, Set
+from typing_extensions import Final
 
 import attr
 
@@ -23,7 +24,7 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.state import SafeSessionState
 from streamlit.uploaded_file_manager import UploadedFileManager
 
-LOGGER = get_logger(__name__)
+LOGGER: Final = get_logger(__name__)
 
 
 @attr.s(auto_attribs=True, slots=True)
@@ -88,7 +89,7 @@ class ScriptRunContext:
         self._enqueue(msg)
 
 
-SCRIPT_RUN_CONTEXT_ATTR_NAME = "streamlit_script_run_ctx"
+SCRIPT_RUN_CONTEXT_ATTR_NAME: Final = "streamlit_script_run_ctx"
 
 
 def add_script_run_ctx(

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -104,7 +104,8 @@ _DATAFRAME_COMPATIBLE_TYPES: Final[Tuple[type, ...]] = (
     type(None),
 )
 
-DataFrameCompatible: TypeAlias = Union[dict, list, None]
+_DataFrameCompatible: TypeAlias = Union[dict, list, None]
+DataFrameCompatible: TypeAlias = Union[_DataFrameCompatible, DataFrameLike]
 
 _BYTES_LIKE_TYPES: Final[Tuple[type, ...]] = (
     bytes,

--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """st.help unit test."""
+import sys
 
 from tests import testutil
 import streamlit as st
@@ -79,7 +80,21 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("dataframe", ds.name)
         self.assertEqual("streamlit", ds.module)
         self.assertEqual("<class 'method'>", ds.type)
-        self.assertEqual("(data=None, width=None, height=None)", ds.signature)
+        if sys.version_info[1] == 7:
+            # Python 3.7 represents the signature slightly differently
+            self.assertEqual(
+                "(data: 'Data' = None, width: Union[int, NoneType] = None, "
+                "height: Union[int, NoneType] = None) -> 'DeltaGenerator'",
+                ds.signature,
+            )
+        else:
+
+            self.assertEqual(
+                "(data: 'Data' = None, width: Optional[int] = None, "
+                "height: Optional[int] = None) -> 'DeltaGenerator'",
+                ds.signature,
+            )
+
         self.assertTrue(ds.doc_string.startswith("Display a dataframe"))
 
     def test_st_cache(self):


### PR DESCRIPTION
## 📚 Context

Continuing from where I left off in #4657, with adding type annotations to Streamlit's public API.

This one touches a lot of files, partly because I was able to remove the need for `typing.cast` that was repeated in about every non-widget element.

- What kind of change does this PR introduce?

  - [X] Other, please describe: Type Annotations

## 🧠 Description of Changes

- Add type annotations to the `DeltaGenerator` class, including;
  - proper annotations for `_value_or_dg`
  - simplify type handling elsewhere, as a result of the above
- Add type annotations to the DeltaGenerator mixins responsible for `pandas.DataFrame` handling.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
