### PR TITLE
Runtime: BackMsg deserialization error handling

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -363,6 +363,37 @@ class Runtime:
 
         session_info.session.handle_backmsg(msg)
 
+    def handle_backmsg_deserialization_exception(
+        self, session_id: str, exc: BaseException
+    ) -> None:
+        """Handle an Exception raised during deserialization of a BackMsg.
+
+        Parameters
+        ----------
+        session_id
+            The session's unique ID.
+        exc
+            The Exception.
+
+        Notes
+        -----
+        Threading: UNSAFE. Must be called on the eventloop thread.
+        """
+        if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
+            raise RuntimeStoppedError(
+                f"Can't handle_backmsg_deserialization_exception (state={self._state})"
+            )
+
+        session_info = self._session_info_by_id.get(session_id)
+        if session_info is None:
+            LOGGER.debug(
+                "Discarding BackMsg Exception for disconnected session (id=%s)",
+                session_id,
+            )
+            return
+
+        session_info.session.handle_backmsg_exception(exc)
+
     @property
     async def is_ready_for_browser_connection(self) -> Tuple[bool, str]:
         if self._state not in (

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import mock
+from unittest.mock import MagicMock
 
 import tornado.httpserver
 import tornado.testing
@@ -20,7 +21,7 @@ import tornado.web
 import tornado.websocket
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.runtime import SessionClientDisconnectedError
+from streamlit.runtime.runtime import SessionClientDisconnectedError, Runtime
 from streamlit.web.server.server import BrowserWebSocketHandler
 from .server_test_case import ServerTestCase
 
@@ -59,3 +60,25 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
                     websocket_handler.write_forward_msg(msg)
 
                 write_message_mock.assert_called_once()
+
+    @tornado.testing.gen_test
+    async def test_backmsg_deserialization_exception(self):
+        """If BackMsg deserialization raises an Exception, we should call the Runtime's
+        handler.
+        """
+        with self._patch_app_session():
+            await self.start_server_loop()
+            await self.ws_connect()
+
+            # Get our BrowserWebSocketHandler
+            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            websocket_handler: BrowserWebSocketHandler = session_info.client
+
+            mock_runtime = MagicMock(spec=Runtime)
+            websocket_handler._runtime = mock_runtime
+
+            # Send a malformed BackMsg
+            websocket_handler.on_message(b"NotABackMsg")
+
+            mock_runtime.handle_backmsg_deserialization_exception.assert_called_once()
+            mock_runtime.handle_backmsg.assert_not_called()


### PR DESCRIPTION
Adds `Runtime.handle_backmsg_deserialization_exception`. BrowserWebSocketHandler calls this if it... gets a deserialization exception.

This resolves the last remaining TODO in the Runtime code. (Previously, BrowserWebSocketHandler just raised a "TODO" exception in this case.)