### PR TITLE
Allow the 'Get help' and 'Report a bug' buttons to link to email addresses

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -89,6 +89,7 @@ def set_page_config(
             A markdown string to show in the About dialog.
             If None, only shows Streamlit's default About text.
 
+        The URL may also refer to an email address e.g. ``mailto:john@example.com``.
 
     Example
     -------
@@ -241,6 +242,8 @@ def valid_url(url: str) -> bool:
     """
     try:
         result = urlparse(url)
+        if result.scheme == "mailto":
+            return all([result.scheme, result.path])
         return all([result.scheme, result.netloc])
     except:
         return False

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -111,6 +111,8 @@ class PageConfigTest(testutil.DeltaGeneratorTestCase):
             (532, False),
             ("dkakasdkjdjakdjadjfalskdjfalk", False),
             ("https://stackoverflow.com", True),
+            ("mailto:test@example.com", True),
+            ("mailto:", False),
         ]
     )
     def test_valid_url(self, url, expected_value):


### PR DESCRIPTION
Close: https://github.com/streamlit/streamlit/issues/5030

Some apps only support via email, so I think it's worth giving the option to open the email client right from the app.

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
