### PR TITLE
Fix timezone issue in quiver test

### DIFF
--- a/frontend/src/lib/Quiver.test.ts
+++ b/frontend/src/lib/Quiver.test.ts
@@ -353,7 +353,7 @@ describe("Quiver", () => {
 
       test("date", () => {
         expect(
-          Quiver.format(new Date(1970, 0, 1), {
+          Quiver.format(new Date(Date.UTC(1970, 0, 1)), {
             pandas_type: "date",
             numpy_type: "object",
           })


### PR DESCRIPTION
## 📚 Context

As mentioned in https://github.com/streamlit/streamlit/issues/4791, there is an issue with the Quiver test if it is run with a certain timezone. The reason is that the date is expected to be UTC (or ambiguous), but `new Date` in JavaScript uses the local timezone instead. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Use `new Date(Date.UTC(1970, 0, 1))` instead of `new Date(1970, 0, 1)`.

## 🌐 References

- Closes: #4791

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
