### PR TITLE
Up version to 1.12.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-browser",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -19,7 +19,7 @@ import sys
 from setuptools.command.install import install
 
 
-VERSION = "1.12.0"  # PEP-440
+VERSION = "1.12.1"  # PEP-440
 
 NAME = "streamlit"
 


### PR DESCRIPTION
Patch release to exclude python 3.9.7 due to incompatibilities, and make the streamlit runtime changes available