### PR TITLE
Runtime: dont pass coroutines to async wait

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -449,7 +449,10 @@ class Runtime:
             while not self._must_stop.is_set():
                 if self._state == RuntimeState.NO_SESSIONS_CONNECTED:
                     await asyncio.wait(
-                        [self._must_stop.wait(), self._has_connection.wait()],
+                        (
+                            asyncio.create_task(self._must_stop.wait()),
+                            asyncio.create_task(self._has_connection.wait()),
+                        ),
                         return_when=asyncio.FIRST_COMPLETED,
                     )
 
@@ -481,7 +484,10 @@ class Runtime:
                     break
 
                 await asyncio.wait(
-                    [self._must_stop.wait(), self._need_send_data.wait()],
+                    (
+                        asyncio.create_task(self._must_stop.wait()),
+                        asyncio.create_task(self._need_send_data.wait()),
+                    ),
                     return_when=asyncio.FIRST_COMPLETED,
                 )
 


### PR DESCRIPTION
Passing coroutines directly `asyncio.wait` [is deprecated](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait) and will raise an error in Python 3.11.

The proper thing to do here is to wrap coroutines in Tasks (which `asyncio.wait` does under the hood). This PR does that (and also passes the tasks as a tuple instead of a list as a micro-optimization).