### PR TITLE
Fix tabs switching couse scrolling up

### DIFF
--- a/e2e/specs/st_tabs.spec.js
+++ b/e2e/specs/st_tabs.spec.js
@@ -36,10 +36,9 @@ describe("st.tabs", () => {
       2
     );
 
-    cy.get("[data-testid='stSidebar'] .stTabs .st-cx")
-      .first()
+    cy.get("[data-testid='stSidebar'] .stTabs").first()
       .within(() => {
-        cy.get(".stMarkdown").should("have.text", "I am in the sidebar");
+        cy.get(".stMarkdown").first().should("have.text", "I am in the sidebar");
       });
 
     // text from every tab should be here because renderAll property is set to true

--- a/e2e/specs/st_tabs.spec.js
+++ b/e2e/specs/st_tabs.spec.js
@@ -36,10 +36,17 @@ describe("st.tabs", () => {
       2
     );
 
-    cy.get("[data-testid='stSidebar'] .stTabs")
+    cy.get("[data-testid='stSidebar'] .stTabs .st-cx")
       .first()
       .within(() => {
         cy.get(".stMarkdown").should("have.text", "I am in the sidebar");
+      });
+
+    // text from every tab should be here because renderAll property is set to true
+    cy.get("[data-testid='stSidebar'] .stTabs")
+      .first()
+      .within(() => {
+        cy.get(".stMarkdown").should("have.text", "I am in the sidebarI'm also in the sidebar");
       });
   });
 

--- a/frontend/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/src/components/elements/Tabs/Tabs.tsx
@@ -62,6 +62,7 @@ function Tabs(props: Props): ReactElement {
         onChange={({ activeKey }) => {
           setActiveKey(activeKey)
         }}
+        renderAll={true}
         disabled={widgetsDisabled}
         overrides={{
           TabHighlight: {

--- a/frontend/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/src/components/elements/Tabs/Tabs.tsx
@@ -62,6 +62,9 @@ function Tabs(props: Props): ReactElement {
         onChange={({ activeKey }) => {
           setActiveKey(activeKey)
         }}
+        /* renderAll on UITabs should always be set to true to avoid scrolling issue
+           https://github.com/streamlit/streamlit/issues/5069
+         */
         renderAll={true}
         disabled={widgetsDisabled}
         overrides={{

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -36,9 +36,11 @@ export default function Video({ element, width }: VideoProps): ReactElement {
   useEffect(() => {
     const videoNode = videoRef.current
 
-    const setStartTime: () => void = () => {
+    const onLoadedMetadata: () => void = () => {
       if (videoNode) {
+        // setStartTime
         videoNode.currentTime = element.startTime
+
         /* height of HTML video element needs to be set to avoid scrolling issue: https://github.com/streamlit/streamlit/issues/5069
            initially HTML video has height 0 and when tabs are switched page auto scrolls up
            because of "lack of content" on the page, setting height of HTML video element fixes it
@@ -48,12 +50,12 @@ export default function Video({ element, width }: VideoProps): ReactElement {
     }
 
     if (videoNode) {
-      videoNode.addEventListener("loadedmetadata", setStartTime)
+      videoNode.addEventListener("loadedmetadata", onLoadedMetadata)
     }
 
     return () => {
       if (videoNode) {
-        videoNode.removeEventListener("loadedmetadata", setStartTime)
+        videoNode.removeEventListener("loadedmetadata", onLoadedMetadata)
       }
     }
   }, [element])

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -39,6 +39,11 @@ export default function Video({ element, width }: VideoProps): ReactElement {
     const setStartTime: () => void = () => {
       if (videoNode) {
         videoNode.currentTime = element.startTime
+        /* height of HTML video element needs to be set to avoid scrolling issue: https://github.com/streamlit/streamlit/issues/5069
+           initially HTML video has height 0 and when tabs are switched page auto scrolls up
+           because of "lack of content" on the page, setting height of HTML video element fixes it
+         */
+        videoNode.height = videoNode.videoHeight
       }
     }
 


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

It's a bug fix for [Issue-#5069](https://github.com/streamlit/streamlit/issues/5069). When using an HTML Video element with tabs it's initial height it's set to 0 and stays like this, which couses unexpected scrolling up on tab change.

This PR fixes it by setting up HTML Video element height on loadedmetadata event inside `useEffect` method

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: It's fixes part of [Issue-#5069](https://github.com/streamlit/streamlit/issues/5069). It is expected that other elements like `st.image` will couse similar issue, when their initial height is set to 0

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
