### PR TITLE
TYP: Add internal type annotations to `json`

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -358,6 +358,16 @@ def is_pydeck(obj: object) -> TypeGuard[Deck]:
     return is_type(obj, "pydeck.bindings.deck.Deck")
 
 
+def is_iterable(obj: object) -> TypeGuard[Iterable[Any]]:
+    try:
+        # The ignore statement here is intentional, as this is a
+        # perfectly fine way of checking for iterables.
+        iter(obj)  # type: ignore[call-overload]
+    except TypeError:
+        return False
+    return True
+
+
 def is_sequence(seq: Any) -> bool:
     """True if input looks like a sequence."""
     if isinstance(seq, str):
@@ -447,11 +457,12 @@ def ensure_iterable(obj: Union[DataFrame, Iterable[T]]) -> Iterable[Any]:
     if is_dataframe(obj):
         return cast(Iterable[Any], obj.iloc[:, 0])
 
-    try:
-        iter(obj)
-        return cast(Iterable[T], obj)
-    except TypeError:
-        raise
+    if is_iterable(obj):
+        return obj
+
+    raise TypeError(
+        f"Object is not an iterable and could not be converted to one. Object: {obj}"
+    )
 
 
 @overload


### PR DESCRIPTION
## 📚 Context

Although externally typed, the internals of `json` wasn't really type checked. I added some type annotations to help document the current state of the logic. This uncovered some unsoundness around the use of a set conversion function, hence the need for an ignore comment:

```py
body = _convert_sets_to_lists(body)  # type: ignore[arg-type]
```

- What kind of change does this PR introduce?

  - [X] Other, please describe: Type annotations

## 🧠 Description of Changes

- Add internal type annotations to `json` and related utilities

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
