### PR TITLE
Split up server_test.py

### DIFF
--- a/lib/tests/streamlit/web/server/message_mocks.py
+++ b/lib/tests/streamlit/web/server/message_mocks.py
@@ -1,0 +1,32 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared protobuf message mocking utilities."""
+
+from streamlit import RootContainer
+from streamlit.cursor import make_delta_path
+from streamlit.elements import legacy_data_frame
+from streamlit.elements.arrow import Data
+from streamlit.logger import get_logger
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+LOGGER = get_logger(__name__)
+
+
+def create_dataframe_msg(df: Data, id: int = 1) -> ForwardMsg:
+    """Create a mock legacy_data_frame ForwardMsg."""
+    msg = ForwardMsg()
+    msg.metadata.delta_path[:] = make_delta_path(RootContainer.SIDEBAR, (), id)
+    legacy_data_frame.marshall_data_frame(df, msg.delta.new_element.data_frame)
+    return msg

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -17,22 +17,19 @@ import tempfile
 from unittest.mock import MagicMock
 
 import tornado.httpserver
-import tornado.httpserver
-import tornado.testing
 import tornado.testing
 import tornado.web
-import tornado.web
-import tornado.websocket
 import tornado.websocket
 
 from streamlit import config
 from streamlit.logger import get_logger
-from streamlit.runtime.forward_msg_cache import ForwardMsgCache
-from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
-from streamlit.web.server.server import DebugHandler
-from streamlit.web.server.server import HealthHandler
-from streamlit.web.server.server import MessageCacheHandler
-from streamlit.web.server.server import StaticFileHandler
+from streamlit.runtime.forward_msg_cache import ForwardMsgCache, populate_hash_if_needed
+from streamlit.web.server.server import (
+    DebugHandler,
+    HealthHandler,
+    MessageCacheHandler,
+    StaticFileHandler,
+)
 from streamlit.web.server.server_util import serialize_forward_msg
 from .message_mocks import create_dataframe_msg
 

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -1,0 +1,167 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import tornado.httpserver
+import tornado.httpserver
+import tornado.testing
+import tornado.testing
+import tornado.web
+import tornado.web
+import tornado.websocket
+import tornado.websocket
+
+from streamlit import config
+from streamlit.logger import get_logger
+from streamlit.runtime.forward_msg_cache import ForwardMsgCache
+from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
+from streamlit.web.server.server import DebugHandler
+from streamlit.web.server.server import HealthHandler
+from streamlit.web.server.server import MessageCacheHandler
+from streamlit.web.server.server import StaticFileHandler
+from streamlit.web.server.server_util import serialize_forward_msg
+from .message_mocks import create_dataframe_msg
+
+LOGGER = get_logger(__name__)
+
+
+class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests the /healthz endpoint"""
+
+    def setUp(self):
+        super(HealthHandlerTest, self).setUp()
+        self._is_healthy = True
+
+    async def is_healthy(self):
+        return self._is_healthy, "ok"
+
+    def get_app(self):
+        return tornado.web.Application(
+            [(r"/healthz", HealthHandler, dict(callback=self.is_healthy))]
+        )
+
+    def test_healthz(self):
+        response = self.fetch("/healthz")
+        self.assertEqual(200, response.code)
+        self.assertEqual(b"ok", response.body)
+
+        self._is_healthy = False
+        response = self.fetch("/healthz")
+        self.assertEqual(503, response.code)
+
+    def test_healthz_without_csrf(self):
+        config._set_option("server.enableXsrfProtection", False, "test")
+        response = self.fetch("/healthz")
+        self.assertEqual(200, response.code)
+        self.assertEqual(b"ok", response.body)
+        self.assertNotIn("Set-Cookie", response.headers)
+
+    def test_healthz_with_csrf(self):
+        config._set_option("server.enableXsrfProtection", True, "test")
+        response = self.fetch("/healthz")
+        self.assertEqual(200, response.code)
+        self.assertEqual(b"ok", response.body)
+        self.assertIn("Set-Cookie", response.headers)
+
+
+class DebugHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests the /debugz endpoint"""
+
+    def get_app(self):
+        return tornado.web.Application([(r"/debugz", DebugHandler)])
+
+    def test_debug(self):
+        # TODO - debugz is currently broken
+        pass
+
+
+class MessageCacheHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        self._cache = ForwardMsgCache()
+        return tornado.web.Application(
+            [(r"/message", MessageCacheHandler, dict(cache=self._cache))]
+        )
+
+    def test_message_cache(self):
+        # Create a new ForwardMsg and cache it
+        msg = create_dataframe_msg([1, 2, 3])
+        msg_hash = populate_hash_if_needed(msg)
+        self._cache.add_message(msg, MagicMock(), 0)
+
+        # Cache hit
+        response = self.fetch("/message?hash=%s" % msg_hash)
+        self.assertEqual(200, response.code)
+        self.assertEqual(serialize_forward_msg(msg), response.body)
+
+        # Cache misses
+        self.assertEqual(404, self.fetch("/message").code)
+        self.assertEqual(404, self.fetch("/message?id=non_existent").code)
+
+
+class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._tmpfile = tempfile.NamedTemporaryFile(dir=self._tmpdir.name, delete=False)
+        self._filename = os.path.basename(self._tmpfile.name)
+
+        super().setUp()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+
+        self._tmpdir.cleanup()
+
+    def get_pages(self):
+        return {"page1": "page_info1", "page2": "page_info2"}
+
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/(.*)",
+                    StaticFileHandler,
+                    {
+                        "path": self._tmpdir.name,
+                        "default_filename": self._filename,
+                        "get_pages": self.get_pages,
+                    },
+                )
+            ]
+        )
+
+    def test_parse_url_path_200(self):
+        responses = [
+            self.fetch("/"),
+            self.fetch(f"/{self._filename}"),
+            self.fetch("/page1/"),
+            self.fetch(f"/page1/{self._filename}"),
+            self.fetch("/page2/"),
+            self.fetch(f"/page2/{self._filename}"),
+        ]
+
+        for r in responses:
+            assert r.code == 200
+
+    def test_parse_url_path_404(self):
+        responses = [
+            self.fetch("/nonexistent"),
+            self.fetch("/page2/nonexistent"),
+            self.fetch(f"/page3/{self._filename}"),
+        ]
+
+        for r in responses:
+            assert r.code == 404

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -61,8 +61,6 @@ def _create_script_finished_msg(status) -> ForwardMsg:
 
 
 class ServerTest(ServerTestCase):
-    _next_session_id = 0
-
     def setUp(self) -> None:
         self.original_ws_compression = config.get_option(
             "server.enableWebsocketCompression"

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -25,16 +25,8 @@ from unittest.mock import patch
 
 import pytest
 import tornado.httpserver
-import tornado.httpserver
-import tornado.httpserver
-import tornado.testing
-import tornado.testing
 import tornado.testing
 import tornado.web
-import tornado.web
-import tornado.web
-import tornado.websocket
-import tornado.websocket
 import tornado.websocket
 
 import streamlit.web.server.server
@@ -44,11 +36,13 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.watcher import event_based_path_watcher
-from streamlit.web.server.server import MAX_PORT_SEARCH_RETRIES
-from streamlit.web.server.server import RetriesExceeded
-from streamlit.web.server.server import Server
-from streamlit.web.server.server import State
-from streamlit.web.server.server import start_listening
+from streamlit.web.server.server import (
+    MAX_PORT_SEARCH_RETRIES,
+    RetriesExceeded,
+    Server,
+    State,
+    start_listening,
+)
 from .message_mocks import create_dataframe_msg
 from .server_test_case import ServerTestCase
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Server.py unit tests"""
+
 import asyncio
 import errno
 import os
