### PR TITLE
Improve compatibility with pydeck v0.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
             # naturally resets daily. We maintain the convention that the
             # version number is always incremented by 1, but technically it can
             # be reset each day when the previous day's cache expires.
-            echo v1 >> ~/python_cache_key.md5
+            echo v2 >> ~/python_cache_key.md5
 
       - run: &create_node_cache_key
           name: Create Node cache key

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -48,7 +48,7 @@ INSTALL_REQUIRES = [
     "pillow>=6.2.0",
     "protobuf<4,>=3.12",
     "pyarrow>=4.0",
-    "pydeck>=0.1.dev5",
+    "pydeck>=0.1.dev5,!=0.8.0b1",
     "pympler>=0.9",
     "python-dateutil",
     "requests>=2.4",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -48,7 +48,7 @@ INSTALL_REQUIRES = [
     "pillow>=6.2.0",
     "protobuf<4,>=3.12",
     "pyarrow>=4.0",
-    "pydeck>=0.1.dev5,!=0.8.0b1",
+    "pydeck>=0.1.dev5",
     "pympler>=0.9",
     "python-dateutil",
     "requests>=2.4",

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -108,14 +108,14 @@ EMPTY_MAP: Dict[str, Any] = {
 }
 
 
-def _get_pydesk_tooltip(pydeck_obj) -> Optional[Dict[str, str]]:
+def _get_pydeck_tooltip(pydeck_obj) -> Optional[Dict[str, str]]:
     if pydeck_obj is None:
         return None
-    # For pydesk <9.8.1 or pydesk>=0.8.1 when jupyter extra is installed.
+    # For pydeck <9.8.1 or pydeck>=0.8.1 when jupyter extra is installed.
     desk_widget = getattr(pydeck_obj, "deck_widget", None)
     if desk_widget is not None and isinstance(desk_widget.tooltip, dict):
         return desk_widget.tooltip
-    # For pydesk >=0.8.1 when jupyter extra is not installed.
+    # For pydeck >=0.8.1 when jupyter extra is not installed.
     # For details, see: https://github.com/visgl/deck.gl/pull/7125/files
     tooltip = getattr(pydeck_obj, "_tooltip", None)
     if tooltip is not None and isinstance(tooltip, dict):
@@ -132,6 +132,6 @@ def marshall(pydeck_proto, pydeck_obj, use_container_width):
     pydeck_proto.json = spec
     pydeck_proto.use_container_width = use_container_width
 
-    tooltip = _get_pydesk_tooltip(pydeck_obj)
+    tooltip = _get_pydeck_tooltip(pydeck_obj)
     if tooltip:
         pydeck_proto.tooltip = json.dumps(tooltip)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This version is a pre-release, so it should not be automatically installed, but for some unknown reason pipenv does not respect it and continues to install this version.

Here is PR that shows the problem.
https://github.com/streamlit/streamlit/pull/5247

```
self = <tests.streamlit.pydeck_test.PyDeckTest testMethod=test_basic>

    def test_basic(self):
        """Test that pydeck object orks."""
    
        st.pydeck_chart(
            pdk.Deck(
                layers=[
>                   pdk.Layer("ScatterplotLayer", data=df1),
                ]
            )
        )

self       = <tests.streamlit.pydeck_test.PyDeckTest testMethod=test_basic>

tests/streamlit/pydeck_test.py:34: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
streamlit/elements/deck_gl_json_chart.py:96: in pydeck_chart
    marshall(pydeck_proto, pydeck_obj, use_container_width)
        pydeck_obj = {"initialViewState": {"latitude": 0, "longitude": 0, "zoom": 1}, "layers": [{"@@type": "ScatterplotLayer", "_kwargs": ...ttps://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json", "views": [{"@@type": "MapView", "controller": true}]}
        pydeck_proto = json: "{\"initialViewState\": {\"latitude\": 0, \"longitude\": 0, \"zoom\": 1}, \"layers\": [{\"@@type\": \"Scatterplo...maps.cartocdn.com/gl/dark-matter-gl-style/style.json\", \"views\": [{\"@@type\": \"MapView\", \"controller\": true}]}"

        self       = DeltaGenerator(_root_container=0, _provided_cursor=None, _parent=None, _block_type=None, _form_data=None)
        use_container_width = False
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pydeck_proto = json: "{\"initialViewState\": {\"latitude\": 0, \"longitude\": 0, \"zoom\": 1}, \"layers\": [{\"@@type\": \"Scatterplo...maps.cartocdn.com/gl/dark-matter-gl-style/style.json\", \"views\": [{\"@@type\": \"MapView\", \"controller\": true}]}"

pydeck_obj = {"initialViewState": {"latitude": 0, "longitude": 0, "zoom": 1}, "layers": [{"@@type": "ScatterplotLayer", "_kwargs": ...ttps://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json", "views": [{"@@type": "MapView", "controller": true}]}
use_container_width = False

    def marshall(pydeck_proto, pydeck_obj, use_container_width):
        if pydeck_obj is None:
            spec = json.dumps(EMPTY_MAP)
        else:
            spec = pydeck_obj.to_json()
    
        pydeck_proto.json = spec
        pydeck_proto.use_container_width = use_container_width
    
>       if pydeck_obj is not None and isinstance(pydeck_obj.deck_widget.tooltip, dict):
E       AttributeError: 'Deck' object has no attribute 'deck_widget'

pydeck_obj = {"initialViewState": {"latitude": 0, "longitude": 0, "zoom": 1}, "layers": [{"@@type": "ScatterplotLayer", "_kwargs": ...ttps://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json", "views": [{"@@type": "MapView", "controller": true}]}
pydeck_proto = json: "{\"initialViewState\": {\"latitude\": 0, \"longitude\": 0, \"zoom\": 1}, \"layers\": [{\"@@type\": \"Scatterplo...maps.cartocdn.com/gl/dark-matter-gl-style/style.json\", \"views\": [{\"@@type\": \"MapView\", \"controller\": true}]}"

spec       = '{"initialViewState": {"latitude": 0, "longitude": 0, "zoom": 1}, "layers": [{"@@type": "ScatterplotLayer", "_kwargs":...tps://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json", "views": [{"@@type": "MapView", "controller": true}]}'
use_container_width = False

streamlit/elements/deck_gl_json_chart.py:120: AttributeError
```

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
