### PR TITLE
Fix magic to ignore await expressions

### DIFF
--- a/lib/streamlit/magic.py
+++ b/lib/streamlit/magic.py
@@ -146,6 +146,10 @@ def _get_st_write_from_expr(node, i, parent_type):
     if type(node.value) is ast.Yield or type(node.value) is ast.YieldFrom:
         return None
 
+    # Don't change await nodes
+    if type(node.value) is ast.Await:
+        return None
+
     # If tuple, call st.write on the 0th element (rather than the
     # whole tuple). This allows us to add a comma at the end of a statement
     # to turn it into an expression that should be st-written. Ex:

--- a/lib/tests/streamlit/magic_test.py
+++ b/lib/tests/streamlit/magic_test.py
@@ -141,6 +141,14 @@ def yield_func():
 """
         self._testCode(CODE_YIELD_FROM_STATEMENT, 0)
 
+    def test_await_expression(self):
+        """Test that 'await' expressions do not get magicked"""
+        CODE_AWAIT_EXPRESSION = """
+async def await_func(a):
+    await coro()
+"""
+        self._testCode(CODE_AWAIT_EXPRESSION, 0)
+
     def test_async_function_statement(self):
         """Test async function definitions"""
         CODE_ASYNC_FUNCTION = """


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

`await` expressions are being magicked and it leads to unexpected `None` displayed, as reported at https://discuss.streamlit.io/t/issue-with-asyncio-run-in-streamlit/7745/7.

A similar problem on `yield` and `yield from` has been taken care of at #138, so I think `await` should also be like that.

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: API change suggestion

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [x] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

https://discuss.streamlit.io/t/issue-with-asyncio-run-in-streamlit/7745/7

As this PR includes only a few lines, I skipped creating an issue. Please just ignore this if it has some problems 🙏 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
