### PR TITLE
session_data.get_url -> server_util.get_url

### DIFF
--- a/lib/streamlit/session_data.py
+++ b/lib/streamlit/session_data.py
@@ -12,42 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import List
 
 import attr
-import os
 
-from streamlit import config
 from streamlit.forward_msg_queue import ForwardMsgQueue
-
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
 LOGGER = get_logger(__name__)
-
-
-def get_url(host_ip: str) -> str:
-    """Get the URL for any app served at the given host_ip.
-
-    Parameters
-    ----------
-    host_ip : str
-        The IP address of the machine that is running the Streamlit Server.
-
-    Returns
-    -------
-    str
-        The URL.
-    """
-    port = _get_browser_address_bar_port()
-    base_path = config.get_option("server.baseUrlPath").strip("/")
-
-    if base_path:
-        base_path = "/" + base_path
-
-    host_ip = host_ip.strip("/")
-
-    return f"http://{host_ip}:{port}{base_path}"
 
 
 @attr.s(auto_attribs=True, slots=True, init=False)
@@ -109,16 +83,3 @@ class SessionData:
 
         """
         return self._browser_queue.flush()
-
-
-def _get_browser_address_bar_port() -> int:
-    """Get the app URL that will be shown in the browser's address bar.
-
-    That is, this is the port where static assets will be served from. In dev,
-    this is different from the URL that will be used to connect to the
-    server-browser websocket.
-
-    """
-    if config.get_option("global.developmentMode"):
-        return 3000
-    return int(config.get_option("browser.serverPort"))

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -25,7 +25,6 @@ from streamlit import config
 from streamlit import env_util
 from streamlit import net_util
 from streamlit import secrets
-from streamlit import session_data
 from streamlit import url_util
 from streamlit import util
 from streamlit import version
@@ -36,6 +35,7 @@ from streamlit.secrets import SECRETS_FILE_LOC
 from streamlit.source_util import invalidate_pages_cache
 from streamlit.watcher import report_watchdog_availability, watch_dir, watch_file
 from streamlit.web.server import Server, server_address_is_unix_socket
+from streamlit.web.server import server_util
 
 LOGGER = get_logger(__name__)
 
@@ -190,7 +190,7 @@ def _on_server_start(server: Server) -> None:
         else:
             addr = "localhost"
 
-        util.open_browser(session_data.get_url(addr))
+        util.open_browser(server_util.get_url(addr))
 
     # Schedule the browser to open using the IO Loop on the main thread, but
     # only if no other browser connects within 1s.
@@ -219,33 +219,33 @@ def _print_url(is_running_hello: bool) -> None:
 
     if config.is_manually_set("browser.serverAddress"):
         named_urls = [
-            ("URL", session_data.get_url(config.get_option("browser.serverAddress")))
+            ("URL", server_util.get_url(config.get_option("browser.serverAddress")))
         ]
 
     elif (
         config.is_manually_set("server.address") and not server_address_is_unix_socket()
     ):
         named_urls = [
-            ("URL", session_data.get_url(config.get_option("server.address"))),
+            ("URL", server_util.get_url(config.get_option("server.address"))),
         ]
 
     elif config.get_option("server.headless"):
         internal_ip = net_util.get_internal_ip()
         if internal_ip:
-            named_urls.append(("Network URL", session_data.get_url(internal_ip)))
+            named_urls.append(("Network URL", server_util.get_url(internal_ip)))
 
         external_ip = net_util.get_external_ip()
         if external_ip:
-            named_urls.append(("External URL", session_data.get_url(external_ip)))
+            named_urls.append(("External URL", server_util.get_url(external_ip)))
 
     else:
         named_urls = [
-            ("Local URL", session_data.get_url("localhost")),
+            ("Local URL", server_util.get_url("localhost")),
         ]
 
         internal_ip = net_util.get_internal_ip()
         if internal_ip:
-            named_urls.append(("Network URL", session_data.get_url(internal_ip)))
+            named_urls.append(("Network URL", server_util.get_url(internal_ip)))
 
     click.secho("")
     click.secho("  %s" % title_message, fg="blue", bold=True)

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -153,3 +153,40 @@ def make_url_path_regex(*path, **kwargs) -> str:
     path = [x.strip("/") for x in path if x]  # Filter out falsy components.
     path_format = r"^/%s/?$" if kwargs.get("trailing_slash", True) else r"^/%s$"
     return path_format % "/".join(path)
+
+
+def get_url(host_ip: str) -> str:
+    """Get the URL for any app served at the given host_ip.
+
+    Parameters
+    ----------
+    host_ip : str
+        The IP address of the machine that is running the Streamlit Server.
+
+    Returns
+    -------
+    str
+        The URL.
+    """
+    port = _get_browser_address_bar_port()
+    base_path = config.get_option("server.baseUrlPath").strip("/")
+
+    if base_path:
+        base_path = "/" + base_path
+
+    host_ip = host_ip.strip("/")
+
+    return f"http://{host_ip}:{port}{base_path}"
+
+
+def _get_browser_address_bar_port() -> int:
+    """Get the app URL that will be shown in the browser's address bar.
+
+    That is, this is the port where static assets will be served from. In dev,
+    this is different from the URL that will be used to connect to the
+    server-browser websocket.
+
+    """
+    if config.get_option("global.developmentMode"):
+        return 3000
+    return int(config.get_option("browser.serverPort"))

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -16,12 +16,11 @@ from typing import Any, Callable, Dict, List
 
 import tornado.httputil
 import tornado.web
-from streamlit import session_data
 
 from streamlit.uploaded_file_manager import UploadedFileRec, UploadedFileManager
 from streamlit import config
 from streamlit.logger import get_logger
-from streamlit.web.server import routes
+from streamlit.web.server import routes, server_util
 
 # /upload_file/(optional session id)/(optional widget id)
 UPLOAD_FILE_ROUTE = "/upload_file/?(?P<session_id>[^/]*)?/?(?P<widget_id>[^/]*)?"
@@ -57,7 +56,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         if config.get_option("server.enableXsrfProtection"):
             self.set_header(
                 "Access-Control-Allow-Origin",
-                session_data.get_url(config.get_option("browser.serverAddress")),
+                server_util.get_url(config.get_option("browser.serverAddress")),
             )
             self.set_header("Access-Control-Allow-Headers", "X-Xsrftoken, Content-Type")
             self.set_header("Vary", "Origin")

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for session_data.py."""
+"""Unit tests for server_util.py."""
 
 import unittest
 from unittest.mock import patch
@@ -20,7 +20,7 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from streamlit import config
-from streamlit.session_data import get_url
+from streamlit.web.server.server_util import get_url
 from tests import testutil
 
 


### PR DESCRIPTION
`session_data.py` contains a function, `get_url()`, that has nothing to do with the SessionData class. This PR moves it to `server_util.py`.