### PR TITLE
* Remove staticmethod decorator from __call__ method of SingletonAPI

### DIFF
--- a/lib/streamlit/caching/singleton_decorator.py
+++ b/lib/streamlit/caching/singleton_decorator.py
@@ -122,22 +122,24 @@ class SingletonAPI:
 
     # Bare decorator usage
     @overload
-    @staticmethod
-    def __call__(func: F) -> F:
+    def __call__(self, func: F) -> F:
         ...
 
     # Decorator with arguments
     @overload
-    @staticmethod
     def __call__(
+        self,
         *,
         show_spinner: bool = True,
         suppress_st_warning=False,
     ) -> Callable[[F], F]:
         ...
 
-    @staticmethod
+    # __call__ should be a static method, but there's a mypy bug that
+    # breaks type checking for overloaded static functions:
+    # https://github.com/python/mypy/issues/7781
     def __call__(
+        self,
         func: Optional[F] = None,
         *,
         show_spinner: bool = True,


### PR DESCRIPTION
Remove staticmethod decorator from __call__ method of SingletonAPI to avoid mypy bug https://github.com/python/mypy/issues/7781

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
