### PR TITLE
MediaFileManager thread-safety

### DIFF
--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -180,7 +180,10 @@ class MediaFileManager(CacheStatsProvider):
             str, Dict[str, MediaFile]
         ] = collections.defaultdict(dict)
 
-        self._lock = threading.RLock()
+        # MediaFileManager is used from multiple threads, so all operations
+        # need to be protected with a Lock. (This is not an RLock, which
+        # means taking it multiple times from the same thread will deadlock.)
+        self._lock = threading.Lock()
 
     def del_expired_files(self) -> None:
         """Delete files that are no longer referenced by any active session.


### PR DESCRIPTION
MediaFileManager is called from multiple threads, so add a lock.

This doesn't change any behavior, and doesn't introduce any new tests. But I'd like to get more serious about testing our multi-threaded classes in the (near) future, and I've added a task to my list to figure out a plan for this.