### PR TITLE
Make st.balloons/st.snow not react to pointer events.

### DIFF
--- a/frontend/src/components/elements/Balloons/styled-components.ts
+++ b/frontend/src/components/elements/Balloons/styled-components.ts
@@ -43,6 +43,7 @@ export const StyledBalloon = styled.img(({ theme }) => ({
   animationDelay: `${Math.random() * DELAY_MAX_MS}ms`,
   height: `${IMAGE_HEIGHT}px`,
   width: `${IMAGE_WIDTH}px`,
+  pointerEvents: "none",
 
   animationDuration: "750ms",
   animationName: moveUp,

--- a/frontend/src/components/elements/Snow/styled-components.ts
+++ b/frontend/src/components/elements/Snow/styled-components.ts
@@ -54,6 +54,7 @@ export const StyledFlake = styled.img(({ theme }) => ({
   animationDelay: `${rand(DELAY_MAX_MS)}ms`,
   height: `${IMAGE_HEIGHT}px`,
   width: `${IMAGE_WIDTH}px`,
+  pointerEvents: "none",
 
   animationDuration: "3000ms",
   animationName: moveDown(),


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

When using st.snow/st.balloons, if you're about to click on an element when a 🎈 or ❄️ happens to move under your cursor, the  🎈/ ❄️ will block the element from receiving your click. This PR fixes that by making  🎈/❄️  "transparent" to pointer events. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

The UI looks the same as today.

**Current:**

n/a

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
