### PR TITLE
MediaFileHandler tests

### DIFF
--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -121,12 +121,15 @@ class MediaFile:
 
     @property
     def url(self) -> str:
-        extension = _get_extension_for_mimetype(self._mimetype)
-        return f"{STATIC_MEDIA_ENDPOINT}/{self.id}{extension}"
+        return f"{STATIC_MEDIA_ENDPOINT}/{self.id}{self.extension}"
 
     @property
     def id(self) -> str:
         return self._file_id
+
+    @property
+    def extension(self) -> str:
+        return _get_extension_for_mimetype(self.mimetype)
 
     @property
     def content(self) -> bytes:
@@ -322,19 +325,19 @@ class MediaFileManager(CacheStatsProvider):
 
             return file
 
-    def get(self, file_id: str) -> MediaFile:
-        """Returns the MediaFile for the given file_id.
+    def get(self, filename: str) -> MediaFile:
+        """Returns the MediaFile for the given filename.
 
         Raises KeyError if not found.
 
         Safe to call from any thread.
         """
-        # Filename is {requested_hash}.{extension} but MediaFileManager
+        # Filename is {file_id}.{extension} but MediaFileManager
         # is indexed by requested_hash.
-        hash = file_id.split(".")[0]
+        file_id = filename.split(".")[0]
 
         # dictionary access is atomic, so no need to take a lock.
-        return self._files_by_id[hash]
+        return self._files_by_id[file_id]
 
     def get_stats(self) -> List[CacheStat]:
         # We operate on a copy of our dict, to avoid race conditions

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -40,9 +40,9 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         Set header value to "attachment" indicating that file should be saved
         locally instead of displaying inline in browser.
 
-        We also set filename to specify filename for  downloaded file.
-        Used for serve downloadable files, like files stored
-        via st.download_button widget
+        We also set filename to specify the filename for downloaded files.
+        Used for serving downloadable files, like files stored via the
+        `st.download_button` widget.
         """
         media_file = media_file_manager.get(path)
 
@@ -67,7 +67,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
     # Overriding StaticFileHandler to use the MediaFileManager
     #
-    # From the Torndado docs:
+    # From the Tornado docs:
     # To replace all interaction with the filesystem (e.g. to serve
     # static content from a database), override `get_content`,
     # `get_content_size`, `get_modified_time`, `get_absolute_path`, and

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -19,7 +19,6 @@ import tornado.web
 
 from streamlit.logger import get_logger
 from streamlit.runtime.media_file_manager import (
-    _get_extension_for_mimetype,
     media_file_manager,
     MediaFileType,
 )
@@ -47,21 +46,18 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
         media_file = media_file_manager.get(path)
 
         if media_file and media_file.file_type == MediaFileType.DOWNLOADABLE:
-            file_name = media_file.file_name
+            filename = media_file.file_name
 
-            if not file_name:
+            if not filename:
                 title = self.get_argument("title", "", True)
                 title = unquote_plus(title)
                 filename = generate_download_filename_from_title(title)
-                file_name = (
-                    f"{filename}{_get_extension_for_mimetype(media_file.mimetype)}"
-                )
+                filename = f"{filename}{media_file.extension}"
 
             try:
-                file_name.encode("ascii")
-                file_expr = 'filename="{}"'.format(file_name)
+                file_expr = 'filename="{}"'.format(filename)
             except UnicodeEncodeError:
