### PR TITLE
No explicit IOLoop

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -260,7 +260,7 @@ class AppSession:
         )
 
         # Send an Exception message to the frontend.
-        # Because _on_scriptrunner_event does its work in an ioloop callback,
+        # Because _on_scriptrunner_event does its work in an eventloop callback,
         # this exception ForwardMsg *must* also be enqueued in a callback,
         # so that it will be enqueued *after* the various ForwardMsgs that
         # _on_scriptrunner_event sends.

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import os
 import signal
 import sys
@@ -361,13 +362,8 @@ def run(
     _install_config_watchers(flag_options)
     _install_pages_watcher(main_script_path)
 
-    # Create our Tornado IOLoop.
-    # (AsyncIOLoop is actually the default IOLoop type - we're just being
-    # explicit about it so that we can grab its asyncio_loop instance.)
-    ioloop = AsyncIOLoop()
-
     # Create the server. It won't start running yet.
-    server = Server(ioloop, main_script_path, command_line)
+    server = Server(main_script_path, command_line)
 
     # Install a signal handler that will shut down the ioloop
     # and close all our threads
@@ -375,5 +371,4 @@ def run(
 
     # Start the server and its ioloop. This function will not return until the
     # server is shut down.
-    server.start(_on_server_start)
-    ioloop.start()
+    asyncio.run(server.start(_on_server_start))

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -66,7 +66,7 @@ def _set_up_signal_handler(server: Server) -> None:
 
     def signal_handler(signal_number, stack_frame):
         # The server will shut down its threads and stop the ioloop
-        server.stop(from_signal=True)
+        server.stop()
 
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
@@ -365,10 +365,9 @@ def run(
     # Create the server. It won't start running yet.
     server = Server(main_script_path, command_line)
 
-    # Install a signal handler that will shut down the ioloop
+    # Install a signal handler that will shut down the server
     # and close all our threads
     _set_up_signal_handler(server)
 
-    # Start the server and its ioloop. This function will not return until the
-    # server is shut down.
+    # Run the server. This function will not return until the server is shut down.
     asyncio.run(server.start(_on_server_start))

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -19,8 +19,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import click
-import tornado.ioloop
-from tornado.platform.asyncio import AsyncIOLoop
 
 from streamlit import config
 from streamlit import env_util
@@ -65,7 +63,7 @@ def _set_up_signal_handler(server: Server) -> None:
     LOGGER.debug("Setting up signal handler")
 
     def signal_handler(signal_number, stack_frame):
-        # The server will shut down its threads and stop the ioloop
+        # The server will shut down its threads and exit its loop.
         server.stop()
 
     signal.signal(signal.SIGTERM, signal_handler)
@@ -195,8 +193,7 @@ def _on_server_start(server: Server) -> None:
 
     # Schedule the browser to open using the IO Loop on the main thread, but
     # only if no other browser connects within 1s.
-    ioloop = tornado.ioloop.IOLoop.current()
-    ioloop.call_later(BROWSER_WAIT_TIMEOUT_SEC, maybe_open_browser)
+    asyncio.get_running_loop().call_later(BROWSER_WAIT_TIMEOUT_SEC, maybe_open_browser)
 
 
 def _fix_pydeck_mapbox_api_warning() -> None:
@@ -352,7 +349,7 @@ def run(
 ) -> None:
     """Run a script in a separate thread and start a server for the app.
 
-    This starts a blocking ioloop.
+    This starts a blocking asyncio eventloop.
     """
     _fix_sys_path(main_script_path)
     _fix_matplotlib_crash()

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -191,8 +191,8 @@ def _on_server_start(server: Server) -> None:
 
         util.open_browser(server_util.get_url(addr))
 
-    # Schedule the browser to open using the IO Loop on the main thread, but
-    # only if no other browser connects within 1s.
+    # Schedule the browser to open on the main thread, but only if no other
+    # browser connects within 1s.
     asyncio.get_running_loop().call_later(BROWSER_WAIT_TIMEOUT_SEC, maybe_open_browser)
 
 

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -25,7 +25,6 @@ from typing import (
 )
 
 import tornado.concurrent
-import tornado.ioloop
 import tornado.locks
 import tornado.netutil
 import tornado.web

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -544,9 +544,6 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 """
             )
 
-        finally:
-            self._on_stopped()
-
     def _send_message(self, session_info: SessionInfo, msg: ForwardMsg) -> None:
         """Send a message to a client.
 
@@ -613,15 +610,6 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             self._ioloop.add_callback_from_signal(self._must_stop.set)
         else:
             self._ioloop.add_callback(self._must_stop.set)
-
-    def _on_stopped(self) -> None:
-        """Called when our runloop is exiting, to shut down the ioloop.
-        This will end our process.
-
-        (Tests can patch this method out, to prevent the test's ioloop
-        from being shutdown.)
-        """
-        self._ioloop.stop()
 
     def _create_app_session(
         self, client: SessionClient, user_info: Dict[str, Optional[str]]

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -478,6 +478,11 @@ class Server:
             else:
                 raise RuntimeError(f"Bad server state at start: {self._state}")
 
+            # Store the eventloop we're running on so that we can schedule
+            # callbacks on it when necessary. (We can't just call
+            # `asyncio.get_running_loop()` whenever we like, because we have
+            # some functions, e.g. `stop`, that can be called from other
+            # threads, and `asyncio.get_running_loop()` is thread-specific.)
             self._eventloop = asyncio.get_running_loop()
 
             if on_started is not None:
@@ -675,6 +680,9 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             self._set_state(State.NO_SESSIONS_CONNECTED)
 
     def _get_eventloop(self) -> asyncio.AbstractEventLoop:
+        """Return the asyncio eventloop that the Server was started with.
+        If the Server hasn't been started, this will raise an error.
+        """
         if self._eventloop is None:
             raise RuntimeError("Server hasn't started yet!")
         return self._eventloop

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -225,9 +225,7 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
 
 
 class Server:
-    def __init__(
-        self, main_script_path: str, command_line: Optional[str]
-    ):
+    def __init__(self, main_script_path: str, command_line: Optional[str]):
         """Create the server. It won't be started yet."""
         _set_tornado_log_levels()
 
@@ -434,7 +432,7 @@ class Server:
         session_data = SessionData(self._main_script_path, self._command_line)
         local_sources_watcher = LocalSourcesWatcher(session_data)
         session = AppSession(
-            event_loop=asyncio.get_event_loop(),
+            event_loop=asyncio.get_running_loop(),
             session_data=session_data,
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -639,7 +637,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         local_sources_watcher = LocalSourcesWatcher(session_data)
 
         session = AppSession(
-            event_loop=asyncio.get_event_loop(),
+            event_loop=asyncio.get_running_loop(),
             session_data=session_data,
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -440,7 +440,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         thread.join()
 
         # _handle_scriptrunner_event_on_main_thread won't have been called
-        # yet, because we haven't yielded the ioloop.
+        # yet, because we haven't yielded the eventloop.
         mock_handle_event.assert_not_called()
 
         # Yield to let the AppSession's callbacks run.
@@ -483,7 +483,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         FAKE_EXCEPTION = RuntimeError("I am error")
         session.handle_backmsg_exception(FAKE_EXCEPTION)
 
-        # Messages get sent in an ioloop callback, which hasn't had a chance
+        # Messages get sent in an eventloop callback, which hasn't had a chance
         # to run yet. Our message queue should be empty.
         self.assertEqual([], forward_msg_queue_events)
 

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -31,7 +31,7 @@ report = SessionData("the/path", "test command line")
 
 
 class BootstrapTest(unittest.TestCase):
-    @patch("streamlit.web.bootstrap.AsyncIOLoop", Mock())
+    @patch("streamlit.web.bootstrap.asyncio.run", Mock())
     @patch("streamlit.web.bootstrap.Server", Mock())
     @patch("streamlit.web.bootstrap._install_pages_watcher", Mock())
     def test_fix_matplotlib_crash(self):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -323,12 +323,14 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             },
         )
 
+    @patch("streamlit.web.bootstrap.asyncio.get_running_loop", Mock())
     @patch("streamlit.web.bootstrap.secrets.load_if_toml_exists")
     def test_load_secrets(self, mock_load_secrets):
         """We should load secrets.toml on startup."""
         bootstrap._on_server_start(Mock())
         mock_load_secrets.assert_called_once()
 
+    @patch("streamlit.web.bootstrap.asyncio.get_running_loop", Mock())
     @patch("streamlit.web.bootstrap.LOGGER.error")
     @patch("streamlit.web.bootstrap.secrets.load_if_toml_exists")
     def test_log_secret_load_error(self, mock_load_secrets, mock_log_error):

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -428,6 +428,21 @@ class ServerTest(ServerTestCase):
             self.assertFalse(self.server.is_active_session("not_a_session_id"))
             self.assertTrue(self.server.is_active_session(session_info.session.id))
 
+    @tornado.testing.gen_test
+    async def test_get_eventloop(self):
+        """Server._get_eventloop() will raise an error if called before the
+        Server is started, and will return the Server's eventloop otherwise.
+        """
+        with self._patch_app_session():
+            with self.assertRaises(RuntimeError):
+                # Server hasn't started yet: error!
+                _ = self.server._get_eventloop()
+
+            # Server has started: no error
+            await self.start_server_loop()
+            eventloop = self.server._get_eventloop()
+            self.assertIsInstance(eventloop, asyncio.AbstractEventLoop)
+
 
 class ServerUtilsTest(unittest.TestCase):
     def test_is_url_from_allowed_origins_allowed_domains(self):

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -682,7 +682,7 @@ class ScriptCheckTest(tornado.testing.AsyncTestCase):
         os.environ["HOME"] = self._home
 
         self._fd, self._path = tempfile.mkstemp()
-        self._server = Server(self.io_loop, self._path, "test command line")
+        self._server = Server(self._path, "test command line")
 
     def tearDown(self) -> None:
         self._server.stop()
@@ -749,7 +749,7 @@ class ScriptCheckEndpointExistsTest(tornado.testing.AsyncHTTPTestCase):
         super().tearDown()
 
     def get_app(self):
-        server = Server(self.io_loop, "mock/script/path", "test command line")
+        server = Server("mock/script/path", "test command line")
         server.does_script_run_without_error = self.does_script_run_without_error
         return server._create_app()
 
@@ -773,7 +773,7 @@ class ScriptCheckEndpointDoesNotExistTest(tornado.testing.AsyncHTTPTestCase):
         super().tearDown()
 
     def get_app(self):
-        server = Server(self.io_loop, "mock/script/path", "test command line")
+        server = Server("mock/script/path", "test command line")
         server.does_script_run_without_error = self.does_script_run_without_error
         return server._create_app()
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -685,8 +685,6 @@ class ScriptCheckTest(tornado.testing.AsyncTestCase):
         self._server = Server(self._path, "test command line")
 
     def tearDown(self) -> None:
-        self._server.stop()
-
         if event_based_path_watcher._MultiPathWatcher._singleton is not None:
             event_based_path_watcher._MultiPathWatcher.get_singleton().close()
             event_based_path_watcher._MultiPathWatcher._singleton = None

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -683,6 +683,7 @@ class ScriptCheckTest(tornado.testing.AsyncTestCase):
 
         self._fd, self._path = tempfile.mkstemp()
         self._server = Server(self._path, "test command line")
+        self._server._eventloop = self.asyncio_loop
 
     def tearDown(self) -> None:
         if event_based_path_watcher._MultiPathWatcher._singleton is not None:

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -19,8 +19,6 @@ from unittest import mock
 import tornado.testing
 import tornado.web
 import tornado.websocket
-from tornado.ioloop import IOLoop
-from tornado.platform.asyncio import AsyncIOLoop
 from tornado.websocket import WebSocketClientConnection
 
 from streamlit.app_session import AppSession
@@ -40,13 +38,6 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
     """
 
     _next_session_id = 0
-
-    def get_new_ioloop(self) -> IOLoop:
-        """Returns the `.IOLoop` to use for this test. We explicitly
-        create a new AsyncIOLoop so that we can access its underlying
-        asyncio_loop instance in our `event_loop` property.
-        """
-        return AsyncIOLoop(make_current=False)
 
     def get_app(self) -> tornado.web.Application:
         self.server = Server(

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import typing
+
 import urllib.parse
 from asyncio import Future
 from unittest import mock
@@ -49,15 +49,10 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         return AsyncIOLoop(make_current=False)
 
     def get_app(self) -> tornado.web.Application:
-        # Create a Server, and patch its _on_stopped function
-        # to no-op. This prevents it from shutting down the
-        # ioloop when it stops.
         self.server = Server(
-            typing.cast(AsyncIOLoop, self.io_loop),
             "/not/a/script.py",
             "test command line",
         )
-        self.server._on_stopped = mock.MagicMock()  # type: ignore[assignment]
         app = self.server._create_app()
         return app
 


### PR DESCRIPTION
Remove all explicit `tornado.ioloop` references and modernize our eventloop usage.

Per the [Tornado docs](https://www.tornadoweb.org/en/stable/ioloop.html), "The `IOLoop` interface is now provided primarily for backwards compatibility; new code should generally use the `asyncio` event loop interface directly. The `IOLoop.current` class method provides the `IOLoop` instance corresponding to the running `asyncio` event loop."

- `bootstrap.py` starts the server via `asyncio.run`
- `Server.start()` is now an `async` function. When it completes, the eventloop automatically ends.
- `Server.stop()` no longer takes a "from_signal" param (it can be safely called from any thread), and it no longer explicitly stops an IOLoop (this now happens automatically by virtue of the Server's loop function just exiting normally).
- There are no more IOLoop mentions (or imports) in the code