### PR TITLE
Replace legacy app URLs in docs with custom subdomains

### DIFF
--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -71,7 +71,7 @@ class BokehMixin:
         >>> st.bokeh_chart(p, use_container_width=True)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.bokeh_chart.py
+           https://doc-bokeh-chart.streamlitapp.com/
            height: 700px
 
         """

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -97,7 +97,7 @@ class ButtonMixin:
         ...     st.write('Goodbye')
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.button.py
+           https://doc-buton.streamlitapp.com/
            height: 220px
 
         """
@@ -219,7 +219,7 @@ class ButtonMixin:
         ...           )
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.download_button.py
+           https://doc-download-buton.streamlitapp.com/
            height: 335px
 
         """

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -84,7 +84,7 @@ class CheckboxMixin:
         ...     st.write('Great!')
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.checkbox.py
+           https://doc-checkbox.streamlitapp.com/
            height: 220px
 
         """

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -83,7 +83,7 @@ class ColorPickerMixin:
         >>> st.write('The current color is', color)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.color_picker.py
+           https://doc-color-picker.streamlitapp.com/
            height: 335px
 
         """

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -72,7 +72,7 @@ class DataFrameSelectorMixin:
         >>> st.dataframe(df)  # Same as st.write(df)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.dataframe.py
+           https://doc-dataframe.streamlitapp.com/
            height: 410px
 
         >>> st.dataframe(df, 200, 100)
@@ -87,7 +87,7 @@ class DataFrameSelectorMixin:
         >>> st.dataframe(df.style.highlight_max(axis=0))
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.dataframe1.py
+           https://doc-dataframe1.streamlitapp.com/
            height: 410px
 
         """
@@ -120,7 +120,7 @@ class DataFrameSelectorMixin:
         >>> st.table(df)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.table.py
+           https://doc-table.streamlitapp.com/
            height: 480px
 
         """
@@ -174,7 +174,7 @@ class DataFrameSelectorMixin:
         >>> st.line_chart(chart_data)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.line_chart.py
+           https://doc-line-chart.streamlitapp.com/
            height: 400px
 
         """
@@ -228,7 +228,7 @@ class DataFrameSelectorMixin:
         >>> st.area_chart(chart_data)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.area_chart.py
+           https://doc-area-chart.streamlitapp.com/
            height: 400px
 
         """
@@ -282,7 +282,7 @@ class DataFrameSelectorMixin:
         >>> st.bar_chart(chart_data)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.bar_chart.py
+           https://doc-bar-chart.streamlitapp.com/
            height: 400px
 
         """
