### PR TITLE
Allow Runtime to be constructed on another thread

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import threading
 import time
 import traceback
 from asyncio import Future
@@ -117,9 +116,6 @@ class AsyncObjects(NamedTuple):
 
     # The eventloop that Runtime is running on.
     eventloop: asyncio.AbstractEventLoop
-
-    # The eventloop's thread.
-    thread: threading.Thread
 
     # Set after Runtime.stop() is called. Never cleared.
     must_stop: asyncio.Event
@@ -479,7 +475,6 @@ class Runtime:
 
         async_objs = AsyncObjects(
             eventloop=asyncio.get_running_loop(),
-            thread=threading.current_thread(),
             must_stop=asyncio.Event(),
             has_connection=asyncio.Event(),
             need_send_data=asyncio.Event(),

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -31,7 +31,7 @@ from streamlit.runtime.runtime import (
     RuntimeConfig,
     RuntimeStoppedError,
     SessionClientDisconnectedError,
-    AsyncData,
+    AsyncObjects,
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.watcher import event_based_path_watcher
@@ -456,18 +456,17 @@ class RuntimeTest(RuntimeTestCase):
             [],
         )
 
-    async def test_get_async_data(self):
-        """Runtime._get_async_data() will raise an error if called before the
-        Runtime is started, and will return the Runtime's eventloop otherwise.
+    async def test_get_async_objs(self):
+        """Runtime._get_async_objs() will raise an error if called before the
+        Runtime is started, and will return the Runtime's AsyncObjects instance otherwise.
         """
         with self.assertRaises(RuntimeError):
             # Runtime hasn't started yet: error!
-            _ = self.runtime._get_async_data()
+            _ = self.runtime._get_async_objs()
 
         # Runtime has started: no error
         await self.start_runtime_loop()
-        data = self.runtime._get_async_data()
-        self.assertIsInstance(data, AsyncData)
+        self.assertIsInstance(self.runtime._get_async_objs(), AsyncObjects)
 
 
 @patch("streamlit.source_util._cached_pages", new=None)

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -31,6 +31,7 @@ from streamlit.runtime.runtime import (
     RuntimeConfig,
     RuntimeStoppedError,
     SessionClientDisconnectedError,
+    AsyncData,
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.watcher import event_based_path_watcher
@@ -455,18 +456,18 @@ class RuntimeTest(RuntimeTestCase):
             [],
         )
 
-    async def test_get_eventloop(self):
-        """Runtime._get_eventloop() will raise an error if called before the
+    async def test_get_async_data(self):
+        """Runtime._get_async_data() will raise an error if called before the
         Runtime is started, and will return the Runtime's eventloop otherwise.
         """
         with self.assertRaises(RuntimeError):
             # Runtime hasn't started yet: error!
-            _ = self.runtime._get_eventloop()
+            _ = self.runtime._get_async_data()
 
         # Runtime has started: no error
         await self.start_runtime_loop()
-        eventloop = self.runtime._get_eventloop()
-        self.assertIsInstance(eventloop, asyncio.AbstractEventLoop)
+        data = self.runtime._get_async_data()
+        self.assertIsInstance(data, AsyncData)
 
 
 @patch("streamlit.source_util._cached_pages", new=None)

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -35,6 +35,11 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
 
         def create_runtime_on_another_thread():
             try:
+                # This function should be called in another thread, which
+                # should not already have an asyncio loop.
+                with self.assertRaises(BaseException):
+                    asyncio.get_running_loop()
+
                 # Create a Runtime instance and put it in the (thread-safe) queue,
                 # so that the main thread can retrieve it safely. If Runtime
                 # creation fails, we'll stick an Exception in the queue instead.

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -53,9 +53,10 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
         if isinstance(runtime, BaseException):
             raise runtime
 
+        # Ensure we can start and stop the Runtime
         runtime_started = asyncio.Future()
         _ = asyncio.create_task(runtime.run(lambda: runtime_started.set_result(None)))
 
-        await asyncio.wait_for(runtime_started, timeout=1)
+        await runtime_started
         runtime.stop()
-        await asyncio.wait_for(runtime.stopped, timeout=1)
+        await runtime.stopped

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -16,8 +16,8 @@ import asyncio
 import threading
 from queue import Queue
 
-from isolated_asyncio_test_case import IsolatedAsyncioTestCase
 from streamlit.runtime.runtime import Runtime, RuntimeConfig
+from tests.isolated_asyncio_test_case import IsolatedAsyncioTestCase
 
 
 class RuntimeThreadingTest(IsolatedAsyncioTestCase):

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -1,0 +1,59 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import threading
+from queue import Queue
+
+from isolated_asyncio_test_case import IsolatedAsyncioTestCase
+from streamlit.runtime.runtime import Runtime, RuntimeConfig
+
+
+class RuntimeThreadingTest(IsolatedAsyncioTestCase):
+    """Threading-related Runtime tests."""
+
+    async def test_create_runtime_on_another_thread(self):
+        """The Runtime can be created on a thread that it doesn't actually
+        run on. This test will fail if Runtime's various asyncio initialization
+        bits are performed in its constructor instead of in "start".
+        """
+
+        queue = Queue()
+
+        def create_runtime_on_another_thread():
+            try:
+                # Create a Runtime instance and put it in the (thread-safe) queue,
+                # so that the main thread can retrieve it safely. If Runtime
+                # creation fails, we'll stick an Exception in the queue instead.
+                config = RuntimeConfig("mock/script/path.py", "")
+                queue.put(Runtime(config))
+            except BaseException as e:
+                queue.put(e)
+
+        thread = threading.Thread(target=create_runtime_on_another_thread)
+        thread.start()
+        thread.join(timeout=1)
+        if thread.is_alive():
+            raise RuntimeError("Thread.join timed out!")
+
+        runtime = queue.get(block=True, timeout=1)
+        if isinstance(runtime, BaseException):
+            raise runtime
+
+        runtime_started = asyncio.Future()
+        _ = asyncio.create_task(runtime.run(lambda: runtime_started.set_result(None)))
+
+        await asyncio.wait_for(runtime_started, timeout=1)
+        runtime.stop()
+        await asyncio.wait_for(runtime.stopped, timeout=1)

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -24,9 +24,11 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
     """Threading-related Runtime tests."""
 
     async def test_create_runtime_on_another_thread(self):
-        """The Runtime can be created on a thread that it doesn't actually
-        run on. This test will fail if Runtime's various asyncio initialization
-        bits are performed in its constructor instead of in "start".
+        """Test that Runtime can be constructed on a thread that it doesn't actually
+        run on.
+
+        (This test will fail if Runtime's various asyncio initialization bits are
+        performed in its constructor instead of in "start".)
         """
 
         queue = Queue()

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -208,7 +208,7 @@ class ServerTest(ServerTestCase):
                 # and the Websocket client's write_message will be called,
                 # raising our WebSocketClosedError.
                 while not flush_browser_queue.called:
-                    self.server._runtime._get_async_data().need_send_data.set()
+                    self.server._runtime._get_async_objs().need_send_data.set()
                     await asyncio.sleep(0)
 
                 flush_browser_queue.assert_called_once()

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -208,7 +208,7 @@ class ServerTest(ServerTestCase):
                 # and the Websocket client's write_message will be called,
                 # raising our WebSocketClosedError.
                 while not flush_browser_queue.called:
-                    self.server._runtime._need_send_data.set()
+                    self.server._runtime._get_async_data().need_send_data.set()
                     await asyncio.sleep(0)
 
                 flush_browser_queue.assert_called_once()


### PR DESCRIPTION
asyncio synchronization primitives (Futures, Events, etc) need to be constructed on a thread that's already running an asyncio event loop. (When constructed, these primitives get associated with the current event loop.)

Currently, Runtime creates its various asyncio primitives in its constructor, which means that things go very wrong if the Runtime is constructed on a different thread (or on a thread that isn't yet running an eventloop). 

This PR changes that: all Runtime async primitives now live inside an `AsyncObjects` object, which is constructed at the start of the Runtime's looping coroutine.