### PR TITLE
Allow MPA pages with duplicate names

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -16,9 +16,10 @@
  */
 
 import React from "react"
-import { ReactWrapper } from "enzyme"
+import { ShallowWrapper, ReactWrapper } from "enzyme"
 import cloneDeep from "lodash/cloneDeep"
 import { LocalStore } from "src/lib/storageUtils"
+import { hashString } from "src/lib/utils"
 import { shallow, mount } from "src/lib/test_util"
 import {
   CustomThemeConfig,
@@ -63,7 +64,7 @@ const getS4ACommunicationState = (
   menuItems: [],
   pageLinkBaseUrl: "",
   queryParams: "",
-  requestedPageName: null,
+  requestedPageScriptHash: null,
   sidebarChevronDownshift: 0,
   streamlitShareMetadata: {},
   toolbarItems: [],
@@ -400,16 +401,22 @@ describe("App", () => {
       getProps({
         s4aCommunication: getS4ACommunicationProp({
           currentState: getS4ACommunicationState({
-            requestedPageName: "page1",
+            requestedPageScriptHash: "hash1",
           }),
         }),
       })
     )
     wrapper.update()
 
-    expect(instance.onPageChange).toHaveBeenCalledWith("page1")
-    expect(props.s4aCommunication.currentState.requestedPageName).toBeNull()
+    expect(instance.onPageChange).toHaveBeenCalledWith("hash1")
+    expect(
+      props.s4aCommunication.currentState.requestedPageScriptHash
+    ).toBeNull()
   })
+})
+
+const mockGetBaseUriParts = (basePath?: string) => () => ({
+  basePath: basePath || "",
 })
 
 describe("App.handleNewSession", () => {
@@ -441,6 +448,10 @@ describe("App.handleNewSession", () => {
       sessionId: "sessionId",
       commandLine: "commandLine",
     },
+    appPages: [
+      { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+    ],
+    pageScriptHash: "page_script_hash",
   }
   const NEW_SESSION = new NewSession(NEW_SESSION_JSON)
 
@@ -701,21 +712,15 @@ describe("App.handleNewSession", () => {
     expect(SessionInfo.isSet()).toBe(true)
   })
 
-  it("plumbs appPages to the AppView component", () => {
+  it("plumbs appPages and currentPageScriptHash to the AppView component", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
     expect(wrapper.find("AppView").prop("appPages")).toEqual([])
 
     const appPages = [
-      {
-        pageName: "page1",
-        scriptPath: "page1.py",
-      },
-      {
-        pageName: "page2",
-        scriptPath: "page2.py",
-      },
+      { pageScriptHash: "hash1", pageName: "page1" },
+      { pageScriptHash: "hash2", pageName: "page2" },
     ]
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
@@ -723,9 +728,14 @@ describe("App.handleNewSession", () => {
     newSessionJson.appPages = appPages
 
     // @ts-ignore
+    newSessionJson.pageScriptHash = "hash1"
+
+    // @ts-ignore
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
-    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("")
+    expect(wrapper.find("AppView").prop("currentPageScriptHash")).toEqual(
+      "hash1"
+    )
     expect(document.title).toBe("page1 · Streamlit")
     expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_APP_PAGES",
@@ -734,7 +744,40 @@ describe("App.handleNewSession", () => {
     expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_CURRENT_PAGE_NAME",
       currentPageName: "",
+      currentPageScriptHash: "hash1",
     })
+  })
+
+  it("calls clearAppState if currentPageScriptHash changes", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    instance.clearAppState = jest.fn()
+
+    const newSessionJson = cloneDeep(NEW_SESSION_JSON)
+    // @ts-ignore
+    newSessionJson.pageScriptHash = "different_hash"
+
+    // @ts-ignore
+    wrapper.instance().handleNewSession(new NewSession(newSessionJson))
+
+    expect(instance.clearAppState).toHaveBeenCalled()
+  })
+
+  it("doesn't call clearAppState if currentPageScriptHash doesn't change", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    wrapper.setState({
+      currentPageScriptHash: "page_script_hash",
+      appHash: hashString("installationId"),
+    })
+    const instance = wrapper.instance() as App
+    instance.clearAppState = jest.fn()
+
+    const newSessionJson = cloneDeep(NEW_SESSION_JSON)
+
+    // @ts-ignore
+    wrapper.instance().handleNewSession(new NewSession(newSessionJson))
+
+    expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
   it("sets hideSidebarNav based on the server config option and s4a setting", () => {
@@ -760,6 +803,88 @@ describe("App.handleNewSession", () => {
     )
 
     expect(wrapper.find("AppView").prop("hideSidebarNav")).toEqual(true)
+  })
+
+  describe("page change URL handling", () => {
+    let wrapper: ShallowWrapper
+    let instance: App
+
+    beforeEach(() => {
+      wrapper = shallow(<App {...getProps()} />)
+      instance = wrapper.instance() as App
+      // @ts-ignore
+      instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+
+      window.history.pushState({}, "", "/")
+      jest.spyOn(
+        window.history,
+        // @ts-ignore
+        "pushState"
+      )
+    })
+
+    afterEach(() => {
+      window.history.pushState({}, "", "/")
+    })
+
+    it("can switch to the main page", () => {
+      const instance = wrapper.instance() as App
+      instance.handleNewSession(new NewSession(NEW_SESSION_JSON))
+
+      expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
+    })
+
+    it("can switch to a non-main page", () => {
+      const instance = wrapper.instance() as App
+      const newSessionJson = cloneDeep(NEW_SESSION_JSON)
+      newSessionJson.appPages = [
+        { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+        { pageScriptHash: "hash2", pageName: "page2" },
+      ]
+      newSessionJson.pageScriptHash = "hash2"
+
+      instance.handleNewSession(new NewSession(newSessionJson))
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/page2"
+      )
+    })
+
+    it("retains the query string", () => {
+      window.history.pushState({}, "", "/?foo=bar")
+
+      const instance = wrapper.instance() as App
+      instance.handleNewSession(new NewSession(NEW_SESSION_JSON))
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/?foo=bar"
+      )
+    })
+
+    it("works with baseUrlPaths", () => {
+      const instance = wrapper.instance() as App
+      // @ts-ignore
+      instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo")
+
+      const newSessionJson = cloneDeep(NEW_SESSION_JSON)
+      newSessionJson.appPages = [
+        { pageScriptHash: "page_script_hash", pageName: "streamlit_app" },
+        { pageScriptHash: "hash2", pageName: "page2" },
+      ]
+      newSessionJson.pageScriptHash = "hash2"
+
+      instance.handleNewSession(new NewSession(newSessionJson))
+
+      expect(window.history.pushState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/foo/page2"
+      )
+    })
   })
 })
 
@@ -871,167 +996,105 @@ describe("App.handlePageInfoChanged", () => {
   })
 })
 
-const mockGetBaseUriParts = (basePath?: string) => () => ({
-  basePath: basePath || "",
-})
-
 describe("App.sendRerunBackMsg", () => {
+  let wrapper: ShallowWrapper
+  let instance: App
+
   beforeEach(() => {
-    window.history.pushState({}, "", "/")
-    jest.spyOn(
-      window.history,
-      // @ts-ignore
-      "pushState"
-    )
+    wrapper = shallow(<App {...getProps()} />)
+    instance = wrapper.instance() as App
+    // @ts-ignore
+    instance.sendBackMsg = jest.fn()
+    // @ts-ignore
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
   })
 
   afterEach(() => {
     window.history.pushState({}, "", "/")
   })
 
-  it("figures out pageName when sendRerunBackMsg isn't given one (case 1: main page)", () => {
-    const props = getProps()
-    const wrapper = shallow(<App {...props} />)
-    const instance = wrapper.instance() as App
-    // @ts-ignore
-    instance.sendBackMsg = jest.fn()
-    // @ts-ignore
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+  it("sends the pageScriptHash if one is given", () => {
+    instance.sendRerunBackMsg(undefined, "some_page_hash")
 
+    // @ts-ignore
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: {
+        pageScriptHash: "some_page_hash",
+        pageName: "",
+        queryString: "",
+      },
+    })
+  })
+
+  it("sends the currentPageScriptHash if no pageScriptHash is given", () => {
+    wrapper.setState({ currentPageScriptHash: "some_other_page_hash" })
     instance.sendRerunBackMsg()
 
     // @ts-ignore
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
-      rerunScript: { pageName: "", queryString: "" },
+      rerunScript: {
+        pageScriptHash: "some_other_page_hash",
+        pageName: "",
+        queryString: "",
+      },
     })
-
-    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("")
   })
 
-  it("figures out pageName when sendRerunBackMsg isn't given one (case 2: non-main page)", () => {
-    const props = getProps()
-    const wrapper = shallow(<App {...props} />)
-    const instance = wrapper.instance() as App
-    // @ts-ignore
-    instance.sendBackMsg = jest.fn()
-    // @ts-ignore
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
-
-    // Set the value of document.location.pathname to '/page1/' (with leading
-    // and trailing slashes to test that they get stripped)
-    window.history.pushState({}, "", "/page1/")
-
+  it("extracts the pageName correctly if we can't get a pageScriptHash (main page)", () => {
     instance.sendRerunBackMsg()
 
     // @ts-ignore
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
-      rerunScript: { pageName: "page1", queryString: "" },
+      rerunScript: {
+        pageScriptHash: "",
+        pageName: "",
+        queryString: "",
+      },
     })
-    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("page1")
   })
 
-  it("figures out pageName when sendRerunBackMsg isn't given one and a baseUrlPath is set", () => {
-    const wrapper = shallow(<App {...getProps()} />)
-    const instance = wrapper.instance() as App
-    // @ts-ignore
-    instance.sendBackMsg = jest.fn()
-    // @ts-ignore
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
-    instance.clearAppState = jest.fn()
-
-    // Set the value of document.location.pathname to '/foo/bar/page1'
-    window.history.pushState({}, "", "/foo/bar/page1")
-
+  it("extracts the pageName correctly if we can't get a pageScriptHash (non-main page)", () => {
+    window.history.pushState({}, "", "/foo/")
     instance.sendRerunBackMsg()
 
     // @ts-ignore
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
-      rerunScript: { pageName: "page1", queryString: "" },
+      rerunScript: {
+        pageScriptHash: "",
+        pageName: "foo",
+        queryString: "",
+      },
     })
-    expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
-  it("switches pages correctly when sendRerunbackMsg is given a pageName", () => {
-    const wrapper = shallow(<App {...getProps()} />)
-    const instance = wrapper.instance() as App
-    // @ts-ignore
-    instance.sendBackMsg = jest.fn()
-    // @ts-ignore
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
-    instance.clearAppState = jest.fn()
-
-    instance.sendRerunBackMsg(undefined, "page1")
-
-    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/page1")
-    // @ts-ignore
-    expect(instance.sendBackMsg).toHaveBeenCalledWith({
-      rerunScript: { pageName: "page1", queryString: "" },
-    })
-    expect(instance.clearAppState).toHaveBeenCalled()
-    expect(wrapper.find("AppView").prop("currentPageName")).toEqual("page1")
-  })
-
-  it("also switches pages correctly when a baseUrlPath is set", () => {
-    const wrapper = shallow(<App {...getProps()} />)
-    const instance = wrapper.instance() as App
-    // @ts-ignore
-    instance.sendBackMsg = jest.fn()
+  it("extracts the pageName correctly if we can't get a pageScriptHash and we have a nonempty basePath", () => {
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
 
-    instance.sendRerunBackMsg(undefined, "page1")
+    window.history.pushState({}, "", "/foo/bar/baz")
+    instance.sendRerunBackMsg()
 
-    // Note that, below, the URL should be set to "/foo/bar/page1", but the
-    // pageName passed back to the server is "page1".
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      {},
-      "",
-      "/foo/bar/page1"
-    )
     // @ts-ignore
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
-      rerunScript: { pageName: "page1", queryString: "" },
-    })
-  })
-
-  it("handles a page change correctly if there is also a query string", () => {
-    const wrapper = shallow(
-      <App
-        {...getProps({
-          s4aCommunication: getS4ACommunicationProp({
-            currentState: getS4ACommunicationState({
-              queryParams: "?foo=bar",
-            }),
-            sendMessage: jest.fn(),
-          }),
-        })}
-      />
-    )
-    const instance = wrapper.instance() as App
-    // @ts-ignore
-    instance.sendBackMsg = jest.fn()
-    // @ts-ignore
-    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
-
-    instance.sendRerunBackMsg(undefined, "page1")
-
-    expect(window.history.pushState).toHaveBeenCalledWith(
-      {},
-      "",
-      "/page1?foo=bar"
-    )
-    // @ts-ignore
-    expect(instance.sendBackMsg).toHaveBeenCalledWith({
-      rerunScript: { pageName: "page1", queryString: "foo=bar" },
+      rerunScript: {
+        pageScriptHash: "",
+        pageName: "baz",
+        queryString: "",
+      },
     })
   })
 })
 
+//   * handlePageNotFound has branching error messages depending on pageName
 describe("App.handlePageNotFound", () => {
-  it("displays an error modal", () => {
+  it("includes the missing page name in error modal message if available", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({
+      appPages: [{ pageScriptHash: "page_hash", pageName: "streamlit_app" }],
+    })
     const instance = wrapper.instance() as App
+
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
     instance.showError = jest.fn()
@@ -1043,11 +1106,40 @@ describe("App.handlePageNotFound", () => {
     expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
     expect(instance.showError).toHaveBeenCalledWith(
       "Page not found",
-      `You have requested page /nonexistentPage, but no corresponding file was found in the app's pages/ directory.`
+      expect.stringMatching("You have requested page /nonexistentPage")
     )
     expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_CURRENT_PAGE_NAME",
       currentPageName: "",
+      currentPageScriptHash: "page_hash",
+    })
+  })
+
+  it("uses a more generic error message if no page name is available", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    wrapper.setState({
+      appPages: [{ pageScriptHash: "page_hash", pageName: "streamlit_app" }],
+    })
+    const instance = wrapper.instance() as App
+
+    // @ts-ignore
+    instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
+    instance.showError = jest.fn()
+
+    instance.handlePageNotFound(new PageNotFound({ pageName: "" }))
+
+    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
+    expect(instance.showError).toHaveBeenCalledWith(
+      "Page not found",
+      expect.stringMatching(
+        "The page that you have requested does not seem to exist"
+      )
+    )
+    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "SET_CURRENT_PAGE_NAME",
+      currentPageName: "",
+      currentPageScriptHash: "page_hash",
     })
   })
 })

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1040,7 +1040,7 @@ describe("App.sendRerunBackMsg", () => {
     })
   })
 
