### PR TITLE
- try to use buildin importlib.metadata first

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -51,7 +51,10 @@ from streamlit.secrets import Secrets, SECRETS_FILE_LOC
 _LOGGER = _logger.get_logger("root")
 
 # Give the package a version.
-from importlib_metadata import version as _version
+try:
+    from importlib.metadata import version as _version
+except:
+    from importlib_metadata import version as _version
 
 __version__: str = _version("streamlit")
 


### PR DESCRIPTION
this is to avoid issues with the backport on zipapps....

## 📚 Context
When trying to run streamlit from a zipapp i have issues with the importlib_metadata backport of importlib.metadata. This should not be a problem on all pythons except 3.7 (only there the backport is needed).

So technically one could argue that it is a bug in importlib_metadata...

The benefit of these changes will go away once suport for 3.7 ends...

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
