### PR TITLE
Send the react app in static file 404 responses

### DIFF
--- a/e2e/specs/multipage_apps.spec.js
+++ b/e2e/specs/multipage_apps.spec.js
@@ -73,4 +73,10 @@ describe("st.map", () => {
     cy.loadApp("http://localhost:3000/page_with_duplicate_name");
     cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
   });
+
+  it("serves the react app and displays the page not found modal if the page does not exist", () => {
+    cy.loadApp("http://localhost:3000/not_a_page");
+
+    cy.get('[role="dialog"]').should("contain", "Page not found");
+  });
 });

--- a/lib/streamlit/server/routes.py
+++ b/lib/streamlit/server/routes.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import json
+import os
 
 import tornado.web
 from urllib.parse import quote, unquote_plus
 
-from streamlit import config
+from streamlit import config, file_util
 from streamlit.logger import get_logger
 from streamlit.server.server_util import serialize_forward_msg
 from streamlit.string_util import generate_download_filename_from_title
@@ -82,6 +83,13 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
             url_path = "/".join(url_parts[1:])
 
         return super().parse_url_path(url_path)
+
+    def write_error(self, status_code: int, **kwargs) -> None:
+        if status_code == 404:
+            index_file = os.path.join(file_util.get_static_dir(), "index.html")
+            self.render(index_file)
+        else:
+            super().write_error(status_code, **kwargs)
 
 
 class AssetsFileHandler(tornado.web.StaticFileHandler):


### PR DESCRIPTION
## 📚 Context

When a user navigates to a path that doesn't exist that may be a page (but
actually isn't one), we want to serve the react app so that it can handle
sending a request to run the nonexistent page to the server and opening the
"Page not found" modal.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- Send the react app in static file 404 responses

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
