### PR TITLE
Remove old code to unwrap decorated function

### DIFF
--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -14,6 +14,8 @@
 
 """Allows us to create and absorb changes (aka Deltas) to elements."""
 
+
+import contextlib
 import inspect
 from typing import Any, cast, TYPE_CHECKING
 from typing_extensions import Final
@@ -121,28 +123,16 @@ def _marshall(doc_string_proto: DocStringProto, obj: Any) -> None:
 
 def _get_signature(f):
     is_delta_gen = False
-    try:
+    with contextlib.suppress(AttributeError):
         is_delta_gen = f.__module__ == "streamlit.delta_generator"
-
-        if is_delta_gen:
-            # DeltaGenerator functions are doubly wrapped, and their function
-            # signatures are useless unless we unwrap them.
-            f = _unwrap_decorated_func(f)
-
-    # Functions such as numpy.minimum don't have a __module__ attribute,
-    # since we're only using it to check if its a DeltaGenerator, its ok
-    # to continue
-    except AttributeError:
-        pass
+        # Functions such as numpy.minimum don't have a __module__ attribute,
+        # since we're only using it to check if its a DeltaGenerator, its ok
+        # to continue
 
     sig = ""
 
-    try:
+    with contextlib.suppress(ValueError):
         sig = str(inspect.signature(f))
-    except ValueError:
-        # f is a builtin.
-        pass
-
     if is_delta_gen:
         for prefix in CONFUSING_STREAMLIT_SIG_PREFIXES:
             if sig.startswith(prefix):
@@ -150,20 +140,3 @@ def _get_signature(f):
                 break
 
     return sig
-
-
-def _unwrap_decorated_func(f):
-    if hasattr(f, "__wrapped__"):
-        try:
-            while getattr(f, "__wrapped__"):
-                contents = f.__wrapped__
-                if not callable(contents):
-                    break
-                f = contents
-            return f
-        except AttributeError:
-            pass
-
-    # Fall back to original function, though it's unlikely we'll reach
-    # this part of the code.
-    return f

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -14,7 +14,6 @@
 
 """Allows us to create and absorb changes (aka Deltas) to elements."""
 
-
 import contextlib
 import inspect
 from typing import Any, cast, TYPE_CHECKING


### PR DESCRIPTION
## 📚 Context

The `st.help` command contains some old code to unwrap a decorator. This was from a few years back when the delta generator was based on a decorator implementation. This functionality is not needed anymore and makes some trouble with planned changes to usage tracking.

## 🧠 Description of Changes

Removed the `_unwrap_decorated_func` functionality.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
