### PR TITLE
Ensure "script_path" fields returned by get_pages are always absolute paths

### DIFF
--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -152,7 +152,7 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
                 "page_script_hash": main_page_script_hash,
                 "page_name": main_page_name,
                 "icon": main_page_icon,
-                "script_path": str(main_script_path),
+                "script_path": str(main_script_path.resolve()),
             }
         }
 
@@ -163,7 +163,7 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
         )
 
         for script_path in page_scripts:
-            script_path_str = str(script_path)
+            script_path_str = str(script_path.resolve())
             pn, pi = page_name_and_icon(script_path)
             psh = calc_md5(script_path_str)
 


### PR DESCRIPTION
## 📚 Context

It seems like #4876 may be caused by weirdness in WSL causing some of the paths
returned by the `get_pages` function to be relative instead of absolute. This PR simply
explicitly specifies that all script paths returned by the function should be absolute to
ensure that this isn't an issue.

This is difficult to test in an automated way since my hunch is that the problem is WSL-specific
so I'll instead see if I can reproduce the issue and verify that it gets fixed by this wheel.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Manual testing done

## 🌐 References

Closes #4876
