### PR TITLE
Fix issue with forward msg cache not cloning messages

### DIFF
--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -133,18 +133,18 @@ test("caches messages correctly", async () => {
 test("caches messages as a deep copy", async () => {
   const { cache, getCachedMessage } = createCache()
 
-  const msg1 = createForwardMsg("Cacheable", true)
-  const encodedMsg1 = ForwardMsg.encode(msg1).finish()
+  const msg = createForwardMsg("Cacheable", true)
+  const encodedMsg = ForwardMsg.encode(msg).finish()
 
-  await cache.processMessagePayload(msg1, encodedMsg1)
+  await cache.processMessagePayload(msg, encodedMsg)
 
   // Check if message is correctly cached
-  expect(getCachedMessage("Cacheable")).toEqual(msg1)
+  expect(getCachedMessage("Cacheable")).toEqual(msg)
   expect(getCachedMessage("Cacheable")?.metadata?.deltaPath).toEqual([])
 
   // Modify the message content
-  if (msg1.metadata) {
-    msg1.metadata.deltaPath = [10]
+  if (msg.metadata) {
+    msg.metadata.deltaPath = [10]
   }
 
   // Check that it does not impact the cached message

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -121,8 +121,8 @@ test("caches messages correctly", async () => {
     msg3.metadata.deltaPath = [2]
   }
   const ref = createRefMsg(msg3)
-  const encodedMsg3 = ForwardMsg.encode(msg3).finish()
-  const unreferenced = await cache.processMessagePayload(ref, encodedMsg3)
+  const encodedRefMsg = ForwardMsg.encode(ref).finish()
+  const unreferenced = await cache.processMessagePayload(ref, encodedRefMsg)
   expect(getCachedMessage(ref.hash)).toBeUndefined()
   expect(unreferenced).toEqual(msg3)
 

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -146,8 +146,10 @@ test("caches messages as a deep copy", async () => {
   // Check if message is correctly cached
   expect(getCachedMessage("Cacheable")).toEqual(msg)
 
-  // Modify the message content
+  // Modify specific values inside the message structure:
+  // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
   msg.delta!.newElement!.text.body = "foo"
+  // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
   msg.metadata!.deltaPath = [10]
 
   // Check that it does not impact the cached message

--- a/frontend/src/lib/ForwardMessageCache.ts
+++ b/frontend/src/lib/ForwardMessageCache.ts
@@ -115,7 +115,6 @@ export class ForwardMsgCache {
     if (!msg.metadata) {
       throw new Error("ForwardMsg has no metadata")
     }
-
     newMsg.metadata = ForwardMsg.decode(encodedMsg).metadata
     return newMsg
   }

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -475,7 +475,8 @@ export class WebsocketConnection {
 
     PerformanceEvents.record({ name: "BeginHandleMessage", messageIndex })
 
-    const msg = ForwardMsg.decode(new Uint8Array(data))
+    const encodedMsg = new Uint8Array(data)
+    const msg = ForwardMsg.decode(encodedMsg)
 
     PerformanceEvents.record({
       name: "DecodedMessage",
@@ -485,7 +486,8 @@ export class WebsocketConnection {
     })
 
     this.messageQueue[messageIndex] = await this.cache.processMessagePayload(
-      msg
+      msg,
+      encodedMsg
     )
 
     PerformanceEvents.record({ name: "GotCachedPayload", messageIndex })


### PR DESCRIPTION
## 📚 Context

The `ForwardMessageCache` currently uses `ForwardMsg.create` to create copies of the incoming message. However, this does not create a deep copy as intended. Changes to the new instance are also reflected in the cache, which leads to unexpected behavior.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Cache the encoded message instead of the decoded one. Thereby, we will always get a real copy of the original message.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #4949

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
