### PR TITLE
future-based Runtime.start, Server.start

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import sys
 import time
 import traceback
 from asyncio import Future
@@ -247,9 +248,14 @@ class Runtime:
         )
         self._async_objs = async_objs
 
-        self._loop_coroutine_task = asyncio.create_task(
-            self._loop_coroutine(), name="Runtime.loop_coroutine"
-        )
+        if sys.version_info >= (3, 8, 0):
+            # Python 3.8+ supports a create_task `name` parameter, which can
+            # make debugging a bit easier.
+            self._loop_coroutine_task = asyncio.create_task(
+                self._loop_coroutine(), name="Runtime.loop_coroutine"
+            )
+        else:
+            self._loop_coroutine_task = asyncio.create_task(self._loop_coroutine())
 
         await async_objs.started
 

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -150,8 +150,8 @@ class Runtime:
         self._async_objs: Optional[AsyncObjects] = None
 
         # The task that runs our main loop. We need to save a reference
-        # to it so that the task doesn't get garbage collected while running.
-        self._loop_coroutine_task: Optional[asyncio.Task] = None
+        # to it so that it doesn't get garbage collected while running.
+        self._loop_coroutine_task: Optional[asyncio.Task[None]] = None
 
         self._main_script_path = config.script_path
         self._command_line = config.command_line or ""

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -17,12 +17,7 @@ import logging
 import os
 import socket
 import sys
-from typing import (
-    Any,
-    Optional,
-    Callable,
-    List,
-)
+from typing import Any, Optional, List, Callable
 
 import click
 import tornado.concurrent
@@ -207,7 +202,9 @@ class Server:
         port = config.get_option("server.port")
         LOGGER.debug("Server started on port %s", port)
 
-        await self._runtime.run(on_started=lambda: on_started(self))
+        await self._runtime.start()
+        on_started(self)
+        await self._runtime.stopped
 
     def _create_app(self) -> tornado.web.Application:
         """Create our tornado web app."""

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -58,7 +58,7 @@ class RuntimeTest(RuntimeTestCase):
         """starting and stopping the Runtime should work as expected."""
         self.assertEqual(RuntimeState.INITIAL, self.runtime.state)
 
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.assertEqual(RuntimeState.NO_SESSIONS_CONNECTED, self.runtime.state)
 
         self.runtime.stop()
@@ -70,7 +70,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_create_session(self):
         """We can create and remove a single session."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         session_id = self.runtime.create_session(
             client=MockSessionClient(), user_info=MagicMock()
@@ -85,7 +85,7 @@ class RuntimeTest(RuntimeTestCase):
     async def test_close_session_shuts_down_appsession(self):
         """Closing a session should shutdown its associated AppSession."""
         with self.patch_app_session():
-            await self.start_runtime_loop()
+            await self.runtime.start()
 
             # Create a session and get its associated AppSession object.
             session_id = self.runtime.create_session(
@@ -99,7 +99,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_multiple_sessions(self):
         """Multiple sessions can be connected."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         session_ids = []
         for _ in range(3):
@@ -126,7 +126,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_close_invalid_session(self):
         """Closing a session that doesn't exist is a no-op: no error raised."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         # Close a session that never existed
         self.runtime.close_session("no_such_session")
@@ -140,7 +140,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_is_active_session(self):
         """`is_active_session` should work as expected."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
         session_id = self.runtime.create_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
@@ -153,7 +153,7 @@ class RuntimeTest(RuntimeTestCase):
     async def test_shutdown_appsessions_on_stop(self):
         """When the Runtime stops, it should shut down open AppSessions."""
         with self.patch_app_session():
-            await self.start_runtime_loop()
+            await self.runtime.start()
 
             # Create a few sessions
             app_sessions = []
@@ -180,7 +180,7 @@ class RuntimeTest(RuntimeTestCase):
     async def test_handle_backmsg(self):
         """BackMsgs should be delivered to the appropriate AppSession."""
         with self.patch_app_session():
-            await self.start_runtime_loop()
+            await self.runtime.start()
             session_id = self.runtime.create_session(
                 client=MockSessionClient(), user_info=MagicMock()
             )
@@ -193,7 +193,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_handle_backmsg_invalid_session(self):
         """A BackMsg for an invalid session should get dropped without an error."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.runtime.handle_backmsg("not_a_session_id", MagicMock())
 
     async def test_handle_backmsg_deserialization_exception(self):
@@ -201,7 +201,7 @@ class RuntimeTest(RuntimeTestCase):
         appropriate AppSession.
         """
         with self.patch_app_session():
