### PR TITLE
move BrowserWebSocketHandler into its own file

### DIFF
--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -1,0 +1,150 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import binascii
+import json
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Awaitable,
+    Union,
+    TYPE_CHECKING,
+    Final,
+)
+
+import tornado.concurrent
+import tornado.ioloop
+import tornado.locks
+import tornado.netutil
+import tornado.web
+import tornado.websocket
+from tornado.websocket import WebSocketHandler
+
+from streamlit import config
+from streamlit.app_session import AppSession
+from streamlit.logger import get_logger
+from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.web.server.server_util import is_url_from_allowed_origins
+from streamlit.web.server.server_util import serialize_forward_msg
+from .session_client import SessionClient, SessionClientDisconnectedError
+
+if TYPE_CHECKING:
+    from .server import Server
+
+LOGGER: Final = get_logger(__name__)
+
+
+class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
+    """Handles a WebSocket connection from the browser"""
+
+    def initialize(self, server: "Server") -> None:
+        self._server = server
+        self._session: Optional[AppSession] = None
+        # The XSRF cookie is normally set when xsrf_form_html is used, but in a pure-Javascript application
+        # that does not use any regular forms we just need to read the self.xsrf_token manually to set the
+        # cookie as a side effect.
+        # See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
+        # for more details.
+        if config.get_option("server.enableXsrfProtection"):
+            _ = self.xsrf_token
+
+    def check_origin(self, origin: str) -> bool:
+        """Set up CORS."""
+        return super().check_origin(origin) or is_url_from_allowed_origins(origin)
+
+    def write_forward_msg(self, msg: ForwardMsg) -> None:
+        """Send a ForwardMsg to the browser."""
+        try:
+            self.write_message(serialize_forward_msg(msg), binary=True)
+        except tornado.websocket.WebSocketClosedError as e:
+            raise SessionClientDisconnectedError from e
+
+    def open(self, *args, **kwargs) -> Optional[Awaitable[None]]:
+        # Extract user info from the X-Streamlit-User header
+        is_public_cloud_app = False
+
+        try:
+            header_content = self.request.headers["X-Streamlit-User"]
+            payload = base64.b64decode(header_content)
+            user_obj = json.loads(payload)
+            email = user_obj["email"]
+            is_public_cloud_app = user_obj["isPublicCloudApp"]
+        except (KeyError, binascii.Error, json.decoder.JSONDecodeError):
+            email = "test@localhost.com"
+
+        user_info: Dict[str, Optional[str]] = dict()
+        if is_public_cloud_app:
+            user_info["email"] = None
+        else:
+            user_info["email"] = email
+
+        self._session = self._server._create_app_session(self, user_info)
+        return None
+
+    def on_close(self) -> None:
+        if not self._session:
+            return
+        self._server._close_app_session(self._session.id)
+        self._session = None
+
+    def get_compression_options(self) -> Optional[Dict[Any, Any]]:
+        """Enable WebSocket compression.
+
+        Returning an empty dict enables websocket compression. Returning
+        None disables it.
+
+        (See the docstring in the parent class.)
+        """
+        if config.get_option("server.enableWebsocketCompression"):
+            return {}
+        return None
+
+    def on_message(self, payload: Union[str, bytes]) -> None:
+        if not self._session:
+            return
+
+        msg = BackMsg()
+
+        try:
+            if isinstance(payload, str):
+                # Sanity check. (The frontend should only be sending us bytes;
+                # Protobuf.ParseFromString does not accept str input.)
+                raise RuntimeError(
+                    "WebSocket received an unexpected `str` message. "
+                    "(We expect `bytes` only.)"
+                )
+
+            msg.ParseFromString(payload)
+            LOGGER.debug("Received the following back message:\n%s", msg)
+
+            if msg.WhichOneof("type") == "close_connection":
+                # "close_connection" is a special developmentMode-only
+                # message used in e2e tests to test disabling widgets.
+                if config.get_option("global.developmentMode"):
+                    self._server.stop()
+                else:
+                    LOGGER.warning(
+                        "Client tried to close connection when "
+                        "not in development mode"
+                    )
+            else:
+                # AppSession handles all other BackMsg types.
+                self._session.handle_backmsg(msg)
+
+        except BaseException as e:
+            LOGGER.error(e)
+            self._session.handle_backmsg_exception(e)

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -22,7 +22,6 @@ from typing import (
     Awaitable,
     Union,
     TYPE_CHECKING,
-    Final,
 )
 
 import tornado.concurrent
