### PR TITLE
Fix row comparison for Vega Lite Chart's dataIsAnAppendOfPrev

### DIFF
--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -472,7 +472,7 @@ function dataIsAnAppendOfPrev(
     return false
   }
 
-  if (prevNumRows > numRows) {
+  if (prevNumRows >= numRows) {
     return false
   }
 

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -447,7 +447,7 @@ function dataIsAnAppendOfPrev(
     return false
   }
 
-  if (prevNumRows > numRows) {
+  if (prevNumRows >= numRows) {
     return false
   }
 


### PR DESCRIPTION
## 📚 Context

The current `dataIsAnAppendOfPrev` comparison of number of rows doesn't take into account dataframes with the same number of rows. This is creating false-positives that the data is an append when it is not, which then causes the vega lite chart not to re-render when it should. 
This PR updates this behavior in both `ArrowVegaLiteChart` & `VegaLiteChart`.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Updated the row comparison in dataIsAnAppendOfPrev for the same the dataframes have the same shape (rows/cols equal)

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Manual Testing

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
