### PR TITLE
Make impossible to modify st.experimental_user keys and attributes

### DIFF
--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -1,6 +1,7 @@
-from streamlit.scriptrunner import get_script_run_ctx as _get_script_run_ctx
+from typing import Mapping, Optional
+
 from streamlit.errors import StreamlitAPIException
-from typing import Mapping, Dict, Optional, Iterator
+from streamlit.scriptrunner import get_script_run_ctx as _get_script_run_ctx
 
 
 class UserInfoProxy(Mapping[str, Optional[str]]):

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -1,4 +1,5 @@
 from streamlit.scriptrunner import get_script_run_ctx as _get_script_run_ctx
+from streamlit.errors import StreamlitAPIException
 from typing import Mapping, Dict, Optional, Iterator
 
 
@@ -22,6 +23,12 @@ class UserInfoProxy(Mapping[str, Optional[str]]):
                 return user_info[key]
             except KeyError:
                 raise AttributeError
+
+    def __setattr__(self, name, value):
+        raise StreamlitAPIException("st.experimental_user cannot be modified")
+
+    def __setitem__(self, key, value):
+        raise StreamlitAPIException("st.experimental_user cannot be modified")
 
     def __iter__(self):
         ctx = _get_script_run_ctx()

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -3,6 +3,7 @@ import threading
 import streamlit as st
 
 from streamlit.forward_msg_queue import ForwardMsgQueue
+from streamlit.errors import StreamlitAPIException
 from streamlit.scriptrunner import (
     add_script_run_ctx,
     get_script_run_ctx,
@@ -32,6 +33,50 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         """Test that an error is raised when called non existed key."""
         with self.assertRaises(KeyError):
             st.write(st.experimental_user["key"])
+
+    def test_user_cannot_be_modified_existing_key(self):
+        """
+        Test that an error is raised when try to assign new value to existing key.
+        """
+        with self.assertRaises(StreamlitAPIException) as e:
+            st.experimental_user["email"] = "NEW_VALUE"
+
+        self.assertEqual(
+            str(e.exception), "st.experimental_user cannot be modified"
+        )
+
+    def test_user_cannot_be_modified_new_key(self):
+        """
+        Test that an error is raised when try to assign new value to new key.
+        """
+        with self.assertRaises(StreamlitAPIException) as e:
+            st.experimental_user["foo"] = "bar"
+
+        self.assertEqual(
+            str(e.exception), "st.experimental_user cannot be modified"
+        )
+
+    def test_user_cannot_be_modified_existing_attr(self):
+        """
+        Test that an error is raised when try to assign new value to existing attr.
+        """
+        with self.assertRaises(StreamlitAPIException) as e:
+            st.experimental_user.email = "bar"
+
+        self.assertEqual(
+            str(e.exception), "st.experimental_user cannot be modified"
+        )
+
+    def test_user_cannot_be_modified_new_attr(self):
+        """
+        Test that an error is raised when try to assign new value to new attr.
+        """
+        with self.assertRaises(StreamlitAPIException) as e:
+            st.experimental_user.foo = "bar"
+
+        self.assertEqual(
+            str(e.exception), "st.experimental_user cannot be modified"
+        )
 
     def test_user_len(self):
         self.assertEqual(len(st.experimental_user), 1)

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -41,9 +41,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         with self.assertRaises(StreamlitAPIException) as e:
             st.experimental_user["email"] = "NEW_VALUE"
 
-        self.assertEqual(
-            str(e.exception), "st.experimental_user cannot be modified"
-        )
+        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
 
     def test_user_cannot_be_modified_new_key(self):
         """
@@ -52,9 +50,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         with self.assertRaises(StreamlitAPIException) as e:
             st.experimental_user["foo"] = "bar"
 
-        self.assertEqual(
-            str(e.exception), "st.experimental_user cannot be modified"
-        )
+        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
 
     def test_user_cannot_be_modified_existing_attr(self):
         """
@@ -63,9 +59,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         with self.assertRaises(StreamlitAPIException) as e:
             st.experimental_user.email = "bar"
 
-        self.assertEqual(
-            str(e.exception), "st.experimental_user cannot be modified"
-        )
+        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
 
     def test_user_cannot_be_modified_new_attr(self):
         """
@@ -74,9 +68,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
         with self.assertRaises(StreamlitAPIException) as e:
             st.experimental_user.foo = "bar"
 
-        self.assertEqual(
-            str(e.exception), "st.experimental_user cannot be modified"
-        )
+        self.assertEqual(str(e.exception), "st.experimental_user cannot be modified")
 
     def test_user_len(self):
         self.assertEqual(len(st.experimental_user), 1)


### PR DESCRIPTION
According to product spec any attempt to modify `st.experimental_user` items or attributes should raise StreamlitAPIException. 

This PR implements those requirements. 
 
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

```
import streamlit as st

st.experimental_user.foo = "bar"
```
or 

```
import streamlit as st

st.experimental_user.foo = "bar"
```

Or 
```
import streamlit as st

st.experimental_user.email = "another_email@example.com"
```
raises StreamlitAPIException

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
