### PR TITLE
TYP: Complete type annotations for `_iframe` and `_html`

### DIFF
--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -27,7 +27,7 @@ class IframeMixin:
         width: Optional[int] = None,
         height: Optional[int] = None,
         scrolling: bool = False,
-    ):
+    ) -> "DeltaGenerator":
         """Load a remote URL in an iframe.
 
         Parameters
@@ -60,7 +60,7 @@ class IframeMixin:
         width: Optional[int] = None,
         height: Optional[int] = None,
         scrolling: bool = False,
-    ):
+    ) -> "DeltaGenerator":
         """Display an HTML string in an iframe.
 
         Parameters


### PR DESCRIPTION
## 📚 Context

It seems I forgot return type annotations on my first pass over the `IframeMixin`. Thought I'd address that.

- What kind of change does this PR introduce?

  - [X] Other, please describe: Type annotations

## 🧠 Description of Changes

- Add return type annotations to `_iframe` and `_html`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
