### PR TITLE
Enable multipage apps by default

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -725,15 +725,8 @@ _create_option(
 
 _create_option(
     "ui.hideSidebarNav",
-    description="""
-    Flag to hide the sidebar page navigation component.
-
-    We have this default to True for now so that we can "soft-launch" the
-    multipage apps feature and merge the feature branch into develop earlier.
-    Once we're ready to have multipage apps enabled by default, we'll flip the
-    default to False.
-    """,
-    default_val=True,
+    description="Flag to hide the sidebar page navigation component.",
+    default_val=False,
     type_=bool,
     visibility="hidden",
 )


### PR DESCRIPTION
## 📚 Context

We initially merged the multipage apps PR with the `ui.hideSidebarNav` config option defaulting to
`True` to use the option as a kind of "feature flag" (we need the option either way in case we ever want
to turn off the nav component and instead build one into Cloud).

Now that we're closer to the release of the multipage apps feature, we can toggle the option to enable
MPAs by default.

- What kind of change does this PR introduce?

  - [x] Feature
