### PR TITLE
Replace static embdedded app in st.pydeck_chart docstring

### DIFF
--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -84,7 +84,7 @@ class PydeckMixin:
         ... ))
 
         .. output::
-           https://static.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i
+           https://doc-pydeck-chart.streamlitapp.com/
            height: 530px
 
         """


### PR DESCRIPTION
## 📚 Context

Most static embedded apps in element docstrings were replaced by live apps in #4317. One that was accidentally not replaced is the static embedded app in the `st.pydeck_chart` docstring.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Replace static embdedded app in `st.pydeck_chart` docstring with custom subdomain of a live [app](https://doc-pydeck-chart.streamlitapp.com/).

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/179917529-6ac48219-a681-4455-b006-f36964b32b58.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/179917588-f3b3f612-5406-41e3-a335-42b197bfedf8.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
