### PR TITLE
add overload to multiselect

### DIFF
--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -23,6 +23,7 @@ from typing import (
     List,
     Sequence,
     Union,
+    TypeVar,
 )
 
 import streamlit
@@ -40,8 +41,44 @@ from streamlit.state import (
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
+T = TypeVar("T")
+
 
 class MultiSelectMixin:
+    @overload
+    def multiselect(
+        self,
+        label: str,
+        options: Sequence[T],
+        default: Optional[Any] = None,
+        format_func: Callable[[Any], Any] = str,
+        key: Optional[Key] = None,
+        help: Optional[str] = None,
+        on_change: Optional[WidgetCallback] = None,
+        args: Optional[WidgetArgs] = None,
+        kwargs: Optional[WidgetKwargs] = None,
+        *,  # keyword-only arguments:
+        disabled: bool = False,
+    ) -> List[T]:
+        ...
+
+    @overload
+    def multiselect(
+        self,
+        label: str,
+        options: OptionSequence,
+        default: Optional[Any] = None,
+        format_func: Callable[[Any], Any] = str,
+        key: Optional[Key] = None,
+        help: Optional[str] = None,
+        on_change: Optional[WidgetCallback] = None,
+        args: Optional[WidgetArgs] = None,
+        kwargs: Optional[WidgetKwargs] = None,
+        *,  # keyword-only arguments:
+        disabled: bool = False,
+    ) -> List[Any]:
+        ...
+
     def multiselect(
         self,
         label: str,

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -83,7 +83,7 @@ class MultiSelectMixin:
         self,
         label: str,
         options: OptionSequence,
-        default: Union[Iterable[Any], Any, None] = None,
+        default: Optional[Any] = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
         help: Optional[str] = None,


### PR DESCRIPTION
## 📚 Context

The return type for `st.multiselect` depends on the value of `options`, but this is not expressed in the type annotations. I've added an overload so that for `Sequence[T]` options you get `List[T]`. For the Pandas types this is not possible as far as I'm aware, so I make no effort on those.

- What kind of change does this PR introduce?
  - [x] Other, please describe:  Type annotations

## 🧠 Description of Changes

- Add overload to `st.multiselect` narrowing the return to `List[T]` when `options` argument is `Sequence[T]`

## 🧪 Testing Done

Ran mypy on some code from the `e2e/scripts/st_multiselect.py` file

```python
import streamlit as st

options = ("male", "female")
i1 = st.multiselect("multiselect 1", options)
reveal_type(i1)
st.text("value 1: %s" % i1)

i2 = st.multiselect("multiselect 2", options, format_func=lambda x: x.capitalize())
reveal_type(i2)
st.text("value 2: %s" % i2)

i3 = st.multiselect("multiselect 3", [])
reveal_type(i3)
st.text("value 3: %s" % i3)

i4 = st.multiselect("multiselect 4", ["coffee", "tea", "water"], ["tea", "water"])
reveal_type(i4)
st.text("value 4: %s" % i4)

i5 = st.multiselect(
    "multiselect 5",
    list(
        map(
            lambda x: f"{x} I am a ridiculously long string to have in a multiselect, so perhaps I should just not wrap and go to the next line.",
            range(5),
        )
    ),
)
reveal_type(i5)
st.text("value 5: %s" % i5)

i6 = st.multiselect("multiselect 6", options, disabled=True)
reveal_type(i6)
st.text("value 6: %s" % i6)

if st._is_running_with_streamlit:

    def on_change():
        st.session_state.multiselect_changed = True

    st.multiselect("multiselect 7", options, key="multiselect7", on_change=on_change)
    st.text("value 7: %s" % st.session_state.multiselect7)
    st.text(f"multiselect changed: {'multiselect_changed' in st.session_state}")
```
Which gives:
```
e2e/scripts/st_multiselect.py:19:13: note: Revealed type is "builtins.list[builtins.str]"
e2e/scripts/st_multiselect.py:23:13: note: Revealed type is "builtins.list[builtins.str]"
e2e/scripts/st_multiselect.py:26:1: error: Need type annotation for "i3" (hint: "i3: List[<type>] = ...")  [var-annotated]
    i3 = st.multiselect("multiselect 3", [])
    ^
e2e/scripts/st_multiselect.py:27:13: note: Revealed type is "builtins.list[Any]"
e2e/scripts/st_multiselect.py:31:13: note: Revealed type is "builtins.list[builtins.str]"
e2e/scripts/st_multiselect.py:43:13: note: Revealed type is "builtins.list[builtins.str]"
e2e/scripts/st_multiselect.py:47:13: note: Revealed type is "builtins.list[builtins.str]"
```

Which is all expected. The missing annotation error is expected since mypy cannot infer type from the empty list `[]` which it would now like to have to satisfy `Sequence[T]`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
