### PR TITLE
Move dependency declarations from Pipfile -> setup.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 * @streamlit/core
 frontend/package.json @jroes @anoctopus @tconkling @kmcgrady
 lib/Pipfile @jroes @anoctopus @tconkling @kmcgrady
+lib/setup.py @jroes @anoctopus @tconkling @kmcgrady

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ frontend: react-build
 
 .PHONY: setup
 setup:
-	pip install pip-tools pipenv "typing-extensions < 3.10" ;
+	pip install pip-tools pipenv ;
 
 .PHONY: pipenv-install
 pipenv-install: pipenv-dev-install py-test-install
@@ -164,7 +164,8 @@ install:
 .PHONY: develop
 # Install Streamlit as links in your Python environment, pointing to local workspace.
 develop:
-	cd lib ; python setup.py develop
+	cd lib; \
+		pipenv install --skip-lock --sequential
 
 .PHONY: distribution
 # Create Python distribution files in dist/.

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -33,35 +33,8 @@ types-typed-ast = "*"
 # test-requirements.txt instead.
 
 [packages]
-# IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
-# And if you do add one, make the required version as general as possible.
-# But include relevant lower bounds for any features we use from our dependencies.
-altair = ">=3.2.0"
-attrs = ">=16.0.0"
-blinker = ">=1.0.0"
-cachetools = ">=4.0"
-click = ">=7.0"
-gitpython = "!=3.1.19"
-# 1.4 introduced the functionality found in python 3.8's importlib.metadata module
-importlib-metadata = ">=1.4"
-numpy = "*"
-packaging = ">=14.1"
-pandas = ">=0.21.0"
-pillow = ">=6.2.0"
-protobuf = ">=3.12, <4"
-pyarrow = ">=4.0"
-pydeck = ">=0.1.dev5"
-pympler = ">=0.9"
-python-dateutil = "*"
-requests = ">=2.4"
-rich = ">=10.11.0"
-semver = "*"
-toml = "*"
-# 5.0 has a fix for etag header: https://github.com/tornadoweb/tornado/issues/2262
-tornado = ">=5.0"
-typing-extensions = ">=3.10.0.0"
-tzlocal = ">=1.1"
-validators = ">=0.2"
-# Don't require watchdog on MacOS, since it'll fail without xcode tools.
-# Without watchdog, we fallback to a polling file watcher to check for app changes.
-watchdog = {version = "*", markers = "platform_system != 'Darwin'"}
+# NOTE: We only use this Pipfile to manage dev and test dependencies.
+# Dependencies for releases of the Streamlit library itself should be added in
+# setup.py. See https://pipenv.pypa.io/en/latest/advanced/#pipfile-vs-setup-py
+# for more information on why things are done in this way.
+streamlit = {editable = true, path = "."}

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -18,21 +18,6 @@ import sys
 
 from setuptools.command.install import install
 
-# Import Pipenv. We support multiple versions.
-try:
-    from pipenv.project import Project
-
-    try:
-        # Pipenv 2022.4.8
-        from pipenv.utils.dependencies import convert_deps_to_pip
-    except:
-        # Older Pipenv
-        from pipenv.utils import convert_deps_to_pip
-except:
-    exit_msg = (
-        "pipenv is required to package Streamlit. Please install pipenv and try again."
-    )
-    sys.exit(exit_msg)
 
 VERSION = "1.10.0"  # PEP-440
 
@@ -47,10 +32,40 @@ LONG_DESCRIPTION = (
     "All in pure Python. All for free."
 )
 
-pipfile = Project(chdir=False).parsed_pipfile
-
-packages = pipfile["packages"].copy()
-requirements = convert_deps_to_pip(packages, r=False)
+# IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
+# And if you do add one, make the required version as general as possible.
+# But include relevant lower bounds for any features we use from our dependencies.
+INSTALL_REQUIRES = [
+    "altair>=3.2.0",
+    "attrs>=16.0.0",
+    "blinker>=1.0.0",
+    "cachetools>=4.0",
+    "click>=7.0",
+    "gitpython!=3.1.19",
+    # 1.4 introduced the functionality found in python 3.8's importlib.metadata module
+    "importlib-metadata>=1.4",
+    "numpy",
+    "packaging>=14.1",
+    "pandas>=0.21.0",
+    "pillow>=6.2.0",
+    "protobuf<4,>=3.12",
+    "pyarrow>=4.0",
+    "pydeck>=0.1.dev5",
+    "pympler>=0.9",
+    "python-dateutil",
+    "requests>=2.4",
+    "rich>=10.11.0",
+    "semver",
+    "toml",
+    # 5.0 has a fix for etag header: https://github.com/tornadoweb/tornado/issues/2262
+    "tornado>=5.0",
+    "typing-extensions>=3.10.0.0",
+    "tzlocal>=1.1",
+    "validators>=0.2",
+    # Don't require watchdog on MacOS, since it'll fail without xcode tools.
+    # Without watchdog, we fallback to a polling file watcher to check for app changes.
+    "watchdog; platform_system != 'Darwin'",
+]
 
 
 class VerifyVersionCommand(install):
@@ -85,7 +100,7 @@ setuptools.setup(
     package_data={"streamlit": ["py.typed", "hello/**/*.py"]},
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     # Requirements
-    install_requires=requirements,
+    install_requires=INSTALL_REQUIRES,
     zip_safe=False,  # install source files not egg
     include_package_data=True,  # copy html and friends
     entry_points={"console_scripts": ["streamlit = streamlit.web.cli:main"]},


### PR DESCRIPTION
## 📚 Context

We've been using our `Pipfile` to manage all dependencies. To ensure that `pip` knows
about these dependencies, we convert the content of the `Pipfile` using `pipenv`'s
`convert_deps_to_pip` utility function and pass the output to `setuptools.setup` as the
`install_requires` argument.

This ended up being problematic when trying to get conda builds of Streamlit working without
any dependencies that don't exist in the conda default channel (`pipenv` only exists in conda-forge).
When looking for ways to resolve this, I noticed [some documentation](https://pipenv.pypa.io/en/latest/advanced/#pipfile-vs-setup-py) and [a GitHub issue](https://github.com/pypa/pipenv/issues/1263) that suggest
that a library's `Pipfile` shouldn't be used for managing its non-dev requirements, and that we should
define the dependencies directly in `setup.py`.

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: dependency reorganization
