### PR TITLE
Allow BackMsg<->ForwardMsg association for easier performance testing

### DIFF
--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -54,5 +54,10 @@ message BackMsg {
     bool load_git_info = 12;
   }
 
+  // An ID used to associate this BackMsg with the corresponding ForwardMsgs
+  // that are sent to the client due to it. As its name suggests, this field
+  // should only be used for testing.
+  string debug_last_backmsg_id = 13;
+
   reserved 1, 2, 3, 4, 8, 9;
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -71,8 +71,13 @@ message ForwardMsg {
     string ref_hash = 11;
   }
 
+  // The ID of the last BackMsg that we received before sending this
+  // ForwardMsg. As its name suggests, this field should only be used for
+  // testing.
+  string debug_last_backmsg_id = 17;
+
   reserved 7, 8;
-  // Next: 17
+  // Next: 18
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)


### PR DESCRIPTION
## 📚 Context

For some performance work that we're doing, we'd like to be able to more easily
associate `ForwardMsg`s with the `BackMsg`s that triggered the script run that
created them.

In order to do this, we allow a new `debug_last_backmsg_id` field to be set
in a `BackMsg` so that all `ForwardMsg`s that are sent from the time the
`BackMsg` is received to the end of the corresponding script run are tagged with
the same ID.

Note that these proto fields are only intended to be used for testing, and
because of this their names begin with the `debug_` prefix. In particular, we
never expect a real Streamlit web client to ever set this field.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Test infrastructure additions

## 🧪 Testing Done

- [x] Added/Updated unit tests
