### PR TITLE
More image.py cleanup

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -53,8 +53,8 @@ AtomicImage: TypeAlias = Union[PILImage, "npt.NDArray[Any]", io.BytesIO, str]
 ImageOrImageList: TypeAlias = Union[AtomicImage, List[AtomicImage]]
 UseColumnWith: TypeAlias = Optional[Union[Literal["auto", "always", "never"], bool]]
 Channels: TypeAlias = Literal["RGB", "BGR"]
-ImageFormatOrAuto: TypeAlias = Literal["JPEG", "PNG", "auto"]
 ImageFormat: TypeAlias = Literal["JPEG", "PNG"]
+ImageFormatOrAuto: TypeAlias = Literal[ImageFormat, "auto"]
 
 
 class ImageMixin:

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -364,6 +364,47 @@ def marshall_images(
     channels: Channels = "RGB",
     output_format: OutputFormat = "auto",
 ) -> None:
+    """Fill an ImageListProto with a list of images and their captions.
+
+    The images will be resized and reformatted as necessary.
+
+    Parameters
+    ----------
+    coordinates
+        A string indentifying the images' location in the frontend.
+    image
+        The image or images to include in the ImageListProto.
+    caption
+        Image caption. If displaying multiple images, caption should be a
+        list of captions (one for each image).
+    width
+        The desired width of the image or images. This parameter will be
+        passed to the frontend, where it has some special meanings:
+        -1: "OriginalWidth" (display the image at its original width)
+        -2: "ColumnWidth" (display the image at the width of the column it's in)
+        -3: "AutoWidth" (display the image at its original width, unless it
+            would exceed the width of its column in which case clamp it to
+            its column width).
+    proto_imgs
+        The ImageListProto to fill in.
+    clamp
+        Clamp image pixel values to a valid range ([0-255] per channel).
+        This is only meaningful for byte array images; the parameter is
+        ignored for image URLs. If this is not set, and an image has an
+        out-of-range value, an error will be thrown.
+    channels
+        If image is an nd.array, this parameter denotes the format used to
+        represent color information. Defaults to 'RGB', meaning
+        `image[:, :, 0]` is the red channel, `image[:, :, 1]` is green, and
+        `image[:, :, 2]` is blue. For images coming from libraries like
+        OpenCV you should set this to 'BGR', instead.
+    output_format
+        This parameter specifies the format to use when transferring the
+        image data. Photos should use the JPEG format for lossy compression
+        while diagrams should use the PNG format for lossless compression.
+        Defaults to 'auto' which identifies the compression type based
+        on the type and format of the image argument.
+    """
     channels = cast(Channels, channels.upper())
 
     # Turn single image and caption into one element list.

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -161,7 +161,7 @@ def _image_may_have_alpha_channel(image: PILImage) -> bool:
         return False
 
 
-def _validate_format(image: PILImage, format: str) -> ImageFormat:
+def _validate_image_format_string(image: PILImage, format: str) -> ImageFormat:
     """Return either "JPEG" or "PNG", based on the input `format` string.
 
     - If `format` is "JPEG" or "JPG" (or any capitalization thereof), return "JPEG"
@@ -207,7 +207,7 @@ def _BytesIO_to_bytes(data: io.BytesIO) -> bytes:
 
 def _np_array_to_bytes(array: "npt.NDArray[Any]", output_format="JPEG") -> bytes:
     img = Image.fromarray(array.astype(np.uint8))
-    format = _validate_format(img, output_format)
+    format = _validate_image_format_string(img, output_format)
 
     return _PIL_to_bytes(img, format)
 
@@ -242,7 +242,7 @@ def _normalize_to_bytes(
     """
     image = Image.open(io.BytesIO(data))
     actual_width, actual_height = image.size
-    format = _validate_format(image, output_format)
+    format = _validate_image_format_string(image, output_format)
     if output_format.lower() == "auto":
         # Inspect the image's header and try to guess its mimetype.
         ext = imghdr.what(None, data)
@@ -297,7 +297,7 @@ def image_to_url(
     """
     # PIL Images
     if isinstance(image, ImageFile.ImageFile) or isinstance(image, Image.Image):
-        format = _validate_format(image, output_format)
+        format = _validate_image_format_string(image, output_format)
         data = _PIL_to_bytes(image, format)
 
     # BytesIO

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -245,9 +245,10 @@ def _normalize_to_bytes(
     actual_width, actual_height = image.size
     format = _format_from_image_type(image, output_format)
     if output_format.lower() == "auto":
+        # Inspect the image's header and try to guess its mimetype.
         ext = imghdr.what(None, data)
         mimetype = mimetypes.guess_type(f"image.{ext}")[0]
-        # if no other options, attempt to convert
+        # If we weren't able to guess the mimetype, use a sensible default.
         if mimetype is None:
             mimetype = f"image/{format.lower()}"
     else:

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -146,12 +146,12 @@ def marshall(
     image = io.BytesIO()
     fig.savefig(image, **kwargs)
     image_utils.marshall_images(
-        coordinates,
-        image,
-        None,
-        -2,
-        image_list_proto,
-        False,
+        coordinates=coordinates,
+        image=image,
+        caption=None,
+        width=-2,
+        proto_imgs=image_list_proto,
+        clamp=False,
         channels="RGB",
         output_format="PNG",
     )


### PR DESCRIPTION
Continuing the effort to make `image.py` understandable:

- Added an `ImageFormat` type literal for our `Literal["JPEG", "PNG"]` type
- The `OutputFormat` type literal is now called `ImageFormatOrAuto`, because it includes our two image format literals, plus the string "auto"
- `format_from_image_type` is now called `validate_image_format_string`, which is actually what it does
- Added a docstring to `marshall_images`, which includes details on the mysterious, magical negative width constants