### PR TITLE
Reduce padding for embedded apps

### DIFF
--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -105,6 +105,7 @@ function AppView(props: AppViewProps): ReactElement {
     <StyledAppViewBlockContainer
       className="block-container"
       isWideMode={wideMode}
+      isEmbedded={embedded}
     >
       <VerticalBlock
         node={node}

--- a/frontend/src/components/core/AppView/styled-components.ts
+++ b/frontend/src/components/core/AppView/styled-components.ts
@@ -72,12 +72,13 @@ export const StyledAppViewMain = styled.section<StyledAppViewMainProps>(
 )
 
 export interface StyledAppViewBlockContainerProps {
-  isWideMode: boolean
+  isWideMode: boolean,
+  isEmbedded: boolean
 }
 
 export const StyledAppViewBlockContainer = styled.div<
   StyledAppViewBlockContainerProps
->(({ isWideMode, theme }) => {
+>(({ isWideMode, isEmbedded, theme }) => {
   const wideSidePadding = isWideMode ? "5rem" : theme.spacing.lg
   return {
     flex: 1,
@@ -89,8 +90,8 @@ export const StyledAppViewBlockContainer = styled.div<
       paddingLeft: theme.inSidebar ? theme.spacing.none : wideSidePadding,
       paddingRight: theme.inSidebar ? theme.spacing.none : wideSidePadding,
     },
-    paddingTop: theme.inSidebar ? theme.spacing.none : "6rem",
-    paddingBottom: theme.inSidebar ? theme.spacing.none : "10rem",
+    paddingTop: theme.inSidebar ? theme.spacing.none : isEmbedded ? '1rem' : '6rem',
+    paddingBottom: theme.inSidebar ? theme.spacing.none : isEmbedded ? '1rem' : '10rem',
     minWidth: isWideMode ? "auto" : undefined,
     maxWidth: isWideMode ? "initial" : theme.sizes.contentMaxWidth,
   }

--- a/frontend/src/components/core/AppView/styled-components.ts
+++ b/frontend/src/components/core/AppView/styled-components.ts
@@ -72,13 +72,15 @@ export const StyledAppViewMain = styled.section<StyledAppViewMainProps>(
 )
 
 export interface StyledAppViewBlockContainerProps {
-  isWideMode: boolean,
+  isWideMode: boolean
   isEmbedded: boolean
 }
 
 export const StyledAppViewBlockContainer = styled.div<
   StyledAppViewBlockContainerProps
 >(({ isWideMode, isEmbedded, theme }) => {
+  const topEmbedPadding = isEmbedded ? "1rem" : "6rem"
+  const bottomEmbedPadding = isEmbedded ? "1rem" : "10rem"
   const wideSidePadding = isWideMode ? "5rem" : theme.spacing.lg
   return {
     flex: 1,
@@ -90,8 +92,8 @@ export const StyledAppViewBlockContainer = styled.div<
       paddingLeft: theme.inSidebar ? theme.spacing.none : wideSidePadding,
       paddingRight: theme.inSidebar ? theme.spacing.none : wideSidePadding,
     },
-    paddingTop: theme.inSidebar ? theme.spacing.none : isEmbedded ? '1rem' : '6rem',
-    paddingBottom: theme.inSidebar ? theme.spacing.none : isEmbedded ? '1rem' : '10rem',
+    paddingTop: theme.inSidebar ? theme.spacing.none : topEmbedPadding,
+    paddingBottom: theme.inSidebar ? theme.spacing.none : bottomEmbedPadding,
     minWidth: isWideMode ? "auto" : undefined,
     maxWidth: isWideMode ? "initial" : theme.sizes.contentMaxWidth,
   }


### PR DESCRIPTION
## 📚 Context

This PR reduces the top and bottom spacing for embedded apps, so they don't take up so much space when embedded using an `<iframe>`

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Design change

## 🧠 Description of Changes

Updated the `paddingTop` and `paddingBottom` for `StyledAppViewBlockContainer` based on the `isEmbedded` boolean prop.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised (embedded in our blog):**

![Screen Shot 2022-08-08 at 2 39 50 PM](https://user-images.githubusercontent.com/34423371/183480956-53de8858-f662-4911-a2d6-86705aad3430.png)

**Current (embedded in our blog):**

![Screen Shot 2022-08-08 at 2 40 36 PM](https://user-images.githubusercontent.com/34423371/183481036-44b1109b-8caf-477e-a645-455c568b58ce.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
