### PR TITLE
InMemoryFileManager -> MediaFileManager

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -364,8 +364,8 @@ class DeltaGenerator(
         """Returns the element's delta path as a string like "[0, 2, 3, 1]".
 
         This uniquely identifies the element's position in the front-end,
-        which allows (among other potential uses) the InMemoryFileManager to maintain
-        session-specific maps of InMemoryFile objects placed with their "coordinates".
+        which allows (among other potential uses) the MediaFileManager to maintain
+        session-specific maps of MediaFile objects placed with their "coordinates".
 
         This way, users can (say) use st.image with a stream of different images,
         and Streamlit will expire the older images and replace them in place.

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -20,7 +20,7 @@ from typing_extensions import Final
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -397,7 +397,7 @@ def marshall_file(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    this_file = in_memory_file_manager.add(
+    this_file = media_file_manager.add(
         data_as_bytes,
         mimetype,
         coordinates,

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -32,7 +32,7 @@ from PIL import Image, ImageFile
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 
 if TYPE_CHECKING:
@@ -351,7 +351,7 @@ def image_to_url(
         data = image
 
     (data, mimetype) = _normalize_to_bytes(data, width, output_format)
-    this_file = in_memory_file_manager.add(data, mimetype, image_id)
+    this_file = media_file_manager.add(data, mimetype, image_id)
     return this_file.url
 
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -405,7 +405,7 @@ def marshall_images(
             proto_img.caption = str(caption)
 
         # We use the index of the image in the input image list to identify this image inside
-        # InMemoryFileManager. For this, we just add the index to the image's "coordinates".
+        # MediaFileManager. For this, we just add the index to the image's "coordinates".
         image_id = "%s-%i" % (coordinates, coord_suffix)
 
         is_svg = False

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -20,7 +20,7 @@ from typing_extensions import Final, TypeAlias
 from validators import url
 
 from streamlit import type_util
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 
@@ -182,7 +182,7 @@ def _marshall_av_media(
     if isinstance(data, str):
         # Assume it's a filename or blank.  Allow OS-based file errors.
         with open(data, "rb") as fh:
-            this_file = in_memory_file_manager.add(fh.read(), mimetype, coordinates)
+            this_file = media_file_manager.add(fh.read(), mimetype, coordinates)
             proto.url = this_file.url
             return
 
@@ -207,7 +207,7 @@ def _marshall_av_media(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    this_file = in_memory_file_manager.add(data_as_bytes, mimetype, coordinates)
+    this_file = media_file_manager.add(data_as_bytes, mimetype, coordinates)
     proto.url = this_file.url
 
 

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -175,7 +175,7 @@ def _marshall_av_media(
     Otherwise assume strings are filenames and let any OS errors raise.
 
     Load data either from file or through bytes-processing methods into a
-    InMemoryFile object.  Pack proto with generated Tornado-based URL.
+    MediaFile object.  Pack proto with generated Tornado-based URL.
     """
     # Audio and Video methods have already checked if this is a URL by this point.
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -37,7 +37,7 @@ from streamlit.proto.PagesChanged_pb2 import PagesChanged
 from streamlit.watcher import LocalSourcesWatcher
 from . import caching, legacy_caching
 from .credentials import Credentials
-from .in_memory_file_manager import in_memory_file_manager
+from .media_file_manager import media_file_manager
 from .metrics_util import Installation
 from .scriptrunner import (
     RerunData,
@@ -183,8 +183,8 @@ class AppSession:
             # Clear any unused session files in upload file manager and media
             # file manager
             self._uploaded_file_mgr.remove_session_files(self.id)
-            in_memory_file_manager.clear_session_files(self.id)
-            in_memory_file_manager.del_expired_files()
+            media_file_manager.clear_session_files(self.id)
+            media_file_manager.del_expired_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
@@ -529,7 +529,7 @@ class AppSession:
             if self._state == AppSessionState.SHUTDOWN_REQUESTED:
                 # Only clear media files if the script is done running AND the
                 # session is actually shutting down.
-                in_memory_file_manager.clear_session_files(self.id)
+                media_file_manager.clear_session_files(self.id)
 
             self._client_state = client_state
             self._scriptrunner = None

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides global InMemoryFileManager object as `in_memory_file_manager`."""
+"""Provides global MediaFileManager object as `in_memory_file_manager`."""
 
 import collections
 import hashlib
@@ -94,7 +94,7 @@ def _get_extension_for_mimetype(mimetype: str) -> str:
     return extension
 
 
-class InMemoryFile:
+class MediaFile:
     """Abstraction for file objects."""
 
     def __init__(
@@ -148,8 +148,8 @@ class InMemoryFile:
         self._is_marked_for_delete = True
 
 
-class InMemoryFileManager(CacheStatsProvider):
-    """In-memory file manager for InMemoryFile objects.
+class MediaFileManager(CacheStatsProvider):
+    """In-memory file manager for MediaFile objects.
 
     This keeps track of:
     - Which files exist, and what their IDs are. This is important so we can
@@ -168,12 +168,12 @@ class InMemoryFileManager(CacheStatsProvider):
     """
 
     def __init__(self):
-        # Dict of file ID to InMemoryFile.
-        self._files_by_id: Dict[str, InMemoryFile] = dict()
+        # Dict of file ID to MediaFile.
+        self._files_by_id: Dict[str, MediaFile] = dict()
 
-        # Dict[session ID][coordinates] -> InMemoryFile.
+        # Dict[session ID][coordinates] -> MediaFile.
         self._files_by_session_and_coord: Dict[
-            str, Dict[str, InMemoryFile]
+            str, Dict[str, MediaFile]
         ] = collections.defaultdict(dict)
 
     def __repr__(self) -> str:
@@ -232,8 +232,8 @@ class InMemoryFileManager(CacheStatsProvider):
         coordinates: str,
         file_name: Optional[str] = None,
         is_for_static_download: bool = False,
-    ) -> InMemoryFile:
-        """Adds new InMemoryFile with given parameters; returns the object.
+    ) -> MediaFile:
+        """Adds new MediaFile with given parameters; returns the object.
 
         If an identical file already exists, returns the existing object
         and registers the current session as a user.
@@ -248,7 +248,7 @@ class InMemoryFileManager(CacheStatsProvider):
         content : bytes
             Raw data to store in file object.
         mimetype : str
-            The mime type for the in-memory file. E.g. "audio/mpeg"
+            The mime type for the file. E.g. "audio/mpeg"
         coordinates : str
             Unique string identifying an element's location.
             Prevents memory leak of "forgotten" file IDs when element media
@@ -270,7 +270,7 @@ class InMemoryFileManager(CacheStatsProvider):
             else:
                 file_type = FILE_TYPE_MEDIA
 
-            imf = InMemoryFile(
+            imf = MediaFile(
                 file_id=file_id,
                 content=content,
                 mimetype=mimetype,
@@ -292,14 +292,14 @@ class InMemoryFileManager(CacheStatsProvider):
 
         return imf
 
-    def get(self, inmemory_filename: str) -> InMemoryFile:
-        """Returns InMemoryFile object for given file_id or InMemoryFile object.
+    def get(self, file_id: str) -> MediaFile:
+        """Returns MediaFile object for given file_id or MediaFile object.
 
         Raises KeyError if not found.
         """
-        # Filename is {requested_hash}.{extension} but InMemoryFileManager
+        # Filename is {requested_hash}.{extension} but MediaFileManager
         # is indexed by requested_hash.
-        hash = inmemory_filename.split(".")[0]
+        hash = file_id.split(".")[0]
         return self._files_by_id[hash]
 
     def get_stats(self) -> List[CacheStat]:
@@ -318,11 +318,11 @@ class InMemoryFileManager(CacheStatsProvider):
             )
         return stats
 
-    def __contains__(self, inmemory_file_or_id):
-        return inmemory_file_or_id in self._files_by_id
+    def __contains__(self, file_id: str) -> bool:
+        return file_id in self._files_by_id
 
     def __len__(self):
         return len(self._files_by_id)
 
 
-in_memory_file_manager = InMemoryFileManager()
+media_file_manager = MediaFileManager()

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -17,6 +17,7 @@
 import collections
 import hashlib
 import mimetypes
+from enum import Enum
 from typing import Dict, Set, Optional, List
 
 from streamlit import util
@@ -31,11 +32,13 @@ PREFERRED_MIMETYPE_EXTENSION_MAP = {
     "audio/wav": ".wav",
 }
 
-# used for images and videos in st.image() and st.video()
-FILE_TYPE_MEDIA = "media_file"
 
-# used for st.download_button files
-FILE_TYPE_DOWNLOADABLE = "downloadable_file"
+class MediaFileType(Enum):
+    # used for images and videos in st.image() and st.video()
+    MEDIA = "media"
+
+    # used for st.download_button files
+    DOWNLOADABLE = "downloadable"
 
 
 def _get_session_id() -> str:
@@ -103,7 +106,7 @@ class MediaFile:
         content: bytes,
         mimetype: str,
         file_name: Optional[str] = None,
-        file_type: str = FILE_TYPE_MEDIA,
+        file_type: MediaFileType = MediaFileType.MEDIA,
     ):
         self._file_id = file_id
         self._content = content
@@ -137,7 +140,7 @@ class MediaFile:
         return len(self._content)
 
     @property
-    def file_type(self) -> str:
+    def file_type(self) -> MediaFileType:
         return self._file_type
 
     @property
@@ -192,10 +195,10 @@ class MediaFileManager(CacheStatsProvider):
         for file_id, imf in list(self._files_by_id.items()):
             if imf.id not in active_file_ids:
 
-                if imf.file_type == FILE_TYPE_MEDIA:
+                if imf.file_type == MediaFileType.MEDIA:
                     LOGGER.debug(f"Deleting File: {file_id}")
                     del self._files_by_id[file_id]
-                elif imf.file_type == FILE_TYPE_DOWNLOADABLE:
+                elif imf.file_type == MediaFileType.DOWNLOADABLE:
                     if imf._is_marked_for_delete:
                         LOGGER.debug(f"Deleting File: {file_id}")
                         del self._files_by_id[file_id]
@@ -266,9 +269,9 @@ class MediaFileManager(CacheStatsProvider):
             LOGGER.debug("Adding media file %s", file_id)
 
             if is_for_static_download:
-                file_type = FILE_TYPE_DOWNLOADABLE
+                file_type = MediaFileType.DOWNLOADABLE
             else:
-                file_type = FILE_TYPE_MEDIA
+                file_type = MediaFileType.MEDIA
 
             imf = MediaFile(
                 file_id=file_id,

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -311,7 +311,7 @@ class MediaFileManager(CacheStatsProvider):
         for file_id, file in files_by_id.items():
             stats.append(
                 CacheStat(
-                    category_name="st_in_memory_file_manager",
+                    category_name="st_media_file_manager",
                     cache_name="",
                     byte_length=file.content_size,
                 )

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides global MediaFileManager object as `in_memory_file_manager`."""
+"""Provides global MediaFileManager object as `media_file_manager`."""
 
 import collections
 import hashlib

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -189,21 +189,21 @@ class MediaFileManager(CacheStatsProvider):
         active_file_ids: Set[str] = set()
 
         for files_by_coord in self._files_by_session_and_coord.values():
-            file_ids = map(lambda imf: imf.id, files_by_coord.values())
+            file_ids = map(lambda file: file.id, files_by_coord.values())
             active_file_ids = active_file_ids.union(file_ids)
 
-        for file_id, imf in list(self._files_by_id.items()):
-            if imf.id not in active_file_ids:
+        for file_id, file in list(self._files_by_id.items()):
+            if file.id not in active_file_ids:
 
-                if imf.file_type == MediaFileType.MEDIA:
+                if file.file_type == MediaFileType.MEDIA:
                     LOGGER.debug(f"Deleting File: {file_id}")
                     del self._files_by_id[file_id]
-                elif imf.file_type == MediaFileType.DOWNLOADABLE:
-                    if imf._is_marked_for_delete:
+                elif file.file_type == MediaFileType.DOWNLOADABLE:
+                    if file._is_marked_for_delete:
                         LOGGER.debug(f"Deleting File: {file_id}")
                         del self._files_by_id[file_id]
                     else:
-                        imf._mark_for_delete()
+                        file._mark_for_delete()
 
     def clear_session_files(self, session_id: Optional[str] = None) -> None:
         """Removes AppSession-coordinate mapping immediately, and id-file mapping later.
@@ -263,9 +263,9 @@ class MediaFileManager(CacheStatsProvider):
             not as a media for rendering at page. [default: None]
         """
         file_id = _calculate_file_id(content, mimetype, file_name=file_name)
-        imf = self._files_by_id.get(file_id, None)
+        file = self._files_by_id.get(file_id, None)
 
-        if imf is None:
+        if file is None:
             LOGGER.debug("Adding media file %s", file_id)
 
             if is_for_static_download:
@@ -273,7 +273,7 @@ class MediaFileManager(CacheStatsProvider):
             else:
                 file_type = MediaFileType.MEDIA
 
-            imf = MediaFile(
+            file = MediaFile(
                 file_id=file_id,
                 content=content,
                 mimetype=mimetype,
@@ -284,8 +284,8 @@ class MediaFileManager(CacheStatsProvider):
             LOGGER.debug("Overwriting media file %s", file_id)
 
         session_id = _get_session_id()
-        self._files_by_id[imf.id] = imf
-        self._files_by_session_and_coord[session_id][coordinates] = imf
+        self._files_by_id[file.id] = file
+        self._files_by_session_and_coord[session_id][coordinates] = file
 
         LOGGER.debug(
             "Files: %s; Sessions with files: %s",
@@ -293,7 +293,7 @@ class MediaFileManager(CacheStatsProvider):
             len(self._files_by_session_and_coord),
         )
 
-        return imf
+        return file
 
     def get(self, file_id: str) -> MediaFile:
         """Returns the MediaFile for the given file_id.

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -293,7 +293,7 @@ class MediaFileManager(CacheStatsProvider):
         return imf
 
     def get(self, file_id: str) -> MediaFile:
-        """Returns MediaFile object for given file_id or MediaFile object.
+        """Returns the MediaFile for the given file_id.
 
         Raises KeyError if not found.
         """

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -36,7 +36,7 @@ from .forward_msg_cache import (
     populate_hash_if_needed,
     create_reference_msg,
 )
-from .in_memory_file_manager import in_memory_file_manager
+from .media_file_manager import media_file_manager
 from .legacy_caching.caching import _mem_caches
 from .session_data import SessionData
 from .state import SessionStateStatProvider, SCRIPT_RUN_WITHOUT_ERRORS_KEY
@@ -172,7 +172,7 @@ class Runtime:
         self._stats_mgr.register_provider(get_singleton_stats_provider())
         self._stats_mgr.register_provider(_mem_caches)
         self._stats_mgr.register_provider(self._message_cache)
-        self._stats_mgr.register_provider(in_memory_file_manager)
+        self._stats_mgr.register_provider(media_file_manager)
         self._stats_mgr.register_provider(self._uploaded_file_mgr)
         self._stats_mgr.register_provider(
             SessionStateStatProvider(self._session_info_by_id)

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -29,7 +29,7 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.runtime.state import (
     SessionState,
@@ -409,7 +409,7 @@ class ScriptRunner:
         LOGGER.debug("Running script %s", rerun_data)
 
         # Reset DeltaGenerators, widgets, media files.
-        in_memory_file_manager.clear_session_files()
+        media_file_manager.clear_session_files()
 
         main_script_path = self._main_script_path
         pages = source_util.get_pages(main_script_path)
@@ -594,7 +594,7 @@ class ScriptRunner:
 
         # Delete expired files now that the script has run and files in use
         # are marked as active.
-        in_memory_file_manager.del_expired_files()
+        media_file_manager.del_expired_files()
 
         # Force garbage collection to run, to help avoid memory use building up
         # This is usually not an issue, but sometimes GC takes time to kick in and

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -169,7 +169,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
     def get_modified_time(self) -> None:
         # We do not track last modified time, but this can be improved to
-        # allow caching among files in the InMemoryFileManager
+        # allow caching among files in the MediaFileManager
         return None
 
     @classmethod

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -20,9 +20,9 @@ import tornado.web
 
 from streamlit import config, file_util
 from streamlit.logger import get_logger
-from streamlit.runtime.in_memory_file_manager import (
+from streamlit.runtime.media_file_manager import (
     _get_extension_for_mimetype,
-    in_memory_file_manager,
+    media_file_manager,
     FILE_TYPE_DOWNLOADABLE,
 )
 from streamlit.runtime.runtime_util import serialize_forward_msg
@@ -122,7 +122,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         Used for serve downloadable files, like files stored
         via st.download_button widget
         """
-        in_memory_file = in_memory_file_manager.get(path)
+        in_memory_file = media_file_manager.get(path)
 
         if in_memory_file and in_memory_file.file_type == FILE_TYPE_DOWNLOADABLE:
             file_name = in_memory_file.file_name
@@ -152,7 +152,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
     # `validate_absolute_path`.
     def validate_absolute_path(self, root, absolute_path):
         try:
-            in_memory_file_manager.get(absolute_path)
+            media_file_manager.get(absolute_path)
         except KeyError:
             LOGGER.error("InMemoryFileManager: Missing file %s" % absolute_path)
             raise tornado.web.HTTPError(404, "not found")
@@ -164,7 +164,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         if abspath is None:
             return 0
 
-        in_memory_file = in_memory_file_manager.get(abspath)
+        in_memory_file = media_file_manager.get(abspath)
         return in_memory_file.content_size
 
     def get_modified_time(self):
@@ -184,7 +184,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
         try:
             # abspath is the hash as used `get_absolute_path`
-            in_memory_file = in_memory_file_manager.get(abspath)
+            in_memory_file = media_file_manager.get(abspath)
         except:
             LOGGER.error("InMemoryFileManager: Missing file %s" % abspath)
             return

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -108,7 +108,7 @@ class AddSlashHandler(tornado.web.RequestHandler):
 
 
 class MediaFileHandler(tornado.web.StaticFileHandler):
-    def set_default_headers(self):
+    def set_default_headers(self) -> None:
         if allow_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -180,7 +180,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
     @classmethod
     def get_content(
-        cls, abspath, start: Optional[int] = None, end: Optional[int] = None
+        cls, abspath: str, start: Optional[int] = None, end: Optional[int] = None
     ):
         LOGGER.debug("MediaFileHandler: GET %s", abspath)
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -23,7 +23,7 @@ from streamlit.logger import get_logger
 from streamlit.runtime.media_file_manager import (
     _get_extension_for_mimetype,
     media_file_manager,
-    FILE_TYPE_DOWNLOADABLE,
+    MediaFileType,
 )
 from streamlit.runtime.runtime_util import serialize_forward_msg
 from streamlit.string_util import generate_download_filename_from_title
@@ -124,7 +124,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         """
         media_file = media_file_manager.get(path)
 
-        if media_file and media_file.file_type == FILE_TYPE_DOWNLOADABLE:
+        if media_file and media_file.file_type == MediaFileType.DOWNLOADABLE:
             file_name = media_file.file_name
 
             if not file_name:

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -128,7 +128,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         * Path
         * Bytes
         """
-        from streamlit.runtime.in_memory_file_manager import _calculate_file_id
+        from streamlit.runtime.media_file_manager import _calculate_file_id
         from streamlit.elements.image import _np_array_to_bytes
 
         file_id = _calculate_file_id(

--- a/lib/tests/streamlit/runtime/in_memory_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/in_memory_file_manager_test.py
@@ -18,10 +18,10 @@ from unittest import mock, TestCase
 import random
 import time
 
-from streamlit.runtime.in_memory_file_manager import (
-    InMemoryFileManager,
+from streamlit.runtime.media_file_manager import (
+    MediaFileManager,
     _calculate_file_id,
-    InMemoryFile,
+    MediaFile,
 )
 
 
@@ -91,7 +91,7 @@ ALL_FIXTURES.update(TEXT_FIXTURES)
 class InMemoryFileManagerTest(TestCase):
     def setUp(self):
         super(InMemoryFileManagerTest, self).setUp()
-        self.in_memory_file_manager = InMemoryFileManager()
+        self.in_memory_file_manager = MediaFileManager()
         random.seed(1337)
 
     def tearDown(self):
@@ -361,14 +361,10 @@ class InMemoryFileManagerTest(TestCase):
         )
 
     def test_media_file_url(self):
-        self.assertEqual(InMemoryFile("abcd", None, "audio/wav").url, "/media/abcd.wav")
-        self.assertEqual(
-            InMemoryFile("abcd", None, "image/jpeg").url, "/media/abcd.jpeg"
-        )
-        self.assertEqual(InMemoryFile("abcd", None, "video/mp4").url, "/media/abcd.mp4")
-        self.assertEqual(
-            InMemoryFile("abcd", None, "video/webm").url, "/media/abcd.webm"
-        )
+        self.assertEqual(MediaFile("abcd", None, "audio/wav").url, "/media/abcd.wav")
+        self.assertEqual(MediaFile("abcd", None, "image/jpeg").url, "/media/abcd.jpeg")
+        self.assertEqual(MediaFile("abcd", None, "video/mp4").url, "/media/abcd.mp4")
+        self.assertEqual(MediaFile("abcd", None, "video/webm").url, "/media/abcd.webm")
 
     @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
     def test_stats_provider(self, _get_session_id):

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for InMemoryFileManager"""
+"""Unit tests for MediaFileManager"""
 
 from unittest import mock, TestCase
 import random
@@ -325,10 +325,10 @@ class MediaFileManagerTest(TestCase):
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
     def test_media_file_url(self):
-        self.assertEqual(MediaFile("abcd", None, "audio/wav").url, "/media/abcd.wav")
-        self.assertEqual(MediaFile("abcd", None, "image/jpeg").url, "/media/abcd.jpeg")
-        self.assertEqual(MediaFile("abcd", None, "video/mp4").url, "/media/abcd.mp4")
-        self.assertEqual(MediaFile("abcd", None, "video/webm").url, "/media/abcd.webm")
+        self.assertEqual(MediaFile("abcd", b"", "audio/wav").url, "/media/abcd.wav")
+        self.assertEqual(MediaFile("abcd", b"", "image/jpeg").url, "/media/abcd.jpeg")
+        self.assertEqual(MediaFile("abcd", b"", "video/mp4").url, "/media/abcd.mp4")
+        self.assertEqual(MediaFile("abcd", b"", "video/webm").url, "/media/abcd.webm")
 
     @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_stats_provider(self, _get_session_id):

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -121,7 +121,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_files(self, _get_session_id):
-        """Test that InMemoryFileManager.add works as expected."""
+        """Test that MediaFileManager.add works as expected."""
         _get_session_id.return_value = "SESSION1"
 
         coord = random_coordinates()
@@ -149,7 +149,7 @@ class MediaFileManagerTest(TestCase):
     @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     @mock.patch("time.time")
     def test_add_files_same_coord(self, _time, _get_session_id):
-        """Test that InMemoryFileManager.add works as expected."""
+        """Test that MediaFileManager.add works as expected."""
         _get_session_id.return_value = "SESSION1"
 
         coord = random_coordinates()
@@ -250,7 +250,7 @@ class MediaFileManagerTest(TestCase):
     @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     @mock.patch("time.time")
     def test_clear_session_files(self, _time, _get_session_id):
-        """Test that InMemoryFileManager removes session maps when requested (even if empty)."""
+        """Test that MediaFileManager removes session maps when requested (even if empty)."""
         _get_session_id.return_value = "SESSION1"
 
         self.assertEqual(len(self.media_file_manager), 0)
@@ -309,7 +309,7 @@ class MediaFileManagerTest(TestCase):
         # There should be 2 sessions with registered files.
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 2)
 
-        # force every InMemoryFile to have a TTD of now, so we can see it get deleted w/o waiting.
+        # force every MediaFile to have a TTD of now, so we can see it get deleted w/o waiting.
         for imf in self.media_file_manager._files_by_id.values():
             imf.ttd = time.time()
 

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -88,15 +88,15 @@ ALL_FIXTURES.update(IMAGE_FIXTURES)
 ALL_FIXTURES.update(TEXT_FIXTURES)
 
 
-class InMemoryFileManagerTest(TestCase):
+class MediaFileManagerTest(TestCase):
     def setUp(self):
-        super(InMemoryFileManagerTest, self).setUp()
-        self.in_memory_file_manager = MediaFileManager()
+        super().setUp()
+        self.media_file_manager = MediaFileManager()
         random.seed(1337)
 
     def tearDown(self):
-        self.in_memory_file_manager._files_by_id.clear()
-        self.in_memory_file_manager._files_by_session_and_coord.clear()
+        self.media_file_manager._files_by_id.clear()
+        self.media_file_manager._files_by_session_and_coord.clear()
 
     def test_calculate_file_id(self):
         """Test that file_id generation from data works as expected."""
@@ -119,7 +119,7 @@ class InMemoryFileManagerTest(TestCase):
             _calculate_file_id(fake_bytes, "audio/wav", file_name="name2.wav"),
         )
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_files(self, _get_session_id):
         """Test that InMemoryFileManager.add works as expected."""
         _get_session_id.return_value = "SESSION1"
@@ -128,27 +128,25 @@ class InMemoryFileManagerTest(TestCase):
 
         # Make sure we reject files containing None
         with self.assertRaises(TypeError):
-            self.in_memory_file_manager.add(None, "media/any", coord)
+            self.media_file_manager.add(None, "media/any", coord)
 
         sample_coords = set()
         while len(sample_coords) < len(ALL_FIXTURES):
             sample_coords.add(random_coordinates())
 
         for sample in ALL_FIXTURES.values():
-            f = self.in_memory_file_manager.add(
+            f = self.media_file_manager.add(
                 sample["content"], sample["mimetype"], sample_coords.pop()
             )
-            self.assertTrue(f.id in self.in_memory_file_manager)
+            self.assertTrue(f.id in self.media_file_manager)
 
         # There should be as many files in MFM as we added.
-        self.assertEqual(len(self.in_memory_file_manager), len(ALL_FIXTURES))
+        self.assertEqual(len(self.media_file_manager), len(ALL_FIXTURES))
 
         # There should only be 1 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     @mock.patch("time.time")
     def test_add_files_same_coord(self, _time, _get_session_id):
         """Test that InMemoryFileManager.add works as expected."""
@@ -157,208 +155,174 @@ class InMemoryFileManagerTest(TestCase):
         coord = random_coordinates()
 
         for sample in ALL_FIXTURES.values():
-            f = self.in_memory_file_manager.add(
+            f = self.media_file_manager.add(
                 sample["content"], sample["mimetype"], coord
             )
-            self.assertTrue(f.id in self.in_memory_file_manager)
+            self.assertTrue(f.id in self.media_file_manager)
 
         # There should be 6 files in MFM.
-        self.assertEqual(len(self.in_memory_file_manager), len(ALL_FIXTURES))
+        self.assertEqual(len(self.media_file_manager), len(ALL_FIXTURES))
 
         # There should only be 1 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
         # There should only be 1 coord in that session.
         self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord["SESSION1"]), 1
+            len(self.media_file_manager._files_by_session_and_coord["SESSION1"]), 1
         )
 
-        self.in_memory_file_manager.clear_session_files()
-        self.in_memory_file_manager.del_expired_files()
+        self.media_file_manager.clear_session_files()
+        self.media_file_manager.del_expired_files()
 
         # There should be only 0 file in MFM.
-        self.assertEqual(len(self.in_memory_file_manager), 0)
+        self.assertEqual(len(self.media_file_manager), 0)
 
         # There should only be 0 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_file_already_exists_same_coord(self, _get_session_id):
         _get_session_id.return_value = "SESSION1"
 
         sample = IMAGE_FIXTURES["png"]
         coord = random_coordinates()
 
-        self.in_memory_file_manager.add(sample["content"], sample["mimetype"], coord)
+        self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
         file_id = _calculate_file_id(sample["content"], sample["mimetype"])
-        self.assertTrue(file_id in self.in_memory_file_manager)
+        self.assertTrue(file_id in self.media_file_manager)
 
-        mediafile = self.in_memory_file_manager.add(
+        mediafile = self.media_file_manager.add(
             sample["content"], sample["mimetype"], coord
         )
-        self.assertTrue(file_id in self.in_memory_file_manager)
+        self.assertTrue(file_id in self.media_file_manager)
         self.assertEqual(mediafile.id, file_id)
 
         # There should only be 1 file in MFM.
-        self.assertEqual(len(self.in_memory_file_manager), 1)
+        self.assertEqual(len(self.media_file_manager), 1)
 
         # There should only be 1 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_file_already_exists_different_coord(self, _get_session_id):
         _get_session_id.return_value = "SESSION1"
 
         sample = IMAGE_FIXTURES["png"]
 
         coord = random_coordinates()
-        self.in_memory_file_manager.add(sample["content"], sample["mimetype"], coord)
+        self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
         file_id = _calculate_file_id(sample["content"], sample["mimetype"])
-        self.assertTrue(file_id in self.in_memory_file_manager)
+        self.assertTrue(file_id in self.media_file_manager)
 
         coord = random_coordinates()
-        mediafile = self.in_memory_file_manager.add(
+        mediafile = self.media_file_manager.add(
             sample["content"], sample["mimetype"], coord
         )
-        self.assertTrue(file_id in self.in_memory_file_manager)
+        self.assertTrue(file_id in self.media_file_manager)
         self.assertEqual(mediafile.id, file_id)
 
         # There should only be 1 file in MFM.
-        self.assertEqual(len(self.in_memory_file_manager), 1)
+        self.assertEqual(len(self.media_file_manager), 1)
 
         # There should only be 1 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_file_different_mimetypes(self, _get_session_id):
         """Test that we create a new file if new mimetype, even with same bytes for content."""
         _get_session_id.return_value = "SESSION1"
         coord = random_coordinates()
 
         sample = AUDIO_FIXTURES["mp3"]
-        f1 = self.in_memory_file_manager.add(sample["content"], "audio/mp3", coord)
-        self.assertTrue(f1.id in self.in_memory_file_manager)
+        f1 = self.media_file_manager.add(sample["content"], "audio/mp3", coord)
+        self.assertTrue(f1.id in self.media_file_manager)
 
-        f2 = self.in_memory_file_manager.add(sample["content"], "video/mp4", coord)
+        f2 = self.media_file_manager.add(sample["content"], "video/mp4", coord)
         self.assertNotEqual(f1.id, f2.id)
-        self.assertTrue(f2.id in self.in_memory_file_manager)
+        self.assertTrue(f2.id in self.media_file_manager)
 
         # There should be only 2 files in MFM, one for each mimetye.
-        self.assertEqual(len(self.in_memory_file_manager), 2)
+        self.assertEqual(len(self.media_file_manager), 2)
 
         # There should be only 1 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     @mock.patch("time.time")
     def test_clear_session_files(self, _time, _get_session_id):
         """Test that InMemoryFileManager removes session maps when requested (even if empty)."""
         _get_session_id.return_value = "SESSION1"
 
-        self.assertEqual(len(self.in_memory_file_manager), 0)
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
-        )
+        self.assertEqual(len(self.media_file_manager), 0)
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
-        self.in_memory_file_manager.clear_session_files()
+        self.media_file_manager.clear_session_files()
 
-        self.assertEqual(len(self.in_memory_file_manager), 0)
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
-        )
+        self.assertEqual(len(self.media_file_manager), 0)
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
-        self.in_memory_file_manager.del_expired_files()
+        self.media_file_manager.del_expired_files()
 
-        self.assertEqual(len(self.in_memory_file_manager), 0)
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
-        )
+        self.assertEqual(len(self.media_file_manager), 0)
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
         for sample in VIDEO_FIXTURES.values():
             coord = random_coordinates()
-            self.in_memory_file_manager.add(
-                sample["content"], sample["mimetype"], coord
-            )
+            self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
 
-        self.assertEqual(len(self.in_memory_file_manager), len(VIDEO_FIXTURES))
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager), len(VIDEO_FIXTURES))
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-        self.in_memory_file_manager.clear_session_files()
+        self.media_file_manager.clear_session_files()
 
         self.assertEqual(
-            len(self.in_memory_file_manager), len(VIDEO_FIXTURES)
+            len(self.media_file_manager), len(VIDEO_FIXTURES)
         )  # Clears later
         self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
+            len(self.media_file_manager._files_by_session_and_coord), 0
         )  # Clears immediately
 
-        self.in_memory_file_manager.del_expired_files()
+        self.media_file_manager.del_expired_files()
 
-        self.assertEqual(
-            len(self.in_memory_file_manager), 0
-        )  # Now this is cleared too!
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
-        )
+        self.assertEqual(len(self.media_file_manager), 0)  # Now this is cleared too!
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_file_multiple_sessions_then_clear(self, _get_session_id):
         _get_session_id.return_value = "SESSION1"
 
         sample = next(iter(ALL_FIXTURES.values()))
 
         coord = random_coordinates()
-        f = self.in_memory_file_manager.add(
-            sample["content"], sample["mimetype"], coord
-        )
-        self.assertTrue(f.id in self.in_memory_file_manager)
+        f = self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
+        self.assertTrue(f.id in self.media_file_manager)
 
         _get_session_id.return_value = "SESSION2"
 
         coord = random_coordinates()
-        f = self.in_memory_file_manager.add(
-            sample["content"], sample["mimetype"], coord
-        )
-        self.assertTrue(f.id in self.in_memory_file_manager)
+        f = self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
+        self.assertTrue(f.id in self.media_file_manager)
 
         # There should be only 1 file in MFM.
-        self.assertEqual(len(self.in_memory_file_manager), 1)
+        self.assertEqual(len(self.media_file_manager), 1)
 
         # There should be 2 sessions with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 2
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 2)
 
         # force every InMemoryFile to have a TTD of now, so we can see it get deleted w/o waiting.
