### PR TITLE
Remove note in `st.multiselect` API docstring

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -99,13 +99,6 @@ class MultiSelectMixin:
            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.multiselect.py
            height: 420px
 
-        .. note::
-           User experience can be degraded for large lists of `options` (100+), as this widget
-           is not designed to handle arbitrary text search efficiently. See this
-           `thread <https://discuss.streamlit.io/t/streamlit-loading-column-data-takes-too-much-time/1791>`_
-           on the Streamlit community forum for more information and
-           `GitHub issue #1059 <https://github.com/streamlit/streamlit/issues/1059>`_ for updates on the issue.
-
         """
         ctx = get_script_run_ctx()
         return self._multiselect(


### PR DESCRIPTION
## 📚 Context

The [API reference for st.multiselect](https://docs.streamlit.io/library/api-reference/widgets/st.multiselect) shows this note at the bottom: 

![image](https://user-images.githubusercontent.com/20672874/172100344-01db56dd-be73-4867-b83b-e1db1baab744.png)

The Github issue linked in there https://github.com/streamlit/streamlit/issues/1059 was closed in 2020 and seems to be resolved (_”I've found 10,000 items to work fine”_).


- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Removes the note about `st.multiselect`'s degraded performance for large list of options from the docstring, since the issue was resolved in 2020.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

<details>
<summary>Toggle to view revised</summary>

![image](https://user-images.githubusercontent.com/20672874/172100910-8dafa042-9c7d-4e19-a386-eb8dab53d003.png)
</details>


**Current:**

<details>
<summary>Toggle to view current</summary>

![image](https://user-images.githubusercontent.com/20672874/172101006-ae68899b-b8c8-4567-9098-48f21a1fb40e.png)
</details>


## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- Issue: https://github.com/streamlit/streamlit/issues/1059
- [Notion](https://www.notion.so/streamlit/Remove-warning-on-st-multiselect-API-docs-6736b19ab4fc4851b2ca83715c8916ae)
- [Forum thread](https://discuss.streamlit.io/t/streamlit-loading-column-data-takes-too-much-time/1791)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
