### PR TITLE
Migrate to GH Actions - Part 5: CLI Regression Test

### DIFF
--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -1,0 +1,41 @@
+name: CLI Regression Test
+
+on:
+  pull_request:
+    types: [opened]
+  push:
+    branches:
+      - '**'
+
+jobs:
+  cli-regression-test:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+
+    defaults:
+      run:
+        shell: bash -ileo pipefail {0}
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v3
+        with: 
+          persist-credentials: false
+          submodules: 'recursive'
+      - name: Set up Python 3.9.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9.7"
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+      - name: Build Package - Fast
+        timeout-minutes: 120
+        run: |
+          sudo apt install rsync
+          BUILD_AS_FAST_AS_POSSIBLE=1 make package
+      - name: Run CLI regression tests
+        run: |
+          export SKIP_VERSION_CHECK=true
+          make cli-regression-tests

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -24,10 +24,10 @@ jobs:
         with: 
           persist-credentials: false
           submodules: 'recursive'
-      - name: Set up Python 3.9.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.7"
+          python-version: "3.10"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Build Package - Fast
@@ -37,5 +37,4 @@ jobs:
           BUILD_AS_FAST_AS_POSSIBLE=1 make package
       - name: Run CLI regression tests
         run: |
-          export SKIP_VERSION_CHECK=true
-          make cli-regression-tests
+          export SKIP_VERSION_CHECK=true make cli-regression-tests

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -37,4 +37,4 @@ jobs:
           BUILD_AS_FAST_AS_POSSIBLE=1 make package
       - name: Run CLI regression tests
         run: |
-          export SKIP_VERSION_CHECK=true make cli-regression-tests
+          export SKIP_VERSION_CHECK=true; make cli-regression-tests


### PR DESCRIPTION
## 📚 Context

As a part of integrating with Snowflake, we are transitioning our CI/CD process/workflows from CircleCI to Github Actions. We will be doing this through multiple PRs into a feature branch to break the review process into several pieces. 

Folder `.github/actions` holds an `action.yml` file that allow for `make-init` steps that are duplicated across multiple workflows to be bundled together

Folder `.github/workflows` holds the `cli-regression.yml` file which verifies that CLI boots as expected when called with `python -m streamlit`. 

- What kind of change does this PR introduce?
  - [x] Other, please describe: Migrating from CircleCI to GH Actions for CI/CD

## 🧠 Description of Changes

- Created `cypress.yml` workflow file

## 🧪 Testing Done

- [x] Manual Testing

## 🌐 References

[Notion Doc](https://www.notion.so/streamlit/Github-Action-Migration-4c36c25b00bf4c21b71272dd82b764a8)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
