### PR TITLE
Create a Pipenv lockfile to get better resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ pipenv-dev-install: lib/Pipfile
 	# "more deterministic", per pipenv's documentation.
 	# (Omitting this flag is causing incorrect dependency version
 	# resolution on CircleCI.)
+	# The lockfile is created to force resolution of all dependencies at once,
+	# but we don't actually want to use the lockfile.
 	cd lib; \
 		rm Pipfile.lock; \
 		pipenv install --dev --sequential

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ pipenv-dev-install: lib/Pipfile
 	# (Omitting this flag is causing incorrect dependency version
 	# resolution on CircleCI.)
 	cd lib; \
-		pipenv install --dev --skip-lock --sequential
+		rm Pipfile.lock; \
+		pipenv install --dev --sequential
 
 SHOULD_INSTALL_TENSORFLOW := $(shell python scripts/should_install_tensorflow.py)
 .PHONY: py-test-install

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -100,6 +100,7 @@ COPY --chown=$USER lib/test-requirements.txt ./lib/
 COPY --chown=$USER lib/setup.py ./lib/
 
 # install python modules
+# This would be `make pipenv-install`, but lockfile creation somehow breaks it
 RUN IS_DOCKER=true CIRCLECI=true cd ./lib/ && pipenv install --dev --sequential --skip-lock && cd -
 RUN IS_DOCKER=true CIRCLECI=true make py-test-install
 

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -100,7 +100,8 @@ COPY --chown=$USER lib/test-requirements.txt ./lib/
 COPY --chown=$USER lib/setup.py ./lib/
 
 # install python modules
-RUN IS_DOCKER=true CIRCLECI=true make pipenv-install
+RUN IS_DOCKER=true CIRCLECI=true cd ./lib/ && pipenv install --dev --sequential --skip-lock && cd -
+RUN IS_DOCKER=true CIRCLECI=true make py-test-install
 
 # copy streamlit code
 COPY --chown=$USER . .

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -12,7 +12,6 @@ mypy = ">=0.930"
 mypy-protobuf = ">=3.2"
 parameterized = "*"
 pipenv = "*"
-
 # Lower protobuf versions cause mypy issues during development builds
 protobuf = ">=3.19, <4"
 pytest = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -12,6 +12,7 @@ mypy = ">=0.930"
 mypy-protobuf = ">=3.2"
 parameterized = "*"
 pipenv = "*"
+
 # Lower protobuf versions cause mypy issues during development builds
 protobuf = ">=3.19, <4"
 pytest = "*"


### PR DESCRIPTION
Otherwise it resolves dev dependencies separately and chooses to install
a version of protobuf that is incompatible with our actual requirements.

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

