### PR TITLE
Remove the debugz endpoint

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -268,17 +268,6 @@ class HealthHandler(_SpecialRequestHandler):
             self.write(msg)
 
 
-class DebugHandler(_SpecialRequestHandler):
-    def initialize(self, server):
-        self._server = server
-
-    def get(self):
-        self.add_header("Cache-Control", "no-cache")
-        self.write(
-            "<code><pre>%s</pre><code>" % json.dumps(self._server.get_debug(), indent=2)
-        )
-
-
 class MessageCacheHandler(tornado.web.RequestHandler):
     """Returns ForwardMsgs from our MessageCache"""
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -66,16 +66,19 @@ from streamlit.runtime.state import (
 from streamlit.runtime.stats import StatsManager
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.watcher import LocalSourcesWatcher
-from streamlit.web.server.routes import AddSlashHandler
-from streamlit.web.server.routes import AssetsFileHandler
-from streamlit.web.server.routes import DebugHandler
-from streamlit.web.server.routes import HealthHandler
-from streamlit.web.server.routes import MediaFileHandler
-from streamlit.web.server.routes import MessageCacheHandler
-from streamlit.web.server.routes import StaticFileHandler
-from streamlit.web.server.server_util import get_max_message_size_bytes
-from streamlit.web.server.server_util import is_cacheable_msg
-from streamlit.web.server.server_util import make_url_path_regex
+from streamlit.web.server.routes import (
+    AddSlashHandler,
+    AssetsFileHandler,
+    HealthHandler,
+    MediaFileHandler,
+    MessageCacheHandler,
+    StaticFileHandler,
+)
+from streamlit.web.server.server_util import (
+    get_max_message_size_bytes,
+    is_cacheable_msg,
+    make_url_path_regex,
+)
 from streamlit.web.server.upload_file_request_handler import (
     UploadFileRequestHandler,
     UPLOAD_FILE_ROUTE,
@@ -329,7 +332,6 @@ class Server:
                 HealthHandler,
                 dict(callback=lambda: self.is_ready_for_browser_connection),
             ),
-            (make_url_path_regex(base, "debugz"), DebugHandler, dict(server=self)),
             (
                 make_url_path_regex(base, "message"),
                 MessageCacheHandler,

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -25,7 +25,6 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.runtime.forward_msg_cache import ForwardMsgCache, populate_hash_if_needed
 from streamlit.web.server.server import (
-    DebugHandler,
     HealthHandler,
     MessageCacheHandler,
     StaticFileHandler,
@@ -73,17 +72,6 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(200, response.code)
         self.assertEqual(b"ok", response.body)
         self.assertIn("Set-Cookie", response.headers)
-
-
-class DebugHandlerTest(tornado.testing.AsyncHTTPTestCase):
-    """Tests the /debugz endpoint"""
-
-    def get_app(self):
-        return tornado.web.Application([(r"/debugz", DebugHandler)])
-
-    def test_debug(self):
-        # TODO - debugz is currently broken
-        pass
 
 
 class MessageCacheHandlerTest(tornado.testing.AsyncHTTPTestCase):


### PR DESCRIPTION
## 📚 Context

It sounds like the `/debugz` endpoint was added years ago and never used, so we should
just remove it at this point as it seems unlikely that functionality for it will ever be added.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Other, please describe: dead code removal

## 🧠 Description of Changes

- Remove the `/debugz` endpoint and associated code
- Compress some import statements

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Closes: #5083
