### PR TITLE
Pin upper protobuf version

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -45,7 +45,7 @@ packaging = "*"
 pandas = ">=0.21.0"
 pillow = ">=6.2.0"
 # protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
-protobuf = ">=3.6.0, !=3.11"
+protobuf = ">=3.6.0, !=3.11, <4.21.0"
 pyarrow = "*"
 pydeck = ">=0.1.dev5"
 pympler = ">=0.9"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -45,7 +45,7 @@ packaging = "*"
 pandas = ">=0.21.0"
 pillow = ">=6.2.0"
 # protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
-protobuf = ">=3.6.0, !=3.11, <4.21.0"
+protobuf = ">=3.6.0, !=3.11, <4"
 pyarrow = "*"
 pydeck = ">=0.1.dev5"
 pympler = ">=0.9"


### PR DESCRIPTION
## 📚 Context

The upcoming protobuf version will break Streamlit. As a quick fix, we need to pin the upper version. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
