### PR TITLE
Will's changes

### DIFF
--- a/lib/snowflake_test.py
+++ b/lib/snowflake_test.py
@@ -17,7 +17,9 @@ class ExampleMessageContext:
     def __init__(self, id: str):
         self._id = id
 
-    def write_forward_msg(self, msg: ForwardMsg) -> None:
+    def write_forward_msg(self, msg_bytes: bytes) -> None:
+        msg = ForwardMsg()
+        msg.ParseFromString(msg_bytes)
         print(f"Got ForwardMsg: {msg.WhichOneof('type')} (id={self._id})")
 
     def on_complete(self, err: Optional[BaseException] = None) -> None:
@@ -26,15 +28,19 @@ class ExampleMessageContext:
         else:
             print(f"Async operation error: {err} (id={self._id})")
 
+    def flush_system_logs(self, msg: Optional[str] = None) -> None:
+        if msg is not None:
+            print(msg)
 
-def create_rerun_msg() -> BackMsg:
+
+def create_rerun_msg() -> bytes:
     msg = BackMsg()
     msg.rerun_script.query_string = ""
-    return msg
+    return msg.SerializeToString()
 
 
 # Start Streamlit
-config = SnowflakeConfig(script_string=SCRIPT_STRING)
+config = SnowflakeConfig(SCRIPT_PATH, {})
 demo = SnowflakeDemo(config)
 demo.start()
 

--- a/lib/streamlit/snowflake_demo.py
+++ b/lib/streamlit/snowflake_demo.py
@@ -276,8 +276,12 @@ class SnowflakeDemo:
 
         def session_created_handler() -> None:
             try:
+
+                def fwd_msg_writer(forward_msg: ForwardMsg):
+                    ctx.write_forward_msg(serialize_forward_msg(forward_msg))
+
                 session = self._require_server().create_demo_app_session(
-                    ctx.write_forward_msg, snowpark_session
+                    fwd_msg_writer, snowpark_session
                 )
                 self._sessions[session_id] = session
                 ctx.flush_system_logs(f"Registered Snowflake session (id={session_id})")

--- a/lib/streamlit/snowflake_demo.py
+++ b/lib/streamlit/snowflake_demo.py
@@ -265,7 +265,7 @@ class SnowflakeDemo:
         """
         if self._state is not _SnowflakeDemoState.RUNNING:
             ctx.on_complete(
-                err=RuntimeError(f"Can't register session (bad state: {self._state})")
+                RuntimeError(f"Can't register session (bad state: {self._state})")
             )
             return "invalid_session_id"
 
@@ -287,7 +287,7 @@ class SnowflakeDemo:
                 ctx.flush_system_logs(f"Registered Snowflake session (id={session_id})")
                 LOGGER.info("Snowflake session registered! (id=%s)", session_id)
             except BaseException as e:
-                ctx.on_complete(err=e)
+                ctx.on_complete(e)
                 return
 
             ctx.on_complete()
@@ -314,13 +314,19 @@ class SnowflakeDemo:
         """
         if self._state is not _SnowflakeDemoState.RUNNING:
             ctx.on_complete(
-                err=RuntimeError(f"Can't handle BackMsg (bad state: {self._state})")
+                RuntimeError(f"Can't handle BackMsg (bad state: {self._state})")
             )
             return
         ctx.flush_system_logs(f"back message handler called (sessionid={session_id})")
 
         msg = BackMsg()
         msg.ParseFromString(msg_bytes)
+        ctx.flush_system_logs(f"BackMsg deserialized (sessionid={session_id})")
+
+        msg_type = msg.WhichOneof("type")
+        ctx.flush_system_logs(
+            f"Will handle BackMsg (sessionid={session_id}, type={msg_type})"
+        )
 
         def backmsg_handler() -> None:
             try:
@@ -341,7 +347,7 @@ class SnowflakeDemo:
                 session.handle_backmsg(msg)
                 ctx.flush_system_logs("session.handle_backmsg(msg) DONE")
             except BaseException as e:
-                ctx.on_complete(err=e)
+                ctx.on_complete(e)
                 return
 
             ctx.on_complete()


### PR DESCRIPTION
- `on_callback`: do not specify the error param name (this breaks things on the C++ side)
- `ForwardMsg` and `BackMsg` are sent and received as serialized bytes
- `AsyncMessageContext.flush_system_logs` callback