### PR TITLE
AppSession.handle_backmsg

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -223,15 +223,15 @@ class AppSession:
             msg_type = msg.WhichOneof("type")
 
             if msg_type == "rerun_script":
-                self.handle_rerun_script_request(msg.rerun_script)
+                self._handle_rerun_script_request(msg.rerun_script)
             elif msg_type == "load_git_info":
-                self.handle_git_information_request()
+                self._handle_git_information_request()
             elif msg_type == "clear_cache":
-                self.handle_clear_cache_request()
+                self._handle_clear_cache_request()
             elif msg_type == "set_run_on_save":
-                self.handle_set_run_on_save_request(msg.set_run_on_save)
+                self._handle_set_run_on_save_request(msg.set_run_on_save)
             elif msg_type == "stop_script":
-                self.handle_stop_script_request()
+                self._handle_stop_script_request()
             else:
                 LOGGER.warning('No handler for "%s"', msg_type)
 
@@ -599,7 +599,7 @@ class AppSession:
         exception_utils.marshall(msg.delta.new_element.exception, e)
         return msg
 
-    def handle_git_information_request(self) -> None:
+    def _handle_git_information_request(self) -> None:
         msg = ForwardMsg()
 
         try:
@@ -633,7 +633,7 @@ class AppSession:
             # error requires no action. It can be useful for debugging.
             LOGGER.debug("Obtaining Git information produced an error", exc_info=e)
 
-    def handle_rerun_script_request(
+    def _handle_rerun_script_request(
         self, client_state: Optional[ClientState] = None
     ) -> None:
         """Tell the ScriptRunner to re-run its script.
@@ -647,12 +647,12 @@ class AppSession:
         """
         self.request_rerun(client_state)
 
-    def handle_stop_script_request(self) -> None:
+    def _handle_stop_script_request(self) -> None:
         """Tell the ScriptRunner to stop running its script."""
         if self._scriptrunner is not None:
             self._scriptrunner.request_stop()
 
-    def handle_clear_cache_request(self) -> None:
+    def _handle_clear_cache_request(self) -> None:
         """Clear this app's cache.
 
         Because this cache is global, it will be cleared for all users.
@@ -663,7 +663,7 @@ class AppSession:
         caching.singleton.clear()
         self._session_state.clear()
 
-    def handle_set_run_on_save_request(self, new_value: bool) -> None:
+    def _handle_set_run_on_save_request(self, new_value: bool) -> None:
         """Change our run_on_save flag to the given value.
 
         The browser will be notified of the change.

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -781,21 +781,11 @@ class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                 )
 
             msg.ParseFromString(payload)
-            msg_type = msg.WhichOneof("type")
-
             LOGGER.debug("Received the following back message:\n%s", msg)
 
-            if msg_type == "rerun_script":
-                self._session.handle_rerun_script_request(msg.rerun_script)
-            elif msg_type == "load_git_info":
-                self._session.handle_git_information_request()
-            elif msg_type == "clear_cache":
-                self._session.handle_clear_cache_request()
-            elif msg_type == "set_run_on_save":
-                self._session.handle_set_run_on_save_request(msg.set_run_on_save)
-            elif msg_type == "stop_script":
-                self._session.handle_stop_script_request()
-            elif msg_type == "close_connection":
+            if msg.WhichOneof("type") == "close_connection":
+                # "close_connection" is a special developmentMode-only
+                # message used in e2e tests to test disabling widgets.
                 if config.get_option("global.developmentMode"):
                     self._server.stop()
                 else:
@@ -804,7 +794,8 @@ class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                         "not in development mode"
                     )
             else:
-                LOGGER.warning('No handler for "%s"', msg_type)
+                # AppSession handles all other BackMsg types.
+                self._session.handle_backmsg(msg)
 
         except BaseException as e:
             LOGGER.error(e)

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -111,7 +111,7 @@ class AppSessionTest(unittest.TestCase):
     def test_clear_cache_resets_session_state(self):
         session = _create_test_session()
         session._session_state["foo"] = "bar"
-        session.handle_clear_cache_request()
+        session._handle_clear_cache_request()
         self.assertTrue("foo" not in session._session_state)
 
     @patch("streamlit.legacy_caching.clear_cache")
@@ -121,7 +121,7 @@ class AppSessionTest(unittest.TestCase):
         self, clear_singleton_cache, clear_memo_cache, clear_legacy_cache
     ):
         session = _create_test_session()
-        session.handle_clear_cache_request()
+        session._handle_clear_cache_request()
         clear_singleton_cache.assert_called_once()
         clear_memo_cache.assert_called_once()
         clear_legacy_cache.assert_called_once()
@@ -528,7 +528,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         with patch.object(
             session, "handle_backmsg_exception"
         ) as handle_backmsg_exception, patch.object(
-            session, "handle_clear_cache_request"
+            session, "_handle_clear_cache_request"
         ) as handle_clear_cache_request:
 
             error = Exception("explode!")


### PR DESCRIPTION
Moves `BackMsg.type` switching logic out of `BrowserWebSocketHandler` and into `AppSession`. This logic is not SessionClient-specific; moving it into AppSession means that other future SessionClient implementations don't have to duplicate it.

This is just a refactor, not a logic change.

We don't have much in the way of AppSession message handling tests - this PR doesn't do much to address that, but it does add a single new test that asserts that exceptions in `AppSession.handle_backmsg` get handled internally.