### PR TITLE
ask for protobuf version only if we're not on circleci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,15 +214,25 @@ protobuf:
 		echo "protoc not installed."; \
 		exit 1; \
 	fi
-	protoc_version=$$(protoc --version | cut -d ' ' -f 2); \
-	protobuf_version=$$(pip show protobuf | grep Version | cut -d " " -f 2-); \
-	if [[ "$${protoc_version%.*.*}" != "$${protobuf_version%.*.*}" ]] ; then \
-		echo -e '\033[31m WARNING: Protoc and protobuf version mismatch \033[0m'; \
-		echo "To avoid compatibility issues, please ensure that the protoc version matches the protobuf version you have installed."; \
-		echo "protoc version: $${protoc_version}"; \
-		echo "protobuf version: $${protobuf_version}"; \
-		echo -n "Do you want to continue anyway? [y/N] " && read ans && [ $${ans:-N} = y ]; \
-	fi
+	protoc_version=$$(protoc --version | cut -d ' ' -f 2);
+	protobuf_version=$$(pip show protobuf | grep Version | cut -d " " -f 2-);
+ifndef CIRCLECI
+			if [[ "$${protoc_version%.*.*}" != "$${protobuf_version%.*.*}" ]] ; then \
+				echo -e '\033[31m WARNING: Protoc and protobuf version mismatch \033[0m'; \
+				echo "To avoid compatibility issues, please ensure that the protoc version matches the protobuf version you have installed."; \
+				echo "protoc version: $${protoc_version}"; \
+				echo "protobuf version: $${protobuf_version}"; \
+				echo -n "Do you want to continue anyway? [y/N] " && read ans && [ $${ans:-N} = y ]; \
+			fi
+else
+		if [[ "$${protoc_version%.*.*}" != "$${protobuf_version%.*.*}" ]] ; then \
+				echo -e '\033[31m WARNING: Protoc and protobuf version mismatch \033[0m'; \
+				echo "To avoid compatibility issues, please ensure that the protoc version matches the protobuf version you have installed."; \
+				echo "protoc version: $${protoc_version}"; \
+				echo "protobuf version: $${protobuf_version}"; \
+				echo "Since we're on CI we try to continue anyway..."; \
+		fi
+endif
 	protoc \
 		--proto_path=proto \
 		--python_out=lib \


### PR DESCRIPTION
## 📚 Context

_Please describe the project or issue background here_

Seems like our CI is broken, because it checks for match between System's `protobuf` and Python's version and asks for confirmation.

I believe for best results we should have same version of this library both on System and CI, but this is out of scope of this PR. This PR removes the check on CI for same protobuf version, which will fix our CI. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
