### PR TITLE
Don't expose SessionInfo to UploadFileRequestHandler

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -308,6 +308,10 @@ class Server:
         """
         return self._session_info_by_id.get(session_id, None)
 
+    def is_active_session(self, session_id: str) -> bool:
+        """True if the session_id belongs to an active session."""
+        return session_id in self._session_info_by_id
+
     def start(self, on_started: Callable[["Server"], Any]) -> None:
         """Start the server.
 
@@ -366,7 +370,7 @@ class Server:
                 UploadFileRequestHandler,
                 dict(
                     file_mgr=self._uploaded_file_mgr,
-                    get_session_info=self._get_session_info,
+                    is_active_session=self.is_active_session,
                 ),
             ),
             (

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -42,7 +42,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             The server's singleton UploadedFileManager. All file uploads
             go here.
         is_active_session:
-            A function that returns true if a session_id belong to an active
+            A function that returns true if a session_id belongs to an active
             session.
         """
         self._file_mgr = file_mgr

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -33,7 +33,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
     """
 
     def initialize(
-        self, file_mgr: UploadedFileManager, get_session_info: Callable[[str], Any]
+        self, file_mgr: UploadedFileManager, is_active_session: Callable[[str], bool]
     ):
         """
         Parameters
@@ -41,14 +41,12 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         file_mgr : UploadedFileManager
             The server's singleton UploadedFileManager. All file uploads
             go here.
-        get_session_info: Server.get_session_info. Used to validate session IDs
+        is_active_session:
+            A function that returns true if a session_id belong to an active
+            session.
         """
         self._file_mgr = file_mgr
-        self._get_session_info = get_session_info
-
-    def _is_valid_session_id(self, session_id: str) -> bool:
-        """True if the given session_id refers to an active session."""
-        return self._get_session_info(session_id) is not None
+        self._is_active_session = is_active_session
 
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -119,7 +117,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         try:
             session_id = self._require_arg(args, "sessionId")
             widget_id = self._require_arg(args, "widgetId")
-            if not self._is_valid_session_id(session_id):
+            if not self._is_active_session(session_id):
                 raise Exception(f"Invalid session_id: '{session_id}'")
 
         except Exception as e:

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -451,6 +451,19 @@ class ServerTest(ServerTestCase):
 
                 write_message_mock.assert_called_once()
 
+    @tornado.testing.gen_test
+    async def test_is_active_session(self):
+        """is_active_session should return True for active session_ids."""
+        with self._patch_app_session():
+            await self.start_server_loop()
+            await self.ws_connect()
+
+            # Get our connected BrowserWebSocketHandler
+            session_info = list(self.server._session_info_by_id.values())[0]
+
+            self.assertFalse(self.server.is_active_session("not_a_session_id"))
+            self.assertTrue(self.server.is_active_session(session_info.session.id))
+
 
 class ServerUtilsTest(unittest.TestCase):
     def test_is_url_from_allowed_origins_allowed_domains(self):

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -46,7 +46,6 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     def get_app(self):
         self.file_mgr = UploadedFileManager()
-        self._get_session_info = lambda x: True
         return tornado.web.Application(
             [
                 (
@@ -54,7 +53,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     UploadFileRequestHandler,
                     dict(
                         file_mgr=self.file_mgr,
-                        get_session_info=self._get_session_info,
+                        is_active_session=lambda session_id: True
                     ),
                 ),
             ]
@@ -138,7 +137,6 @@ class UploadFileRequestHandlerInvalidSessionTest(tornado.testing.AsyncHTTPTestCa
 
     def get_app(self):
         self.file_mgr = UploadedFileManager()
-        self._get_session_info = lambda x: None
         return tornado.web.Application(
             [
                 (
@@ -146,7 +144,7 @@ class UploadFileRequestHandlerInvalidSessionTest(tornado.testing.AsyncHTTPTestCa
                     UploadFileRequestHandler,
                     dict(
                         file_mgr=self.file_mgr,
-                        get_session_info=self._get_session_info,
+                        is_active_session=lambda session_id: False,
                     ),
                 ),
             ]

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -53,7 +53,7 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     UploadFileRequestHandler,
                     dict(
                         file_mgr=self.file_mgr,
-                        is_active_session=lambda session_id: True
+                        is_active_session=lambda session_id: True,
                     ),
                 ),
             ]


### PR DESCRIPTION
Currently, `UploadFileRequestHandler` takes a reference to server's private `_get_session_info` function, which returns SessionInfo instances. But SessionInfo is really a private implementation detail of server, so we'd rather not expose it externally.

This PR adds a `Server.is_active_session()` function that doesn't expose SessionInfo, so that UploadFileRequestHandler is decoupled from SessionInfo.