### PR TITLE
Avoid recursively watching directories when possible

### DIFF
--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -52,7 +52,6 @@ class NoOpPathWatcher:
         _on_changed: Callable[[str], None],
         *,  # keyword-only arguments:
         glob_pattern: Optional[str] = None,
-        allow_nonexistent: bool = False,
     ):
         pass
 
@@ -91,7 +90,6 @@ def _watch_path(
     watcher_type: Optional[str] = None,
     *,  # keyword-only arguments:
     glob_pattern: Optional[str] = None,
-    allow_nonexistent: bool = False,
 ) -> bool:
     """Create a PathWatcher for the given path if we have a viable
     PathWatcher class.
@@ -109,9 +107,6 @@ def _watch_path(
         Optional glob pattern to use when watching a directory. If set, only
         files matching the pattern will be counted as being created/deleted
         within the watched directory.
-    allow_nonexistent
-        If True, allow the file or directory at the given path to be
-        nonexistent.
 
     Returns
     -------
@@ -130,7 +125,6 @@ def _watch_path(
         path,
         on_path_changed,
         glob_pattern=glob_pattern,
-        allow_nonexistent=allow_nonexistent,
     )
     return True
 
@@ -149,14 +143,12 @@ def watch_dir(
     watcher_type: Optional[str] = None,
     *,  # keyword-only arguments:
     glob_pattern: Optional[str] = None,
-    allow_nonexistent: bool = False,
 ) -> bool:
     return _watch_path(
         path,
         on_dir_changed,
         watcher_type,
         glob_pattern=glob_pattern,
-        allow_nonexistent=allow_nonexistent,
     )
 
 

--- a/lib/streamlit/watcher/polling_path_watcher.py
+++ b/lib/streamlit/watcher/polling_path_watcher.py
@@ -51,7 +51,6 @@ class PollingPathWatcher:
         on_changed: Callable[[str], None],
         *,  # keyword-only arguments:
         glob_pattern: Optional[str] = None,
-        allow_nonexistent: bool = False,
     ) -> None:
         """Constructor.
 
@@ -64,17 +63,13 @@ class PollingPathWatcher:
         self._on_changed = on_changed
 
         self._glob_pattern = glob_pattern
-        self._allow_nonexistent = allow_nonexistent
 
         self._active = True
 
-        self._modification_time = util.path_modification_time(
-            self._path, self._allow_nonexistent
-        )
+        self._modification_time = util.path_modification_time(self._path)
         self._md5 = util.calc_md5_with_blocking_retries(
             self._path,
             glob_pattern=self._glob_pattern,
-            allow_nonexistent=self._allow_nonexistent,
         )
         self._schedule()
 
@@ -93,9 +88,7 @@ class PollingPathWatcher:
             # Don't call self._schedule()
             return
 
-        modification_time = util.path_modification_time(
-            self._path, self._allow_nonexistent
-        )
+        modification_time = util.path_modification_time(self._path)
         if modification_time <= self._modification_time:
             self._schedule()
             return
@@ -105,7 +98,6 @@ class PollingPathWatcher:
         md5 = util.calc_md5_with_blocking_retries(
             self._path,
             glob_pattern=self._glob_pattern,
-            allow_nonexistent=self._allow_nonexistent,
         )
         if md5 == self._md5:
             self._schedule()

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -36,7 +36,6 @@ def calc_md5_with_blocking_retries(
     path: str,
     *,  # keyword-only arguments:
     glob_pattern: Optional[str] = None,
-    allow_nonexistent: bool = False,
 ) -> str:
     """Calculate the MD5 checksum of a given path.
 
@@ -48,9 +47,7 @@ def calc_md5_with_blocking_retries(
     should only use this outside the main thread.
     """
 
-    if allow_nonexistent and not os.path.exists(path):
-        content = path.encode("UTF-8")
-    elif os.path.isdir(path):
+    if os.path.isdir(path):
         glob_pattern = glob_pattern or "*"
         content = _stable_dir_identifier(path, glob_pattern).encode("UTF-8")
     else:
