### PR TITLE
Use immutable tuples instead of lists for defaults

### DIFF
--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -35,7 +35,7 @@ class SelectSliderMixin:
     def select_slider(
         self,
         label: str,
-        options: OptionSequence = [],
+        options: OptionSequence = (),
         value: Any = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -136,7 +136,7 @@ class SelectSliderMixin:
     def _select_slider(
         self,
         label: str,
-        options: OptionSequence = [],
+        options: OptionSequence = (),
         value: Any = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,


### PR DESCRIPTION
## 📚 Context

Using lists as argument defaults is frowned upon, because the lists can be mutated during runtime, leading to unexpected behaviour.

This PR replaces some lists used as defaults with tuples, serving the same purpose.

- What kind of change does this PR introduce?

  - [X] Bugfix

## 🧠 Description of Changes

- Replace default lists with tuples

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
