### PR TITLE
Use an appropriate number of workers for frontend unit tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,9 +282,9 @@ ifndef CIRCLECI
 	cd frontend; yarn run test
 else
 	# Previously we used --runInBand here, which just completely turns off parallelization.
-	# But since our CircleCI instance has 4 CPUs, use maxWorkers instead:
+	# But since our CircleCI instance has 2 CPUs, use maxWorkers instead:
 	# https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server
-	cd frontend; yarn run test --maxWorkers=4
+	cd frontend; yarn run test --maxWorkers=2
 endif
 
 .PHONY: jscoverage


### PR DESCRIPTION
2, to match the actual core count of the medium instance it runs on.


## 📚 Context

I noticed that the python-max-version job is pretty slow, sometimes even slower than the e2e tests, so I ran some experiments on instance size and worker count to check for easy speedups.

It could be made even faster by using a larger instance, but this is a free win that should make things good enough.