-                file_expr = "filename*=utf-8''{}".format(quote(file_name))
+                file_expr = "filename*=utf-8''{}".format(quote(filename))
 
             self.set_header("Content-Disposition", f"attachment; {file_expr}")
 

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -1,0 +1,130 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+from urllib.parse import quote, unquote_plus
+
+import tornado.web
+
+from streamlit.logger import get_logger
+from streamlit.runtime.media_file_manager import (
+    _get_extension_for_mimetype,
+    media_file_manager,
+    MediaFileType,
+)
+from streamlit.string_util import generate_download_filename_from_title
+from streamlit.web.server import allow_cross_origin_requests
+
+LOGGER = get_logger(__name__)
+
+
+class MediaFileHandler(tornado.web.StaticFileHandler):
+    def set_default_headers(self) -> None:
+        if allow_cross_origin_requests():
+            self.set_header("Access-Control-Allow-Origin", "*")
+
+    def set_extra_headers(self, path: str) -> None:
+        """Add Content-Disposition header for downloadable files.
+
+        Set header value to "attachment" indicating that file should be saved
+        locally instead of displaying inline in browser.
+
+        We also set filename to specify filename for  downloaded file.
+        Used for serve downloadable files, like files stored
+        via st.download_button widget
+        """
+        media_file = media_file_manager.get(path)
+
+        if media_file and media_file.file_type == MediaFileType.DOWNLOADABLE:
+            file_name = media_file.file_name
+
+            if not file_name:
+                title = self.get_argument("title", "", True)
+                title = unquote_plus(title)
+                filename = generate_download_filename_from_title(title)
+                file_name = (
+                    f"{filename}{_get_extension_for_mimetype(media_file.mimetype)}"
+                )
+
+            try:
+                file_name.encode("ascii")
+                file_expr = 'filename="{}"'.format(file_name)
+            except UnicodeEncodeError:
+                file_expr = "filename*=utf-8''{}".format(quote(file_name))
+
+            self.set_header("Content-Disposition", f"attachment; {file_expr}")
+
+    # Overriding StaticFileHandler to use the MediaFileManager
+    #
+    # From the Torndado docs:
+    # To replace all interaction with the filesystem (e.g. to serve
+    # static content from a database), override `get_content`,
+    # `get_content_size`, `get_modified_time`, `get_absolute_path`, and
+    # `validate_absolute_path`.
+    def validate_absolute_path(self, root: str, absolute_path: str) -> str:
+        try:
+            media_file_manager.get(absolute_path)
+        except KeyError:
+            LOGGER.error("MediaFileHandler: Missing file %s", absolute_path)
+            raise tornado.web.HTTPError(404, "not found")
+
+        return absolute_path
+
+    def get_content_size(self) -> int:
+        abspath = self.absolute_path
+        if abspath is None:
+            return 0
+
+        media_file = media_file_manager.get(abspath)
+        return media_file.content_size
+
+    def get_modified_time(self) -> None:
+        # We do not track last modified time, but this can be improved to
+        # allow caching among files in the MediaFileManager
+        return None
+
+    @classmethod
+    def get_absolute_path(cls, root: str, path: str) -> str:
+        # All files are stored in memory, so the absolute path is just the
+        # path itself. In the MediaFileHandler, it's just the filename
+        return path
+
+    @classmethod
+    def get_content(
+        cls, abspath: str, start: Optional[int] = None, end: Optional[int] = None
+    ):
+        LOGGER.debug("MediaFileHandler: GET %s", abspath)
+
+        try:
+            # abspath is the hash as used `get_absolute_path`
+            media_file = media_file_manager.get(abspath)
+        except:
+            LOGGER.error("MediaFileHandler: Missing file %s", abspath)
+            return
+
+        LOGGER.debug(
+            "MediaFileHandler: Sending %s file %s", media_file.mimetype, abspath
+        )
+
+        # If there is no start and end, just return the full content
+        if start is None and end is None:
+            return media_file.content
+
+        if start is None:
+            start = 0
+        if end is None:
+            end = len(media_file.content)
+
+        # content is bytes that work just by slicing supplied by start and end
+        return media_file.content[start:end]

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -13,20 +13,12 @@
 # limitations under the License.
 
 import os
-from typing import Optional
-from urllib.parse import quote, unquote_plus
 
 import tornado.web
 
 from streamlit import config, file_util
 from streamlit.logger import get_logger
-from streamlit.runtime.media_file_manager import (
-    _get_extension_for_mimetype,
-    media_file_manager,
-    MediaFileType,
-)
 from streamlit.runtime.runtime_util import serialize_forward_msg
-from streamlit.string_util import generate_download_filename_from_title
 
 LOGGER = get_logger(__name__)
 
@@ -105,107 +97,6 @@ class AddSlashHandler(tornado.web.RequestHandler):
     @tornado.web.addslash
     def get(self):
         pass