-            await self.start_runtime_loop()
+            await self.runtime.start()
             session_id = self.runtime.create_session(
                 client=MockSessionClient(), user_info=MagicMock()
             )
@@ -215,14 +215,14 @@ class RuntimeTest(RuntimeTestCase):
     async def test_handle_backmsg_exception_invalid_session(self):
         """A BackMsg exception for an invalid session should get dropped without an
         error."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.runtime.handle_backmsg_deserialization_exception(
             "not_a_session_id", MagicMock()
         )
 
     async def test_create_session_after_stop(self):
         """After Runtime.stop is called, `create_session` is an error."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.runtime.stop()
         await self.tick_runtime_loop()
 
@@ -231,7 +231,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_handle_backmsg_after_stop(self):
         """After Runtime.stop is called, `handle_backmsg` is an error."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.runtime.stop()
         await self.tick_runtime_loop()
 
@@ -244,14 +244,14 @@ class RuntimeTest(RuntimeTestCase):
         """
         # This will frequently be True from other tests
         streamlit._is_running_with_streamlit = False
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.assertTrue(streamlit._is_running_with_streamlit)
 
     async def test_handle_session_client_disconnected(self):
         """Runtime should gracefully handle `SessionClient.write_forward_msg`
         raising a `SessionClientDisconnectedError`.
         """
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         client = MagicMock(spec=SessionClient)
         session_id = self.runtime.create_session(client, MagicMock())
@@ -275,7 +275,7 @@ class RuntimeTest(RuntimeTestCase):
 
     async def test_forwardmsg_hashing(self):
         """Test that outgoing ForwardMsgs contain hashes."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         client = MockSessionClient()
         session_id = self.runtime.create_session(client=client, user_info=MagicMock())
@@ -293,7 +293,7 @@ class RuntimeTest(RuntimeTestCase):
     async def test_forwardmsg_cacheable_flag(self):
         """Test that the metadata.cacheable flag is set properly on outgoing
         ForwardMsgs."""
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         client = MockSessionClient()
         session_id = self.runtime.create_session(client=client, user_info=MagicMock())
@@ -319,7 +319,7 @@ class RuntimeTest(RuntimeTestCase):
     async def test_duplicate_forwardmsg_caching(self):
         """Test that duplicate ForwardMsgs are sent only once."""
         with patch_config_options({"global.minCachedMessageSize": 0}):
-            await self.start_runtime_loop()
+            await self.runtime.start()
 
             client = MockSessionClient()
             session_id = self.runtime.create_session(
@@ -356,7 +356,7 @@ class RuntimeTest(RuntimeTestCase):
         with patch_config_options(
             {"global.minCachedMessageSize": 0, "global.maxCachedMessageAge": 1}
         ):
-            await self.start_runtime_loop()
+            await self.runtime.start()
 
             client = MockSessionClient()
             session_id = self.runtime.create_session(
@@ -416,7 +416,7 @@ class RuntimeTest(RuntimeTestCase):
         """An uploaded file with no associated AppSession should be
         deleted.
         """
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
         client = MockSessionClient()
         session_id = self.runtime.create_session(client=client, user_info=MagicMock())
@@ -465,7 +465,7 @@ class RuntimeTest(RuntimeTestCase):
             _ = self.runtime._get_async_objs()
 
         # Runtime has started: no error
-        await self.start_runtime_loop()
+        await self.runtime.start()
         self.assertIsInstance(self.runtime._get_async_objs(), AsyncObjects)
 
 
@@ -485,7 +485,7 @@ class ScriptCheckTest(RuntimeTestCase):
     async def asyncSetUp(self):
         config = RuntimeConfig(script_path=self._path, command_line="mock command line")
         self.runtime = Runtime(config)
-        await self.start_runtime_loop()
+        await self.runtime.start()
 
     def tearDown(self) -> None:
         if event_based_path_watcher._MultiPathWatcher._singleton is not None:

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-from asyncio import Future
 from unittest import mock
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -36,17 +35,6 @@ class RuntimeTestCase(IsolatedAsyncioTestCase):
         if self.runtime.state != RuntimeState.INITIAL:
             self.runtime.stop()
             await self.runtime.stopped
-
-    async def start_runtime_loop(self) -> None:
-        """Start the Runtime loop. Call this before calling any other Runtime functions."""
-        runtime_started = Future()
-        on_started = lambda: runtime_started.set_result(None)
-
-        # Per the create_task docs, we need to retain a reference to this
-        # task. https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-        self._runtime_task = asyncio.create_task(self.runtime.run(on_started))
-
-        await runtime_started
 
     @staticmethod
     async def tick_runtime_loop() -> None:

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -59,9 +59,6 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
             raise runtime
 
         # Ensure we can start and stop the Runtime
-        runtime_started = asyncio.Future()
-        _ = asyncio.create_task(runtime.run(lambda: runtime_started.set_result(None)))
-
-        await runtime_started
+        await runtime.start()
         runtime.stop()
         await runtime.stopped

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -34,7 +34,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
         """
 
         with self._patch_app_session():
