### PR TITLE
Fix (some) logger.py nits

### DIFF
--- a/lib/tests/streamlit/logger_test.py
+++ b/lib/tests/streamlit/logger_test.py
@@ -113,7 +113,7 @@ class LoggerTest(unittest.TestCase):
     def test_init_tornado_logs(self):
         """Test streamlit.logger.init_tornado_logs."""
         logger.init_tornado_logs()
-        loggers = [x for x in logger.LOGGERS.keys() if "tornado." in x]
+        loggers = [x for x in logger._loggers.keys() if "tornado." in x]
         truth = ["tornado.access", "tornado.application", "tornado.general"]
         self.assertEqual(sorted(truth), sorted(loggers))
 


### PR DESCRIPTION
- `LOG_LEVEL` -> `_global_log_level` (not a constant)
- `LOGGERS` -> `_loggers` (not a constant)
- `init_tornado_logs`: don't print "Initialized tornado logs", because who cares (and it looks like Tornado is probably being imported, even though it's not)