### PR TITLE
Various typing improvements

### DIFF
--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -15,15 +15,16 @@
 from typing import cast, Optional, TYPE_CHECKING
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.string_util import clean_text
+from streamlit.type_util import SupportsStr
 
 if TYPE_CHECKING:
-    import sympy
-
     from streamlit.delta_generator import DeltaGenerator
 
 
 class HeadingMixin:
-    def header(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
+    def header(
+        self, body: SupportsStr, anchor: Optional[str] = None
+    ) -> "DeltaGenerator":
         """Display text in header formatting.
 
         Parameters
@@ -47,7 +48,9 @@ class HeadingMixin:
         header_proto.tag = "h2"
         return self.dg._enqueue("heading", header_proto)
 
-    def subheader(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
+    def subheader(
+        self, body: SupportsStr, anchor: Optional[str] = None
+    ) -> "DeltaGenerator":
         """Display text in subheader formatting.
 
         Parameters
@@ -72,7 +75,9 @@ class HeadingMixin:
 
         return self.dg._enqueue("heading", subheader_proto)
 
-    def title(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
+    def title(
+        self, body: SupportsStr, anchor: Optional[str] = None
+    ) -> "DeltaGenerator":
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -14,10 +14,9 @@
 
 from typing import cast, Optional, TYPE_CHECKING, Union
 
-from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.string_util import clean_text
-from ..type_util import SupportsStr
+from streamlit.type_util import SupportsStr, is_sympy_expession
 
 if TYPE_CHECKING:
     import sympy
@@ -81,7 +80,9 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
-    def code(self, body: SupportsStr, language: Optional[str] = "python") -> "DeltaGenerator":
+    def code(
+        self, body: SupportsStr, language: Optional[str] = "python"
+    ) -> "DeltaGenerator":
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -111,7 +112,9 @@ class MarkdownMixin:
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
-    def caption(self, body: SupportsStr, unsafe_allow_html: bool = False) -> "DeltaGenerator":
+    def caption(
+        self, body: SupportsStr, unsafe_allow_html: bool = False
+    ) -> "DeltaGenerator":
         """Display text in small font.
 
         This should be used for captions, asides, footnotes, sidenotes, and
@@ -179,7 +182,7 @@ class MarkdownMixin:
         ...     ''')
 
         """
-        if type_util.is_sympy_expession(body):
+        if is_sympy_expession(body):
             import sympy
 
             body = sympy.latex(body)

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -17,6 +17,7 @@ from typing import cast, Optional, TYPE_CHECKING, Union
 from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.string_util import clean_text
+from ..type_util import SupportsStr
 
 if TYPE_CHECKING:
     import sympy
@@ -25,7 +26,9 @@ if TYPE_CHECKING:
 
 
 class MarkdownMixin:
-    def markdown(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
+    def markdown(
+        self, body: SupportsStr, unsafe_allow_html: bool = False
+    ) -> "DeltaGenerator":
         """Display string formatted as Markdown.
 
         Parameters
@@ -78,7 +81,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
-    def code(self, body: str, language: Optional[str] = "python") -> "DeltaGenerator":
+    def code(self, body: SupportsStr, language: Optional[str] = "python") -> "DeltaGenerator":
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -104,14 +107,11 @@ class MarkdownMixin:
 
         """
         code_proto = MarkdownProto()
-        markdown = "```%(language)s\n%(body)s\n```" % {
-            "language": language or "",
-            "body": body,
-        }
+        markdown = f'```{language or ""}\n{body}\n```'
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
-    def caption(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
+    def caption(self, body: SupportsStr, unsafe_allow_html: bool = False) -> "DeltaGenerator":
         """Display text in small font.
 
         This should be used for captions, asides, footnotes, sidenotes, and
@@ -154,7 +154,7 @@ class MarkdownMixin:
         caption_proto.is_caption = True
         return self.dg._enqueue("markdown", caption_proto)
 
-    def latex(self, body: Union[str, "sympy.Expr"]) -> "DeltaGenerator":
+    def latex(self, body: Union[SupportsStr, "sympy.Expr"]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.
         r"""Display mathematical expressions formatted as LaTeX.

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -31,7 +31,14 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
-from streamlit.type_util import Key, OptionSequence, ensure_indexable, is_type, to_key
+from streamlit.type_util import (
+    Key,
+    OptionSequence,
+    ensure_indexable,
+    is_type,
+    to_key,
+    V_co,
+)
 
 from streamlit.runtime.state import (
     register_widget,
@@ -47,10 +54,10 @@ T = TypeVar("T")
 
 class MultiSelectMixin:
     @overload
-    def multiselect(
+    def multiselect(  # type: ignore[misc]
         self,
         label: str,
-        options: Sequence[T],
+        options: OptionSequence[Enum],
         default: Optional[Any] = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -60,14 +67,14 @@ class MultiSelectMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
-    ) -> List[T]:
+    ) -> List[str]:
         ...
 
     @overload
     def multiselect(
         self,
         label: str,
-        options: OptionSequence,
+        options: OptionSequence[V_co],
         default: Optional[Any] = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -77,13 +84,13 @@ class MultiSelectMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
-    ) -> List[Any]:
+    ) -> List[V_co]:
         ...
 
     def multiselect(
         self,
         label: str,
-        options: OptionSequence,
+        options: OptionSequence[V_co],
         default: Optional[Any] = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -93,7 +100,7 @@ class MultiSelectMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
-    ) -> List[Any]:
+    ) -> Union[List[V_co], List[str]]:
         """Display a multiselect widget.
         The multiselect widget starts as empty.
 
@@ -166,7 +173,7 @@ class MultiSelectMixin:
     def _multiselect(
         self,
         label: str,
-        options: OptionSequence,
+        options: OptionSequence[V_co],
         default: Union[Iterable[Any], Any, None] = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -177,7 +184,7 @@ class MultiSelectMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         ctx: Optional[ScriptRunContext] = None,
-    ) -> List[Any]:
+    ) -> Union[List[str], List[V_co]]:
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=default, key=key)

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -25,7 +25,7 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key, V_co
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -35,7 +35,7 @@ class RadioMixin:
     def radio(
         self,
         label: str,
-        options: OptionSequence,
+        options: OptionSequence[V_co],
         index: int = 0,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -125,7 +125,7 @@ class RadioMixin:
     def _radio(
         self,
         label: str,
-        options: OptionSequence,
+        options: OptionSequence[V_co],
         index: int = 0,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -25,7 +25,7 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key, V_co
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -35,7 +35,7 @@ class SelectSliderMixin:
     def select_slider(
         self,
         label: str,
-        options: OptionSequence = (),
+        options: OptionSequence[V_co] = (),
         value: Any = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -136,7 +136,7 @@ class SelectSliderMixin:
     def _select_slider(
         self,
         label: str,
-        options: OptionSequence = (),
+        options: OptionSequence[V_co] = (),
         value: Any = None,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -198,7 +198,7 @@ class SelectSliderMixin:
                 ui_value = slider_value
 
             # The widget always returns floats, so convert to ints before indexing
-            return_value = list(map(lambda x: opt[int(x)], ui_value))  # type: ignore[no-any-return]
+            return_value = list(map(lambda x: opt[int(x)], ui_value))
 
             # If the original value was a list/tuple, so will be the output (and vice versa)
             return tuple(return_value) if is_range_value else return_value[0]

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -13,8 +13,16 @@
 # limitations under the License.
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, TypeVar, cast
-from typing import overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    Sequence,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
@@ -25,7 +33,7 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
-from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
+from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key, V_co
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -33,15 +41,12 @@ from .utils import check_callback_rules, check_session_state_rules
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
-T = TypeVar("T")
-
 
 class SelectboxMixin:
-    @overload
     def selectbox(
         self,
         label: str,
-        options: Sequence[T],
+        options: OptionSequence[V_co],
         index: int = 0,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -51,40 +56,7 @@ class SelectboxMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
-    ) -> Optional[T]:
-        ...
-
-    @overload
-    def selectbox(
-        self,
-        label: str,
-        options: OptionSequence,
-        index: int = 0,
-        format_func: Callable[[Any], Any] = str,
-        key: Optional[Key] = None,
-        help: Optional[str] = None,
-        on_change: Optional[WidgetCallback] = None,
-        args: Optional[WidgetArgs] = None,
-        kwargs: Optional[WidgetKwargs] = None,
-        *,  # keyword-only arguments:
-        disabled: bool = False,
-    ) -> Optional[Any]:
-        ...
-
-    def selectbox(
-        self,
-        label: str,
-        options: OptionSequence,
-        index: int = 0,
-        format_func: Callable[[Any], Any] = str,
-        key: Optional[Key] = None,
-        help: Optional[str] = None,
-        on_change: Optional[WidgetCallback] = None,
-        args: Optional[WidgetArgs] = None,
-        kwargs: Optional[WidgetKwargs] = None,
-        *,  # keyword-only arguments:
-        disabled: bool = False,
-    ) -> Optional[Any]:
+    ) -> Optional[V_co]:
         """Display a select widget.
 
         Parameters
@@ -152,7 +124,7 @@ class SelectboxMixin:
     def _selectbox(
         self,
         label: str,
-        options: OptionSequence,
+        options: OptionSequence[V_co],
         index: int = 0,
         format_func: Callable[[Any], Any] = str,
         key: Optional[Key] = None,
@@ -163,7 +135,7 @@ class SelectboxMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         ctx: Optional[ScriptRunContext] = None,
-    ) -> Optional[Any]:
+    ) -> Optional[V_co]:
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if index == 0 else index, key=key)

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -13,14 +13,20 @@
 # limitations under the License.
 
 from datetime import date, time, datetime, timedelta, timezone
-from typing import Sequence
-from typing import Tuple
-from typing import TypeVar
-from typing import Union
+from typing import (
+    Any,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+    TypeVar,
+    cast,
+)
 
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
-from typing import Any, List, cast, Optional, TYPE_CHECKING
 from typing_extensions import TypeAlias
 from textwrap import dedent
 
@@ -89,7 +95,12 @@ class SliderMixin:
         kwargs: Optional[WidgetKwargs] = None,
         *,  # keyword-only arguments:
         disabled: bool = False,
-    ) -> SliderReturn:
+        # TODO(harahu): Add overload definitions. The return type is
+        #  `SliderReturn`, in reality, but the return type is left as `Any`
+        #  until we have proper overload definitions in place. Otherwise the
+        #  user would have to cast the return value more often than not, which
+        #  can be annoying.
+    ) -> Any:
         """Display a slider widget.
 
         This supports int, float, date, time, and datetime types.

--- a/lib/streamlit/hello/pages/0_Animation_Demo.py
+++ b/lib/streamlit/hello/pages/0_Animation_Demo.py
@@ -14,7 +14,7 @@
 
 import streamlit as st
 import numpy as np
-from typing import Any, cast
+from typing import Any
 from streamlit.hello.utils import show_code
 
 
@@ -50,7 +50,7 @@ def animation_demo() -> None:
         M: Any = np.full((n, m), True, dtype=bool)
         N = np.zeros((n, m))
 
-        for i in range(cast(int, iterations)):
+        for i in range(iterations):
             Z[M] = Z[M] * Z[M] + C[M]
             M[np.abs(Z) > 2] = False
             N[M] = i

--- a/lib/streamlit/hello/pages/0_Animation_Demo.py
+++ b/lib/streamlit/hello/pages/0_Animation_Demo.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import streamlit as st
-import inspect
-import textwrap
 import numpy as np
-from typing import Any
+from typing import Any, cast
 from streamlit.hello.utils import show_code
 
 
-def animation_demo():
+def animation_demo() -> None:
 
     # Interactive Streamlit elements, like these sliders, return their value.
     # This gives you an extremely simple interaction model.
@@ -52,7 +50,7 @@ def animation_demo():
         M: Any = np.full((n, m), True, dtype=bool)
         N = np.zeros((n, m))
 
-        for i in range(iterations):
+        for i in range(cast(int, iterations)):
             Z[M] = Z[M] * Z[M] + C[M]
             M[np.abs(Z) > 2] = False
             N[M] = i

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -31,7 +31,7 @@ ESCAPED_EMOJI = [re.escape(e) for e in sorted(ALL_EMOJIS, reverse=True)]
 EMOJI_EXTRACTION_REGEX = re.compile(f"^({'|'.join(ESCAPED_EMOJI)})[_ -]*(.*)")
 
 
-def decode_ascii(string):
+def decode_ascii(string: bytes) -> str:
     """Decodes a string as ascii."""
     return string.decode("ascii")
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -47,9 +47,9 @@ from pandas.api.types import infer_dtype
 from streamlit import errors
 
 if TYPE_CHECKING:
-    import numpy as np
     import sympy
     from pandas import DataFrame, Series, Index
+    from pandas.core.indexing import _iLocIndexer
     from pandas.io.formats.style import Styler
     from plotly.graph_objs._figure import Figure
     from pydeck.bindings.deck import Deck  # type: ignore[import]
@@ -97,18 +97,30 @@ ValueFieldName: TypeAlias = Literal[
     "trigger_value",
 ]
 
+V_co = TypeVar("V_co", covariant=True)
+
+
+class DataFrameGenericAlias(Protocol[V_co]):
+    """Technically not a GenericAlias, but serves the same purpose in
+    OptionSequence below, in that it is a type which admits DataFrame,
+    but is generic. This allows OptionSequence to be a fully generic type,
+    significantly increasing its usefulness.
+
+    We can't use types.GenericAlias is only available from python >= 3.9, and
+    isn't easily back-ported."""
+
+    @property
+    def iloc(self) -> _iLocIndexer:
+        ...
+
+
 OptionSequence: TypeAlias = Union[
-    Sequence[Any],
-    "DataFrame",
-    "Series",
-    "Index",
-    "np.ndarray",
+    Iterable[V_co],
+    DataFrameGenericAlias[V_co],
 ]
 
