### PR TITLE
Don't run local-e2e-env-test workflow for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,12 +260,6 @@ workflows:
               only: /^(([0-9]+\.){3}dev[0-9]+)/
             branches:
               ignore: /^release\/([0-9]+\.){2}([0-9]+)/
-      - local-e2e-env-test:
-          filters:
-            tags:
-              only: /^(([0-9]+\.){3}dev[0-9]+)/
-            branches:
-              ignore: /^release\/([0-9]+\.){2}([0-9]+)/
       - nightly-release:
           requires:
             - python-min-version


### PR DESCRIPTION
## 📚 Context

We're having some trouble with the new `local-e2e-env-test` workflow in our
nightly release pipeline, and we came to the conclusion that, regardless of what
the root cause of the issue is, there's not really much of a point in running
tests for our dev env in a pipeline meant for releases.

This PR removes the tag filter for `local-e2e-env-test` so that it no longer
runs on nightly or normal releases.

- What kind of change does this PR introduce?

  - [x] Other, please describe: CI tweaks
