### PR TITLE
Improve usage metrics gathering - Part 1

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,6 +63,7 @@ import {
   PageInfo,
   PageNotFound,
   PagesChanged,
+  PageProfile,
   SessionEvent,
   WidgetStates,
   SessionState,
@@ -425,6 +426,8 @@ export class App extends PureComponent<Props, State> {
           this.handleGitInfoChanged(gitInfo),
         scriptFinished: (status: ForwardMsg.ScriptFinishedStatus) =>
           this.handleScriptFinished(status),
+        pageProfile: (pageProfile: PageProfile) =>
+          this.handlePageProfileMsg(pageProfile),
       })
     } catch (e) {
       const err = ensureError(e)
@@ -514,6 +517,10 @@ export class App extends PureComponent<Props, State> {
         appPages,
       })
     })
+  }
+
+  handlePageProfileMsg = (pageProfile: PageProfile): void => {
+    // TODO(lukasmasuch): Add logic to send page profile to Segment.
   }
 
   /**

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -65,6 +65,8 @@ class ConfigOption:
     where_defined : str
         Indicates which file set this config option.
         ConfigOption.DEFAULT_DEFINITION means this file.
+    is_default: bool
+        True if the config value is equal to its default value.
     visibility : {"visible", "hidden"}
         See __init__.
     scriptable : bool
@@ -163,6 +165,7 @@ class ConfigOption:
         self.default_val = default_val
         self.deprecated = deprecated
         self.replaced_by = replaced_by
+        self.is_default = True
         self._get_val_func: Optional[Callable[[], Any]] = None
         self.where_defined = ConfigOption.DEFAULT_DEFINITION
         self.type = type_
@@ -231,6 +234,8 @@ class ConfigOption:
             self.where_defined = ConfigOption.DEFAULT_DEFINITION
         else:
             self.where_defined = where_defined
+
+        self.is_default = value == self.default_val
 
         if self.deprecated and self.where_defined != ConfigOption.DEFAULT_DEFINITION:
 

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -16,6 +16,7 @@ from typing import cast, TYPE_CHECKING
 
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.string_util import clean_text
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
 
 
 class TextMixin:
+    @gather_metrics
     def text(self, body: "SupportsStr") -> "DeltaGenerator":
         """Write fixed-width and preformatted text.
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -22,7 +22,9 @@ import inspect
 from collections.abc import Sized
 from functools import wraps
 from timeit import default_timer as timer
-from typing import Any, Callable, List, Optional, TypeVar, cast, Final, Set
+from typing import Any, Callable, List, Optional, TypeVar, cast, Set
+
+from typing_extensions import Final
 
 from streamlit import util
 from streamlit import config

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -153,13 +153,7 @@ def _get_callable_name(callable: Callable[..., Any]) -> str:
 
 def _get_arg_metadata(arg: object) -> Optional[str]:
     with contextlib.suppress(Exception):
-        if isinstance(arg, bool):
-            return f"val:{arg}"
-
-        if isinstance(arg, int):
-            return f"val:{arg}"
-
-        if isinstance(arg, enum.Enum):
+        if isinstance(arg, (bool, int)):
             return f"val:{arg}"
 
         if isinstance(arg, Sized):

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -15,10 +15,48 @@
 import os
 import threading
 import uuid
-
-from typing import Optional
+import contextlib
+import enum
+import sys
+import inspect
+from collections.abc import Sized
+from functools import wraps
+from timeit import default_timer as timer
+from typing import Any, Callable, List, Optional, TypeVar, cast, Final, Set
 
 from streamlit import util
+from streamlit import config
+from streamlit.logger import get_logger
+from streamlit.proto.PageProfile_pb2 import Argument, Command
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+LOGGER = get_logger(__name__)
+
+# Limit the number of commands to keep the page profile message small
+# since Segment allows only a maximum of 32kb per event.
+_MAX_TRACKED_COMMANDS: Final = 200
+# A mapping to convert from the actual name to preferred/shorter representations
+_OBJECT_NAME_MAPPING: Final = {
+    "streamlit.delta_generator.DeltaGenerator": "DG",
+    "pandas.core.frame.DataFrame": "DataFrame",
+    "plotly.graph_objs._figure.Figure": "PlotlyFigure",
+    "bokeh.plotting.figure.Figure": "BokehFigure",
+    "matplotlib.figure.Figure": "MatplotlibFigure",
+    "pandas.io.formats.style.Styler": "PandasStyler",
+    "pandas.core.indexes.base.Index": "PandasIndex",
+    "pandas.core.series.Series": "PandasSeries",
+}
+_CALLABLE_NAME_MAPPING: Final = {
+    "_transparent_write": "magic",
+    "MemoAPI.__call__": "experimental_memo",
+    "SingletonAPI.__call__": "experimental_singleton",
+    "SingletonCache.write_result": "_cache_singleton_object",
+    "MemoCache.write_result": "_cache_memo_object",
+    "_write_to_cache": "_cache_object",
+}
+# A list of dependencies to check for attribution
+_ATTRIBUTIONS_TO_CHECK: Final = ["snowflake"]
 
 _ETC_MACHINE_ID_PATH = "/etc/machine-id"
 _DBUS_MACHINE_ID_PATH = "/var/lib/dbus/machine-id"
@@ -72,3 +110,189 @@ class Installation:
     @property
     def installation_id(self):
         return self.installation_id_v3
+
+
+def _get_type_name(obj: object) -> str:
+    with contextlib.suppress(Exception):
+        obj_type = type(obj)
+        type_name = "unknown"
+        if hasattr(obj_type, "__qualname__"):
+            type_name = obj_type.__qualname__
+        elif hasattr(obj_type, "__name__"):
+            type_name = obj_type.__name__
+
+        if obj_type.__module__ != "builtins":
+            # Add the full module path
+            type_name = f"{obj_type.__module__}.{type_name}"
+
+        if type_name in _OBJECT_NAME_MAPPING:
+            type_name = _OBJECT_NAME_MAPPING[type_name]
+        return type_name
+    return "failed"
+
+
+def _get_callable_name(callable: Callable) -> str:
+    with contextlib.suppress(Exception):
+        name = "unknown"
+        if inspect.isclass(callable):
+            name = callable.__class__.__name__
+        elif hasattr(callable, "__qualname__"):
+            name = callable.__qualname__
+        elif hasattr(callable, "__name__"):
+            name = callable.__name__
+        if name in _CALLABLE_NAME_MAPPING:
+            name = _CALLABLE_NAME_MAPPING[name]
+        elif "." in name:
+            # Only return actual function name
+            name = name.split(".")[-1]
+        return name
+    return "failed"
+
+
+def _get_arg_metadata(arg: object) -> Optional[str]:
+    with contextlib.suppress(Exception):
+        if isinstance(arg, bool):
+            return f"val:{arg}"
+
+        if isinstance(arg, int):
+            return f"val:{arg}"
+
+        if isinstance(arg, enum.Enum):
+            return f"val:{arg}"
+
+        if isinstance(arg, Sized):
+            return f"len:{len(arg)}"
+
+    return None
+
+
+def _get_command_telemetry(callable: Callable, *args, **kwargs) -> Command:
+    arg_keywords = inspect.getfullargspec(callable).args
+    self_arg: Optional[Any] = None
+    arguments: List[Argument] = []
+    is_method = inspect.ismethod(callable)
+
+    for i, arg in enumerate(args):
+        pos = i
+        if is_method:
+            # If the callable is a method, ignore the first argument (self)
+            i = i + 1
+
+        keyword = arg_keywords[i] if len(arg_keywords) > i else f"{i}"
+        if keyword == "self":
+            self_arg = arg
+            continue
+        argument = Argument(k=keyword, t=_get_type_name(arg), p=pos)
+        if arg_metadata := _get_arg_metadata(arg):
+            argument.m = arg_metadata
+        arguments.append(argument)
+    for kwarg, kwarg_value in kwargs.items():
+        argument = Argument(k=kwarg, t=_get_type_name(kwarg_value))
+        if arg_metadata := _get_arg_metadata(kwarg_value):
+            argument.m = arg_metadata
+        arguments.append(argument)
+    name = _get_callable_name(callable)
+    if (
+        name == "create_instance"
+        and self_arg
+        and hasattr(self_arg, "name")
+        and self_arg.name
+    ):
+        name = f"component:{self_arg.name}"
+    return Command(name=name, args=arguments)
+
+
+def to_microseconds(seconds):
+    return int(seconds * 1000000)
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def gather_metrics(callable: F) -> F:
+    @wraps(callable)
+    def wrap(*args, **kwargs):
+        ctx = get_script_run_ctx()
+
+        tracking_activated = (
+            ctx is not None
+            and ctx.gather_usage_stats
+            and not ctx.command_tracking_deactivated
+            and len(ctx.tracked_commands)
+            < _MAX_TRACKED_COMMANDS  # Prevent too much memory usage
+        )
+
+        # Deactivate tracking to prevent calls inside already tracked commands
+        if ctx:
+            ctx.command_tracking_deactivated = True
+
+        exec_start = timer()
+        result = callable(*args, **kwargs)
+
+        # Activate tracking again
+        if ctx:
+            ctx.command_tracking_deactivated = False
+
+        if not tracking_activated:
+            return result
+
+        try:
+            command_telemetry = _get_command_telemetry(callable, *args, **kwargs)
+            command_telemetry.time = to_microseconds(timer() - exec_start)
+            if ctx:
+                ctx.tracked_commands.append(command_telemetry)
+        except Exception as ex:
+            # Always capture all exceptions since we want to make sure that
+            # the telemetry never causes any issues.
+            LOGGER.debug("Failed to collect command telemetry", exc_info=ex)
+        return result
+
+    with contextlib.suppress(AttributeError):
+        # Make this a well-behaved decorator by preserving important function
+        # attributes.
+        wrap.__dict__.update(callable.__dict__)
+        wrap.__signature__ = inspect.signature(callable)  # type: ignore
+    return cast(F, wrap)
+
+
+def create_page_profile_message(
+    commands: List[Command],
+    exec_time: int,
+    prep_time: int,
+    uncaught_exception: Optional[str] = None,
+) -> ForwardMsg:
+    """Create and return an PageProfile ForwardMsg."""
+
+    msg = ForwardMsg()
+    msg.page_profile.commands.extend(commands)
+    msg.page_profile.exec_time = exec_time
+    msg.page_profile.prep_time = prep_time
+
+    # Collect all config options that have been manually set
+    config_options: Set[str] = set()
+    if config._config_options:
+        for option_name in config._config_options.keys():
+            if not config.is_manually_set(option_name):
+                # We only care about manually defined options
+                continue
+
+            config_option = config._config_options[option_name]
+            if config_option.is_default:
+                option_name = f"{option_name}:default"
+            config_options.add(option_name)
+
+    msg.page_profile.config.extend(config_options)
+
+    # Check the predefined set of modules for attribution
+    attributions: Set[str] = {
+        attribution
+        for attribution in _ATTRIBUTIONS_TO_CHECK
+        if attribution in sys.modules
+    }
+
+    msg.page_profile.attributions.extend(attributions)
+
+    if uncaught_exception:
+        msg.page_profile.uncaught_exception = uncaught_exception
+
+    return msg

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -183,12 +183,16 @@ def _get_command_telemetry(callable: Callable, *args, **kwargs) -> Command:
             self_arg = arg
             continue
         argument = Argument(k=keyword, t=_get_type_name(arg), p=pos)
-        if arg_metadata := _get_arg_metadata(arg):
+
+        arg_metadata = _get_arg_metadata(arg)
+        if arg_metadata:
             argument.m = arg_metadata
         arguments.append(argument)
     for kwarg, kwarg_value in kwargs.items():
         argument = Argument(k=kwarg, t=_get_type_name(kwarg_value))
-        if arg_metadata := _get_arg_metadata(kwarg_value):
+
+        arg_metadata = _get_arg_metadata(kwarg_value)
+        if arg_metadata:
             argument.m = arg_metadata
         arguments.append(argument)
     name = _get_callable_name(callable)

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -131,7 +131,7 @@ def _get_type_name(obj: object) -> str:
     return "failed"
 
 
-def _get_callable_name(callable: Callable) -> str:
+def _get_callable_name(callable: Callable[..., Any]) -> str:
     with contextlib.suppress(Exception):
         name = "unknown"
         if inspect.isclass(callable):
@@ -166,7 +166,7 @@ def _get_arg_metadata(arg: object) -> Optional[str]:
     return None
 
 
-def _get_command_telemetry(callable: Callable, *args, **kwargs) -> Command:
+def _get_command_telemetry(callable: Callable[..., Any], *args, **kwargs) -> Command:
     arg_keywords = inspect.getfullargspec(callable).args
     self_arg: Optional[Any] = None
     arguments: List[Argument] = []

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -22,6 +22,7 @@ from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.state import SafeSessionState
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+from streamlit.proto.PageProfile_pb2 import Command
 
 LOGGER: Final = get_logger(__name__)
 
@@ -50,6 +51,9 @@ class ScriptRunContext:
     page_script_hash: str
     user_info: UserInfo
 
+    gather_usage_stats: bool = False
+    command_tracking_deactivated: bool = False
+    tracked_commands: List[Command] = field(default_factory=list)
     _set_page_config_allowed: bool = True
     _has_script_started: bool = False
     widget_ids_this_run: Set[str] = field(default_factory=set)
@@ -70,6 +74,8 @@ class ScriptRunContext:
         # Permit set_page_config when the ScriptRunContext is reused on a rerun
         self._set_page_config_allowed = True
         self._has_script_started = False
+        self.command_tracking_deactivated: bool = False
+        self.tracked_commands = []
 
     def on_script_start(self) -> None:
         self._has_script_started = True

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable
+import datetime
 import unittest
 from unittest.mock import patch, mock_open, MagicMock
+from parameterized import parameterized
+import pandas as pd
 
+import streamlit
 from streamlit.runtime import metrics_util
+
+from tests import testutil
 
 MAC = "mac"
 UUID = "uuid"
@@ -80,3 +87,97 @@ class MetricsUtilTest(unittest.TestCase):
 
             machine_id = metrics_util._get_machine_id_v3()
         self.assertEqual(machine_id, MAC)
+
+
+class PageTelemetryTest(testutil.DeltaGeneratorTestCase):
+    @parameterized.expand(
+        [
+            (streamlit.dataframe, "dataframe"),
+            (streamlit._transparent_write, "magic"),
+            (streamlit.write, "write"),
+            (streamlit.cache, "cache"),
+        ]
+    )
+    def test_get_callable_name(self, callable: Callable, expected_name: str):
+        """Test getting the callable name _get_callable_name"""
+
+        self.assertEqual(metrics_util._get_callable_name(callable), expected_name)
+
+    @parameterized.expand(
+        [
+            (10, "int"),
+            (0.01, "float"),
+            (True, "bool"),
+            (None, "NoneType"),
+            (["1"], "list"),
+            ({"foo": "bar"}, "dict"),
+            ("foo", "str"),
+            (datetime.date.today(), "datetime.date"),
+            (datetime.datetime.today().time(), "datetime.time"),
+            (pd.DataFrame(), "DataFrame"),
+            (pd.Series(), "PandasSeries"),
+        ]
+    )
+    def test_get_type_name(self, obj: object, expected_type: str):
+        """Test getting the type name via _get_type_name"""
+
+        self.assertEqual(metrics_util._get_type_name(obj), expected_type)
+
+    def test_get_command_telemetry(self):
+        """Test getting command telemetry via _get_command_telemetry"""
+
+        # Test with dataframe command:
+        command_metadata = metrics_util._get_command_telemetry(
+            streamlit.dataframe, pd.DataFrame(), width=250
+        )
+
+        self.assertEqual(command_metadata.name, "dataframe")
+        self.assertEqual(len(command_metadata.args), 2)
+        self.assertEqual(
+            str(command_metadata.args[0]).strip(),
+            'k: "data"\nt: "DataFrame"\nm: "len:0"',
+        )
+        self.assertEqual(
+            str(command_metadata.args[1]).strip(),
+            'k: "width"\nt: "int"\nm: "val:250"',
+        )
+
+        # Test with text_input command:
+        command_metadata = metrics_util._get_command_telemetry(
+            streamlit.text_input, label="text input", value="foo", disabled=True
+        )
+
+        self.assertEqual(command_metadata.name, "text_input")
+        self.assertEqual(len(command_metadata.args), 3)
+        self.assertEqual(
+            str(command_metadata.args[0]).strip(),
+            'k: "label"\nt: "str"\nm: "len:10"',
+        )
+        self.assertEqual(
+            str(command_metadata.args[1]).strip(),
+            'k: "value"\nt: "str"\nm: "len:3"',
+        )
+        self.assertEqual(
+            str(command_metadata.args[2]).strip(),
+            'k: "disabled"\nt: "bool"\nm: "val:True"',
+        )
+
+    def test_create_page_profile_message(self):
+        """Test creating the page profile message via create_page_profile_message"""
+
+        forward_msg = metrics_util.create_page_profile_message(
+            commands=[
+                metrics_util._get_command_telemetry(
+                    streamlit.dataframe, pd.DataFrame(), width=250
+                )
+            ],
+            exec_time=1000,
+            prep_time=2000,
+        )
+
+        self.assertEqual(len(forward_msg.page_profile.commands), 1)
+        self.assertEqual(forward_msg.page_profile.exec_time, 1000)
+        self.assertEqual(forward_msg.page_profile.prep_time, 2000)
+        self.assertEqual(forward_msg.page_profile.commands[0].name, "dataframe")
+
+    # TODO (lukasmasuch): the test for the actual decorator will be added in a later PR

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -21,6 +21,7 @@ import "streamlit/proto/GitInfo.proto";
 import "streamlit/proto/NewSession.proto";
 import "streamlit/proto/PageConfig.proto";
 import "streamlit/proto/PageInfo.proto";
+import "streamlit/proto/PageProfile.proto";
 import "streamlit/proto/PageNotFound.proto";
 import "streamlit/proto/PagesChanged.proto";
 import "streamlit/proto/SessionEvent.proto";
@@ -55,6 +56,7 @@ message ForwardMsg {
     PageConfig page_config_changed = 13;
     ScriptFinishedStatus script_finished = 6;
     GitInfo git_info_changed = 14;
+    PageProfile page_profile = 18;
 
     // State change and event messages.
     SessionState session_state_changed = 9;
@@ -77,7 +79,7 @@ message ForwardMsg {
   string debug_last_backmsg_id = 17;
 
   reserved 7, 8;
-  // Next: 18
+  // Next: 19
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)

--- a/proto/streamlit/proto/PageProfile.proto
+++ b/proto/streamlit/proto/PageProfile.proto
@@ -1,0 +1,47 @@
+/**
+* Copyright 2018-2022 Streamlit Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+
+
+message PageProfile {
+  repeated Command commands = 1;
+  int64 exec_time = 2;
+  int64 prep_time = 3;
+  repeated string config = 5;
+  string uncaught_exception = 6;
+  repeated string attributions = 7;
+}
+
+// The field names are used as part of the event json sent
+// to Segment. Since there is a 32kb limit for the event
+// size we are using short names to optimize for the size.
+message Argument {
+  // The keyword of the argument:
+  string k = 1;
+  // The type of the argument:
+  string t = 2;
+  // Some metadata about the argument value:
+  string m = 3;
+  // Contains the position (if positional argument):
+  int32 p = 5;
+}
+
+message Command {
+  string name = 1;
+  repeated Argument args = 2;
+  int64 time = 4;
+}


### PR DESCRIPTION
## 📚 Context

This is the first part of the improved usage metrics gathering capability. The goal is to capture metrics about the usage of `st` commands if usage tracking is activated. Our current way of doing usage tracking on the `proto` message level can only capture a subset of our commands and misses a lot of important insights (time measurements, used config options, ...)

This part contains the main logic (the decorator) that adds the ability to collect usage metrics for `st` commands usage and some other app-related metrics (e.g. used config options and various time measurements).

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Add `PageProfile` proto message that contains the summarized metrics for a one-page run.
- Add `gather_metrics` decorator and related utility functions. 
- Apply the decorato to `st.text` as an example. It will be applied to all our `st` commands in a later PR.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
