### PR TITLE
Handle old memo persist format files

### DIFF
--- a/lib/streamlit/caching/memo_decorator.py
+++ b/lib/streamlit/caching/memo_decorator.py
@@ -422,7 +422,10 @@ class MemoCache(Cache):
         try:
             entry = pickle.loads(pickled_entry)
             if not isinstance(entry, CachedResult):
-                raise CacheError(f"Failed to unpickle {key}")
+                # Loaded an old cache file format, remove it and let the caller
+                # rerun the function.
+                self._remove_from_disk_cache(key)
+                raise CacheKeyNotFoundError()
             return entry
         except pickle.UnpicklingError as exc:
             raise CacheError(f"Failed to unpickle {key}") from exc

--- a/lib/tests/streamlit/caching/memo_test.py
+++ b/lib/tests/streamlit/caching/memo_test.py
@@ -294,6 +294,21 @@ class MemoPersistTest(DeltaGeneratorTestCase):
         ]
         assert text == ["1"]
 
+    @patch("streamlit.file_util.os.stat", MagicMock())
+    @patch("streamlit.caching.memo_decorator.streamlit_write", MagicMock())
+    @patch(
+        "streamlit.file_util.open",
+        wraps=mock_open(read_data=pickle.dumps(1)),
+    )
+    def test_cached_format_migration(self, _):
+        @st.experimental_memo(persist="disk")
+        def foo(i):
+            st.text(i)
+            return i
+
+        # Executes normally, without raising any errors
+        foo(1)
+
 
 class MemoStatsProviderTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION

## 📚 Context

My replay PR failed to handle encountering the old memo file format, so here is a small fix that deletes the file and continues as if it was never there.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

