### PR TITLE
Remove staticmethod decorator from __call__ method of MemoAPI to avoi…

### DIFF
--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -214,6 +214,9 @@ class MemoAPI:
     ) -> Callable[[F], F]:
         ...
 
+    # __call__ should be a static method, but there's a mypy bug that
+    # breaks type checking for overloaded static functions:
+    # https://github.com/python/mypy/issues/7781
     def __call__(
         self,
         func: Optional[F] = None,

--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -198,14 +198,13 @@ class MemoAPI:
 
     # Bare decorator usage
     @overload
-    @staticmethod
-    def __call__(func: F) -> F:
+    def __call__(self, func: F) -> F:
         ...
 
     # Decorator with arguments
     @overload
-    @staticmethod
     def __call__(
+        self,
         *,
         persist: Optional[str] = None,
         show_spinner: bool = True,
@@ -215,8 +214,8 @@ class MemoAPI:
     ) -> Callable[[F], F]:
         ...
 
-    @staticmethod
     def __call__(
+        self,
         func: Optional[F] = None,
         *,
         persist: Optional[str] = None,


### PR DESCRIPTION
Remove staticmethod decorator from __call__ method of MemoAPI to avoid mypy bug and fix #4634

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4634

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
