### PR TITLE
Require more strict reviews on protobuf changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 frontend/package.json @jroes @anoctopus @tconkling @kmcgrady
 lib/Pipfile @jroes @anoctopus @tconkling @kmcgrady
 lib/setup.py @jroes @anoctopus @tconkling @kmcgrady
+proto/ @vdonato @tconkling @LukasMasuch


### PR DESCRIPTION
## 📚 Context

We'll soon be in a world where we have to be more careful about the changes made
to our protobuf schemas. Previously, we were never too strict about following
best-practices to guarantee backwards/forwards compatibility since our protos
are never persisted anywhere (unless some third party is doing so, but they're
doing that at their own risk), and we're guaranteed that the server and web
client always have matching schema versions.

This soon won't be true (the reasons are Snowflake-internal, but we're okay with
having this bleed slightly into the open source library as it doesn't cause any
changes for users or contributors. All of the change required will be additional
process/code review work for maintainers), and thus we'll soon need to ensure
that protobuf schemas evolve in backwards/forwards compatible ways. For now,
we'll just try to enforce this by making a small subset of maintainers code owners
of the `proto/` directory so that they can verify that proto schema changes are made
in a backwards/forwards compatible way.

Since changes to our protobufs don't happen very often, using this brute-force
approach to help ensure compatibility should be fine for now, but we may have to
rethink this if it eventually ends up being too much work for the people responsible.

Currently, we're giving @vdonato, @tconkling, and @LukasMasuch these additional
responsibilities, but we may always choose to expand this group of reviewers
down the line.

- What kind of change does this PR introduce?

  - [x] Other, please describe: CODEOWNERS change
