### PR TITLE
Parameterize map markers radius and color.

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -26,10 +26,10 @@ import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
 
+from .arrow import Data
+
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
-
-    from .arrow import Data
 
 
 class MapMixin:


### PR DESCRIPTION
## 📚 Context

https://github.com/streamlit/streamlit/issues/582#issue-515218996

Parameterize map markers radius and color.
And do type check.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**
```python
import streamlit as st
st.map(gps_data, radius=10, color=[0, 128, 128, 160])
```
![image](https://user-images.githubusercontent.com/56434476/180898607-c9d7826c-3371-446a-88b7-5129ad5093c6.png)

**Current:**
```python
import streamlit as st

st.map(gps_data)
```
![image](https://user-images.githubusercontent.com/56434476/180898859-07339ad1-029d-47e5-91a3-48bd244c323c.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References
- **Issue**: Closes #582 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
