### PR TITLE
Type check e2e scripts

### DIFF
--- a/e2e/scripts/st_arrow_dataframe_canvas_rendering.py
+++ b/e2e/scripts/st_arrow_dataframe_canvas_rendering.py
@@ -268,7 +268,7 @@ table1 = pa.Table.from_pandas(df_arr1)
 st._arrow_dataframe(table1)
 
 st.header("Input Data: numpy.ndarray")
-np_array = np.ndarray(
+np_array: "np.typing.NDArray[np.int_]" = np.ndarray(
     shape=(5, 5),
     buffer=np.arange(40),
     dtype=int,

--- a/e2e/scripts/st_arrow_empty_charts.py
+++ b/e2e/scripts/st_arrow_empty_charts.py
@@ -62,6 +62,6 @@ except Exception as e:
     st.write(e)
 
 try:
-    st._arrow_altair_chart(use_container_width=True)
+    st._arrow_altair_chart(use_container_width=True)  # type: ignore[call-arg]
 except Exception as e:
     st.write(e)

--- a/e2e/scripts/st_legacy_dataframe_sort_column.py
+++ b/e2e/scripts/st_legacy_dataframe_sort_column.py
@@ -11,11 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
 import streamlit as st
 
 cols = st.number_input("Number of columns", value=5)
-df = pd.DataFrame(np.random.randint(0, 10, size=(10, cols)))
+df = pd.DataFrame(
+    np.random.randint(
+        0,
+        10,
+        # Cast is needed due to faulty typing from numpy
+        size=cast(Any, (10, cols)),
+    )
+)
 st._legacy_dataframe(df)

--- a/e2e/scripts/st_legacy_empty_charts.py
+++ b/e2e/scripts/st_legacy_empty_charts.py
@@ -62,6 +62,6 @@ except Exception as e:
     st.write(e)
 
 try:
-    st._legacy_altair_chart(use_container_width=True)
+    st._legacy_altair_chart(use_container_width=True)  # type: ignore[call-arg]
 except Exception as e:
     st.write(e)

--- a/e2e/scripts/st_main_menu.py
+++ b/e2e/scripts/st_main_menu.py
@@ -17,5 +17,7 @@ import streamlit as st
 # Not possible to test the urls in the menu as they are hidden behind
 # the click handler of the button
 # https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js
-menu_items = {"about": "_*This can be markdown!*_"}
+from streamlit.commands.page_config import MenuItems
+
+menu_items: MenuItems = {"about": "_*This can be markdown!*_"}
 st.set_page_config(menu_items=menu_items)

--- a/e2e/scripts/st_map.py
+++ b/e2e/scripts/st_map.py
@@ -23,6 +23,8 @@ st.map()
 
 # Simple map.
 
+# Cast is needed due to mypy not understanding the outcome of divinging 
+# an array by a list of numbers.
 coords: "np.typing.NDArray[np.float_]" = cast(
     Any,
     np.random.randn(1000, 2) / [50, 50],

--- a/e2e/scripts/st_map.py
+++ b/e2e/scripts/st_map.py
@@ -23,7 +23,7 @@ st.map()
 
 # Simple map.
 
-# Cast is needed due to mypy not understanding the outcome of divinging 
+# Cast is needed due to mypy not understanding the outcome of dividing 
 # an array by a list of numbers.
 coords: "np.typing.NDArray[np.float_]" = cast(
     Any,

--- a/e2e/scripts/st_map.py
+++ b/e2e/scripts/st_map.py
@@ -23,7 +23,7 @@ st.map()
 
 # Simple map.
 
-# Cast is needed due to mypy not understanding the outcome of dividing 
+# Cast is needed due to mypy not understanding the outcome of dividing
 # an array by a list of numbers.
 coords: "np.typing.NDArray[np.float_]" = cast(
     Any,

--- a/e2e/scripts/st_map.py
+++ b/e2e/scripts/st_map.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any, cast
 
 import streamlit as st
 import pandas as pd
@@ -22,7 +23,10 @@ st.map()
 
 # Simple map.
 
-coords = np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4]
+coords: "np.typing.NDArray[np.float_]" = cast(
+    Any,
+    np.random.randn(1000, 2) / [50, 50],
+) + [37.76, -122.4]
 df = pd.DataFrame(coords, columns=["lat", "lon"])
 
 st.map(df)

--- a/e2e/scripts/st_multiselect.py
+++ b/e2e/scripts/st_multiselect.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, List
+
 import streamlit as st
 
 options = ("male", "female")
+
 i1 = st.multiselect("multiselect 1", options)
 st.text("value 1: %s" % i1)
 
 i2 = st.multiselect("multiselect 2", options, format_func=lambda x: x.capitalize())
 st.text("value 2: %s" % i2)
 
-i3 = st.multiselect("multiselect 3", [])
+i3: List[Any] = st.multiselect("multiselect 3", [])
 st.text("value 3: %s" % i3)
 
 i4 = st.multiselect("multiselect 4", ["coffee", "tea", "water"], ["tea", "water"])

--- a/e2e/scripts/st_plotly_chart.py
+++ b/e2e/scripts/st_plotly_chart.py
@@ -20,9 +20,9 @@ from plotly import figure_factory
 np.random.seed(0)
 
 # Add histogram data
-x1 = np.random.randn(200) - 2
-x2 = np.random.randn(200)
-x3 = np.random.randn(200) + 2
+x1: "np.typing.NDArray[np.float_]" = np.random.randn(200) - 2
+x2: "np.typing.NDArray[np.float_]" = np.random.randn(200)
+x3: "np.typing.NDArray[np.float_]" = np.random.randn(200) + 2
 
 # Group data together
 hist_data = [x1, x2, x3]

--- a/e2e/scripts/st_pydeck_chart.py
+++ b/e2e/scripts/st_pydeck_chart.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any, cast
 
 import streamlit as st
 import numpy as np
@@ -26,7 +27,8 @@ st.pydeck_chart()
 np.random.seed(12345)
 
 df = pd.DataFrame(
-    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4], columns=["lat", "lon"]
+    cast(Any, np.random.randn(1000, 2) / [50, 50]) + [37.76, -122.4],
+    columns=["lat", "lon"],
 )
 
 st.pydeck_chart(

--- a/e2e/scripts/st_pyplot_kwargs.py
+++ b/e2e/scripts/st_pyplot_kwargs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import textwrap
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -28,9 +29,12 @@ yLabel = "Very long long y label"
 # Generate data
 n = 200
 np.random.seed(1234)
-xData = np.random.randn(n, 1) * 30 + 30
-yData = np.random.randn(n, 1) * 30
-data = np.random.randn(n, 2)
+
+# Casting to Any in order to support differences in typing behaviour for
+# python 3.7
+xData: "np.typing.NDArray[np.float_]" = cast(Any, np.random.randn(n, 1) * 30) + 30
+yData: "np.typing.NDArray[np.float_]" = np.random.randn(n, 1) * 30
+data: "np.typing.NDArray[np.float_]" = np.random.randn(n, 2)
 
 # Generate plot
 fig, ax = plt.subplots(figsize=(4.5, 4.5))

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -42,7 +42,7 @@ ignore_missing_imports = True
 [mypy-pympler.*]
 ignore_missing_imports = True
 
-[mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,matplotlib,matplotlib.pyplot,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers]
+[mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,graphviz,matplotlib,matplotlib.pyplot,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,seaborn,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers]
 ignore_missing_imports = true
 
 [mypy-semver.*]

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Mapping
 from urllib.parse import urlparse
 from textwrap import dedent
 from typing import cast, Dict, Optional, TYPE_CHECKING, Union
@@ -38,7 +39,7 @@ _GetHelp: TypeAlias = Literal["Get help", "Get Help", "get help"]
 _ReportABug: TypeAlias = Literal["Report a bug", "report a bug"]
 _About: TypeAlias = Literal["About", "about"]
 MenuKey: TypeAlias = Literal[_GetHelp, _ReportABug, _About]
-MenuItems: TypeAlias = Dict[MenuKey, Optional[str]]
+MenuItems: TypeAlias = Mapping[MenuKey, Optional[str]]
 
 
 def set_page_config(
@@ -216,8 +217,8 @@ def set_menu_items_proto(lowercase_menu_items, menu_items_proto) -> None:
             menu_items_proto.about_section_md = dedent(lowercase_menu_items[ABOUT_KEY])
 
 
-def validate_menu_items(dict: MenuItems) -> None:
-    for k, v in dict.items():
+def validate_menu_items(menu_items: MenuItems) -> None:
+    for k, v in menu_items.items():
         if not valid_menu_item_key(k):
             raise StreamlitAPIException(
                 "We only accept the keys: "

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -30,13 +30,14 @@ from streamlit.state import (
 
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
+from ..type_util import SupportsStr
 
 
 class TextWidgetsMixin:
     def text_input(
         self,
         label: str,
-        value: str = "",
+        value: SupportsStr = "",
         max_chars: Optional[int] = None,
         key: Optional[Key] = None,
         type: str = "default",
@@ -55,7 +56,7 @@ class TextWidgetsMixin:
         ----------
         label : str
             A short label explaining to the user what this input is for.
-        value : any
+        value : object
             The text value of this widget when it first renders. This will be
             cast to str internally.
         max_chars : int or None
@@ -124,7 +125,7 @@ class TextWidgetsMixin:
     def _text_input(
         self,
         label: str,
-        value: str = "",
+        value: SupportsStr = "",
         max_chars: Optional[int] = None,
         key: Optional[Key] = None,
         type: str = "default",
@@ -200,7 +201,7 @@ class TextWidgetsMixin:
     def text_area(
         self,
         label: str,
-        value: str = "",
+        value: SupportsStr = "",
         height: Optional[int] = None,
         max_chars: Optional[int] = None,
         key: Optional[Key] = None,
@@ -218,7 +219,7 @@ class TextWidgetsMixin:
         ----------
         label : str
             A short label explaining to the user what this input is for.
-        value : any
+        value : object
             The text value of this widget when it first renders. This will be
             cast to str internally.
         height : int or None
@@ -282,7 +283,7 @@ class TextWidgetsMixin:
     def _text_area(
         self,
         label: str,
-        value: str = "",
+        value: SupportsStr = "",
         height: Optional[int] = None,
         max_chars: Optional[int] = None,
         key: Optional[Key] = None,

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -226,9 +226,7 @@ class WriteMixin:
                 self.dg.pydeck_chart(arg)
             elif inspect.isclass(arg):
                 flush_buffer()
-                # Cast is needed due to:
-                # https://github.com/python/mypy/issues/12933
-                self.dg.text(cast(type, arg))
+                self.dg.text(arg)
             elif hasattr(arg, "_repr_html_"):
                 self.dg.markdown(
                     arg._repr_html_(),

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -30,7 +30,9 @@ from typing import (
     cast,
     overload,
 )
+from typing import Callable
 
+from typing_extensions import ClassVar
 from typing_extensions import (
     Final,
     Literal,
@@ -109,9 +111,10 @@ Key: TypeAlias = Union[str, int]
 T = TypeVar("T")
 
 
-class SupportsStr(Protocol):
-    def __str__(self) -> str:
-        ...
+# This should really be a Protocol, but can't be, due to:
+# https://github.com/python/mypy/issues/12933
+# https://github.com/python/mypy/issues/13081
+SupportsStr: TypeAlias = object
 
 
 def is_array_value_field_name(obj: object) -> TypeGuard[ArrayValueFieldName]:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -30,9 +30,7 @@ from typing import (
     cast,
     overload,
 )
-from typing import Callable
 
-from typing_extensions import ClassVar
 from typing_extensions import (
     Final,
     Literal,

--- a/scripts/mypy
+++ b/scripts/mypy
@@ -28,8 +28,8 @@ import click
 import mypy.main as mypy_main
 
 
-PATHS = ["lib/streamlit/", "scripts/*"]
-EXCLUDE_FILES = {"scripts/add_license_headers.py"}
+PATHS = ["lib/streamlit/", "scripts/*", "e2e/scripts/*"]
+EXCLUDE_FILES = {"scripts/add_license_headers.py", "e2e/scripts/st_reuse_label.py"}
 
 
 class Module:


### PR DESCRIPTION
## 📚 Context

I figured it would be helpful when adding/improving type hints on the public API, that there are type checked usages of the API in the code base. This would help ensure that the annotations are aligned with intended use cases. The e2e scripts are already using the widgets, and, as far as I can see, represent a broad selection of intended usage patterns. So all that is needed to achieve this benefit is to ensure e2e scripts are type checked. This PR does just that.

In the process, I discovered that the value type on the text widgets was a bit too strict, so I loosened this by going from `str` to `SupportsStr`. This better reflects the intended use.

Upon doing this, I noticed several types that did not adhere to the `SupportsStr` protocol, according to `mypy`, even though they do in practice. Most notably `None`. I solved this by just letting `SupportsStr` alias `object` for now, as I struggled to modify the Protocol to a point where it is liberal enough.

- What kind of change does this PR introduce?

  - [X] Other, please describe: Improved type annotations, wider type checking

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
