### PR TITLE
Improve usage metrics gathering - Part 3

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -119,6 +119,7 @@ jest.mock("moment", () =>
 describe("App", () => {
   beforeEach(() => {
     SessionInfo.current = new SessionInfo({
+      appId: "aid",
       sessionId: "sessionId",
       streamlitVersion: "sv",
       pythonVersion: "pv",

--- a/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
+++ b/frontend/src/hocs/withMapboxToken/MapboxToken.test.ts
@@ -25,6 +25,7 @@ function setSessionInfo(
   commandLine = "streamlit hello"
 ): void {
   SessionInfo.current = new SessionInfo({
+    appId: "aid",
     sessionId: "mockSessionId",
     streamlitVersion: "sv",
     pythonVersion: "pv",

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
@@ -45,6 +45,7 @@ describe("withMapboxToken", () => {
 
   beforeAll(() => {
     SessionInfo.current = new SessionInfo({
+      appId: "aid",
       sessionId: "mockSessionId",
       streamlitVersion: "sv",
       pythonVersion: "pv",

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -39,6 +39,7 @@ describe("FileUploadClient Upload", () => {
   beforeEach(() => {
     axiosMock = new MockAdapter(axios)
     SessionInfo.current = new SessionInfo({
+      appId: "aid",
       sessionId: "sessionId",
       streamlitVersion: "sv",
       pythonVersion: "pv",

--- a/frontend/src/lib/HttpClient.test.ts
+++ b/frontend/src/lib/HttpClient.test.ts
@@ -31,6 +31,7 @@ describe("HttpClient", () => {
 
   beforeEach(() => {
     SessionInfo.current = new SessionInfo({
+      appId: "aid",
       sessionId: "sessionId",
       streamlitVersion: "sv",
       pythonVersion: "pv",

--- a/frontend/src/lib/MetricsManager.test.ts
+++ b/frontend/src/lib/MetricsManager.test.ts
@@ -26,6 +26,7 @@ jest.mock("src/lib/utils", () => ({
 
 const createSessionInfo = (): SessionInfo =>
   new SessionInfo({
+    appId: "aid",
     sessionId: "sessionId",
     streamlitVersion: "sv",
     pythonVersion: "pv",

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -24,6 +24,7 @@ test("Throws an error when used before initialization", () => {
 
 test("Clears session info", () => {
   SessionInfo.current = new SessionInfo({
+    appId: "aid",
     sessionId: "sessionId",
     streamlitVersion: "sv",
     pythonVersion: "pv",

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -23,7 +23,10 @@ import {
   UserInfo,
 } from "src/autogen/proto"
 
+import { hashString } from "src/lib/utils"
+
 export interface Args {
+  appId: string
   sessionId: string
   streamlitVersion: string
   pythonVersion: string
@@ -37,6 +40,8 @@ export interface Args {
 
 export class SessionInfo {
   // Fields that don't change during the lifetime of a session (i.e. a browser tab).
+  public readonly appId: string
+
   public readonly sessionId: string
 
   public readonly streamlitVersion: string
@@ -101,6 +106,7 @@ export class SessionInfo {
     const environmentInfo = initialize.environmentInfo as EnvironmentInfo
 
     return new SessionInfo({
+      appId: hashString(userInfo.installationIdV3 + newSession.mainScriptPath),
       sessionId: initialize.sessionId,
       streamlitVersion: environmentInfo.streamlitVersion,
       pythonVersion: environmentInfo.pythonVersion,
@@ -114,6 +120,7 @@ export class SessionInfo {
   }
 
   public constructor({
+    appId,
     sessionId,
     streamlitVersion,
     pythonVersion,
@@ -125,6 +132,7 @@ export class SessionInfo {
     userMapboxToken,
   }: Args) {
     if (
+      appId == null ||
       sessionId == null ||
       streamlitVersion == null ||
       pythonVersion == null ||
@@ -138,6 +146,7 @@ export class SessionInfo {
       throw new Error("SessionInfo arguments must be non-null")
     }
 
+    this.appId = appId
     this.sessionId = sessionId
     this.streamlitVersion = streamlitVersion
     this.pythonVersion = pythonVersion

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -152,7 +152,7 @@ def _get_callable_name(callable: Callable[..., Any]) -> str:
 
 def _get_arg_metadata(arg: object) -> Optional[str]:
     with contextlib.suppress(Exception):
-        if isinstance(arg, (bool, int)):
+        if isinstance(arg, (bool)):
             return f"val:{arg}"
 
         if isinstance(arg, Sized):

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -52,6 +52,8 @@ _CALLABLE_NAME_MAPPING: Final = {
     "_transparent_write": "magic",
     "MemoAPI.__call__": "experimental_memo",
     "SingletonAPI.__call__": "experimental_singleton",
+    "SingletonAPI.clear": "clear_singleton",
+    "MemoAPI.clear": "clear_memo",
     "SingletonCache.write_result": "_cache_singleton_object",
     "MemoCache.write_result": "_cache_memo_object",
     "_write_to_cache": "_cache_object",

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -139,7 +139,7 @@ class PageTelemetryTest(testutil.DeltaGeneratorTestCase):
         )
         self.assertEqual(
             str(command_metadata.args[1]).strip(),
-            'k: "width"\nt: "int"\nm: "val:250"',
+            'k: "width"\nt: "int"',
         )
 
         # Test with text_input command:


### PR DESCRIPTION
## 📚 Context

This is the final PR for the improved usage metrics project. This contains a mix of some glue code to get everything running and minor aspects that still require some modifications.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Add logic to send `pageProfile` event to Segment.
- Add loading time tracking from frontend.
- Remove tracking of argument value of `int` types.
- Add name mappings for clear cache methods.
- Remove tracking of `title` from `pageConfigChanged`
- Add new app ID that is a hash of the installation ID v3 and the main script path, replacing the report hash which is based on the old installation ID.

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
