### PR TITLE
Improve metric label height for prototype

### DIFF
--- a/frontend/src/components/elements/Metric/styled-components.ts
+++ b/frontend/src/components/elements/Metric/styled-components.ts
@@ -31,6 +31,7 @@ export const StyledTruncateText = styled.div(({ theme }) => ({
 export const StyledMetricLabelText = styled(StyledWidgetLabel)(
   ({ theme }) => ({
     marginBottom: 0,
+    minHeight: "0.5rem !important",
   })
 )
 


### PR DESCRIPTION
## 📚 Context

Improve label height for `st.metric` in the prototype. Requested by @jrieke.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
