### PR TITLE
Improve usage metrics gathering - Part 2

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -77,16 +77,19 @@ from streamlit.runtime.scriptrunner import (
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import ForwardMsg_pb2 as _ForwardMsg_pb2
+from streamlit.runtime.metrics_util import gather_metrics
 
 # Modules that the user should have access to. These are imported with "as"
 # syntax pass mypy checking with implicit_reexport disabled.
 
 from streamlit.echo import echo as echo
-from streamlit.runtime.legacy_caching import cache as cache
+from streamlit.runtime.legacy_caching import cache as _cache
 from streamlit.runtime.caching import (
     singleton as experimental_singleton,
     memo as experimental_memo,
 )
+
+cache = gather_metrics(_cache)
 
 # This is set to True inside cli._main_run(), and is False otherwise.
 # If False, we should assume that DeltaGenerator functions are effectively
@@ -206,11 +209,12 @@ experimental_user = UserInfoProxy()
 
 # Beta APIs
 
-beta_container = _main.beta_container
-beta_expander = _main.beta_expander
-beta_columns = _main.beta_columns
+beta_container = gather_metrics(_main.beta_container)
+beta_expander = gather_metrics(_main.beta_expander)
+beta_columns = gather_metrics(_main.beta_columns)
 
 
+@gather_metrics
 def set_option(key: str, value: Any) -> None:
     """Set config option.
 
@@ -250,6 +254,7 @@ def set_option(key: str, value: Any) -> None:
     )
 
 
+@gather_metrics
 def experimental_show(*args: Any) -> None:
     """Write arguments and *argument names* to your app for debugging purposes.
 
@@ -296,8 +301,9 @@ def experimental_show(*args: Any) -> None:
             warning("`show` not enabled in the shell")
             return
 
-        if current_frame.f_back is not None:
-            lines = inspect.getframeinfo(current_frame.f_back)[3]
+        # Use two f_back because of telemetry decorator
+        if current_frame.f_back is not None and current_frame.f_back.f_back is not None:
+            lines = inspect.getframeinfo(current_frame.f_back.f_back)[3]
         else:
             lines = None
 
@@ -330,6 +336,7 @@ def experimental_show(*args: Any) -> None:
         exception(exc)
 
 
+@gather_metrics
 def experimental_get_query_params() -> Dict[str, List[str]]:
     """Return the query parameters that is currently showing in the browser's URL bar.
 
@@ -360,6 +367,7 @@ def experimental_get_query_params() -> Dict[str, List[str]]:
     return _parse.parse_qs(ctx.query_string)
 
 
+@gather_metrics
 def experimental_set_query_params(**query_params: Any) -> None:
     """Set the query parameters that are shown in the browser's URL bar.
 
@@ -451,6 +459,7 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
                 message.empty()
 
 
+@gather_metrics
 def _transparent_write(*args: Any) -> Any:
     """This is just st.write, but returns the arguments you passed to it."""
     write(*args)
@@ -511,6 +520,8 @@ def stop() -> NoReturn:
     raise StopException()
 
 
+# TODO: does this make sense?
+@gather_metrics
 def experimental_rerun() -> NoReturn:
     """Rerun the script immediately.
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -520,8 +520,6 @@ def stop() -> NoReturn:
     raise StopException()
 
 
-# TODO: does this make sense?
-@gather_metrics
 def experimental_rerun() -> NoReturn:
     """Rerun the script immediately.
 

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -27,6 +27,7 @@ from streamlit.proto.PageConfig_pb2 import PageConfig as PageConfigProto
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.string_util import is_emoji
 from streamlit.util import lower_clean_dict_keys
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
@@ -111,6 +112,7 @@ def _get_favicon_string(page_icon: PageIcon) -> str:
         raise
 
 
+@gather_metrics
 def set_page_config(
     page_title: Optional[str] = None,
     page_icon: Optional[PageIcon] = None,

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -29,6 +29,7 @@ from streamlit.proto.Element_pb2 import Element
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import NoValue, register_widget
 from streamlit.type_util import to_bytes
+from streamlit.runtime.metrics_util import gather_metrics
 
 LOGGER = get_logger(__name__)
 
@@ -77,6 +78,7 @@ class CustomComponent:
         """An alias for create_instance."""
         return self.create_instance(*args, default=default, key=key, **kwargs)
 
+    @gather_metrics
     def create_instance(
         self,
         *args,

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -24,7 +24,7 @@ _SPACES_RE = re.compile("\\s*")
 _EMPTY_LINE_RE = re.compile("\\s*\n")
 
 
-@gather_metrics  # TODO: test this
+@gather_metrics
 @contextlib.contextmanager
 def echo(code_location="above"):
     """Use in a `with` block to draw some code on the app, then execute it.

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -18,10 +18,13 @@ import textwrap
 import traceback
 from typing import List, Iterable, Optional
 
+from streamlit.runtime.metrics_util import gather_metrics
+
 _SPACES_RE = re.compile("\\s*")
 _EMPTY_LINE_RE = re.compile("\\s*\n")
 
 
+@gather_metrics  # TODO: test this
 @contextlib.contextmanager
 def echo(code_location="above"):
     """Use in a `with` block to draw some code on the app, then execute it.

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -17,6 +17,7 @@ from typing import cast, Optional, TYPE_CHECKING
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.string_util import clean_text, is_emoji
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -35,6 +36,7 @@ def validate_emoji(maybe_emoji: Optional[str]) -> str:
 
 
 class AlertMixin:
+    @gather_metrics
     def error(
         self,
         body: "SupportsStr",
@@ -63,6 +65,7 @@ class AlertMixin:
         alert_proto.format = AlertProto.ERROR
         return self.dg._enqueue("alert", alert_proto)
 
+    @gather_metrics
     def warning(
         self,
         body: "SupportsStr",
@@ -92,6 +95,7 @@ class AlertMixin:
         alert_proto.format = AlertProto.WARNING
         return self.dg._enqueue("alert", alert_proto)
 
+    @gather_metrics
     def info(
         self,
         body: "SupportsStr",
@@ -122,6 +126,7 @@ class AlertMixin:
         alert_proto.format = AlertProto.INFO
         return self.dg._enqueue("alert", alert_proto)
 
+    @gather_metrics
     def success(
         self,
         body: "SupportsStr",

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -23,6 +23,7 @@ import pyarrow as pa
 
 from streamlit import type_util
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -31,6 +32,7 @@ Data = Union[DataFrame, Styler, pa.Table, ndarray, Iterable, Dict[str, List[Any]
 
 
 class ArrowMixin:
+    @gather_metrics
     def _arrow_dataframe(
         self,
         data: Data = None,
@@ -97,6 +99,7 @@ class ArrowMixin:
         marshall(proto, data, default_uuid)
         return self.dg._enqueue("arrow_data_frame", proto)
 
+    @gather_metrics
     def _arrow_table(self, data: Data = None) -> "DeltaGenerator":
         """Display a static table.
 

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -41,6 +41,7 @@ from streamlit import type_util
 from streamlit.proto.ArrowVegaLiteChart_pb2 import (
     ArrowVegaLiteChart as ArrowVegaLiteChartProto,
 )
+from streamlit.runtime.metrics_util import gather_metrics
 
 from .arrow import Data
 from .utils import last_index_for_melted_dataframes
@@ -65,6 +66,7 @@ class ChartType(Enum):
 
 
 class ArrowAltairMixin:
+    @gather_metrics
     def _arrow_line_chart(
         self,
         data: Data = None,
@@ -133,6 +135,7 @@ class ArrowAltairMixin:
 
         return self.dg._enqueue("arrow_line_chart", proto, last_index=last_index)
 
+    @gather_metrics
     def _arrow_area_chart(
         self,
         data: Data = None,
@@ -200,6 +203,7 @@ class ArrowAltairMixin:
 
         return self.dg._enqueue("arrow_area_chart", proto, last_index=last_index)
 
+    @gather_metrics
     def _arrow_bar_chart(
         self,
         data: Data = None,
@@ -268,6 +272,7 @@ class ArrowAltairMixin:
 
         return self.dg._enqueue("arrow_bar_chart", proto, last_index=last_index)
 
+    @gather_metrics
     def _arrow_altair_chart(
         self,
         altair_chart: Chart,

--- a/lib/streamlit/elements/arrow_vega_lite.py
+++ b/lib/streamlit/elements/arrow_vega_lite.py
@@ -23,6 +23,7 @@ from streamlit.logger import get_logger
 from streamlit.proto.ArrowVegaLiteChart_pb2 import (
     ArrowVegaLiteChart as ArrowVegaLiteChartProto,
 )
+from streamlit.runtime.metrics_util import gather_metrics
 
 from . import arrow
 from .arrow import Data
@@ -35,6 +36,7 @@ LOGGER: Final = get_logger(__name__)
 
 
 class ArrowVegaLiteMixin:
+    @gather_metrics
     def _arrow_vega_lite_chart(
         self,
         data: Data = None,

--- a/lib/streamlit/elements/balloons.py
+++ b/lib/streamlit/elements/balloons.py
@@ -15,12 +15,14 @@
 from typing import cast, TYPE_CHECKING
 
 from streamlit.proto.Balloons_pb2 import Balloons as BalloonsProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
 class BalloonsMixin:
+    @gather_metrics
     def balloons(self) -> "DeltaGenerator":
         """Draw celebratory balloons.
 

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -21,6 +21,7 @@ from typing_extensions import Final
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.BokehChart_pb2 import BokehChart as BokehChartProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from bokeh.plotting.figure import Figure
@@ -30,6 +31,7 @@ ST_BOKEH_VERSION: Final = "2.4.3"
 
 
 class BokehMixin:
+    @gather_metrics
     def bokeh_chart(
         self,
         figure: "Figure",

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -31,6 +31,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
 )
 from streamlit.type_util import Key, to_key
+from streamlit.runtime.metrics_util import gather_metrics
 
 from .form import current_form_id, is_in_form
 from .utils import check_callback_rules, check_session_state_rules
@@ -58,6 +59,7 @@ class ButtonSerde:
 
 
 class ButtonMixin:
+    @gather_metrics
     def button(
         self,
         label: str,
@@ -125,6 +127,7 @@ class ButtonMixin:
             ctx=ctx,
         )
 
+    @gather_metrics
     def download_button(
         self,
         label: str,

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -28,6 +28,7 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
 
 from ..proto.Common_pb2 import (
     FileUploaderState as FileUploaderStateProto,
@@ -108,6 +109,7 @@ class CameraInputSerde:
 
 
 class CameraInputMixin:
+    @gather_metrics
     def camera_input(
         self,
         label: str,

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -25,6 +25,8 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -45,6 +47,7 @@ class CheckboxSerde:
 
 
 class CheckboxMixin:
+    @gather_metrics
     def checkbox(
         self,
         label: str,

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -28,6 +28,8 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -44,6 +46,7 @@ class ColorPickerSerde:
 
 
 class ColorPickerMixin:
+    @gather_metrics
     def color_picker(
         self,
         label: str,

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -19,6 +19,7 @@ from typing import Dict
 from typing import cast, Optional, TYPE_CHECKING, Union, Sequence
 
 from streamlit import config
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from .arrow import Data
@@ -34,6 +35,7 @@ def _use_arrow() -> bool:
 
 
 class DataFrameSelectorMixin:
+    @gather_metrics
     def dataframe(
         self,
         data: "Data" = None,
@@ -107,6 +109,7 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_dataframe(data, width, height)
 
+    @gather_metrics
     def table(self, data: "Data" = None) -> "DeltaGenerator":
         """Display a static table.
 
@@ -140,6 +143,7 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_table(data)
 
+    @gather_metrics
     def line_chart(
         self,
         data: "Data" = None,
@@ -222,6 +226,7 @@ class DataFrameSelectorMixin:
                 use_container_width=use_container_width,
             )
 
+    @gather_metrics
     def area_chart(
         self,
         data: "Data" = None,
@@ -304,6 +309,7 @@ class DataFrameSelectorMixin:
                 use_container_width=use_container_width,
             )
 
+    @gather_metrics
     def bar_chart(
         self,
         data: "Data" = None,
@@ -387,6 +393,7 @@ class DataFrameSelectorMixin:
                 use_container_width=use_container_width,
             )
 
+    @gather_metrics
     def altair_chart(
         self,
         altair_chart: "Chart",
@@ -433,6 +440,7 @@ class DataFrameSelectorMixin:
         else:
             return self.dg._legacy_altair_chart(altair_chart, use_container_width)
 
+    @gather_metrics
     def vega_lite_chart(
         self,
         data: "Data" = None,
@@ -502,6 +510,7 @@ class DataFrameSelectorMixin:
                 data, spec, use_container_width, **kwargs
             )
 
+    @gather_metrics
     def add_rows(self, data: "Data" = None, **kwargs) -> Optional["DeltaGenerator"]:
         """Concatenate a dataframe to the bottom of the current one.
 

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Mapping, Optional, TYPE_CHECKING, cast
 from typing_extensions import Final
 
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as PydeckProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from pydeck import Deck
@@ -32,6 +33,7 @@ EMPTY_MAP: Final[Mapping[str, Any]] = {
 
 
 class PydeckMixin:
+    @gather_metrics
     def pydeck_chart(
         self,
         pydeck_obj: Optional["Deck"] = None,

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -21,6 +21,7 @@ from typing_extensions import Final
 
 from streamlit.proto.DocString_pb2 import DocString as DocStringProto
 from streamlit.logger import get_logger
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -39,6 +40,7 @@ CONFUSING_STREAMLIT_SIG_PREFIXES: Final = ("(element, ",)
 
 
 class HelpMixin:
+    @gather_metrics
     def help(self, obj: Any) -> "DeltaGenerator":
         """Display object's doc string, nicely formatted.
 

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -25,6 +25,7 @@ from streamlit.errors import StreamlitAPIWarning
 from streamlit.errors import StreamlitDeprecationWarning
 from streamlit.errors import UncaughtAppException
 from streamlit.logger import get_logger
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -43,6 +44,7 @@ _STREAMLIT_DIR: Final = os.path.join(
 
 
 class ExceptionMixin:
+    @gather_metrics
     def exception(self, exception: BaseException) -> "DeltaGenerator":
         """Display an exception.
 

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -29,6 +29,8 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from ..proto.Common_pb2 import (
     FileUploaderState as FileUploaderStateProto,
@@ -197,6 +199,7 @@ class FileUploaderMixin:
     ) -> Optional[UploadedFile]:
         ...
 
+    @gather_metrics
     def file_uploader(
         self,
         label: str,

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -19,6 +19,7 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
+from streamlit.runtime.metrics_util import gather_metrics
 
 
 class FormData(NamedTuple):
@@ -109,6 +110,7 @@ def _build_duplicate_form_message(user_key: Optional[str] = None) -> str:
 
 
 class FormMixin:
+    @gather_metrics
     def form(self, key: str, clear_on_submit: bool = False):
         """Create a form that batches elements together with a "Submit" button.
 
@@ -197,6 +199,7 @@ class FormMixin:
         block_dg._form_data = FormData(form_id)
         return block_dg
 
+    @gather_metrics
     def form_submit_button(
         self,
         label: str = "Submit",

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -23,6 +23,7 @@ from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.GraphVizChart_pb2 import GraphVizChart as GraphVizChartProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     import graphviz
@@ -35,6 +36,7 @@ FigureOrDot: TypeAlias = Union["graphviz.Graph", "graphviz.Digraph", str]
 
 
 class GraphvizMixin:
+    @gather_metrics
     def graphviz_chart(
         self,
         figure_or_dot: FigureOrDot,

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -16,12 +16,14 @@ from typing import cast, Optional, TYPE_CHECKING
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.string_util import clean_text
 from streamlit.type_util import SupportsStr
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
 class HeadingMixin:
+    @gather_metrics
     def header(
         self, body: SupportsStr, anchor: Optional[str] = None
     ) -> "DeltaGenerator":
@@ -48,6 +50,7 @@ class HeadingMixin:
         header_proto.tag = "h2"
         return self.dg._enqueue("heading", header_proto)
 
+    @gather_metrics
     def subheader(
         self, body: SupportsStr, anchor: Optional[str] = None
     ) -> "DeltaGenerator":
@@ -75,6 +78,7 @@ class HeadingMixin:
 
         return self.dg._enqueue("heading", subheader_proto)
 
+    @gather_metrics
     def title(
         self, body: SupportsStr, anchor: Optional[str] = None
     ) -> "DeltaGenerator":

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -15,12 +15,14 @@
 from typing import cast, Optional, TYPE_CHECKING
 
 from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
 class IframeMixin:
+    @gather_metrics
     def _iframe(
         self,
         src: str,
@@ -54,6 +56,7 @@ class IframeMixin:
         )
         return self.dg._enqueue("iframe", iframe_proto)
 
+    @gather_metrics
     def _html(
         self,
         html: str,

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -33,6 +33,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -57,6 +58,7 @@ ImageFormatOrAuto: TypeAlias = Literal[ImageFormat, "auto"]
 
 
 class ImageMixin:
+    @gather_metrics
     def image(
         self,
         image: ImageOrImageList,

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -24,7 +24,7 @@ from typing import (
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.state import SessionStateProxy
 from streamlit.user_info import UserInfoProxy
-
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -38,6 +38,7 @@ def _ensure_serialization(o: object) -> Union[str, List[Any]]:
 
 
 class JsonMixin:
+    @gather_metrics
     def json(
         self,
         body: object,

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -17,6 +17,7 @@ from typing import cast, List, Sequence, TYPE_CHECKING, Union, Optional
 from streamlit.beta_util import function_beta_warning
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -25,6 +26,7 @@ SpecType = Union[int, Sequence[Union[int, float]]]
 
 
 class LayoutsMixin:
+    @gather_metrics
     def container(self) -> "DeltaGenerator":
         """Insert a multi-element container.
 
@@ -69,6 +71,7 @@ class LayoutsMixin:
         return self.dg._block()
 
     # TODO: Enforce that columns are not nested or in Sidebar
+    @gather_metrics
     def columns(
         self, spec: SpecType, *, gap: Optional[str] = "small"
     ) -> List["DeltaGenerator"]:
@@ -193,6 +196,7 @@ class LayoutsMixin:
         total_weight = sum(weights)
         return [row._block(column_proto(w / total_weight)) for w in weights]
 
+    @gather_metrics
     def tabs(self, tabs: Sequence[str]) -> Sequence["DeltaGenerator"]:
         """Insert containers separated into tabs.
 
@@ -280,6 +284,7 @@ class LayoutsMixin:
         tab_container = self.dg._block(block_proto)
         return tuple(tab_container._block(tab_proto(tab_label)) for tab_label in tabs)
 
+    @gather_metrics
     def expander(self, label: str, expanded: bool = False) -> "DeltaGenerator":
         """Insert a multi-element container that can be expanded/collapsed.
 

--- a/lib/streamlit/elements/legacy_altair.py
+++ b/lib/streamlit/elements/legacy_altair.py
@@ -23,6 +23,8 @@ from typing import cast, TYPE_CHECKING
 from streamlit import errors, type_util
 from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart as VegaLiteChartProto
 import streamlit.elements.legacy_vega_lite as vega_lite
+from streamlit.runtime.metrics_util import gather_metrics
+
 import altair as alt
 import pandas as pd
 import pyarrow as pa
@@ -38,6 +40,7 @@ if TYPE_CHECKING:
 
 
 class LegacyAltairMixin:
+    @gather_metrics
     def _legacy_line_chart(
         self,
         data: "Data" = None,
@@ -94,6 +97,7 @@ class LegacyAltairMixin:
             "line_chart", vega_lite_chart_proto, last_index=last_index
         )
 
+    @gather_metrics
     def _legacy_area_chart(
         self,
         data: "Data" = None,
@@ -149,6 +153,7 @@ class LegacyAltairMixin:
             "area_chart", vega_lite_chart_proto, last_index=last_index
         )
 
+    @gather_metrics
     def _legacy_bar_chart(
         self,
         data: "Data" = None,
@@ -204,6 +209,7 @@ class LegacyAltairMixin:
             "bar_chart", vega_lite_chart_proto, last_index=last_index
         )
 
+    @gather_metrics
     def _legacy_altair_chart(
         self, altair_chart: "Chart", use_container_width: bool = False
     ) -> "DeltaGenerator":

--- a/lib/streamlit/elements/legacy_data_frame.py
+++ b/lib/streamlit/elements/legacy_data_frame.py
@@ -31,6 +31,7 @@ from streamlit.proto.DataFrame_pb2 import (
     DataFrame as DataFrameProto,
     TableStyle as TableStyleProto,
 )
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -44,6 +45,7 @@ class CSSStyle(NamedTuple):
 
 
 class LegacyDataFrameMixin:
+    @gather_metrics
     def _legacy_dataframe(
         self,
         data: Data = None,
@@ -108,6 +110,7 @@ class LegacyDataFrameMixin:
             element_height=height,
         )
 
+    @gather_metrics
     def _legacy_table(self, data: Data = None) -> "DeltaGenerator":
         """Display a static table.
 

--- a/lib/streamlit/elements/legacy_vega_lite.py
+++ b/lib/streamlit/elements/legacy_vega_lite.py
@@ -22,6 +22,7 @@ import streamlit.elements.legacy_data_frame as data_frame
 import streamlit.elements.lib.dicttools as dicttools
 from streamlit.logger import get_logger
 from streamlit.proto.VegaLiteChart_pb2 import VegaLiteChart as VegaLiteChartProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from .arrow import Data
@@ -31,6 +32,7 @@ LOGGER: Final = get_logger(__name__)
 
 
 class LegacyVegaLiteMixin:
+    @gather_metrics
     def _legacy_vega_lite_chart(
         self,
         data: "Data" = None,

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -24,6 +24,7 @@ from typing_extensions import Final, TypeAlias
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
@@ -71,6 +72,7 @@ _ZOOM_LEVELS: Final = [
 
 
 class MapMixin:
+    @gather_metrics
     def map(
         self,
         data: Data = None,

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -17,6 +17,7 @@ from typing import cast, Optional, TYPE_CHECKING, Union
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.string_util import clean_text
 from streamlit.type_util import SupportsStr, is_sympy_expession
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     import sympy
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
 
 
 class MarkdownMixin:
+    @gather_metrics
     def markdown(
         self, body: SupportsStr, unsafe_allow_html: bool = False
     ) -> "DeltaGenerator":
@@ -80,6 +82,7 @@ class MarkdownMixin:
 
         return self.dg._enqueue("markdown", markdown_proto)
 
+    @gather_metrics
     def code(
         self, body: SupportsStr, language: Optional[str] = "python"
     ) -> "DeltaGenerator":
@@ -112,6 +115,7 @@ class MarkdownMixin:
         code_proto.body = clean_text(markdown)
         return self.dg._enqueue("markdown", code_proto)
 
+    @gather_metrics
     def caption(
         self, body: SupportsStr, unsafe_allow_html: bool = False
     ) -> "DeltaGenerator":
@@ -157,6 +161,7 @@ class MarkdownMixin:
         caption_proto.is_caption = True
         return self.dg._enqueue("markdown", caption_proto)
 
+    @gather_metrics
     def latex(self, body: Union[SupportsStr, "sympy.Expr"]) -> "DeltaGenerator":
         # This docstring needs to be "raw" because of the backslashes in the
         # example below.

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -23,6 +23,7 @@ from streamlit import type_util
 from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from typing import Any
@@ -38,6 +39,7 @@ Data: TypeAlias = Union[
 
 
 class MediaMixin:
+    @gather_metrics
     def audio(
         self,
         data: Data,
@@ -76,6 +78,7 @@ class MediaMixin:
         marshall_audio(coordinates, audio_proto, data, format, start_time)
         return self.dg._enqueue("audio", audio_proto)
 
+    @gather_metrics
     def video(
         self,
         data: Data,

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -20,6 +20,7 @@ from typing_extensions import TypeAlias, Literal
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Metric_pb2 import Metric as MetricProto
 from streamlit.string_util import clean_text
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     import numpy as np
@@ -39,6 +40,7 @@ class MetricColorAndDirection:
 
 
 class MetricMixin:
+    @gather_metrics
     def metric(
         self,
         label: str,

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -32,13 +32,14 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, is_type, to_key
-
 from streamlit.runtime.state import (
     register_widget,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -140,6 +141,7 @@ class MultiSelectMixin:
     ) -> List[Any]:
         ...
 
+    @gather_metrics
     def multiselect(
         self,
         label: str,

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -30,6 +30,8 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -48,6 +50,7 @@ class NumberInputSerde:
 
 
 class NumberInputMixin:
+    @gather_metrics
     def number_input(
         self,
         label: str,

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -23,6 +23,7 @@ from streamlit.runtime.legacy_caching import caching
 from streamlit import type_util
 from streamlit.logger import get_logger
 from streamlit.proto.PlotlyChart_pb2 import PlotlyChart as PlotlyChartProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     import matplotlib
@@ -64,6 +65,7 @@ FigureOrData: TypeAlias = Union[
 
 
 class PlotlyMixin:
+    @gather_metrics
     def plotly_chart(
         self,
         figure_or_data: FigureOrData,

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -17,7 +17,6 @@ from typing_extensions import TypeAlias
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Progress_pb2 import Progress as ProgressProto
-from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -17,6 +17,7 @@ from typing_extensions import TypeAlias
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Progress_pb2 import Progress as ProgressProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -23,6 +23,7 @@ from streamlit import config
 from streamlit.errors import StreamlitDeprecationWarning
 from streamlit.logger import get_logger
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -33,6 +34,7 @@ LOGGER: Final = get_logger(__name__)
 
 
 class PyplotMixin:
+    @gather_metrics
     def pyplot(
         self,
         fig: Optional["Figure"] = None,

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -28,6 +28,8 @@ from streamlit.runtime.state import (
 )
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -53,6 +55,7 @@ class RadioSerde:
 
 
 class RadioMixin:
+    @gather_metrics
     def radio(
         self,
         label: str,

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -28,6 +28,8 @@ from streamlit.runtime.state import (
 )
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -72,6 +74,7 @@ class SelectSliderSerde:
 
 
 class SelectSliderMixin:
+    @gather_metrics
     def select_slider(
         self,
         label: str,

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -28,6 +28,8 @@ from streamlit.runtime.state import (
 )
 from streamlit.type_util import Key, OptionSequence, ensure_indexable, to_key
 from streamlit.util import index_
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -53,6 +55,7 @@ class SelectboxSerde:
 
 
 class SelectboxMixin:
+    @gather_metrics
     def selectbox(
         self,
         label: str,

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -42,6 +42,8 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -165,6 +167,7 @@ class SliderSerde:
 
 
 class SliderMixin:
+    @gather_metrics
     def slider(
         self,
         label: str,

--- a/lib/streamlit/elements/snow.py
+++ b/lib/streamlit/elements/snow.py
@@ -15,12 +15,14 @@
 from typing import cast, TYPE_CHECKING
 
 from streamlit.proto.Snow_pb2 import Snow as SnowProto
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
 class SnowMixin:
+    @gather_metrics
     def snow(self) -> "DeltaGenerator":
         """Draw celebratory snowfall.
 

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -17,7 +17,6 @@ from typing import cast, TYPE_CHECKING
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.string_util import clean_text
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -17,6 +17,7 @@ from typing import cast, TYPE_CHECKING
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.string_util import clean_text
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -28,6 +28,7 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
 
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
@@ -57,6 +58,7 @@ class TextAreaSerde:
 
 
 class TextWidgetsMixin:
+    @gather_metrics
     def text_input(
         self,
         label: str,
@@ -220,6 +222,7 @@ class TextWidgetsMixin:
         self.dg._enqueue("text_input", text_input_proto)
         return widget_state.value
 
+    @gather_metrics
     def text_area(
         self,
         label: str,

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -31,6 +31,8 @@ from streamlit.runtime.state import (
     WidgetCallback,
     WidgetKwargs,
 )
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .form import current_form_id
 from .utils import check_callback_rules, check_session_state_rules
 
@@ -205,6 +207,7 @@ class DateInputSerde:
 
 
 class TimeWidgetsMixin:
+    @gather_metrics
     def time_input(
         self,
         label: str,
@@ -332,6 +335,7 @@ class TimeWidgetsMixin:
         self.dg._enqueue("time_input", time_input_proto)
         return widget_state.value
 
+    @gather_metrics
     def date_input(
         self,
         label: str,

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -20,6 +20,7 @@ from streamlit import type_util
 from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import get_session_state, WidgetCallback
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -20,7 +20,6 @@ from streamlit import type_util
 from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import get_session_state, WidgetCallback
-from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -24,6 +24,7 @@ from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import SessionStateProxy
 from streamlit.user_info import UserInfoProxy
+from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -40,6 +41,7 @@ HELP_TYPES: Final[Tuple[Type[Any], ...]] = (
 
 
 class WriteMixin:
+    @gather_metrics
     def write(self, *args: Any, **kwargs: Any) -> None:
         """Write arguments to the app.
 

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -34,6 +34,8 @@ from streamlit.file_util import (
 )
 from streamlit.logger import get_logger
 from streamlit.runtime.stats import CacheStatsProvider, CacheStat
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .cache_errors import (
     CacheError,
     CacheKeyNotFoundError,
@@ -225,6 +227,7 @@ class MemoAPI:
     # __call__ should be a static method, but there's a mypy bug that
     # breaks type checking for overloaded static functions:
     # https://github.com/python/mypy/issues/7781
+    @gather_metrics
     def __call__(
         self,
         func: Optional[F] = None,
@@ -359,6 +362,7 @@ class MemoAPI:
         )
 
     @staticmethod
+    @gather_metrics
     def clear() -> None:
         """Clear all in-memory and on-disk memo caches."""
         _memo_caches.clear_all()
@@ -430,6 +434,7 @@ class MemoCache(Cache):
         except pickle.UnpicklingError as exc:
             raise CacheError(f"Failed to unpickle {key}") from exc
 
+    @gather_metrics
     def write_result(self, key: str, value: Any, messages: List[MsgData]) -> None:
         """Write a value and associated messages to the cache.
         The value must be pickleable.

--- a/lib/streamlit/runtime/caching/singleton_decorator.py
+++ b/lib/streamlit/runtime/caching/singleton_decorator.py
@@ -23,6 +23,8 @@ from pympler import asizeof
 import streamlit as st
 from streamlit.logger import get_logger
 from streamlit.runtime.stats import CacheStatsProvider, CacheStat
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .cache_errors import CacheKeyNotFoundError, CacheType
 from .cache_utils import (
     Cache,
@@ -147,6 +149,7 @@ class SingletonAPI:
     # __call__ should be a static method, but there's a mypy bug that
     # breaks type checking for overloaded static functions:
     # https://github.com/python/mypy/issues/7781
+    @gather_metrics
     def __call__(
         self,
         func: Optional[F] = None,
@@ -246,6 +249,7 @@ class SingletonAPI:
         )
 
     @staticmethod
+    @gather_metrics
     def clear() -> None:
         """Clear all singleton caches."""
         _singleton_caches.clear_all()
@@ -271,6 +275,7 @@ class SingletonCache(Cache):
             else:
                 raise CacheKeyNotFoundError()
 
+    @gather_metrics
     def write_result(self, key: str, value: Any, messages: List[MsgData]) -> None:
         """Write a value and associated messages to the cache."""
         main_id = st._main.id

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -50,6 +50,8 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIWarning
 from streamlit.logger import get_logger
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider
+from streamlit.runtime.metrics_util import gather_metrics
+
 from .hashing import update_hash, HashFuncsDict, HashReason
 
 _LOGGER = get_logger(__name__)
@@ -345,6 +347,7 @@ def _read_from_cache(
         raise e
 
 
+@gather_metrics
 def _write_to_cache(
     mem_cache: MemCache,
     key: str,

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -16,7 +16,6 @@ import os
 import threading
 import uuid
 import contextlib
-import enum
 import sys
 import inspect
 from collections.abc import Sized


### PR DESCRIPTION
## 📚 Context

Part 2 of the improved usage metrics gathering feature. This PR adds the `gather_metrics` decorator to all relevant `st` commands. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Add `gather_metrics` decorator to all relevant `st` commands. This excludes the following commands:
    - `experimental_rerun`: This never would get captured since it directly triggers a reset of the run context / tracked commands.
    - `stop`: This directly stops the script preventing the metrics gathering logic to be executed.
    - `progress`: This is often executed many times in a loop and would add a lot of useful insights.
    - `spinner`: This command is also executed with all caching stuff and does not add a lot of useful insights.  
    - `empty`: This command can get executed lots of times and does not add a lot of useful insights. 
- Fix issue with wrapped `st. experimental_show` command.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
