### PR TITLE
Make st.write render sets as list instead of strings

### DIFF
--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import copy
 from typing import Any, cast, TYPE_CHECKING
 
 from streamlit.proto.Json_pb2 import Json as JsonProto
@@ -22,6 +23,20 @@ from streamlit.user_info import UserInfoProxy
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+
+
+def _convert_sets_to_lists(body: Any) -> Any:
+    # Convert sets into lists, which render more nicely on the frontend
+    set_found = False
+    for key in body:
+        if isinstance(body[key], set):
+            if not set_found:
+                # When set is found to prevent mutation of input body, we need to shallow copy it once
+                # To avoid copying it multiple times we use set_found flag
+                body = copy.copy(body)
+                set_found = True
+            body[key] = list(body[key])
+    return body
 
 
 class JsonMixin:
@@ -69,7 +84,17 @@ class JsonMixin:
             body = body.to_dict()
 
         if not isinstance(body, str):
+            # Check if body is iterable, if it is convert it's sets to lists
             try:
+                iter(body)
+            except TypeError:
+                # body is not iterable, do nothing with the body
+                pass
+            else:
+                # body is iterable, look for sets and change them to lists
+                body = _convert_sets_to_lists(body)
+            try:
+                # Serialize body to string
                 body = json.dumps(body, default=repr)
             except TypeError as err:
                 st.warning(

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -463,6 +463,29 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(json_string, element.json.body)
         self.assertEqual(False, element.json.expanded)
 
+    def test_json_not_mutates_data_containing_sets(self):
+        """Test st.json do not mutate data containing sets,
+        pass a dict-containing-a-set to st.json; ensure that it's not mutated
+        """
+        json_data = {"some_set": {"a", "b"}}
+        self.assertIsInstance(json_data["some_set"], set)
+
+        st.json(json_data)
+        self.assertIsInstance(json_data["some_set"], set)
+
+    def test_json_serializes_sets_as_lists(self):
+        """Test st.json serializes sets as lists"""
+        json_data = {"some_set": {"a", "b"}}
+
+        st.json(json_data)
+        element = self.get_delta_from_queue().new_element
+
+        parsed_element = json.loads(element.json.body)
+        set_as_list = parsed_element.get("some_set")
+
+        self.assertIsInstance(set_as_list, list)
+        self.assertSetEqual(json_data["some_set"], set(set_as_list))
+
     def test_markdown(self):
         """Test Markdown element."""
         test_string = "    data         "


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:

This PR is related to [Issue-#4923](https://github.com/streamlit/streamlit/issues/4923). It makes `st.write` to serialize `set` as `list` instead of `string`, so the user can benefit on existing collapse mechanism when browsing the data.

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

Currently `set` is serialized to string, when using `st.write`, like this:

```
{
  "list": [],
  "set": "set()",
  "dict": {}
}
```
I'd like to render them as `list`, so we can benefit on existing `st.json` collapse mechanism when browsing the data.

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes [#4923](https://github.com/streamlit/streamlit/issues/4923)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
