### PR TITLE
Replace `attrs` with stdlib `dataclass`

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -37,7 +37,6 @@ LONG_DESCRIPTION = (
 # But include relevant lower bounds for any features we use from our dependencies.
 INSTALL_REQUIRES = [
     "altair>=3.2.0",
-    "attrs>=16.0.0",
     "blinker>=1.0.0",
     "cachetools>=4.0",
     "click>=7.0",

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import cast, TYPE_CHECKING, Union, Optional
 from typing_extensions import TypeAlias, Literal
 
-import attr
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Metric_pb2 import Metric as MetricProto
 
@@ -33,7 +33,7 @@ Delta: TypeAlias = Union[float, str, None]
 DeltaColor: TypeAlias = Literal["normal", "inverse", "off"]
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class MetricColorAndDirection:
     color: "MetricProto.MetricColor.ValueType"
     direction: "MetricProto.MetricDirection.ValueType"

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from datetime import datetime, date, time
 from textwrap import dedent
 from typing import Any, cast, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
-import attr
 from dateutil import relativedelta
 from typing_extensions import TypeAlias
 
@@ -113,7 +113,7 @@ def _parse_max_date(
     return parsed_max_date
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class _DateInputValues:
     value: Sequence[date]
     is_range: bool
@@ -142,7 +142,7 @@ class _DateInputValues:
             ),
         )
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         if self.min > self.max:
             raise StreamlitAPIException(
                 f"The `min_value`, set to {self.min}, shouldn't be larger "

--- a/lib/streamlit/legacy_caching/caching.py
+++ b/lib/streamlit/legacy_caching/caching.py
@@ -15,6 +15,7 @@
 """A library of caching utilities."""
 
 import contextlib
+from dataclasses import dataclass
 import functools
 import hashlib
 import inspect
@@ -37,8 +38,6 @@ from typing import (
     Union,
     cast,
 )
-
-import attr
 
 from cachetools import TTLCache
 
@@ -67,7 +66,7 @@ _CacheEntry = namedtuple("_CacheEntry", ["value", "hash"])
 _DiskCacheEntry = namedtuple("_DiskCacheEntry", ["value"])
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class MemCache:
     cache: TTLCache
     display_name: str

--- a/lib/streamlit/scriptrunner/script_requests.py
+++ b/lib/streamlit/scriptrunner/script_requests.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import threading
 from enum import Enum
 from typing import Optional, cast
-
-import attr
 
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.state import coalesce_widget_states
@@ -36,7 +35,7 @@ class ScriptRequestType(Enum):
     RERUN = "RERUN"
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class RerunData:
     """Data attached to RERUN requests. Immutable."""
 
@@ -46,7 +45,7 @@ class RerunData:
     page_name: str = ""
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class ScriptRequest:
     """A STOP or RERUN request and associated data."""
 

--- a/lib/streamlit/scriptrunner/script_run_context.py
+++ b/lib/streamlit/scriptrunner/script_run_context.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass, field
 import threading
 from typing import Dict, Optional, List, Callable, Set
 from typing_extensions import Final, TypeAlias
-
-import attr
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
@@ -30,7 +29,7 @@ LOGGER: Final = get_logger(__name__)
 UserInfo: TypeAlias = Dict[str, Optional[str]]
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class ScriptRunContext:
     """A context object that contains data for a "script run" - that is,
     data that's scoped to a single ScriptRunner execution (and therefore also
@@ -53,10 +52,12 @@ class ScriptRunContext:
 
     _set_page_config_allowed: bool = True
     _has_script_started: bool = False
-    widget_ids_this_run: Set[str] = attr.Factory(set)
-    form_ids_this_run: Set[str] = attr.Factory(set)
-    cursors: Dict[int, "streamlit.cursor.RunningCursor"] = attr.Factory(dict)
-    dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = attr.Factory(list)
+    widget_ids_this_run: Set[str] = field(default_factory=set)
+    form_ids_this_run: Set[str] = field(default_factory=set)
+    cursors: Dict[int, "streamlit.cursor.RunningCursor"] = field(default_factory=dict)
+    dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = field(
+        default_factory=list
+    )
 
     def reset(self, query_string: str = "", page_script_hash: str = "") -> None:
         self.cursors = {}

--- a/lib/streamlit/scriptrunner/script_runner.py
+++ b/lib/streamlit/scriptrunner/script_runner.py
@@ -278,7 +278,7 @@ class ScriptRunner:
         # Create and attach the thread's ScriptRunContext
         ctx = ScriptRunContext(
             session_id=self._session_id,
-            enqueue=self._enqueue_forward_msg,
+            _enqueue=self._enqueue_forward_msg,
             query_string=self._client_state.query_string,
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,

--- a/lib/streamlit/session_data.py
+++ b/lib/streamlit/session_data.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import os
 from typing import List
-
-import attr
 
 from streamlit.forward_msg_queue import ForwardMsgQueue
 from streamlit.logger import get_logger
@@ -24,7 +23,7 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 LOGGER = get_logger(__name__)
 
 
-@attr.s(auto_attribs=True, slots=True, init=False)
+@dataclass(init=False)
 class SessionData:
     """
     Contains parameters related to running a script, and also houses

--- a/lib/streamlit/state/session_state.py
+++ b/lib/streamlit/state/session_state.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
+from dataclasses import dataclass, field, replace
 import json
 
 from streamlit.stats import CacheStat, CacheStatsProvider
@@ -33,7 +34,6 @@ from typing import (
     cast,
 )
 
-import attr
 from pympler.asizeof import asizeof
 from typing_extensions import Final, TypeAlias
 
@@ -71,14 +71,14 @@ SCRIPT_RUN_WITHOUT_ERRORS_KEY: Final = (
 )
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class Serialized:
     """A widget value that's serialized to a protobuf. Immutable."""
 
     value: WidgetStateProto
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class Value:
     """A widget value that's not serialized. Immutable."""
 
@@ -88,13 +88,13 @@ class Value:
 WState: TypeAlias = Union[Value, Serialized]
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclass(frozen=True)
 class WidgetMetadata(Generic[T]):
     """Metadata associated with a single widget. Immutable."""
 
     id: str
-    deserializer: WidgetDeserializer[T] = attr.ib(repr=False)
-    serializer: WidgetSerializer[T] = attr.ib(repr=False)
+    deserializer: WidgetDeserializer[T] = field(repr=False)
+    serializer: WidgetSerializer[T] = field(repr=False)
     value_type: ValueFieldName
 
     # An optional user-code callback invoked when the widget's value changes.
@@ -105,15 +105,15 @@ class WidgetMetadata(Generic[T]):
     callback_kwargs: Optional[WidgetKwargs] = None
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class WStates(MutableMapping[str, Any]):
     """A mapping of widget IDs to values. Widget values can be stored in
     serialized or deserialized form, but when values are retrieved from the
     mapping, they'll always be deserialized.
     """
 
-    states: Dict[str, WState] = attr.Factory(dict)
-    widget_metadata: Dict[str, WidgetMetadata[Any]] = attr.Factory(dict)
+    states: Dict[str, WState] = field(default_factory=dict)
+    widget_metadata: Dict[str, WidgetMetadata[Any]] = field(default_factory=dict)
 
     def __getitem__(self, k: str) -> Any:
         """Return the value of the widget with the given key.
@@ -153,7 +153,7 @@ class WStates(MutableMapping[str, Any]):
 
         # Update metadata to reflect information from WidgetState proto
         self.set_widget_metadata(
-            attr.evolve(
+            replace(
                 metadata,
                 value_type=value_field_name,
             )
@@ -285,7 +285,7 @@ def _missing_key_error_message(key: str) -> str:
     )
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclass(frozen=True)
 class RegisterWidgetResult(Generic[T_co]):
     """Result returned by the `register_widget` family of functions/methods.
 
@@ -319,7 +319,7 @@ class RegisterWidgetResult(Generic[T_co]):
         return cls(value=deserializer(None, ""), value_changed=False)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SessionState:
     """SessionState allows users to store values that persist between app
     reruns.
@@ -338,17 +338,17 @@ class SessionState:
     """
 
     # All the values from previous script runs, squished together to save memory
-    _old_state: Dict[str, Any] = attr.Factory(dict)
+    _old_state: Dict[str, Any] = field(default_factory=dict)
 
     # Values set in session state during the current script run, possibly for
     # setting a widget's value. Keyed by a user provided string.
-    _new_session_state: Dict[str, Any] = attr.Factory(dict)
+    _new_session_state: Dict[str, Any] = field(default_factory=dict)
 
     # Widget values from the frontend, usually one changing prompted the script rerun
-    _new_widget_state: WStates = attr.Factory(WStates)
+    _new_widget_state: WStates = field(default_factory=WStates)
 
     # Keys used for widgets will be eagerly converted to the matching widget id
-    _key_id_mapping: Dict[str, str] = attr.Factory(dict)
+    _key_id_mapping: Dict[str, str] = field(default_factory=dict)
 
     # is it possible for a value to get through this without being deserialized?
     def _compact_state(self) -> None:
@@ -690,7 +690,7 @@ def require_valid_user_key(key: str) -> None:
         )
 
 
-@attr.s(auto_attribs=True, slots=True)
+@dataclass
 class SessionStateStatProvider(CacheStatsProvider):
     _session_info_by_id: Dict[str, "SessionInfo"]
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -364,7 +364,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         orig_ctx = get_script_run_ctx()
         ctx = ScriptRunContext(
             session_id="TestSessionID",
-            enqueue=session._session_data.enqueue,
+            _enqueue=session._session_data.enqueue,
             query_string="",
             session_state=MagicMock(),
             uploaded_file_mgr=MagicMock(),

--- a/lib/tests/streamlit/caching/common_cache_test.py
+++ b/lib/tests/streamlit/caching/common_cache_test.py
@@ -174,7 +174,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
             threading.current_thread(),
             ScriptRunContext(
                 session_id="test session id",
-                enqueue=forward_msg_queue.enqueue,
+                _enqueue=forward_msg_queue.enqueue,
                 query_string="",
                 session_state=SessionState(),
                 uploaded_file_mgr=None,

--- a/lib/tests/streamlit/script_run_context_test.py
+++ b/lib/tests/streamlit/script_run_context_test.py
@@ -28,7 +28,7 @@ class ScriptRunContextTest(unittest.TestCase):
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
             session_id="TestSessionID",
-            enqueue=fake_enqueue,
+            _enqueue=fake_enqueue,
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
@@ -50,7 +50,7 @@ class ScriptRunContextTest(unittest.TestCase):
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
             session_id="TestSessionID",
-            enqueue=fake_enqueue,
+            _enqueue=fake_enqueue,
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
@@ -76,7 +76,7 @@ class ScriptRunContextTest(unittest.TestCase):
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
             session_id="TestSessionID",
-            enqueue=fake_enqueue,
+            _enqueue=fake_enqueue,
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),
@@ -101,7 +101,7 @@ class ScriptRunContextTest(unittest.TestCase):
         fake_enqueue = lambda msg: None
         ctx = ScriptRunContext(
             session_id="TestSessionID",
-            enqueue=fake_enqueue,
+            _enqueue=fake_enqueue,
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -556,7 +556,7 @@ class ScriptRunnerTest(AsyncTestCase):
 
         # Assert that Widget registration is a no-op
         widget_state = scriptrunner._session_state.register_widget(
-            MagicMock(spec=WidgetMetadata),
+            MagicMock(),
             user_key="mock_user_key",
         )
         self.assertEqual(False, widget_state.value_changed)

--- a/lib/tests/streamlit/state/session_state_proxy_test.py
+++ b/lib/tests/streamlit/state/session_state_proxy_test.py
@@ -108,7 +108,7 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.state.session_state_proxy.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
+        return_value=SessionState(_new_session_state={"foo": "bar"}),
     )
     def test_delattr(self, _):
         del self.session_state_proxy.foo
@@ -116,14 +116,14 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.state.session_state_proxy.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
+        return_value=SessionState(_new_session_state={"foo": "bar"}),
     )
     def test_getattr(self, _):
         assert self.session_state_proxy.foo == "bar"
 
     @patch(
         "streamlit.state.session_state_proxy.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
+        return_value=SessionState(_new_session_state={"foo": "bar"}),
     )
     def test_getattr_error(self, _):
         with pytest.raises(AttributeError):
@@ -131,7 +131,7 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.state.session_state_proxy.get_session_state",
-        return_value=SessionState(new_session_state={"foo": "bar"}),
+        return_value=SessionState(_new_session_state={"foo": "bar"}),
     )
     def test_setattr(self, _):
         self.session_state_proxy.corge = "grault2"

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -693,12 +693,12 @@ class SessionStateStatProviderTests(testutil.DeltaGeneratorTestCase):
         assert stat.category_name == "st_session_state"
 
         init_size = stat.byte_length
