### PR TITLE
Add explanatory comments to VegaLite's dataIsAnAppendOfPrev

### DIFF
--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -468,7 +468,7 @@ function dataIsAnAppendOfPrev(
 ): boolean {
   // Check whether dataframes have the same shape.
 
-  // if number of df columns not equal, not an append
+  // not an append
   if (prevNumCols !== numCols) {
     return false
   }

--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -468,14 +468,18 @@ function dataIsAnAppendOfPrev(
 ): boolean {
   // Check whether dataframes have the same shape.
 
+  // if number of df columns not equal, not an append
   if (prevNumCols !== numCols) {
     return false
   }
 
+  // an append would have prev number of rows < new number of rows
+  // the = handles cases of dynamic inputs to data having same number of rows as previous
   if (prevNumRows >= numRows) {
     return false
   }
 
+  // if no previous data, should render from scratch
   if (prevNumRows === 0) {
     return false
   }

--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -473,13 +473,13 @@ function dataIsAnAppendOfPrev(
     return false
   }
 
-  // an append would have prev number of rows < new number of rows
-  // the = handles cases of dynamic inputs to data having same number of rows as previous
+  // Data can be updated, but still have the same number of rows.
+  // We consider the case an append only when the number of rows has increased
   if (prevNumRows >= numRows) {
     return false
   }
 
-  // if no previous data, should render from scratch
+  // if no previous data, render from scratch
   if (prevNumRows === 0) {
     return false
   }

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -443,14 +443,18 @@ function dataIsAnAppendOfPrev(
 ): boolean {
   // Check whether dataframes have the same shape.
 
+  // if number of df columns not equal, not an append
   if (prevNumCols !== numCols) {
     return false
   }
 
+  // an append would have prev number of rows < new number of rows
+  // the = handles cases of dynamic inputs to data having same number of rows as previous
   if (prevNumRows >= numRows) {
     return false
   }
 
+  // if no previous data, should render from scratch
   if (prevNumRows === 0) {
     return false
   }

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -448,13 +448,13 @@ function dataIsAnAppendOfPrev(
     return false
   }
 
-  // an append would have prev number of rows < new number of rows
-  // the = handles cases of dynamic inputs to data having same number of rows as previous
+  // Data can be updated, but still have the same number of rows.
+  // We consider the case an append only when the number of rows has increased
   if (prevNumRows >= numRows) {
     return false
   }
 
-  // if no previous data, should render from scratch
+  // if no previous data, render from scratch
   if (prevNumRows === 0) {
     return false
   }

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -443,7 +443,7 @@ function dataIsAnAppendOfPrev(
 ): boolean {
   // Check whether dataframes have the same shape.
 
-  // if number of df columns not equal, not an append
+  // not an append
   if (prevNumCols !== numCols) {
     return false
   }


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Adding additional comments to better explain the resulting boolean from `VegaLiteChart.tsx`'s and `ArrowVegaLiteChart.tsx`'s helper function `dataIsAnAppendOfPrev`.

- What kind of change does this PR introduce?
  - [x] Other, please describe: Adding addtl explanatory comments 

## 🧠 Description of Changes

- Comments added 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
