### PR TITLE
Improve emoji handling for multipage apps

### DIFF
--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -52,46 +52,46 @@ class PageHelperFunctionTests(unittest.TestCase):
     @parameterized.expand(
         [
             # Test that the page number is removed as expected.
-            ("/foo/01_bar.py", ("bar", "")),
-            ("/foo/02-bar.py", ("bar", "")),
-            ("/foo/03 bar.py", ("bar", "")),
-            ("/foo/04 bar baz.py", ("bar_baz", "")),
-            ("/foo/05 -_- bar.py", ("bar", "")),
-            ("/foo/06 -_- 🎉bar.py", ("bar", "🎉")),
-            ("/foo/07 -_- 🎉-_bar.py", ("bar", "🎉")),
-            ("/foo/08 -_- 🎉 _ bar.py", ("bar", "🎉")),
+            ("/foo/01_bar.py", ("", "bar")),
+            ("/foo/02-bar.py", ("", "bar")),
+            ("/foo/03 bar.py", ("", "bar")),
+            ("/foo/04 bar baz.py", ("", "bar_baz")),
+            ("/foo/05 -_- bar.py", ("", "bar")),
+            ("/foo/06 -_- 🎉bar.py", ("🎉", "bar")),
+            ("/foo/07 -_- 🎉-_bar.py", ("🎉", "bar")),
+            ("/foo/08 -_- 🎉 _ bar.py", ("🎉", "bar")),
             # Test cases with no page number.
-            ("/foo/bar.py", ("bar", "")),
-            ("/foo/bar baz.py", ("bar_baz", "")),
-            ("/foo/😐bar baz.py", ("bar_baz", "😐")),
-            ("/foo/😐_bar baz.py", ("bar_baz", "😐")),
+            ("/foo/bar.py", ("", "bar")),
+            ("/foo/bar baz.py", ("", "bar_baz")),
+            ("/foo/😐bar baz.py", ("😐", "bar_baz")),
+            ("/foo/😐_bar baz.py", ("😐", "bar_baz")),
             # Test that separator characters in the page name are removed as
             # as expected.
-            ("/foo/1 - first page.py", ("first_page", "")),
-            ("/foo/123_hairy_koala.py", ("hairy_koala", "")),
+            ("/foo/1 - first page.py", ("", "first_page")),
+            ("/foo/123_hairy_koala.py", ("", "hairy_koala")),
             (
                 "/foo/123 wow_this_has a _lot_ _of  _ ___ separators.py",
-                ("wow_this_has_a_lot_of_separators", ""),
+                ("", "wow_this_has_a_lot_of_separators"),
             ),
             (
                 "/foo/1-dashes in page-name stay.py",
-                ("dashes_in_page-name_stay", ""),
+                ("", "dashes_in_page-name_stay"),
             ),
-            ("/foo/2 - 🙃second page.py", ("second_page", "🙃")),
+            ("/foo/2 - 🙃second page.py", ("🙃", "second_page")),
             # Test other weirdness that might happen with numbers.
-            ("12 monkeys.py", ("monkeys", "")),
-            ("12 😰monkeys.py", ("monkeys", "😰")),
-            ("_12 monkeys.py", ("12_monkeys", "")),
-            ("_12 😰monkeys.py", ("12_😰monkeys", "")),
-            ("_😰12 monkeys.py", ("12_monkeys", "😰")),
-            ("123.py", ("123", "")),
-            ("😰123.py", ("123", "😰")),
+            ("12 monkeys.py", ("", "monkeys")),
+            ("12 😰monkeys.py", ("😰", "monkeys")),
+            ("_12 monkeys.py", ("", "12_monkeys")),
+            ("_12 😰monkeys.py", ("", "12_😰monkeys")),
+            ("_😰12 monkeys.py", ("😰", "12_monkeys")),
+            ("123.py", ("", "123")),
+            ("😰123.py", ("😰", "123")),
             # Test the default case for non-Python files.
             ("not_a_python_script.rs", ("", "")),
         ]
     )
-    def test_page_name_and_icon(self, path_str, expected):
-        assert source_util.page_name_and_icon(Path(path_str)) == expected
+    def test_page_icon_and_name(self, path_str, expected):
+        assert source_util.page_icon_and_name(Path(path_str)) == expected
 
     @patch("streamlit.source_util._on_pages_changed", new=MagicMock())
     @patch("streamlit.source_util._cached_pages", new="Some pages")

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -39,6 +39,29 @@ class StringUtilTest(unittest.TestCase):
         """Test streamlit.string_util.is_emoji."""
         self.assertEqual(string_util.is_emoji(text), expected)
 
+    @parameterized.expand(
+        [
+            ("", ("", "")),
+            ("A", ("", "A")),
+            ("%", ("", "%")),
+            ("😃", ("😃", "")),
+            ("😃 page name", ("😃", "page name")),
+            ("😃-page name", ("😃", "page name")),
+            ("😃_page name", ("😃", "page name")),
+            ("😃 _- page name", ("😃", "page name")),
+            # Test that multi-character emoji are fully extracted.
+            ("👨‍👨‍👧‍👦_page name", ("👨‍👨‍👧‍👦", "page name")),
+            ("😃😃", ("😃", "😃")),
+            ("1️⃣X", ("1️⃣", "X")),
+            ("X😃", ("", "X😃")),
+            # Test that certain non-emoji unicode characters don't get
+            # incorrectly detected as emoji.
+            ("何_is_this", ("", "何_is_this")),
+        ]
+    )
+    def test_extract_leading_emoji(self, text, expected):
+        self.assertEqual(string_util.extract_leading_emoji(text), expected)
+
     def test_snake_case_to_camel_case(self):
         """Test streamlit.string_util.snake_case_to_camel_case."""
         self.assertEqual(


### PR DESCRIPTION
## 📚 Context

Now that #5076 is merged, we can also improve our emoji handling for multipage apps.
This PR does this by using the `ALL_EMOJIS` set to construct a regex for leading emoji
extraction.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Add a `extract_leading_emoji` helper function that returns a tuple where the first
   element is the leading emoji and the second is the rest of the string.
- Use this new function in the multipage apps helper functions
- Change `page_name_and_icon ` to `page_icon_and_name ` to play more nicely with
   `extract_leading_emoji`

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Closes #4913
