### PR TITLE
Add the ability to exclude dependencies from conda builds of Streamlit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ conda-distribution:
 	# This can take upwards of 20 minutes to complete in a fresh conda installation! (Dependency solving is slow.)
 	# NOTE: Running the following command requires both conda and conda-build to
 	# be installed.
-	GIT_HASH=$$(git rev-parse --short HEAD) conda build lib/conda-recipe --output-folder lib/conda-recipe/dist
+	ST_CONDA_BUILD=1 GIT_HASH=$$(git rev-parse --short HEAD) conda build lib/conda-recipe --output-folder lib/conda-recipe/dist
 
 .PHONY: conda-package
 # Build lib and frontend, and then run 'conda-distribution'

--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -39,6 +39,7 @@ build:
     {% endfor %}
   script_env:
    - GIT_HASH
+   - ST_CONDA_BUILD
 
 requirements:
   host:
@@ -55,23 +56,18 @@ requirements:
       # by default in our conda distribution due to this.
       {% elif 'watchdog' in req %}
         - watchdog
-      # TODO(vdonato): Possibly remove this check if gitpython and pydeck are
-      # moved to extras_require.
-      {% elif 'gitpython' not in req and 'pydeck' not in req %}
+      {% else %}
         - {{ req }}
       {% endif %}
     {% endfor %}
 
-# TODO(vdonato): Uncomment this section once we've figured out what to do with
-# optional dependencies (pip check will currently fail due to gitpython and
-# pydeck being uninstalled).
-# test:
-#   imports:
-#     - streamlit
-#   commands:
-#     - pip check
-#   requires:
-#     - pip
+test:
+  imports:
+    - streamlit
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://streamlit.io

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -41,7 +41,6 @@ INSTALL_REQUIRES = [
     "blinker>=1.0.0",
     "cachetools>=4.0",
     "click>=7.0",
-    "gitpython!=3.1.19",
     # 1.4 introduced the functionality found in python 3.8's importlib.metadata module
     "importlib-metadata>=1.4",
     "numpy",
@@ -66,6 +65,20 @@ INSTALL_REQUIRES = [
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
     "watchdog; platform_system != 'Darwin'",
 ]
+
+# We want to exclude some dependencies in our internal conda distribution of
+# Streamlit.
+CONDA_OPTIONAL_DEPENDENCIES = [
+    "gitpython!=3.1.19",
+]
+
+# NOTE: ST_CONDA_BUILD is used here (even though CONDA_BUILD is set
+# automatically when using the `conda build` command) because the
+# `load_setup_py_data()` conda build helper function does not have the
+# CONDA_BUILD environment variable set when it runs to generate our build
+# recipe from meta.yaml.
+if not os.getenv("ST_CONDA_BUILD"):
+    INSTALL_REQUIRES.extend(CONDA_OPTIONAL_DEPENDENCIES)
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
## 📚 Context

We want to be able to exclude certain dependencies from our private (that is, SnowPark-specific)
conda builds of Streamlit. This PR allows us to do this by setting some environment variables in the
`make conda-package` target and using them to conditionally add dependencies to `INSTALL_REQUIRES`
in `setup.py`.

Currently, the `ST_CONDA_BUILD` env var is used to exclude the `gitpython` dependency when set.

- What kind of change does this PR introduce?

  - [x] Other, please describe: fun with dependencies
