### PR TITLE
Migrate to GH Actions - Part 6: Python Prod Deps Smoke Test

### DIFF
--- a/.github/workflows/py-prod-deps-smoke-test.yml
+++ b/.github/workflows/py-prod-deps-smoke-test.yml
@@ -1,0 +1,38 @@
+name: Python Prod Deps Smoke Test
+
+on:
+  pull_request:
+    types: [opened]
+  push:
+    branches:
+      - '**'
+
+jobs:
+  python-prod-deps-smoke-test:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+
+    defaults:
+      run:
+        shell: bash -ileo pipefail {0}
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v3
+        with: 
+          persist-credentials: false
+          submodules: 'recursive'
+      - name: Set up Python 3.9.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9.7"
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+        with:
+          use_cached_venv: 'false'
+      - name: Run make develop
+        run: make develop
+      - name: Run CLI smoke tests
+        run: make cli-smoke-tests

--- a/.github/workflows/py-prod-deps-smoke-test.yml
+++ b/.github/workflows/py-prod-deps-smoke-test.yml
@@ -24,10 +24,10 @@ jobs:
         with: 
           persist-credentials: false
           submodules: 'recursive'
-      - name: Set up Python 3.9.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.7"
+          python-version: "3.10"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
         with:


### PR DESCRIPTION
## 📚 Context

As a part of integrating with Snowflake, we are transitioning our CI/CD process/workflows from CircleCI to Github Actions. We will be doing this through multiple PRs into a feature branch to break the review process into several pieces. 

Folder `.github/actions` holds an `action.yml` file that allows for `make-init` steps that are duplicated across multiple workflows to be bundled together

Folder `.github/workflows` holds the ``py-prod-deps-smoke-test.yml` file which makes sure Streamlit runs without dev dependencies.

- What kind of change does this PR introduce?
  - [x] Other, please describe: Migrating from CircleCI to GH Actions for CI/CD

## 🧠 Description of Changes

- Created `py-prod-deps-smoke-test.yml` workflow file

## 🧪 Testing Done

- [x] Manual Testing

## 🌐 References

[Notion Doc](https://www.notion.so/streamlit/Github-Action-Migration-4c36c25b00bf4c21b71272dd82b764a8)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
