### PR TITLE
server: SessionClient interface

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -727,18 +727,23 @@ class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
 
     def open(self, *args, **kwargs) -> Optional[Awaitable[None]]:
         # Extract user info from the X-Streamlit-User header
-        email: Optional[str] = None
+        is_public_cloud_app = False
+
         try:
             header_content = self.request.headers["X-Streamlit-User"]
             payload = base64.b64decode(header_content)
             user_obj = json.loads(payload)
+            email = user_obj["email"]
             is_public_cloud_app = user_obj["isPublicCloudApp"]
-            if not is_public_cloud_app:
-                email = user_obj["email"]
         except (KeyError, binascii.Error, json.decoder.JSONDecodeError):
-            email = None
+            email = "test@localhost.com"
 
-        user_info = {"email": email}
+        user_info: Dict[str, Optional[str]] = dict()
+        if is_public_cloud_app:
+            user_info["email"] = None
+        else:
+            user_info["email"] = email
+
         self._session = self._server._create_app_session(self, user_info)
         return None
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -145,7 +145,7 @@ class SessionInfo:
             The concrete SessionClient for this session.
         """
         self.session = session
-        self.handler = client
+        self.client = client
         self.script_run_count = 0
 
     def __repr__(self) -> str:
@@ -611,7 +611,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             )
 
         # Ship it off!
-        session_info.handler.write_forward_msg(msg_to_send)
+        session_info.client.write_forward_msg(msg_to_send)
 
     def _enqueued_some_message(self) -> None:
         self._ioloop.add_callback(self._need_send_data.set)

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -120,7 +120,7 @@ SCRIPT_RUN_CHECK_TIMEOUT = 60
 
 
 class SessionClient(Protocol):
-    """Interface for sending data a session's client."""
+    """Interface for sending data to a session's client."""
 
     def write_forward_msg(self, msg: ForwardMsg) -> None:
         """Deliver a ForwardMsg to the client."""

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -732,7 +732,7 @@ class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             header_content = self.request.headers["X-Streamlit-User"]
             payload = base64.b64decode(header_content)
             user_obj = json.loads(payload)
-            is_public_cloud_app = bool(user_obj["isPublicCloudApp"])
+            is_public_cloud_app = user_obj["isPublicCloudApp"]
             if not is_public_cloud_app:
                 email = user_obj["email"]
         except (KeyError, binascii.Error, json.decoder.JSONDecodeError):

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -91,10 +91,10 @@ class ServerTest(ServerTestCase):
             "streamlit.web.server.server.LocalSourcesWatcher"
         ), self._patch_app_session():
             await self.start_server_loop()
-            self.assertEqual(State.WAITING_FOR_FIRST_BROWSER, self.server._state)
+            self.assertEqual(State.WAITING_FOR_FIRST_SESSION, self.server._state)
 
             await self.ws_connect()
-            self.assertEqual(State.ONE_OR_MORE_BROWSERS_CONNECTED, self.server._state)
+            self.assertEqual(State.ONE_OR_MORE_SESSIONS_CONNECTED, self.server._state)
 
             self.server.stop()
             self.assertEqual(State.STOPPING, self.server._state)


### PR DESCRIPTION
Introduces the SessionClient interface, an abstraction for sending data to a session's connected client.

Currently, we just have one `SessionClient` implementation, the `_BrowserWebSocketHandler`. But this prepares us for the near future when we have a "StreamlitRuntime" object that doesn't know anything about websockets or any other tornado bits.

This also renames the members of the Server "State" enum to refer to "sessions" instead of "browsers".

(This is just a refactor, not a behavior change.)