### PR TITLE
Use string_util.clean_text instead of elements.utils.clean_text

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -409,8 +409,8 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
     """
     import streamlit.runtime.legacy_caching.caching as legacy_caching
     import streamlit.runtime.caching as caching
-    from streamlit.elements.utils import clean_text
     from streamlit.proto.Spinner_pb2 import Spinner as SpinnerProto
+    from streamlit.string_util import clean_text
 
     # @st.cache optionally uses spinner for long-running computations.
     # Normally, streamlit warns the user when they call st functions

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -16,8 +16,7 @@ from typing import cast, Optional, TYPE_CHECKING
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
-from streamlit.string_util import is_emoji
-from .utils import clean_text
+from streamlit.string_util import clean_text, is_emoji
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -14,7 +14,7 @@
 
 from typing import cast, Optional, TYPE_CHECKING
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
-from .utils import clean_text
+from streamlit.string_util import clean_text
 
 if TYPE_CHECKING:
     import sympy

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -16,7 +16,7 @@ from typing import cast, Optional, TYPE_CHECKING, Union
 
 from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
-from .utils import clean_text
+from streamlit.string_util import clean_text
 
 if TYPE_CHECKING:
     import sympy

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -19,8 +19,7 @@ from typing_extensions import TypeAlias, Literal
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Metric_pb2 import Metric as MetricProto
-
-from .utils import clean_text
+from streamlit.string_util import clean_text
 
 if TYPE_CHECKING:
     import numpy as np

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -15,7 +15,7 @@
 from typing import cast, TYPE_CHECKING
 
 from streamlit.proto.Text_pb2 import Text as TextProto
-from .utils import clean_text
+from streamlit.string_util import clean_text
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -23,12 +23,7 @@ from streamlit.runtime.state import get_session_state, WidgetCallback
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.type_util import DataFrameCompatible, SupportsStr
-
-
-def clean_text(text: "SupportsStr") -> str:
-    """Convert an object to text, dedent it, and strip whitespace."""
-    return textwrap.dedent(str(text)).strip()
+    from streamlit.type_util import DataFrameCompatible
 
 
 def last_index_for_melted_dataframes(

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -14,10 +14,14 @@
 
 import re
 import textwrap
+from typing import TYPE_CHECKING
 
 from datetime import datetime
 from streamlit.errors import StreamlitAPIException
 from streamlit.emojis import ALL_EMOJIS
+
+if TYPE_CHECKING:
+    from streamlit.type_util import SupportsStr
 
 
 def decode_ascii(string):
@@ -25,7 +29,8 @@ def decode_ascii(string):
     return string.decode("ascii")
 
 
-def clean_text(text: str) -> str:
+def clean_text(text: "SupportsStr") -> str:
+    """Convert an object to text, dedent it, and strip whitespace."""
     return textwrap.dedent(str(text)).strip()
 
 


### PR DESCRIPTION
## 📚 Context

We seem to have two `clean_text` functions that are identical. The actually used one
previously lived in `elements.utils.clean_text`, but it seems slightly more correct to have
this sort of helper function live in `string_util`.

- What kind of change does this PR introduce?

  - [x] Refactoring
