### PR TITLE
Fix issue with wrongly applied colors with Pandas styler

### DIFF
--- a/frontend/src/components/widgets/DataFrame/DataFrameCells.test.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrameCells.test.tsx
@@ -19,24 +19,25 @@ import { extractCssProperty } from "./DataFrameCells"
 
 test("extractCssProperty should extract the correct property value", () => {
   const cssStyle1 = `
-  #T_f116e_row10_col0, #T_f116e_row10_col1, #T_f116e_row10_col3 { color: red }
-  #T_f116e_row0_col1, #T_f116e_row1_col0 { color: white; background-color: pink }
-  #T_f116e_row0_col2 { color: red; opacity: 20% }
-  #T_f116e_row2_col2, #T_f116e_row5_col1 { opacity: 20% }
-  #T_f116e_row3_col3, #T_f116e_row12_col1 { color: white; background-color: darkblue; color: white; background-color: pink }`
+   #T_f116e_row10_col0, #T_f116e_row10_col1, #T_f116e_row10_col3 { color: red }
+   #T_f116e_row0_col1, #T_f116e_row1_col0 { color: white; background-color: pink }
+   #T_f116e_row0_col2 { color: red; opacity: 20% }
+   #T_f116e_row2_col2, #T_f116e_row5_col1 { opacity: 20% }
+   #T_f116e_row3_col3, #T_f116e_row12_col1 { color: white; background-color: darkblue; color: white; background-color: pink }
+   #T_f116e_row11_col10, #T_f116e_row11_col10 {  background-color: darkblue }`
 
   const cssStyle2 = `
-  #T_7e5cc_row6_col0 { background-color: #f8fcc9; color: #000000 }
-  #T_7e5cc_row7_col1 { background-color: #1c2d81; color: #f1f1f1 }
-  #T_7e5cc_row8_col0 { background-color: #289cc1; color: #f1f1f1 }
-  #T_7e5cc_row8_col1 { background-color: #2165ab; color: #f1f1f1 }
-  #T_7e5cc_row9_col0 { background-color: #f0f9b8; color: #000000 }`
+   #T_7e5cc_row6_col0 { background-color: #f8fcc9; color: #000000 }
+   #T_7e5cc_row7_col1 { background-color: #1c2d81; color: #f1f1f1 }
+   #T_7e5cc_row8_col0 { background-color: #289cc1; color: #f1f1f1 }
+   #T_7e5cc_row8_col1 { background-color: #2165ab; color: #f1f1f1 }
+   #T_7e5cc_row9_col0 { background-color: #f0f9b8; color: #000000 }`
 
   // Badly Formatted
   const cssStyle3 = `
-  #T_f116e_row10_col0,#T_7e5cc_row6_col0   {   background-color: #f8fcc9;     color: #000000 }
-  #T_7e5cc_row7_col1{ background-color:#1c2d81; color: #f1f1f1 }
-  #T_7e5cc_row8_col0{background-color: #289cc1;color: #f1f1f1}`
+   #T_f116e_row10_col0,#T_7e5cc_row6_col0   {   background-color: #f8fcc9;     color: #000000 }
+   #T_7e5cc_row7_col1{ background-color:#1c2d81; color: #f1f1f1 }
+   #T_7e5cc_row8_col0{background-color: #289cc1;color: #f1f1f1}`
 
   expect(extractCssProperty("#T_f116e_row10_col1", "color", cssStyle1)).toBe(
     "red"
@@ -51,6 +52,13 @@ test("extractCssProperty should extract the correct property value", () => {
   expect(extractCssProperty("#T_f116e_row0_col2", "color", cssStyle1)).toBe(
     "red"
   )
+  expect(
+    extractCssProperty("#T_f116e_row11_col10", "background-color", cssStyle1)
+  ).toBe("darkblue")
+  // Should not extract if it only partly matches:
+  expect(
+    extractCssProperty("#T_f116e_row11_col1", "background-color", cssStyle1)
+  ).toBe(undefined)
 
   expect(
     extractCssProperty("#T_7e5cc_row6_col0", "background-color", cssStyle2)

--- a/frontend/src/components/widgets/DataFrame/DataFrameCells.test.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrameCells.test.tsx
@@ -19,25 +19,25 @@ import { extractCssProperty } from "./DataFrameCells"
 
 test("extractCssProperty should extract the correct property value", () => {
   const cssStyle1 = `
-   #T_f116e_row10_col0, #T_f116e_row10_col1, #T_f116e_row10_col3 { color: red }
-   #T_f116e_row0_col1, #T_f116e_row1_col0 { color: white; background-color: pink }
-   #T_f116e_row0_col2 { color: red; opacity: 20% }
-   #T_f116e_row2_col2, #T_f116e_row5_col1 { opacity: 20% }
-   #T_f116e_row3_col3, #T_f116e_row12_col1 { color: white; background-color: darkblue; color: white; background-color: pink }
-   #T_f116e_row11_col10, #T_f116e_row11_col10 {  background-color: darkblue }`
+  #T_f116e_row10_col0, #T_f116e_row10_col1, #T_f116e_row10_col3 { color: red }
+  #T_f116e_row0_col1, #T_f116e_row1_col0 { color: white; background-color: pink }
+  #T_f116e_row0_col2 { color: red; opacity: 20% }
+  #T_f116e_row2_col2, #T_f116e_row5_col1 { opacity: 20% }
+  #T_f116e_row3_col3, #T_f116e_row12_col1 { color: white; background-color: darkblue; color: white; background-color: pink }
+  #T_f116e_row11_col10, #T_f116e_row11_col10 {  background-color: darkblue }`
 
   const cssStyle2 = `
-   #T_7e5cc_row6_col0 { background-color: #f8fcc9; color: #000000 }
-   #T_7e5cc_row7_col1 { background-color: #1c2d81; color: #f1f1f1 }
-   #T_7e5cc_row8_col0 { background-color: #289cc1; color: #f1f1f1 }
-   #T_7e5cc_row8_col1 { background-color: #2165ab; color: #f1f1f1 }
-   #T_7e5cc_row9_col0 { background-color: #f0f9b8; color: #000000 }`
+  #T_7e5cc_row6_col0 { background-color: #f8fcc9; color: #000000 }
+  #T_7e5cc_row7_col1 { background-color: #1c2d81; color: #f1f1f1 }
+  #T_7e5cc_row8_col0 { background-color: #289cc1; color: #f1f1f1 }
+  #T_7e5cc_row8_col1 { background-color: #2165ab; color: #f1f1f1 }
+  #T_7e5cc_row9_col0 { background-color: #f0f9b8; color: #000000 }`
 
   // Badly Formatted
   const cssStyle3 = `
-   #T_f116e_row10_col0,#T_7e5cc_row6_col0   {   background-color: #f8fcc9;     color: #000000 }
-   #T_7e5cc_row7_col1{ background-color:#1c2d81; color: #f1f1f1 }
-   #T_7e5cc_row8_col0{background-color: #289cc1;color: #f1f1f1}`
+  #T_f116e_row10_col0,#T_7e5cc_row6_col0   {   background-color: #f8fcc9;     color: #000000 }
+  #T_7e5cc_row7_col1{ background-color:#1c2d81; color: #f1f1f1 }
+  #T_7e5cc_row8_col0{background-color: #289cc1;color: #f1f1f1}`
 
   expect(extractCssProperty("#T_f116e_row10_col1", "color", cssStyle1)).toBe(
     "red"

--- a/frontend/src/components/widgets/DataFrame/DataFrameCells.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrameCells.tsx
@@ -87,9 +87,11 @@ export function extractCssProperty(
   // This regex is supposed to extract the value of a CSS property
   // for a specified HTML element ID from a CSS style string:
   const regex = new RegExp(
-    `${htmlElementId}[^{]*{(?:[^}]*[\\s;]{1})?${property}:\\s*([^;\\s]+)[;]?.*}`,
+    `${htmlElementId}[,\\s].*{(?:[^}]*[\\s;]{1})?${property}:\\s*([^;\\s]+)[;]?.*}`,
     "gm"
   )
+  // Makes the regex simpler to match the element correctly:
+  cssStyle = cssStyle.replaceAll("{", " {")
 
   const match = regex.exec(cssStyle)
   if (match) {

--- a/frontend/src/components/widgets/DataFrame/DataFrameCells.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrameCells.tsx
@@ -91,7 +91,7 @@ export function extractCssProperty(
     "gm"
   )
   // Makes the regex simpler to match the element correctly:
-  cssStyle = cssStyle.replaceAll("{", " {")
+  cssStyle = cssStyle.replace(/{/g, " {")
 
   const match = regex.exec(cssStyle)
   if (match) {


### PR DESCRIPTION
## 📚 Context

This PR fixes [an issue](https://github.com/streamlit/streamlit/issues/4938) with wrongly applied color values with using Pandas Styler in the new `st.dataframe`.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Fix extraction regex to not match wrong columns.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4938

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
