### PR TITLE
Fix for Issue #4538, based on PR #4648

### DIFF
--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -24,6 +24,7 @@ from streamlit.js_number import JSNumber
 from streamlit.js_number import JSNumberBoundsException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.state import (
+    get_session_state,
     register_widget,
     WidgetArgs,
     WidgetCallback,
@@ -187,7 +188,10 @@ class SliderMixin:
         check_session_state_rules(default_value=value, key=key)
 
         # Set value default.
-        if value is None:
+        session_state = get_session_state().filtered_state
+        if key is not None and key in session_state:
+            value = session_state[key]
+        else:
             value = min_value if min_value is not None else 0
 
         SUPPORTED_TYPES = {

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -187,13 +187,14 @@ class SliderMixin:
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 
-        # Set value from session_state if exists.
-        session_state = get_session_state().filtered_state
-        if key is not None and key in session_state:
-            value = session_state[key]
-        # Set value default.
         if value is None:
-            value = min_value if min_value is not None else 0
+            # Set value from session_state if exists.
+            session_state = get_session_state().filtered_state
+            if key is not None and key in session_state:
+                value = session_state[key]
+            else:
+                # Set value default.
+                value = min_value if min_value is not None else 0
 
         SUPPORTED_TYPES = {
             int: SliderProto.INT,

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -187,11 +187,12 @@ class SliderMixin:
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=value, key=key)
 
-        # Set value default.
+        # Set value from session_state if exists.
         session_state = get_session_state().filtered_state
         if key is not None and key in session_state:
             value = session_state[key]
-        else:
+        # Set value default.
+        if value is None:
             value = min_value if min_value is not None else 0
 
         SUPPORTED_TYPES = {


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Currently st.slider handles both range and single value sliders. 
Problem is happening when range value set from `session_state`. The problem is that by default since we have not read a value from session_state during creation, a single slider initiates, which then leads to incorrect behavior. 

The solution here (based on an idea from at #4648 ) is to access session_state, inspect is there a default value set from session_state, and if so, use that value during initialization. 
 

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #4538 


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
