### PR TITLE
TYP: Add type annotations to `map`

### DIFF
--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -13,14 +13,30 @@
 # limitations under the License.
 
 import json
-from typing import Any, Dict, cast, Optional
+from typing import Any, Dict, Mapping, Optional, TYPE_CHECKING, cast
 
-import streamlit
+from typing_extensions import Final
+
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as PydeckProto
+
+if TYPE_CHECKING:
+    from pydeck import Deck
+
+    from streamlit.delta_generator import DeltaGenerator
+
+
+# Mapping used when no data is passed.
+EMPTY_MAP: Final[Mapping[str, Any]] = {
+    "initialViewState": {"latitude": 0, "longitude": 0, "pitch": 0, "zoom": 1},
+}
 
 
 class PydeckMixin:
-    def pydeck_chart(self, pydeck_obj=None, use_container_width=False):
+    def pydeck_chart(
+        self,
+        pydeck_obj: Optional["Deck"] = None,
+        use_container_width: bool = False,
+    ) -> "DeltaGenerator":
         """Draw a chart using the PyDeck library.
 
         This supports 3D maps, point clouds, and more! More info about PyDeck
@@ -42,8 +58,9 @@ class PydeckMixin:
 
         Parameters
         ----------
-        spec: pydeck.Deck or None
+        pydeck_obj: pydeck.Deck or None
             Object specifying the PyDeck chart to draw.
+        use_container_width: bool
 
         Example
         -------
@@ -97,33 +114,34 @@ class PydeckMixin:
         return self.dg._enqueue("deck_gl_json_chart", pydeck_proto)
 
     @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
+    def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
+        return cast("DeltaGenerator", self)
 
 
-# Map used when no data is passed.
-EMPTY_MAP: Dict[str, Any] = {
-    "initialViewState": {"latitude": 0, "longitude": 0, "pitch": 0, "zoom": 1},
-}
-
-
-def _get_pydeck_tooltip(pydeck_obj) -> Optional[Dict[str, str]]:
+def _get_pydeck_tooltip(pydeck_obj: Optional["Deck"]) -> Optional[Dict[str, str]]:
     if pydeck_obj is None:
         return None
-    # For pydeck <9.8.1 or pydeck>=0.8.1 when jupyter extra is installed.
+
+    # For pydeck <0.8.1 or pydeck>=0.8.1 when jupyter extra is installed.
     desk_widget = getattr(pydeck_obj, "deck_widget", None)
     if desk_widget is not None and isinstance(desk_widget.tooltip, dict):
         return desk_widget.tooltip
+
     # For pydeck >=0.8.1 when jupyter extra is not installed.
     # For details, see: https://github.com/visgl/deck.gl/pull/7125/files
     tooltip = getattr(pydeck_obj, "_tooltip", None)
     if tooltip is not None and isinstance(tooltip, dict):
         return tooltip
+
     return None
 
 
-def marshall(pydeck_proto, pydeck_obj, use_container_width):
+def marshall(
+    pydeck_proto: PydeckProto,
+    pydeck_obj: Optional["Deck"],
+    use_container_width: bool,
+) -> None:
     if pydeck_obj is None:
         spec = json.dumps(EMPTY_MAP)
     else:

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -16,77 +16,36 @@
 
 import copy
 import json
-from typing import Any, Dict, cast
+from typing import Any, Dict, Iterable, Optional, Union, cast, TYPE_CHECKING
 
 import pandas as pd
+from typing_extensions import Final, TypeAlias
 
-import streamlit
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
 
+if TYPE_CHECKING:
+    from pandas.io.formats.style import Styler
 
-class MapMixin:
-    def map(self, data=None, zoom=None, use_container_width=True):
-        """Display a map with points on it.
+    from streamlit.delta_generator import DeltaGenerator
 
-        This is a wrapper around st.pydeck_chart to quickly create scatterplot
-        charts on top of a map, with auto-centering and auto-zoom.
 
