### PR TITLE
Wrap some types in quotes to take into account imports sometimes failing

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -123,7 +123,7 @@ def set_page_config(
             allow_emoji=True,
         )
 
-    pb_layout: PageConfigProto.Layout.ValueType
+    pb_layout: "PageConfigProto.Layout.ValueType"
     if layout == "centered":
         pb_layout = PageConfigProto.CENTERED
     elif layout == "wide":
@@ -134,7 +134,7 @@ def set_page_config(
         )
     msg.page_config_changed.layout = pb_layout
 
-    pb_sidebar_state: PageConfigProto.SidebarState.ValueType
+    pb_sidebar_state: "PageConfigProto.SidebarState.ValueType"
     if initial_sidebar_state == "auto":
         pb_sidebar_state = PageConfigProto.AUTO
     elif initial_sidebar_state == "expanded":

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -35,8 +35,8 @@ DeltaColor: TypeAlias = Literal["normal", "inverse", "off"]
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
 class MetricColorAndDirection:
-    color: MetricProto.MetricColor.ValueType
-    direction: MetricProto.MetricDirection.ValueType
+    color: "MetricProto.MetricColor.ValueType"
+    direction: "MetricProto.MetricDirection.ValueType"
 
 
 class MetricMixin:


### PR DESCRIPTION
## 📚 Context

It seems like importing `MetricProto.MetricColor.ValueType` (more specifically, the
`ValueType` attr of any protobuf enum) doesn't always work as the attr was added in a
`mypy-protobuf` version a few months ago, so things break depending on how
dependencies are resolved. This PR wraps these types in quotes so that the types
are used when available and don't break when not.

- What kind of change does this PR introduce?

  - [x] Bugfix