### PR TITLE
image_test cleanup

### DIFF
--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -12,20 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit test for image."""
+"""st.image unit tests."""
 
-import pytest
-from PIL import Image, ImageDraw
-from parameterized import parameterized
-
-from streamlit.errors import StreamlitAPIException
-from tests import testutil
+import PIL.Image as Image
 import cv2
 import numpy as np
+import pytest
+from PIL import ImageDraw
+from parameterized import parameterized
 
 import streamlit as st
 import streamlit.elements.image as image
+from streamlit.elements.image import _np_array_to_bytes
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
+from streamlit.runtime.media_file_manager import (
+    _calculate_file_id,
+    media_file_manager,
+)
+from tests import testutil
 
 
 def create_image(size, format="RGB", add_alpha=True):
@@ -116,9 +121,6 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         * Path
         * Bytes
         """
-        from streamlit.runtime.media_file_manager import _calculate_file_id
-        from streamlit.elements.image import _np_array_to_bytes
-
         file_id = _calculate_file_id(
             _np_array_to_bytes(data_in, output_format=format),
             mimetype="image/" + format,
@@ -241,3 +243,89 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
     def test_image_may_have_alpha_channel(self, format: str, expected_alpha: bool):
         img = Image.new(format, (1, 1))
         self.assertEqual(image._image_may_have_alpha_channel(img), expected_alpha)
+
+    def test_st_image_PIL_image(self):
+        """Test st.image with PIL image."""
+        img = Image.new("RGB", (64, 64), color="red")
+
+        st.image(img, caption="some caption", width=100, output_format="PNG")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.imgs.width, 100)
+        self.assertEqual(el.imgs.imgs[0].caption, "some caption")
+
+        # locate resultant file in the file manager and check its metadata.
+        from streamlit.elements.image import _PIL_to_bytes
+
+        file_id = _calculate_file_id(_PIL_to_bytes(img, format="PNG"), "image/png")
+        self.assertTrue(file_id in media_file_manager)
+
+        afile = media_file_manager.get(file_id)
+        self.assertEqual(afile.mimetype, "image/png")
+        self.assertEqual(afile.url, el.imgs.imgs[0].url)
+
+    def test_st_image_PIL_array(self):
+        """Test st.image with a PIL array."""
+        imgs = [
+            Image.new("RGB", (64, 64), color="red"),
+            Image.new("RGB", (64, 64), color="blue"),
+            Image.new("RGB", (64, 64), color="green"),
+        ]
+
+        st.image(
+            imgs,
+            caption=["some caption"] * 3,
+            width=200,
+            use_column_width=True,
+            clamp=True,
+            output_format="PNG",
+        )
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.imgs.width, -2)
+
+        # locate resultant file in the file manager and check its metadata.
+        from streamlit.elements.image import _PIL_to_bytes
+
+        for idx in range(len(imgs)):
+            file_id = _calculate_file_id(
+                _PIL_to_bytes(imgs[idx], format="PNG"), "image/png"
+            )
+            self.assertEqual(el.imgs.imgs[idx].caption, "some caption")
+            self.assertTrue(file_id in media_file_manager)
+            afile = media_file_manager.get(file_id)
+            self.assertEqual(afile.mimetype, "image/png")
+            self.assertEqual(afile.url, el.imgs.imgs[idx].url)
+
+    def test_st_image_with_single_url(self):
+        """Test st.image with single url."""
+        url = "http://server/fake0.jpg"
+
+        st.image(url, caption="some caption", width=300)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.imgs.width, 300)
+        self.assertEqual(el.imgs.imgs[0].caption, "some caption")
+        self.assertEqual(el.imgs.imgs[0].url, url)
+
+    def test_st_image_with_list_of_urls(self):
+        """Test st.image with list of urls."""
+        urls = [
+            "http://server/fake0.jpg",
+            "http://server/fake1.jpg",
+            "http://server/fake2.jpg",
+        ]
+        st.image(urls, caption=["some caption"] * 3, width=300)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.imgs.width, 300)
+        for idx, url in enumerate(urls):
+            self.assertEqual(el.imgs.imgs[idx].caption, "some caption")
+            self.assertEqual(el.imgs.imgs[idx].url, url)
+
+    def test_st_image_bad_width(self):
+        """Test st.image with bad width."""
+        with self.assertRaises(StreamlitAPIException) as ctx:
+            st.image("does/not/exist", width=-1234)
+
+        self.assertTrue("Image width must be positive." in str(ctx.exception))

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""st.image unit tests."""
+"""Unit tests for st.image and other image.py utility code."""
 
 import PIL.Image as Image
 import cv2

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -23,7 +23,7 @@ from parameterized import parameterized
 
 import streamlit as st
 import streamlit.elements.image as image
-from streamlit.elements.image import _np_array_to_bytes
+from streamlit.elements.image import _np_array_to_bytes, _PIL_to_bytes
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.runtime.media_file_manager import (
@@ -255,8 +255,6 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(el.imgs.imgs[0].caption, "some caption")
 
         # locate resultant file in the file manager and check its metadata.
-        from streamlit.elements.image import _PIL_to_bytes
-
         file_id = _calculate_file_id(_PIL_to_bytes(img, format="PNG"), "image/png")
         self.assertTrue(file_id in media_file_manager)
 
@@ -285,8 +283,6 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(el.imgs.width, -2)
 
         # locate resultant file in the file manager and check its metadata.
-        from streamlit.elements.image import _PIL_to_bytes
-
         for idx in range(len(imgs)):
             file_id = _calculate_file_id(
                 _PIL_to_bytes(imgs[idx], format="PNG"), "image/png"


### PR DESCRIPTION
Minor refactor: move various `st.image` tests out of `streamlit_test.py` and into `image_test.py`. No behavior changes.