### PR TITLE
Ignore component requests outside of the component root

### DIFF
--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -38,14 +38,15 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             self.set_status(404)
             return
 
+        # follow symlinks to get an accurate normalized path
+        component_root = os.path.realpath(component_root)
         filename = "/".join(parts[1:])
-        # follow symlinks to get an accurate path
         abspath = os.path.realpath(os.path.join(component_root, filename))
 
         # Do NOT expose anything outside of the component root.
         if os.path.commonprefix([component_root, abspath]) != component_root:
-            self.write("not found")
-            self.set_status(404)
+            self.write("forbidden")
+            self.set_status(403)
             return
 
         LOGGER.debug("ComponentRequestHandler: GET: %s -> %s", path, abspath)

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -41,6 +41,12 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
         filename = "/".join(parts[1:])
         abspath = os.path.join(component_root, filename)
 
+        # Do NOT expose anything outside of the component root.
+        if os.path.commonprefix([component_root, abspath]) != component_root:
+            self.write("not found")
+            self.set_status(404)
+            return
+
         LOGGER.debug("ComponentRequestHandler: GET: %s -> %s", path, abspath)
 
         try:

--- a/lib/streamlit/web/server/component_request_handler.py
+++ b/lib/streamlit/web/server/component_request_handler.py
@@ -39,7 +39,8 @@ class ComponentRequestHandler(tornado.web.RequestHandler):
             return
 
         filename = "/".join(parts[1:])
-        abspath = os.path.join(component_root, filename)
+        # follow symlinks to get an accurate path
+        abspath = os.path.realpath(os.path.join(component_root, filename))
 
         # Do NOT expose anything outside of the component root.
         if os.path.commonprefix([component_root, abspath]) != component_root:

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -81,6 +81,24 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(404, response.code)
         self.assertEqual(b"not found", response.body)
 
+    def test_symlink_outside_component_root_request(self):
+        """Tests to ensure anything outside of the component root is disallowed."""
+
+        with mock.patch("streamlit.components.v1.components.os.path.isdir"):
+            # We don't need the return value in this case.
+            declare_component("test", path=PATH)
+
+        with mock.patch(
+            "streamlit.web.server.component_request_handler.os.path.realpath",
+            return_value="/etc/hosts",
+        ):
+            response = self._request_component(
+                "web.server.component_request_handler_test.test"
+            )
+
+        self.assertEqual(404, response.code)
+        self.assertEqual(b"not found", response.body)
+
     def test_invalid_component_request(self):
         """Test request failure when invalid component name is provided."""
 

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -66,7 +66,7 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(200, response.code)
         self.assertEqual(b"Test Content", response.body)
-    
+
     def test_outside_component_root_request(self):
         """Tests to ensure anything outside of the component root is disallowed."""
 
@@ -74,7 +74,6 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             # We don't need the return value in this case.
             declare_component("test", path=PATH)
 
-        
         response = self._request_component(
             "web.server.component_request_handler_test.test//etc/hosts"
         )

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -68,7 +68,8 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(b"Test Content", response.body)
 
     def test_outside_component_root_request(self):
-        """Tests to ensure anything outside of the component root is disallowed."""
+        """Tests to ensure a path based on the root directory (and therefore
+        outside of the component root) is disallowed."""
 
         with mock.patch("streamlit.components.v1.components.os.path.isdir"):
             # We don't need the return value in this case.
@@ -78,11 +79,27 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "web.server.component_request_handler_test.test//etc/hosts"
         )
 
-        self.assertEqual(404, response.code)
-        self.assertEqual(b"not found", response.body)
+        self.assertEqual(403, response.code)
+        self.assertEqual(b"forbidden", response.body)
+
+    def test_relative_outside_component_root_request(self):
+        """Tests to ensure a path relative to the component root directory
+        (and specifically outside of the component root) is disallowed."""
+
+        with mock.patch("streamlit.components.v1.components.os.path.isdir"):
+            # We don't need the return value in this case.
+            declare_component("test", path=PATH)
+
+        response = self._request_component(
+            "web.server.component_request_handler_test.test/../foo"
+        )
+
+        self.assertEqual(403, response.code)
+        self.assertEqual(b"forbidden", response.body)
 
     def test_symlink_outside_component_root_request(self):
-        """Tests to ensure anything outside of the component root is disallowed."""
+        """Tests to ensure a path symlinked to a file outside the component
+        root directory is disallowed."""
 
         with mock.patch("streamlit.components.v1.components.os.path.isdir"):
             # We don't need the return value in this case.
@@ -90,14 +107,14 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         with mock.patch(
             "streamlit.web.server.component_request_handler.os.path.realpath",
-            return_value="/etc/hosts",
+            side_effect=[PATH, "/etc/hosts"],
         ):
             response = self._request_component(
                 "web.server.component_request_handler_test.test"
             )
 
-        self.assertEqual(404, response.code)
-        self.assertEqual(b"not found", response.body)
+        self.assertEqual(403, response.code)
+        self.assertEqual(b"forbidden", response.body)
 
     def test_invalid_component_request(self):
         """Test request failure when invalid component name is provided."""

--- a/lib/tests/streamlit/web/server/component_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/component_request_handler_test.py
@@ -66,6 +66,21 @@ class ComponentRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(200, response.code)
         self.assertEqual(b"Test Content", response.body)
+    
+    def test_outside_component_root_request(self):
+        """Tests to ensure anything outside of the component root is disallowed."""
+
+        with mock.patch("streamlit.components.v1.components.os.path.isdir"):
+            # We don't need the return value in this case.
+            declare_component("test", path=PATH)
+
+        
+        response = self._request_component(
+            "web.server.component_request_handler_test.test//etc/hosts"
+        )
+
+        self.assertEqual(404, response.code)
+        self.assertEqual(b"not found", response.body)
 
     def test_invalid_component_request(self):
         """Test request failure when invalid component name is provided."""


### PR DESCRIPTION
## 📚 Context

Custom components have a file path registered that joins the path from the url from the user. This allows complex combinations to work.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

Return 404s for any URLs outside of the component root.

## 🧪 Testing Done

- [x] Added/Updated unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