-        for imf in self.in_memory_file_manager._files_by_id.values():
+        for imf in self.media_file_manager._files_by_id.values():
             imf.ttd = time.time()
 
-        self.in_memory_file_manager.clear_session_files()
+        self.media_file_manager.clear_session_files()
 
         # There should be 1 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 1
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
         _get_session_id.return_value = "SESSION1"
-        self.in_memory_file_manager.clear_session_files()
+        self.media_file_manager.clear_session_files()
 
         # There should be 0 session with registered files.
-        self.assertEqual(
-            len(self.in_memory_file_manager._files_by_session_and_coord), 0
-        )
+        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
     def test_media_file_url(self):
         self.assertEqual(MediaFile("abcd", None, "audio/wav").url, "/media/abcd.wav")
@@ -366,17 +330,15 @@ class InMemoryFileManagerTest(TestCase):
         self.assertEqual(MediaFile("abcd", None, "video/mp4").url, "/media/abcd.mp4")
         self.assertEqual(MediaFile("abcd", None, "video/webm").url, "/media/abcd.webm")
 
-    @mock.patch("streamlit.runtime.in_memory_file_manager._get_session_id")
+    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_stats_provider(self, _get_session_id):
         _get_session_id.return_value = "SESSION1"
-        manager = self.in_memory_file_manager
+        manager = self.media_file_manager
         assert len(manager.get_stats()) == 0
 
         for sample in VIDEO_FIXTURES.values():
             coord = random_coordinates()
