### PR TITLE
Fix docstring tests under Python 3.8

### DIFF
--- a/lib/tests/streamlit/help_test.py
+++ b/lib/tests/streamlit/help_test.py
@@ -80,8 +80,8 @@ class StHelpTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("dataframe", ds.name)
         self.assertEqual("streamlit", ds.module)
         self.assertEqual("<class 'method'>", ds.type)
-        if sys.version_info[1] == 7:
-            # Python 3.7 represents the signature slightly differently
+        if sys.version_info < (3, 9):
+            # Python < 3.9 represents the signature slightly differently
             self.assertEqual(
                 "(data: 'Data' = None, width: Union[int, NoneType] = None, "
                 "height: Union[int, NoneType] = None) -> 'DeltaGenerator'",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -420,8 +420,8 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             el.doc_string.doc_string.startswith("Display text in header formatting.")
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        if sys.version_info[1] == 7:
-            # Python 3.7 represents the signature slightly differently
+        if sys.version_info < (3, 9):
+            # Python < 3.9 represents the signature slightly differently
             self.assertEqual(
                 el.doc_string.signature,
                 "(body: str, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",


### PR DESCRIPTION
`test_unwrapped_deltagenerator_func` and `test_st_help` both fail under Python 3.8 because of an incorrect `version_info` comparison. This PR fixes that. 

(The related functionality isn't broken under Python 3.8, just the tests.)