### PR TITLE
Remove emoji support from `image_to_url`

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -104,6 +104,9 @@ def _get_favicon_string(page_icon: PageIcon) -> str:
         )
     except BaseException:
         if isinstance(page_icon, str):
+            # This fall-thru handles emoji shortcode strings (e.g. ":shark:"),
+            # which aren't valid filenames and so will cause an Exception from
+            # `image_to_url`.
             return page_icon
         raise
 

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -11,18 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Mapping
-from urllib.parse import urlparse
+
+import random
 from textwrap import dedent
+from typing import Mapping
 from typing import cast, Optional, TYPE_CHECKING, Union
+from urllib.parse import urlparse
 
 from typing_extensions import Final, Literal, TypeAlias
 
-from streamlit.runtime.scriptrunner import get_script_run_ctx
-from streamlit.proto.ForwardMsg_pb2 import ForwardMsg as ForwardProto
-from streamlit.proto.PageConfig_pb2 import PageConfig as PageConfigProto
 from streamlit.elements import image
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg as ForwardProto
+from streamlit.proto.PageConfig_pb2 import PageConfig as PageConfigProto
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.string_util import is_emoji
 from streamlit.util import lower_clean_dict_keys
 
 if TYPE_CHECKING:
@@ -32,7 +35,7 @@ GET_HELP_KEY: Final = "get help"
 REPORT_A_BUG_KEY: Final = "report a bug"
 ABOUT_KEY: Final = "about"
 
-PageIcon: TypeAlias = Union[image.AtomicImage, str, None]
+PageIcon: TypeAlias = Union[image.AtomicImage, str]
 Layout: TypeAlias = Literal["centered", "wide"]
 InitialSideBarState: TypeAlias = Literal["auto", "expanded", "collapsed"]
 _GetHelp: TypeAlias = Literal["Get help", "Get Help", "get help"]
@@ -41,10 +44,73 @@ _About: TypeAlias = Literal["About", "about"]
 MenuKey: TypeAlias = Literal[_GetHelp, _ReportABug, _About]
 MenuItems: TypeAlias = Mapping[MenuKey, Optional[str]]
 
