### PR TITLE
Fix some Runtime nits

### DIFF
--- a/lib/runtime_example.py
+++ b/lib/runtime_example.py
@@ -54,7 +54,7 @@ async def main():
     # down the Runtime. This demonstrates how to we run and communicate with
     # the Streamlit Runtime without needing to create an additional thread.
     await asyncio.wait(
-        [asyncio.create_task(runtime.start()), asyncio.create_task(example_app())],
+        [asyncio.create_task(runtime.run()), asyncio.create_task(example_app())],
         return_when=asyncio.FIRST_EXCEPTION,
     )
 

--- a/lib/runtime_example.py
+++ b/lib/runtime_example.py
@@ -31,7 +31,17 @@ async def main():
     config = RuntimeConfig(SCRIPT_PATH, "")
     runtime = Runtime(config)
 
+    # Create a Future that will be resolved when the Runtime is ready
+    # to receive new sessions.
+    runtime_started = asyncio.get_running_loop().create_future()
+
+    def on_runtime_started():
+        runtime_started.set_result(None)
+
     async def example_app():
+        # Wait for the Runtime to be ready for new sessions
+        await runtime_started
+
         # Add a session
         session_id = runtime.create_session(ExampleClient(), {})
 
@@ -40,8 +50,8 @@ async def main():
         # session)
         runtime.handle_backmsg(session_id, create_rerun_msg())
 
-        print("Sleeping for 10...")
-        await asyncio.sleep(10)
+        print("Sleeping for a few seconds...")
+        await asyncio.sleep(3)
 
         # Close the session
         runtime.close_session(session_id)
@@ -49,12 +59,15 @@ async def main():
         print("stopping...")
         runtime.stop()
 
-    # Run two tasks in parallel: the first task runs the Runtime,
+    # Run two coroutines in parallel: the first task runs the Runtime,
     # and the second creates a session, waits a few seconds, and then shuts
     # down the Runtime. This demonstrates how to we run and communicate with
     # the Streamlit Runtime without needing to create an additional thread.
     await asyncio.wait(
-        [asyncio.create_task(runtime.run()), asyncio.create_task(example_app())],
+        [
+            asyncio.create_task(runtime.run(on_runtime_started)),
+            asyncio.create_task(example_app()),
+        ],
         return_when=asyncio.FIRST_EXCEPTION,
     )
 

--- a/lib/streamlit/runtime.py
+++ b/lib/streamlit/runtime.py
@@ -97,9 +97,8 @@ class SessionInfo:
 
 class RuntimeState(Enum):
     INITIAL = "INITIAL"
-    WAITING_FOR_FIRST_SESSION = "WAITING_FOR_FIRST_SESSION"
-    ONE_OR_MORE_SESSIONS_CONNECTED = "ONE_OR_MORE_SESSIONS_CONNECTED"
     NO_SESSIONS_CONNECTED = "NO_SESSIONS_CONNECTED"
+    ONE_OR_MORE_SESSIONS_CONNECTED = "ONE_OR_MORE_SESSIONS_CONNECTED"
     STOPPING = "STOPPING"
     STOPPED = "STOPPED"
 
@@ -413,7 +412,7 @@ class Runtime:
         """
         try:
             if self._state == RuntimeState.INITIAL:
-                self._set_state(RuntimeState.WAITING_FOR_FIRST_SESSION)
+                self._set_state(RuntimeState.NO_SESSIONS_CONNECTED)
             elif self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
                 pass
             else:
@@ -430,7 +429,7 @@ class Runtime:
                 on_started()
 
             while not self._must_stop.is_set():
-                if self._state == RuntimeState.WAITING_FOR_FIRST_SESSION:
+                if self._state == RuntimeState.NO_SESSIONS_CONNECTED:
                     await asyncio.wait(
                         [self._must_stop.wait(), self._has_connection.wait()],
                         return_when=asyncio.FIRST_COMPLETED,
@@ -458,12 +457,6 @@ class Runtime:
                     # Yield for a few milliseconds between session message
                     # flushing.
                     await asyncio.sleep(0.01)
-
-                elif self._state == RuntimeState.NO_SESSIONS_CONNECTED:
-                    await asyncio.wait(
-                        [self._must_stop.wait(), self._has_connection.wait()],
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
 
                 else:
                     # Break out of the thread loop if we encounter any other state.

--- a/lib/streamlit/runtime.py
+++ b/lib/streamlit/runtime.py
@@ -214,14 +214,18 @@ class Runtime:
 
         Notes
         -----
-        Threading: UNSAFE. May be called on any thread.
+        Threading: SAFE. May be called from any thread.
         """
