### PR TITLE
Fix convert sets to lists to handle iterables

### DIFF
--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
-def _convert_sets_to_lists_repr(o: object) -> Union[str, List[Any]]:
+def _ensure_serialization(o: object) -> Union[str, List[Any]]:
     """repr function for json.dumps default arg, which tries to serialize sets as lists"""
     if isinstance(o, set):
         return list(o)
@@ -84,14 +84,13 @@ class JsonMixin:
         if not isinstance(body, str):
             try:
                 # Serialize body to string and try to interpret sets as lists
-                body = json.dumps(body, default=_convert_sets_to_lists_repr)
-            # It's safer to have more general exception catch, because of our usage of custom serialization function
-            except Exception as err:
+                body = json.dumps(body, default=_ensure_serialization)
+            except TypeError as err:
                 st.warning(
                     "Warning: this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"
                 )
-                body = json.dumps(body, skipkeys=True, default=repr)
+                body = json.dumps(body, skipkeys=True, default=_ensure_serialization)
 
         json_proto = JsonProto()
         json_proto.body = body

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -15,16 +15,11 @@
 import json
 from typing import (
     Any,
-    Hashable,
     List,
-    MutableMapping,
-    Tuple,
     Union,
     cast,
     TYPE_CHECKING,
 )
-
-from typing_extensions import TypeAlias
 
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.state import SessionStateProxy

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
-def _convert_sets_to_lists_repr(o: Any) -> Union[str, List[Any]]:
+def _convert_sets_to_lists_repr(o: object) -> Union[str, List[Any]]:
     """repr function for json.dumps default arg, which tries to serialize sets as lists"""
     if isinstance(o, set):
         return list(o)

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -34,8 +34,6 @@ from streamlit.user_info import UserInfoProxy
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
-Body: TypeAlias = Union[List[Any], Tuple[Any, ...], MutableMapping[Hashable, Any]]
-
 
 def _convert_sets_to_lists_repr(o: Any) -> Union[str, List[Any]]:
     """repr function for json.dumps default arg, which tries to serialize sets as lists"""

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import copy
 from typing import (
     Any,
     Hashable,
@@ -29,7 +28,6 @@ from typing_extensions import TypeAlias
 
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.state import SessionStateProxy
-from streamlit.type_util import is_iterable
 from streamlit.user_info import UserInfoProxy
 
 
@@ -39,26 +37,11 @@ if TYPE_CHECKING:
 Body: TypeAlias = Union[List[Any], Tuple[Any, ...], MutableMapping[Hashable, Any]]
 
 
-def _convert_sets_to_lists(body: Body) -> Body:
-    if isinstance(body, (list, tuple)):
-        # We could technically iterate through the elements of a list/tuple and convert
-        # any sets that we find to lists like we do below, but lists/tuples of sets
-        # seem like a strange enough use-case that it's probably not worth the
-        # additional complexity.
-        return body
-
-    # Convert sets into lists, which render more nicely on the frontend
-    set_found = False
-    for key in body:
-        if isinstance(body[key], set):
-            if not set_found:
-                # When set is found to prevent mutation of input body, we need
-                # to shallow copy it once. To avoid copying it multiple times
-                # we use set_found flag.
-                body = copy.copy(body)
-                set_found = True
-            body[key] = list(body[key])
-    return body
+def _convert_sets_to_lists_repr(o: Any) -> Union[str, List[Any]]:
+    """repr function for json.dumps default arg, which tries to serialize sets as lists"""
+    if isinstance(o, set):
+        return list(o)
+    return repr(o)
 
 
 class JsonMixin:
@@ -106,18 +89,11 @@ class JsonMixin:
             body = body.to_dict()
 
         if not isinstance(body, str):
-            # Check if body is iterable, if it is, convert its sets to lists
-            if is_iterable(body):
-                # body is iterable, look for sets and change them to lists
-                # TODO(harahu): This function does not handle iterables in
-                #  general. Either generalize the function, or do further type
-                #  checking here.
-                body = _convert_sets_to_lists(body)  # type: ignore[arg-type]
-
             try:
-                # Serialize body to string
-                body = json.dumps(body, default=repr)
-            except TypeError as err:
+                # Serialize body to string and try to interpret sets as lists
+                body = json.dumps(body, default=_convert_sets_to_lists_repr)
+            # It's safer to have more general exception catch, because of our usage of custom serialization function
+            except Exception as err:
                 st.warning(
                     "Warning: this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -497,16 +497,32 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
 
     def test_json_serializes_sets_as_lists(self):
         """Test st.json serializes sets as lists"""
-        json_data = {"some_set": {"a", "b"}}
 
+        # Test set inside dict is serialized as list
+        json_data = {"some_set": {"a", "b"}}
         st.json(json_data)
         element = self.get_delta_from_queue().new_element
-
         parsed_element = json.loads(element.json.body)
         set_as_list = parsed_element.get("some_set")
-
         self.assertIsInstance(set_as_list, list)
         self.assertSetEqual(json_data["some_set"], set(set_as_list))
+
+        # Test set is serialized as list
+        json_data = {"a", "b", "c", "d"}
+        st.json(json_data)
+        element = self.get_delta_from_queue().new_element
+        parsed_element = json.loads(element.json.body)
+        self.assertIsInstance(parsed_element, list)
+        for el in json_data:
+            self.assertIn(el, parsed_element)
+
+        # Test generator is serialized as string
+        json_data = (c for c in "foo")
+        st.json(json_data)
+        element = self.get_delta_from_queue().new_element
+        parsed_element = json.loads(element.json.body)
+        self.assertIsInstance(parsed_element, str)
+        self.assertIn("generator", parsed_element)
 
     def test_markdown(self):
         """Test Markdown element."""

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -495,19 +495,8 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
         st.json(json_data)
         self.assertIsInstance(json_data["some_set"], set)
 
-    def test_json_serializes_sets_as_lists(self):
-        """Test st.json serializes sets as lists"""
-
-        # Test set inside dict is serialized as list
-        json_data = {"some_set": {"a", "b"}}
-        st.json(json_data)
-        element = self.get_delta_from_queue().new_element
-        parsed_element = json.loads(element.json.body)
-        set_as_list = parsed_element.get("some_set")
-        self.assertIsInstance(set_as_list, list)
-        self.assertSetEqual(json_data["some_set"], set(set_as_list))
-
-        # Test set is serialized as list
+    def test_st_json_set_is_serialized_as_list(self):
+        """Test st.json serializes set as list"""
         json_data = {"a", "b", "c", "d"}
         st.json(json_data)
         element = self.get_delta_from_queue().new_element
@@ -516,7 +505,18 @@ class DeltaGeneratorWriteTest(testutil.DeltaGeneratorTestCase):
         for el in json_data:
             self.assertIn(el, parsed_element)
 
-        # Test generator is serialized as string
+    def test_st_json_serializes_sets_inside_iterables_as_lists(self):
+        """Test st.json serializes sets inside iterables as lists"""
+        json_data = {"some_set": {"a", "b"}}
+        st.json(json_data)
+        element = self.get_delta_from_queue().new_element
+        parsed_element = json.loads(element.json.body)
+        set_as_list = parsed_element.get("some_set")
+        self.assertIsInstance(set_as_list, list)
+        self.assertSetEqual(json_data["some_set"], set(set_as_list))
+
+    def test_st_json_generator_is_serialized_as_string(self):
+        """Test st.json serializes generator as string"""
         json_data = (c for c in "foo")
         st.json(json_data)
         element = self.get_delta_from_queue().new_element


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

With the [PR-#5176 Make st.write render sets as list instead of strings](https://github.com/streamlit/streamlit/pull/5176) I've introduced the bug which coused `st.json` to fail on proper datasets. 

This was improved in the @vdonato [PR-#5223 Make sure st.json doesn't explode when passed a list](https://github.com/streamlit/streamlit/pull/5223).

In @harahu [PR-#5245 TYP: Add internal type annotations to json](https://github.com/streamlit/streamlit/pull/5245) @harahu @LukasMasuch @sfc-gh-kbregula discussed improvements to still unreliable code.

This PR uses @sfc-gh-kbregula [proposition](https://github.com/streamlit/streamlit/pull/5245#issuecomment-1230938631) mentioned in [PR-#5245 TYP: Add internal type annotations to json](https://github.com/streamlit/streamlit/pull/5245).

```
def _my_repr(o):
  if isinstance(o, set):
    return list(o)
  return repr(o)
print(json.dumps(set(), default=_my_repr)
```

Since it uses `json.dumps` mechanism to serialize the data most of the quirks and quarks are solved with it, also I've used more general `try except` catch.

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
