### PR TITLE
Upgrade Python Max Test CI resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,8 @@ jobs:
 
     working_directory: ~/repo
 
+    resource_class: large
+
     steps:
       - checkout:
           name: Checkout Streamlit code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,7 +466,6 @@ jobs:
     docker:
       - image: circleci/python:3.10.1
 
-    
     resource_class: large
 
     working_directory: ~/repo
@@ -920,10 +919,13 @@ jobs:
                 failure_message: ":blobonfire: Nightly job failed on E2E tests"
 
   cli-regression-test:
-    resource_class: large
     docker:
       - image: circleci/python:3.10.1
+
+    # resource_class: large
+
     working_directory: ~/repo
+
     steps:
       - checkout:
           name: Checkout Streamlit code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,13 +919,10 @@ jobs:
                 failure_message: ":blobonfire: Nightly job failed on E2E tests"
 
   cli-regression-test:
+    resource_class: large
     docker:
       - image: circleci/python:3.10.1
-
-    resource_class: large
-
     working_directory: ~/repo
-
     steps:
       - checkout:
           name: Checkout Streamlit code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,9 +466,10 @@ jobs:
     docker:
       - image: circleci/python:3.10.1
 
-    working_directory: ~/repo
-
+    
     resource_class: large
+
+    working_directory: ~/repo
 
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,7 +922,7 @@ jobs:
     docker:
       - image: circleci/python:3.10.1
 
-    # resource_class: large
+    resource_class: large
 
     working_directory: ~/repo
 


### PR DESCRIPTION
## 📚 Context

The `python-max-version` CI check has been running much slower as of late, particularly the frontend tests. Per Vincent's investigation, the big jump seems to happen around May 31 when the new dataframe component was merged - PR #4797.
This PR designates the job to use a higher resource class on CircleCI, which seems to reduce the test time by at least several minutes.

- What kind of change does this PR introduce?
  - [x] Other, please describe: Python Max Test Update

## 🧠 Description of Changes

- Added more resources to `python-max-version` test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