-        assert init_size < 1500
+        assert init_size < 2000
 
         state["foo"] = 2
         new_size = state.get_stats()[0].byte_length
         assert new_size > init_size
-        assert new_size < 1500
+        assert new_size < 2000
 
         state["foo"] = 1
         new_size_2 = state.get_stats()[0].byte_length

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -707,7 +707,7 @@ class SessionStateStatProviderTests(testutil.DeltaGeneratorTestCase):
         st.checkbox("checkbox", key="checkbox")
         new_size_3 = state.get_stats()[0].byte_length
         assert new_size_3 > new_size_2
-        assert new_size_3 - new_size_2 < 1500
+        assert new_size_3 - new_size_2 < 2000
 
         state._compact_state()
         new_size_4 = state.get_stats()[0].byte_length

--- a/lib/tests/streamlit/state/session_state_test.py
+++ b/lib/tests/streamlit/state/session_state_test.py
@@ -693,12 +693,12 @@ class SessionStateStatProviderTests(testutil.DeltaGeneratorTestCase):
         assert stat.category_name == "st_session_state"
 
         init_size = stat.byte_length
-        assert init_size < 2000
+        assert init_size < 2500
 
         state["foo"] = 2
         new_size = state.get_stats()[0].byte_length
         assert new_size > init_size
