### PR TITLE
Validate version of protoc and protobuff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,7 +591,7 @@ jobs:
             python -m venv venv
             source venv/bin/activate
             pip install --upgrade pip
-            pip install pipenv mypy mypy-protobuf
+            pip install pipenv mypy mypy-protobuf 'protobuf<4'
             deactivate
 
             # Add 'activate venv' to $BASH_ENV. This means that our venv will be active

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ protobuf:
 	fi
 	protoc_version=$$(protoc --version | cut -d ' ' -f 2); \
 	protobuf_version=$$(python -c "import importlib.metadata; print(importlib.metadata.version('protobuf'))"); \
-	if [[ "$${protoc_version}" != "$${protobuf_version}" ]] ; then \
+	if [[ "$${protoc_version%.*.*}" != "$${protobuf_version%.*.*}" ]] ; then \
 		echo -e '\033[31m WARNING: Protoc and protobuf version mismatch \033[0m'; \
 		echo "To avoid compatibility issues, please ensure that the protoc version matches the protobuf version you have installed."; \
 		echo "protoc version: $${protoc_version}"; \

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,19 @@ clean:
 # Recompile Protobufs for Python and the frontend.
 protobuf:
 	@# Python protobuf generation
+	if ! command -v protoc &> /dev/null ; then \
+		echo "protoc not installed."; \
+		exit 1; \
+	fi
+	protoc_version=$$(protoc --version | cut -d ' ' -f 2); \
+	protobuf_version=$$(python -c "import importlib.metadata; print(importlib.metadata.version('protobuf'))"); \
+	if [[ "$${protoc_version}" != "$${protobuf_version}" ]] ; then \
+		echo -e '\033[31m WARNING: Protoc and protobuf version mismatch \033[0m'; \
+		echo "To avoid compatibility issues, please ensure that the protoc version matches the protobuf version you have installed."; \
+		echo "protoc version: $${protoc_version}"; \
+		echo "protobuf version: $${protobuf_version}"; \
+		echo -n "Do you want to continue anyway? [y/N] " && read ans && [ $${ans:-N} = y ]; \
+	fi
 	protoc \
 		--proto_path=proto \
 		--python_out=lib \

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ protobuf:
 		exit 1; \
 	fi
 	protoc_version=$$(protoc --version | cut -d ' ' -f 2); \
-	protobuf_version=$$(python -c "import importlib.metadata; print(importlib.metadata.version('protobuf'))"); \
+	protobuf_version=$$(pip show protobuf | grep Version | cut -d " " -f 2-); \
 	if [[ "$${protoc_version%.*.*}" != "$${protobuf_version%.*.*}" ]] ; then \
 		echo -e '\033[31m WARNING: Protoc and protobuf version mismatch \033[0m'; \
 		echo "To avoid compatibility issues, please ensure that the protoc version matches the protobuf version you have installed."; \


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

We need the old version of `protoc`, because the new version of protoc is not compatible with the currently supported version of `protobuf`. 
To improve DX, I add a version check to warn a developer when they is using an incompatible version of `protoc`.


_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
