### PR TITLE
Update version for react-map-gl from 5.2.19 to 5.3.19

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
     "react-hotkeys": "^1.1.4",
     "react-html-parser": "^2.0.2",
     "react-json-view": "^1.19.1",
-    "react-map-gl": "^5.2.19",
+    "react-map-gl": "^5.3.19",
     "react-markdown": "^6.0.3",
     "react-plotly.js": "^2.4.0",
     "react-syntax-highlighter": "^15.4.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15084,7 +15084,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-map-gl@^5.2.19:
+react-map-gl@^5.3.19:
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-5.3.19.tgz#8c012eb7328c64dc2a4bb65eeceacd4a66734f72"
   integrity sha512-Ia8OlbFJIjC9x7XMaUCNtm179NKiD/bjQOt1R/SbBcaz35pSFPUyI0SwOnIUQ98/mR4xopL6phgIfs0B3yZhtQ==


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
It looks like 5.2.19 react-map-gl doesn't exist.  React-map-gl 5.2.11 exists and 5.3.19 exists and yarn technically will resolve it to 5.3.19 but there still seems to be some yarn issues by setting it to 5.2.19 because it does not exist. This is to resolve that yarn issue.
_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:

## 🧠 Description of Changes
Change package.json and yarn.lock
- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done
Manually tested by checking console and checking that st.map runs.
- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
