### PR TITLE
example of width, height 0 with tabs issue couse scrolling up with youtube videos

### DIFF
--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -73,6 +73,7 @@ export default function Video({ element, width }: VideoProps): ReactElement {
     */
   if (type === VideoProto.Type.YOUTUBE_IFRAME) {
     const height = width * 0.75
+    console.info(`VideoProto.Type.YOUTUBE_IFRAME: width: ${width}, height: ${height}`)
 
     return (
       <iframe


### PR DESCRIPTION
This is an example of Video IFrame element having width 0 (and thus height also 0, since it's width 0*0.75).

To test it out:
* Checkout to this branch
* Rebuild and run the following app
```
import streamlit as st

for i in range(20):
    st.markdown("dummy text")

tab1, tab2 = st.tabs(["tab1", "tab2"])

with tab1:
    st.video("https://www.youtube.com/watch?v=R2nr1uZ8ffc")

with tab2:
    st.video("https://www.youtube.com/watch?v=R2nr1uZ8ffc")
```
* Open the console
* Refresh the page, you can see that IFrame has width 0