### PR TITLE
Fix chart studio link in `st.plotly_chart` docstring

### DIFF
--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -95,7 +95,7 @@ class PlotlyMixin:
             Use 'streamlit' to insert the plot and all its dependencies
             directly in the Streamlit app using plotly's offline mode (default).
             Use any other sharing mode to send the chart to Plotly chart studio, which
-            requires an account. See https://plotly.com/chart-studio/ for more information.
+            requires an account. See https://plot.ly/python/chart-studio/ for more information.
 
         **kwargs
             Any argument accepted by Plotly's `plot()` function.


### PR DESCRIPTION
## 📚 Context

The `st.plotly_chart` docstring contains a [dead link](https://plotly.com/chart-studio/) to Plotly Chart Studio.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Replaces the dead link in the plotly chart docstring with https://plot.ly/python/chart-studio/

  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/180374786-7640f7fc-0e71-4822-8817-29be2388fe2f.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/180374815-8dd17d62-fd71-44eb-9ee5-bd57b59c8e07.png)

## 🧪 Testing Done

- [x] Screenshots included
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