@@ -328,7 +328,7 @@ class DataFrameSelectorMixin:
         https://altair-viz.github.io/gallery/.
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.vega_lite_chart.py
+           https://doc-vega-lite-chart.streamlitapp.com/
            height: 300px
 
         """
@@ -390,7 +390,7 @@ class DataFrameSelectorMixin:
         ... })
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.vega_lite_chart.py
+           https://doc-vega-lite-chart.streamlitapp.com/
            height: 300px
 
         Examples of Vega-Lite usage without Streamlit can be found at

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -230,7 +230,7 @@ class FileUploaderMixin:
         ...     st.write(bytes_data)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.file_uploader.py
+           https://doc-file-uploader.streamlitapp.com/
            height: 375px
 
         """

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -85,7 +85,7 @@ class GraphvizMixin:
         ''')
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.graphviz_chart.py
+           https://doc-graphviz-chart.streamlitapp.com/
            height: 600px
 
         """

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -120,7 +120,7 @@ class ImageMixin:
         >>> st.image(image, caption='Sunrise by the mountains')
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.image.py
+           https://doc-image.streamlitapp.com/
            height: 710px
 
         """

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -59,7 +59,7 @@ class JsonMixin:
         ... })
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/data.json.py
+           https://doc-json.streamlitapp.com/
            height: 385px
 
         """

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -240,7 +240,7 @@ class LayoutsMixin:
 
         .. output ::
             https://doc-tabs1.streamlitapp.com/
-            height: 700px
+            height: 620px
 
         Or you can just call methods directly in the returned objects:
 

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -50,7 +50,7 @@ class LayoutsMixin:
         >>> st.write("This is outside the container")
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.container1.py
+            https://doc-container1.streamlitapp.com/
             height: 520px
 
         Inserting elements out of order:
@@ -63,7 +63,7 @@ class LayoutsMixin:
         >>> container.write("This is inside too")
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.container2.py
+            https://doc-container2.streamlitapp.com/
             height: 480px
         """
         return self.dg._block()
@@ -129,7 +129,7 @@ class LayoutsMixin:
         ...    st.image("https://static.streamlit.io/examples/owl.jpg")
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.columns1.py
+            https://doc-columns1.streamlitapp.com/
             height: 620px
 
         Or you can just call methods directly in the returned objects:
@@ -144,7 +144,7 @@ class LayoutsMixin:
         >>> col2.write(data)
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.columns2.py
+            https://doc-columns2.streamlitapp.com/
             height: 550px
 
         """
@@ -239,7 +239,7 @@ class LayoutsMixin:
         ...    st.image("https://static.streamlit.io/examples/owl.jpg", width=200)
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.tabs1.py
+            https://doc-tabs1.streamlitapp.com/
             height: 700px
 
         Or you can just call methods directly in the returned objects:
@@ -255,7 +255,7 @@ class LayoutsMixin:
 
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.tabs2.py
+            https://doc-tabs2.streamlitapp.com/
             height: 700px
 
         """
@@ -318,7 +318,7 @@ class LayoutsMixin:
         ...     st.image("https://static.streamlit.io/examples/dice.jpg")
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
+            https://doc-expander.streamlitapp.com/
             height: 750px
 
         Or you can just call methods directly in the returned objects:
@@ -334,7 +334,7 @@ class LayoutsMixin:
         >>> expander.image("https://static.streamlit.io/examples/dice.jpg")
 
         .. output ::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/layout.expander.py
+            https://doc-expander.streamlitapp.com/
             height: 750px
 
         """

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -66,7 +66,7 @@ class MapMixin:
         >>> st.map(df)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.map.py
+           https://doc-map.streamlitapp.com/
            height: 650px
 
         """

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -67,7 +67,7 @@ class MediaMixin:
         >>> st.audio(audio_bytes, format='audio/ogg')
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.audio.py
+           https://doc-audio.streamlitapp.com/
            height: 465px
 
         """
@@ -106,7 +106,7 @@ class MediaMixin:
         >>> st.video(video_bytes)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.video.py
+           https://doc-video.streamlitapp.com/
            height: 700px
 
         .. note::

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -81,7 +81,7 @@ class MetricMixin:
         >>> st.metric(label="Temperature", value="70 °F", delta="1.2 °F")
 
         .. output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/metric.example1.py
+            https://doc-metric-example1.streamlitapp.com/
             height: 210px
 
         ``st.metric`` looks especially nice in combination with ``st.columns``:
@@ -92,7 +92,7 @@ class MetricMixin:
         >>> col3.metric("Humidity", "86%", "4%")
 
         .. output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/metric.example2.py
+            https://doc-metric-example2.streamlitapp.com/
             height: 210px
 
         The delta indicator color can also be inverted or turned off:
@@ -104,7 +104,7 @@ class MetricMixin:
         ...     delta_color="off")
 
         .. output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/metric.example3.py
+            https://doc-metric-example3.streamlitapp.com/
             height: 320px
 
         """

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -106,7 +106,7 @@ class MultiSelectMixin:
         >>> st.write('You selected:', options)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.multiselect.py
+           https://doc-multiselect.streamlitapp.com/
            height: 420px
 
         """

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -105,7 +105,7 @@ class NumberInputMixin:
         >>> st.write('The current number is ', number)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.number_input.py
+           https://doc-number-input.streamlitapp.com/
            height: 260px
 
         """

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -128,7 +128,7 @@ class PlotlyMixin:
         >>> st.plotly_chart(fig, use_container_width=True)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.plotly_chart.py
+           https://doc-plotly-chart.streamlitapp.com/
            height: 400px
 
         """

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -63,7 +63,7 @@ class PyplotMixin:
         >>> st.pyplot(fig)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.pyplot.py
+           https://doc-pyplot.streamlitapp.com/
            height: 630px
 
         Notes

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -102,7 +102,7 @@ class RadioMixin:
         ...     st.write("You didn\'t select comedy.")
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.radio.py
+           https://doc-radio.streamlitapp.com/
            height: 260px
 
         """

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -114,7 +114,7 @@ class SelectSliderMixin:
         >>> st.write('You selected wavelengths between', start_color, 'and', end_color)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.select_slider.py
+           https://doc-select-slider.streamlitapp.com/
            height: 450px
 
         """

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -91,7 +91,7 @@ class SelectboxMixin:
         >>> st.write('You selected:', option)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.selectbox.py
+           https://doc-selectbox.streamlitapp.com/
            height: 320px
 
         """

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -144,7 +144,7 @@ class SliderMixin:
         >>> st.write("Start time:", start_time)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.slider.py
+           https://doc-slider.streamlitapp.com/
            height: 300px
 
         """

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -100,7 +100,7 @@ class TextWidgetsMixin:
         >>> st.write('The current movie title is', title)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.text_input.py
+           https://doc-text-input.streamlitapp.com/
            height: 260px
 
         """

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -211,7 +211,7 @@ class TimeWidgetsMixin:
         >>> st.write('Alarm is set for', t)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.time_input.py
+           https://doc-time-input.streamlitapp.com/
            height: 260px
 
         """
@@ -362,7 +362,7 @@ class TimeWidgetsMixin:
         >>> st.write('Your birthday is:', d)
 
         .. output::
-           https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.date_input.py
+           https://doc-date-input.streamlitapp.com/
            height: 260px
 
         """

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -108,7 +108,7 @@ class WriteMixin:
         >>> write('Hello, *World!* :sunglasses:')
 
         ..  output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/text.write1.py
+            https://doc-write1.streamlitapp.com/
             height: 150px
 
         As mentioned earlier, `st.write()` also accepts other data formats, such as
@@ -121,7 +121,7 @@ class WriteMixin:
         ... }))
 
         ..  output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/text.write2.py
+            https://doc-write2.streamlitapp.com/
             height: 350px
 
         Finally, you can pass in multiple arguments to do things like:
@@ -130,7 +130,7 @@ class WriteMixin:
         >>> st.write('Below is a DataFrame:', data_frame, 'Above is a dataframe.')
 
         ..  output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/text.write3.py
+            https://doc-write3.streamlitapp.com/
             height: 410px
 
         Oh, one more thing: `st.write` accepts chart objects too! For example:
@@ -149,7 +149,7 @@ class WriteMixin:
         >>> st.write(c)
 
         ..  output::
-            https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.vega_lite_chart.py
+            https://doc-vega-lite-chart.streamlitapp.com/
             height: 300px
 
         """


### PR DESCRIPTION
## 📚 Context

The custom subdomain feature on Streamlit Cloud will soon be ready for GA. As such, legacy [share.streamlit.io](share.streamlit.io) URLs of apps embedded in element docstrings should be replaced by their custom subdomain counterparts. These URLs are parsed from docstrings, and the associated apps are iframed/embedded in our docs. Apps with the legacy URLs will no longer work in iframes. We should include this PR in the upcoming release.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Replaces legacy [share.streamlit.io](share.streamlit.io) URLs in element docstrings with custom subdomains. The mapping between old and new app URLs is found in this [Notion table](https://www.notion.so/streamlit/Cloud-apps-embedded-in-our-docs-9ea9818fa1274bbbbb82aa020a2153d6).

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/178461127-342d3b32-d559-4340-a5d6-3a9a57b8541d.png)


**Current:**

![image](https://user-images.githubusercontent.com/20672874/178461252-8c299ffd-fee5-4c99-860b-3ebd2931c1de.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
