### PR TITLE
Add usage metrics message for headless mode

### DIFF
--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -79,6 +79,11 @@ _TELEMETRY_TEXT = """
     "config": click.style(_CONFIG_FILE_PATH),
 }
 
+_TELEMETRY_HEADLESS_TEXT = """
+The collection of usage statistics is activated. You can deactivate it
+by setting the browser.gatherUsageStats config option to False.
+"""
+
 # IMPORTANT: Break the text below at 80 chars.
 _INSTRUCTIONS_TEXT = """
   %(start)s
@@ -282,5 +287,8 @@ def check_credentials():
     from streamlit import config
 
     if not _check_credential_file_exists() and config.get_option("server.headless"):
+        if not config.is_manually_set("browser.gatherUsageStats"):
+            # If not manually defined, show short message about usage stats gathering.
+            click.secho(_TELEMETRY_HEADLESS_TEXT)
         return
     Credentials.get_current()._check_activated()

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -80,8 +80,7 @@ _TELEMETRY_TEXT = """
 }
 
 _TELEMETRY_HEADLESS_TEXT = """
-The collection of usage statistics is activated. You can deactivate it
-by setting the browser.gatherUsageStats config option to False.
+Collecting usage statistics. To deactivate, set browser.gatherUsageStats to False.
 """
 
 # IMPORTANT: Break the text below at 80 chars.

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -285,13 +285,13 @@ class CliTest(unittest.TestCase):
         self.assertTrue(mock_check.called)
         self.assertEqual(0, result.exit_code)
 
-    def test_headless_telemetry_message(self):
-        """If headless mode and usage stats not explicitly configured,
-        show a message about usage metrics gathering."""
+    @parameterized.expand([(True,), (False,)])
+    def test_headless_telemetry_message(self, headless_mode):
+        """If headless mode, show a message about usage metrics gathering."""
 
         from streamlit import config
 
-        config._set_option("server.headless", True, "test")
+        config._set_option("server.headless", headless_mode, "test")
 
         with patch("validators.url", return_value=False), patch(
             "os.path.exists", return_value=True
@@ -302,7 +302,10 @@ class CliTest(unittest.TestCase):
             result = self.runner.invoke(cli, ["run", "file_name.py"])
 
         self.assertNotEqual(0, result.exit_code)
-        self.assertTrue("collection of usage statistics is activated" in result.output)
+        self.assertEqual(
+            "collection of usage statistics is activated" in result.output,
+            headless_mode,  # Should only be shown if n headless mode
+        )
 
     def test_help_command(self):
         """Tests the help command redirects to using the --help flag"""

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -34,6 +34,8 @@ from streamlit.runtime.credentials import Credentials
 from streamlit.web import cli
 from streamlit.web.cli import _convert_config_option_to_click_option
 
+from tests import testutil
+
 
 class CliTest(unittest.TestCase):
     """Unit tests for the cli."""
@@ -246,22 +248,19 @@ class CliTest(unittest.TestCase):
     def test_credentials_headless_no_config(self):
         """If headless mode and no config is present,
         activation should be None."""
-        from streamlit import config
+        with testutil.patch_config_options({"server.headless": True}):
+            with patch("validators.url", return_value=False), patch(
+                "streamlit.web.bootstrap.run"
+            ), patch("os.path.exists", return_value=True), patch(
+                "streamlit.runtime.credentials._check_credential_file_exists",
+                return_value=False,
+            ):
+                result = self.runner.invoke(cli, ["run", "some script.py"])
+            from streamlit.runtime.credentials import Credentials
 
-        config._set_option("server.headless", True, "test")
-
-        with patch("validators.url", return_value=False), patch(
-            "streamlit.web.bootstrap.run"
-        ), patch("os.path.exists", return_value=True), patch(
-            "streamlit.runtime.credentials._check_credential_file_exists",
-            return_value=False,
-        ):
-            result = self.runner.invoke(cli, ["run", "some script.py"])
-        from streamlit.runtime.credentials import Credentials
-
-        credentials = Credentials.get_current()
-        self.assertIsNone(credentials.activation)
-        self.assertEqual(0, result.exit_code)
+            credentials = Credentials.get_current()
+            self.assertIsNone(credentials.activation)
+            self.assertEqual(0, result.exit_code)
 
     @parameterized.expand([(True,), (False,)])
     def test_credentials_headless_with_config(self, headless_mode):
@@ -269,43 +268,37 @@ class CliTest(unittest.TestCase):
         defined.
         So we call `_check_activated`.
         """
