### PR TITLE
Fix: Full Screen setting from Resizable Sidebar

### DIFF
--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -38,9 +38,7 @@ export const StyledSidebar = styled.section<StyledSidebarProps>(
 
       minWidth,
       maxWidth,
-      transform: isCollapsed
-        ? `translateX(-${sidebarWidth}px)`
-        : "translateX(0px)",
+      transform: isCollapsed ? `translateX(-${sidebarWidth}px)` : "none",
       transition: "transform 300ms, min-width 300ms, max-width 300ms",
 
       "&:focus": {


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Full Screen button from sidebar elements was not rendering properly. This PR fixes the issue.

- What kind of change does this PR introduce?
  - [x] Bugfix

## 🧠 Description of Changes

- Removed unnecessary translate property that interfered with full screen framing

  - [x] This is a visible (user-facing) change

**Revised:**
<img width="400" alt="Screen Shot 2022-07-28 at 5 28 25 PM" src="https://user-images.githubusercontent.com/63436329/181658772-7e0ba0b6-e713-44e2-8ef4-1390813ec4f5.png">


**Current:**
<img width="200" alt="Screen Shot 2022-07-28 at 5 29 05 PM" src="https://user-images.githubusercontent.com/63436329/181658766-93e91f9e-52cd-4590-b95d-950acd9de677.png">


## 🧪 Testing Done

- [x] Screenshots included

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
