### PR TITLE
Number input returns consistent type after rerun

### DIFF
--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -50,12 +50,22 @@ Number = Union[int, float]
 @dataclass
 class NumberInputSerde:
     value: Union[int, float]
+    data_type: int
 
     def serialize(self, v: Number) -> Number:
         return v
 
     def deserialize(self, ui_value: Optional[Number], widget_id: str = "") -> Number:
-        return ui_value if ui_value is not None else self.value
+        if ui_value is not None:
+            val = ui_value
+        else:
+            # Widget has not been used; fallback to the original value,
+            val = self.value
+
+        if self.data_type == NumberInputProto.INT:
+            val = int(val)
+
+        return val
 
 
 class NumberInputMixin:
@@ -290,10 +300,10 @@ class NumberInputMixin:
         except JSNumberBoundsException as e:
             raise StreamlitAPIException(str(e))
 
+        data_type = NumberInputProto.INT if all_ints else NumberInputProto.FLOAT
+
         number_input_proto = NumberInputProto()
-        number_input_proto.data_type = (
-            NumberInputProto.INT if all_ints else NumberInputProto.FLOAT
-        )
+        number_input_proto.data_type = data_type
         number_input_proto.label = label
         number_input_proto.default = value
         number_input_proto.form_id = current_form_id(self.dg)
@@ -314,7 +324,7 @@ class NumberInputMixin:
         if format is not None:
             number_input_proto.format = format
 
-        serde = NumberInputSerde(value)
+        serde = NumberInputSerde(value, data_type)
         widget_state = register_widget(
             "number_input",
             number_input_proto,

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -24,6 +24,7 @@ from streamlit.js_number import JSNumber
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from streamlit.proto.NumberInput_pb2 import NumberInput
+from streamlit.proto.WidgetStates_pb2 import WidgetState
 from tests import testutil
 
 
@@ -288,3 +289,24 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
                 "Unsupported label_visibility option 'wrong_value'. Valid values are "
                 "'visible', 'hidden' or 'collapsed'.",
             )
+
+    def test_should_keep_type_of_return_value_after_rerun(self):
+        # Generate widget id and reset context
+        st.number_input("a number", min_value=1, max_value=100, key="number")
+        widget_id = self.new_script_run_ctx.session_state.get_widget_states()[0].id
+        self.new_script_run_ctx.reset()
+
+        # Set the state of the widgets to the test state
+        widget_state = WidgetState()
+        widget_state.id = widget_id
+        widget_state.double_value = 42.0
+        self.new_script_run_ctx.session_state._state._new_widget_state.set_widget_from_proto(
+            widget_state
+        )
+
+        # Render widget again with the same parameters
+        number = st.number_input("a number", min_value=1, max_value=100, key="number")
+
+        # Assert output
+        self.assertEqual(number, 42)
+        self.assertEqual(type(number), int)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Hi. 
I noticed that number_input does not affect the type response when deserializing.
Close: https://github.com/streamlit/streamlit/issues/4319

Best regards,
Kamil Breguła

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