+
 Key: TypeAlias = Union[str, int]
-
-
-T = TypeVar("T")
 
 
 # This should really be a Protocol, but can't be, due to:
@@ -169,9 +181,7 @@ def is_type(obj: object, fqn_type_pattern: Union[str, re.Pattern[str]]) -> bool:
 
 def get_fqn(the_type: type) -> str:
     """Get module.type_name for a given type."""
-    module = the_type.__module__
-    name = the_type.__qualname__
-    return "%s.%s" % (module, name)
+    return f"{the_type.__module__}.{the_type.__qualname__}"
 
 
 def get_fqn_type(obj: object) -> str:
@@ -420,7 +430,7 @@ Offending object:
 
 
 @overload
-def ensure_iterable(obj: Iterable[T]) -> Iterable[T]:
+def ensure_iterable(obj: Iterable[V_co]) -> Iterable[V_co]:
     ...
 
 
@@ -429,7 +439,7 @@ def ensure_iterable(obj: DataFrame) -> Iterable[Any]:
     ...
 
 
-def ensure_iterable(obj: Union[DataFrame, Iterable[T]]) -> Iterable[Any]:
+def ensure_iterable(obj: Union[DataFrame, Iterable[V_co]]) -> Iterable[Any]:
     """Try to convert different formats to something iterable. Most inputs
     are assumed to be iterable, but if we have a DataFrame, we can just
     select the first column to iterate over. If the input is not iterable,
@@ -445,26 +455,17 @@ def ensure_iterable(obj: Union[DataFrame, Iterable[T]]) -> Iterable[Any]:
 
     """
     if is_dataframe(obj):
