### PR TITLE
Add Error constant to catch numpy precision errors

### DIFF
--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -27,7 +27,7 @@ from streamlit import env_util
 
 # URL of Streamlit's help page.
 HELP_DOC: Final = "https://docs.streamlit.io/"
-ERROR_CONSTANT: Final = 0.000000000005
+FLOAT_EQUALITY_EPSILON: Final = 0.000000000005
 
 
 def memoize(func):
@@ -131,7 +131,7 @@ def index_(iterable, x) -> int:
         # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
         # https://github.com/streamlit/streamlit/issues/4663
         if isinstance(iterable, np.ndarray):
-            if abs(x - value) < ERROR_CONSTANT:
+            if abs(x - value) < FLOAT_EQUALITY_EPSILON:
                 return i
         if x == value:
             return i

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -27,7 +27,7 @@ from streamlit import env_util
 
 # URL of Streamlit's help page.
 HELP_DOC: Final = "https://docs.streamlit.io/"
-ERROR_CONSTANT: Final = .000000000005
+ERROR_CONSTANT: Final = 0.000000000005
 
 def memoize(func):
     """Decorator to memoize the result of a no-args func."""
@@ -130,7 +130,7 @@ def index_(iterable, x) -> int:
         # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
         # https://github.com/streamlit/streamlit/issues/4663
         if isinstance(iterable, np.ndarray):
-            if abs(x-value) < ERROR_CONSTANT:
+            if abs(x - value) < ERROR_CONSTANT:
                 return True
         if x == value:
             return i

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -29,6 +29,7 @@ from streamlit import env_util
 HELP_DOC: Final = "https://docs.streamlit.io/"
 ERROR_CONSTANT: Final = 0.000000000005
 
+
 def memoize(func):
     """Decorator to memoize the result of a no-args func."""
     result = []  # type: List[Any]
@@ -131,7 +132,7 @@ def index_(iterable, x) -> int:
         # https://github.com/streamlit/streamlit/issues/4663
         if isinstance(iterable, np.ndarray):
             if abs(x - value) < ERROR_CONSTANT:
-                return True
+                return i
         if x == value:
             return i
     raise ValueError("{} is not in iterable".format(str(x)))

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -18,6 +18,7 @@ import functools
 import hashlib
 import os
 import subprocess
+import numpy as np
 
 from typing import Any, Dict, List, Mapping, TypeVar
 from typing_extensions import Final
@@ -26,7 +27,7 @@ from streamlit import env_util
 
 # URL of Streamlit's help page.
 HELP_DOC: Final = "https://docs.streamlit.io/"
-
+ERROR_CONSTANT: Final = .000000000005
 
 def memoize(func):
     """Decorator to memoize the result of a no-args func."""
