### PR TITLE
Fix to Arrow Vega Lite - dataIsAnAppendOfPrev's broken light data comparison 

### DIFF
--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -18,7 +18,7 @@
 import React, { PureComponent } from "react"
 import { withTheme } from "@emotion/react"
 import { logMessage } from "src/lib/log"
-import { get, merge } from "lodash"
+import { merge } from "lodash"
 import withFullScreenWrapper from "src/hocs/withFullScreenWrapper"
 import { ensureError } from "src/lib/ErrorHandling"
 import { IndexTypeName, Quiver } from "src/lib/Quiver"
@@ -480,16 +480,14 @@ function dataIsAnAppendOfPrev(
     return false
   }
 
-  const df0 = prevData.data
-  const df1 = data.data
   const c = numCols - 1
   const r = prevNumRows - 1
 
   // Check if the new dataframe looks like it's a superset of the old one.
   // (this is a very light check, and not guaranteed to be right!)
   if (
-    get(df0, [c, 0]) !== get(df1, [c, 0]) ||
-    get(df0, [c, r]) !== get(df1, [c, r])
+    prevData.getDataValue(0, c) !== data.getDataValue(0, c) ||
+    prevData.getDataValue(r, c) !== data.getDataValue(r, c)
   ) {
     return false
   }


### PR DESCRIPTION
## 📚 Context

As a precursor to fixing `st.vega_lite_chart` re-rendering flow, it was discovered that the light check in `dataIsAnAppendOfPrev` comparing a couple cells of the previous and current data to check if the new data is an append is broken. This PR substitutes lodash's `get()` function on `ArrowVegaLiteChart`'s Quiver data type, which was always returning undefined. 

- What kind of change does this PR introduce?
  - [x] Bugfix

## 🧠 Description of Changes

- Substituted lodash `get()` function with Quiver's `getDataValue`

## 🧪 Testing Done

- [x] Manual testing
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
