### PR TITLE
Make sure st.json doesn't explode when passed a list

### DIFF
--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
 
 
 def _convert_sets_to_lists(body: Any) -> Any:
+    if isinstance(body, (list, tuple)):
+        # We could technically iterate through the elements of a list/tuple and convert
+        # any sets that we find to lists like we do below, but lists/tuples of sets
+        # seem like a strange enough use-case that it's probably not worth the
+        # additional complexity.
+        return body
+
     # Convert sets into lists, which render more nicely on the frontend
     set_found = False
     for key in body:
@@ -93,6 +100,7 @@ class JsonMixin:
             else:
                 # body is iterable, look for sets and change them to lists
                 body = _convert_sets_to_lists(body)
+
             try:
                 # Serialize body to string
                 body = json.dumps(body, default=repr)

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -215,7 +215,7 @@ class WriteMixin:
                 flush_buffer()
                 dot = vis_utils.model_to_dot(arg)
                 self.dg.graphviz_chart(dot.to_string())
-            elif isinstance(arg, (dict, list, SessionStateProxy, UserInfoProxy)):
+            elif isinstance(arg, (dict, list, SessionStateProxy, tuple, UserInfoProxy)):
                 flush_buffer()
                 self.dg.json(arg)
             elif type_util.is_namedtuple(arg):

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -415,6 +415,28 @@ class DeltaGeneratorWithTest(testutil.DeltaGeneratorTestCase):
 class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
     """Test DeltaGenerator Text, Alert, Json, and Markdown Classes."""
 
+    def test_json_list(self):
+        """Test Text.JSON list."""
+        json_data = [5, 6, 7, 8]
+
+        st.json(json_data)
+
+        json_string = json.dumps(json_data)
+
+        element = self.get_delta_from_queue().new_element
+        self.assertEqual(json_string, element.json.body)
+
+    def test_json_tuple(self):
+        """Test Text.JSON tuple."""
+        json_data = (5, 6, 7, 8)
+
+        st.json(json_data)
+
+        json_string = json.dumps(json_data)
+
+        element = self.get_delta_from_queue().new_element
+        self.assertEqual(json_string, element.json.body)
+
     def test_json_object(self):
         """Test Text.JSON object."""
         json_data = {"key": "value"}


### PR DESCRIPTION
## 📚 Context

The helper function added in #5176 to convert an object's elements from sets to
lists breaks when called on a list because it tries to index into the list using
its elements, which doesn't work for most lists since their elements aren't valid
list indexes.

This PR simply tweaks the function to not attept the conversion on lists and
tuples, which is done mostly because I doubt lists/tuples/etc of sets are seen
commonly enough to be worth the added complexity of handling.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests
