### PR TITLE
Prevent class TestScriptRunner to be collected by PyTest

### DIFF
--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -1033,6 +1033,13 @@ class ScriptRunnerTest(AsyncTestCase):
 class TestScriptRunner(ScriptRunner):
     """Subclasses ScriptRunner to provide some testing features."""
 
+    # PyTest is unable to collect Test classes with __init__,
+    # and issues PytestCollectionWarning: cannot collect test class
+    # Since class TestScriptRunner is a helper class,
+    # there is no need for class TestScriptRunner to be collected by PyTest
+    # To prevent PytestCollectionWarning we set __test__ property to False
+    __test__ = False
+
     def __init__(self, script_name: str):
         """Initializes the ScriptRunner for the given script_name"""
         # DeltaGenerator deltas will be enqueued into self.forward_msg_queue.


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
PyTest is unable to collect Test classes with __init__, and issues PytestCollectionWarning: cannot collect test class. This PR addresses this issue by preventing class TestScriptRunner to be collected by PyTest.

## 🧠 Description of Changes

Since class TestScriptRunner is a helper class, there is no need for class TestScriptRunner to be collected by PyTest.
To prevent PytestCollectionWarning we set __test__ property to False.

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