-        if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
-            return
 
-        LOGGER.debug("Runtime stopping...")
-        self._set_state(RuntimeState.STOPPING)
-        self._must_stop.set()
+        def stop_on_eventloop():
+            if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
+                return
+
+            LOGGER.debug("Runtime stopping...")
+            self._set_state(RuntimeState.STOPPING)
+            self._must_stop.set()
+
+        self._eventloop.call_soon_threadsafe(stop_on_eventloop)
 
     def is_active_session(self, session_id: str) -> bool:
         """True if the session_id belongs to an active session.

--- a/lib/streamlit/runtime.py
+++ b/lib/streamlit/runtime.py
@@ -227,7 +227,7 @@ class Runtime:
             self._set_state(RuntimeState.STOPPING)
             self._must_stop.set()
 
-        self._eventloop.call_soon_threadsafe(stop_on_eventloop)
+        self._get_eventloop().call_soon_threadsafe(stop_on_eventloop)
 
     def is_active_session(self, session_id: str) -> bool:
         """True if the session_id belongs to an active session.

--- a/lib/streamlit/runtime.py
+++ b/lib/streamlit/runtime.py
@@ -192,14 +192,16 @@ class Runtime:
         """
         return self._session_info_by_id.get(session_id, None)
 
-    async def start(self, on_started: Optional[Callable[[], Any]] = None) -> None:
+    async def run(self, on_started: Optional[Callable[[], Any]] = None) -> None:
         """Start the runtime. This must be called only once, before
         any other functions are called.
+
+        This coroutine will return when the Runtime has stopped.
 
         Parameters
         ----------
         on_started
-            An optional callback that will be called when the runtime's loop
+            An optional callback that will be called when the Runtime's loop
             has started. It will be called on the eventloop thread.
 
         Notes

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -206,7 +206,7 @@ class Server:
         port = config.get_option("server.port")
         LOGGER.debug("Server started on port %s", port)
 
-        await self._runtime.start(on_started=lambda: on_started(self))
+        await self._runtime.run(on_started=lambda: on_started(self))
 
     def _create_app(self) -> tornado.web.Application:
         """Create our tornado web app."""

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -88,7 +88,7 @@ class ServerTest(ServerTestCase):
         with patch("streamlit.runtime.LocalSourcesWatcher"), self._patch_app_session():
             await self.start_server_loop()
             self.assertEqual(
-                RuntimeState.WAITING_FOR_FIRST_SESSION, self.server._runtime._state
+                RuntimeState.NO_SESSIONS_CONNECTED, self.server._runtime._state
             )
 
             await self.ws_connect()

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -97,6 +97,7 @@ class ServerTest(ServerTestCase):
             )
 
             self.server.stop()
+            await asyncio.sleep(0)  # Wait a tick for the stop to be acknowledged
             self.assertEqual(RuntimeState.STOPPING, self.server._runtime._state)
 
             await asyncio.sleep(0.1)


### PR DESCRIPTION
- Remove superfluous `RuntimeState.WAITING_FOR_FIRST_SESSION`. This is equivalent to `RuntimeState. NO_SESSIONS_CONNECTED`.
- `Runtime.start` -> `Runtime.run`. It doesn't just start the Runtime!
- Make `Runtime.stop` actually thread-safe, as advertised.