### PR TITLE
Remove Server._singleton

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -235,30 +235,10 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
 
 
 class Server:
-    _singleton: Optional["Server"] = None
-
-    @classmethod
-    def get_current(cls) -> "Server":
-        """
-        Returns
-        -------
-        Server
-            The singleton Server object.
-        """
-        if Server._singleton is None:
-            raise RuntimeError("Server has not been initialized yet")
-
-        return Server._singleton
-
     def __init__(
         self, ioloop: AsyncIOLoop, main_script_path: str, command_line: Optional[str]
     ):
         """Create the server. It won't be started yet."""
-        if Server._singleton is not None:
-            raise RuntimeError("Server already initialized. Use .get_current() instead")
-
-        Server._singleton = self
-
         _set_tornado_log_levels()
 
         self._ioloop = ioloop
@@ -804,7 +784,7 @@ class _BrowserWebSocketHandler(WebSocketHandler):
                 self._session.handle_stop_script_request()
             elif msg_type == "close_connection":
                 if config.get_option("global.developmentMode"):
-                    Server.get_current().stop()
+                    self._server.stop()
                 else:
                     LOGGER.warning(
                         "Client tried to close connection when "

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -651,7 +651,6 @@ class ScriptCheckTest(tornado.testing.AsyncTestCase):
 
     def tearDown(self) -> None:
         self._server.stop()
-        Server._singleton = None
 
         if event_based_path_watcher._MultiPathWatcher._singleton is not None:
             event_based_path_watcher._MultiPathWatcher.get_singleton().close()
@@ -712,7 +711,6 @@ class ScriptCheckEndpointExistsTest(tornado.testing.AsyncHTTPTestCase):
 
     def tearDown(self):
         config._set_option("server.scriptHealthCheckEnabled", self._old_config, "test")
-        Server._singleton = None
         super().tearDown()
 
     def get_app(self):
@@ -737,7 +735,6 @@ class ScriptCheckEndpointDoesNotExistTest(tornado.testing.AsyncHTTPTestCase):
 
     def tearDown(self):
         config._set_option("server.scriptHealthCheckEnabled", self._old_config, "test")
-        Server._singleton = None
         super().tearDown()
 
     def get_app(self):

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -61,11 +61,6 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         app = self.server._create_app()
         return app
 
-    def tearDown(self):
-        super(ServerTestCase, self).tearDown()
-        # Clear the Server singleton for the next test
-        Server._singleton = None
-
     async def start_server_loop(self) -> None:
         """Starts the server's loop coroutine."""
         server_started = Future()


### PR DESCRIPTION
This isn't buying us anything - we already have a reference to the server in the two places we use `Server.get_current()`.