-        from streamlit import config
-
-        config._set_option("server.headless", headless_mode, "test")
-
-        with patch("validators.url", return_value=False), patch(
-            "streamlit.web.bootstrap.run"
-        ), patch("os.path.exists", return_value=True), mock.patch(
-            "streamlit.runtime.credentials.Credentials._check_activated"
-        ) as mock_check, patch(
-            "streamlit.runtime.credentials._check_credential_file_exists",
-            return_value=True,
-        ):
-            result = self.runner.invoke(cli, ["run", "some script.py"])
-        self.assertTrue(mock_check.called)
-        self.assertEqual(0, result.exit_code)
+        with testutil.patch_config_options({"server.headless": headless_mode}):
+            with patch("validators.url", return_value=False), patch(
+                "streamlit.web.bootstrap.run"
+            ), patch("os.path.exists", return_value=True), mock.patch(
+                "streamlit.runtime.credentials.Credentials._check_activated"
+            ) as mock_check, patch(
+                "streamlit.runtime.credentials._check_credential_file_exists",
+                return_value=True,
+            ):
+                result = self.runner.invoke(cli, ["run", "some script.py"])
+            self.assertTrue(mock_check.called)
+            self.assertEqual(0, result.exit_code)
 
     @parameterized.expand([(True,), (False,)])
     def test_headless_telemetry_message(self, headless_mode):
         """If headless mode, show a message about usage metrics gathering."""
 
-        from streamlit import config
+        with testutil.patch_config_options({"server.headless": headless_mode}):
+            with patch("validators.url", return_value=False), patch(
+                "os.path.exists", return_value=True
+            ), patch("streamlit.config.is_manually_set", return_value=False), patch(
+                "streamlit.runtime.credentials._check_credential_file_exists",
+                return_value=False,
+            ):
+                result = self.runner.invoke(cli, ["run", "file_name.py"])
 
-        config._set_option("server.headless", headless_mode, "test")
-
-        with patch("validators.url", return_value=False), patch(
-            "os.path.exists", return_value=True
-        ), patch("streamlit.config.is_manually_set", return_value=False), patch(
-            "streamlit.runtime.credentials._check_credential_file_exists",
-            return_value=False,
-        ):
-            result = self.runner.invoke(cli, ["run", "file_name.py"])
-
-        self.assertNotEqual(0, result.exit_code)
-        self.assertEqual(
-            "collection of usage statistics is activated" in result.output,
-            headless_mode,  # Should only be shown if n headless mode
-        )
+            self.assertNotEqual(0, result.exit_code)
+            self.assertEqual(
+                "collection of usage statistics is activated" in result.output,
+                headless_mode,  # Should only be shown if n headless mode
+            )
 
     def test_help_command(self):
         """Tests the help command redirects to using the --help flag"""

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -285,6 +285,25 @@ class CliTest(unittest.TestCase):
         self.assertTrue(mock_check.called)
         self.assertEqual(0, result.exit_code)
 
+    def test_headless_telemetry_message(self):
+        """If headless mode and usage stats not explicitly configured,
+        show a message about usage metrics gathering."""
+
+        from streamlit import config
+
+        config._set_option("server.headless", True, "test")
+
+        with patch("validators.url", return_value=False), patch(
+            "os.path.exists", return_value=True
+        ), patch("streamlit.config.is_manually_set", return_value=False), patch(
+            "streamlit.runtime.credentials._check_credential_file_exists",
+            return_value=False,
+        ):
+            result = self.runner.invoke(cli, ["run", "file_name.py"])
+
+        self.assertNotEqual(0, result.exit_code)
+        self.assertTrue("collection of usage statistics is activated" in result.output)
+
     def test_help_command(self):
         """Tests the help command redirects to using the --help flag"""
         with patch.object(sys, "argv", ["streamlit", "help"]) as args:

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -296,7 +296,7 @@ class CliTest(unittest.TestCase):
 
             self.assertNotEqual(0, result.exit_code)
             self.assertEqual(
-                "collection of usage statistics is activated" in result.output,
+                "Collecting usage statistics" in result.output,
                 headless_mode,  # Should only be shown if n headless mode
             )
 


### PR DESCRIPTION
## 📚 Context

We are showing a message about usage metrics collection when the user first uses Streamlit. However, we are not showing any information about this when the `server.headless` is used. 

## 🧠 Description of Changes

This PR adds an additional short message about usage tracking when streamlit is started with `server.headless=True`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
