### PR TITLE
Fix some minor edge cases with index_ float handling

### DIFF
--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -132,11 +132,11 @@ def index_(iterable: Iterable[_Value], x: _Value) -> int:
     """
 
     for i, value in enumerate(iterable):
-        if isinstance(value, float) and isinstance(x, float):
+        if x == value:
+            return i
+        elif isinstance(value, float) and isinstance(x, float):
             if abs(x - value) < FLOAT_EQUALITY_EPSILON:
                 return i
-        elif x == value:
-            return i
     raise ValueError("{} is not in iterable".format(str(x)))
 
 

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -99,6 +99,8 @@ class UtilTest(unittest.TestCase):
             (np.arange(0.0, 0.25, 0.05), 0.15, 3),
             ([0, 1, 2, 3], 3, 3),
             ([0.1, 0.2, 0.3], 0.2, 1),
+            ([0.1, 0.2, None], None, 2),
+            ([0.1, 0.2, float("inf")], float("inf"), 2),
             (["He", "ello w", "orld"], "He", 0),
             (list(np.arange(0.0, 0.25, 0.05)), 0.15, 3),
         ]
@@ -113,6 +115,7 @@ class UtilTest(unittest.TestCase):
             (np.arange(0.0, 0.25, 0.05), 0.1500002),
             ([0, 1, 2, 3], 3.00001),
             ([0.1, 0.2, 0.3], 0.3000004),
+            ([0.1, 0.2, 0.3], None),
             (["He", "ello w", "orld"], "world"),
             (list(np.arange(0.0, 0.25, 0.05)), 0.150002),
         ]


### PR DESCRIPTION
## 📚 Context

https://github.com/streamlit/streamlit/pull/5173 pointed out a few edge cases where the `index_` function gets tripped up:

- None may run into a `TypeError` when being compared with a float
- `float("inf")` cannot be searched correctly for since
  `float("inf") - float("inf") == nan`

The `None`-related issue was already fixed by #5190, so this PR fixes the second
issue by doing a normal equality-check first before falling back to the check
meant to handle floating point error. It also adds a few test cases to handle
these scenarios.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