-        When using this command, we advise all users to use a personal Mapbox
-        token. This ensures the map tiles used in this chart are more
-        robust. You can do this with the mapbox.token config option.
-
-        To get a token for yourself, create an account at
-        https://mapbox.com. It's free! (for moderate usage levels). For more
-        info on how to set config options, see
-        https://docs.streamlit.io/library/advanced-features/configuration#set-configuration-options
-
-        Parameters
-        ----------
-        data : pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,
-            or None
-            The data to be plotted. Must have columns called 'lat', 'lon',
-            'latitude', or 'longitude'.
-        zoom : int
-            Zoom level as specified in
-            https://wiki.openstreetmap.org/wiki/Zoom_levels
-
-        Example
-        -------
-        >>> import streamlit as st
-        >>> import pandas as pd
-        >>> import numpy as np
-        >>>
-        >>> df = pd.DataFrame(
-        ...     np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],
-        ...     columns=['lat', 'lon'])
-        >>>
-        >>> st.map(df)
-
-        .. output::
-           https://doc-map.streamlitapp.com/
-           height: 650px
-
-        """
-        map_proto = DeckGlJsonChartProto()
-        map_proto.json = to_deckgl_json(data, zoom)
-        map_proto.use_container_width = use_container_width
-        return self.dg._enqueue("deck_gl_json_chart", map_proto)
-
-    @property
-    def dg(self) -> "streamlit.delta_generator.DeltaGenerator":
-        """Get our DeltaGenerator."""
-        return cast("streamlit.delta_generator.DeltaGenerator", self)
-
+Data: TypeAlias = Union[
+    pd.DataFrame,
+    "Styler",
+    Iterable[Any],
+    Dict[Any, Any],
+    None,
+]
 
 # Map used as the basis for st.map.
-_DEFAULT_MAP = dict(deck_gl_json_chart.EMPTY_MAP)  # type: Dict[str, Any]
+_DEFAULT_MAP: Final[Dict[str, Any]] = dict(deck_gl_json_chart.EMPTY_MAP)
 
 # Other default parameters for st.map.
-_DEFAULT_COLOR = [200, 30, 0, 160]
-_DEFAULT_ZOOM_LEVEL = 12
-_ZOOM_LEVELS = [
+_DEFAULT_COLOR: Final = [200, 30, 0, 160]
+_DEFAULT_ZOOM_LEVEL: Final = 12
+_ZOOM_LEVELS: Final = [
     360,
     180,
     90,
@@ -111,7 +70,67 @@ _ZOOM_LEVELS = [
 ]
 
 
-def _get_zoom_level(distance):
+class MapMixin:
+    def map(
+        self,
+        data: Data = None,
+        zoom: Optional[int] = None,
+        use_container_width: bool = True,
+    ) -> "DeltaGenerator":
+        """Display a map with points on it.
+
+        This is a wrapper around st.pydeck_chart to quickly create scatterplot
+        charts on top of a map, with auto-centering and auto-zoom.
+
+        When using this command, we advise all users to use a personal Mapbox
+        token. This ensures the map tiles used in this chart are more
+        robust. You can do this with the mapbox.token config option.
+
+        To get a token for yourself, create an account at
+        https://mapbox.com. It's free! (for moderate usage levels). For more
+        info on how to set config options, see
+        https://docs.streamlit.io/library/advanced-features/configuration#set-configuration-options
+
+        Parameters
+        ----------
+        data : pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,
+            or None
+            The data to be plotted. Must have columns called 'lat', 'lon',
+            'latitude', or 'longitude'.
+        zoom : int
+            Zoom level as specified in
+            https://wiki.openstreetmap.org/wiki/Zoom_levels
+        use_container_width: bool
+
+        Example
+        -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
+        >>> df = pd.DataFrame(
+        ...     np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],
+        ...     columns=['lat', 'lon'])
+        >>>
+        >>> st.map(df)
+
+        .. output::
+           https://doc-map.streamlitapp.com/
+           height: 650px
+
+        """
+        map_proto = DeckGlJsonChartProto()
+        map_proto.json = to_deckgl_json(data, zoom)
+        map_proto.use_container_width = use_container_width
+        return self.dg._enqueue("deck_gl_json_chart", map_proto)
+
+    @property
+    def dg(self) -> "DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)
+
+
+def _get_zoom_level(distance: float) -> int:
     """Get the zoom level for a given distance in degrees.
 
     See https://wiki.openstreetmap.org/wiki/Zoom_levels for reference.