@@ -126,6 +127,11 @@ def index_(iterable, x) -> int:
     """
 
     for i, value in enumerate(iterable):
+        # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
+        # https://github.com/streamlit/streamlit/issues/4663
+        if isinstance(iterable, np.ndarray):
+            if abs(x-value) < ERROR_CONSTANT:
+                return True
         if x == value:
             return i
     raise ValueError("{} is not in iterable".format(str(x)))

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -95,6 +95,7 @@ class UtilTest(unittest.TestCase):
     @parameterized.expand(
         [
             (np.array([1, 2, 3, 4, 5]), 5, 4),
+            # This one will have 0.15000000000000002 because of floating point precision
             (np.arange(0.0, 0.25, 0.05), .15, 3),
             ([0,1,2,3], 3, 3),
             ([0.1,0.2,0.3], .2, 1),

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -95,11 +95,11 @@ class UtilTest(unittest.TestCase):
     @parameterized.expand(
         [
             (np.array([1, 2, 3, 4, 5]), 5, 4),
-            # This one will have 0.15000000000000002 because of floating point precision 
+            # This one will have 0.15000000000000002 because of floating point precision
             (np.arange(0.0, 0.25, 0.05), 0.15, 3),
-            ([0,1,2,3], 3, 3),
-            ([0.1,0.2,0.3], 0.2, 1),
-            (["He","ello w","orld"], "He", 0),
+            ([0, 1, 2, 3], 3, 3),
+            ([0.1, 0.2, 0.3], 0.2, 1),
+            (["He", "ello w", "orld"], "He", 0),
         ]
     )
     def test_successful_index_(self, input, find_value, expected_index):
@@ -110,9 +110,9 @@ class UtilTest(unittest.TestCase):
         [
             (np.array([1, 2, 3, 4, 5]), 6),
             (np.arange(0.0, 0.25, 0.05), 0.1500002),
-            ([0,1,2,3], 3.00001), 
-            ([0.1,0.2,0.3], 0.3000004),
-            (["He","ello w","orld"], "world"),
+            ([0, 1, 2, 3], 3.00001),
+            ([0.1, 0.2, 0.3], 0.3000004),
+            (["He", "ello w", "orld"], "world"),
         ]
     )
     def test_unsuccessful_index_(self, input, find_value):

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -94,18 +94,26 @@ class UtilTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (np.array([1, 2, 3, 4, 5]), 5, True),
-            (np.array([1, 2, 3, 4, 5]), 6, False),
-            (np.arange(0.0, 0.25, 0.05), .15, True),
-            (np.arange(0.0, 0.25, 0.05), .1500002, False),
-            ([0,1,2,3], 3, True),
-            ([0,1,2,3], 3.000000000000000000000001, False),
-            ([0.1,0.2,0.3], .3, True),
-            ([0.1,0.2,0.3], .3000000000000000000000000004, False),
-            (["He","ello w","orld"], "He", True),
-            (["He","ello w","orld"], "world", False),
+            (np.array([1, 2, 3, 4, 5]), 5, 4),
+            (np.arange(0.0, 0.25, 0.05), .15, 3),
+            ([0,1,2,3], 3, 3),
+            ([0.1,0.2,0.3], .2, 1),
+            (["He","ello w","orld"], "He", 0),
         ]
     )
-    def test_index_(self, input, find_value, expected):
-        actual_return_bool = util._index(input, find_value)
-        self.assertEqual(actual_return_bool, expected)
+    def test_successful_index_(self, input, find_value, expected_index):
+        actual_index = util.index_(input, find_value)
+        self.assertEqual(actual_index, expected_index)
+
+    @parameterized.expand(
+        [
+            (np.array([1, 2, 3, 4, 5]), 6),
+            (np.arange(0.0, 0.25, 0.05), .1500002),
+            ([0,1,2,3], 3.00001), 
+            ([0.1,0.2,0.3], .3000004),
+            (["He","ello w","orld"], "world"),
+        ]
+    )
+    def test_unsuccessful_index_(self, input, find_value):
+        with self.assertRaises(ValueError):
+            util.index_(input, find_value)

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -15,6 +15,7 @@
 import random
 import unittest
 from unittest.mock import patch
+import numpy as np
 
 from parameterized import parameterized
 
@@ -90,3 +91,21 @@ class UtilTest(unittest.TestCase):
     def test_lower_clean_dict_keys(self, input_dict, answer_dict):
         return_dict = util.lower_clean_dict_keys(input_dict)
         self.assertEqual(return_dict, answer_dict)
+
+    @parameterized.expand(
+        [
+            (np.array([1, 2, 3, 4, 5]), 5, True),
+            (np.array([1, 2, 3, 4, 5]), 6, False),
+            (np.arange(0.0, 0.25, 0.05), .15, True),
+            (np.arange(0.0, 0.25, 0.05), .1500002, False),
+            ([0,1,2,3], 3, True),
+            ([0,1,2,3], 3.000000000000000000000001, False),
+            ([0.1,0.2,0.3], .3, True),
+            ([0.1,0.2,0.3], .3000000000000000000000000004, False),
+            (["He","ello w","orld"], "He", True),
+            (["He","ello w","orld"], "world", False),
+        ]
+    )
+    def test_index_(self, input, find_value, expected):
+        actual_return_bool = util._index(input, find_value)
+        self.assertEqual(actual_return_bool, expected)

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -95,10 +95,10 @@ class UtilTest(unittest.TestCase):
     @parameterized.expand(
         [
             (np.array([1, 2, 3, 4, 5]), 5, 4),
-            # This one will have 0.15000000000000002 because of floating point precision
-            (np.arange(0.0, 0.25, 0.05), .15, 3),
+            # This one will have 0.15000000000000002 because of floating point precision 
+            (np.arange(0.0, 0.25, 0.05), 0.15, 3),
             ([0,1,2,3], 3, 3),
-            ([0.1,0.2,0.3], .2, 1),
+            ([0.1,0.2,0.3], 0.2, 1),
             (["He","ello w","orld"], "He", 0),
         ]
     )
@@ -109,9 +109,9 @@ class UtilTest(unittest.TestCase):
     @parameterized.expand(
         [
             (np.array([1, 2, 3, 4, 5]), 6),
-            (np.arange(0.0, 0.25, 0.05), .1500002),
+            (np.arange(0.0, 0.25, 0.05), 0.1500002),
             ([0,1,2,3], 3.00001), 
-            ([0.1,0.2,0.3], .3000004),
+            ([0.1,0.2,0.3], 0.3000004),
             (["He","ello w","orld"], "world"),
         ]
     )


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
https://github.com/streamlit/streamlit/issues/4663
_Please describe the project or issue background here_
The problem is stated here basically with a solution: 
https://stackoverflow.com/questions/588004/is-floating-point-math-broken
- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_
This just adds an error constant and adds an extra case for numpy.arrays to check that the difference in values < error constant.
  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4663 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
