### PR TITLE
Remove a unused contextType in <App /> component class

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -180,8 +180,6 @@ export class App extends PureComponent<Props, State> {
 
   private readonly componentRegistry: ComponentRegistry
 
-  static contextType = AppContext
-
   constructor(props: Props) {
     super(props)
 


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

`<App />` component class is not consuming `AppContext`, so its `contextType` is not necessary. `<App />` is now the provider of `AppContext`.

## 🧪 Testing Done

No regression on `make jstest`

## 🌐 References

No reference.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
