### PR TITLE
Prevent logging exceptions on pytest sessionfinish

### DIFF
--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -19,6 +19,7 @@ are executed.
 
 from unittest.mock import patch, mock_open
 import os
+import logging
 
 # Do not import any Streamlit modules here! See below for details.
 
@@ -62,3 +63,14 @@ with patch(
     # source_util.get_pages to depend on the filesystem can patch this value
     # back to None.
     source_util._cached_pages = {}
+
+
+def pytest_sessionfinish():
+    # We're not waiting for scriptrunner threads to cleanly close before ending the PyTest,
+    # which results in raised exception ValueError: I/O operation on closed file.
+    # This is well known issue in PyTest, check out these discussions for more:
+    # * https://github.com/pytest-dev/pytest/issues/5502
+    # * https://github.com/pytest-dev/pytest/issues/5282
+    # To prevent the exception from being raised on pytest_sessionfinish
+    # we disable exception raising in logging module
+    logging.raiseExceptions = False


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
 When running `make pytest` command I got the following error on the end of test:
 > --- Logging error ---
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 1084, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/tszerszen/streamlit/lib/streamlit/scriptrunner/script_runner.py", line 296, in _run_script_thread
    self._run_script(request.rerun_data)
  File "/Users/tszerszen/streamlit/lib/streamlit/scriptrunner/script_runner.py", line 574, in _run_script
    self._on_script_finished(ctx, finished_event)
  File "/Users/tszerszen/streamlit/lib/streamlit/scriptrunner/script_runner.py", line 598, in _on_script_finished
    in_memory_file_manager.del_expired_files()
  File "/Users/tszerszen/streamlit/lib/streamlit/in_memory_file_manager.py", line 183, in del_expired_files
    LOGGER.debug("Deleting expired files...")
Message: 'Deleting expired files...'
Arguments: ()

## 🧠 Description of Changes

~I have a controversial fix proposition, since it overrides .debug method of logging.Logger . The method will be overridden only when running the tests with pytest. What's your opinion on this?~

After @LukasMasuch suggestion I have read the Pytest issues [5502](https://github.com/pytest-dev/pytest/issues/5502) and [5282](https://github.com/pytest-dev/pytest/issues/5282). And I'm proposing to fix this with
```
def pytest_sessionfinish():
    logging.raiseExceptions = False
```
patch. It's not fixing the core issue, but it's much cleaner than my 1st proposition and based on the discussions  [5502](https://github.com/pytest-dev/pytest/issues/5502) and [5282](https://github.com/pytest-dev/pytest/issues/5282) in Pytest repository I don't think it's going to be trivial to fix the issue by waiting for all threads to finish.

What's your opinion on this approach? @LukasMasuch @tconkling If we want to fix this properly anyway I'm going to close this PR and move on, since as for now I don't see clear fix for this issue.

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

The `make pytest` command passes without any errors and without `--- Logging error ---` at the end.

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
