### PR TITLE
Test that GitRepo can handle import failures

### DIFF
--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -76,3 +76,8 @@ class GitUtilTest(unittest.TestCase):
             repo = GitRepo(".")
             self.assertTrue(repo.is_valid())
             self.assertEqual((2, 20, 3), repo.git_version)
+
+    def test_gitpython_not_installed(self):
+        with patch.dict("sys.modules", {"git": None}):
+            repo = GitRepo(".")
+            self.assertFalse(repo.is_valid())


### PR DESCRIPTION
## 📚 Context

We're working toward proper/official support for a conda distribution of Streamlit (there's currently
only a `conda-forge` release of the library that we don't treat with the same amount of care
as our PyPI distribution). In this release, we only want to include dependencies that exist in the
conda default channel, which will require us to make certain conda-forge-only dependencies optional
or to remove them entirely.

For the `gitpython` dependency (which is one of these conda-forge-only dependencies), we already
quite conveniently wrote the code using it in such a way that it's resilient to the package not being
installed, but we didn't have a unit test to verify that things work as expected in this case. This PR
simply adds that unit test.

- What kind of change does this PR introduce?

  - [x] Other, please describe: more tests


## 🧪 Testing Done

- [x] Added/Updated unit tests