-
-
-class MediaFileHandler(tornado.web.StaticFileHandler):
-    def set_default_headers(self) -> None:
-        if allow_cross_origin_requests():
-            self.set_header("Access-Control-Allow-Origin", "*")
-
-    def set_extra_headers(self, path: str) -> None:
-        """Add Content-Disposition header for downloadable files.
-
-        Set header value to "attachment" indicating that file should be saved
-        locally instead of displaying inline in browser.
-
-        We also set filename to specify filename for  downloaded file.
-        Used for serve downloadable files, like files stored
-        via st.download_button widget
-        """
-        media_file = media_file_manager.get(path)
-
-        if media_file and media_file.file_type == MediaFileType.DOWNLOADABLE:
-            file_name = media_file.file_name
-
-            if not file_name:
-                title = self.get_argument("title", "", True)
-                title = unquote_plus(title)
-                filename = generate_download_filename_from_title(title)
-                file_name = (
-                    f"{filename}{_get_extension_for_mimetype(media_file.mimetype)}"
-                )
-
-            try:
-                file_name.encode("ascii")
-                file_expr = 'filename="{}"'.format(file_name)
-            except UnicodeEncodeError:
-                file_expr = "filename*=utf-8''{}".format(quote(file_name))
-
-            self.set_header("Content-Disposition", f"attachment; {file_expr}")
-
-    # Overriding StaticFileHandler to use the MediaFileManager
-    #
-    # From the Torndado docs:
-    # To replace all interaction with the filesystem (e.g. to serve
-    # static content from a database), override `get_content`,
-    # `get_content_size`, `get_modified_time`, `get_absolute_path`, and
-    # `validate_absolute_path`.
-    def validate_absolute_path(self, root: str, absolute_path: str) -> str:
-        try:
-            media_file_manager.get(absolute_path)
-        except KeyError:
-            LOGGER.error("MediaFileHandler: Missing file %s", absolute_path)
-            raise tornado.web.HTTPError(404, "not found")
-
-        return absolute_path
-
-    def get_content_size(self) -> int:
-        abspath = self.absolute_path
-        if abspath is None:
-            return 0
-
-        media_file = media_file_manager.get(abspath)
-        return media_file.content_size
-
-    def get_modified_time(self) -> None:
-        # We do not track last modified time, but this can be improved to
-        # allow caching among files in the MediaFileManager
-        return None
-
-    @classmethod
-    def get_absolute_path(cls, root: str, path: str) -> str:
-        # All files are stored in memory, so the absolute path is just the
-        # path itself. In the MediaFileHandler, it's just the filename
-        return path
-
-    @classmethod
-    def get_content(
-        cls, abspath: str, start: Optional[int] = None, end: Optional[int] = None
-    ):
-        LOGGER.debug("MediaFileHandler: GET %s", abspath)
-
-        try:
-            # abspath is the hash as used `get_absolute_path`
-            media_file = media_file_manager.get(abspath)
-        except:
-            LOGGER.error("MediaFileHandler: Missing file %s", abspath)
-            return
-
-        LOGGER.debug(
-            "MediaFileHandler: Sending %s file %s", media_file.mimetype, abspath
-        )
-
-        # If there is no start and end, just return the full content
-        if start is None and end is None:
-            return media_file.content
-
-        if start is None:
-            start = 0
-        if end is None:
-            end = len(media_file.content)
-
-        # content is bytes that work just by slicing supplied by start and end
-        return media_file.content[start:end]
 
 
 class _SpecialRequestHandler(tornado.web.RequestHandler):

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -44,7 +44,6 @@ from streamlit.web.server.routes import (
     AddSlashHandler,
     AssetsFileHandler,
     HealthHandler,
-    MediaFileHandler,
     MessageCacheHandler,
     StaticFileHandler,
 )
@@ -55,6 +54,7 @@ from streamlit.web.server.upload_file_request_handler import (
 )
 from .browser_websocket_handler import BrowserWebSocketHandler
 from .component_request_handler import ComponentRequestHandler
+from .media_file_handler import MediaFileHandler
 from .stats_request_handler import StatsRequestHandler
 
 LOGGER = get_logger(__name__)

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -1,0 +1,31 @@
+# Copyright 2018-2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tornado.testing
+import tornado.web
+
+from streamlit.web.server.media_file_handler import MediaFileHandler
+
+
+class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def tearDown(self) -> None:
+        super().tearDown()
+
+    def get_app(self):
+        return tornado.web.Application(
+            [("/media/(.*)", MediaFileHandler, {"path": ""})]
+        )
+
+    def test_good_request(self):
+        pass

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -11,21 +11,73 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import mock
 
 import tornado.testing
 import tornado.web