@@ -60,6 +61,11 @@ def _create_script_finished_msg(status) -> ForwardMsg:
     return msg
 
 
+def _patch_local_sources_watcher():
+    """Return a mock.patch for LocalSourcesWatcher"""
+    return patch("streamlit.web.server.server.LocalSourcesWatcher")
+
+
 class ServerTest(ServerTestCase):
     def setUp(self) -> None:
         self.original_ws_compression = config.get_option(
@@ -76,9 +82,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_start_stop(self):
         """Test that we can start and stop the server."""
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
             self.assertEqual(State.WAITING_FOR_FIRST_SESSION, self.server._state)
 
@@ -94,10 +98,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_websocket_connect(self):
         """Test that we can connect to the server via websocket."""
-
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
 
             self.assertFalse(self.server.browser_is_connected)
@@ -123,10 +124,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_multiple_connections(self):
         """Test multiple websockets can connect simultaneously."""
-
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
 
             self.assertFalse(self.server.browser_is_connected)
@@ -159,9 +157,7 @@ class ServerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_websocket_compression(self):
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             config._set_option("server.enableWebsocketCompression", True, "test")
             await self.start_server_loop()
 
@@ -177,9 +173,7 @@ class ServerTest(ServerTestCase):
 
     @tornado.testing.gen_test
     async def test_websocket_compression_disabled(self):
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             config._set_option("server.enableWebsocketCompression", False, "test")
             await self.start_server_loop()
 
@@ -195,9 +189,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_forwardmsg_hashing(self):
         """Test that outgoing ForwardMsgs contain hashes."""
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
 
             ws_client = await self.ws_connect()
@@ -218,9 +210,7 @@ class ServerTest(ServerTestCase):
     async def test_forwardmsg_cacheable_flag(self):
         """Test that the metadata.cacheable flag is set properly on outgoing
         ForwardMsgs."""
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
 
             ws_client = await self.ws_connect()
@@ -245,9 +235,7 @@ class ServerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_duplicate_forwardmsg_caching(self):
         """Test that duplicate ForwardMsgs are sent only once."""
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             config._set_option("global.minCachedMessageSize", 0, "test")
 
             await self.start_server_loop()
@@ -281,9 +269,7 @@ class ServerTest(ServerTestCase):
         """Test that report_run_count is incremented when a report
         finishes running.
         """
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             config._set_option("global.minCachedMessageSize", 0, "test")
             config._set_option("global.maxCachedMessageAge", 1, "test")
 
@@ -341,9 +327,7 @@ class ServerTest(ServerTestCase):
     async def test_orphaned_upload_file_deletion(self):
         """An uploaded file with no associated AppSession should be
         deleted."""
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
             await self.ws_connect()
 
@@ -366,9 +350,7 @@ class ServerTest(ServerTestCase):
         """Sending a message to a disconnected SessionClient raises an error.
         We should gracefully handle the error by cleaning up the session.
         """
-        with patch(
-            "streamlit.web.server.server.LocalSourcesWatcher"
-        ), self._patch_app_session():
+        with _patch_local_sources_watcher(), self._patch_app_session():
             await self.start_server_loop()
             await self.ws_connect()
 

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -15,16 +15,89 @@
 """Unit tests for server_util.py."""
 
 import unittest
+from typing import Optional
 from unittest.mock import patch
 
 from parameterized import parameterized
 
-from streamlit import config
-from streamlit.web.server.server_util import get_url
+from streamlit import config, RootContainer
+from streamlit.cursor import make_delta_path
+from streamlit.elements import legacy_data_frame
+from streamlit.elements.arrow import Data as ArrowData
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.web.server.server_util import (
+    get_url,
+    is_url_from_allowed_origins,
+    is_cacheable_msg,
+    serialize_forward_msg,
+)
 from tests import testutil
+from testutil import patch_config_options
 
 
-class SessionDataTest(unittest.TestCase):
+def _create_dataframe_msg(df: ArrowData, id: int = 1) -> ForwardMsg:
+    msg = ForwardMsg()
+    msg.metadata.delta_path[:] = make_delta_path(RootContainer.SIDEBAR, (), id)
+    legacy_data_frame.marshall_data_frame(df, msg.delta.new_element.data_frame)
+    return msg
+
+
+class ServerUtilTest(unittest.TestCase):
+    def test_is_url_from_allowed_origins_allowed_domains(self):
+        self.assertTrue(is_url_from_allowed_origins("localhost"))
+        self.assertTrue(is_url_from_allowed_origins("127.0.0.1"))
+
+    def test_is_url_from_allowed_origins_CORS_off(self):
+        with patch(
+            "streamlit.web.server.server_util.config.get_option", side_effect=[False]
+        ):
+            self.assertTrue(is_url_from_allowed_origins("does not matter"))
+
+    def test_is_url_from_allowed_origins_browser_serverAddress(self):
+        with patch(
+            "streamlit.web.server.server_util.config.is_manually_set",
+            side_effect=[True],
+        ), patch(
+            "streamlit.web.server.server_util.config.get_option",
+            side_effect=[True, "browser.server.address"],
+        ):
+            self.assertTrue(is_url_from_allowed_origins("browser.server.address"))
+
+    def test_should_cache_msg(self):
+        """Test server_util.should_cache_msg"""
+        with patch_config_options({"global.minCachedMessageSize": 0}):
+            self.assertTrue(is_cacheable_msg(_create_dataframe_msg([1, 2, 3])))
+
+        with patch_config_options({"global.minCachedMessageSize": 1000}):
+            self.assertFalse(is_cacheable_msg(_create_dataframe_msg([1, 2, 3])))
+
+    def test_should_limit_msg_size(self):
+        max_message_size_mb = 50
+        # Set max message size to defined value
+        from streamlit.web.server import server_util
+
+        server_util._max_message_size_bytes = None  # Reset cached value
+        config._set_option("server.maxMessageSize", max_message_size_mb, "test")
+
+        # Set up a larger than limit ForwardMsg string
+        large_msg = _create_dataframe_msg([1, 2, 3])
+        large_msg.delta.new_element.markdown.body = (
+            "X" * (max_message_size_mb + 10) * 1000 * 1000
+        )
+        # Create a copy, since serialize_forward_msg modifies the original proto
+        large_msg_copy = ForwardMsg()
+        large_msg_copy.CopyFrom(large_msg)
+        deserialized_msg = ForwardMsg()
+        deserialized_msg.ParseFromString(serialize_forward_msg(large_msg_copy))
+
+        # The metadata should be the same, but contents should be replaced
+        self.assertEqual(deserialized_msg.metadata, large_msg.metadata)
+        self.assertNotEqual(deserialized_msg, large_msg)
+        self.assertTrue(
+            "exceeds the message size limit"
+            in deserialized_msg.delta.new_element.exception.message
+        )
+
     @parameterized.expand(
         [
             (None, None, "http://the_ip_address:8501"),
@@ -35,11 +108,13 @@ class SessionDataTest(unittest.TestCase):
             ("/foo/bar/", 9988, "http://the_ip_address:9988/foo/bar"),
         ]
     )
-    def test_get_url(self, baseUrl, port, expected_url):
+    def test_get_url(
+        self, base_url: Optional[str], port: Optional[int], expected_url: str
+    ):
         options = {"server.headless": False, "global.developmentMode": False}
 
-        if baseUrl:
-            options["server.baseUrlPath"] = baseUrl
+        if base_url:
+            options["server.baseUrlPath"] = base_url
 
         if port:
             options["server.port"] = port

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -29,7 +29,7 @@ from streamlit.web.server.server_util import (
     serialize_forward_msg,
 )
 from tests import testutil
-from testutil import patch_config_options
+from tests.testutil import patch_config_options
 from .message_mocks import create_dataframe_msg
 
 


### PR DESCRIPTION
`server_test.py` contains tests for `server.py`, `server_util.py`, and `routes.py` - and it's gigantic! 

This PR splits out tests for the other source files into their own test files, and modernizes a few tests.