### PR TITLE
MediaFileManager: improve file deletion function names and tests

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -183,8 +183,8 @@ class AppSession:
             # Clear any unused session files in upload file manager and media
             # file manager
             self._uploaded_file_mgr.remove_session_files(self.id)
-            media_file_manager.clear_session_files(self.id)
-            media_file_manager.del_expired_files()
+            media_file_manager.clear_session_refs(self.id)
+            media_file_manager.remove_orphaned_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
@@ -529,7 +529,7 @@ class AppSession:
             if self._state == AppSessionState.SHUTDOWN_REQUESTED:
                 # Only clear media files if the script is done running AND the
                 # session is actually shutting down.
-                media_file_manager.clear_session_files(self.id)
+                media_file_manager.clear_session_refs(self.id)
 
             self._client_state = client_state
             self._scriptrunner = None

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -207,7 +207,7 @@ class MediaFileManager(CacheStatsProvider):
 
         Safe to call from any thread.
         """
-        LOGGER.debug("Deleting expired files...")
+        LOGGER.debug("Removing orphaned files...")
 
         with self._lock:
             for file_id in self._get_inactive_file_ids():

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -19,7 +19,7 @@ import hashlib
 import mimetypes
 import threading
 from enum import Enum
-from typing import Dict, Set, Optional, List
+from typing import Dict, Set, Optional, List, Iterable
 
 from streamlit import util
 from streamlit.logger import get_logger
@@ -185,32 +185,53 @@ class MediaFileManager(CacheStatsProvider):
         # means taking it multiple times from the same thread will deadlock.)
         self._lock = threading.Lock()
 
+    def _get_session_file_ids(self, session_id: str) -> Iterable[str]:
+        """Return an iterable containing all the file IDs that the given session
+        is using.
+
+        Thread safety: callers must hold `self._lock`.
+        """
+        files_by_coord = self._files_by_session_and_coord.get(session_id)
+        if files_by_coord is None:
+            return ()
+
+        return map(lambda file: file.id, files_by_coord.values())
+
+    def _get_inactive_file_ids(self) -> Set[str]:
+        """Compute the set of files that are stored in the manager, but are
+        not referenced by any active session. These are files that can be
+        safely deleted.
+
+        Thread safety: callers must hold `self._lock`.
+        """
+        # Get the set of all our file IDs.
+        file_ids = set(self._files_by_id.keys())
+
+        # Subtract all IDs that are in use by each session
+        for session_id in self._files_by_session_and_coord.keys():
+            file_ids.difference_update(self._get_session_file_ids(session_id))
+
+        return file_ids
+
     def del_expired_files(self) -> None:
         """Delete files that are no longer referenced by any active session.
 
         Safe to call from any thread.
         """
         LOGGER.debug("Deleting expired files...")
+
         with self._lock:
-            # Get a flat set of every file ID in the session ID map.
-            active_file_ids: Set[str] = set()
-
-            for files_by_coord in self._files_by_session_and_coord.values():
-                file_ids = map(lambda file: file.id, files_by_coord.values())
-                active_file_ids = active_file_ids.union(file_ids)
-
-            for file_id, file in list(self._files_by_id.items()):
-                if file.id not in active_file_ids:
-
-                    if file.file_type == MediaFileType.MEDIA:
+            for file_id in self._get_inactive_file_ids():
+                file = self._files_by_id[file_id]
+                if file.file_type == MediaFileType.MEDIA:
+                    LOGGER.debug(f"Deleting File: {file_id}")
+                    del self._files_by_id[file_id]
+                elif file.file_type == MediaFileType.DOWNLOADABLE:
+                    if file._is_marked_for_delete:
                         LOGGER.debug(f"Deleting File: {file_id}")
                         del self._files_by_id[file_id]
-                    elif file.file_type == MediaFileType.DOWNLOADABLE:
-                        if file._is_marked_for_delete:
-                            LOGGER.debug(f"Deleting File: {file_id}")
-                            del self._files_by_id[file_id]
-                        else:
-                            file._mark_for_delete()
+                    else:
+                        file._mark_for_delete()
 
     def clear_session_files(self, session_id: Optional[str] = None) -> None:
         """Removes AppSession-coordinate mapping immediately, and id-file mapping later.

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -213,8 +213,8 @@ class MediaFileManager(CacheStatsProvider):
 
         return file_ids
 