@@ -63,22 +60,8 @@ def calc_md5_with_blocking_retries(
     return md5.hexdigest()
 
 
-def path_modification_time(path: str, allow_nonexistent: bool = False) -> float:
-    """Return the modification time of a path (file or directory).
-
-    If allow_nonexistent is True and the path does not exist, we return 0.0 to
-    guarantee that any file/dir later created at the path has a later
-    modification time than the last time returned by this function for that
-    path.
-
-    If allow_nonexistent is False and no file/dir exists at the path, a
-    FileNotFoundError is raised (by os.stat).
-
-    For any path that does correspond to an existing file/dir, we return its
-    modification time.
-    """
-    if allow_nonexistent and not os.path.exists(path):
-        return 0.0
+def path_modification_time(path: str) -> float:
+    """Return the modification time of a path (file or directory)."""
     return os.stat(path).st_mtime
 
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -333,12 +333,12 @@ def _install_pages_watcher(main_script_path_str: str) -> None:
     main_script_path = Path(main_script_path_str)
     pages_dir = main_script_path.parent / "pages"
 
-    watch_dir(
-        str(pages_dir),
-        _on_pages_changed,
-        glob_pattern="*.py",
-        allow_nonexistent=True,
-    )
+    if pages_dir.exists():
+        watch_dir(
+            str(pages_dir),
+            _on_pages_changed,
+            glob_pattern="*.py",
+        )
 
 
 def run(

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -108,14 +108,12 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         ro.close()
 
     def test_kwargs_plumbed_to_calc_md5(self):
-        """Test that we pass the glob_pattern and allow_nonexistent kwargs to
-        calc_md5_with_blocking_retries.
+        """Test that we pass the glob_pattern kwarg to calc_md5_with_blocking_retries.
 
         `EventBasedPathWatcher`s can be created with optional kwargs allowing
         the caller to specify what types of files to watch (when watching a
-        directory) and whether to allow watchers on paths with no files/dirs.
-        This test ensures that these optional parameters make it to our hash
-        calculation helpers across different on_changed events.
+        directory). This test ensures that these optional parameters make it
+        to our hash calculation helpers across different on_changed events.
         """
         cb = Mock()
 
@@ -126,7 +124,6 @@ class EventBasedPathWatcherTest(unittest.TestCase):
             "/this/is/my/dir",
             cb,
             glob_pattern="*.py",
-            allow_nonexistent=True,
         )
 
         fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
@@ -135,7 +132,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         folder_handler = fo._observer.schedule.call_args[0][0]
 
         _, kwargs = self.mock_util.calc_md5_with_blocking_retries.call_args
-        assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
+        assert kwargs == {"glob_pattern": "*.py"}
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
@@ -147,7 +144,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         folder_handler.on_modified(ev)
 
         _, kwargs = self.mock_util.calc_md5_with_blocking_retries.call_args
-        assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
+        assert kwargs == {"glob_pattern": "*.py"}
         cb.assert_called_once()
 
         ro.close()

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -119,7 +119,6 @@ class FileWatcherTest(unittest.TestCase):
                             "some/file/path",
                             on_file_changed,
                             glob_pattern=None,
-                            allow_nonexistent=False,
                         )
                         self.assertTrue(watching_file)
                     else:
@@ -138,7 +137,6 @@ class FileWatcherTest(unittest.TestCase):
             on_file_changed,
             watcher_type="watchdog",
             glob_pattern="*.py",
-            allow_nonexistent=True,
         )
 
         self.assertTrue(watching_dir)
@@ -146,5 +144,4 @@ class FileWatcherTest(unittest.TestCase):
             "some/dir/path",
             on_file_changed,
             glob_pattern="*.py",
-            allow_nonexistent=True,
         )

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -129,14 +129,12 @@ class PollingPathWatcherTest(unittest.TestCase):
         watcher.close()
 
     def test_kwargs_plumbed_to_calc_md5(self):
-        """Test that we pass the glob_pattern and allow_nonexistent kwargs to
-        calc_md5_with_blocking_retries.
+        """Test that we pass the glob_pattern kwarg to calc_md5_with_blocking_retries.
 
         `PollingPathWatcher`s can be created with optional kwargs allowing
         the caller to specify what types of files to watch (when watching a
-        directory) and whether to allow watchers on paths with no files/dirs.
-        This test ensures that these optional parameters make it to our hash
-        calculation helpers across different on_changed events.
+        directory). This test ensures that these optional parameters make it
+        to our hash calculation helpers across different on_changed events.
         """
         callback = mock.Mock()
 
@@ -147,13 +145,12 @@ class PollingPathWatcherTest(unittest.TestCase):
             "/this/is/my/dir",
             callback,
             glob_pattern="*.py",
-            allow_nonexistent=True,
         )
 
         self._run_executor_tasks()
         callback.assert_not_called()
         _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
-        assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
+        assert kwargs == {"glob_pattern": "*.py"}
 
         self.util_mock.path_modification_time = lambda *args: 102.0
         self.util_mock.calc_md5_with_blocking_retries = mock.Mock(return_value="2")
