### PR TITLE
Exclude Python 3.9.7 from supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,11 @@ commands:
             md5sum lib/test-requirements-with-tensorflow.txt >> ~/python_cache_key.md5
             md5sum lib/setup.py >> ~/python_cache_key.md5
             date +%F >> ~/python_cache_key.md5
+            # Cache version that can be used to bust the cache before it
+            # naturally resets daily. We maintain the convention that the
+            # version number is always incremented by 1, but technically it can
+            # be reset each day when the previous day's cache expires.
+            echo v1 >> ~/python_cache_key.md5
 
       - run: &create_node_cache_key
           name: Create Node cache key
@@ -315,7 +320,7 @@ jobs:
   build-deploy-rc:
     resource_class: large
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
     working_directory: ~/repo
     steps:
       - checkout:
@@ -371,7 +376,7 @@ jobs:
   build-deploy-release:
     resource_class: large
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
     working_directory: ~/repo
     steps:
       - checkout:
@@ -465,7 +470,7 @@ jobs:
 
   python-max-version: &job-template
     docker:
-      - image: circleci/python:3.10.0
+      - image: circleci/python:3.10.1
 
     working_directory: ~/repo
 
@@ -574,7 +579,7 @@ jobs:
 
   python-prod-deps-smoke-test:
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
 
     working_directory: ~/repo
 
@@ -626,7 +631,7 @@ jobs:
 
   create-tag:
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
 
     working_directory: ~/repo
 
@@ -673,7 +678,7 @@ jobs:
 
   nightly-release:
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
 
     resource_class: large
 
@@ -719,7 +724,7 @@ jobs:
 
   pr-preview:
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
 
     resource_class: large
 
@@ -920,7 +925,7 @@ jobs:
   cli-regression-test:
     resource_class: large
     docker:
-      - image: circleci/python:3.9.7
+      - image: circleci/python:3.10.1
     working_directory: ~/repo
     steps:
       - checkout:

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -106,7 +106,10 @@ setuptools.setup(
     },
     author="Streamlit Inc",
     author_email="hello@streamlit.io",
-    python_requires=">=3.7",
+    # We exclude Python 3.9.7 from our compatible versions due to a bug in that version
+    # with typing.Protocol. See https://github.com/streamlit/streamlit/issues/5140 and
+    # https://bugs.python.org/issue45121
+    python_requires=">=3.7, !=3.9.7",
     license="Apache 2",
     # PEP 561: https://mypy.readthedocs.io/en/stable/installed_packages.html
     package_data={"streamlit": ["py.typed", "hello/**/*.py"]},


### PR DESCRIPTION
## 📚 Context

#5140 was caused by an issue specific to Python 3.9.7 (see https://bugs.python.org/issue45121).
Some typing improvements that made use of `typing.Protocol` introduced in `streamlit 1.2.0` started
breaking on this version due to that Python bug.

Assuming that these types of issues don't come up very often, a reasonable thing to do here is to
encourage people to upgrade to a patch version of Python 3.9 that doesn't have this issue. This PR
marks version 3.9.7 as not supported so that people running that version of Python get a friendly(-ish)
error message from pip when trying to install Streamlit.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Supported version change

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change

## 🌐 References

Closes #5140
