### PR TITLE
Convert widget serde function closures to objects

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -50,7 +50,7 @@ DownloadButtonDataType = Union[str, bytes, TextIO, BinaryIO, io.RawIOBase]
 
 @dataclass
 class ButtonSerde:
-    def serialize(self, v):
+    def serialize(self, v: bool) -> bool:
         return bool(v)
 
     def deserialize(self, ui_value: Optional[bool], widget_id: str = "") -> bool:
@@ -301,7 +301,7 @@ class ButtonMixin:
         download_button_proto.disabled = disabled
 
         self.dg._enqueue("download_button", download_button_proto)
-        return cast(bool, button_state.value)
+        return button_state.value
 
     def _button(
         self,
@@ -363,7 +363,7 @@ class ButtonMixin:
 
         self.dg._enqueue("button", button_proto)
 
-        return cast(bool, button_state.value)
+        return button_state.value
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -301,7 +301,7 @@ class ButtonMixin:
         download_button_proto.disabled = disabled
 
         self.dg._enqueue("download_button", download_button_proto)
-        return button_state.value
+        return cast(bool, button_state.value)
 
     def _button(
         self,
@@ -363,7 +363,7 @@ class ButtonMixin:
 
         self.dg._enqueue("button", button_proto)
 
-        return button_state.value
+        return cast(bool, button_state.value)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import io
 from typing import cast, Optional, Union, BinaryIO, TextIO, TYPE_CHECKING
 from textwrap import dedent
@@ -45,6 +46,15 @@ For more information, refer to the
 """
 
 DownloadButtonDataType = Union[str, bytes, TextIO, BinaryIO, io.RawIOBase]
+
+
+@dataclass
+class ButtonSerde:
+    def serialize(self, v):
+        return bool(v)
+
+    def deserialize(self, ui_value: Optional[bool], widget_id: str = "") -> bool:
+        return ui_value or False
 
 
 class ButtonMixin:
@@ -272,8 +282,7 @@ class ButtonMixin:
         if help is not None:
             download_button_proto.help = dedent(help)
 
-        def deserialize_button(ui_value: Optional[bool], widget_id: str = "") -> bool:
-            return ui_value or False
+        serde = ButtonSerde()
 
         button_state = register_widget(
             "download_button",
@@ -282,8 +291,8 @@ class ButtonMixin:
             on_change_handler=on_click,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_button,
-            serializer=bool,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -334,8 +343,7 @@ class ButtonMixin:
         if help is not None:
             button_proto.help = dedent(help)
 
-        def deserialize_button(ui_value: Optional[bool], widget_id: str = "") -> bool:
-            return ui_value or False
+        serde = ButtonSerde()
 
         button_state = register_widget(
             "button",
@@ -344,8 +352,8 @@ class ButtonMixin:
             on_change_handler=on_click,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_button,
-            serializer=bool,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from streamlit.type_util import Key, to_key
 from textwrap import dedent
 from typing import Optional, cast, List, TYPE_CHECKING
@@ -41,6 +42,69 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 SomeUploadedSnapshotFile = Optional[UploadedFile]
+
+
+def _get_file_recs_for_camera_input_widget(
+    widget_id: str, widget_value: Optional[FileUploaderStateProto]
+) -> List[UploadedFileRec]:
+    if widget_value is None:
+        return []
+
+    ctx = get_script_run_ctx()
+    if ctx is None:
+        return []
+
+    uploaded_file_info = widget_value.uploaded_file_info
+    if len(uploaded_file_info) == 0:
+        return []
+
+    active_file_ids = [f.id for f in uploaded_file_info]
+
+    # Grab the files that correspond to our active file IDs.
+    return ctx.uploaded_file_mgr.get_files(
+        session_id=ctx.session_id,
+        widget_id=widget_id,
+        file_ids=active_file_ids,
+    )
+
+
+@dataclass
+class CameraInputSerde:
+    def serialize(
+        self,
+        snapshot: SomeUploadedSnapshotFile,
+    ) -> FileUploaderStateProto:
+        state_proto = FileUploaderStateProto()
+
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            return state_proto
+
+        # ctx.uploaded_file_mgr._file_id_counter stores the id to use for
+        # the *next* uploaded file, so the current highest file id is the
+        # counter minus 1.
+        state_proto.max_file_id = ctx.uploaded_file_mgr._file_id_counter - 1
+
+        if not snapshot:
+            return state_proto
+
+        file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
+        file_info.id = snapshot.id
+        file_info.name = snapshot.name
+        file_info.size = snapshot.size
+
+        return state_proto
+
+    def deserialize(
+        self, ui_value: Optional[FileUploaderStateProto], widget_id: str
+    ) -> SomeUploadedSnapshotFile:
+        file_recs = _get_file_recs_for_camera_input_widget(widget_id, ui_value)
+
+        if len(file_recs) == 0:
+            return_value = None
+        else:
+            return_value = UploadedFile(file_recs[0])
+        return return_value
 
 
 class CameraInputMixin:
@@ -138,40 +202,7 @@ class CameraInputMixin:
         if help is not None:
             camera_input_proto.help = dedent(help)
 
-        def serialize_camera_image_input(
-            snapshot: SomeUploadedSnapshotFile,
-        ) -> FileUploaderStateProto:
-            state_proto = FileUploaderStateProto()
-
-            ctx = get_script_run_ctx()
-            if ctx is None:
-                return state_proto
-
-            # ctx.uploaded_file_mgr._file_id_counter stores the id to use for
-            # the *next* uploaded file, so the current highest file id is the
-            # counter minus 1.
-            state_proto.max_file_id = ctx.uploaded_file_mgr._file_id_counter - 1
-
-            if not snapshot:
-                return state_proto
-
-            file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
-            file_info.id = snapshot.id
-            file_info.name = snapshot.name
-            file_info.size = snapshot.size
-
-            return state_proto
-
-        def deserialize_camera_image_input(
-            ui_value: Optional[FileUploaderStateProto], widget_id: str
-        ) -> SomeUploadedSnapshotFile:
-            file_recs = self._get_file_recs_for_camera_input_widget(widget_id, ui_value)
-
-            if len(file_recs) == 0:
-                return_value = None
-            else:
-                return_value = UploadedFile(file_recs[0])
-            return return_value
+        serde = CameraInputSerde()
 
         camera_input_state = register_widget(
             "camera_input",
@@ -180,8 +211,8 @@ class CameraInputMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_camera_image_input,
-            serializer=serialize_camera_image_input,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -190,9 +221,7 @@ class CameraInputMixin:
         camera_input_proto.disabled = disabled
 
         ctx = get_script_run_ctx()
-        camera_image_input_state = serialize_camera_image_input(
-            camera_input_state.value
-        )
+        camera_image_input_state = serde.serialize(camera_input_state.value)
 
         uploaded_shapshot_info = camera_image_input_state.uploaded_file_info
 
@@ -214,27 +243,3 @@ class CameraInputMixin:
     def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
         return cast("DeltaGenerator", self)
-
-    @staticmethod
-    def _get_file_recs_for_camera_input_widget(
-        widget_id: str, widget_value: Optional[FileUploaderStateProto]
-    ) -> List[UploadedFileRec]:
-        if widget_value is None:
-            return []
-
-        ctx = get_script_run_ctx()
-        if ctx is None:
-            return []
-
-        uploaded_file_info = widget_value.uploaded_file_info
-        if len(uploaded_file_info) == 0:
-            return []
-
-        active_file_ids = [f.id for f in uploaded_file_info]
-
-        # Grab the files that correspond to our active file IDs.
-        return ctx.uploaded_file_mgr.get_files(
-            session_id=ctx.session_id,
-            widget_id=widget_id,
-            file_ids=active_file_ids,
-        )

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -161,7 +161,7 @@ class CheckboxMixin:
             checkbox_proto.set_value = True
 
         self.dg._enqueue("checkbox", checkbox_proto)
-        return checkbox_state.value
+        return cast(bool, checkbox_state.value)
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class CheckboxSerde:
     value: bool
 
-    def serialize(self, v):
+    def serialize(self, v: bool) -> bool:
         return bool(v)
 
     def deserialize(self, ui_value: Optional[bool], widget_id: str = "") -> bool:
@@ -161,7 +161,7 @@ class CheckboxMixin:
             checkbox_proto.set_value = True
 
         self.dg._enqueue("checkbox", checkbox_proto)
-        return cast(bool, checkbox_state.value)
+        return checkbox_state.value
 
     @property
     def dg(self) -> "DeltaGenerator":

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
 from textwrap import dedent
@@ -30,6 +31,17 @@ from .utils import check_callback_rules, check_session_state_rules
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+
+
+@dataclass
+class CheckboxSerde:
+    value: bool
+
+    def serialize(self, v):
+        return bool(v)
+
+    def deserialize(self, ui_value: Optional[bool], widget_id: str = "") -> bool:
+        return bool(ui_value if ui_value is not None else self.value)
 
 
 class CheckboxMixin:
@@ -127,8 +139,7 @@ class CheckboxMixin:
         if help is not None:
             checkbox_proto.help = dedent(help)
 
-        def deserialize_checkbox(ui_value: Optional[bool], widget_id: str = "") -> bool:
-            return bool(ui_value if ui_value is not None else value)
+        serde = CheckboxSerde(value)
 
         checkbox_state = register_widget(
             "checkbox",
@@ -137,8 +148,8 @@ class CheckboxMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_checkbox,
-            serializer=bool,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -184,7 +184,7 @@ class ColorPickerMixin:
             color_picker_proto.set_value = True
 
         self.dg._enqueue("color_picker", color_picker_proto)
-        return widget_state.value
+        return cast(str, widget_state.value)
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import re
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
@@ -29,6 +30,17 @@ from streamlit.runtime.state import (
 )
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
+
+
+@dataclass
+class ColorPickerSerde:
+    value: str
+
+    def serialize(self, v):
+        return str(v)
+
+    def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> str:
+        return str(ui_value if ui_value is not None else self.value)
 
 
 class ColorPickerMixin:
@@ -150,10 +162,7 @@ class ColorPickerMixin:
         if help is not None:
             color_picker_proto.help = dedent(help)
 
-        def deserialize_color_picker(
-            ui_value: Optional[str], widget_id: str = ""
-        ) -> str:
-            return str(ui_value if ui_value is not None else value)
+        serde = ColorPickerSerde(value)
 
         widget_state = register_widget(
             "color_picker",
@@ -162,8 +171,8 @@ class ColorPickerMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_color_picker,
-            serializer=str,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -36,7 +36,7 @@ from .utils import check_callback_rules, check_session_state_rules
 class ColorPickerSerde:
     value: str
 
-    def serialize(self, v):
+    def serialize(self, v: str) -> str:
         return str(v)
 
     def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> str:
@@ -184,7 +184,7 @@ class ColorPickerMixin:
             color_picker_proto.set_value = True
 
         self.dg._enqueue("color_picker", color_picker_proto)
-        return cast(str, widget_state.value)
+        return widget_state.value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from streamlit.type_util import Key, to_key
 from typing import cast, overload, List, Optional, Union
 from textwrap import dedent
@@ -39,6 +40,73 @@ from .utils import check_callback_rules, check_session_state_rules
 LOGGER = get_logger(__name__)
 
 SomeUploadedFiles = Optional[Union[UploadedFile, List[UploadedFile]]]
+
+
+def _get_file_recs(
+    widget_id: str, widget_value: Optional[FileUploaderStateProto]
+) -> List[UploadedFileRec]:
+    if widget_value is None:
+        return []
+
+    ctx = get_script_run_ctx()
+    if ctx is None:
+        return []
+
+    uploaded_file_info = widget_value.uploaded_file_info
+    if len(uploaded_file_info) == 0:
+        return []
+
+    active_file_ids = [f.id for f in uploaded_file_info]
+
+    # Grab the files that correspond to our active file IDs.
+    return ctx.uploaded_file_mgr.get_files(
+        session_id=ctx.session_id,
+        widget_id=widget_id,
+        file_ids=active_file_ids,
+    )
+
+
+@dataclass
+class FileUploaderSerde:
+    accept_multiple_files: bool
+
+    def deserialize(
+        self, ui_value: Optional[FileUploaderStateProto], widget_id: str
+    ) -> SomeUploadedFiles:
+        file_recs = _get_file_recs(widget_id, ui_value)
+        if len(file_recs) == 0:
+            return_value: Optional[Union[List[UploadedFile], UploadedFile]] = (
+                [] if self.accept_multiple_files else None
+            )
+        else:
+            files = [UploadedFile(rec) for rec in file_recs]
+            return_value = files if self.accept_multiple_files else files[0]
+        return return_value
+
+    def serialize(self, files: SomeUploadedFiles) -> FileUploaderStateProto:
+        state_proto = FileUploaderStateProto()
+
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            return state_proto
+
+        # ctx.uploaded_file_mgr._file_id_counter stores the id to use for
+        # the *next* uploaded file, so the current highest file id is the
+        # counter minus 1.
+        state_proto.max_file_id = ctx.uploaded_file_mgr._file_id_counter - 1
+
+        if not files:
+            return state_proto
+        elif not isinstance(files, list):
+            files = [files]
+
+        for f in files:
+            file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
+            file_info.id = f.id
+            file_info.name = f.name
+            file_info.size = f.size
+
+        return state_proto
 
 
 class FileUploaderMixin:
@@ -288,43 +356,7 @@ class FileUploaderMixin:
         if help is not None:
             file_uploader_proto.help = dedent(help)
 
-        def deserialize_file_uploader(
-            ui_value: Optional[FileUploaderStateProto], widget_id: str
-        ) -> SomeUploadedFiles:
-            file_recs = self._get_file_recs(widget_id, ui_value)
-            if len(file_recs) == 0:
-                return_value: Optional[Union[List[UploadedFile], UploadedFile]] = (
-                    [] if accept_multiple_files else None
-                )
-            else:
-                files = [UploadedFile(rec) for rec in file_recs]
-                return_value = files if accept_multiple_files else files[0]
-            return return_value
-
-        def serialize_file_uploader(files: SomeUploadedFiles) -> FileUploaderStateProto:
-            state_proto = FileUploaderStateProto()
-
-            ctx = get_script_run_ctx()
-            if ctx is None:
-                return state_proto
-
-            # ctx.uploaded_file_mgr._file_id_counter stores the id to use for
-            # the *next* uploaded file, so the current highest file id is the
-            # counter minus 1.
-            state_proto.max_file_id = ctx.uploaded_file_mgr._file_id_counter - 1
-
-            if not files:
-                return state_proto
-            elif not isinstance(files, list):
-                files = [files]
-
-            for f in files:
-                file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
-                file_info.id = f.id
-                file_info.name = f.name
-                file_info.size = f.size
-
-            return state_proto
+        serde = FileUploaderSerde(accept_multiple_files)
 
         # FileUploader's widget value is a list of file IDs
         # representing the current set of files that this uploader should
@@ -336,8 +368,8 @@ class FileUploaderMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_file_uploader,
-            serializer=serialize_file_uploader,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -345,7 +377,7 @@ class FileUploaderMixin:
         # the following proto fields to affect a widget's ID.
         file_uploader_proto.disabled = disabled
 
-        file_uploader_state = serialize_file_uploader(widget_state.value)
+        file_uploader_state = serde.serialize(widget_state.value)
         uploaded_file_info = file_uploader_state.uploaded_file_info
         if ctx is not None and len(uploaded_file_info) != 0:
             newest_file_id = file_uploader_state.max_file_id
@@ -360,30 +392,6 @@ class FileUploaderMixin:
 
         self.dg._enqueue("file_uploader", file_uploader_proto)
         return widget_state.value
-
-    @staticmethod
-    def _get_file_recs(
-        widget_id: str, widget_value: Optional[FileUploaderStateProto]
-    ) -> List[UploadedFileRec]:
-        if widget_value is None:
-            return []
-
-        ctx = get_script_run_ctx()
-        if ctx is None:
-            return []
-
-        uploaded_file_info = widget_value.uploaded_file_info
-        if len(uploaded_file_info) == 0:
-            return []
-
-        active_file_ids = [f.id for f in uploaded_file_info]
-
-        # Grab the files that correspond to our active file IDs.
-        return ctx.uploaded_file_mgr.get_files(
-            session_id=ctx.session_id,
-            widget_id=widget_id,
-            file_ids=active_file_ids,
-        )
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -100,7 +100,7 @@ def _check_and_convert_to_indices(
 
 @dataclass
 class MultiSelectSerde:
-    options: Sequence
+    options: Sequence[Any]
     default_value: List[int]
 
     def deserialize(

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
 from typing import (
@@ -43,6 +44,75 @@ from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
 T = TypeVar("T")
+
+
+@overload
+def _check_and_convert_to_indices(  # type: ignore[misc]
+    opt: Sequence[Any], default_values: None
+) -> Optional[List[int]]:
+    ...
+
+
+@overload
+def _check_and_convert_to_indices(
+    opt: Sequence[Any], default_values: Union[Iterable[Any], Any]
+) -> List[int]:
+    ...
+
+
+def _check_and_convert_to_indices(
+    opt: Sequence[Any], default_values: Union[Iterable[Any], Any, None]
+) -> Optional[List[int]]:
+    """Perform validation checks and return indices based on the default values."""
+    if default_values is None and None not in opt:
+        return None
+
+    if not isinstance(default_values, list):
+        # This if is done before others because calling if not x (done
+        # right below) when x is of type pd.Series() or np.array() throws a
+        # ValueError exception.
+        if is_type(default_values, "numpy.ndarray") or is_type(
+            default_values, "pandas.core.series.Series"
+        ):
+            default_values = list(cast(Iterable[Any], default_values))
+        elif not default_values or default_values in opt:
+            default_values = [default_values]
+        else:
+            default_values = list(default_values)
+    if len(default_values) != 0 and isinstance(default_values[0], Enum):
+        str_default_values = [str(enum) for enum in default_values]
+        mapped_opt_keys = [str(enum) for enum in opt]
+        for value in str_default_values:
+            if value not in mapped_opt_keys:
+                raise StreamlitAPIException(
+                    "Every Multiselect default value must exist in options"
+                )
+        return [mapped_opt_keys.index(value) for value in str_default_values]
+
+    for value in default_values:
+        if value not in opt:
+            raise StreamlitAPIException(
+                "Every Multiselect default value must exist in options"
+            )
+
+    return [opt.index(value) for value in default_values]
+
+
+@dataclass
+class MultiSelectSerde:
+    options: Sequence
+    default_value: List[int]
+
+    def deserialize(
+        self, ui_value: Optional[List[int]], widget_id: str = ""
+    ) -> List[Any]:
+        current_value: List[int] = (
+            ui_value if ui_value is not None else self.default_value
+        )
+        return [self.options[i] for i in current_value]
+
+    def serialize(self, value: List[Any]) -> List[int]:
+        return _check_and_convert_to_indices(self.options, value)
 
 
 class MultiSelectMixin:
@@ -184,55 +254,6 @@ class MultiSelectMixin:
 
         opt = ensure_indexable(options)
 
-        @overload
-        def _check_and_convert_to_indices(  # type: ignore[misc]
-            opt: Sequence[Any], default_values: None
-        ) -> Optional[List[int]]:
-            ...
-
-        @overload
-        def _check_and_convert_to_indices(
-            opt: Sequence[Any], default_values: Union[Iterable[Any], Any]
-        ) -> List[int]:
-            ...
-
-        def _check_and_convert_to_indices(
-            opt: Sequence[Any], default_values: Union[Iterable[Any], Any, None]
-        ) -> Optional[List[int]]:
-            """Perform validation checks and return indices based on the default values."""
-            if default_values is None and None not in opt:
-                return None
-
-            if not isinstance(default_values, list):
-                # This if is done before others because calling if not x (done
-                # right below) when x is of type pd.Series() or np.array() throws a
-                # ValueError exception.
-                if is_type(default_values, "numpy.ndarray") or is_type(
-                    default_values, "pandas.core.series.Series"
-                ):
-                    default_values = list(cast(Iterable[Any], default_values))
-                elif not default_values or default_values in opt:
-                    default_values = [default_values]
-                else:
-                    default_values = list(default_values)
-            if len(default_values) != 0 and isinstance(default_values[0], Enum):
-                str_default_values = [str(enum) for enum in default_values]
-                mapped_opt_keys = [str(enum) for enum in opt]
-                for value in str_default_values:
-                    if value not in mapped_opt_keys:
-                        raise StreamlitAPIException(
-                            "Every Multiselect default value must exist in options"
-                        )
-                return [mapped_opt_keys.index(value) for value in str_default_values]
-
-            for value in default_values:
-                if value not in opt:
-                    raise StreamlitAPIException(
-                        "Every Multiselect default value must exist in options"
-                    )
-
-            return [opt.index(value) for value in default_values]
-
         indices = _check_and_convert_to_indices(opt, default)
         multiselect_proto = MultiSelectProto()
         multiselect_proto.label = label
@@ -243,16 +264,7 @@ class MultiSelectMixin:
         if help is not None:
             multiselect_proto.help = dedent(help)
 
-        def deserialize_multiselect(
-            ui_value: Optional[List[int]], widget_id: str = ""
-        ) -> List[Any]:
-            current_value: List[int] = (
-                ui_value if ui_value is not None else default_value
-            )
-            return [opt[i] for i in current_value]
-
-        def serialize_multiselect(value: List[Any]) -> List[int]:
-            return _check_and_convert_to_indices(opt, value)
+        serde = MultiSelectSerde(opt, default_value)
 
         widget_state = register_widget(
             "multiselect",
@@ -261,15 +273,15 @@ class MultiSelectMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_multiselect,
-            serializer=serialize_multiselect,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
         # This needs to be done after register_widget because we don't want
         # the following proto fields to affect a widget's ID.
         multiselect_proto.disabled = disabled
         if widget_state.value_changed:
-            multiselect_proto.value[:] = serialize_multiselect(widget_state.value)
+            multiselect_proto.value[:] = serde.serialize(widget_state.value)
             multiselect_proto.set_value = True
 
         self.dg._enqueue("multiselect", multiselect_proto)

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -44,7 +44,7 @@ class NumberInputSerde:
         return v
 
     def deserialize(self, ui_value: Optional[Number], widget_id: str = "") -> Number:
-        return ui_value if ui_value is not None else cast(Number, self.value)
+        return ui_value if ui_value is not None else self.value
 
 
 class NumberInputMixin:
@@ -308,7 +308,7 @@ class NumberInputMixin:
             number_input_proto.set_value = True
 
         self.dg._enqueue("number_input", number_input_proto)
-        return widget_state.value
+        return cast(Number, widget_state.value)
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -40,7 +40,7 @@ Number = Union[int, float]
 class NumberInputSerde:
     value: Union[int, float]
 
-    def serialize(self, v):
+    def serialize(self, v: Number) -> Number:
         return v
 
     def deserialize(self, ui_value: Optional[Number], widget_id: str = "") -> Number:
@@ -308,7 +308,7 @@ class NumberInputMixin:
             number_input_proto.set_value = True
 
         self.dg._enqueue("number_input", number_input_proto)
-        return cast(Number, widget_state.value)
+        return widget_state.value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import numbers
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
@@ -33,6 +34,17 @@ from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
 Number = Union[int, float]
+
+
+@dataclass
+class NumberInputSerde:
+    value: Union[int, float]
+
+    def serialize(self, v):
+        return v
+
+    def deserialize(self, ui_value: Optional[Number], widget_id: str = "") -> Number:
+        return ui_value if ui_value is not None else cast(Number, self.value)
 
 
 class NumberInputMixin:
@@ -275,11 +287,7 @@ class NumberInputMixin:
         if format is not None:
             number_input_proto.format = format
 
-        def deserialize_number_input(
-            ui_value: Optional[Number], widget_id: str = ""
-        ) -> Number:
-            return ui_value if ui_value is not None else cast(Number, value)
-
+        serde = NumberInputSerde(value)
         widget_state = register_widget(
             "number_input",
             number_input_proto,
@@ -287,8 +295,8 @@ class NumberInputMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_number_input,
-            serializer=lambda x: x,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Callable, Optional, cast
 
@@ -29,6 +30,26 @@ from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
+
+
+@dataclass
+class RadioSerde:
+    options: OptionSequence
+    index: int
+
+    def serialize(self, v):
+        if len(self.options) == 0:
+            return 0
+        return index_(self.options, v)
+
+    def deserialize(self, ui_value, widget_id=""):
+        idx = ui_value if ui_value is not None else self.index
+
+        return (
+            self.options[idx]
+            if len(self.options) > 0 and self.options[idx] is not None
+            else None
+        )
 
 
 class RadioMixin:
@@ -163,15 +184,7 @@ class RadioMixin:
         if help is not None:
             radio_proto.help = dedent(help)
 
-        def deserialize_radio(ui_value, widget_id=""):
-            idx = ui_value if ui_value is not None else index
-
-            return opt[idx] if len(opt) > 0 and opt[idx] is not None else None
-
-        def serialize_radio(v):
-            if len(opt) == 0:
-                return 0
-            return index_(opt, v)
+        serde = RadioSerde(opt, index)
 
         widget_state = register_widget(
             "radio",
@@ -180,8 +193,8 @@ class RadioMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_radio,
-            serializer=serialize_radio,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -189,7 +202,7 @@ class RadioMixin:
         # the following proto fields to affect a widget's ID.
         radio_proto.disabled = disabled
         if widget_state.value_changed:
-            radio_proto.value = serialize_radio(widget_state.value)
+            radio_proto.value = serde.serialize(widget_state.value)
             radio_proto.set_value = True
 
         self.dg._enqueue("radio", radio_proto)

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Callable, Optional, cast
 
@@ -29,6 +30,26 @@ from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
+
+
+@dataclass
+class SelectboxSerde:
+    options: OptionSequence
+    index: int
+
+    def deserialize(self, ui_value, widget_id=""):
+        idx = ui_value if ui_value is not None else self.index
+
+        return (
+            self.options[idx]
+            if len(self.options) > 0 and self.options[idx] is not None
+            else None
+        )
+
+    def serialize(self, v):
+        if len(self.options) == 0:
+            return 0
+        return index_(self.options, v)
 
 
 class SelectboxMixin:
@@ -149,15 +170,7 @@ class SelectboxMixin:
         if help is not None:
             selectbox_proto.help = dedent(help)
 
-        def deserialize_select_box(ui_value, widget_id=""):
-            idx = ui_value if ui_value is not None else index
-
-            return opt[idx] if len(opt) > 0 and opt[idx] is not None else None
-
-        def serialize_select_box(v):
-            if len(opt) == 0:
-                return 0
-            return index_(opt, v)
+        serde = SelectboxSerde(opt, index)
 
         widget_state = register_widget(
             "selectbox",
@@ -166,8 +179,8 @@ class SelectboxMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_select_box,
-            serializer=serialize_select_box,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -175,7 +188,7 @@ class SelectboxMixin:
         # the following proto fields to affect a widget's ID.
         selectbox_proto.disabled = disabled
         if widget_state.value_changed:
-            selectbox_proto.value = serialize_select_box(widget_state.value)
+            selectbox_proto.value = serde.serialize(widget_state.value)
             selectbox_proto.set_value = True
 
         self.dg._enqueue("selectbox", selectbox_proto)

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from datetime import date, time, datetime, timedelta, timezone
+from datetime import date, time, datetime, timedelta, timezone, tzinfo
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
 from typing import Any, List, cast, Optional
@@ -46,14 +46,14 @@ class SliderSerde:
     value: List[float]
     data_type: int
     single_value: bool
-    orig_tz: ...
+    orig_tz: Optional[tzinfo]
 
     def deserialize(self, ui_value: Optional[List[float]], widget_id=""):
         if ui_value is not None:
             val = ui_value
         else:
             # Widget has not been used; fallback to the original value,
-            val = cast(List[float], self.value)
+            val = self.value
 
         # The widget always returns a float array, so fix the return type if necessary
         if self.data_type == SliderProto.INT:

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from datetime import date, time, datetime, timedelta, timezone
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
@@ -32,6 +33,83 @@ from streamlit.runtime.state import (
 )
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
+
+SECONDS_TO_MICROS = 1000 * 1000
+DAYS_TO_MICROS = 24 * 60 * 60 * SECONDS_TO_MICROS
+
+
+UTC_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+@dataclass
+class SliderSerde:
+    value: List[float]
+    data_type: int
+    single_value: bool
+    orig_tz: ...
+
+    def deserialize(self, ui_value: Optional[List[float]], widget_id=""):
+        if ui_value is not None:
+            val = ui_value
+        else:
+            # Widget has not been used; fallback to the original value,
+            val = cast(List[float], self.value)
+
+        # The widget always returns a float array, so fix the return type if necessary
+        if self.data_type == SliderProto.INT:
+            val = [int(v) for v in val]
+        if self.data_type == SliderProto.DATETIME:
+            val = [self._micros_to_datetime(int(v)) for v in val]
+        if self.data_type == SliderProto.DATE:
+            val = [self._micros_to_datetime(int(v)).date() for v in val]
+        if self.data_type == SliderProto.TIME:
+            val = [
+                self._micros_to_datetime(int(v)).time().replace(tzinfo=self.orig_tz)
+                for v in val
+            ]
+        return val[0] if self.single_value else tuple(val)
+
+    def serialize(self, v: Any) -> List[Any]:
+        range_value = isinstance(v, (list, tuple))
+        value = list(v) if range_value else [v]
+        if self.data_type == SliderProto.DATE:
+            value = [self._datetime_to_micros(self._date_to_datetime(v)) for v in value]
+        if self.data_type == SliderProto.TIME:
+            value = [self._datetime_to_micros(self._time_to_datetime(v)) for v in value]
+        if self.data_type == SliderProto.DATETIME:
+            value = [self._datetime_to_micros(v) for v in value]
+        return value
+
+    def _time_to_datetime(self, time):
+        # Note, here we pick an arbitrary date well after Unix epoch.
+        # This prevents pre-epoch timezone issues (https://bugs.python.org/issue36759)
+        # We're dropping the date from datetime laters, anyways.
+        return datetime.combine(date(2000, 1, 1), time)
+
+    def _date_to_datetime(self, date):
+        return datetime.combine(date, time())
+
+    def _datetime_to_micros(self, dt):
+        # The frontend is not aware of timezones and only expects a UTC-based timestamp (in microseconds).
+        # Since we want to show the date/time exactly as it is in the given datetime object,
+        # we just set the tzinfo to UTC and do not do any timezone conversions.
+        # Only the backend knows about original timezone and will replace the UTC timestamp in the deserialization.
+        utc_dt = dt.replace(tzinfo=timezone.utc)
+        return self._delta_to_micros(utc_dt - UTC_EPOCH)
+
+    def _delta_to_micros(self, delta):
+        return (
+            delta.microseconds
+            + delta.seconds * SECONDS_TO_MICROS
+            + delta.days * DAYS_TO_MICROS
+        )
+
+    # Restore times/datetimes to original timezone (dates are always naive)
+    def _micros_to_datetime(self, micros):
+        utc_dt = UTC_EPOCH + timedelta(microseconds=micros)
+        # Add the original timezone. No conversion is required here,
+        # since in the serialization, we also just replace the timestamp with UTC.
+        return utc_dt.replace(tzinfo=self.orig_tz)
 
 
 class SliderMixin:
@@ -374,6 +452,7 @@ class SliderMixin:
         except JSNumberBoundsException as e:
             raise StreamlitAPIException(str(e))
 
+        orig_tz = None
         # Convert dates or times into datetimes
         if data_type == SliderProto.TIME:
 
@@ -454,37 +533,7 @@ class SliderMixin:
         if help is not None:
             slider_proto.help = dedent(help)
 
-        def deserialize_slider(ui_value: Optional[List[float]], widget_id=""):
-            if ui_value is not None:
-                val = ui_value
-            else:
-                # Widget has not been used; fallback to the original value,
-                val = cast(List[float], value)
-
-            # The widget always returns a float array, so fix the return type if necessary
-            if data_type == SliderProto.INT:
-                val = [int(v) for v in val]
-            if data_type == SliderProto.DATETIME:
-                val = [_micros_to_datetime(int(v)) for v in val]
-            if data_type == SliderProto.DATE:
-                val = [_micros_to_datetime(int(v)).date() for v in val]
-            if data_type == SliderProto.TIME:
-                val = [
-                    _micros_to_datetime(int(v)).time().replace(tzinfo=orig_tz)
-                    for v in val
-                ]
-            return val[0] if single_value else tuple(val)
-
-        def serialize_slider(v: Any) -> List[Any]:
-            range_value = isinstance(v, (list, tuple))
-            value = list(v) if range_value else [v]
-            if data_type == SliderProto.DATE:
-                value = [_datetime_to_micros(_date_to_datetime(v)) for v in value]
-            if data_type == SliderProto.TIME:
-                value = [_datetime_to_micros(_time_to_datetime(v)) for v in value]
-            if data_type == SliderProto.DATETIME:
-                value = [_datetime_to_micros(v) for v in value]
-            return value
+        serde = SliderSerde(value, data_type, single_value, orig_tz)
 
         widget_state = register_widget(
             "slider",
@@ -493,8 +542,8 @@ class SliderMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_slider,
-            serializer=serialize_slider,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -502,7 +551,7 @@ class SliderMixin:
         # the following proto fields to affect a widget's ID.
         slider_proto.disabled = disabled
         if widget_state.value_changed:
-            slider_proto.value[:] = serialize_slider(widget_state.value)
+            slider_proto.value[:] = serde.serialize(widget_state.value)
             slider_proto.set_value = True
 
         self.dg._enqueue("slider", slider_proto)

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -41,7 +41,7 @@ class TextInputSerde:
     def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> str:
         return str(ui_value if ui_value is not None else self.value)
 
-    def serialize(self, v):
+    def serialize(self, v: str) -> str:
         return v
 
 
@@ -52,7 +52,7 @@ class TextAreaSerde:
     def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> str:
         return str(ui_value if ui_value is not None else self.value)
 
-    def serialize(self, v):
+    def serialize(self, v: str) -> str:
         return v
 
 
@@ -218,7 +218,7 @@ class TextWidgetsMixin:
             text_input_proto.set_value = True
 
         self.dg._enqueue("text_input", text_input_proto)
-        return cast(str, widget_state.value)
+        return widget_state.value
 
     def text_area(
         self,
@@ -360,7 +360,7 @@ class TextWidgetsMixin:
             text_area_proto.set_value = True
 
         self.dg._enqueue("text_area", text_area_proto)
-        return cast(str, widget_state.value)
+        return widget_state.value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, to_key
 from textwrap import dedent
@@ -31,6 +32,28 @@ from streamlit.runtime.state import (
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 from ..type_util import SupportsStr
+
+
+@dataclass
+class TextInputSerde:
+    value: SupportsStr
+
+    def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> str:
+        return str(ui_value if ui_value is not None else self.value)
+
+    def serialize(self, v):
+        return v
+
+
+@dataclass
+class TextAreaSerde:
+    value: SupportsStr
+
+    def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> str:
+        return str(ui_value if ui_value is not None else self.value)
+
+    def serialize(self, v):
+        return v
 
 
 class TextWidgetsMixin:
@@ -173,8 +196,7 @@ class TextWidgetsMixin:
             autocomplete = "new-password" if type == "password" else ""
         text_input_proto.autocomplete = autocomplete
 
-        def deserialize_text_input(ui_value: Optional[str], widget_id: str = "") -> str:
-            return str(ui_value if ui_value is not None else value)
+        serde = TextInputSerde(value)
 
         widget_state = register_widget(
             "text_input",
@@ -183,8 +205,8 @@ class TextWidgetsMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_text_input,
-            serializer=lambda x: x,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 
@@ -317,9 +339,7 @@ class TextWidgetsMixin:
         if placeholder is not None:
             text_area_proto.placeholder = str(placeholder)
 
-        def deserialize_text_area(ui_value, widget_id="") -> str:
-            return str(ui_value if ui_value is not None else value)
-
+        serde = TextAreaSerde(value)
         widget_state = register_widget(
             "text_area",
             text_area_proto,
@@ -327,8 +347,8 @@ class TextWidgetsMixin:
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
-            deserializer=deserialize_text_area,
-            serializer=lambda x: x,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
             ctx=ctx,
         )
 

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -218,7 +218,7 @@ class TextWidgetsMixin:
             text_input_proto.set_value = True
 
         self.dg._enqueue("text_input", text_input_proto)
-        return widget_state.value
+        return cast(str, widget_state.value)
 
     def text_area(
         self,
@@ -360,7 +360,7 @@ class TextWidgetsMixin:
             text_area_proto.set_value = True
 
         self.dg._enqueue("text_area", text_area_proto)
-        return widget_state.value
+        return cast(str, widget_state.value)
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/tests/streamlit/file_uploader_test.py
+++ b/lib/tests/streamlit/file_uploader_test.py
@@ -54,7 +54,7 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, [".png", ".svg", ".jpeg"])
 
-    @patch("streamlit.elements.file_uploader.FileUploaderMixin._get_file_recs")
+    @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_multiple_files(self, get_file_recs_patch):
         """Test the accept_multiple_files flag"""
         # Patch UploadFileManager to return two files
@@ -104,7 +104,7 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
             c.max_upload_size_mb, config.get_option("server.maxUploadSize")
         )
 
-    @patch("streamlit.elements.file_uploader.FileUploaderMixin._get_file_recs")
+    @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_unique_uploaded_file_instance(self, get_file_recs_patch):
         """We should get a unique UploadedFile instance each time we access
         the file_uploader widget."""
@@ -133,7 +133,7 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
     @patch(
         "streamlit.runtime.uploaded_file_manager.UploadedFileManager.remove_orphaned_files"
     )
-    @patch("streamlit.elements.file_uploader.FileUploaderMixin._get_file_recs")
+    @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_remove_orphaned_files(
         self, get_file_recs_patch, remove_orphaned_files_patch
     ):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -315,7 +315,7 @@ class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
         )
         check_roundtrip("date_interval", date_interval)
 
-    @patch("streamlit.elements.file_uploader.FileUploaderMixin._get_file_recs")
+    @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_file_uploader_serde(self, get_file_recs_patch):
         file_recs = [
             UploadedFileRec(1, "file1", "type", b"123"),


### PR DESCRIPTION
As part of widget replay, I want to store `WidgetMetadata` in cache
results, but memo requires everything be pickleable, and functions
defined not at the top level can't be pickled. So I used the equivalence
between closures and objects, and converted the widget serde functions
into methods on a top level object.

## 📚 Context

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change



## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

