### PR TITLE
Fix wordwrap for Alert elements

### DIFF
--- a/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-55asu9-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-8npnmo-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;
+exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><div class=\\"css-55asu9-ThemedStyledSpinner e17lx80j1 \\"></div><div data-testid=\\"stMarkdownContainer\\" class=\\"css-5r63x0-StyledStreamlitMarkdown e16nr0p33\\"><p>Loading...</p></div></div>"`;

--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -36,7 +36,7 @@ export const StyledStreamlitMarkdown = styled.div<
   },
 
   p: {
-    wordWrap: "break-word",
+    wordBreak: "break-word",
   },
 
   li: {


### PR DESCRIPTION
## 📚 Context

When a long string with no break words is passed to Alert elements (`st.error`, `st.info`, `st.success`, `st.warning`) the rendered text overflows the bounds of the container in the x-axis. 

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Replaces the CSS property `wordWrap` with `wordBreak` in the StreamlitMarkdown styled component, so that unbreakable words can be broken and wrapped to fit the container width.

  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/184598354-fe45ac90-0a37-4ec5-89b2-4e2fa19d7769.png)

```python
import streamlit as st

st.error(
    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
)
st.info(
    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
)
st.warning(
    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
)
st.success(
    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
)

```

**Current:**

![image](https://user-images.githubusercontent.com/20672874/184598641-0d230a70-6701-482b-9c11-ffc3b532f95f.png)


## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #5139 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