-            self.in_memory_file_manager.add(
-                sample["content"], sample["mimetype"], coord
-            )
+            self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
 
         stats = manager.get_stats()
         assert len(stats) == 2

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -310,8 +310,8 @@ class MediaFileManagerTest(TestCase):
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 2)
 
         # force every MediaFile to have a TTD of now, so we can see it get deleted w/o waiting.
-        for imf in self.media_file_manager._files_by_id.values():
-            imf.ttd = time.time()
+        for file in self.media_file_manager._files_by_id.values():
+            file.ttd = time.time()
 
         self.media_file_manager.clear_session_files()
 

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -342,7 +342,7 @@ class MediaFileManagerTest(TestCase):
 
         stats = manager.get_stats()
         assert len(stats) == 2
-        assert stats[0].category_name == "st_in_memory_file_manager"
+        assert stats[0].category_name == "st_media_file_manager"
         assert sum(stat.byte_length for stat in stats) == 232
 
         manager.clear_session_files("SESSION1")

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -210,7 +210,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
 
-        # locate resultant file in InMemoryFileManager and test its properties.
+        # locate resultant file in MediaFileManager and test its properties.
         file_id = _calculate_file_id(fake_audio_data, "audio/wav")
         self.assertTrue(file_id in media_file_manager)
 