+# Emojis recommended by https://share.streamlit.io/rensdimmendaal/emoji-recommender/main/app/streamlit.py
+# for the term "streamlit". Watch out for zero-width joiners,
+# as they won't parse correctly in the list() call!
+RANDOM_EMOJIS: Final = list(
+    "🔥™🎉🚀🌌💣✨🌙🎆🎇💥🤩🤙🌛🤘⬆💡🤪🥂⚡💨🌠🎊🍿😛🔮🤟🌃🍃🍾💫▪🌴🎈🎬🌀🎄😝☔⛽🍂💃😎🍸🎨🥳☀😍🅱🌞😻🌟😜💦💅🦄😋😉👻🍁🤤👯🌻‼🌈👌🎃💛😚🔫🙌👽🍬🌅☁🍷👭☕🌚💁👅🥰🍜😌🎥🕺❕🧡☄💕🍻✅🌸🚬🤓🍹®☺💪😙☘🤠✊🤗🍵🤞😂💯😏📻🎂💗💜🌊❣🌝😘💆🤑🌿🦋😈⛄🚿😊🌹🥴😽💋😭🖤🙆👐⚪💟☃🙈🍭💻🥀🚗🤧🍝💎💓🤝💄💖🔞⁉⏰🕊🎧☠♥🌳🏾🙉⭐💊🍳🌎🙊💸❤🔪😆🌾✈📚💀🏠✌🏃🌵🚨💂🤫🤭😗😄🍒👏🙃🖖💞😅🎅🍄🆓👉💩🔊🤷⌚👸😇🚮💏👳🏽💘💿💉👠🎼🎶🎤👗❄🔐🎵🤒🍰👓🏄🌲🎮🙂📈🚙📍😵🗣❗🌺🙄👄🚘🥺🌍🏡♦💍🌱👑👙☑👾🍩🥶📣🏼🤣☯👵🍫➡🎀😃✋🍞🙇😹🙏👼🐝⚫🎁🍪🔨🌼👆👀😳🌏📖👃🎸👧💇🔒💙😞⛅🏻🍴😼🗿🍗♠🦁✔🤖☮🐢🐎💤😀🍺😁😴📺☹😲👍🎭💚🍆🍋🔵🏁🔴🔔🧐👰☎🏆🤡🐠📲🙋📌🐬✍🔑📱💰🐱💧🎓🍕👟🐣👫🍑😸🍦👁🆗🎯📢🚶🦅🐧💢🏀🚫💑🐟🌽🏊🍟💝💲🐍🍥🐸☝♣👊⚓❌🐯🏈📰🌧👿🐳💷🐺📞🆒🍀🤐🚲🍔👹🙍🌷🙎🐥💵🔝📸⚠❓🎩✂🍼😑⬇⚾🍎💔🐔⚽💭🏌🐷🍍✖🍇📝🍊🐙👋🤔🥊🗽🐑🐘🐰💐🐴♀🐦🍓✏👂🏴👇🆘😡🏉👩💌😺✝🐼🐒🐶👺🖕👬🍉🐻🐾⬅⏬▶👮🍌♂🔸👶🐮👪⛳🐐🎾🐕👴🐨🐊🔹©🎣👦👣👨👈💬⭕📹📷"
+)
+
+# Also pick out some vanity emojis.
+ENG_EMOJIS: Final = [
+    "🎈",  # st.balloons 🎈🎈
+    "🤓",  # Abhi
+    "🏈",  # Amey
+    "🚲",  # Thiago
+    "🐧",  # Matteo
+    "🦒",  # Ken
+    "🐳",  # Karrie
+    "🕹️",  # Jonathan
+    "🇦🇲",  # Henrikh
+    "🎸",  # Guido
+    "🦈",  # Austin
+    "💎",  # Emiliano
+    "👩‍🎤",  # Naomi
+    "🧙‍♂️",  # Jon
+    "🐻",  # Brandon
+    "🎎",  # James
+    # TODO: Solicit emojis from the rest of Streamlit
+]
+
+
+def _get_favicon_string(page_icon: PageIcon) -> str:
+    """Return the string to pass to the frontend to have it show
+    the given PageIcon.
+
+    If page_icon is a string that looks like an emoji (or an emoji shortcode),
+    we return it as-is. Otherwise we use `image_to_url` to return a URL.
+
+    (If `image_to_url` raises an error and page_icon is a string, return
+    the unmodified page_icon string instead of re-raising the error.)
+    """
+
+    # Choose a random emoji.
+    if page_icon == "random":
+        return get_random_emoji()
+
+    # If page_icon is an emoji, return it as is.
+    if isinstance(page_icon, str) and is_emoji(page_icon):
+        return page_icon
+
+    # Fall back to image_to_url.
+    try:
+        return image.image_to_url(
+            page_icon,
+            width=-1,  # Always use full width for favicons
+            clamp=False,
+            channels="RGB",
+            output_format="auto",
+            image_id="favicon",
+        )
+    except BaseException:
+        if isinstance(page_icon, str):
+            return page_icon
+        raise
+
 
 def set_page_config(
     page_title: Optional[str] = None,
-    page_icon: PageIcon = None,
+    page_icon: Optional[PageIcon] = None,
     layout: Layout = "centered",
     initial_sidebar_state: InitialSideBarState = "auto",
     menu_items: Optional[MenuItems] = None,
@@ -108,22 +174,11 @@ def set_page_config(
 
     msg = ForwardProto()
 
-    if page_title:
+    if page_title is not None:
         msg.page_config_changed.title = page_title
 
-    if page_icon:
-        if page_icon == "random":
-            page_icon = get_random_emoji()
-
-        msg.page_config_changed.favicon = image.image_to_url(
-            page_icon,
-            width=-1,  # Always use full width for favicons
-            clamp=False,
-            channels="RGB",
-            output_format="auto",
-            image_id="favicon",
-            allow_emoji=True,
-        )
+    if page_icon is not None:
+        msg.page_config_changed.favicon = _get_favicon_string(page_icon)
 
     pb_layout: "PageConfigProto.Layout.ValueType"
     if layout == "centered":
@@ -165,35 +220,6 @@ def set_page_config(
 
 
 def get_random_emoji() -> str:
-    import random
-
-    # Emojis recommended by https://share.streamlit.io/rensdimmendaal/emoji-recommender/main/app/streamlit.py
-    # for the term "streamlit". Watch out for zero-width joiners,
-    # as they won't parse correctly in the list() call!
-    RANDOM_EMOJIS = list(
-        "🔥™🎉🚀🌌💣✨🌙🎆🎇💥🤩🤙🌛🤘⬆💡🤪🥂⚡💨🌠🎊🍿😛🔮🤟🌃🍃🍾💫▪🌴🎈🎬🌀🎄😝☔⛽🍂💃😎🍸🎨🥳☀😍🅱🌞😻🌟😜💦💅🦄😋😉👻🍁🤤👯🌻‼🌈👌🎃💛😚🔫🙌👽🍬🌅☁🍷👭☕🌚💁👅🥰🍜😌🎥🕺❕🧡☄💕🍻✅🌸🚬🤓🍹®☺💪😙☘🤠✊🤗🍵🤞😂💯😏📻🎂💗💜🌊❣🌝😘💆🤑🌿🦋😈⛄🚿😊🌹🥴😽💋😭🖤🙆👐⚪💟☃🙈🍭💻🥀🚗🤧🍝💎💓🤝💄💖🔞⁉⏰🕊🎧☠♥🌳🏾🙉⭐💊🍳🌎🙊💸❤🔪😆🌾✈📚💀🏠✌🏃🌵🚨💂🤫🤭😗😄🍒👏🙃🖖💞😅🎅🍄🆓👉💩🔊🤷⌚👸😇🚮💏👳🏽💘💿💉👠🎼🎶🎤👗❄🔐🎵🤒🍰👓🏄🌲🎮🙂📈🚙📍😵🗣❗🌺🙄👄🚘🥺🌍🏡♦💍🌱👑👙☑👾🍩🥶📣🏼🤣☯👵🍫➡🎀😃✋🍞🙇😹🙏👼🐝⚫🎁🍪🔨🌼👆👀😳🌏📖👃🎸👧💇🔒💙😞⛅🏻🍴😼🗿🍗♠🦁✔🤖☮🐢🐎💤😀🍺😁😴📺☹😲👍🎭💚🍆🍋🔵🏁🔴🔔🧐👰☎🏆🤡🐠📲🙋📌🐬✍🔑📱💰🐱💧🎓🍕👟🐣👫🍑😸🍦👁🆗🎯📢🚶🦅🐧💢🏀🚫💑🐟🌽🏊🍟💝💲🐍🍥🐸☝♣👊⚓❌🐯🏈📰🌧👿🐳💷🐺📞🆒🍀🤐🚲🍔👹🙍🌷🙎🐥💵🔝📸⚠❓🎩✂🍼😑⬇⚾🍎💔🐔⚽💭🏌🐷🍍✖🍇📝🍊🐙👋🤔🥊🗽🐑🐘🐰💐🐴♀🐦🍓✏👂🏴👇🆘😡🏉👩💌😺✝🐼🐒🐶👺🖕👬🍉🐻🐾⬅⏬▶👮🍌♂🔸👶🐮👪⛳🐐🎾🐕👴🐨🐊🔹©🎣👦👣👨👈💬⭕📹📷"
-    )
-
-    # Also pick out some vanity emojis.
-    ENG_EMOJIS = [
-        "🎈",  # st.balloons 🎈🎈
-        "🤓",  # Abhi
-        "🏈",  # Amey
-        "🚲",  # Thiago
-        "🐧",  # Matteo
-        "🦒",  # Ken
-        "🐳",  # Karrie
-        "🕹️",  # Jonathan
-        "🇦🇲",  # Henrikh
-        "🎸",  # Guido
-        "🦈",  # Austin
-        "💎",  # Emiliano
-        "👩‍🎤",  # Naomi
-        "🧙‍♂️",  # Jon
-        "🐻",  # Brandon
-        "🎎",  # James
-        # TODO: Solicit emojis from the rest of Streamlit
-    ]
 
     # Weigh our emojis 10x, cuz we're awesome!
     # TODO: fix the random seed with a hash of the user's app code, for stability?

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -290,11 +290,9 @@ def image_to_url(
     channels: Channels,
     output_format: OutputFormat,
     image_id: str,
-    allow_emoji: bool = False,
 ) -> str:
     """Return a URL that an image can be served from.
     If `image` is already a URL, return it unmodified.
-    If `image` is an emoji, return it unmodified.
     Otherwise, add the image to the MediaFileManager and return the URL.
     """
     # PIL Images
@@ -335,7 +333,7 @@ def image_to_url(
 
     # Strings
     elif isinstance(image, str):
-        # If it's a url, then set the protobuf and continue
+        # If it's a url, return it directly.
         try:
             p = urlparse(image)
             if p.scheme:
@@ -343,17 +341,9 @@ def image_to_url(
         except UnicodeDecodeError:
             pass
 
-        # Finally, see if it's a file.
-        try:
-            with open(image, "rb") as f:
-                data = f.read()
-        except:
-            if allow_emoji:
-                # This might be an emoji string, so just pass it to the frontend
-                return image
-            else:
-                # Allow OS filesystem errors to raise
-                raise
+        # Otherwise, open it as a file.
+        with open(image, "rb") as f:
+            data = f.read()
 
     # Assume input in bytes.
     else:

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -50,7 +50,7 @@ class PageConfigTest(testutil.DeltaGeneratorTestCase):
         self.assertTrue(is_emoji(c.favicon))
 
     def test_set_page_config_icon_invalid_string(self):
-        """If set_page_config is passed a garbage string, we just pass it
+        """If set_page_config is passed a garbage icon string, we just pass it
         through without an error (even though nothing will be displayed).
         """
         st.set_page_config(page_icon="st.balloons")

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -1,10 +1,32 @@
-from tests import testutil
-from parameterized import parameterized
-import streamlit as st
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+from unittest import mock
+
+from parameterized import parameterized, param
+
+import streamlit as st
+from streamlit.commands.page_config import (
+    valid_url,
+    ENG_EMOJIS,
+    RANDOM_EMOJIS,
+    PageIcon,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.PageConfig_pb2 import PageConfig as PageConfigProto
-from streamlit.commands.page_config import valid_url
+from streamlit.string_util import is_emoji
+from tests import testutil
 
 
 class PageConfigTest(testutil.DeltaGeneratorTestCase):
@@ -13,10 +35,38 @@ class PageConfigTest(testutil.DeltaGeneratorTestCase):
         c = self.get_message_from_queue().page_config_changed
         self.assertEqual(c.title, "Hello")
 
-    def test_set_page_config_icon(self):
+    @parameterized.expand(["🦈", ":shark:", "https://foo.com/image.png"])
+    def test_set_page_config_icon_strings(self, icon_string: str):
+        """page_config icons can be emojis, emoji shortcodes, and image URLs."""
+        st.set_page_config(page_icon=icon_string)
+        c = self.get_message_from_queue().page_config_changed
+        self.assertEqual(c.favicon, icon_string)
+
+    def test_set_page_config_icon_random(self):
+        """If page_icon == "random", we choose a random emoji."""
+        st.set_page_config(page_icon="random")
+        c = self.get_message_from_queue().page_config_changed
+        self.assertIn(c.favicon, set(RANDOM_EMOJIS + ENG_EMOJIS))
+        self.assertTrue(is_emoji(c.favicon))
+
+    def test_set_page_config_icon_invalid_string(self):
+        """If set_page_config is passed a garbage string, we just pass it
+        through without an error (even though nothing will be displayed).
+        """
         st.set_page_config(page_icon="st.balloons")
         c = self.get_message_from_queue().page_config_changed
         self.assertEqual(c.favicon, "st.balloons")
+
+    @parameterized.expand([param(b"123"), param("file/on/disk.png")])
+    def test_set_page_config_icon_calls_image_to_url(self, icon: PageIcon):
+        """For all other page_config icon inputs, we just call image_to_url."""
+        with mock.patch(
+            "streamlit.commands.page_config.image.image_to_url",
+            return_value="https://mock.url",
+        ):
+            st.set_page_config(page_icon=icon)
+            c = self.get_message_from_queue().page_config_changed
+            self.assertEqual(c.favicon, "https://mock.url")
 
     def test_set_page_config_layout_wide(self):
         st.set_page_config(layout="wide")

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -203,7 +203,6 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         ]
     )
     def test_image_to_url(self, img, expected_prefix):
-
         url = image.image_to_url(
             img,
             width=-1,

--- a/lib/tests/streamlit/image_test.py
+++ b/lib/tests/streamlit/image_test.py
@@ -200,14 +200,6 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
                 "https://streamlit.io/test.png",
             ),
             ("https://streamlit.io/test.svg", "https://streamlit.io/test.svg"),
-            (
-                "🦈",
-                "🦈",
-            ),
-            (
-                ":shark:",
-                ":shark:",
-            ),
         ]
     )
     def test_image_to_url(self, img, expected_prefix):
@@ -219,7 +211,6 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
             channels="RGB",
             output_format="JPEG",
             image_id="blah",
-            allow_emoji=True,
         )
         self.assertTrue(url.startswith(expected_prefix))
 


### PR DESCRIPTION
`images.image_to_url` currently takes an `allow_emoji` param; if the input string is an emoji and this flag is True, we return the input string as-is (despite the input string not being a URL). This flag is only used by the `set_page_config` command, which allows for setting emoji as page icons.

This PR removes the emoji bits from `image_to_url` and moves them to an internal `_get_favicon_string` function in `page_config.py`. It also adds additional test coverage for `page_config` icon-related stuff.

This emoji-removal makes the upcoming MediaFileManager refactor easier to reason about! (And also makes image_to_url actually work as advertised.)