-            await self.start_server_loop()
+            await self.server.start()
             await self.ws_connect()
 
             # Get our connected BrowserWebSocketHandler
@@ -67,7 +67,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
         handler.
         """
         with self._patch_app_session():
-            await self.start_server_loop()
+            await self.server.start()
             await self.ws_connect()
 
             # Get our BrowserWebSocketHandler

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -72,7 +72,7 @@ class ServerTest(ServerTestCase):
     async def test_start_stop(self):
         """Test that we can start and stop the server."""
         with _patch_local_sources_watcher(), self._patch_app_session():
-            await self.start_server_loop()
+            await self.server.start()
             self.assertEqual(
                 RuntimeState.NO_SESSIONS_CONNECTED, self.server._runtime._state
             )
@@ -93,7 +93,7 @@ class ServerTest(ServerTestCase):
     async def test_websocket_connect(self):
         """Test that we can connect to the server via websocket."""
         with _patch_local_sources_watcher(), self._patch_app_session():
-            await self.start_server_loop()
+            await self.server.start()
 
             self.assertFalse(self.server.browser_is_connected)
 
@@ -119,7 +119,7 @@ class ServerTest(ServerTestCase):
     async def test_multiple_connections(self):
         """Test multiple websockets can connect simultaneously."""
         with _patch_local_sources_watcher(), self._patch_app_session():
-            await self.start_server_loop()
+            await self.server.start()
 
             self.assertFalse(self.server.browser_is_connected)
 
@@ -153,7 +153,7 @@ class ServerTest(ServerTestCase):
     async def test_websocket_compression(self):
         with _patch_local_sources_watcher(), self._patch_app_session():
             config._set_option("server.enableWebsocketCompression", True, "test")
-            await self.start_server_loop()
+            await self.server.start()
 
             # Connect to the server, and explicitly request compression.
             ws_client = await tornado.websocket.websocket_connect(
@@ -169,7 +169,7 @@ class ServerTest(ServerTestCase):
     async def test_websocket_compression_disabled(self):
         with _patch_local_sources_watcher(), self._patch_app_session():
             config._set_option("server.enableWebsocketCompression", False, "test")
-            await self.start_server_loop()
+            await self.server.start()
 
             # Connect to the server, and explicitly request compression.
             ws_client = await tornado.websocket.websocket_connect(
@@ -186,7 +186,7 @@ class ServerTest(ServerTestCase):
         We should gracefully handle the error by cleaning up the session.
         """
         with _patch_local_sources_watcher(), self._patch_app_session():
-            await self.start_server_loop()
+            await self.server.start()
             await self.ws_connect()
 
             # Get the server's socket and session for this client

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import urllib.parse
-from asyncio import Future
 from unittest import mock
 
 import tornado.testing
@@ -21,8 +20,8 @@ import tornado.web
 import tornado.websocket
 from tornado.websocket import WebSocketClientConnection
 
-from streamlit.runtime.app_session import AppSession
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.app_session import AppSession
 from streamlit.web.server import Server
 
 
@@ -46,15 +45,6 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         )
         app = self.server._create_app()
         return app
-
-    async def start_server_loop(self) -> None:
-        """Starts the server's loop coroutine."""
-        server_started = Future()
-        self.io_loop.spawn_callback(
-            self.server.start,
-            lambda _: server_started.set_result(None),
-        )
-        await server_started
 
     def get_ws_url(self, path):
         """Return a ws:// URL with the given path for our test server."""

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -51,8 +51,8 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         """Starts the server's loop coroutine."""
         server_started = Future()
         self.io_loop.spawn_callback(
-            self.server._runtime._loop_coroutine,
-            lambda: server_started.set_result(None),
+            self.server.start,
+            lambda _: server_started.set_result(None),
         )
         await server_started
 


### PR DESCRIPTION
Simplifies starting the Runtime (and starting the Server).

- Previously, we used a callback to signal that the Runtime/Server had started and was ready to accept connections
- But now that we're using asyncio, we can make this much nicer by using Futures instead of Callbacks.
- This means that `Runtime.start`/`Server.start` now both complete immediately, rather than being functions that run forever (until the Runtime/Server is stopped).
- (To implement this, `Runtime.start` kicks off an asyncio.Task that will run its main loop.)
- It also makes our tests a little cleaner.