### PR TITLE
List languages supported by st.code for syntax highlighting

### DIFF
--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -36,7 +36,7 @@ class MarkdownMixin:
 
             This also supports:
 
-            * Emoji shortcodes, such as `:+1:`  and `:sunglasses:`.
+            * Emoji shortcodes, such as ``:+1:``  and ``:sunglasses:``.
               For a list of all supported codes,
               see https://share.streamlit.io/streamlit/emoji-shortcodes.
 
@@ -55,7 +55,7 @@ class MarkdownMixin:
 
             https://github.com/streamlit/streamlit/issues/152
 
-            *Also note that `unsafe_allow_html` is a temporary measure and may
+            *Also note that ``unsafe_allow_html`` is a temporary measure and may
             be removed from Streamlit at any time.*
 
             If you decide to turn on HTML anyway, we ask you to please tell us
@@ -142,6 +142,10 @@ class MarkdownMixin:
         language : str
             The language that the code is written in, for syntax highlighting.
             If omitted, the code will be unstyled.
+            
+            For a list of available ``language`` imports, see:
+
+            https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD
 
         Example
         -------

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -142,7 +142,7 @@ class MarkdownMixin:
         language : str
             The language that the code is written in, for syntax highlighting.
             If omitted, the code will be unstyled.
-            
+
             For a list of available ``language`` imports, see:
 
             https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD


### PR DESCRIPTION
## 📚 Context

The `st.code` [docstring](https://docs.streamlit.io/library/api-reference/text/st.code) has a `language` parameter for syntax highlighting. The docs don't include a list of all supported languages. 

[CodeBlock.tsx](https://github.com/streamlit/streamlit/blob/develop/frontend/src/components/elements/CodeBlock/CodeBlock.tsx) uses the [react-syntax-highligher](https://www.npmjs.com/package/react-syntax-highlighter) NPM package for syntax highlighting and the available `language` imports are listed [here](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD).

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Added a [link](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD) in the st.code docstring to the list of all available language imports 
- Fixes reStructuredText inline code formatting in st.markdown docstring


  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/180715854-9db866e5-72e3-4577-bc53-f63f07d38471.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/180715935-890330f3-c59a-494b-82da-cae92fc8e5e0.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #5028 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
