### PR TITLE
add option to provide function to validate cached result for st.memo …

### DIFF
--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -75,11 +75,12 @@ class MemoizedFunction(CachedFunction):
         func: types.FunctionType,
         show_spinner: bool,
         suppress_st_warning: bool,
+        validate: types.FunctionType,
         persist: Optional[str],
         max_entries: Optional[int],
         ttl: Optional[float],
     ):
-        super().__init__(func, show_spinner, suppress_st_warning)
+        super().__init__(func, show_spinner, suppress_st_warning, validate)
         self.persist = persist
         self.max_entries = max_entries
         self.ttl = ttl
@@ -219,6 +220,7 @@ class MemoAPI:
         persist: Optional[str] = None,
         show_spinner: bool = True,
         suppress_st_warning: bool = False,
+        validate: Optional[F] = None,
         max_entries: Optional[int] = None,
         ttl: Optional[float] = None,
     ) -> Callable[[F], F]:
@@ -235,6 +237,7 @@ class MemoAPI:
         persist: Optional[str] = None,
         show_spinner: bool = True,
         suppress_st_warning: bool = False,
+        validate: Optional[F] = None,
         max_entries: Optional[int] = None,
         ttl: Optional[float] = None,
     ):
@@ -274,6 +277,11 @@ class MemoAPI:
             None if cache entries should not expire. The default is None.
             Note that ttl is incompatible with `persist="disk"` - `ttl` will be
             ignored if `persist` is specified.
+
+        validate : callable (returning bool)
+            Function that will check if cached object is still valid.
+            For example, if the object is a database session, check that
+            the session is still open.
 
         Example
         -------
@@ -352,6 +360,7 @@ class MemoAPI:
                     persist=persist,
                     show_spinner=show_spinner,
                     suppress_st_warning=suppress_st_warning,
+                    validate=validate,
                     max_entries=max_entries,
                     ttl=ttl,
                 )
@@ -368,6 +377,7 @@ class MemoAPI:
                 persist=persist,
                 show_spinner=show_spinner,
                 suppress_st_warning=suppress_st_warning,
+                validate=validate,
                 max_entries=max_entries,
                 ttl=ttl,
             )


### PR DESCRIPTION
…and st.singleton

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_
Sometimes return values from functions can become invalid, which means that the cached result via @st.memo or @st.singleton would be invalid. For example, many databases will close a connection from the server side after a period of inactivity. The goal is to allow the user to provide a function (which returns a bool) that will be called to validate the cached value before returning it to the user. If the function returns False, then the function is called as if there was a cache miss and the new return value is saved in the cache.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_
This PR adds a new option to @st.memo and @st.singleton for the user to provide an optional `validate` option. `validate` should be a function that takes as input the return type of the function that is being decorated and returns a bool (True if the value is still valid, False if the value is invalid). 
`CachedFunction` is modified to take an additional argument, `validate` that is a FunctionType. If that optional argument is not None, `CachedFunction.create_cache_wrapper.wrapper.get_or_create_cached_value` will check the cache for a value (as before), but before passing that along it will add an additional check by running the `validate()` method on the returned value.
Memo and Singleton have been updated simply to pass along the `validate` option though.

  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_
No new UI update

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_
No

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
