### PR TITLE
runtime_example.py

### DIFF
--- a/lib/runtime_example.py
+++ b/lib/runtime_example.py
@@ -1,0 +1,62 @@
+import asyncio
+
+import streamlit
+from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime import Runtime, RuntimeConfig, SessionClient
+
+SCRIPT_PATH = "runtime_example_script.py"
+
+
+class ExampleClient(SessionClient):
+    """Example SessionClient implementation. The Snowflake implementation
+    should write each ForwardMsg to the session's websocket.
+    """
+
+    def write_forward_msg(self, msg: ForwardMsg) -> None:
+        print(f"ExampleClient got ForwardMsg: {msg.WhichOneof('type')}")
+
+
+def create_rerun_msg() -> BackMsg:
+    msg = BackMsg()
+    msg.rerun_script.query_string = ""
+    return msg
+
+
+async def main():
+    print(f"Starting Runtime Example")
+
+    streamlit._is_running_with_streamlit = True
+
+    config = RuntimeConfig(SCRIPT_PATH, "")
+    runtime = Runtime(config)
+
+    async def example_app():
+        # Add a session
+        session_id = runtime.create_session(ExampleClient(), {})
+
+        # Send a BackMsg (these will arrive from the frontend - you shouldn't
+        # need to construct them manually, just pass them on to the appropriate
+        # session)
+        runtime.handle_backmsg(session_id, create_rerun_msg())
+
+        print("Sleeping for 10...")
+        await asyncio.sleep(10)
+
+        # Close the session
+        runtime.close_session(session_id)
+
+        print("stopping...")
+        runtime.stop()
+
+    # Run two tasks in parallel: the first task runs the Runtime,
+    # and the second creates a session, waits a few seconds, and then shuts
+    # down the Runtime. This demonstrates how to we run and communicate with
+    # the Streamlit Runtime without needing to create an additional thread.
+    await asyncio.wait(
+        [asyncio.create_task(runtime.start()), asyncio.create_task(example_app())],
+        return_when=asyncio.FIRST_EXCEPTION,
+    )
+
+
+asyncio.run(main())

--- a/lib/runtime_example_script.py
+++ b/lib/runtime_example_script.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+
+def increment_num_clicks():
+    num_clicks = st.session_state.get("num_clicks", 0)
+    st.session_state["num_clicks"] = num_clicks + 1
+
+
+st.write(f"Hello, Snowflake!")
+st.write(f"You've clicked {st.session_state.get('num_clicks', 0)} times.")
+st.button("Click Me!", on_click=increment_num_clicks)

--- a/lib/streamlit/runtime.py
+++ b/lib/streamlit/runtime.py
@@ -203,10 +203,6 @@ class Runtime:
             An optional callback that will be called when the runtime's loop
             has started. It will be called on the eventloop thread.
 
-        Returns
-        -------
-        None
-
         Notes
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
@@ -306,10 +302,6 @@ class Runtime:
         session_id
             The session's unique ID.
 
-        Returns
-        -------
-        None
-
         Notes
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
@@ -335,10 +327,6 @@ class Runtime:
             The session's unique ID.
         msg
             The BackMsg to deliver to the session.
-
-        Returns
-        -------
-        None
 
         Notes
         -----
@@ -418,10 +406,6 @@ class Runtime:
         self, on_started: Optional[Callable[[], Any]] = None
     ) -> None:
         """The main Runtime loop.
-
-        Returns
-        -------
-        None
 
         Notes
         -----
@@ -518,10 +502,6 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         msg : ForwardMsg
             The message to send to the client
 
-        Returns
-        -------
-        None
-
         Notes
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
@@ -571,10 +551,6 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         """Callback called by AppSession after the AppSession has enqueued a
         message. Sets the "needs_send_data" event, which causes our core
         loop to wake up and flush client message queues.
-
-        Returns
-        -------
-        None
 
         Notes
         -----

--- a/lib/streamlit/runtime.py
+++ b/lib/streamlit/runtime.py
@@ -172,9 +172,9 @@ class Runtime:
         """Event handler for UploadedFileManager.on_file_added.
         Ensures that uploaded files from stale sessions get deleted.
 
-        Threading
-        ---------
-        SAFE. May be called on any thread.
+        Notes
+        -----
+        Threading: SAFE. May be called on any thread.
         """
         session_info = self._get_session_info(session_id)
         if session_info is None:
@@ -186,10 +186,10 @@ class Runtime:
         """Return the SessionInfo with the given id, or None if no such
         session exists.
 
-        Threading
-        ---------
-        SAFE. May be called on any thread. (But note that SessionInfo mutations
-        are not thread-safe!)
+        Notes
+        -----
+        Threading: SAFE. May be called on any thread. (But note that SessionInfo
+        mutations are not thread-safe!)
         """
         return self._session_info_by_id.get(session_id, None)
 
@@ -207,9 +207,9 @@ class Runtime:
         -------
         None
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         await self._loop_coroutine(on_started)
 
@@ -217,9 +217,9 @@ class Runtime:
         """Request that Streamlit close all sessions and stop running.
         Note that Streamlit won't stop running immediately.
 
-        Threading
-        ---------
-        UNSAFE. May be called on any thread.
+        Notes
+        -----
+        Threading: UNSAFE. May be called on any thread.
         """
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             return
@@ -231,9 +231,9 @@ class Runtime:
     def is_active_session(self, session_id: str) -> bool:
         """True if the session_id belongs to an active session.
 
-        Threading
-        ---------
-        SAFE. May be called on any thread.
+        Notes
+        -----
+        Threading: SAFE. May be called on any thread.
         """
         # Dictionary membership is atomic in CPython, so this is thread-safe.
         return session_id in self._session_info_by_id
@@ -263,9 +263,9 @@ class Runtime:
         str
             The session's unique string ID.
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             raise RuntimeError(f"Can't create_session (state={self._state})")
@@ -310,9 +310,9 @@ class Runtime:
         -------
         None
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         if session_id in self._session_info_by_id:
             session_info = self._session_info_by_id[session_id]
@@ -340,9 +340,9 @@ class Runtime:
         -------
         None
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             raise RuntimeError(f"Can't handle_backmsg (state={self._state})")
@@ -375,9 +375,9 @@ class Runtime:
         (True, "ok") if the script completes without error, or (False, err_msg)
         if the script raises an exception.
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         session_data = SessionData(self._main_script_path, self._command_line)
         local_sources_watcher = LocalSourcesWatcher(session_data)
@@ -423,9 +423,9 @@ class Runtime:
         -------
         None
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         try:
             if self._state == RuntimeState.INITIAL:
@@ -522,9 +522,9 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         -------
         None
 
-        Threading
-        ---------
-        UNSAFE. Must be called on the eventloop thread.
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
         """
         msg.metadata.cacheable = is_cacheable_msg(msg)
         msg_to_send = msg
@@ -576,9 +576,9 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         -------
         None
 
-        Threading
-        ---------
-        SAFE. May be called on any thread.
+        Notes
+        -----
+        Threading: SAFE. May be called on any thread.
         """
         self._get_eventloop().call_soon_threadsafe(self._need_send_data.set)
 


### PR DESCRIPTION
Adds `runtime_example.py`, which is just a sample app that demonstrates how to start and interact with `Runtime`.

Also contains an unrelated change: I changed the "Threading" headings on the Runtime docstrings to "Notes". "Threading" is not a valid numpy docstring section name, and PyCharm was mis-parsing this section as a return type, resulting in annoying warnings.

(We _won't_ merge runtime_example.py to develop, but I think it's useful to have in the feature branch during development, so that implementors can refer to it.)