### PR TITLE
Close the sidebar on mobile after the user selects a page to run

### DIFF
--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -198,10 +198,11 @@ class Sidebar extends PureComponent<SidebarProps, State> {
           {!hideSidebarNav && (
             <SidebarNav
               appPages={appPages}
-              hasSidebarElements={hasElements}
-              onPageChange={onPageChange}
-              hideParentScrollbar={this.hideScrollbar}
+              collapseSidebar={this.toggleCollapse}
               currentPageScriptHash={currentPageScriptHash}
+              hasSidebarElements={hasElements}
+              hideParentScrollbar={this.hideScrollbar}
+              onPageChange={onPageChange}
               pageLinkBaseUrl={pageLinkBaseUrl}
             />
           )}

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -23,6 +23,7 @@ import {
   Description,
 } from "@emotion-icons/material-outlined"
 import React from "react"
+import * as reactDeviceDetect from "react-device-detect"
 import { act } from "react-dom/test-utils"
 
 import Icon from "src/components/shared/Icon"
@@ -55,10 +56,11 @@ const getProps = (props: Partial<Props> = {}): Props => ({
     { pageScriptHash: "main_page_hash", pageName: "streamlit_app" },
     { pageScriptHash: "other_page_hash", pageName: "my_other_page" },
   ],
-  hasSidebarElements: false,
-  onPageChange: jest.fn(),
-  hideParentScrollbar: jest.fn(),
+  collapseSidebar: jest.fn(),
   currentPageScriptHash: "",
+  hasSidebarElements: false,
+  hideParentScrollbar: jest.fn(),
+  onPageChange: jest.fn(),
   pageLinkBaseUrl: "",
   ...props,
 })
@@ -68,6 +70,9 @@ const mockClickEvent = new MouseEvent("click") as any
 describe("SidebarNav", () => {
   afterEach(() => {
     mockUseIsOverflowing.mockReset()
+
+    // @ts-ignore
+    reactDeviceDetect.isMobile = false
   })
 
   it("returns null if 0 appPages (may be true before the first script run)", () => {
@@ -358,6 +363,23 @@ describe("SidebarNav", () => {
 
     expect(preventDefault).toHaveBeenCalled()
     expect(props.onPageChange).toHaveBeenCalledWith("other_page_hash")
+    expect(props.collapseSidebar).not.toHaveBeenCalled()
+  })
+
+  it("collapses sidebar on page change when on mobile", () => {
+    // @ts-ignore
+    reactDeviceDetect.isMobile = true
+
+    const props = getProps()
+    const wrapper = shallow(<SidebarNav {...props} />)
+
+    const preventDefault = jest.fn()
+    const links = wrapper.find(StyledSidebarNavLink)
+    links.at(1).simulate("click", { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(props.onPageChange).toHaveBeenCalledWith("other_page_hash")
+    expect(props.collapseSidebar).toHaveBeenCalled()
   })
 
   it("calls hideParentScrollbar onMouseOut", () => {

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -16,6 +16,9 @@
  */
 
 import React, { ReactElement, useCallback, useRef, useState } from "react"
+// We import react-device-detect in this way so that tests can mock its
+// isMobile field sanely.
+import * as reactDeviceDetect from "react-device-detect"
 import {
   ExpandMore,
   ExpandLess,
@@ -37,20 +40,21 @@ import {
 
 export interface Props {
   appPages: IAppPage[]
-  hasSidebarElements: boolean
-  onPageChange: (pageName: string) => void
-  hideParentScrollbar: (newValue: boolean) => void
-
+  collapseSidebar: () => void
   currentPageScriptHash: string
+  hasSidebarElements: boolean
+  hideParentScrollbar: (newValue: boolean) => void
+  onPageChange: (pageName: string) => void
   pageLinkBaseUrl: string
 }
 
 const SidebarNav = ({
   appPages,
-  hasSidebarElements,
-  onPageChange,
-  hideParentScrollbar,
+  collapseSidebar,
   currentPageScriptHash,
+  hasSidebarElements,
+  hideParentScrollbar,
+  onPageChange,
   pageLinkBaseUrl,
 }: Props): ReactElement | null => {
   if (appPages.length < 2) {
@@ -127,6 +131,9 @@ const SidebarNav = ({
                     onClick={e => {
                       e.preventDefault()
                       onPageChange(pageScriptHash as string)
+                      if (reactDeviceDetect.isMobile) {
+                        collapseSidebar()
+                      }
                     }}
                   >
                     {pageIcon && pageIcon.length ? (


### PR DESCRIPTION
## 📚 Context

When viewing a multipage app on a mobile device, it makes sense to close the sidebar after the
user has selected a new page to run since otherwise it's hard to tell that anything happened
in response to the user's action.

- What kind of change does this PR introduce?

  - [x] Other, please describe: UX improvements

## 🧠 Description of Changes

- Close the sidebar on mobile after the user selects a page to run
- Reorder some props to be alphabetical

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests