### PR TITLE
BrowserWebSocketHandler.on_message: fix type signature

### DIFF
--- a/lib/streamlit/server/server.py
+++ b/lib/streamlit/server/server.py
@@ -34,7 +34,7 @@ from typing import (
     Awaitable,
     Generator,
     List,
-    Set,
+    Union,
 )
 
 import tornado.concurrent
@@ -782,13 +782,21 @@ class _BrowserWebSocketHandler(WebSocketHandler):
         return None
 
     @tornado.gen.coroutine
-    def on_message(self, payload: bytes) -> None:
+    def on_message(self, payload: Union[str, bytes]) -> None:
         if not self._session:
             return
 
         msg = BackMsg()
 
         try:
+            if isinstance(payload, str):
+                # Sanity check. (The frontend should only be sending us bytes;
+                # Protobuf.ParseFromString does not accept str input.)
+                raise RuntimeError(
+                    "WebSocket received an unexpected `str` message. "
+                    "(We expect `bytes` only.)"
+                )
+
             msg.ParseFromString(payload)
             msg_type = msg.WhichOneof("type")
 


### PR DESCRIPTION
`WebSocketHandler.on_message` actually takes a `Union[str, bytes]`. We only handle `bytes` in our subclass, so raise an exception if the frontend incorrectly sends us a str.

(The protobuf `ParseFromString()` function will throw an error if it receives a `str`, so this doesn't actually introduce a new exception path into the lib, it just makes the exception that will inevitable be thrown a bit more understandable.)

The `@tornado.gen.coroutine` decorator strips our type signature, which is why this isn't caught by mypy. We're going to ditch this decorator in the near future.
