### PR TITLE
Use `primary` color for progress elements if a custom theme is set

### DIFF
--- a/frontend/src/components/elements/Spinner/Spinner.tsx
+++ b/frontend/src/components/elements/Spinner/Spinner.tsx
@@ -17,7 +17,7 @@
 
 import React, { ReactElement } from "react"
 import { useTheme } from "@emotion/react"
-import { Theme } from "src/theme"
+import { Theme, isPresetTheme } from "src/theme"
 import { Spinner as SpinnerProto } from "src/autogen/proto"
 import StreamlitMarkdown from "src/components/shared/StreamlitMarkdown"
 import AppContext from "src/components/core/AppContext"
@@ -34,6 +34,7 @@ export interface SpinnerProps {
 function Spinner({ width, element }: SpinnerProps): ReactElement {
   const theme: Theme = useTheme()
   const { activeTheme } = React.useContext(AppContext)
+  const usingCustomTheme = !isPresetTheme(activeTheme)
   const styleProp = { width }
 
   return (
@@ -41,7 +42,7 @@ function Spinner({ width, element }: SpinnerProps): ReactElement {
       <StyledSpinnerContainer>
         <ThemedStyledSpinner
           $size={theme.iconSizes.twoXL}
-          $themeName={activeTheme.name}
+          $usingCustomTheme={usingCustomTheme}
         />
         <StreamlitMarkdown source={element.text} allowHTML={false} />
       </StyledSpinnerContainer>

--- a/frontend/src/components/elements/Spinner/Spinner.tsx
+++ b/frontend/src/components/elements/Spinner/Spinner.tsx
@@ -20,6 +20,7 @@ import { useTheme } from "@emotion/react"
 import { Theme } from "src/theme"
 import { Spinner as SpinnerProto } from "src/autogen/proto"
 import StreamlitMarkdown from "src/components/shared/StreamlitMarkdown"
+import AppContext from "src/components/core/AppContext"
 import {
   StyledSpinnerContainer,
   ThemedStyledSpinner,
@@ -32,12 +33,16 @@ export interface SpinnerProps {
 
 function Spinner({ width, element }: SpinnerProps): ReactElement {
   const theme: Theme = useTheme()
+  const { activeTheme } = React.useContext(AppContext)
   const styleProp = { width }
 
   return (
     <div className="stSpinner" style={styleProp}>
       <StyledSpinnerContainer>
-        <ThemedStyledSpinner $size={theme.iconSizes.twoXL} />
+        <ThemedStyledSpinner
+          $size={theme.iconSizes.twoXL}
+          $themeName={activeTheme.name}
+        />
         <StreamlitMarkdown source={element.text} allowHTML={false} />
       </StyledSpinnerContainer>
     </div>

--- a/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-55asu9-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-8npnmo-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;
+exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-j904cj-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-8npnmo-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;

--- a/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-j904cj-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-8npnmo-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;
+exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-55asu9-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-8npnmo-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;

--- a/frontend/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/src/components/elements/Spinner/styled-components.ts
@@ -21,14 +21,17 @@ import isPropValid from "@emotion/is-prop-valid"
 
 export const ThemedStyledSpinner = styled(StyledSpinnerNext, {
   shouldForwardProp: isPropValid,
-})(({ theme }) => {
+})(({ theme, $themeName }) => {
   return {
     marginTop: theme.spacing.none,
     marginBottom: theme.spacing.none,
     marginRight: theme.spacing.none,
     marginLeft: theme.spacing.none,
     borderColor: theme.colors.fadedText10,
-    borderTopColor: theme.colors.primary,
+    borderTopColor:
+      $themeName === "Custom Theme"
+        ? theme.colors.primary
+        : theme.colors.blue70,
     flexGrow: 0,
     flexShrink: 0,
   }

--- a/frontend/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/src/components/elements/Spinner/styled-components.ts
@@ -21,17 +21,16 @@ import isPropValid from "@emotion/is-prop-valid"
 
 export const ThemedStyledSpinner = styled(StyledSpinnerNext, {
   shouldForwardProp: isPropValid,
-})(({ theme, $themeName }) => {
+})(({ theme, $usingCustomTheme }) => {
   return {
     marginTop: theme.spacing.none,
     marginBottom: theme.spacing.none,
     marginRight: theme.spacing.none,
     marginLeft: theme.spacing.none,
     borderColor: theme.colors.fadedText10,
-    borderTopColor:
-      $themeName === "Custom Theme"
-        ? theme.colors.primary
-        : theme.colors.blue70,
+    borderTopColor: $usingCustomTheme
+      ? theme.colors.primary
+      : theme.colors.blue70,
     flexGrow: 0,
     flexShrink: 0,
   }

--- a/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -18,7 +18,7 @@
 import React, { ReactElement } from "react"
 import { useTheme } from "@emotion/react"
 import AppContext from "src/components/core/AppContext"
-import { Theme } from "src/theme"
+import { Theme, isPresetTheme } from "src/theme"
 import {
   ProgressBar as UIProgressBar,
   ProgressBarOverrides,
@@ -56,6 +56,7 @@ function ProgressBar({
     xl: theme.spacing.twoXL,
   }
   const { activeTheme } = React.useContext(AppContext)
+  const usingCustomTheme = !isPresetTheme(activeTheme)
   const defaultOverrides: Overrides<ProgressBarOverrides> = {
     BarContainer: {
       style: {
@@ -82,10 +83,9 @@ function ProgressBar({
     },
     BarProgress: {
       style: ({ $theme }: { $theme: any }) => ({
-        backgroundColor:
-          activeTheme.name === "Custom Theme"
-            ? theme.colors.primary
-            : theme.colors.blue70,
+        backgroundColor: usingCustomTheme
+          ? theme.colors.primary
+          : theme.colors.blue70,
         borderTopLeftRadius: theme.spacing.twoXS,
         borderTopRightRadius: theme.spacing.twoXS,
         borderBottomLeftRadius: theme.spacing.twoXS,

--- a/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -17,6 +17,7 @@
 
 import React, { ReactElement } from "react"
 import { useTheme } from "@emotion/react"
+import AppContext from "src/components/core/AppContext"
 import { Theme } from "src/theme"
 import {
   ProgressBar as UIProgressBar,
@@ -54,6 +55,7 @@ function ProgressBar({
     lg: theme.spacing.xl,
     xl: theme.spacing.twoXL,
   }
+  const { activeTheme } = React.useContext(AppContext)
   const defaultOverrides: Overrides<ProgressBarOverrides> = {
     BarContainer: {
       style: {
@@ -80,7 +82,10 @@ function ProgressBar({
     },
     BarProgress: {
       style: ({ $theme }: { $theme: any }) => ({
-        backgroundColor: theme.colors.blue70,
+        backgroundColor:
+          activeTheme.name === "Custom Theme"
+            ? theme.colors.primary
+            : theme.colors.blue70,
         borderTopLeftRadius: theme.spacing.twoXS,
         borderTopRightRadius: theme.spacing.twoXS,
         borderBottomLeftRadius: theme.spacing.twoXS,


### PR DESCRIPTION
## 📚 Context

This PR introduces a change proposed by @jrieke, where:

* `st.progress` and `st.spinner` are blue by default;
* But if you set a custom theme (with a `primaryColor` different from our defaults), they take this custom primary color.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Design change

## 🧠 Description of Changes

* Get the theme name by using `AppContext`, and determine the final color based on the result

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised (don't judge my awful custom themes):**

![Screen Shot 2022-08-03 at 2 19 19 PM](https://user-images.githubusercontent.com/34423371/182679287-05b20570-7d0c-4f4b-b79d-e06a66d26c36.png)

![Screen Shot 2022-08-03 at 2 21 53 PM](https://user-images.githubusercontent.com/34423371/182679294-3327162d-f4ac-47db-b277-0bb54cda8fb7.png)

**Current:**

_Insert screenshot of existing UI/code here_

![Screen Shot 2022-08-03 at 3 15 17 PM](https://user-images.githubusercontent.com/34423371/182680129-e979f8cf-98d0-4145-a24c-8ca5d1b55a28.png)

![Screen Shot 2022-08-03 at 3 16 51 PM](https://user-images.githubusercontent.com/34423371/182680132-cbae8854-ee80-4f99-8d92-7143df7d183c.png)

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- https://www.notion.so/streamlit/st-spinner-color-update-006b17cc5152416b9230c9522d27c137

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
