### PR TITLE
Fix test using the now-nonexistent _handle_scriptrunner_event_on_main_thread

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -401,7 +401,7 @@ class AppSession:
         """Called when our ScriptRunner emits an event.
 
         This is generally called from the sender ScriptRunner's script thread.
-        We forward the event on to _handle_scriptrunner_event_on_main_thread,
+        We forward the event on to _handle_scriptrunner_event_on_event_loop,
         which will be called on the main thread.
         """
         self._event_loop.call_soon_threadsafe(

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -268,13 +268,17 @@ class AppSessionTest(unittest.TestCase):
         session._create_scriptrunner(initial_rerun_data=RerunData())
         session._debug_last_backmsg_id = "some_backmsg_id"
 
-        session._handle_scriptrunner_event_on_main_thread(
-            sender=session._scriptrunner,
-            event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
-            forward_msg=ForwardMsg(),
-        )
+        with patch(
+            "streamlit.runtime.app_session.asyncio.get_running_loop",
+            return_value=session._event_loop,
+        ):
+            session._handle_scriptrunner_event_on_event_loop(
+                sender=session._scriptrunner,
+                event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                forward_msg=ForwardMsg(),
+            )
 
-        self.assertIsNone(session._debug_last_backmsg_id)
+            self.assertIsNone(session._debug_last_backmsg_id)
 
     def test_passes_client_state_on_run_on_save(self):
         session = _create_test_session()


### PR DESCRIPTION
## 📚 Context

One of the tests that I wrote as part of #5169 used the
`_handle_scriptrunner_event_on_main_thread` function, which was renamed in #5196.
These two PRs ended up racing with each other and are now causing a build failure on
`develop`.

- What kind of change does this PR introduce?

  - [x] Other, please describe: test fixes

## 🧪 Testing Done

- [x] Added/Updated unit tests
