### PR TITLE
Handle dataclasses as args to memo/singleton functions

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -79,10 +79,7 @@ setuptools.setup(
     },
     author="Streamlit Inc",
     author_email="hello@streamlit.io",
-    # We *officially* support Python 3.7+, but we're still technically
-    # installable on 3.6. If we use any 3.7+ language features, we should
-    # update python_requires to reflect that.
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     license="Apache 2",
     # PEP 561: https://mypy.readthedocs.io/en/stable/installed_packages.html
     package_data={"streamlit": ["py.typed", "hello/**/*.py"]},

--- a/lib/streamlit/caching/hashing.py
+++ b/lib/streamlit/caching/hashing.py
@@ -14,6 +14,7 @@
 
 """Hashing for st.memo and st.singleton."""
 import collections
+import dataclasses
 import functools
 import hashlib
 import inspect
@@ -260,6 +261,9 @@ class _CacheFuncHasher:
 
         elif obj is False:
             return b"0"
+
+        elif dataclasses.is_dataclass(obj):
+            return self.to_bytes(dataclasses.asdict(obj))
 
         elif type_util.is_type(obj, "pandas.core.frame.DataFrame") or type_util.is_type(
             obj, "pandas.core.series.Series"

--- a/lib/tests/streamlit/caching/hashing_test.py
+++ b/lib/tests/streamlit/caching/hashing_test.py
@@ -14,10 +14,12 @@
 
 """st.memo/singleton hashing tests."""
 
+from dataclasses import dataclass
 import functools
 import hashlib
 import os
 import re
+
 import tempfile
 import types
 import unittest
@@ -270,6 +272,15 @@ class HashTest(unittest.TestCase):
         # (This also tests that MagicMock can hash at all, without blowing the
         # stack due to an infinite recursion.)
         self.assertNotEqual(get_hash(MagicMock()), get_hash(MagicMock()))
+
+    def test_dataclass(self):
+        @dataclass(frozen=True, eq=True)
+        class Data:
+            foo: str
+
+        bar = Data("bar")
+
+        assert get_hash(bar)
 
 
 class NotHashableTest(unittest.TestCase):


### PR DESCRIPTION
This uses some functionality from the dataclasses module, so 3.7 is now
actually required.

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Check for dataclasses and convert them to dicts, when hashing for st.memo/singleton

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #3944 
