### PR TITLE
Remove jest snapshot testing for status widget

### DIFF
--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -21,7 +21,7 @@ import { ConnectionState } from "src/lib/ConnectionState"
 import { ScriptRunState } from "src/lib/ScriptRunState"
 import { SessionEventDispatcher } from "src/lib/SessionEventDispatcher"
 import { SessionEvent } from "src/autogen/proto"
-import { darkTheme, lightTheme } from "src/theme"
+import { lightTheme } from "src/theme"
 
 import StatusWidget, { StatusWidgetProps } from "./StatusWidget"
 
@@ -37,22 +37,6 @@ const getProps = (
   theme: lightTheme.emotion,
   ...propOverrides,
 })
-
-const customLightTheme = {
-  ...lightTheme.emotion,
-  colors: {
-    ...lightTheme.emotion.colors,
-    bgColor: "#dddddd",
-  },
-}
-
-const customDarkTheme = {
-  ...darkTheme.emotion,
-  colors: {
-    ...darkTheme.emotion.colors,
-    bgColor: "#203d3f",
-  },
-}
 
 describe("Tooltip element", () => {
   it("renders a Tooltip", () => {
@@ -109,32 +93,6 @@ describe("Tooltip element", () => {
     )
 
     expect(wrapper.find("Tooltip").exists()).toBeFalsy()
-  })
-
-  it("renders running img correctly with lightTheme", () => {
-    const wrapper = mount(<StatusWidget {...getProps()} />)
-    expect(wrapper).toMatchSnapshot()
-  })
-
-  it("renders running img correctly with custom light background color", () => {
-    const wrapper = mount(
-      <StatusWidget {...getProps({ theme: customLightTheme })} />
-    )
-    expect(wrapper).toMatchSnapshot()
-  })
-
-  it("renders running img correctly with darkTheme", () => {
-    const wrapper = mount(
-      <StatusWidget {...getProps({ theme: darkTheme.emotion })} />
-    )
-    expect(wrapper).toMatchSnapshot()
-  })
-
-  it("renders running img correctly with custom dark background color", () => {
-    const wrapper = mount(
-      <StatusWidget {...getProps({ theme: customDarkTheme })} />
-    )
-    expect(wrapper).toMatchSnapshot()
   })
 
   it("sets and unsets the sessionEventConnection", () => {


### PR DESCRIPTION
## 📚 Context

The StatusWidget is currently tested against a snapshot in jest based on the full StatusWidget mount. However, this one contains all our theming information which means that whenever we change anything related to our global theming we have to update the StatusWidget snapshot as well. Also, this file is huge (8MB, 12k lines) and contains a lot other aspects that might requiring to update the snapshot for complelty unrelated tasks. I removed this snapshot and the related tests since I don't think that they add a lot of value and cause some trouble with unrelated tasks. 

An alternative way to test if it behaves correctly with different theming would be via e2e snapshot tests. However, this is a bit more complicated in this case since the status widget is animated and I'm not sure if it is worth the effort to get this working. 

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
