### PR TITLE
Don't handle delta messages from stale script runs

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -937,7 +937,6 @@ describe("App.sendRerunBackMsg", () => {
     instance.sendBackMsg = jest.fn()
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
-    instance.clearAppState = jest.fn()
 
     // Set the value of document.location.pathname to '/foo/bar/page1'
     window.history.pushState({}, "", "/foo/bar/page1")
@@ -948,7 +947,6 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
-    expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
   it("switches pages correctly when sendRerunbackMsg is given a pageName", () => {
@@ -958,7 +956,6 @@ describe("App.sendRerunBackMsg", () => {
     instance.sendBackMsg = jest.fn()
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
-    instance.clearAppState = jest.fn()
 
     instance.sendRerunBackMsg(undefined, "page1")
 
@@ -967,7 +964,6 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "" },
     })
-    expect(instance.clearAppState).toHaveBeenCalled()
     expect(wrapper.find("AppView").prop("currentPageName")).toEqual("page1")
   })
 
@@ -1024,6 +1020,29 @@ describe("App.sendRerunBackMsg", () => {
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: { pageName: "page1", queryString: "foo=bar" },
     })
+  })
+
+  it("calls clearAppState if the page changed", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.clearAppState = jest.fn()
+    // @ts-ignore
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+
+    instance.sendRerunBackMsg(undefined, "page1")
+    expect(instance.clearAppState).toHaveBeenCalled()
+  })
+
+  it("doesn't call clearAppState if the page hasn't changed", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    wrapper.setState({ currentPageName: "page1" })
+    const instance = wrapper.instance() as App
+    instance.clearAppState = jest.fn()
+    // @ts-ignore
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+
+    instance.sendRerunBackMsg(undefined, "page1")
+    expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 })
 

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -105,6 +105,7 @@ class AppSession:
         """
         # Each AppSession has a unique string ID.
         self.id = str(uuid.uuid4())
+        self._script_run_id = _generate_scriptrun_id()
 
         self._ioloop = ioloop
         self._session_data = session_data
@@ -200,6 +201,7 @@ class AppSession:
         if not config.get_option("client.displayEnabled"):
             return
 
+        msg.metadata.script_run_id = self._script_run_id
         self._session_data.enqueue(msg)
         if self._message_enqueued_callback:
             self._message_enqueued_callback()
@@ -512,7 +514,8 @@ class AppSession:
         """Create and return a new_session ForwardMsg."""
         msg = ForwardMsg()
 
-        msg.new_session.script_run_id = _generate_scriptrun_id()
+        self._script_run_id = _generate_scriptrun_id()
+        msg.new_session.script_run_id = self._script_run_id
         msg.new_session.name = self._session_data.name
         msg.new_session.main_script_path = self._session_data.main_script_path
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -515,6 +515,12 @@ class AppSessionScriptEventTest(tornado.testing.AsyncTestCase):
                 ]
             )
 
+        # Simulate the enqueue function adding the script_run_id to the
+        # metadata of each forward msg.
+        for msg in expected_events:
+            if hasattr(msg, "metadata"):
+                msg.metadata.script_run_id = "mock_scriptrun_id"
+
         # Assert the results!
         self.assertEqual(expected_events, forward_msg_queue_events)
 

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -87,6 +87,9 @@ message ForwardMsgMetadata {
   repeated uint32 delta_path = 2;
 
   ElementDimensionSpec element_dimension_spec = 3;
+
+  // The ID of the script run that this forward message was sent in.
+  string script_run_id = 4;
 }
 
 // Specifies the dimensions for the element


### PR DESCRIPTION
## 📚 Context

There's a race condition in the multipage apps world that can be triggered as follows:
1. Have a multipage app with a page sending a ton of deltas as well as any other second page. For example,
   the page with a ton of deltas can be something like
```python
import streamlit as st

for _ in range(1000):
    st.write("hello")
```
2. Run the page generating lots of deltas, then rapidly switch to the second page.
3. If you're quick enough, you'll notice a modal with a message that says something like
```
Bad 'setIn' index 99 (should be between [0, 0])
```

The reason this happens is because we clear the screen when switching between pages,
but since the first script may still be running, there's a chance that we get a delta message
with a deltaPath that was invalidated by the page clearing. 

To fix this issue, we tag each outgoing forward message with the `scriptRunId` of the
script run that generated the message, then we drop delta messages corresponding to
stale script runs in `handleDeltaMsg`.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Tag each outgoing forward message with a script run ID so that stale deltas can be ignored
- Only clear app elements if the page actually changed 

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests
