### PR TITLE
Ignore a sometimes-redundant cast

### DIFF
--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -17,7 +17,6 @@ strict_equality = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
-warn_unused_ignores = true
 warn_unreachable = true
 
 show_error_context = true

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -310,8 +310,12 @@ def image_to_url(
                     "have exactly 3 color channels"
                 )
 
+        # Depending on the version of numpy that the user has installed, the
+        # typechecker may not be able to deduce that indexing into a
+        # `npt.NDArray[Any]` returns a `npt.NDArray[Any]`, so we need to
+        # ignore redundant casts below.
         data = _np_array_to_bytes(
-            array=cast("npt.NDArray[Any]", image),
+            array=cast("npt.NDArray[Any]", image),  # type: ignore[redundant-cast]
             output_format=output_format,
         )
 


### PR DESCRIPTION
## 📚 Context

A new version of `numpy` that was released ~2 hours ago apparently made some improvements
to type inference when indexing into an NDArray. This caused `mypy` to get upset with us over what
was previously a necessary cast that is now redundant. We fixed this by adding a
`# type: ignore[redundant-cast]` so that we can support both older and newer `numpy` versions. 

Note that we also had to turn off `warn_unused_ignores` since the ignore is sometimes used and
sometimes not depending on the Python version, but I don't see a good way around this.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Fix the build