@@ -852,7 +852,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
 
-        # locate resultant file in InMemoryFileManager and test its properties.
+        # locate resultant file in MediaFileManager and test its properties.
         file_id = _calculate_file_id(fake_video_data, "video/mp4")
         self.assertTrue(file_id in media_file_manager)
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -38,9 +38,9 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Alert_pb2 import Alert
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
-from streamlit.runtime.in_memory_file_manager import (
+from streamlit.runtime.media_file_manager import (
     _calculate_file_id,
-    in_memory_file_manager,
+    media_file_manager,
     STATIC_MEDIA_ENDPOINT,
 )
 from tests import testutil
@@ -212,9 +212,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
         # locate resultant file in InMemoryFileManager and test its properties.
         file_id = _calculate_file_id(fake_audio_data, "audio/wav")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "audio/wav")
         self.assertEqual(afile.url, el.audio.url)
 
@@ -264,7 +264,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
     def test_st_audio_options(self):
         """Test st.audio with options."""
-        from streamlit.runtime.in_memory_file_manager import _calculate_file_id
+        from streamlit.runtime.media_file_manager import _calculate_file_id
 
         fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
         st.audio(fake_audio_data, format="audio/mp3", start_time=10)
@@ -459,9 +459,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         from streamlit.elements.image import _PIL_to_bytes
 
         file_id = _calculate_file_id(_PIL_to_bytes(img, format="PNG"), "image/png")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "image/png")
         self.assertEqual(afile.url, el.imgs.imgs[0].url)
 