@@ -127,19 +146,20 @@ def _get_zoom_level(distance):
         The zoom level, from 0 to 20.
 
     """
-
-    # For small number of points the default zoom level will be used.
-    if distance < _ZOOM_LEVELS[-1]:
-        return _DEFAULT_ZOOM_LEVEL
-
     for i in range(len(_ZOOM_LEVELS) - 1):
         if _ZOOM_LEVELS[i + 1] < distance <= _ZOOM_LEVELS[i]:
             return i
 
+    # For small number of points the default zoom level will be used.
+    return _DEFAULT_ZOOM_LEVEL
 
-def to_deckgl_json(data, zoom):
 
-    if data is None or data.empty:
+def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
+    # TODO(harahu): The ignore statement here is because iterables don't have
+    #  the empty attribute. This is either a bug, or the documented data type
+    #  is too broad. One or the other should be addressed, and the ignore
+    #  statement removed.
+    if data is None or data.empty:  # type: ignore[union-attr]
         return json.dumps(_DEFAULT_MAP)
 
     if "lat" in data:
@@ -160,7 +180,11 @@ def to_deckgl_json(data, zoom):
             'Map data must contain a column called "longitude" or "lon".'
         )
 
-    if data[lon].isnull().values.any() or data[lat].isnull().values.any():
+    # TODO(harahu): The ignore statement here is because iterables don't have
+    #  the empty attribute. This is either a bug, or the documented data type
+    #  is too broad. One or the other should be addressed, and the ignore
+    #  statement removed.
+    if data[lon].isnull().values.any() or data[lat].isnull().values.any():  # type: ignore[index]
         raise StreamlitAPIException("Latitude and longitude data must be numeric.")
 
     data = pd.DataFrame(data)
@@ -174,7 +198,7 @@ def to_deckgl_json(data, zoom):
     range_lon = abs(max_lon - min_lon)
     range_lat = abs(max_lat - min_lat)
 
-    if zoom == None:
+    if zoom is None:
         if range_lon > range_lat:
             longitude_distance = range_lon
         else:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -35,7 +35,6 @@ from typing import (
 from typing_extensions import (
     Final,
     Literal,
-    Protocol,
     TypeAlias,
     TypeGuard,
     get_args,
@@ -51,8 +50,8 @@ if TYPE_CHECKING:
     import sympy
     from pandas import DataFrame, Series, Index
     from pandas.io.formats.style import Styler
-    from plotly.graph_objs._figure import Figure
-    from pydeck.bindings.deck import Deck  # type: ignore[import]
+    from plotly.graph_objs import Figure
+    from pydeck import Deck
 
 
 # The array value field names are part of the larger set of possible value


### PR DESCRIPTION
## 📚 Context

Just adding annotations to yet another part of the public API I'd forgotten to cover.

I annotated `map` in accordance with the docstring. Doing so revealed unsoundness in `to_deckgl_json`. It doesn't handle iterables in general, contrary to the type support claimed in the docstring. I don't consider it part of the scope of this PR to fix said unsoundness, so I added two TODO-comments for any takers.

I rebased this on top of #5242 to deal with a build error. I suggest that PR is merged first.

- What kind of change does this PR introduce?

  - [X] Other, please describe: Type annotations

## 🧠 Description of Changes

- Add type annotations to `map` and related utilities.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
