### PR TITLE
(Hopefully) Ensure demo apps are included in all distributions

### DIFF
--- a/lib/MANIFEST.in
+++ b/lib/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md
 include Pipfile
-include streamlit/config/config.yaml
+include streamlit/py.typed
+recursive-include streamlit/hello *
 recursive-include streamlit/static *


### PR DESCRIPTION
## 📚 Context

I'm not entirely sure if this is the correct fix, but my current theory as to why the
`streamlit hello` demo apps don't appear in `conda-forge` distributions of streamlit is
that they're not included in our `MANIFEST.in`. What may be happening here is that
PyPI takes the tarballs that we upload and repackages them to only include specified files,
so while the tarballs that we generate in CI include the demo apps, those downloadable
from PyPI do not.

- What kind of change does this PR introduce?

  - [x] Bugfix: attempt at including demo apps in conda distributions of streamlit

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change
