### PR TITLE
Add tests for VegaLite's dataIsAnAppendOfPrev

### DIFF
--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.test.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.test.tsx
@@ -144,11 +144,8 @@ describe("VegaLiteChart Element", () => {
     [baseCase, case7, true, "Case 7: data is an append"],
   ]
 
-  cases.forEach(test => {
-    it(`tests for appended data properly - ${test[3]}`, () => {
-      const prevData = test[0]
-      const data = test[1]
-      const expected = test[2]
+  cases.forEach(([prevData, data, expected, testDescription]) => {
+    it(`tests for appended data properly - ${testDescription}`, () => {
       const [prevNumRows, prevNumCols] = tableGetRowsAndCols(
         prevData.get("data")
       )

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.test.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.test.tsx
@@ -20,9 +20,14 @@ import { mount } from "src/lib/test_util"
 import { fromJS } from "immutable"
 import { VegaLiteChart as VegaLiteChartProto } from "src/autogen/proto"
 import { darkTheme, lightTheme } from "src/theme"
+import { tableGetRowsAndCols } from "src/lib/dataFrameProto"
 
 import mock from "./mock"
-import { PropsWithHeight, VegaLiteChart } from "./VegaLiteChart"
+import {
+  PropsWithHeight,
+  VegaLiteChart,
+  dataIsAnAppendOfPrev,
+} from "./VegaLiteChart"
 
 const getProps = (
   elementProps: Partial<VegaLiteChartProto> = {},
@@ -38,12 +43,128 @@ const getProps = (
   ...props,
 })
 
+const baseCase = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55, 12] }, type: "int64s" },
+      { strings: { data: ["A", "B", "C"] }, type: "strings" },
+    ],
+  },
+})
+
+const case1 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55, 12] }, type: "int64s" },
+      { strings: { data: ["A", "B", "C"] }, type: "strings" },
+      { strings: { data: ["D", "E", "F"] }, type: "strings" },
+    ],
+  },
+})
+
+const case2 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55, 12] }, type: "int64s" },
+      { strings: { data: ["A", "B", "C"] }, type: "strings" },
+    ],
+  },
+})
+
+const case3 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55] }, type: "int64s" },
+      { strings: { data: ["A", "B"] }, type: "strings" },
+    ],
+  },
+})
+
+const case4 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [] }, type: "int64s" },
+      { strings: { data: [] }, type: "strings" },
+    ],
+  },
+})
+
+const case5 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55, 12, 17] }, type: "int64s" },
+      { strings: { data: ["Z", "B", "C", "D"] }, type: "strings" },
+    ],
+  },
+})
+
+const case6 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55, 12, 17] }, type: "int64s" },
+      { strings: { data: ["A", "B", "Z", "D"] }, type: "strings" },
+    ],
+  },
+})
+
+const case7 = fromJS({
+  data: {
+    cols: [
+      { int64s: { data: [28, 55, 12, 17] }, type: "int64s" },
+      { strings: { data: ["A", "B", "C", "D"] }, type: "strings" },
+    ],
+  },
+})
+
 describe("VegaLiteChart Element", () => {
   it("renders without crashing", () => {
     const props = getProps()
     const wrapper = mount(<VegaLiteChart {...props} />)
 
     expect(wrapper.find("StyledVegaLiteChartContainer").length).toBe(1)
+  })
+
+  const cases = [
+    [baseCase, case1, false, "Case 1: number of columns don't match"],
+    [baseCase, case2, false, "Case 2: same number of rows"],
+    [baseCase, case3, false, "Case 3: previous number of rows greater"],
+    [case4, baseCase, false, "Case 4: no previous rows"],
+    [
+      baseCase,
+      case5,
+      false,
+      "Case 5: light comparison fails, changed value of last column, first row",
+    ],
+    [
+      baseCase,
+      case6,
+      false,
+      "Case 6: light comparison fails, changed value of last column, second to last row",
+    ],
+    [baseCase, case7, true, "Case 7: data is an append"],
+  ]
+
+  cases.forEach(test => {
+    it(`tests for appended data properly - ${test[3]}`, () => {
+      const prevData = test[0]
+      const data = test[1]
+      const expected = test[2]
+      const [prevNumRows, prevNumCols] = tableGetRowsAndCols(
+        prevData.get("data")
+      )
+      const [numRows, numCols] = tableGetRowsAndCols(data.get("data"))
+
+      expect(
+        dataIsAnAppendOfPrev(
+          prevData,
+          prevNumRows,
+          prevNumCols,
+          data,
+          numRows,
+          numCols
+        )
+      ).toEqual(expected)
+    })
   })
 
   it("pulls default config values from theme", () => {

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -433,7 +433,7 @@ function getDataArray(
 /**
  * Checks if data looks like it's just prevData plus some appended rows.
  */
- export function dataIsAnAppendOfPrev(
+export function dataIsAnAppendOfPrev(
   prevData: ImmutableMap<string, number>,
   prevNumRows: number,
   prevNumCols: number,

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -433,7 +433,7 @@ function getDataArray(
 /**
  * Checks if data looks like it's just prevData plus some appended rows.
  */
-function dataIsAnAppendOfPrev(
+ export function dataIsAnAppendOfPrev(
   prevData: ImmutableMap<string, number>,
   prevNumRows: number,
   prevNumCols: number,


### PR DESCRIPTION
## 📚 Context

Adding test coverage for `VegaLiteChart.tsx`'s  helper function `dataIsAnAppendOfPrev`, which determines if updating the VegaLiteChart requires a full re-render or an insert.

- What kind of change does this PR introduce?
  - [x] Refactoring

## 🧠 Description of Changes

- Added 7 test cases to cover different not an append/is an append scenarios for `dataIsAnAppendOfPrev`

## 🧪 Testing Done

- [x] Added/Updated unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
