### PR TITLE
Add note about `map_style=None` to `st.pydeck_chart` docstring

### DIFF
--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -15,8 +15,6 @@
 import json
 from typing import Any, Dict, cast
 
-import pydeck as pdk
-
 import streamlit
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as PydeckProto
 
@@ -49,14 +47,15 @@ class PydeckMixin:
 
         Example
         -------
-        Here's a chart using a HexagonLayer and a ScatterplotLayer on top of
-        the light map style:
+        Here's a chart using a HexagonLayer and a ScatterplotLayer. It uses either the
+        light or dark map style, based on which Streamlit theme is currently active:
 
         >>> df = pd.DataFrame(
         ...    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],
         ...    columns=['lat', 'lon'])
         >>>
         >>> st.pydeck_chart(pdk.Deck(
+        ...     map_style=None,
         ...     initial_view_state=pdk.ViewState(
         ...         latitude=37.76,
         ...         longitude=-122.4,
@@ -87,6 +86,10 @@ class PydeckMixin:
         .. output::
            https://doc-pydeck-chart.streamlitapp.com/
            height: 530px
+
+        .. note::
+           To make the PyDeck chart's style consistent with Streamlit's theme,
+           you can set ``map_style=None`` in the ``pydeck.Deck`` object.
 
         """
         pydeck_proto = PydeckProto()


### PR DESCRIPTION
## 📚 Context

#5074 made it so that `st.map` uses either the light or dark Pydeck map style, based on which Streamlit theme is currently active. To make this behavior work for `st.pydeck_chart`, users need to set `map_style=None` in the `pydeck.Deck` object. Doing so would make the Pydeck chart use either the light or dark map style based on Streamlit's theme.

A note about this behavior should have been included in #5074 but wasn't.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Add note about `map_style=None` to `st.pydeck_chart` docstring
- Removed the unused pydeck import in `deck_gl_json_chart.py` that was accidentally added in #5074 

  - [x] This is a visible (user-facing) change

**Revised:**

<details><summary>Revised</summary>

![image](https://user-images.githubusercontent.com/20672874/183419063-c54a2e52-0eee-4325-a670-8d2a1c986649.png)
</details>

**Current:**

<details><summary>Current</summary>

![image](https://user-images.githubusercontent.com/20672874/183419125-ce42895c-aa6b-40cc-a540-f7f43ef3d232.png)
</details>

## 🧪 Testing Done

- [x] Screenshots included

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
