### PR TITLE
Pin lower version of protobuf

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -44,7 +44,6 @@ numpy = "*"
 packaging = "*"
 pandas = ">=0.21.0"
 pillow = ">=6.2.0"
-# protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
 protobuf = ">=3.12, <4"
 pyarrow = "*"
 pydeck = ">=0.1.dev5"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -45,7 +45,7 @@ packaging = "*"
 pandas = ">=0.21.0"
 pillow = ">=6.2.0"
 # protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234
-protobuf = ">=3.6.0, !=3.11, <4"
+protobuf = ">=3.12, <4"
 pyarrow = "*"
 pydeck = ">=0.1.dev5"
 pympler = ">=0.9"


### PR DESCRIPTION
## 📚 Context

Streamlit is not compatible with protobuf versions under `3.12`. Therefore, we need to adapt the pinned lower version. 

Lower versions (< 3.12) will throw this error: 

<img width="808" alt="image" src="https://user-images.githubusercontent.com/2852129/170543735-63389ed1-5158-4c93-a9e1-70748212ee03.png">

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
