### PR TITLE
Don't install streamlit locally when making packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ cli-smoke-tests:
 
 .PHONY: cli-regression-tests
 # Verify that CLI boots as expected when called with `python -m streamlit`
-cli-regression-tests:
+cli-regression-tests: install
 	pytest scripts/cli_regression_tests.py
 
 .PHONY: install
@@ -176,7 +176,7 @@ distribution:
 
 .PHONY: package
 # Build lib and frontend, and then run 'distribution'.
-package: mini-devel frontend install distribution
+package: mini-devel frontend distribution
 
 .PHONY: conda-distribution
 # Create conda distribution files in lib/conda-recipe/dist.
@@ -190,7 +190,7 @@ conda-distribution:
 
 .PHONY: conda-package
 # Build lib and frontend, and then run 'conda-distribution'
-conda-package: mini-devel frontend install conda-distribution
+conda-package: mini-devel frontend conda-distribution
 
 
 .PHONY: clean


### PR DESCRIPTION
## 📚 Context

While working on getting conda builds of Streamlit working, I ran into a permissions error when
installing Streamlit as a local Python package.

This made me wonder why we're bothering to install streamlit as a local python package when
making wheel files / conda distributions in the first place. Doing so isn't strictly necessary when
building a Streamlit release, so we should stop doing so to avoid doing unnecessary work in the
make target.

- What kind of change does this PR introduce?

  - [x] Other, please describe: make target cleanup
