### PR TITLE
Pytest ignore deprecation warnings

### DIFF
--- a/lib/pytest.ini
+++ b/lib/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 markers =
     slow: marks tests as slow
+filterwarnings =
+    # PyTest filter syntax cheatsheet -> action:message:category:module:line
+    ignore::UserWarning:altair.*:
+    ignore::DeprecationWarning:flatbuffers.*:
+    ignore::DeprecationWarning:keras_preprocessing.*:

--- a/lib/tests/streamlit/legacy_add_rows_test.py
+++ b/lib/tests/streamlit/legacy_add_rows_test.py
@@ -16,6 +16,7 @@
 from typing import Optional
 
 import pandas as pd
+import pytest
 import pyarrow as pa
 
 from streamlit.errors import StreamlitAPIException
@@ -111,6 +112,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             get_script_run_ctx().reset()
             self.forward_msg_queue.clear()
 
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_with_index_legacy_add_rows(self):
         """Test plain old _legacy_add_rows."""
         all_methods = self._get_unnamed_data_methods()
@@ -139,6 +141,7 @@ class DeltaGeneratorAddRowsTest(testutil.DeltaGeneratorTestCase):
             get_script_run_ctx().reset()
             self.forward_msg_queue.clear()
 
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_with_index_no_data_legacy_add_rows(self):
         """Test plain old _legacy_add_rows."""
         all_methods = self._get_unnamed_data_methods()

--- a/lib/tests/streamlit/legacy_data_frame_test.py
+++ b/lib/tests/streamlit/legacy_data_frame_test.py
@@ -98,6 +98,7 @@ class LegacyDataFrameProtoTest(unittest.TestCase):
         with self.assertRaises(StreamlitAPIException):
             data_frame.marshall_data_frame(pa.Table.from_pandas(df), proto)
 
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_marshall_index(self):
         """Test streamlit.data_frame._marshall_index."""
         df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
@@ -182,6 +183,7 @@ class LegacyDataFrameProtoTest(unittest.TestCase):
         truth = [["1", "2"], ["3", "4"]]
         self.assertEqual(ret, truth)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_marshall_any_array(self):
         """Test streamlit.data_frame._marshall_any_array."""
         # list

--- a/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
@@ -17,6 +17,7 @@
 import functools
 import hashlib
 import os
+import pytest
 import re
 import socket
 import tempfile
@@ -535,6 +536,7 @@ class HashTest(unittest.TestCase):
         self.assertIn(get_fqn_type(foo), _FFI_TYPE_NAMES)
         self.assertEqual(get_hash(foo), get_hash(bar))
 
+    @pytest.mark.filterwarnings("ignore:No driver name specified")
     def test_sqlite_sqlalchemy_engine(self):
         """Separate tests for sqlite since it uses a file based
         and in memory database and has no auth
@@ -565,6 +567,7 @@ class HashTest(unittest.TestCase):
             hash_engine(foo, creator=lambda: True),
         )
 
+    @pytest.mark.filterwarnings("ignore:No driver name specified")
     def test_mssql_sqlalchemy_engine(self):
         """Specialized tests for mssql since it uses a different way of
         passing connection arguments to the engine
@@ -623,6 +626,7 @@ class HashTest(unittest.TestCase):
             ("mssql", "password"),
         ]
     )
+    @pytest.mark.filterwarnings("ignore:No driver name specified")
     def test_sqlalchemy_engine(self, dialect, password_key):
         def connect():
             pass


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
When devs run `make pytest` they see bunch of Deprecation and Future warnings mostly related to `numpy` and `pandas` usage, these are only Warnings and they are not bugs. This Warnings can be distracting when people work on specific feature unrelated to them.

For that reason I propose to supress the warnings which we expect, if we want to get rid of deprecated code let's write issues for it instead of being loud in the tests. What's your opinion on this?

## 🧠 Description of Changes
This PR ignores deprecation and future warnings when running `pytest` selectively in places in which they are expected anyway, all other warnings will not be supressed.

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
