### PR TITLE
fix: Allow renderData.args to be typed

### DIFF
--- a/component-lib/src/StreamlitReact.tsx
+++ b/component-lib/src/StreamlitReact.tsx
@@ -22,9 +22,9 @@ import { RenderData, Streamlit, Theme } from "./streamlit";
 /**
  * Props passed to custom Streamlit components.
  */
-export interface ComponentProps {
+export interface ComponentProps<ArgType=any> {
   /** Named dictionary of arguments passed from Python. */
-  args: any;
+  args: ArgType;
 
   /** The component's width. */
   width: number;
@@ -48,8 +48,8 @@ export interface ComponentProps {
  * `componentDidMount` and `componentDidUpdate` functions in your own class,
  * so that your plugin properly resizes.
  */
-export class StreamlitComponentBase<S = {}> extends React.PureComponent<
-  ComponentProps,
+export class StreamlitComponentBase<S = {}, ArgType=any> extends React.PureComponent<
+  ComponentProps<ArgType>,
   S
 > {
   public componentDidMount(): void {
@@ -69,13 +69,13 @@ export class StreamlitComponentBase<S = {}> extends React.PureComponent<
  *
  * Bootstraps the communication interface between Streamlit and the component.
  */
-export function withStreamlitConnection(
+export function withStreamlitConnection<ArgType=any>(
   WrappedComponent: React.ComponentType<ComponentProps>
 ): React.ComponentType {
   interface WrapperProps {}
 
   interface WrapperState {
-    renderData?: RenderData;
+    renderData?: RenderData<ArgType>;
     componentError?: Error;
   }
 
@@ -136,7 +136,7 @@ export function withStreamlitConnection(
      */
     private onRenderEvent = (event: Event): void => {
       // Update our state with the newest render data
-      const renderEvent = event as CustomEvent<RenderData>;
+      const renderEvent = event as CustomEvent<RenderData<ArgType>>;
       this.setState({ renderData: renderEvent.detail });
     };
 

--- a/component-lib/src/index.ts
+++ b/component-lib/src/index.ts
@@ -27,5 +27,5 @@ export {
 export { ArrowTable } from "./ArrowTable";
 export { Streamlit } from "./streamlit";
 export type ComponentProps = ComponentProps_;
-export type RenderData = RenderData_;
+export type RenderData<ArgType=any> = RenderData_<ArgType>;
 export type Theme = Theme_;

--- a/component-lib/src/streamlit.ts
+++ b/component-lib/src/streamlit.ts
@@ -30,8 +30,8 @@ export interface Theme {
 }
 
 /** Data sent in the custom Streamlit render event. */
-export interface RenderData {
-  args: any;
+export interface RenderData<ArgType=any> {
+  args: ArgType;
   disabled: boolean;
   theme?: Theme;
 }
@@ -168,13 +168,13 @@ export class Streamlit {
    * Handle an untyped Streamlit render event and redispatch it as a
    * StreamlitRenderEvent.
    */
-  private static onRenderMessage = (data: any): void => {
+  private static onRenderMessage = <ArgType=any, >(data: {args: ArgType, dfs?: ArgsDataframe[], disabled?: boolean, theme?: Theme}): void => {
     let args = data["args"];
     if (args == null) {
       console.error(
         `Got null args in onRenderMessage. This should never happen`
       );
-      args = {};
+      args = {} as ArgType;
     }
 
     // Parse our dataframe arguments with arrow, and merge them into our args dict
@@ -196,7 +196,7 @@ export class Streamlit {
 
     // Dispatch a render event!
     const eventData = { disabled, args, theme };
-    const event = new CustomEvent<RenderData>(Streamlit.RENDER_EVENT, {
+    const event = new CustomEvent<RenderData<ArgType>>(Streamlit.RENDER_EVENT, {
       detail: eventData
     });
     Streamlit.events.dispatchEvent(event);


### PR DESCRIPTION
## 📚 Context

When using the typescript component template, the returned `renderData.args` is any and has to be manually typed.  
This PR allows for user to specify the type of `args`, while making this type any by default so that it is compatible with old code.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Type declaration

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change
  - [x] This is a non-breaking type declaration change

**Revised:**

```ts
class MyComponent extends StreamlitComponentBase<State, {name: string}> {
```
Note that the user can also decide to skip it and keep using the current implementation:
```ts
class MyComponent extends StreamlitComponentBase<State> {
``` 

**Current:**
```ts
class MyComponent extends StreamlitComponentBase<State> {
``` 

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

As this changes the types, testing seemed superfluous. Let me know if some should be made instead

## 🌐 References

This would allow a PR to https://github.com/whitphx/streamlit-component-template-react-hooks/ to change from `useRenderData` to `useRenderData<ArgType>`

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
