### PR TITLE
Fix: Sidebar border styling

### DIFF
--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -311,6 +311,6 @@ export const StyledResizeHandle = styled.div(({ theme }) => ({
   zIndex: theme.zIndices.sidebarMobile,
 
   "&:hover": {
-    backgroundImage: `linear-gradient(to right, transparent 40%, ${theme.colors.fadedText10} 45%, transparent 60%)`,
+    backgroundImage: `linear-gradient(to right, transparent 42%, ${theme.colors.fadedText20} 50%, transparent 58%)`,
   },
 }))

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -298,7 +298,7 @@ const computeDerivedColors = (
 
   const fadedText05 = transparentize(bodyText, 0.9) // Mostly used for very faint 1px lines.
   const fadedText10 = transparentize(bodyText, 0.8) // Mostly used for 1px lines.
-  const fadedText20 = transparentize(bodyText, 0.7) // Mostly used for 1px lines.
+  const fadedText20 = transparentize(bodyText, 0.7) // Used for 1px lines.
   const fadedText40 = transparentize(bodyText, 0.6) // Backgrounds.
   const fadedText60 = transparentize(bodyText, 0.4) // Secondary text.
 

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -272,6 +272,7 @@ type DerivedColors = {
   linkText: string
   fadedText05: string
   fadedText10: string
+  fadedText20: string
   fadedText40: string
   fadedText60: string
 
@@ -297,6 +298,7 @@ const computeDerivedColors = (
 
   const fadedText05 = transparentize(bodyText, 0.9) // Mostly used for very faint 1px lines.
   const fadedText10 = transparentize(bodyText, 0.8) // Mostly used for 1px lines.
+  const fadedText20 = transparentize(bodyText, 0.7) // Mostly used for 1px lines.
   const fadedText40 = transparentize(bodyText, 0.6) // Backgrounds.
   const fadedText60 = transparentize(bodyText, 0.4) // Secondary text.
 
@@ -314,6 +316,7 @@ const computeDerivedColors = (
     linkText,
     fadedText05,
     fadedText10,
+    fadedText20,
     fadedText40,
     fadedText60,
 


### PR DESCRIPTION
## 📚 Context

Adjust the hover color of the sidebar line to better match the multi-page apps navigation menu border color

- What kind of change does this PR introduce?
  - [x] Other, please describe: styling update for sidebar

## 🧠 Description of Changes

- Added an intermediate faded text option to better match MPA border
- Adjusted linear gradient on sidebar handle
  - [x] This is a visible (user-facing) change

**Revised:**
<img width="890" alt="Screen Shot 2022-08-04 at 12 26 18 PM" src="https://user-images.githubusercontent.com/63436329/182936457-f80ad370-c202-4d2c-8ac3-f35a30bc79bd.png">

**Current:**
<img width="894" alt="Screen Shot 2022-08-04 at 12 25 58 PM" src="https://user-images.githubusercontent.com/63436329/182936449-2fc748d2-3c8b-417b-a293-9122572a02e3.png">

## 🧪 Testing Done

- [x] Screenshots included

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
