### PR TITLE
Update vega_lite theme config to add header's labelColor

### DIFF
--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -523,6 +523,9 @@ function configWithThemeDefaults(config: any, theme: Theme): any {
       subtitleColor: colors.bodyText,
       ...themeFonts,
     },
+    header: {
+      labelColor: colors.bodyText,
+    }
   }
 
   if (!config) {

--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -525,7 +525,7 @@ function configWithThemeDefaults(config: any, theme: Theme): any {
     },
     header: {
       labelColor: colors.bodyText,
-    }
+    },
   }
 
   if (!config) {

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -498,6 +498,9 @@ function configWithThemeDefaults(config: any, theme: Theme): any {
       subtitleColor: colors.bodyText,
       ...themeFonts,
     },
+    header: {
+      labelColor: colors.bodyText,
+    }
   }
 
   if (!config) {

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -500,7 +500,7 @@ function configWithThemeDefaults(config: any, theme: Theme): any {
     },
     header: {
       labelColor: colors.bodyText,
-    }
+    },
   }
 
   if (!config) {


### PR DESCRIPTION
## 📚 Context

Vega-lite charts do not show titles in dark mode, and this PR updates `st.vega_lite_chart`'s theme config, adding the `labelColor` for header to fix this.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Added `labelColor` for header under `themeDefaults` config

  - [x] This is a visible (user-facing) change

**Revised:**
<img width="271" alt="Screen Shot 2022-05-16 at 12 09 06 PM" src="https://user-images.githubusercontent.com/63436329/168667183-77684490-f8e3-49e4-981a-730f614a7192.png">

**Current:**
<img width="276" alt="Screen Shot 2022-05-16 at 12 08 53 PM" src="https://user-images.githubusercontent.com/63436329/168667195-8c23e7ec-3288-41a7-9497-6e24f5c98315.png">

## 🧪 Testing Done

- [x] Screenshots included

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4643 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
