### PR TITLE
Use 'yarn run' to use pbjs and pbts commands instead of specifying the paths directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ protobuf:
 	cd frontend/ ; ( \
 		echo "/* eslint-disable */" ; \
 		echo ; \
-		./node_modules/protobufjs/bin/pbjs \
+		yarn --silent pbjs \
 			../proto/streamlit/proto/*.proto \
 			-t static-module --wrap es6 \
 	) > ./src/autogen/proto.js
@@ -223,7 +223,7 @@ protobuf:
 	cd frontend/ ; ( \
 		echo "/* eslint-disable */" ; \
 		echo ; \
-		./node_modules/protobufjs/bin/pbts ./src/autogen/proto.js \
+		yarn --silent pbts ./src/autogen/proto.js \
 	) > ./src/autogen/proto.d.ts
 
 .PHONY: react-init


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

Fix the script in Makefile to use `yarn run` to call `pbjs` and `pbts` commands instead of specifying the direct path of the command files.

This is more robust than the original.
There may be some cases where these commands are installed in a different path, for example, when using yarn workspace. And in such cases, `yarn run` still works well.

Yes, such a case is kind of a special situation, but `yarn run` is still a standard way to call commands installed via yarn and there is no downside in introducing it, so I support this change.

(Practically, I needed this change in [my project forked from streamlit](https://github.com/whitphx/streamlit/tree/stlite), though I know it can't be a reason this repo should merge it.)

## 🧪 Testing Done

I confirmed that `make mini-devel` succeeded.

## 🌐 References

This was needed in [my forked project](https://github.com/whitphx/streamlit/tree/stlite) and I just thought it would be nice if this could be merged into the upstream.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