-  it("extracts the pageName correctly if we can't get a pageScriptHash (main page)", () => {
+  it("extracts the pageName as an empty string if we can't get a pageScriptHash (main page)", () => {
     instance.sendRerunBackMsg()
 
     // @ts-ignore
@@ -1053,7 +1053,7 @@ describe("App.sendRerunBackMsg", () => {
     })
   })
 
-  it("extracts the pageName correctly if we can't get a pageScriptHash (non-main page)", () => {
+  it("extracts the pageName as the URL path if we can't get a pageScriptHash (non-main page)", () => {
     window.history.pushState({}, "", "/foo/")
     instance.sendRerunBackMsg()
 
@@ -1067,7 +1067,7 @@ describe("App.sendRerunBackMsg", () => {
     })
   })
 
-  it("extracts the pageName correctly if we can't get a pageScriptHash and we have a nonempty basePath", () => {
+  it("extracts the pageName as the last part of the URL if we can't get a pageScriptHash and we have a nonempty basePath", () => {
     // @ts-ignore
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1052,10 +1052,12 @@ export class App extends PureComponent<Props, State> {
       // below, but that doesn't work because basePath may contain unescaped
       // regex special-characters. This is why we're stuck with the
       // weird-looking triple `replace()`.
-      pageName = document.location.pathname
-        .replace(`/${basePath}`, "")
-        .replace(new RegExp("^/?"), "")
-        .replace(new RegExp("/$"), "")
+      pageName = decodeURIComponent(
+        document.location.pathname
+          .replace(`/${basePath}`, "")
+          .replace(new RegExp("^/?"), "")
+          .replace(new RegExp("/$"), "")
+      )
       pageScriptHash = ""
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,6 +71,7 @@ import {
   IGitInfo,
   GitInfo,
   IAppPage,
+  AppPage,
 } from "src/autogen/proto"
 import { without, concat } from "lodash"
 
@@ -143,7 +144,7 @@ interface State {
   hideTopBar: boolean
   hideSidebarNav: boolean
   appPages: IAppPage[]
-  currentPageName: string
+  currentPageScriptHash: string
 }
 
 const ELEMENT_LIST_BUFFER_TIMEOUT_MS = 10
@@ -211,7 +212,7 @@ export class App extends PureComponent<Props, State> {
       gitInfo: null,
       formsData: createFormsData(),
       appPages: [],
-      currentPageName: "",
+      currentPageScriptHash: "",
       // We set hideTopBar to true by default because this information isn't
       // available on page load (we get it when the script begins to run), so
       // the user would see top bar elements for a few ms if this defaulted to
@@ -305,9 +306,11 @@ export class App extends PureComponent<Props, State> {
       this.closeDialog()
     }
 
-    const { requestedPageName } = this.props.s4aCommunication.currentState
-    if (requestedPageName !== null) {
-      this.onPageChange(requestedPageName)
+    const {
+      requestedPageScriptHash,
+    } = this.props.s4aCommunication.currentState
+    if (requestedPageScriptHash !== null) {
+      this.onPageChange(requestedPageScriptHash)
       this.props.s4aCommunication.onPageChanged()
     }
   }
@@ -491,16 +494,17 @@ export class App extends PureComponent<Props, State> {
 
   handlePageNotFound = (pageNotFound: PageNotFound): void => {
     const { pageName } = pageNotFound
-    this.showError(
-      "Page not found",
-      `You have requested page /${pageName}, but no corresponding file was found in the app's pages/ directory.`
-    )
+    const errMsg = pageName
+      ? `You have requested page /${pageName}, but no corresponding file was found in the app's pages/ directory`
+      : "The page that you have requested does not seem to exist"
+    this.showError("Page not found", `${errMsg}. Running the app's main page.`)
 
-    const currentPageName = ""
-    this.setState({ currentPageName }, () => {
+    const currentPageScriptHash = this.state.appPages[0]?.pageScriptHash || ""
+    this.setState({ currentPageScriptHash }, () => {
       this.props.s4aCommunication.sendMessage({
         type: "SET_CURRENT_PAGE_NAME",
-        currentPageName,
+        currentPageName: "",
+        currentPageScriptHash,
       })
     })
   }
@@ -618,8 +622,6 @@ export class App extends PureComponent<Props, State> {
    */
   handleNewSession = (newSessionProto: NewSession): void => {
     const initialize = newSessionProto.initialize as Initialize
-    const config = newSessionProto.config as Config
-    const themeInput = newSessionProto.customTheme as CustomThemeConfig
 
     if (App.hasStreamlitVersionChanged(initialize)) {
       window.location.reload()
@@ -634,12 +636,36 @@ export class App extends PureComponent<Props, State> {
       this.handleOneTimeInitialization(newSessionProto)
     }
 
-    // mainPageName must be a string as we're guaranteed at this point that
+    const config = newSessionProto.config as Config
+    const themeInput = newSessionProto.customTheme as CustomThemeConfig
+    const { currentPageScriptHash } = this.state
+    const newPageScriptHash = newSessionProto.pageScriptHash
+
+    // mainPage must be a string as we're guaranteed at this point that
     // newSessionProto.appPages is nonempty and has a truthy pageName.
     // Otherwise, we'd either have no main script or a nameless main script,
     // neither of which can happen.
-    const mainPageName = newSessionProto.appPages[0]?.pageName as string
-    const { currentPageName } = this.state
+    const mainPage = newSessionProto.appPages[0] as AppPage
+    // We're similarly guaranteed that newPageName will be found / truthy
+    // here.
+    const newPageName = newSessionProto.appPages.find(
+      p => p.pageScriptHash === newPageScriptHash
+    )?.pageName as string
+    const viewingMainPage = newPageScriptHash === mainPage.pageScriptHash
+
+    const baseUriParts = this.getBaseUriParts()
+    if (baseUriParts) {
+      const { basePath } = baseUriParts
+      const queryString = this.getQueryString()
+
+      const qs = queryString ? `?${queryString}` : ""
+      const basePathPrefix = basePath ? `/${basePath}` : ""
+
+      const pagePath = viewingMainPage ? "" : newPageName
+      const pageUrl = `${basePathPrefix}/${pagePath}${qs}`
+
+      window.history.pushState({}, "", pageUrl)
+    }
 
     this.processThemeInput(themeInput)
     this.setState(
@@ -648,6 +674,7 @@ export class App extends PureComponent<Props, State> {
         hideTopBar: config.hideTopBar,
         hideSidebarNav: config.hideSidebarNav,
         appPages: newSessionProto.appPages,
+        currentPageScriptHash: newPageScriptHash,
       },
       () => {
         this.props.s4aCommunication.sendMessage({
@@ -657,7 +684,8 @@ export class App extends PureComponent<Props, State> {
 
         this.props.s4aCommunication.sendMessage({
           type: "SET_CURRENT_PAGE_NAME",
-          currentPageName,
+          currentPageName: viewingMainPage ? "" : newPageName,
+          currentPageScriptHash: newPageScriptHash,
         })
       }
     )
@@ -670,7 +698,7 @@ export class App extends PureComponent<Props, State> {
     )
 
     // Set the title and favicon to their default values
-    document.title = `${currentPageName || mainPageName} · Streamlit`
+    document.title = `${newPageName} · Streamlit`
     handleFavicon(
       `${process.env.PUBLIC_URL}/favicon.png`,
       this.getBaseUriParts()
@@ -684,10 +712,13 @@ export class App extends PureComponent<Props, State> {
 
     MetricsManager.current.enqueue("updateReport", {
       numPages: newSessionProto.appPages.length,
-      isMainPage: currentPageName === "" || currentPageName === mainPageName,
+      isMainPage: viewingMainPage,
     })
 
-    if (appHash === newSessionHash) {
+    if (
+      appHash === newSessionHash &&
+      currentPageScriptHash === newPageScriptHash
+    ) {
       this.setState({
         scriptRunId,
       })
@@ -971,13 +1002,13 @@ export class App extends PureComponent<Props, State> {
     )
   }
 
-  onPageChange = (pageName: string): void => {
-    this.sendRerunBackMsg(undefined, pageName)
+  onPageChange = (pageScriptHash: string): void => {
+    this.sendRerunBackMsg(undefined, pageScriptHash)
   }
 
   sendRerunBackMsg = (
     widgetStates?: WidgetStates,
-    pageName?: string
+    pageScriptHash?: string
   ): void => {
     const baseUriParts = this.getBaseUriParts()
     if (!baseUriParts) {
@@ -989,16 +1020,26 @@ export class App extends PureComponent<Props, State> {
       return
     }
 
+    const { currentPageScriptHash } = this.state
     const { basePath } = baseUriParts
     const queryString = this.getQueryString()
+    let pageName = ""
 
-    // NOTE: We specifically check for `null` or `undefined` instead of making
-    //       a falsy check below because navigating to "" can be used to
-    //       navigate to the main page of an app.
-    if (pageName === undefined) {
-      // If pageName is undefined, we're not switching pages, so we should
-      // use the current URL to determine the pageName.
-      //
+    if (pageScriptHash) {
+      // The user specified exactly which page to run. We can simply use this
+      // value in the BackMsg we send to the server.
+    } else if (currentPageScriptHash) {
+      // The user didn't specify which page to run, which happens when they
+      // click the "Rerun" button in the hamburger menu. In this case, we
+      // rerun the current page.
+      pageScriptHash = currentPageScriptHash
+    } else {
+      // We must be in the case where the user is navigating directly to a
+      // non-main page of this app. Since we haven't received the list of the
+      // app's pages from the server at this point, we fall back to requesting
+      // requesting the page to run via pageName, which we extract from
+      // document.location.pathname
+
       // Note also that we'd prefer to write something like
       //
       // ```
@@ -1010,27 +1051,17 @@ export class App extends PureComponent<Props, State> {
       //
       // below, but that doesn't work because basePath may contain unescaped
       // regex special-characters. This is why we're stuck with the
-      // weird-looking double `replace()`.
+      // weird-looking triple `replace()`.
       pageName = document.location.pathname
         .replace(`/${basePath}`, "")
         .replace(new RegExp("^/?"), "")
         .replace(new RegExp("/$"), "")
-    } else {
-      const { appHash, scriptRunId, scriptName } = this.state
-      this.clearAppState(appHash as string, scriptRunId, scriptName)
-
-      const qs = queryString ? `?${queryString}` : ""
-      const basePathPrefix = basePath ? `/${basePath}` : ""
-
-      const pageUrl = `${basePathPrefix}/${pageName}${qs}`
-      window.history.pushState({}, "", pageUrl)
+      pageScriptHash = ""
     }
-
-    this.setState({ currentPageName: pageName })
 
     this.sendBackMsg(
       new BackMsg({
-        rerunScript: { queryString, widgetStates, pageName },
+        rerunScript: { queryString, widgetStates, pageScriptHash, pageName },
       })
     )
 
@@ -1212,7 +1243,7 @@ export class App extends PureComponent<Props, State> {
       gitInfo,
       hideTopBar,
       hideSidebarNav,
-      currentPageName,
+      currentPageScriptHash,
     } = this.state
 
     const {
@@ -1318,7 +1349,7 @@ export class App extends PureComponent<Props, State> {
               formsData={this.state.formsData}
               appPages={this.state.appPages}
               onPageChange={this.onPageChange}
-              currentPageName={currentPageName}
+              currentPageScriptHash={currentPageScriptHash}
               hideSidebarNav={hideSidebarNav || s4AHideSidebarNav}
               pageLinkBaseUrl={
                 this.props.s4aCommunication.currentState.pageLinkBaseUrl

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -48,9 +48,9 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     widgetsDisabled: true,
     componentRegistry: new ComponentRegistry(() => undefined),
     formsData,
-    appPages: [{ pageName: "streamlit_app", scriptPath: "streamlit_app.py" }],
+    appPages: [{ pageName: "streamlit_app", pageScriptHash: "page_hash" }],
     onPageChange: jest.fn(),
-    currentPageName: "streamlit_app",
+    currentPageScriptHash: "main_page_script_hash",
     hideSidebarNav: false,
     pageLinkBaseUrl: "",
     ...props,
@@ -94,15 +94,15 @@ describe("AppView element", () => {
     expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
     expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
-    expect(wrapper.find("ThemedSidebar").prop("currentPageName")).toBe(
-      "streamlit_app"
+    expect(wrapper.find("ThemedSidebar").prop("currentPageScriptHash")).toBe(
+      "main_page_script_hash"
     )
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
     const appPages = [
-      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      { pageName: "streamlit_app", pageScriptHash: "page_hash" },
+      { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const wrapper = shallow(<AppView {...getProps({ appPages })} />)
 
@@ -126,8 +126,8 @@ describe("AppView element", () => {
     const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
 
     const appPages = [
-      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      { pageName: "streamlit_app", pageScriptHash: "page_hash" },
+      { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const props = getProps({
       elements: new AppRoot(new BlockNode([main, sidebar])),
@@ -142,8 +142,8 @@ describe("AppView element", () => {
 
   it("does not render the sidebar if there are no elements, multiple pages but hideSidebarNav is true", () => {
     const appPages = [
-      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      { pageName: "streamlit_app", pageScriptHash: "page_hash" },
+      { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const props = getProps({
       appPages,

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -60,7 +60,7 @@ export interface AppViewProps {
 
   onPageChange: (pageName: string) => void
 
-  currentPageName: string
+  currentPageScriptHash: string
 
   hideSidebarNav: boolean
 
@@ -82,7 +82,7 @@ function AppView(props: AppViewProps): ReactElement {
     formsData,
     appPages,
     onPageChange,
-    currentPageName,
+    currentPageScriptHash,
     hideSidebarNav,
     pageLinkBaseUrl,
   } = props
@@ -137,7 +137,7 @@ function AppView(props: AppViewProps): ReactElement {
           appPages={appPages}
           hasElements={hasSidebarElements}
           onPageChange={onPageChange}
-          currentPageName={currentPageName}
+          currentPageScriptHash={currentPageScriptHash}
           hideSidebarNav={hideSidebarNav}
           pageLinkBaseUrl={pageLinkBaseUrl}
         >

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -35,7 +35,7 @@ function renderSideBar(props: Partial<SidebarProps> = {}): ReactWrapper {
       theme={lightTheme}
       appPages={[]}
       onPageChange={jest.fn()}
-      currentPageName={""}
+      currentPageScriptHash={""}
       hasElements
       pageLinkBaseUrl={""}
       hideSidebarNav={false}
@@ -114,9 +114,7 @@ describe("Sidebar Component", () => {
 
   it("has extra top and bottom padding if no SidebarNav is displayed", () => {
     const wrapper = renderSideBar({
-      appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      ],
+      appPages: [{ pageName: "streamlit_app", pageScriptHash: "page_hash" }],
     })
 
     expect(wrapper.find("StyledSidebarUserContent")).toHaveStyleRule(
@@ -128,8 +126,8 @@ describe("Sidebar Component", () => {
   it("has less padding if the SidebarNav is displayed", () => {
     const wrapper = renderSideBar({
       appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-        { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+        { pageName: "streamlit_app", pageScriptHash: "page_hash" },
+        { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
       ],
     })
 
@@ -165,8 +163,8 @@ describe("Sidebar Component", () => {
 
   it("renders SidebarNav component", () => {
     const appPages = [
-      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      { pageName: "streamlit_app", pageScriptHash: "page_hash" },
+      { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const wrapper = renderSideBar({ appPages })
 
@@ -182,8 +180,8 @@ describe("Sidebar Component", () => {
 
   it("can hide SidebarNav with the hideSidebarNav option", () => {
     const appPages = [
-      { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-      { pageName: "streamlit_app2", scriptPath: "streamlit_app2.py" },
+      { pageName: "streamlit_app", pageScriptHash: "page_hash" },
+      { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const wrapper = renderSideBar({ appPages, hideSidebarNav: true })
 

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ export interface SidebarProps {
   hasElements: boolean
   appPages: IAppPage[]
   onPageChange: (pageName: string) => void
-  currentPageName: string
+  currentPageScriptHash: string
   hideSidebarNav: boolean
   pageLinkBaseUrl: string
 }
@@ -162,6 +162,8 @@ class Sidebar extends PureComponent<SidebarProps, State> {
     this.setState({ hideScrollbar: newValue })
   }
 
+  // BUG(tvst): X button should have same color as hamburger.
+  // BUG(tvst): X and > buttons should have same margins as hamburger.
   public render(): ReactNode {
     const { collapsedSidebar } = this.state
     const {
@@ -170,7 +172,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
       children,
       hasElements,
       onPageChange,
-      currentPageName,
+      currentPageScriptHash,
       hideSidebarNav,
       pageLinkBaseUrl,
     } = this.props
@@ -199,7 +201,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
               hasSidebarElements={hasElements}
               onPageChange={onPageChange}
               hideParentScrollbar={this.hideScrollbar}
-              currentPageName={currentPageName}
+              currentPageScriptHash={currentPageScriptHash}
               pageLinkBaseUrl={pageLinkBaseUrl}
             />
           )}

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -52,13 +52,13 @@ const mockUseIsOverflowing = useIsOverflowing as jest.MockedFunction<
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   appPages: [
-    { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-    { pageName: "my_other_page", scriptPath: "my_other_page.py" },
+    { pageScriptHash: "main_page_hash", pageName: "streamlit_app" },
+    { pageScriptHash: "other_page_hash", pageName: "my_other_page" },
   ],
   hasSidebarElements: false,
   onPageChange: jest.fn(),
   hideParentScrollbar: jest.fn(),
-  currentPageName: "",
+  currentPageScriptHash: "",
   pageLinkBaseUrl: "",
   ...props,
 })
@@ -348,19 +348,7 @@ describe("SidebarNav", () => {
     )
   })
 
-  it("passes the empty string to onPageChange if the main page link is clicked", () => {
-    const props = getProps()
-    const wrapper = shallow(<SidebarNav {...props} />)
-
-    const preventDefault = jest.fn()
-    const links = wrapper.find(StyledSidebarNavLink)
-    links.at(0).simulate("click", { preventDefault })
-
-    expect(preventDefault).toHaveBeenCalled()
-    expect(props.onPageChange).toHaveBeenCalledWith("")
-  })
-
-  it("passes the page name to onPageChange if any other link is clicked", () => {
+  it("passes the pageScriptHash to onPageChange if a link is clicked", () => {
     const props = getProps()
     const wrapper = shallow(<SidebarNav {...props} />)
 
@@ -369,7 +357,7 @@ describe("SidebarNav", () => {
     links.at(1).simulate("click", { preventDefault })
 
     expect(preventDefault).toHaveBeenCalled()
-    expect(props.onPageChange).toHaveBeenCalledWith("my_other_page")
+    expect(props.onPageChange).toHaveBeenCalledWith("other_page_hash")
   })
 
   it("calls hideParentScrollbar onMouseOut", () => {
@@ -403,12 +391,8 @@ describe("SidebarNav", () => {
   it("handles default and custom page icons", () => {
     const props = getProps({
       appPages: [
-        { pageName: "streamlit_app", scriptPath: "streamlit_app.py" },
-        {
-          pageName: "my_other_page",
-          scriptPath: "my_other_page.py",
-          icon: "🦈",
-        },
+        { pageName: "streamlit_app" },
+        { pageName: "my_other_page", icon: "🦈" },
       ],
     })
 
@@ -433,7 +417,7 @@ describe("SidebarNav", () => {
   })
 
   it("indicates the current page as active", () => {
-    const props = getProps({ currentPageName: "my_other_page" })
+    const props = getProps({ currentPageScriptHash: "other_page_hash" })
 
     const wrapper = shallow(<SidebarNav {...props} />)
 
@@ -449,24 +433,5 @@ describe("SidebarNav", () => {
         .at(1)
         .prop("isActive")
     ).toBe(true)
-  })
-
-  it("sets the main page as active if currentPageName is the empty string", () => {
-    const props = getProps()
-
-    const wrapper = shallow(<SidebarNav {...props} />)
-
-    expect(
-      wrapper
-        .find(StyledSidebarNavLink)
-        .at(0)
-        .prop("isActive")
-    ).toBe(true)
-    expect(
-      wrapper
-        .find(StyledSidebarNavLink)
-        .at(1)
-        .prop("isActive")
-    ).toBe(false)
   })
 })

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -41,17 +41,7 @@ export interface Props {
   onPageChange: (pageName: string) => void
   hideParentScrollbar: (newValue: boolean) => void
 
-  // BUG(vdonato): currentPageName is not guaranteed to be unique. This means we show 2+ pages
-  // as "active" at the same time, if they have the same name.
-  //
-  // Potential solutions:
-  // 1. Add "isActive" boolean to items inside appPages
-  // 2. Instead of currentPageName send currentPageIndex (i.e. index of active page in the appPages
-  //    array).
-  //
-  // BUG(tvst): X button should have same color as hamburger.
-  // BUG(tvst): X and > buttons should have same margins as hamburger.
-  currentPageName: string
+  currentPageScriptHash: string
   pageLinkBaseUrl: string
 }
 
@@ -60,7 +50,7 @@ const SidebarNav = ({
   hasSidebarElements,
   onPageChange,
   hideParentScrollbar,
-  currentPageName,
+  currentPageScriptHash,
   pageLinkBaseUrl,
 }: Props): ReactElement | null => {
   if (appPages.length < 2) {
@@ -103,7 +93,10 @@ const SidebarNav = ({
         onMouseOut={onMouseOut}
       >
         {appPages.map(
-          ({ icon: pageIcon, pageName }: IAppPage, pageIndex: number) => {
+          (
+            { icon: pageIcon, pageName, pageScriptHash }: IAppPage,
+            pageIndex: number
+          ) => {
             pageName = pageName as string
             // NOTE: We use window.location to get the port instead of
             // getBaseUriParts() because the port may differ in dev mode (since
@@ -125,24 +118,15 @@ const SidebarNav = ({
               pageUrl = `${protocol}//${host}${portSection}/${basePathSection}${navigateTo}`
             }
 
-            // The main page can be specified either by its full name or by
-            // having currentPageName === "". We could have alternatively made
-            // it such that currentPageName is always the full page name, but
-            // it turns out that taking that approach makes things messier
-            // overall.
-            const isActive =
-              (pageIndex === 0 && !currentPageName) ||
-              currentPageName === pageName
-
             return (
               <li key={pageName}>
                 <StyledSidebarNavLinkContainer>
                   <StyledSidebarNavLink
-                    isActive={isActive}
+                    isActive={pageScriptHash === currentPageScriptHash}
                     href={pageUrl}
                     onClick={e => {
                       e.preventDefault()
-                      onPageChange(navigateTo)
+                      onPageChange(pageScriptHash as string)
                     }}
                   >
                     {pageIcon && pageIcon.length ? (

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -27,7 +27,7 @@ function getProps(
   return {
     appPages: [],
     onPageChange: jest.fn(),
-    currentPageName: "streamlit_app",
+    currentPageScriptHash: "page_hash",
     hasElements: true,
     hideSidebarNav: false,
     pageLinkBaseUrl: "",
@@ -60,8 +60,8 @@ describe("ThemedSidebar Component", () => {
     const wrapper = mount(<ThemedSidebar {...getProps({ appPages })} />)
 
     expect(wrapper.find("Sidebar").prop("appPages")).toEqual(appPages)
-    expect(wrapper.find("Sidebar").prop("currentPageName")).toBe(
-      "streamlit_app"
+    expect(wrapper.find("Sidebar").prop("currentPageScriptHash")).toBe(
+      "page_hash"
     )
     expect(typeof wrapper.find("Sidebar").prop("onPageChange")).toBe(
       "function"

--- a/frontend/src/hocs/withS4ACommunication/types.ts
+++ b/frontend/src/hocs/withS4ACommunication/types.ts
@@ -35,7 +35,7 @@ export interface S4ACommunicationState {
   menuItems: IMenuItem[]
   pageLinkBaseUrl: string
   queryParams: string
-  requestedPageName: string | null
+  requestedPageScriptHash: string | null
   sidebarChevronDownshift: number
   streamlitShareMetadata: StreamlitShareMetadata
   toolbarItems: IToolbarItem[]
@@ -66,7 +66,7 @@ export type IHostToGuestMessage = {
     }
   | {
       type: "REQUEST_PAGE_CHANGE"
-      pageName: string
+      pageScriptHash: string
     }
   | {
       type: "SET_IS_OWNER"
@@ -125,6 +125,7 @@ export type IGuestToHostMessage =
   | {
       type: "SET_CURRENT_PAGE_NAME"
       currentPageName: string
+      currentPageScriptHash: string
     }
   | {
       type: "SET_PAGE_FAVICON"

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.test.tsx
@@ -195,7 +195,7 @@ describe("withS4ACommunication HOC", () => {
           data: {
             stCommVersion: S4A_COMM_VERSION,
             type: "REQUEST_PAGE_CHANGE",
-            pageName: "page1",
+            pageScriptHash: "hash1",
           },
           origin: "http://devel.streamlit.test",
         })
@@ -205,7 +205,7 @@ describe("withS4ACommunication HOC", () => {
 
     const innerComponent = wrapper.find(TestComponentNaked)
     const props = innerComponent.prop("s4aCommunication")
-    expect(props.currentState.requestedPageName).toBe("page1")
+    expect(props.currentState.requestedPageScriptHash).toBe("hash1")
 
     act(() => {
       innerComponent.prop("s4aCommunication").onPageChanged()
@@ -214,7 +214,7 @@ describe("withS4ACommunication HOC", () => {
 
     const innerComponent2 = wrapper.find(TestComponentNaked)
     const props2 = innerComponent2.prop("s4aCommunication")
-    expect(props2.currentState.requestedPageName).toBe(null)
+    expect(props2.currentState.requestedPageScriptHash).toBe(null)
   })
 
   it("can process a received SET_PAGE_LINK_BASE_URL message", () => {

--- a/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
+++ b/frontend/src/hocs/withS4ACommunication/withS4ACommunication.tsx
@@ -62,9 +62,9 @@ function withS4ACommunication(
     const [menuItems, setMenuItems] = useState<IMenuItem[]>([])
     const [pageLinkBaseUrl, setPageLinkBaseUrl] = useState("")
     const [queryParams, setQueryParams] = useState("")
-    const [requestedPageName, setRequestedPageName] = useState<string | null>(
-      null
-    )
+    const [requestedPageScriptHash, setRequestedPageScriptHash] = useState<
+      string | null
+    >(null)
     const [sidebarChevronDownshift, setSidebarChevronDownshift] = useState(0)
     const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
     const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
@@ -95,7 +95,7 @@ function withS4ACommunication(
         }
 
         if (message.type === "REQUEST_PAGE_CHANGE") {
-          setRequestedPageName(message.pageName)
+          setRequestedPageScriptHash(message.pageScriptHash)
         }
 
         if (message.type === "SET_IS_OWNER") {
@@ -153,7 +153,7 @@ function withS4ACommunication(
               menuItems,
               pageLinkBaseUrl,
               queryParams,
-              requestedPageName,
+              requestedPageScriptHash,
               sidebarChevronDownshift,
               streamlitShareMetadata,
               toolbarItems,
@@ -167,7 +167,7 @@ function withS4ACommunication(
               setForcedModalClose(false)
             },
             onPageChanged: () => {
-              setRequestedPageName(null)
+              setRequestedPageScriptHash(null)
             },
             sendMessage: sendS4AMessage,
           } as S4ACommunicationHOC

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -520,14 +520,14 @@ def experimental_rerun() -> NoReturn:
     ctx = _get_script_run_ctx()
 
     query_string = ""
-    page_name = ""
+    page_script_hash = ""
     if ctx is not None:
         query_string = ctx.query_string
-        page_name = ctx.page_name
+        page_script_hash = ctx.page_script_hash
 
     raise _RerunException(
         _RerunData(
             query_string=query_string,
-            page_name=page_name,
+            page_script_hash=page_script_hash,
         )
     )

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -45,6 +45,7 @@ from streamlit.scriptrunner import (
     ScriptRunner,
     ScriptRunnerEvent,
 )
+from streamlit.util import calc_md5
 from streamlit.watcher import LocalSourcesWatcher
 
 LOGGER = get_logger(__name__)
@@ -216,7 +217,9 @@ class AppSession:
             self._scriptrunner, ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
         )
         self._on_scriptrunner_event(
-            self._scriptrunner, ScriptRunnerEvent.SCRIPT_STARTED
+            self._scriptrunner,
+            ScriptRunnerEvent.SCRIPT_STARTED,
+            page_script_hash="",
         )
         self._on_scriptrunner_event(
             self._scriptrunner, ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
@@ -249,10 +252,12 @@ class AppSession:
             return
 
         if client_state:
+            # TODO(vdonato): Fall back to page_name if page_script_hash is unavailable.
+            # Also handle page not found cases.
             rerun_data = RerunData(
                 client_state.query_string,
                 client_state.widget_states,
-                client_state.page_name,
+                client_state.page_script_hash,
             )
         else:
             rerun_data = RerunData()
@@ -296,30 +301,16 @@ class AppSession:
 
     def _should_rerun_on_file_change(self, filepath: str) -> bool:
         main_script_path = self._session_data.main_script_path
+        pages = source_util.get_pages(main_script_path)
 
-        def has_matching_script_path(page_info):
-            # When iterating through source_util.get_pages(main_script_path).items(),
-            # we get a tuple of form (page_name, page_info).
-            _, page_info = page_info
-            return page_info["script_path"] == filepath
-
-        changed_page_name, changed_page_info = next(
-            filter(
-                has_matching_script_path,
-                source_util.get_pages(main_script_path).items(),
-            ),
-            (None, None),
+        changed_page_script_hash = next(
+            filter(lambda k: pages[k]["script_path"] == filepath, pages),
+            None,
         )
 
-        # We technically only need to check one of the if statement clauses
-        # below, but checking both helps out the type checker.
-        if changed_page_name is not None and changed_page_info is not None:
-            is_main_page = changed_page_info["script_path"] == main_script_path
-            current_page_name = self._client_state.page_name
-
-            return (is_main_page and current_page_name == "") or (
-                current_page_name == changed_page_name
-            )
+        if changed_page_script_hash is not None:
+            current_page_script_hash = self._client_state.page_script_hash
+            return changed_page_script_hash == current_page_script_hash
 
         return True
 
@@ -363,6 +354,7 @@ class AppSession:
         forward_msg: Optional[ForwardMsg] = None,
         exception: Optional[BaseException] = None,
         client_state: Optional[ClientState] = None,
+        page_script_hash: Optional[str] = None,
     ) -> None:
         """Called when our ScriptRunner emits an event.
 
@@ -372,7 +364,7 @@ class AppSession:
         """
         self._ioloop.spawn_callback(
             lambda: self._handle_scriptrunner_event_on_main_thread(
-                sender, event, forward_msg, exception, client_state
+                sender, event, forward_msg, exception, client_state, page_script_hash
             )
         )
 
@@ -383,6 +375,7 @@ class AppSession:
         forward_msg: Optional[ForwardMsg] = None,
         exception: Optional[BaseException] = None,
         client_state: Optional[ClientState] = None,
+        page_script_hash: Optional[str] = None,
     ) -> None:
         """Handle a ScriptRunner event.
 
@@ -410,6 +403,9 @@ class AppSession:
             The ScriptRunner's final ClientState. Set only for the
             SHUTDOWN event.
 
+        page_script_hash : str | None
+            A hash of the script path corresponding to the page currently being
+            run. Set only for the SCRIPT_STARTED event.
         """
 
         assert (
@@ -431,8 +427,14 @@ class AppSession:
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_IS_RUNNING
 
+            assert (
+                page_script_hash is not None
+            ), "page_script_hash must be set for the SCRIPT_STARTED event"
+
             self._clear_queue()
-            self._enqueue_forward_msg(self._create_new_session_message())
+            self._enqueue_forward_msg(
+                self._create_new_session_message(page_script_hash)
+            )
 
         elif (
             event == ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
@@ -508,13 +510,14 @@ class AppSession:
         msg.session_event.script_changed_on_disk = True
         return msg
 
-    def _create_new_session_message(self) -> ForwardMsg:
+    def _create_new_session_message(self, page_script_hash: str) -> ForwardMsg:
         """Create and return a new_session ForwardMsg."""
         msg = ForwardMsg()
 
         msg.new_session.script_run_id = _generate_scriptrun_id()
         msg.new_session.name = self._session_data.name
         msg.new_session.main_script_path = self._session_data.main_script_path
+        msg.new_session.page_script_hash = page_script_hash
 
         _populate_app_pages(msg.new_session, self._session_data.main_script_path)
         _populate_config_msg(msg.new_session.config)
@@ -702,9 +705,9 @@ def _populate_user_info_msg(msg: UserInfo) -> None:
 def _populate_app_pages(
     msg: Union[NewSession, PagesChanged], main_script_path: str
 ) -> None:
-    for page_name, page_info in source_util.get_pages(main_script_path).items():
+    for page_script_hash, page_info in source_util.get_pages(main_script_path).items():
         page_proto = msg.app_pages.add()
 
-        page_proto.page_name = page_name
-        page_proto.script_path = page_info["script_path"]
+        page_proto.page_script_hash = page_script_hash
+        page_proto.page_name = page_info["page_name"]
         page_proto.icon = page_info["icon"]

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -252,12 +252,11 @@ class AppSession:
             return
 
         if client_state:
-            # TODO(vdonato): Fall back to page_name if page_script_hash is unavailable.
-            # Also handle page not found cases.
             rerun_data = RerunData(
                 client_state.query_string,
                 client_state.widget_states,
                 client_state.page_script_hash,
+                client_state.page_name,
             )
         else:
             rerun_data = RerunData()

--- a/lib/streamlit/scriptrunner/script_requests.py
+++ b/lib/streamlit/scriptrunner/script_requests.py
@@ -43,6 +43,7 @@ class RerunData:
     query_string: str = ""
     widget_states: Optional[WidgetStates] = None
     page_script_hash: str = ""
+    page_name: str = ""
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
@@ -122,6 +123,7 @@ class ScriptRequests:
                         query_string=new_data.query_string,
                         widget_states=coalesced_states,
                         page_script_hash=new_data.page_script_hash,
+                        page_name=new_data.page_name,
                     )
                     return True
 

--- a/lib/streamlit/scriptrunner/script_requests.py
+++ b/lib/streamlit/scriptrunner/script_requests.py
@@ -42,7 +42,7 @@ class RerunData:
 
     query_string: str = ""
     widget_states: Optional[WidgetStates] = None
-    page_name: str = ""
+    page_script_hash: str = ""
 
 
 @attr.s(auto_attribs=True, slots=True, frozen=True)
@@ -121,7 +121,7 @@ class ScriptRequests:
                     self._rerun_data = RerunData(
                         query_string=new_data.query_string,
                         widget_states=coalesced_states,
-                        page_name=new_data.page_name,
+                        page_script_hash=new_data.page_script_hash,
                     )
                     return True
 

--- a/lib/streamlit/scriptrunner/script_run_context.py
+++ b/lib/streamlit/scriptrunner/script_run_context.py
@@ -45,7 +45,7 @@ class ScriptRunContext:
     query_string: str
     session_state: SafeSessionState
     uploaded_file_mgr: UploadedFileManager
-    page_name: str
+    page_script_hash: str
 
     _set_page_config_allowed: bool = True
     _has_script_started: bool = False
@@ -54,12 +54,12 @@ class ScriptRunContext:
     cursors: Dict[int, "streamlit.cursor.RunningCursor"] = attr.Factory(dict)
     dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = attr.Factory(list)
 
-    def reset(self, query_string: str = "", page_name: str = "") -> None:
+    def reset(self, query_string: str = "", page_script_hash: str = "") -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
         self.form_ids_this_run = set()
         self.query_string = query_string
-        self.page_name = page_name
+        self.page_script_hash = page_script_hash
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False

--- a/lib/streamlit/scriptrunner/script_runner.py
+++ b/lib/streamlit/scriptrunner/script_runner.py
@@ -395,40 +395,72 @@ class ScriptRunner:
         # Reset DeltaGenerators, widgets, media files.
         in_memory_file_manager.clear_session_files()
 
+        main_script_path = self._session_data.main_script_path
+        pages = source_util.get_pages(main_script_path)
+        # Safe because pages will at least contain the app's main page.
+        main_page_info = list(pages.values())[0]
+        current_page_info = None
+
+        if rerun_data.page_script_hash:
+            current_page_info = pages.get(rerun_data.page_script_hash, None)
+        elif not rerun_data.page_script_hash and rerun_data.page_name:
+            # If a user navigates directly to a non-main page of an app, we get
+            # the first script run request before the list of pages has been
+            # sent to the frontend. In this case, we choose the first script
+            # with a name matching the requested page name.
+            current_page_info = next(
+                filter(
+                    # There seems to be this weird bug with mypy where it
+                    # thinks that p can be None (which is impossible given the
+                    # types of pages), so we add `p and` at the beginning of
+                    # the predicate to circumvent this.
+                    lambda p: p and (p["page_name"] == rerun_data.page_name),
+                    pages.values(),
+                ),
+                None,
+            )
+        else:
+            # If no information about what page to run is given, default to
+            # running the main page.
+            current_page_info = main_page_info
+
+        page_script_hash = (
+            current_page_info["page_script_hash"]
+            if current_page_info is not None
+            else main_page_info["page_script_hash"]
+        )
+
         ctx = self._get_script_run_ctx()
         ctx.reset(
             query_string=rerun_data.query_string,
-            page_script_hash=rerun_data.page_script_hash,
+            page_script_hash=page_script_hash,
         )
 
         self.on_event.send(
             self,
             event=ScriptRunnerEvent.SCRIPT_STARTED,
-            page_script_hash=rerun_data.page_script_hash,
+            page_script_hash=page_script_hash,
         )
 
         # Compile the script. Any errors thrown here will be surfaced
         # to the user via a modal dialog in the frontend, and won't result
         # in their previous script elements disappearing.
-
         try:
-            script_path = None
+            if current_page_info:
+                script_path = current_page_info["script_path"]
+            else:
+                script_path = main_script_path
 
-            if rerun_data.page_script_hash:
-                page_info = source_util.get_pages(
-                    self._session_data.main_script_path
-                ).get(rerun_data.page_script_hash, None)
-
-                if page_info:
-                    script_path = page_info["script_path"]
-                else:
-                    msg = ForwardMsg()
-                    # TODO(vdonato): Write an explanatory comment.
-                    msg.page_not_found.page_name = ""
-                    ctx.enqueue(msg)
-
-            if not script_path:
-                script_path = self._session_data.main_script_path
+                # At this point, we know that either
+                #   * the script corresponding to the hash requested no longer
+                #     exists, or
+                #   * we were not able to find a script with the requested page
+                #     name.
+                # In both of these cases, we want to send a page_not_found
+                # message to the frontend.
+                msg = ForwardMsg()
+                msg.page_not_found.page_name = rerun_data.page_name
+                ctx.enqueue(msg)
 
             with source_util.open_python_file(script_path) as f:
                 filebody = f.read()

--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -419,8 +419,13 @@ class Server:
                         {
                             "path": "%s/" % static_path,
                             "default_filename": "index.html",
-                            "get_pages": lambda: source_util.get_pages(
-                                self.main_script_path
+                            "get_pages": lambda: set(
+                                [
+                                    page_info["page_name"]
+                                    for page_info in source_util.get_pages(
+                                        self.main_script_path
+                                    ).values()
+                                ]
                             ),
                         },
                     ),

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 from blinker import Signal
 
 from streamlit.logger import get_logger
+from streamlit.util import calc_md5
 
 LOGGER = get_logger(__name__)
 
@@ -142,9 +143,9 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
         main_script_path = Path(main_script_path_str)
         main_page_name, main_page_icon = page_name_and_icon(main_script_path)
 
-        used_page_names = {main_page_name}
         pages = {
-            main_page_name: {
+            calc_md5(main_script_path_str): {
+                "page_name": main_page_name,
                 "icon": main_page_icon,
                 "script_path": str(main_script_path),
             }
@@ -157,12 +158,13 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
         )
 
         for script_path in page_scripts:
+            script_path_str = str(script_path)
             pn, pi = page_name_and_icon(script_path)
-            if pn in used_page_names:
-                continue
-
-            used_page_names.add(pn)
-            pages[pn] = {"icon": pi, "script_path": str(script_path)}
+            pages[calc_md5(script_path_str)] = {
+                "page_name": pn,
+                "icon": pi,
+                "script_path": script_path_str,
+            }
 
         _cached_pages = pages
 

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -142,9 +142,14 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
 
         main_script_path = Path(main_script_path_str)
         main_page_name, main_page_icon = page_name_and_icon(main_script_path)
+        main_page_script_hash = calc_md5(main_script_path_str)
 
+        # NOTE: We include the page_script_hash in the dict even though it is
+        #       already used as the key because that occasionally makes things
+        #       easier for us when we need to iterate over pages.
         pages = {
-            calc_md5(main_script_path_str): {
+            main_page_script_hash: {
+                "page_script_hash": main_page_script_hash,
                 "page_name": main_page_name,
                 "icon": main_page_icon,
                 "script_path": str(main_script_path),
@@ -160,7 +165,10 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
         for script_path in page_scripts:
             script_path_str = str(script_path)
             pn, pi = page_name_and_icon(script_path)
-            pages[calc_md5(script_path_str)] = {
+            psh = calc_md5(script_path_str)
+
+            pages[psh] = {
+                "page_script_hash": psh,
                 "page_name": pn,
                 "icon": pi,
                 "script_path": script_path_str,

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -15,6 +15,7 @@
 """A bunch of useful utilities."""
 
 import functools
+import hashlib
 import os
 import subprocess
 
@@ -141,3 +142,10 @@ def lower_clean_dict_keys(dict: Mapping[_Key, _Value]) -> Dict[str, _Value]:
 # TODO: Move this into errors.py? Replace with StreamlitAPIException?
 class Error(Exception):
     pass
+
+
+def calc_md5(s: str) -> str:
+    """Return the md5 hash of the given string."""
+    h = hashlib.new("md5")
+    h.update(s.encode("utf-8"))
+    return h.hexdigest()

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -57,7 +57,7 @@ with patch(
     config.get_config_options(force_reparse=True)
 
     # Set source_util._cached_pages to the empty dict below so that
-    # source_util.get_pages behavior is deterministic and doesn't depend on the
+    # source_util.get_pages' behavior is deterministic and doesn't depend on the
     # filesystem of the machine tests are being run on. Tests that need
     # source_util.get_pages to depend on the filesystem can patch this value
     # back to None.

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -178,7 +178,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
                 query_string="",
                 session_state=SessionState(),
                 uploaded_file_mgr=None,
-                page_name="",
+                page_script_hash="",
             ),
         )
         with patch.object(call_stack, "_show_cached_st_function_warning") as warning:

--- a/lib/tests/streamlit/script_run_context_test.py
+++ b/lib/tests/streamlit/script_run_context_test.py
@@ -32,7 +32,7 @@ class ScriptRunContextTest(unittest.TestCase):
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
-            page_name="",
+            page_script_hash="",
         )
 
         msg = ForwardMsg()
@@ -53,7 +53,7 @@ class ScriptRunContextTest(unittest.TestCase):
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
-            page_name="",
+            page_script_hash="",
         )
 
         ctx.on_script_start()
@@ -78,7 +78,7 @@ class ScriptRunContextTest(unittest.TestCase):
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
-            page_name="",
+            page_script_hash="",
         )
 
         ctx.on_script_start()
@@ -102,7 +102,7 @@ class ScriptRunContextTest(unittest.TestCase):
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
-            page_name="",
+            page_script_hash="",
         )
 
         ctx.on_script_start()

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -613,10 +613,22 @@ class ScriptRunnerTest(AsyncTestCase):
         scriptrunner.join()
         self._assert_no_exceptions(scriptrunner)
 
-    def test_query_string_and_page_name_saved(self):
+    @patch(
+        "streamlit.source_util.get_pages",
+        MagicMock(
+            return_value={
+                "hash1": {
+                    "script_path": os.path.join(
+                        os.path.dirname(__file__), "test_data", "good_script.py"
+                    ),
+                },
+            },
+        ),
+    )
+    def test_query_string_and_page_script_hash_saved(self):
         scriptrunner = TestScriptRunner("good_script.py")
         scriptrunner.request_rerun(
-            RerunData(query_string="foo=bar", page_name="good_script")
+            RerunData(query_string="foo=bar", page_script_hash="hash1")
         )
         scriptrunner.start()
         scriptrunner.join()
@@ -634,7 +646,7 @@ class ScriptRunnerTest(AsyncTestCase):
 
         shutdown_data = scriptrunner.event_data[-1]
         self.assertEqual(shutdown_data["client_state"].query_string, "foo=bar")
-        self.assertEqual(shutdown_data["client_state"].page_name, "good_script")
+        self.assertEqual(shutdown_data["client_state"].page_script_hash, "hash1")
 
     def test_coalesce_rerun(self):
         """Tests that multiple pending rerun requests get coalesced."""
@@ -807,7 +819,7 @@ class ScriptRunnerTest(AsyncTestCase):
         "streamlit.source_util.get_pages",
         MagicMock(
             return_value={
-                "page2": {
+                "hash2": {
                     "script_path": os.path.join(
                         os.path.dirname(__file__), "test_data", "good_script2.py"
                     ),
@@ -815,9 +827,9 @@ class ScriptRunnerTest(AsyncTestCase):
             },
         ),
     )
-    def test_page_name_to_script_path(self):
+    def test_page_script_hash_to_script_path(self):
         scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.request_rerun(RerunData(page_name="page2"))
+        scriptrunner.request_rerun(RerunData(page_script_hash="hash2"))
         scriptrunner.start()
         scriptrunner.join()
 
@@ -842,13 +854,13 @@ class ScriptRunnerTest(AsyncTestCase):
         "streamlit.source_util.get_pages",
         MagicMock(
             return_value={
-                "page2": {"script_path": "script2"},
+                "hash2": {"script_path": "script2"},
             }
         ),
     )
-    def test_page_name_to_script_path_404(self):
+    def test_page_script_hash_to_script_path_404(self):
         scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.request_rerun(RerunData(page_name="page3"))
+        scriptrunner.request_rerun(RerunData(page_script_hash="hash3"))
         scriptrunner.start()
         scriptrunner.join()
 
@@ -866,7 +878,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self._assert_text_deltas(scriptrunner, [text_utf])
 
         page_not_found_msg = scriptrunner.forward_msg_queue._queue[0].page_not_found
-        self.assertEqual(page_not_found_msg.page_name, "page3")
+        self.assertEqual(page_not_found_msg.page_name, "")
 
         self.assertEqual(
             scriptrunner._session_data.main_script_path,

--- a/lib/tests/streamlit/server_test.py
+++ b/lib/tests/streamlit/server_test.py
@@ -634,6 +634,7 @@ class MessageCacheHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(404, self.fetch("/message?id=non_existent").code)
 
 
+@patch("streamlit.source_util._cached_pages", new=None)
 class ScriptCheckTest(tornado.testing.AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -20,6 +20,7 @@ import pytest
 from parameterized import parameterized
 
 import streamlit.source_util as source_util
+from streamlit.util import calc_md5
 
 
 class PageHelperFunctionTests(unittest.TestCase):
@@ -128,11 +129,10 @@ def test_get_pages(tmpdir):
         # These pages are out of order so that we can check that they're sorted
         # in the assert below.
         "03_other_page.py",
-        "last page.py",
+        "04 last numbered page.py",
         "01-page.py",
-        # The next two pages have duplicate names so shouldn't appear.
+        # This page should appear last since it doesn't have an integer prefix.
         "page.py",
-        "streamlit_app.py",
         # This file shouldn't appear as a page because it's hidden.
         ".hidden_file.py",
         # This shouldn't appear because it's not a Python file.
@@ -145,20 +145,29 @@ def test_get_pages(tmpdir):
 
     received_pages = source_util.get_pages(main_script_path)
     assert received_pages == {
-        "streamlit_app": {
+        calc_md5(main_script_path): {
+            "page_name": "streamlit_app",
             "script_path": main_script_path,
             "icon": "",
         },
-        "page": {
+        calc_md5(str(pages_dir / "01-page.py")): {
+            "page_name": "page",
             "script_path": str(pages_dir / "01-page.py"),
             "icon": "",
         },
-        "other_page": {
+        calc_md5(str(pages_dir / "03_other_page.py")): {
+            "page_name": "other_page",
             "script_path": str(pages_dir / "03_other_page.py"),
             "icon": "",
         },
-        "last_page": {
-            "script_path": str(pages_dir / "last page.py"),
+        calc_md5(str(pages_dir / "04 last numbered page.py")): {
+            "page_name": "last_numbered_page",
+            "script_path": str(pages_dir / "04 last numbered page.py"),
+            "icon": "",
+        },
+        calc_md5(str(pages_dir / "page.py")): {
+            "page_name": "page",
+            "script_path": str(pages_dir / "page.py"),
             "icon": "",
         },
     }

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -146,26 +146,31 @@ def test_get_pages(tmpdir):
     received_pages = source_util.get_pages(main_script_path)
     assert received_pages == {
         calc_md5(main_script_path): {
+            "page_script_hash": calc_md5(main_script_path),
             "page_name": "streamlit_app",
             "script_path": main_script_path,
             "icon": "",
         },
         calc_md5(str(pages_dir / "01-page.py")): {
+            "page_script_hash": calc_md5(str(pages_dir / "01-page.py")),
             "page_name": "page",
             "script_path": str(pages_dir / "01-page.py"),
             "icon": "",
         },
         calc_md5(str(pages_dir / "03_other_page.py")): {
+            "page_script_hash": calc_md5(str(pages_dir / "03_other_page.py")),
             "page_name": "other_page",
             "script_path": str(pages_dir / "03_other_page.py"),
             "icon": "",
         },
         calc_md5(str(pages_dir / "04 last numbered page.py")): {
+            "page_script_hash": calc_md5(str(pages_dir / "04 last numbered page.py")),
             "page_name": "last_numbered_page",
             "script_path": str(pages_dir / "04 last numbered page.py"),
             "icon": "",
         },
         calc_md5(str(pages_dir / "page.py")): {
+            "page_script_hash": calc_md5(str(pages_dir / "page.py")),
             "page_name": "page",
             "script_path": str(pages_dir / "page.py"),
             "icon": "",

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -323,8 +323,14 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         "streamlit.watcher.local_sources_watcher.get_pages",
         MagicMock(
             return_value={
-                "streamlit_app": {"script_path": "streamlit_app.py"},
-                "streamlit_app2": {"script_path": "streamlit_app2.py"},
+                "someHash1": {
+                    "page_name": "streamlit_app",
+                    "script_path": "streamlit_app.py",
+                },
+                "someHash2": {
+                    "page_name": "streamlit_app2",
+                    "script_path": "streamlit_app2.py",
+                },
             }
         ),
     )

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -90,7 +90,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
-            page_name="",
+            page_script_hash="",
         )
 
         if self.override_root:

--- a/proto/streamlit/proto/AppPage.proto
+++ b/proto/streamlit/proto/AppPage.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 // A page in the app. Includes both the name of the page as well as the full
 // path to the corresponding script file.
 message AppPage {
-  string page_name = 1;
-  string script_path = 2;
+  string page_script_hash = 1;
+  string page_name = 2;
   string icon = 3;
 }

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -22,5 +22,6 @@ import "streamlit/proto/WidgetStates.proto";
 message ClientState {
   string query_string = 1;
   WidgetStates widget_states = 2;
-  string page_name = 3;
+  string page_script_hash = 3;
+  string page_name = 4;
 }

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -52,6 +52,9 @@ message NewSession {
 
   // A list of all of this app's pages, in order and including the main page.
   repeated AppPage app_pages = 8;
+
+  // A hash of the script corresponding to the page currently being viewed.
+  string page_script_hash = 9;
 }
 
 // Contains the session state that existed at the time the user connected.


### PR DESCRIPTION
## 📚 Context

It turns out that I misinterpreted a part of the multipage apps product spec regarding
what happens when there are multiple pages with the same name. I somehow read it as
something like "only the first page with the duplicate name is displayed in the app" rather
than what it actually says.

The correct behavior only comes into play when a user navigates directly to a subpage of
a multipage app via URL. In this case, the behavior defined by the spec is to choose the first
page with a matching page name (if multiple pages share a name).

This PR reworks things to follow the product spec correctly. Technical details of the changes
made are described in the section below. e2e tests will be made in a followup PR to keep the
line count of this one from getting too bloated (it's already pretty borderline).

NOTE: It's likely easiest to read this PR commit-wise.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Refactoring

## 🧠 Description of Changes

- Stop sending raw `script_path`s to the frontend and instead send hashes of `script_path`s
  - Doing this probably wasn't strictly necessary -- we could get away with requesting which script
     to run using the paths themselves, but leaking even more information about the user's filesystem
     to the frontend seems incorrect.
- Have the client request the page to run from the server using script hashes as opposed to page names
   most of the time.
- When connecting directly to a page via URL (when we don't have script hashes available), request the
   page to run via page name.
- Teach the `ScriptRunner` how to deal with the different kinds of script run requests it can now receive.
- Move some handling of where we clear the previous page's contents and determination of which page
   we are running from `sendRerunBackMsg` to `handleNewSession`.
   - Conveniently, doing this here also gets rid of the race condition that causes the `setIn` bug.

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
