### PR TITLE
Runtime tests: part 3

### DIFF
--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -149,6 +149,33 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.close_session(session_id)
         self.assertFalse(self.runtime.is_active_session(session_id))
 
+    async def test_shutdown_appsessions_on_stop(self):
+        """When the Runtime stops, it should shut down open AppSessions."""
+        with self.patch_app_session():
+            await self.start_runtime_loop()
+
+            # Create a few sessions
+            app_sessions = []
+            for _ in range(3):
+                session_id = self.runtime.create_session(
+                    MockSessionClient(), MagicMock()
+                )
+                app_session = self.runtime._get_session_info(session_id).session
+                app_sessions.append(app_session)
+
+            # Sanity check
+            for app_session in app_sessions:
+                app_session.shutdown.assert_not_called()
+
+            # Stop the Runtime
+            self.runtime.stop()
+            await self.runtime.stopped
+
+            # All sessions should be shut down
+            self.assertEqual(RuntimeState.STOPPED, self.runtime.state)
+            for app_session in app_sessions:
+                app_session.shutdown.assert_called_once()
+
     async def test_handle_backmsg(self):
         """BackMsgs should be delivered to the appropriate AppSession."""
         with self.patch_app_session():

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -404,6 +404,19 @@ class RuntimeTest(RuntimeTestCase):
             [],
         )
 
+    async def test_get_eventloop(self):
+        """Runtime._get_eventloop() will raise an error if called before the
+        Runtime is started, and will return the Runtime's eventloop otherwise.
+        """
+        with self.assertRaises(RuntimeError):
+            # Runtime hasn't started yet: error!
+            _ = self.runtime._get_eventloop()
+
+        # Runtime has started: no error
+        await self.start_runtime_loop()
+        eventloop = self.runtime._get_eventloop()
+        self.assertIsInstance(eventloop, asyncio.AbstractEventLoop)
+
 
 @patch("streamlit.source_util._cached_pages", new=None)
 class ScriptCheckTest(RuntimeTestCase):

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -70,7 +70,7 @@ class RuntimeTestCase(IsolatedAsyncioTestCase):
         session_info.session._enqueue_forward_msg(msg)
 
     def patch_app_session(self):
-        """Mock the Runtime's AppSession import. We don't want
+        """Mock the Runtime's AppSession import. Use this on tests where we don't want
         actual sessions to be instantiated, or scripts to be run.
         """
         return mock.patch(

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -220,36 +220,6 @@ class ServerTest(ServerTestCase):
                     self.server._runtime._get_session_info(session_info.session.id)
                 )
 
-    @tornado.testing.gen_test
-    async def test_is_active_session(self):
-        """is_active_session should return True for active session_ids."""
-        with self._patch_app_session():
-            await self.start_server_loop()
-            await self.ws_connect()
-
-            # Get our connected BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
-
-            self.assertFalse(self.server._runtime.is_active_session("not_a_session_id"))
-            self.assertTrue(
-                self.server._runtime.is_active_session(session_info.session.id)
-            )
-
-    @tornado.testing.gen_test
-    async def test_get_eventloop(self):
-        """Server._get_eventloop() will raise an error if called before the
-        Server is started, and will return the Server's eventloop otherwise.
-        """
-        with self._patch_app_session():
-            with self.assertRaises(RuntimeError):
-                # Server hasn't started yet: error!
-                _ = self.server._runtime._get_eventloop()
-
-            # Server has started: no error
-            await self.start_server_loop()
-            eventloop = self.server._runtime._get_eventloop()
-            self.assertIsInstance(eventloop, asyncio.AbstractEventLoop)
-
 
 class PortRotateAHundredTest(unittest.TestCase):
     """Tests port rotation handles a MAX_PORT_SEARCH_RETRIES attempts then sys exits"""


### PR DESCRIPTION
Final (?) round of tests:
- `test_shutdown_appsessions_on_stop`
- `test_get_eventloop` (moved from server_test)
- Removed `server_test.test_is_active_session` (it's redundant: we have essentially the same test in RuntimeTest now.)