+        # Select fist column
         return cast(Iterable[Any], obj.iloc[:, 0])
 
     try:
         iter(obj)
-        return cast(Iterable[T], obj)
+        return cast(Iterable[V_co], obj)
     except TypeError:
         raise
 
 
-@overload
-def ensure_indexable(obj: Sequence[T]) -> Sequence[T]:
-    ...
-
-
-@overload
-def ensure_indexable(obj: OptionSequence) -> Sequence[Any]:
-    ...
-
-
-def ensure_indexable(obj: OptionSequence) -> Sequence[Any]:
+def ensure_indexable(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     """Try to ensure a value is an indexable Sequence. If the collection already
     is one, it has the index method that we need. Otherwise, convert it to a list.
     """

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -132,8 +132,6 @@ def index_(iterable: Iterable[_Value], x: _Value) -> int:
     """
 
     for i, value in enumerate(iterable):
-        # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
-        # https://github.com/streamlit/streamlit/issues/4663
         if isinstance(value, float) and isinstance(x, float):
             if abs(x - value) < FLOAT_EQUALITY_EPSILON:
                 return i

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -20,14 +20,14 @@ import os
 import subprocess
 import numpy as np
 
-from typing import Any, Dict, List, Mapping, TypeVar
+from typing import Any, Dict, Iterable, List, Mapping, TypeVar
 from typing_extensions import Final
 
 from streamlit import env_util
 
 # URL of Streamlit's help page.
 HELP_DOC: Final = "https://docs.streamlit.io/"
-FLOAT_EQUALITY_EPSILON: Final = 0.000000000005
+FLOAT_EQUALITY_EPSILON: Final[float] = 0.000000000005
 
 
 def memoize(func):
@@ -111,7 +111,10 @@ def repr_(cls) -> str:
     return f"{classname}({args})"
 
 
-def index_(iterable, x) -> int:
+_Value = TypeVar("_Value")
+
+
+def index_(iterable: Iterable[_Value], x: _Value) -> int:
     """Return zero-based index of the first item whose value is equal to x.
     Raises a ValueError if there is no such item.
 
@@ -121,6 +124,7 @@ def index_(iterable, x) -> int:
     Parameters
     ----------
     iterable : list, tuple, numpy.ndarray, pandas.Series
+    x : Any
 
     Returns
     -------
@@ -130,7 +134,7 @@ def index_(iterable, x) -> int:
     for i, value in enumerate(iterable):
         # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
         # https://github.com/streamlit/streamlit/issues/4663
-        if isinstance(value, np.float64) or isinstance(value, float):
+        if isinstance(value, float) and isinstance(x, float):
             if abs(x - value) < FLOAT_EQUALITY_EPSILON:
                 return i
         elif x == value:
@@ -139,7 +143,6 @@ def index_(iterable, x) -> int:
 
 
 _Key = TypeVar("_Key", bound=str)
-_Value = TypeVar("_Value")
 
 
 def lower_clean_dict_keys(dict: Mapping[_Key, _Value]) -> Dict[str, _Value]:

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -437,12 +437,12 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             # Python < 3.9 represents the signature slightly differently
             self.assertEqual(
                 el.doc_string.signature,
-                "(body: str, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",
+                "(body: object, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",
             )
         else:
             self.assertEqual(
                 el.doc_string.signature,
-                "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'",
+                "(body: object, anchor: Optional[str] = None) -> 'DeltaGenerator'",
             )
 
     def test_st_image_PIL_image(self):


### PR DESCRIPTION
## 📚 Context

_Improve type annotations for streamlit's public API_

- What kind of change does this PR introduce?

  - [X] Other, please describe: Type annotations

## 🧠 Description of Changes

- _Relax `str` arguments for markdown methods to `SupportsStr` in line with actual behavior. The reasoning for this has been discussed in past PRs: https://github.com/streamlit/streamlit/pull/4808#discussion_r887411102_
- _An initial pass at adding types for `st.slider`. For now I've only defined the return type as the union of all possible return values. Having the return type be variable with regards to input would be more helpful, but also requires a lot more effort. I'll get back to this later._
- _Add overload definitions to selectbox, inspired by #4926_

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