-        assert new_size < 2000
+        assert new_size < 2500
 
         state["foo"] = 1
         new_size_2 = state.get_stats()[0].byte_length
@@ -707,7 +707,7 @@ class SessionStateStatProviderTests(testutil.DeltaGeneratorTestCase):
         st.checkbox("checkbox", key="checkbox")
         new_size_3 = state.get_stats()[0].byte_length
         assert new_size_3 > new_size_2
-        assert new_size_3 - new_size_2 < 2000
+        assert new_size_3 - new_size_2 < 2500
 
         state._compact_state()
         new_size_4 = state.get_stats()[0].byte_length

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -86,7 +86,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
                 threading.current_thread(),
                 ScriptRunContext(
                     session_id="test session id",
-                    enqueue=forward_msg_queue.enqueue,
+                    _enqueue=forward_msg_queue.enqueue,
                     query_string="",
                     session_state=SafeSessionState(SessionState()),
                     uploaded_file_mgr=None,

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -86,7 +86,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
         self.orig_report_ctx = None
         self.new_script_run_ctx = ScriptRunContext(
             session_id="test session id",
-            enqueue=self.forward_msg_queue.enqueue,
+            _enqueue=self.forward_msg_queue.enqueue,
             query_string="",
             session_state=SafeSessionState(SessionState()),
             uploaded_file_mgr=UploadedFileManager(),


### PR DESCRIPTION
## 📚 Context

As part of #4936, the team decided to prefer `dataclass` over `attrs`, so this converts the existing uses and removes the direct dependency.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Replace decorators
- `attr.Factory` -> `dataclasses.field`
- Change keyword arguments for dataclasses to include underscore, since that is no longer being removed by attrs

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change



## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