+from tornado.httpclient import HTTPResponse
 
+from streamlit.runtime.media_file_manager import media_file_manager
 from streamlit.web.server.media_file_handler import MediaFileHandler
 
 
 class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
-    def tearDown(self) -> None:
-        super().tearDown()
+    def setUp(self) -> None:
+        super().setUp()
+        # Clear the MediaFileManager before each test
+        media_file_manager._files_by_id.clear()
+        media_file_manager._files_by_session_and_coord.clear()
 
     def get_app(self):
         return tornado.web.Application(
             [("/media/(.*)", MediaFileHandler, {"path": ""})]
         )
 
-    def test_good_request(self):
-        pass
+    def _fetch_file(self, filename) -> HTTPResponse:
+        return self.fetch(f"/media/{filename}", method="GET")
+
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_media_file(self, _):
+        """Requests for media files in MediaFileManager should succeed."""
+        # Add a media file and read it back
+        media_file = media_file_manager.add(b"mock_data", "video/mp4", "mock_coords")
+        rsp = self._fetch_file(f"{media_file.id}{media_file.extension}")
+
+        self.assertEqual(200, rsp.code)
+        self.assertEqual(b"mock_data", rsp.body)
+        self.assertEqual("video/mp4", rsp.headers["Content-Type"])
+        self.assertEqual(str(len(b"mock_data")), rsp.headers["Content-Length"])
+
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        return_value="mock_session_id",
+    )
+    def test_downloadable_file(self, _):
+        """Downloadable files get an additional 'Content-Disposition' header
+        that includes their user-specified filename.
+        """
+        # Add a downloadable file with a filename
+        media_file = media_file_manager.add(
+            b"mock_data",
+            "video/mp4",
+            "mock_coords",
+            file_name="MockVideo.mp4",
+            is_for_static_download=True,
+        )
+        rsp = self._fetch_file(f"{media_file.id}{media_file.extension}")
+
+        self.assertEqual(200, rsp.code)
+        self.assertEqual(b"mock_data", rsp.body)
+        self.assertEqual("video/mp4", rsp.headers["Content-Type"])
+        self.assertEqual(str(len(b"mock_data")), rsp.headers["Content-Length"])
+        self.assertEqual(
+            'attachment; filename="MockVideo.mp4"', rsp.headers["Content-Disposition"]
+        )
+
+    def test_invalid_file(self):
+        """Requests for invalid files fail with 404."""
+        rsp = self._fetch_file("invalid_media_file")
+        self.assertEqual(404, rsp.code)

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from unittest import mock
 
 import tornado.testing
@@ -28,7 +29,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         media_file_manager._files_by_id.clear()
         media_file_manager._files_by_session_and_coord.clear()
 
-    def get_app(self):
+    def get_app(self) -> tornado.web.Application:
         return tornado.web.Application(
             [("/media/(.*)", MediaFileHandler, {"path": ""})]
         )
@@ -40,7 +41,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.runtime.media_file_manager._get_session_id",
         return_value="mock_session_id",
     )
-    def test_media_file(self, _):
+    def test_media_file(self, _) -> None:
         """Requests for media files in MediaFileManager should succeed."""
         # Add a media file and read it back
         media_file = media_file_manager.add(b"mock_data", "video/mp4", "mock_coords")
@@ -55,7 +56,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.runtime.media_file_manager._get_session_id",
         return_value="mock_session_id",
     )
-    def test_downloadable_file(self, _):
+    def test_downloadable_file(self, _) -> None:
         """Downloadable files get an additional 'Content-Disposition' header
         that includes their user-specified filename.
         """
@@ -77,7 +78,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
             'attachment; filename="MockVideo.mp4"', rsp.headers["Content-Disposition"]
         )
 
-    def test_invalid_file(self):
+    def test_invalid_file(self) -> None:
         """Requests for invalid files fail with 404."""
         rsp = self._fetch_file("invalid_media_file")
         self.assertEqual(404, rsp.code)


### PR DESCRIPTION
Our MediaFileHandler route doesn't have any tests! This PR:

- Moves `MediaFileHandler` out of `routes.py` and into its own `media_file_handler.py` (this is literally just a copy-paste)
- Adds `media_file_handler_test.py`, with tests for fetching media files, fetching "downloadable" files, and fetching invalid files