@@ -32,6 +31,7 @@ import tornado.netutil
 import tornado.web
 import tornado.websocket
 from tornado.websocket import WebSocketHandler
+from typing_extensions import Final
 
 from streamlit import config
 from streamlit.app_session import AppSession

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 LOGGER: Final = get_logger(__name__)
 
 
-class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
+class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
     """Handles a WebSocket connection from the browser"""
 
     def initialize(self, server: "Server") -> None:

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -54,10 +54,10 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
     def initialize(self, server: "Server") -> None:
         self._server = server
         self._session: Optional[AppSession] = None
-        # The XSRF cookie is normally set when xsrf_form_html is used, but in a pure-Javascript application
-        # that does not use any regular forms we just need to read the self.xsrf_token manually to set the
-        # cookie as a side effect.
-        # See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
+        # The XSRF cookie is normally set when xsrf_form_html is used, but in a
+        # pure-Javascript application that does not use any regular forms we just
+        # need to read the self.xsrf_token manually to set the cookie as a side
+        # effect. See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
         # for more details.
         if config.get_option("server.enableXsrfProtection"):
             _ = self.xsrf_token

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -77,7 +77,7 @@ from streamlit.web.server.upload_file_request_handler import (
     UploadFileRequestHandler,
     UPLOAD_FILE_ROUTE,
 )
-from .browser_websocket_handler import _BrowserWebSocketHandler
+from .browser_websocket_handler import BrowserWebSocketHandler
 from .component_request_handler import ComponentRequestHandler
 from .session_client import SessionClient, SessionClientDisconnectedError
 from .stats_request_handler import StatsRequestHandler
