### PR TITLE
Don't explode when a list-like dataframe is passed to st.radio

### DIFF
--- a/e2e/scripts/st_radio.py
+++ b/e2e/scripts/st_radio.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pandas as pd
 import streamlit as st
 
 options = ("female", "male")
@@ -30,11 +31,15 @@ st.write("value 4:", i4)
 i5 = st.radio("radio 5", options, horizontal=True)
 st.write("value 5:", i5)
 
+i6 = st.radio("radio 6", pd.DataFrame({"foo": list(options)}))
+st.write("value 6:", i6)
+
+
 if st._is_running_with_streamlit:
 
     def on_change():
         st.session_state.radio_changed = True
 
-    st.radio("radio 6", options, 1, key="radio6", on_change=on_change)
-    st.write("value 6:", st.session_state.radio6)
+    st.radio("radio 7", options, 1, key="radio7", on_change=on_change)
+    st.write("value 7:", st.session_state.radio7)
     st.write("radio changed:", "radio_changed" in st.session_state)

--- a/e2e/specs/st_radio.spec.js
+++ b/e2e/specs/st_radio.spec.js
@@ -23,7 +23,7 @@ describe("st.radio", () => {
   });
 
   it("shows widget correctly", () => {
-    cy.get(".stRadio").should("have.length", 6);
+    cy.get(".stRadio").should("have.length", 7);
 
     cy.get(".stRadio").each((el, idx) => {
       return cy.wrap(el).matchThemedSnapshots("radio" + idx);
@@ -93,7 +93,8 @@ describe("st.radio", () => {
         "value 3: None" +
         "value 4: female" +
         "value 5: female" +
-        "value 6: male" +
+        "value 6: female" +
+        "value 7: male" +
         "radio changed: False"
     );
   });
@@ -135,12 +136,13 @@ describe("st.radio", () => {
         "value 4: female" +
         "value 5: male" +
         "value 6: male" +
+        "value 7: male" +
         "radio changed: False"
     );
   });
 
   it("calls callback if one is registered", () => {
-    cy.getIndexed(".stRadio", 5).then(el => {
+    cy.getIndexed(".stRadio", 6).then(el => {
       return cy
         .wrap(el)
         .find("input")
@@ -156,6 +158,7 @@ describe("st.radio", () => {
         "value 4: female" +
         "value 5: female" +
         "value 6: female" +
+        "value 7: female" +
         "radio changed: True"
     );
   });

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -169,9 +169,9 @@ class RadioMixin:
             return opt[idx] if len(opt) > 0 and opt[idx] is not None else None
 
         def serialize_radio(v):
-            if len(options) == 0:
+            if len(opt) == 0:
                 return 0
-            return index_(options, v)
+            return index_(opt, v)
 
         widget_state = register_widget(
             "radio",


### PR DESCRIPTION
## 📚 Context

See #4296 for a description of the bug and some example code demonstrating it. The reason
this bug occurs is that we're using the raw `options` argument passed to the `st.radio` function
rather than the `opt` variable, which has been massaged into the form what we want in the case
of `options` being a list-like dataframe.

- What kind of change does this PR introduce?

  - [x] Bugfix


## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated e2e tests

## 🌐 References

Closes #4296
