### PR TITLE
Custom index implementation supporting improvement

### DIFF
--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -126,15 +126,17 @@ def index_(iterable, x) -> int:
     -------
     int
     """
-
+    if x is None:
+        return 0
+    
     for i, value in enumerate(iterable):
         # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
         # https://github.com/streamlit/streamlit/issues/4663
-        if isinstance(value, np.float64) or isinstance(value, float):
+        if x == value:
+            return i
+        elif isinstance(value, np.float64) or isinstance(value, float):
             if abs(x - value) < FLOAT_EQUALITY_EPSILON:
                 return i
-        elif x == value:
-            return i
     raise ValueError("{} is not in iterable".format(str(x)))
 
 


### PR DESCRIPTION
Using the current implementation of the index I found two edge cases which where not working as expected:

1. Value which is looked for is `None` which when compared to a `float` is returning a `TypeError`. We could do as in the higher level use of `index_` where when `None` the `0` index is returned.
2. When value to check or in the iterable is `float("inf")`, which is a `float` number but `float("inf") - float("inf")` results on `nan` which makes the statement of float comparison fail. Then, I think it is better to first compare values directly and only check the float equality with epsilon in case of not matching.