### PR TITLE
Don't drop widget state when script stops for rerun

### DIFF
--- a/e2e/scripts/widget_state_heavy_usage.py
+++ b/e2e/scripts/widget_state_heavy_usage.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import time
+
+number = st.number_input("test", value=100)
+st.write(number)
+
+time.sleep(1)

--- a/e2e/specs/widget_state_heavy_usage.spec.js
+++ b/e2e/specs/widget_state_heavy_usage.spec.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2018-2022 Streamlit Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression test for issue #4836
+describe("widget state under heavy load", () => {
+  before(() => {
+    cy.loadApp("http://localhost:3000/");
+  });
+
+  it("doesn't loose state", () => {
+    // Rapidly click many (40) times
+    cy.get(".stNumberInput button.step-down")
+      .first()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click()
+      .click();
+
+    // Has not lost any clicks due to state resetting
+    cy.get(".stMarkdown").should("have.text", "60");
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -811,52 +811,42 @@ export class App extends PureComponent<Props, State> {
    * @param status the ScriptFinishedStatus that the script finished with
    */
   handleScriptFinished(status: ForwardMsg.ScriptFinishedStatus): void {
-    if (status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY) {
-      // Notify any subscribers of this event (and do it on the next cycle of
-      // the event loop)
-      window.setTimeout(() => {
-        this.state.scriptFinishedHandlers.map(handler => handler())
-      }, 0)
-
-      // Clear any stale elements left over from the previous run.
-      // (We don't do this if our script had a compilation error and didn't
-      // finish successfully.)
-      this.setState(
-        ({ scriptRunId }) => ({
-          // Apply any pending elements that haven't been applied.
-          elements: this.pendingElementsBuffer.clearStaleNodes(scriptRunId),
-        }),
-        () => {
-          // We now have no pending elements.
-          this.pendingElementsBuffer = this.state.elements
-        }
-      )
-
-      // Tell the WidgetManager which widgets still exist. It will remove
-      // widget state for widgets that have been removed.
-      const activeWidgetIds = new Set(
-        Array.from(this.state.elements.getElements())
-          .map(element => getElementWidgetID(element))
-          .filter(notUndefined)
-      )
-      this.widgetMgr.removeInactive(activeWidgetIds)
-
-      // Tell the ConnectionManager to increment the message cache run
-      // count. This will result in expired ForwardMsgs being removed from
-      // the cache.
-      if (this.connectionManager !== null) {
-        this.connectionManager.incrementMessageCacheRunCount(
-          SessionInfo.current.maxCachedMessageAge
-        )
-      }
-    } else if (
+    if (
+      status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
       status === ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
     ) {
+      const successful =
+        status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
       // Notify any subscribers of this event (and do it on the next cycle of
       // the event loop)
       window.setTimeout(() => {
         this.state.scriptFinishedHandlers.map(handler => handler())
       }, 0)
+
+      if (successful) {
+        // Clear any stale elements left over from the previous run.
+        // (We don't do this if our script had a compilation error and didn't
+        // finish successfully.)
+        this.setState(
+          ({ scriptRunId }) => ({
+            // Apply any pending elements that haven't been applied.
+            elements: this.pendingElementsBuffer.clearStaleNodes(scriptRunId),
+          }),
+          () => {
+            // We now have no pending elements.
+            this.pendingElementsBuffer = this.state.elements
+          }
+        )
+
+        // Tell the WidgetManager which widgets still exist. It will remove
+        // widget state for widgets that have been removed.
+        const activeWidgetIds = new Set(
+          Array.from(this.state.elements.getElements())
+            .map(element => getElementWidgetID(element))
+            .filter(notUndefined)
+        )
+        this.widgetMgr.removeInactive(activeWidgetIds)
+      }
 
       // Tell the ConnectionManager to increment the message cache run
       // count. This will result in expired ForwardMsgs being removed from

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -849,6 +849,23 @@ export class App extends PureComponent<Props, State> {
           SessionInfo.current.maxCachedMessageAge
         )
       }
+    } else if (
+      status === ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+    ) {
+      // Notify any subscribers of this event (and do it on the next cycle of
+      // the event loop)
+      window.setTimeout(() => {
+        this.state.scriptFinishedHandlers.map(handler => handler())
+      }, 0)
+
+      // Tell the ConnectionManager to increment the message cache run
+      // count. This will result in expired ForwardMsgs being removed from
+      // the cache.
+      if (this.connectionManager !== null) {
+        this.connectionManager.incrementMessageCacheRunCount(
+          SessionInfo.current.maxCachedMessageAge
+        )
+      }
     }
   }
 

--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -483,6 +483,13 @@ class AppSession:
                 )
                 self._enqueue_forward_msg(msg)
 
+        elif event == ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN:
+            script_finished_msg = self._create_script_finished_message(
+                ForwardMsg.FINISHED_EARLY_FOR_RERUN
+            )
+            self._enqueue_forward_msg(script_finished_msg)
+            self._local_sources_watcher.update_watched_modules()
+
         elif event == ScriptRunnerEvent.SHUTDOWN:
             assert (
                 client_state is not None

--- a/lib/streamlit/scriptrunner/script_runner.py
+++ b/lib/streamlit/scriptrunner/script_runner.py
@@ -61,6 +61,9 @@ class ScriptRunnerEvent(Enum):
     # interrupted by the user.
     SCRIPT_STOPPED_WITH_SUCCESS = "SCRIPT_STOPPED_WITH_SUCCESS"
 
+    # The script run stopped in order to start a script run with newer widget state.
+    SCRIPT_STOPPED_FOR_RERUN = "SCRIPT_STOPPED_FOR_RERUN"
+
     # The ScriptRunner is done processing the ScriptEventQueue and
     # is shut down.
     SHUTDOWN = "SHUTDOWN"
@@ -571,7 +574,14 @@ class ScriptRunner:
         _log_if_error(_clean_problem_modules)
 
         if rerun_exception_data is not None:
+            self.on_event.send(self, event=ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN)
             self._run_script(rerun_exception_data)
+        else:
+            # Signal that the script has finished. (We use SCRIPT_STOPPED_WITH_SUCCESS
+            # even if we were stopped with an exception.)
+            self.on_event.send(
+                self, event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
+            )
 
     def _on_script_finished(self, ctx: ScriptRunContext) -> None:
         """Called when our script finishes executing, even if it finished
@@ -580,9 +590,6 @@ class ScriptRunner:
         # Tell session_state to update itself in response
         self._session_state.on_script_finished(ctx.widget_ids_this_run)
 
-        # Signal that the script has finished. (We use SCRIPT_STOPPED_WITH_SUCCESS
-        # even if we were stopped with an exception.)
-        self.on_event.send(self, event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS)
         # Delete expired files now that the script has run and files in use
         # are marked as active.
         in_memory_file_manager.del_expired_files()

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -407,7 +407,7 @@ class ScriptRunnerTest(AsyncTestCase):
             scriptrunner,
             [
                 ScriptRunnerEvent.SCRIPT_STARTED,
-                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN,
                 ScriptRunnerEvent.SCRIPT_STARTED,
                 # We use the SCRIPT_STOPPED_WITH_SUCCESS event even if the
                 # script runs into an error during execution. The user is
@@ -507,7 +507,7 @@ class ScriptRunnerTest(AsyncTestCase):
             scriptrunner,
             [
                 ScriptRunnerEvent.SCRIPT_STARTED,
-                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN,
                 ScriptRunnerEvent.SCRIPT_STARTED,
                 ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
                 ScriptRunnerEvent.SHUTDOWN,

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -42,6 +42,9 @@ message ForwardMsg {
 
     // The script failed to compile
     FINISHED_WITH_COMPILE_ERROR = 1;
+
+    // Script was interrupted by rerun
+    FINISHED_EARLY_FOR_RERUN = 2;
   }
 
   oneof type {


### PR DESCRIPTION
This was the cause of a race condition bug that dropped frontend widget
state sometimes when lots of widget interactions happened in a short
period.

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Adds a new ScriptFinishedStatus to indicate the script execution was interrupted to start a rerun
- Uses the new status to avoid dropping widget state because of an interrupted script run

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: #4836 
