### PR TITLE
AppSession: allow running on another thread

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import sys
-import threading
 import time
 import traceback
 from asyncio import Future

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -119,9 +119,6 @@ class AsyncObjects(NamedTuple):
     # The event loop that Runtime is running on.
     event_loop: asyncio.AbstractEventLoop
 
-    # The thread that our event loop is running on.
-    event_loop_thread: threading.Thread
-
     # Set after Runtime.stop() is called. Never cleared.
     must_stop: asyncio.Event
 
@@ -244,7 +241,6 @@ class Runtime:
         # instantiate our various synchronization primitives.
         async_objs = AsyncObjects(
             event_loop=asyncio.get_running_loop(),
-            event_loop_thread=threading.current_thread(),
             must_stop=asyncio.Event(),
             has_connection=asyncio.Event(),
             need_send_data=asyncio.Event(),
@@ -331,7 +327,6 @@ class Runtime:
 
         session = AppSession(
             event_loop=async_objs.event_loop,
-            event_loop_thread=async_objs.event_loop_thread,
             session_data=SessionData(self._main_script_path, self._command_line or ""),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -460,11 +455,8 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        async_objs = self._get_async_objs()
-
         session = AppSession(
-            event_loop=async_objs.event_loop,
-            event_loop_thread=async_objs.event_loop_thread,
+            event_loop=self._get_async_objs().event_loop,
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -115,8 +115,8 @@ class AsyncObjects(NamedTuple):
     These cannot be initialized until the Runtime's eventloop is assigned.
     """
 
-    # The event loop that Runtime is running on.
-    event_loop: asyncio.AbstractEventLoop
+    # The eventloop that Runtime is running on.
+    eventloop: asyncio.AbstractEventLoop
 
     # Set after Runtime.stop() is called. Never cleared.
     must_stop: asyncio.Event
@@ -239,7 +239,7 @@ class Runtime:
         # Create our AsyncObjects. We need to have a running eventloop to
         # instantiate our various synchronization primitives.
         async_objs = AsyncObjects(
-            event_loop=asyncio.get_running_loop(),
+            eventloop=asyncio.get_running_loop(),
             must_stop=asyncio.Event(),
             has_connection=asyncio.Event(),
             need_send_data=asyncio.Event(),
@@ -278,7 +278,7 @@ class Runtime:
             self._set_state(RuntimeState.STOPPING)
             async_objs.must_stop.set()
 
-        async_objs.event_loop.call_soon_threadsafe(stop_on_eventloop)
+        async_objs.eventloop.call_soon_threadsafe(stop_on_eventloop)
 
     def is_active_session(self, session_id: str) -> bool:
         """True if the session_id belongs to an active session.
@@ -325,7 +325,7 @@ class Runtime:
         async_objs = self._get_async_objs()
 
         session = AppSession(
-            event_loop=async_objs.event_loop,
+            event_loop=async_objs.eventloop,
             session_data=SessionData(self._main_script_path, self._command_line or ""),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -455,7 +455,7 @@ class Runtime:
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
         session = AppSession(
-            event_loop=self._get_async_objs().event_loop,
+            event_loop=self._get_async_objs().eventloop,
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -640,7 +640,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         Threading: SAFE. May be called on any thread.
         """
         async_objs = self._get_async_objs()
-        async_objs.event_loop.call_soon_threadsafe(async_objs.need_send_data.set)
+        async_objs.eventloop.call_soon_threadsafe(async_objs.need_send_data.set)
 
     def _get_async_objs(self) -> AsyncObjects:
         """Return our AsyncObjects instance. If the Runtime hasn't been

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import sys
+import threading
 import time
 import traceback
 from asyncio import Future
@@ -115,8 +116,11 @@ class AsyncObjects(NamedTuple):
     These cannot be initialized until the Runtime's eventloop is assigned.
     """
 
-    # The eventloop that Runtime is running on.
-    eventloop: asyncio.AbstractEventLoop
+    # The event loop that Runtime is running on.
+    event_loop: asyncio.AbstractEventLoop
+
+    # The thread that our event loop is running on.
+    event_loop_thread: threading.Thread
 
     # Set after Runtime.stop() is called. Never cleared.
     must_stop: asyncio.Event
@@ -239,7 +243,8 @@ class Runtime:
         # Create our AsyncObjects. We need to have a running eventloop to
         # instantiate our various synchronization primitives.
         async_objs = AsyncObjects(
-            eventloop=asyncio.get_running_loop(),
+            event_loop=asyncio.get_running_loop(),
+            event_loop_thread=threading.current_thread(),
             must_stop=asyncio.Event(),
             has_connection=asyncio.Event(),
             need_send_data=asyncio.Event(),
@@ -278,7 +283,7 @@ class Runtime:
             self._set_state(RuntimeState.STOPPING)
             async_objs.must_stop.set()
 
-        async_objs.eventloop.call_soon_threadsafe(stop_on_eventloop)
+        async_objs.event_loop.call_soon_threadsafe(stop_on_eventloop)
 
     def is_active_session(self, session_id: str) -> bool:
         """True if the session_id belongs to an active session.
@@ -325,7 +330,8 @@ class Runtime:
         async_objs = self._get_async_objs()
 
         session = AppSession(
-            event_loop=async_objs.eventloop,
+            event_loop=async_objs.event_loop,
+            event_loop_thread=async_objs.event_loop_thread,
             session_data=SessionData(self._main_script_path, self._command_line or ""),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -454,8 +460,11 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
+        async_objs = self._get_async_objs()
+
         session = AppSession(
-            event_loop=self._get_async_objs().eventloop,
+            event_loop=async_objs.event_loop,
+            event_loop_thread=async_objs.event_loop_thread,
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -640,7 +649,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
         Threading: SAFE. May be called on any thread.
         """
         async_objs = self._get_async_objs()
-        async_objs.eventloop.call_soon_threadsafe(async_objs.need_send_data.set)
+        async_objs.event_loop.call_soon_threadsafe(async_objs.need_send_data.set)
 
     def _get_async_objs(self) -> AsyncObjects:
         """Return our AsyncObjects instance. If the Runtime hasn't been

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -238,6 +238,8 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         session._create_scriptrunner(initial_rerun_data=RerunData())
 
+        # Our test AppSession is created with a mock EventLoop, so
+        # we pretend that this function is called on that same mock EventLoop.
         with patch(
             "streamlit.runtime.app_session.asyncio.get_running_loop",
             return_value=session._event_loop,
@@ -455,7 +457,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
 
     async def test_event_handler_asserts_if_called_off_event_loop(self):
         """AppSession._handle_scriptrunner_event_on_event_loop will assert
-        if it's called from another thread.
+        if it's called from another event loop (or no event loop).
         """
         event_loop = asyncio.get_running_loop()
         session = _create_test_session(event_loop)

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -55,6 +55,7 @@ def _create_test_session(event_loop: Optional[AbstractEventLoop] = None) -> AppS
 
     return AppSession(
         event_loop=event_loop,
+        event_loop_thread=threading.current_thread(),
         session_data=SessionData("/fake/script_path.py", "fake_command_line"),
         uploaded_file_manager=MagicMock(),
         message_enqueued_callback=None,

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -427,16 +427,13 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
 
     async def test_events_handled_on_event_loop(self):
         """ScriptRunner events should be handled on the main thread only."""
-        session = _create_test_session(asyncio.get_running_loop())
+        event_loop = asyncio.get_running_loop()
+        session = _create_test_session(event_loop)
 
-        # Patch the session's "_handle_scriptrunner_event_on_main_thread"
-        # to test that the function is called, and that it's only called
-        # on the main thread.
-        def assert_is_on_main_thread(*args, **kwargs):
-            self.assertEqual(threading.main_thread(), threading.current_thread())
-
-        mock_handle_event = MagicMock(side_effect=assert_is_on_main_thread)
-        session._handle_scriptrunner_event_on_event_loop = mock_handle_event
+        handle_event_spy = MagicMock(
+            side_effect=session._handle_scriptrunner_event_on_event_loop
+        )
+        session._handle_scriptrunner_event_on_event_loop = handle_event_spy
 
         # Send a ScriptRunner event from another thread
         thread = threading.Thread(
@@ -447,15 +444,32 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         thread.start()
         thread.join()
 
-        # _handle_scriptrunner_event_on_main_thread won't have been called
+        # _handle_scriptrunner_event_on_event_loop won't have been called
         # yet, because we haven't yielded the eventloop.
-        mock_handle_event.assert_not_called()
+        handle_event_spy.assert_not_called()
 
         # Yield to let the AppSession's callbacks run.
-        # _handle_scriptrunner_event_on_main_thread will be called here.
+        # _handle_scriptrunner_event_on_event_loop will be called here.
         await asyncio.sleep(0)
 
-        mock_handle_event.assert_called_once()
+        handle_event_spy.assert_called_once()
+
+    async def test_event_handler_asserts_if_called_off_event_loop(self):
+        """AppSession._handle_scriptrunner_event_on_event_loop will assert
+        if it's called from another thread.
+        """
+        event_loop = asyncio.get_running_loop()
+        session = _create_test_session(event_loop)
+
+        # Pretend we're calling this function from a thread with another event_loop.
+        with patch(
+            "streamlit.runtime.app_session.asyncio.get_running_loop",
+            return_value=MagicMock(),
+        ):
+            with self.assertRaises(AssertionError):
+                session._handle_scriptrunner_event_on_event_loop(
+                    sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED
+                )
 
     @patch(
         "streamlit.runtime.app_session.config.get_options_for_section",

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -236,13 +236,12 @@ class AppSessionTest(unittest.TestCase):
         current ScriptRunner, we should silently ignore them.
         """
         session = _create_test_session()
+        session._create_scriptrunner(initial_rerun_data=RerunData())
 
         with patch(
             "streamlit.runtime.app_session.asyncio.get_running_loop",
             return_value=session._event_loop,
         ):
-            session._create_scriptrunner(initial_rerun_data=RerunData())
-
             session._handle_scriptrunner_event_on_event_loop(
                 sender=session._scriptrunner,
                 event=ScriptRunnerEvent.ENQUEUE_FORWARD_MSG,


### PR DESCRIPTION
Currently, `AppSession._handle_scriptrunner_event_on_main_thread` asserts that it's called on the main thread. This is subtly incorrect - the function must be called on the AppSession's asyncio event loop thread, which is generally but not necessarily the main thread.

(Specifically, Snowpark is currently running the Streamlit Runtime on another thread.)

This PR changes the assertion - we now assert that the function is called on the event loop. (The PR also renames the function.)