@@ -493,8 +493,8 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
                 _PIL_to_bytes(imgs[idx], format="PNG"), "image/png"
             )
             self.assertEqual(el.imgs.imgs[idx].caption, "some caption")
-            self.assertTrue(file_id in in_memory_file_manager)
-            afile = in_memory_file_manager.get(file_id)
+            self.assertTrue(file_id in media_file_manager)
+            afile = media_file_manager.get(file_id)
             self.assertEqual(afile.mimetype, "image/png")
             self.assertEqual(afile.url, el.imgs.imgs[idx].url)
 
@@ -854,9 +854,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
         # locate resultant file in InMemoryFileManager and test its properties.
         file_id = _calculate_file_id(fake_video_data, "video/mp4")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "video/mp4")
         self.assertEqual(afile.url, el.video.url)
 
@@ -902,7 +902,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
     def test_st_video_options(self):
         """Test st.video with options."""
 
-        from streamlit.runtime.in_memory_file_manager import _calculate_file_id
+        from streamlit.runtime.media_file_manager import _calculate_file_id
 
         fake_video_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
         st.video(fake_video_data, format="video/mp4", start_time=10)


### PR DESCRIPTION
Renames "InMemoryFileManager" to "MediaFileManager" (and "InMemoryFile" to "MediaFile")

Motivation:
- `InMemoryFileManager` is not a great name; the fact that media files are stored in memory is an implementation detail, and not an important part of its identity. And in fact:
- The storage layer for MediaFileManager will soon become an abstract interface, and we'll have multiple implementations (an in-memory implementation for vanilla Streamlit, and an S3-based implementation for Snowpark)

Other stuff:
- `MediaFile.file_type` is now an enum rather than a string, for type safety
- Adds some missing type annotations and other minor fixes to `MediaFileHandler`