### PR TITLE
Relax types for markdown and heading APIs

### DIFF
--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -15,15 +15,16 @@
 from typing import cast, Optional, TYPE_CHECKING
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.string_util import clean_text
+from streamlit.type_util import SupportsStr
 
 if TYPE_CHECKING:
-    import sympy
-
     from streamlit.delta_generator import DeltaGenerator
 
 
 class HeadingMixin:
-    def header(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
+    def header(
+        self, body: SupportsStr, anchor: Optional[str] = None
+    ) -> "DeltaGenerator":
         """Display text in header formatting.
 
         Parameters
@@ -47,7 +48,9 @@ class HeadingMixin:
         header_proto.tag = "h2"
         return self.dg._enqueue("heading", header_proto)
 
-    def subheader(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
+    def subheader(
+        self, body: SupportsStr, anchor: Optional[str] = None
+    ) -> "DeltaGenerator":
         """Display text in subheader formatting.
 
         Parameters
@@ -72,7 +75,9 @@ class HeadingMixin:
 
         return self.dg._enqueue("heading", subheader_proto)
 
-    def title(self, body: str, anchor: Optional[str] = None) -> "DeltaGenerator":
+    def title(
+        self, body: SupportsStr, anchor: Optional[str] = None
+    ) -> "DeltaGenerator":
         """Display text in title formatting.
 
         Each document should have a single `st.title()`, although this is not

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -14,9 +14,9 @@
 
 from typing import cast, Optional, TYPE_CHECKING, Union
 
-from streamlit import type_util
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.string_util import clean_text
+from streamlit.type_util import SupportsStr, is_sympy_expession
 
 if TYPE_CHECKING:
     import sympy
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 
 
 class MarkdownMixin:
-    def markdown(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
+    def markdown(
+        self, body: SupportsStr, unsafe_allow_html: bool = False
+    ) -> "DeltaGenerator":
         """Display string formatted as Markdown.
 
         Parameters
@@ -78,7 +80,9 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
-    def code(self, body: str, language: Optional[str] = "python") -> "DeltaGenerator":
+    def code(
+        self, body: SupportsStr, language: Optional[str] = "python"
+    ) -> "DeltaGenerator":
         """Display a code block with optional syntax highlighting.
 
         (This is a convenience wrapper around `st.markdown()`)
@@ -104,14 +108,13 @@ class MarkdownMixin:
 
         """
         code_proto = MarkdownProto()
-        markdown = "```%(language)s\n%(body)s\n```" % {
-            "language": language or "",
-            "body": body,
-        }
+        markdown = f'```{language or ""}\n{body}\n```'
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
-    def caption(self, body: str, unsafe_allow_html: bool = False) -> "DeltaGenerator":
+    def caption(
+        self, body: SupportsStr, unsafe_allow_html: bool = False
+    ) -> "DeltaGenerator":
         """Display text in small font.
 
         This should be used for captions, asides, footnotes, sidenotes, and
@@ -154,7 +157,7 @@ class MarkdownMixin:
         caption_proto.is_caption = True
         return self.dg._enqueue("markdown", caption_proto)
 
-    def latex(self, body: Union[str, "sympy.Expr"]) -> "DeltaGenerator":
+    def latex(self, body: Union[SupportsStr, "sympy.Expr"]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.
         r"""Display mathematical expressions formatted as LaTeX.
@@ -179,7 +182,7 @@ class MarkdownMixin:
         ...     ''')
 
         """
-        if type_util.is_sympy_expession(body):
+        if is_sympy_expession(body):
             import sympy
 
             body = sympy.latex(body)

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -31,7 +31,7 @@ ESCAPED_EMOJI = [re.escape(e) for e in sorted(ALL_EMOJIS, reverse=True)]
 EMOJI_EXTRACTION_REGEX = re.compile(f"^({'|'.join(ESCAPED_EMOJI)})[_ -]*(.*)")
 
 
-def decode_ascii(string):
+def decode_ascii(string: bytes) -> str:
     """Decodes a string as ascii."""
     return string.decode("ascii")
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -20,14 +20,14 @@ import os
 import subprocess
 import numpy as np
 
-from typing import Any, Dict, List, Mapping, TypeVar
+from typing import Any, Dict, Iterable, List, Mapping, TypeVar
 from typing_extensions import Final
 
 from streamlit import env_util
 
 # URL of Streamlit's help page.
 HELP_DOC: Final = "https://docs.streamlit.io/"
-FLOAT_EQUALITY_EPSILON: Final = 0.000000000005
+FLOAT_EQUALITY_EPSILON: Final[float] = 0.000000000005
 
 
 def memoize(func):
@@ -111,7 +111,10 @@ def repr_(cls) -> str:
     return f"{classname}({args})"
 
 
-def index_(iterable, x) -> int:
+_Value = TypeVar("_Value")
+
+
+def index_(iterable: Iterable[_Value], x: _Value) -> int:
     """Return zero-based index of the first item whose value is equal to x.
     Raises a ValueError if there is no such item.
 
@@ -121,6 +124,7 @@ def index_(iterable, x) -> int:
     Parameters
     ----------
     iterable : list, tuple, numpy.ndarray, pandas.Series
+    x : Any
 
     Returns
     -------
@@ -128,9 +132,7 @@ def index_(iterable, x) -> int:
     """
 
     for i, value in enumerate(iterable):
-        # https://stackoverflow.com/questions/588004/is-floating-point-math-broken
-        # https://github.com/streamlit/streamlit/issues/4663
-        if isinstance(value, np.float64) or isinstance(value, float):
+        if isinstance(value, float) and isinstance(x, float):
             if abs(x - value) < FLOAT_EQUALITY_EPSILON:
                 return i
         elif x == value:
@@ -139,7 +141,6 @@ def index_(iterable, x) -> int:
 
 
 _Key = TypeVar("_Key", bound=str)
-_Value = TypeVar("_Value")
 
 
 def lower_clean_dict_keys(dict: Mapping[_Key, _Value]) -> Dict[str, _Value]:

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -437,12 +437,12 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
             # Python < 3.9 represents the signature slightly differently
             self.assertEqual(
                 el.doc_string.signature,
-                "(body: str, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",
+                "(body: object, anchor: Union[str, NoneType] = None) -> 'DeltaGenerator'",
             )
         else:
             self.assertEqual(
                 el.doc_string.signature,
-                "(body: str, anchor: Optional[str] = None) -> 'DeltaGenerator'",
+                "(body: object, anchor: Optional[str] = None) -> 'DeltaGenerator'",
             )
 
     def test_st_image_PIL_image(self):


### PR DESCRIPTION
This PR is a subset of #5101, made in order to facilitate discussion and review.

## 📚 Context

_Improve type annotations for streamlit's public API_

- What kind of change does this PR introduce?

  - [X] Other, please describe: Type annotations

## 🧠 Description of Changes

- _Relax `str` arguments for markdown methods to `SupportsStr` in line with actual behavior. The reasoning for this has been discussed in past PRs: https://github.com/streamlit/streamlit/pull/4808#discussion_r887411102_

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