@@ -319,7 +319,7 @@ class Server:
         routes: List[Any] = [
             (
                 make_url_path_regex(base, "stream"),
-                _BrowserWebSocketHandler,
+                BrowserWebSocketHandler,
                 dict(server=self),
             ),
             (

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -13,17 +13,13 @@
 # limitations under the License.
 
 import asyncio
-import base64
-import binascii
+import errno
 import logging
 import os
 import socket
 import sys
-import errno
-import json
 import time
 import traceback
-import click
 from enum import Enum
 from typing import (
     Any,
@@ -31,52 +27,42 @@ from typing import (
     Optional,
     Tuple,
     Callable,
-    Awaitable,
     List,
-    Union,
 )
 
+import click
 import tornado.concurrent
 import tornado.ioloop
 import tornado.locks
 import tornado.netutil
 import tornado.web
 import tornado.websocket
-from tornado.platform.asyncio import AsyncIOLoop
-from tornado.websocket import WebSocketHandler
 from tornado.httpserver import HTTPServer
-from typing_extensions import Protocol
+from tornado.platform.asyncio import AsyncIOLoop
 
 from streamlit import config
 from streamlit import file_util
 from streamlit import source_util
 from streamlit import util
+from streamlit.app_session import AppSession
 from streamlit.caching import get_memo_stats_provider, get_singleton_stats_provider
+from streamlit.components.v1.components import ComponentRegistry
 from streamlit.config_option import ConfigOption
 from streamlit.forward_msg_cache import ForwardMsgCache
 from streamlit.forward_msg_cache import create_reference_msg
 from streamlit.forward_msg_cache import populate_hash_if_needed
 from streamlit.in_memory_file_manager import in_memory_file_manager
 from streamlit.legacy_caching.caching import _mem_caches
-from streamlit.app_session import AppSession
-from streamlit.stats import StatsManager
-from streamlit.uploaded_file_manager import UploadedFileManager
 from streamlit.logger import get_logger
-from streamlit.components.v1.components import ComponentRegistry
-from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from .stats_request_handler import StatsRequestHandler
-from .component_request_handler import ComponentRequestHandler
-from streamlit.web.server.upload_file_request_handler import (
-    UploadFileRequestHandler,
-    UPLOAD_FILE_ROUTE,
-)
-
 from streamlit.session_data import SessionData
 from streamlit.state import (
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
     SessionStateStatProvider,
 )
+from streamlit.stats import StatsManager
+from streamlit.uploaded_file_manager import UploadedFileManager
+from streamlit.watcher import LocalSourcesWatcher
 from streamlit.web.server.routes import AddSlashHandler
 from streamlit.web.server.routes import AssetsFileHandler
 from streamlit.web.server.routes import DebugHandler
@@ -84,12 +70,17 @@ from streamlit.web.server.routes import HealthHandler
 from streamlit.web.server.routes import MediaFileHandler
 from streamlit.web.server.routes import MessageCacheHandler
 from streamlit.web.server.routes import StaticFileHandler
-from streamlit.web.server.server_util import is_cacheable_msg
-from streamlit.web.server.server_util import is_url_from_allowed_origins
-from streamlit.web.server.server_util import make_url_path_regex
-from streamlit.web.server.server_util import serialize_forward_msg
 from streamlit.web.server.server_util import get_max_message_size_bytes
-from streamlit.watcher import LocalSourcesWatcher
+from streamlit.web.server.server_util import is_cacheable_msg
+from streamlit.web.server.server_util import make_url_path_regex
+from streamlit.web.server.upload_file_request_handler import (
+    UploadFileRequestHandler,
+    UPLOAD_FILE_ROUTE,
+)
+from .browser_websocket_handler import _BrowserWebSocketHandler
+from .component_request_handler import ComponentRequestHandler
+from .session_client import SessionClient, SessionClientDisconnectedError
+from .stats_request_handler import StatsRequestHandler
 
 LOGGER = get_logger(__name__)
 
@@ -117,21 +108,6 @@ UNIX_SOCKET_PREFIX = "unix://"
 
 # Wait for the script run result for 60s and if no result is available give up
 SCRIPT_RUN_CHECK_TIMEOUT = 60
-
-
-class SessionClientDisconnectedError(Exception):
-    """Raised by operations on a disconnected SessionClient."""
-
-
-class SessionClient(Protocol):
-    """Interface for sending data to a session's client."""
-
-    def write_forward_msg(self, msg: ForwardMsg) -> None:
-        """Deliver a ForwardMsg to the client.
-
-        If the SessionClient has been disconnected, it should raise a
-        SessionClientDisconnectedError.
-        """
 
 
 class SessionInfo:
@@ -713,108 +689,6 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 
         if len(self._session_info_by_id) == 0:
             self._set_state(State.NO_SESSIONS_CONNECTED)
-
-
-class _BrowserWebSocketHandler(WebSocketHandler, SessionClient):
-    """Handles a WebSocket connection from the browser"""
-
-    def initialize(self, server: Server) -> None:
-        self._server = server
-        self._session: Optional[AppSession] = None
-        # The XSRF cookie is normally set when xsrf_form_html is used, but in a pure-Javascript application
-        # that does not use any regular forms we just need to read the self.xsrf_token manually to set the
-        # cookie as a side effect.
-        # See https://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
-        # for more details.
-        if config.get_option("server.enableXsrfProtection"):
-            _ = self.xsrf_token
-
-    def check_origin(self, origin: str) -> bool:
-        """Set up CORS."""
-        return super().check_origin(origin) or is_url_from_allowed_origins(origin)
-
-    def write_forward_msg(self, msg: ForwardMsg) -> None:
-        """Send a ForwardMsg to the browser."""
-        try:
-            self.write_message(serialize_forward_msg(msg), binary=True)
-        except tornado.websocket.WebSocketClosedError as e:
-            raise SessionClientDisconnectedError from e
-
-    def open(self, *args, **kwargs) -> Optional[Awaitable[None]]:
-        # Extract user info from the X-Streamlit-User header
-        is_public_cloud_app = False
-
-        try:
-            header_content = self.request.headers["X-Streamlit-User"]
-            payload = base64.b64decode(header_content)
-            user_obj = json.loads(payload)
-            email = user_obj["email"]
-            is_public_cloud_app = user_obj["isPublicCloudApp"]
-        except (KeyError, binascii.Error, json.decoder.JSONDecodeError):
-            email = "test@localhost.com"
-
-        user_info: Dict[str, Optional[str]] = dict()
-        if is_public_cloud_app:
-            user_info["email"] = None
-        else:
-            user_info["email"] = email
-
-        self._session = self._server._create_app_session(self, user_info)
-        return None
-
-    def on_close(self) -> None:
-        if not self._session:
-            return
-        self._server._close_app_session(self._session.id)
-        self._session = None
-
-    def get_compression_options(self) -> Optional[Dict[Any, Any]]:
-        """Enable WebSocket compression.
-
-        Returning an empty dict enables websocket compression. Returning
-        None disables it.
-
-        (See the docstring in the parent class.)
-        """
-        if config.get_option("server.enableWebsocketCompression"):
-            return {}
-        return None
-
-    def on_message(self, payload: Union[str, bytes]) -> None:
-        if not self._session:
-            return
-
-        msg = BackMsg()
-
-        try:
-            if isinstance(payload, str):
-                # Sanity check. (The frontend should only be sending us bytes;
-                # Protobuf.ParseFromString does not accept str input.)
-                raise RuntimeError(
-                    "WebSocket received an unexpected `str` message. "
-                    "(We expect `bytes` only.)"
-                )
-
-            msg.ParseFromString(payload)
-            LOGGER.debug("Received the following back message:\n%s", msg)
-
-            if msg.WhichOneof("type") == "close_connection":
-                # "close_connection" is a special developmentMode-only
-                # message used in e2e tests to test disabling widgets.
-                if config.get_option("global.developmentMode"):
-                    self._server.stop()
-                else:
-                    LOGGER.warning(
-                        "Client tried to close connection when "
-                        "not in development mode"
-                    )
-            else:
-                # AppSession handles all other BackMsg types.
-                self._session.handle_backmsg(msg)
-
-        except BaseException as e:
-            LOGGER.error(e)
-            self._session.handle_backmsg_exception(e)
 
 
 def _set_tornado_log_levels() -> None:

--- a/lib/streamlit/web/server/session_client.py
+++ b/lib/streamlit/web/server/session_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Protocol
+from typing_extensions import Protocol
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 

--- a/lib/streamlit/web/server/session_client.py
+++ b/lib/streamlit/web/server/session_client.py
@@ -1,0 +1,32 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Protocol
+
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+
+class SessionClientDisconnectedError(Exception):
+    """Raised by operations on a disconnected SessionClient."""
+
+
+class SessionClient(Protocol):
+    """Interface for sending data to a session's client."""
+
+    def write_forward_msg(self, msg: ForwardMsg) -> None:
+        """Deliver a ForwardMsg to the client.
+
+        If the SessionClient has been disconnected, it should raise a
+        SessionClientDisconnectedError.
+        """

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -1,0 +1,63 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import tornado.httpserver
+import tornado.testing
+import tornado.web
+import tornado.websocket
+
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.web.server.server import (
+    BrowserWebSocketHandler,
+    SessionClientDisconnectedError,
+)
+from .server_test_case import ServerTestCase
+
+
+class BrowserWebSocketHandlerTest(ServerTestCase):
+    @tornado.testing.gen_test
+    async def test_write_forward_msg_reraises_websocket_closed_error(self):
+        """`write_forward_msg` should re-raise WebSocketClosedError as
+        as SessionClientDisconnectedError.
+        """
+
+        with self._patch_app_session():
+            await self.start_server_loop()
+            await self.ws_connect()
+
+            # Get our connected BrowserWebSocketHandler
+            session_info = list(self.server._session_info_by_id.values())[0]
+            websocket_handler = session_info.client
+            self.assertIsInstance(websocket_handler, BrowserWebSocketHandler)
+
+            # Patch _BrowserWebSocketHandler.write_message to raise an error
+            with mock.patch.object(
+                websocket_handler, "write_message"
+            ) as write_message_mock:
+                write_message_mock.side_effect = tornado.websocket.WebSocketClosedError
+
+                msg = ForwardMsg()
+                msg.script_finished = (
+                    ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+                )
+
+                # Send a ForwardMsg. write_message will raise a
+                # WebSocketClosedError, and write_forward_msg should re-raise
+                # it as a SessionClientDisconnectedError.
+                with self.assertRaises(SessionClientDisconnectedError):
+                    websocket_handler.write_forward_msg(msg)
+
+                write_message_mock.assert_called_once()

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -32,6 +32,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     def tearDown(self) -> None:
         ComponentRegistry._instance = None
+        super().tearDown()
 
     def get_app(self):
         ComponentRegistry._instance = None

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -50,10 +50,12 @@ from streamlit.web.server.server import (
     _BrowserWebSocketHandler,
     SessionClientDisconnectedError,
 )
-from streamlit.web.server.server import is_cacheable_msg
-from streamlit.web.server.server import is_url_from_allowed_origins
-from streamlit.web.server.server import serialize_forward_msg
 from streamlit.web.server.server import start_listening
+from streamlit.web.server.server_util import (
+    is_cacheable_msg,
+    is_url_from_allowed_origins,
+    serialize_forward_msg,
+)
 from .server_test_case import ServerTestCase
 
 LOGGER = get_logger(__name__)

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -47,7 +47,7 @@ from streamlit.web.server.server import Server
 from streamlit.web.server.server import State
 from streamlit.web.server.server import StaticFileHandler
 from streamlit.web.server.server import (
-    _BrowserWebSocketHandler,
+    BrowserWebSocketHandler,
     SessionClientDisconnectedError,
 )
 from streamlit.web.server.server import start_listening
@@ -432,7 +432,7 @@ class ServerTest(ServerTestCase):
             # Get our connected BrowserWebSocketHandler
             session_info = list(self.server._session_info_by_id.values())[0]
             websocket_handler = session_info.client
-            self.assertIsInstance(websocket_handler, _BrowserWebSocketHandler)
+            self.assertIsInstance(websocket_handler, BrowserWebSocketHandler)
 
             # Patch _BrowserWebSocketHandler.write_message to raise an error
             with mock.patch.object(

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -46,10 +46,6 @@ from streamlit.web.server.server import RetriesExceeded
 from streamlit.web.server.server import Server
 from streamlit.web.server.server import State
 from streamlit.web.server.server import StaticFileHandler
-from streamlit.web.server.server import (
-    BrowserWebSocketHandler,
-    SessionClientDisconnectedError,
-)
 from streamlit.web.server.server import start_listening
 from streamlit.web.server.server_util import (
     is_cacheable_msg,
@@ -418,40 +414,6 @@ class ServerTest(ServerTestCase):
                 self.assertIsNone(
                     self.server._get_session_info(session_info.session.id)
                 )
-
-    @tornado.testing.gen_test
-    async def test_write_forward_msg_reraises_websocket_closed_error(self):
-        """`write_forward_msg` should re-raise WebSocketClosedError as
-        as SessionClientDisconnectedError.
-        """
-
-        with self._patch_app_session():
-            await self.start_server_loop()
-            await self.ws_connect()
-
-            # Get our connected BrowserWebSocketHandler
-            session_info = list(self.server._session_info_by_id.values())[0]
-            websocket_handler = session_info.client
-            self.assertIsInstance(websocket_handler, BrowserWebSocketHandler)
-
-            # Patch _BrowserWebSocketHandler.write_message to raise an error
-            with mock.patch.object(
-                websocket_handler, "write_message"
-            ) as write_message_mock:
-                write_message_mock.side_effect = tornado.websocket.WebSocketClosedError
-
-                msg = ForwardMsg()
-                msg.script_finished = (
-                    ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
-                )
-
-                # Send a ForwardMsg. write_message will raise a
-                # WebSocketClosedError, and write_forward_msg should re-raise
-                # it as a SessionClientDisconnectedError.
-                with self.assertRaises(SessionClientDisconnectedError):
-                    websocket_handler.write_forward_msg(msg)
-
-                write_message_mock.assert_called_once()
 
     @tornado.testing.gen_test
     async def test_is_active_session(self):

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -46,7 +46,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         create a new AsyncIOLoop so that we can access its underlying
         asyncio_loop instance in our `event_loop` property.
         """
-        return AsyncIOLoop()
+        return AsyncIOLoop(make_current=False)
 
     def get_app(self) -> tornado.web.Application:
         # Create a Server, and patch its _on_stopped function


### PR DESCRIPTION
Split `BrowserWebSocketHandler` out into its own source file, to reduce the size of `server.py`. (This necessitates also moving `SessionClient` into its own source file to avoid a circular dependency.)

In the imminent StreamlitRuntime future, `BrowserWebSocketHandler` will call functions on the `Runtime` object (instead of the `Server` object), so it will have no circular dependency on Server.

(This is just a minor refactor; no logic changes.)