@@ -161,7 +158,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         self._run_executor_tasks()
         callback.assert_called_once()
         _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
-        assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
+        assert kwargs == {"glob_pattern": "*.py"}
 
         watcher.close()
 

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -42,11 +42,6 @@ class UtilTest(unittest.TestCase):
         md5 = util.calc_md5_with_blocking_retries("foo", glob_pattern="*.py")
         mock_stable_dir_identifier.assert_called_once_with("foo", "*.py")
 
-    @patch("os.path.exists", MagicMock(return_value=False))
-    def test_md5_calculation_allow_nonexistent(self):
-        md5 = util.calc_md5_with_blocking_retries("hello", allow_nonexistent=True)
-        self.assertEqual(md5, "5d41402abc4b2a76b9719d911017c592")
-
     def test_md5_calculation_opens_file_with_rb(self):
         # This tests implementation :( . But since the issue this is addressing
         # could easily come back to bite us if a distracted coder tweaks the
@@ -70,17 +65,6 @@ class PathModificationTimeTests(unittest.TestCase):
     @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
     def test_st_mtime_if_file_exists(self):
         assert util.path_modification_time("foo") == 101.0
-
-    @patch(
-        "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
-    )
-    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
-    def test_st_mtime_if_file_exists_and_allow_nonexistent(self):
-        assert util.path_modification_time("foo", allow_nonexistent=True) == 101.0
-
-    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=False))
-    def test_zero_if_file_nonexistent_and_allow_nonexistent(self):
-        assert util.path_modification_time("foo", allow_nonexistent=True) == 0.0
 
 
 class DirHelperTests(unittest.TestCase):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -368,6 +368,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
 
     @patch("streamlit.web.bootstrap.invalidate_pages_cache")
     @patch("streamlit.web.bootstrap.watch_dir")
+    @patch("streamlit.web.bootstrap.Path.exists", Mock(return_value=True))
     def test_install_pages_watcher(
         self, patched_watch_dir, patched_invalidate_pages_cache
     ):
@@ -380,8 +381,13 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             "/foo/bar/pages",
             on_pages_changed,
             glob_pattern="*.py",
-            allow_nonexistent=True,
         )
 
         on_pages_changed("/foo/bar/pages")
         patched_invalidate_pages_cache.assert_called_once()
+
+    @patch("streamlit.web.bootstrap.watch_dir")
+    @patch("streamlit.web.bootstrap.Path.exists", Mock(return_value=False))
+    def test_install_pages_watcher_not_installed_if_no_dir(self, patched_watch_dir):
+        bootstrap._install_pages_watcher("/foo/bar/streamlit_app.py")
+        patched_watch_dir.assert_not_called()


### PR DESCRIPTION
## 📚 Context

NOTE: It's easiest to review this PR commit-wise since the two commits contain logically
distinct changes.

As part of the work to rework `file_watcher` into `path_watcher` (enabling us to
watch for changes to directories), I somewhat haphazardly set the `recursive`
argument on (`watchdog` level) directory watchers to `True` in all cases. This most
likely isn't great for performance as we now can't drop as many obviously-unimportant
filesystem events as early as we were previously able to, but more importantly it resulted
in some strange-looking bugs when trying to run a streamlit main script from the root
directory of a Linux filesystem (this was previously actually quite commonly done
when dockerizing a Streamlit app).

To avoid this issue, this PR changes things to only install directory watchers
recursively when we are specifically watching a directory (rather than a file
contained in a directory). Since the only directory watcher we install today is
on an app's `pages/` directory, this amounts to us only watching the `pages`
directory recursively. (Ideally we wouldn't even want to do this as we only search
for an app's pages 1-layer deep in the directory anyway, but the `watchdog` API
doesn't support any sort of depth limiting when recursively watching a directory).

After I did this, I realized that the change makes it impossible for the Streamlit
server to notice when a previously-nonexistent `pages/` directory is created (assuming
we rely on watching a path to do this), so users will have to restart their streamlit
server the first time they create a `pages/` dir to see the changes. Because of this, I
got rid of all of the `allow_nonexistent` flags that exist only to support noticing when
a `pages/` directory is created for the first time.

This is a small product change, but I think it's worth doing to fix the bug since

* most developer tools don't handle looking for files/directories that don't
   currently exist very well anyway
* fixing #5239
   seems worth slightly inconveniencing people to have to restart their streamlit
   server the first time they create the `pages` dir for an app


- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Refactoring

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Closes #5239 