-    def del_expired_files(self) -> None:
-        """Delete files that are no longer referenced by any active session.
+    def remove_orphaned_files(self) -> None:
+        """Remove all files that are no longer referenced by any active session.
 
         Safe to call from any thread.
         """
@@ -233,8 +233,11 @@ class MediaFileManager(CacheStatsProvider):
                     else:
                         file._mark_for_delete()
 
-    def clear_session_files(self, session_id: Optional[str] = None) -> None:
-        """Removes AppSession-coordinate mapping immediately, and id-file mapping later.
+    def clear_session_refs(self, session_id: Optional[str] = None) -> None:
+        """Remove the given session's file references.
+
+        (This does not remove any files from the manager - you must call
+        `remove_orphaned_files` for that.)
 
         Should be called whenever ScriptRunner completes and when a session ends.
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -623,7 +623,7 @@ class ScriptRunner:
         # even if we were stopped with an exception.)
         self.on_event.send(self, event=event)
 
-        # Delete expired files now that the script has run and files in use
+        # Remove orphaned files now that the script has run and files in use
         # are marked as active.
         media_file_manager.remove_orphaned_files()
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -413,7 +413,7 @@ class ScriptRunner:
         start_time: float = timer()
 
         # Reset DeltaGenerators, widgets, media files.
-        media_file_manager.clear_session_files()
+        media_file_manager.clear_session_refs()
 
         main_script_path = self._main_script_path
         pages = source_util.get_pages(main_script_path)
@@ -625,7 +625,7 @@ class ScriptRunner:
 
         # Delete expired files now that the script has run and files in use
         # are marked as active.
-        media_file_manager.del_expired_files()
+        media_file_manager.remove_orphaned_files()
 
         # Force garbage collection to run, to help avoid memory use building up
         # This is usually not an issue, but sometimes GC takes time to kick in and

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -16,7 +16,6 @@
 
 from unittest import mock, TestCase
 import random
-import time
 
 from streamlit.runtime.media_file_manager import (
     MediaFileManager,
@@ -309,43 +308,6 @@ class MediaFileManagerTest(TestCase):
         # After a final call to remove_orphaned_files, the files should be gone.
         self.media_file_manager.remove_orphaned_files()
         self.assertEqual(len(self.media_file_manager), 0)
-
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    def test_add_file_multiple_sessions_then_clear(self, _get_session_id):
-        _get_session_id.return_value = "mock_session_1"
-
-        sample = next(iter(ALL_FIXTURES.values()))
-
-        coord = random_coordinates()
-        f = self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
-        self.assertTrue(f.id in self.media_file_manager)
-
-        _get_session_id.return_value = "mock_session_2"
-
-        coord = random_coordinates()
-        f = self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
-        self.assertTrue(f.id in self.media_file_manager)
-
-        # There should be only 1 file in MFM.
-        self.assertEqual(len(self.media_file_manager), 1)
-
-        # There should be 2 sessions with registered files.
-        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 2)
-
-        # force every MediaFile to have a TTD of now, so we can see it get deleted w/o waiting.
-        for file in self.media_file_manager._files_by_id.values():
-            file.ttd = time.time()
-
-        self.media_file_manager.clear_session_refs()
-
-        # There should be 1 session with registered files.
-        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
-
-        _get_session_id.return_value = "mock_session_1"
-        self.media_file_manager.clear_session_refs()
-
-        # There should be 0 session with registered files.
-        self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
     def test_media_file_url(self):
         self.assertEqual(MediaFile("abcd", b"", "audio/wav").url, "/media/abcd.wav")

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -119,11 +119,12 @@ class MediaFileManagerTest(TestCase):
             _calculate_file_id(fake_bytes, "audio/wav", file_name="name2.wav"),
         )
 
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    def test_add_files(self, _get_session_id):
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_add_files(self, _):
         """Test that MediaFileManager.add works as expected."""
-        _get_session_id.return_value = "SESSION1"
-
         coord = random_coordinates()
 
         # Make sure we reject files containing None
@@ -146,12 +147,12 @@ class MediaFileManagerTest(TestCase):
         # There should only be 1 session with registered files.
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    @mock.patch("time.time")
-    def test_add_files_same_coord(self, _time, _get_session_id):
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_add_files_same_coord(self, _):
         """Test that MediaFileManager.add works as expected."""
-        _get_session_id.return_value = "SESSION1"
-
         coord = random_coordinates()
 
         for sample in ALL_FIXTURES.values():
@@ -168,7 +169,8 @@ class MediaFileManagerTest(TestCase):
 
         # There should only be 1 coord in that session.
         self.assertEqual(
-            len(self.media_file_manager._files_by_session_and_coord["SESSION1"]), 1
+            len(self.media_file_manager._files_by_session_and_coord["mock_session_id"]),
+            1,
         )
 
         self.media_file_manager.clear_session_refs()
@@ -180,10 +182,11 @@ class MediaFileManagerTest(TestCase):
         # There should only be 0 session with registered files.
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 0)
 
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    def test_add_file_already_exists_same_coord(self, _get_session_id):
-        _get_session_id.return_value = "SESSION1"
-
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_add_file_already_exists_same_coord(self, _):
         sample = IMAGE_FIXTURES["png"]
         coord = random_coordinates()
 
@@ -203,10 +206,11 @@ class MediaFileManagerTest(TestCase):
         # There should only be 1 session with registered files.
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    def test_add_file_already_exists_different_coord(self, _get_session_id):
-        _get_session_id.return_value = "SESSION1"
-
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_add_file_already_exists_different_coord(self, _):
         sample = IMAGE_FIXTURES["png"]
 
         coord = random_coordinates()
@@ -227,10 +231,12 @@ class MediaFileManagerTest(TestCase):
         # There should only be 1 session with registered files.
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    def test_add_file_different_mimetypes(self, _get_session_id):
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_add_file_different_mimetypes(self, _):
         """Test that we create a new file if new mimetype, even with same bytes for content."""
-        _get_session_id.return_value = "SESSION1"
         coord = random_coordinates()
 
         sample = AUDIO_FIXTURES["mp3"]
@@ -289,7 +295,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
     def test_add_file_multiple_sessions_then_clear(self, _get_session_id):
-        _get_session_id.return_value = "SESSION1"
+        _get_session_id.return_value = "mock_session_1"
 
         sample = next(iter(ALL_FIXTURES.values()))
 
@@ -297,7 +303,7 @@ class MediaFileManagerTest(TestCase):
         f = self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
         self.assertTrue(f.id in self.media_file_manager)
 
-        _get_session_id.return_value = "SESSION2"
+        _get_session_id.return_value = "mock_session_2"
 
         coord = random_coordinates()
         f = self.media_file_manager.add(sample["content"], sample["mimetype"], coord)
@@ -318,7 +324,7 @@ class MediaFileManagerTest(TestCase):
         # There should be 1 session with registered files.
         self.assertEqual(len(self.media_file_manager._files_by_session_and_coord), 1)
 
-        _get_session_id.return_value = "SESSION1"
+        _get_session_id.return_value = "mock_session_1"
         self.media_file_manager.clear_session_refs()
 
         # There should be 0 session with registered files.
@@ -330,9 +336,11 @@ class MediaFileManagerTest(TestCase):
         self.assertEqual(MediaFile("abcd", b"", "video/mp4").url, "/media/abcd.mp4")
         self.assertEqual(MediaFile("abcd", b"", "video/webm").url, "/media/abcd.webm")
 
-    @mock.patch("streamlit.runtime.media_file_manager._get_session_id")
-    def test_stats_provider(self, _get_session_id):
-        _get_session_id.return_value = "SESSION1"
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_stats_provider(self, _):
         manager = self.media_file_manager
         assert len(manager.get_stats()) == 0
 
@@ -345,6 +353,6 @@ class MediaFileManagerTest(TestCase):
         assert stats[0].category_name == "st_media_file_manager"
         assert sum(stat.byte_length for stat in stats) == 232
 
-        manager.clear_session_refs("SESSION1")
+        manager.clear_session_refs("mock_session_id")
         manager.remove_orphaned_files()
         assert len(manager.get_stats()) == 0


### PR DESCRIPTION
This is a small refactor to make MediaFileManager file deletion logic less confusing, and more well-tested.

- `MediaFileManager.clear_session_files()` is now `MediaFileManager.clear_session_refs()`, to make it clear that this function does not actually remove any files.
- `MediaFileManager.del_expired_files()` is now `MediaFileManager.remove_orphaned_files()`. These files aren't really "expired" (there's no TTL on them); instead, they just don't have any sessions referencing them anymore.
- `MediaFileManagerTest.test_remove_orphaned_files_multiple_sessions` is a new test that ensures that files referenced from multiple sessions are not removed until they are dereferenced from all sessions. (This was not properly tested before!)
- There's some additional MediaFIleManagerTest cleanup (some larger tests are now broken down into multiple smaller, more-atomic tests)