### PR TITLE
Fix svg images newlines

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -416,7 +416,7 @@ def marshall_images(
                     image = textfile.read()
 
             # Following regex allows svg image files to start either via a "<?xml...>" tag eventually followed by a "<svg...>" tag or directly starting with a "<svg>" tag
-            if re.search(r"(^\s?(<\?xml[\s\S]*<svg )|^\s?<svg )", image):
+            if re.search(r"(^\s?(<\?xml[\s\S]*<svg\s)|^\s?<svg\s)", image):
                 proto_img.markup = f"data:image/svg+xml,{image}"
                 is_svg = True
         if not is_svg:

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -230,8 +230,16 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
                 "data:image/svg+xml,<svg fake></svg>",
             ),
             (
+                "<svg\nfake></svg>",
+                "data:image/svg+xml,<svg\nfake></svg>",
+            ),
+            (
                 "\n<svg fake></svg>",
                 "data:image/svg+xml,\n<svg fake></svg>",
+            ),
+            (
+                '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<!-- Created with Inkscape (http://www.inkscape.org/) -->\n\n<svg\n fake></svg>',
+                'data:image/svg+xml,<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<!-- Created with Inkscape (http://www.inkscape.org/) -->\n\n<svg\n fake></svg>',
             ),
             (
                 '<?xml version="1.0" encoding="utf-8"?><!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg fake></svg>',


### PR DESCRIPTION
## 📚 Context

Streamlit gives an error (see below) when loading an SVG from Inkscape.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

Inkscape SVGs start like this:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!-- Created with Inkscape (http://www.inkscape.org/) -->

<svg
   width="210mm"
   height="297mm"
...
```
The changes in the PR allow more whitespace characters after the tag.

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

![circle](https://user-images.githubusercontent.com/18382390/180971867-a03b11e4-b09d-49b7-8674-21b87c0c7204.png)

**Current:**

![screen](https://user-images.githubusercontent.com/18382390/180971833-9cf123af-a528-4364-a96b-e0d4397253c5.png)


## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
