### PR TITLE
Don't expose SessionData class

### DIFF
--- a/lib/streamlit/app_session.py
+++ b/lib/streamlit/app_session.py
@@ -319,7 +319,7 @@ class AppSession:
         """Create and run a new ScriptRunner with the given RerunData."""
         self._scriptrunner = ScriptRunner(
             session_id=self.id,
-            session_data=self._session_data,
+            main_script_path=self._session_data.main_script_path,
             client_state=self._client_state,
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -426,14 +426,12 @@ class Server:
         (True, "ok") if the script completes without error, or (False, err_msg)
         if the script raises an exception.
         """
-        session_data = SessionData(self._main_script_path, self._command_line)
-        local_sources_watcher = LocalSourcesWatcher(session_data)
         session = AppSession(
             event_loop=self._get_eventloop(),
-            session_data=session_data,
+            session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
-            local_sources_watcher=local_sources_watcher,
+            local_sources_watcher=LocalSourcesWatcher(self._main_script_path),
             user_info={"email": "test@test.com"},
         )
 
@@ -634,15 +632,12 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
             The newly-created AppSession for this browser connection.
 
         """
-        session_data = SessionData(self._main_script_path, self._command_line)
-        local_sources_watcher = LocalSourcesWatcher(session_data)
-
         session = AppSession(
             event_loop=self._get_eventloop(),
-            session_data=session_data,
+            session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
-            local_sources_watcher=local_sources_watcher,
+            local_sources_watcher=LocalSourcesWatcher(self._main_script_path),
             user_info=user_info,
         )
 

--- a/lib/tests/streamlit/app_session_test.py
+++ b/lib/tests/streamlit/app_session_test.py
@@ -209,7 +209,7 @@ class AppSessionTest(unittest.TestCase):
         # Assert that the ScriptRunner constructor was called.
         mock_scriptrunner.assert_called_once_with(
             session_id=session.id,
-            session_data=session._session_data,
+            main_script_path=session._session_data.main_script_path,
             client_state=session._client_state,
             session_state=session._session_state,
             uploaded_file_mgr=session._uploaded_file_mgr,

--- a/lib/tests/streamlit/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/scriptrunner/script_runner_test.py
@@ -36,7 +36,6 @@ from streamlit.scriptrunner.script_requests import (
     ScriptRequestType,
     ScriptRequests,
 )
-from streamlit.session_data import SessionData
 from streamlit.forward_msg_queue import ForwardMsgQueue
 from streamlit.scriptrunner import (
     ScriptRunner,
@@ -255,7 +254,7 @@ class ScriptRunnerTest(AsyncTestCase):
         # files contained in the directory of __main__.__file__, which we
         # assume is the main script directory.
         self.assertEqual(
-            scriptrunner._session_data.main_script_path,
+            scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
             (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
@@ -929,7 +928,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(page_not_found_msg.page_name, "")
 
         self.assertEqual(
-            scriptrunner._session_data.main_script_path,
+            scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
             (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
@@ -969,7 +968,7 @@ class ScriptRunnerTest(AsyncTestCase):
         self.assertEqual(page_not_found_msg.page_name, "nonexistent")
 
         self.assertEqual(
-            scriptrunner._session_data.main_script_path,
+            scriptrunner._main_script_path,
             sys.modules["__main__"].__file__,
             (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
@@ -1051,7 +1050,7 @@ class TestScriptRunner(ScriptRunner):
 
         super().__init__(
             session_id="test session id",
-            session_data=SessionData(main_script_path, "test command line"),
+            main_script_path=main_script_path,
             client_state=ClientState(),
             session_state=SessionState(),
             uploaded_file_mgr=UploadedFileManager(),

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -20,7 +20,6 @@ import sys
 import unittest
 
 from streamlit import config
-from streamlit.session_data import SessionData
 from streamlit.watcher import local_sources_watcher
 from streamlit.watcher.path_watcher import NoOpPathWatcher, watchdog_available
 
@@ -31,7 +30,6 @@ import tests.streamlit.watcher.test_data.nested_module_parent as NESTED_MODULE_P
 import tests.streamlit.watcher.test_data.nested_module_child as NESTED_MODULE_CHILD
 
 SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "test_data/not_a_real_script.py")
-SESSION_DATA = SessionData(SCRIPT_PATH, "test command line")
 
 DUMMY_MODULE_1_FILE = os.path.abspath(DUMMY_MODULE_1.__file__)
 DUMMY_MODULE_2_FILE = os.path.abspath(DUMMY_MODULE_2.__file__)

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -30,8 +30,8 @@ import tests.streamlit.watcher.test_data.misbehaved_module as MISBEHAVED_MODULE
 import tests.streamlit.watcher.test_data.nested_module_parent as NESTED_MODULE_PARENT
 import tests.streamlit.watcher.test_data.nested_module_child as NESTED_MODULE_CHILD
 
-REPORT_PATH = os.path.join(os.path.dirname(__file__), "test_data/not_a_real_script.py")
-REPORT = SessionData(REPORT_PATH, "test command line")
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "test_data/not_a_real_script.py")
+SESSION_DATA = SessionData(SCRIPT_PATH, "test command line")
 
 DUMMY_MODULE_1_FILE = os.path.abspath(DUMMY_MODULE_1.__file__)
 DUMMY_MODULE_2_FILE = os.path.abspath(DUMMY_MODULE_2.__file__)
@@ -70,12 +70,12 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_just_script(self, fob, _):
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
         args, _ = fob.call_args
-        self.assertEqual(args[0], REPORT_PATH)
+        self.assertEqual(args[0], SCRIPT_PATH)
         method_type = type(self.setUp)
         self.assertEqual(type(args[1]), method_type)
 
@@ -90,12 +90,12 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_permission_error(self, fob, _):
         fob.side_effect = PermissionError("This error should be caught!")
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_script_and_2_modules_at_once(self, fob, _):
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -128,7 +128,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_script_and_2_modules_in_series(self, fob, _):
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -164,7 +164,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     @patch("streamlit.watcher.local_sources_watcher.LOGGER")
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_misbehaved_module(self, fob, patched_logger, _):
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -181,7 +181,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_nested_module_parent_unloaded(self, fob, _):
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -212,7 +212,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             "server.folderWatchBlacklist", [os.path.dirname(DUMMY_MODULE_1.__file__)]
         )
 
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -264,7 +264,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=NoOpPathWatcher)
     def test_does_nothing_if_NoOpPathWatcher(self, _):
-        lsw = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lsw.register_file_change_callback(NOOP_CALLBACK)
         lsw.update_watched_modules()
         self.assertEqual(len(lsw._watched_modules), 0)
@@ -275,7 +275,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
         pkg_path = os.path.abspath(pkg.__path__._path[0])
 
-        lsw = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
         fob.assert_called_once()
@@ -293,7 +293,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_module_caching(self, _fob, _):
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
         register = MagicMock()
@@ -336,7 +336,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
     )
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_watches_all_page_scripts(self, fob, _):
-        lsw = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
         args1, _ = fob.call_args_list[0]
@@ -354,13 +354,13 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
             saved_filepath = filepath
 
-        lso = local_sources_watcher.LocalSourcesWatcher(REPORT)
+        lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(callback)
 
         # Simulate a change to the report script
-        lso.on_file_changed(REPORT_PATH)
+        lso.on_file_changed(SCRIPT_PATH)
 
-        self.assertEqual(saved_filepath, REPORT_PATH)
+        self.assertEqual(saved_filepath, SCRIPT_PATH)
 
 
 def test_get_module_paths_outputs_abs_paths():


### PR DESCRIPTION
`SessionData` is an internal implementation detail of `AppSession` (it contains the `ForwardMsgQueue` that we use to send forward messages to the frontend). 

We're currently unnecessarily exposing it to `ScriptRunner` and `LocalSourcesWatcher`; these classes actually only need `SessionData.main_script_path`.

This PR removes the coupling, but doesn't change any functionality. (This is part of a larger upcoming "streamlit.runtime" refactor.)