### PR TITLE
Revive the warn-unused-ignores mypy config option

### DIFF
--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -17,6 +17,7 @@ strict_equality = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
+warn_unused_ignores = true
 warn_unreachable = true
 
 show_error_context = true

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Some casts in this file are only occasionally necessary depending on the
+# user's Python version, and mypy doesn't have a good way of toggling this
+# specific config option at a per-line level.
+# mypy: no-warn-unused-ignores
+
 """Image marshalling."""
 
 import imghdr


### PR DESCRIPTION
## 📚 Context

We previously disabled a mypy config option at the project level when we can instead
get away with a more granular disabling of it.

- What kind of change does this PR introduce?

  - [x] Other, please describe: better typechecking
