### PR TITLE
InMemoryFileManager -> MediaFileManager

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -364,8 +364,8 @@ class DeltaGenerator(
         """Returns the element's delta path as a string like "[0, 2, 3, 1]".
 
         This uniquely identifies the element's position in the front-end,
-        which allows (among other potential uses) the InMemoryFileManager to maintain
-        session-specific maps of InMemoryFile objects placed with their "coordinates".
+        which allows (among other potential uses) the MediaFileManager to maintain
+        session-specific maps of MediaFile objects placed with their "coordinates".
 
         This way, users can (say) use st.image with a stream of different images,
         and Streamlit will expire the older images and replace them in place.

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -21,7 +21,7 @@ from typing_extensions import Final
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
@@ -408,7 +408,7 @@ def marshall_file(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    this_file = in_memory_file_manager.add(
+    this_file = media_file_manager.add(
         data_as_bytes,
         mimetype,
         coordinates,

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -31,8 +31,8 @@ from typing_extensions import Final, Literal, TypeAlias
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
@@ -362,7 +362,7 @@ def image_to_url(
     image_data = _ensure_image_size_and_format(image_data, width, image_format)
     mimetype = _get_image_format_mimetype(image_format)
 
-    this_file = in_memory_file_manager.add(image_data, mimetype, image_id)
+    this_file = media_file_manager.add(image_data, mimetype, image_id)
     return this_file.url
 
 
@@ -457,7 +457,7 @@ def marshall_images(
             proto_img.caption = str(caption)
 
         # We use the index of the image in the input image list to identify this image inside
-        # InMemoryFileManager. For this, we just add the index to the image's "coordinates".
+        # MediaFileManager. For this, we just add the index to the image's "coordinates".
         image_id = "%s-%i" % (coordinates, coord_suffix)
 
         is_svg = False

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -20,7 +20,7 @@ from typing_extensions import Final, TypeAlias
 from validators import url
 
 from streamlit import type_util
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -178,14 +178,14 @@ def _marshall_av_media(
     Otherwise assume strings are filenames and let any OS errors raise.
 
     Load data either from file or through bytes-processing methods into a
-    InMemoryFile object.  Pack proto with generated Tornado-based URL.
+    MediaFile object.  Pack proto with generated Tornado-based URL.
     """
     # Audio and Video methods have already checked if this is a URL by this point.
 
     if isinstance(data, str):
         # Assume it's a filename or blank.  Allow OS-based file errors.
         with open(data, "rb") as fh:
-            this_file = in_memory_file_manager.add(fh.read(), mimetype, coordinates)
+            this_file = media_file_manager.add(fh.read(), mimetype, coordinates)
             proto.url = this_file.url
             return
 
@@ -210,7 +210,7 @@ def _marshall_av_media(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    this_file = in_memory_file_manager.add(data_as_bytes, mimetype, coordinates)
+    this_file = media_file_manager.add(data_as_bytes, mimetype, coordinates)
     proto.url = this_file.url
 
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -37,7 +37,7 @@ from streamlit.proto.PagesChanged_pb2 import PagesChanged
 from streamlit.watcher import LocalSourcesWatcher
 from . import caching, legacy_caching
 from .credentials import Credentials
-from .in_memory_file_manager import in_memory_file_manager
+from .media_file_manager import media_file_manager
 from .metrics_util import Installation
 from .scriptrunner import (
     RerunData,
@@ -183,8 +183,8 @@ class AppSession:
             # Clear any unused session files in upload file manager and media
             # file manager
             self._uploaded_file_mgr.remove_session_files(self.id)
-            in_memory_file_manager.clear_session_files(self.id)
-            in_memory_file_manager.del_expired_files()
+            media_file_manager.clear_session_files(self.id)
+            media_file_manager.del_expired_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
@@ -529,7 +529,7 @@ class AppSession:
             if self._state == AppSessionState.SHUTDOWN_REQUESTED:
                 # Only clear media files if the script is done running AND the
                 # session is actually shutting down.
-                in_memory_file_manager.clear_session_files(self.id)
+                media_file_manager.clear_session_files(self.id)
 
             self._client_state = client_state
             self._scriptrunner = None

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -36,7 +36,7 @@ from .forward_msg_cache import (
     populate_hash_if_needed,
     create_reference_msg,
 )
-from .in_memory_file_manager import in_memory_file_manager
+from .media_file_manager import media_file_manager
 from .legacy_caching.caching import _mem_caches
 from .session_data import SessionData
 from .state import SessionStateStatProvider, SCRIPT_RUN_WITHOUT_ERRORS_KEY
@@ -172,7 +172,7 @@ class Runtime:
         self._stats_mgr.register_provider(get_singleton_stats_provider())
         self._stats_mgr.register_provider(_mem_caches)
         self._stats_mgr.register_provider(self._message_cache)
-        self._stats_mgr.register_provider(in_memory_file_manager)
+        self._stats_mgr.register_provider(media_file_manager)
         self._stats_mgr.register_provider(self._uploaded_file_mgr)
         self._stats_mgr.register_provider(
             SessionStateStatProvider(self._session_info_by_id)

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -30,7 +30,7 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.in_memory_file_manager import in_memory_file_manager
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.runtime.state import (
     SessionState,
@@ -413,7 +413,7 @@ class ScriptRunner:
         start_time: float = timer()
 
         # Reset DeltaGenerators, widgets, media files.
-        in_memory_file_manager.clear_session_files()
+        media_file_manager.clear_session_files()
 
         main_script_path = self._main_script_path
         pages = source_util.get_pages(main_script_path)
@@ -625,7 +625,7 @@ class ScriptRunner:
 
         # Delete expired files now that the script has run and files in use
         # are marked as active.
-        in_memory_file_manager.del_expired_files()
+        media_file_manager.del_expired_files()
 
         # Force garbage collection to run, to help avoid memory use building up
         # This is usually not an issue, but sometimes GC takes time to kick in and

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
+from typing import Optional
 from urllib.parse import quote, unquote_plus
 
 import tornado.web
 
 from streamlit import config, file_util
 from streamlit.logger import get_logger
-from streamlit.runtime.in_memory_file_manager import (
+from streamlit.runtime.media_file_manager import (
     _get_extension_for_mimetype,
-    in_memory_file_manager,
-    FILE_TYPE_DOWNLOADABLE,
+    media_file_manager,
+    MediaFileType,
 )
 from streamlit.runtime.runtime_util import serialize_forward_msg
 from streamlit.string_util import generate_download_filename_from_title
@@ -108,7 +108,7 @@ class AddSlashHandler(tornado.web.RequestHandler):
 
 
 class MediaFileHandler(tornado.web.StaticFileHandler):
-    def set_default_headers(self):
+    def set_default_headers(self) -> None:
         if allow_cross_origin_requests():
             self.set_header("Access-Control-Allow-Origin", "*")
 
@@ -122,17 +122,17 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         Used for serve downloadable files, like files stored
         via st.download_button widget
         """
-        in_memory_file = in_memory_file_manager.get(path)
+        media_file = media_file_manager.get(path)
 
-        if in_memory_file and in_memory_file.file_type == FILE_TYPE_DOWNLOADABLE:
-            file_name = in_memory_file.file_name
+        if media_file and media_file.file_type == MediaFileType.DOWNLOADABLE:
+            file_name = media_file.file_name
 
             if not file_name:
                 title = self.get_argument("title", "", True)
                 title = unquote_plus(title)
                 filename = generate_download_filename_from_title(title)
                 file_name = (
-                    f"{filename}{_get_extension_for_mimetype(in_memory_file.mimetype)}"
+                    f"{filename}{_get_extension_for_mimetype(media_file.mimetype)}"
                 )
 
             try:
@@ -143,68 +143,69 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
             self.set_header("Content-Disposition", f"attachment; {file_expr}")
 
-    # Overriding StaticFileHandler to use the InMemoryFileManager
+    # Overriding StaticFileHandler to use the MediaFileManager
     #
     # From the Torndado docs:
     # To replace all interaction with the filesystem (e.g. to serve
     # static content from a database), override `get_content`,
     # `get_content_size`, `get_modified_time`, `get_absolute_path`, and
     # `validate_absolute_path`.
-    def validate_absolute_path(self, root, absolute_path):
+    def validate_absolute_path(self, root: str, absolute_path: str) -> str:
         try:
-            in_memory_file_manager.get(absolute_path)
+            media_file_manager.get(absolute_path)
         except KeyError:
-            LOGGER.error("InMemoryFileManager: Missing file %s" % absolute_path)
+            LOGGER.error("MediaFileHandler: Missing file %s", absolute_path)
             raise tornado.web.HTTPError(404, "not found")
 
         return absolute_path
 
-    def get_content_size(self):
+    def get_content_size(self) -> int:
         abspath = self.absolute_path
         if abspath is None:
             return 0
 
-        in_memory_file = in_memory_file_manager.get(abspath)
-        return in_memory_file.content_size
+        media_file = media_file_manager.get(abspath)
+        return media_file.content_size
 
-    def get_modified_time(self):
+    def get_modified_time(self) -> None:
         # We do not track last modified time, but this can be improved to
-        # allow caching among files in the InMemoryFileManager
+        # allow caching among files in the MediaFileManager
         return None
 
     @classmethod
-    def get_absolute_path(cls, root, path):
+    def get_absolute_path(cls, root: str, path: str) -> str:
         # All files are stored in memory, so the absolute path is just the
         # path itself. In the MediaFileHandler, it's just the filename
         return path
 
     @classmethod
-    def get_content(cls, abspath, start=None, end=None):
-        LOGGER.debug("MediaFileHandler: GET %s" % abspath)
+    def get_content(
+        cls, abspath: str, start: Optional[int] = None, end: Optional[int] = None
+    ):
+        LOGGER.debug("MediaFileHandler: GET %s", abspath)
 
         try:
             # abspath is the hash as used `get_absolute_path`
-            in_memory_file = in_memory_file_manager.get(abspath)
+            media_file = media_file_manager.get(abspath)
         except:
-            LOGGER.error("InMemoryFileManager: Missing file %s" % abspath)
+            LOGGER.error("MediaFileHandler: Missing file %s", abspath)
             return
 
         LOGGER.debug(
-            "InMemoryFileManager: Sending %s file %s"
-            % (in_memory_file.mimetype, abspath)
+            "MediaFileHandler: Sending %s file %s", media_file.mimetype, abspath
         )
 
         # If there is no start and end, just return the full content
         if start is None and end is None:
-            return in_memory_file.content
+            return media_file.content
 
         if start is None:
             start = 0
         if end is None:
-            end = len(in_memory_file.content)
+            end = len(media_file.content)
 
         # content is bytes that work just by slicing supplied by start and end
-        return in_memory_file.content[start:end]
+        return media_file.content[start:end]
 
 
 class _SpecialRequestHandler(tornado.web.RequestHandler):

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -22,9 +22,9 @@ import numpy as np
 from scipy.io import wavfile
 
 import streamlit as st
-from streamlit.runtime.in_memory_file_manager import (
+from streamlit.runtime.media_file_manager import (
     _calculate_file_id,
-    in_memory_file_manager,
+    media_file_manager,
     STATIC_MEDIA_ENDPOINT,
 )
 from tests import testutil
@@ -43,9 +43,9 @@ class AudioTest(testutil.DeltaGeneratorTestCase):
 
         # locate resultant file in InMemoryFileManager and test its properties.
         file_id = _calculate_file_id(fake_audio_data, "audio/wav")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "audio/wav")
         self.assertEqual(afile.url, el.audio.url)
 

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -116,7 +116,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         * Path
         * Bytes
         """
-        from streamlit.runtime.in_memory_file_manager import _calculate_file_id
+        from streamlit.runtime.media_file_manager import _calculate_file_id
         from streamlit.elements.image import _np_array_to_bytes
 
         file_id = _calculate_file_id(

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -19,9 +19,9 @@ from io import BytesIO
 import numpy as np
 
 import streamlit as st
-from streamlit.runtime.in_memory_file_manager import (
+from streamlit.runtime.media_file_manager import (
     _calculate_file_id,
-    in_memory_file_manager,
+    media_file_manager,
     STATIC_MEDIA_ENDPOINT,
 )
 from tests import testutil
@@ -40,9 +40,9 @@ class VideoTest(testutil.DeltaGeneratorTestCase):
 
         # locate resultant file in InMemoryFileManager and test its properties.
         file_id = _calculate_file_id(fake_video_data, "video/mp4")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "video/mp4")
         self.assertEqual(afile.url, el.video.url)
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -22,6 +22,7 @@ import sys
 import textwrap
 import time
 import unittest
+from io import BytesIO
 from unittest.mock import patch
 
 import PIL.Image as Image
@@ -778,9 +779,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
 
         # locate resultant file in InMemoryFileManager and test its properties.
         file_id = _calculate_file_id(fake_video_data, "video/mp4")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "video/mp4")
         self.assertEqual(afile.url, el.video.url)
 
@@ -826,7 +827,7 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
     def test_st_video_options(self):
         """Test st.video with options."""
 
-        from streamlit.runtime.in_memory_file_manager import _calculate_file_id
+        from streamlit.runtime.media_file_manager import _calculate_file_id
 
         fake_video_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
         st.video(fake_video_data, format="video/mp4", start_time=10)

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -22,7 +22,6 @@ import sys
 import textwrap
 import time
 import unittest
-from io import BytesIO
 from unittest.mock import patch
 
 import PIL.Image as Image
@@ -765,79 +764,6 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
     def test_st_legacy_vega_lite_chart(self):
         """Test st._legacy_vega_lite_chart."""
         pass
-
-    def test_st_video(self):
-        """Test st.video."""
-
-        # Make up some bytes to pretend we have a video.  The server should not vet
-        # the video before sending it to the browser.
-        fake_video_data = "\x12\x10\x35\x44\x55\x66".encode("utf-8")
-
-        st.video(fake_video_data)
-
-        el = self.get_delta_from_queue().new_element
-
-        # locate resultant file in InMemoryFileManager and test its properties.
-        file_id = _calculate_file_id(fake_video_data, "video/mp4")
-        self.assertTrue(file_id in media_file_manager)
-
-        afile = media_file_manager.get(file_id)
-        self.assertEqual(afile.mimetype, "video/mp4")
-        self.assertEqual(afile.url, el.video.url)
-
-        # Test with an arbitrary URL in place of data
-        some_url = "http://www.marmosetcare.com/video/in-the-wild/intro.webm"
-        st.video(some_url)
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.video.url, some_url)
-
-        # Test with sufficiently varied youtube URLs
-        yt_urls = (
-            "https://youtu.be/_T8LGqJtuGc",
-            "https://www.youtube.com/watch?v=kmfC-i9WgH0",
-            "https://www.youtube.com/embed/sSn4e1lLVpA",
-        )
-        yt_embeds = (
-            "https://www.youtube.com/embed/_T8LGqJtuGc",
-            "https://www.youtube.com/embed/kmfC-i9WgH0",
-            "https://www.youtube.com/embed/sSn4e1lLVpA",
-        )
-        # url should be transformed into an embed link (or left alone).
-        for x in range(0, len(yt_urls)):
-            st.video(yt_urls[x])
-            el = self.get_delta_from_queue().new_element
-            self.assertEqual(el.video.url, yt_embeds[x])
-
-        # Test that a non-URL string is assumed to be a filename
-        bad_filename = "blah"
-        with self.assertRaises(FileNotFoundError):
-            st.video(bad_filename)
-
-        # Test that we can use an empty/None value without error.
-        st.video(None)
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.video.url, "")
-
-        # Test that our other data types don't result in an error.
-        st.video(b"bytes_data")
-        st.video("str_data".encode("utf-8"))
-        st.video(BytesIO(b"bytesio_data"))
-        st.video(np.array([0, 1, 2, 3]))
-
-    def test_st_video_options(self):
-        """Test st.video with options."""
-
-        from streamlit.runtime.media_file_manager import _calculate_file_id
-
-        fake_video_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
-        st.video(fake_video_data, format="video/mp4", start_time=10)
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.video.start_time, 10)
-        self.assertTrue(el.video.url.startswith(STATIC_MEDIA_ENDPOINT))
-        self.assertTrue(
-            _calculate_file_id(fake_video_data, "video/mp4") in el.video.url
-        )
 
     def test_st_warning(self):
         """Test st.warning."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -36,9 +36,9 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Alert_pb2 import Alert
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
-from streamlit.runtime.in_memory_file_manager import (
+from streamlit.runtime.media_file_manager import (
     _calculate_file_id,
-    in_memory_file_manager,
+    media_file_manager,
     STATIC_MEDIA_ENDPOINT,
 )
 from tests import testutil
@@ -383,9 +383,9 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
         from streamlit.elements.image import _PIL_to_bytes
 
         file_id = _calculate_file_id(_PIL_to_bytes(img, format="PNG"), "image/png")
-        self.assertTrue(file_id in in_memory_file_manager)
+        self.assertTrue(file_id in media_file_manager)
 
-        afile = in_memory_file_manager.get(file_id)
+        afile = media_file_manager.get(file_id)
         self.assertEqual(afile.mimetype, "image/png")
         self.assertEqual(afile.url, el.imgs.imgs[0].url)
 
@@ -417,8 +417,8 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
                 _PIL_to_bytes(imgs[idx], format="PNG"), "image/png"
             )
             self.assertEqual(el.imgs.imgs[idx].caption, "some caption")
-            self.assertTrue(file_id in in_memory_file_manager)
-            afile = in_memory_file_manager.get(file_id)
+            self.assertTrue(file_id in media_file_manager)
+            afile = media_file_manager.get(file_id)
             self.assertEqual(afile.mimetype, "image/png")
             self.assertEqual(afile.url, el.imgs.imgs[idx].url)
 
@@ -764,6 +764,79 @@ class StreamlitAPITest(testutil.DeltaGeneratorTestCase):
     def test_st_legacy_vega_lite_chart(self):
         """Test st._legacy_vega_lite_chart."""
         pass
+
+    def test_st_video(self):
+        """Test st.video."""
+
+        # Make up some bytes to pretend we have a video.  The server should not vet
+        # the video before sending it to the browser.
+        fake_video_data = "\x12\x10\x35\x44\x55\x66".encode("utf-8")
+
+        st.video(fake_video_data)
+
+        el = self.get_delta_from_queue().new_element
+
+        # locate resultant file in InMemoryFileManager and test its properties.
+        file_id = _calculate_file_id(fake_video_data, "video/mp4")
+        self.assertTrue(file_id in in_memory_file_manager)
+
+        afile = in_memory_file_manager.get(file_id)
+        self.assertEqual(afile.mimetype, "video/mp4")
+        self.assertEqual(afile.url, el.video.url)
+
+        # Test with an arbitrary URL in place of data
+        some_url = "http://www.marmosetcare.com/video/in-the-wild/intro.webm"
+        st.video(some_url)
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.video.url, some_url)
+
+        # Test with sufficiently varied youtube URLs
+        yt_urls = (
+            "https://youtu.be/_T8LGqJtuGc",
+            "https://www.youtube.com/watch?v=kmfC-i9WgH0",
+            "https://www.youtube.com/embed/sSn4e1lLVpA",
+        )
+        yt_embeds = (
+            "https://www.youtube.com/embed/_T8LGqJtuGc",
+            "https://www.youtube.com/embed/kmfC-i9WgH0",
+            "https://www.youtube.com/embed/sSn4e1lLVpA",
+        )
+        # url should be transformed into an embed link (or left alone).
+        for x in range(0, len(yt_urls)):
+            st.video(yt_urls[x])
+            el = self.get_delta_from_queue().new_element
+            self.assertEqual(el.video.url, yt_embeds[x])
+
+        # Test that a non-URL string is assumed to be a filename
+        bad_filename = "blah"
+        with self.assertRaises(FileNotFoundError):
+            st.video(bad_filename)
+
+        # Test that we can use an empty/None value without error.
+        st.video(None)
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.video.url, "")
+
+        # Test that our other data types don't result in an error.
+        st.video(b"bytes_data")
+        st.video("str_data".encode("utf-8"))
+        st.video(BytesIO(b"bytesio_data"))
+        st.video(np.array([0, 1, 2, 3]))
+
+    def test_st_video_options(self):
+        """Test st.video with options."""
+
+        from streamlit.runtime.in_memory_file_manager import _calculate_file_id
+
+        fake_video_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        st.video(fake_video_data, format="video/mp4", start_time=10)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.video.start_time, 10)
+        self.assertTrue(el.video.url.startswith(STATIC_MEDIA_ENDPOINT))
+        self.assertTrue(
+            _calculate_file_id(fake_video_data, "video/mp4") in el.video.url
+        )
 
     def test_st_warning(self):
         """Test st.warning."""


### PR DESCRIPTION
(This is a cherry-pick of https://github.com/streamlit/streamlit/commit/e7fdcab5896d537a77cee505136f8bda1fc51ad7. The motivation is to shrink the size of the eventual `feature/MediaFileManager` merge, and also to make it easier to add some remaining missing tests and documentation to MediaFileManager before that merge.)

Original PR:
---
Renames "InMemoryFileManager" to "MediaFileManager" (and "InMemoryFile" to "MediaFile")

Motivation:
- `InMemoryFileManager` is not a great name; the fact that media files are stored in memory is an implementation detail, and not an important part of its identity. And in fact:
- The storage layer for MediaFileManager will soon become an abstract interface, and we'll have multiple implementations (an in-memory implementation for vanilla Streamlit, and an S3-based implementation for Snowpark)

Other stuff:
- `MediaFile.file_type` is now an enum rather than a string, for type safety
- Adds some missing type annotations and other minor fixes to `MediaFileHandler`