### PR TITLE
Use the new hasLightBackgroundColor function more and add tests

### DIFF
--- a/frontend/src/components/core/StatusWidget/styled-components.ts
+++ b/frontend/src/components/core/StatusWidget/styled-components.ts
@@ -16,8 +16,7 @@
  */
 
 import styled, { CSSObject } from "@emotion/styled"
-import { Theme } from "src/theme"
-import { getLuminance } from "color2k"
+import { hasLightBackgroundColor, Theme } from "src/theme"
 
 /*
   "ConnectionStatus" styles are used for displaying
@@ -118,7 +117,7 @@ export const StyledAppButtonContainer = styled.span<
 
 export const StyledAppRunningIcon = styled.img(({ theme }) => {
   // Testing if current background color is light or dark to modify img:
-  const filter = getLuminance(theme.colors.bgColor) > 0.5 ? "" : "invert(1)"
+  const filter = hasLightBackgroundColor(theme) ? "" : "invert(1)"
 
   return {
     opacity: 0.4,

--- a/frontend/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
@@ -16,12 +16,10 @@
  */
 
 import { merge, mergeWith, isArray } from "lodash"
-import { getLuminance } from "color2k"
 
-import { Theme } from "src/theme"
+import { hasLightBackgroundColor, Theme } from "src/theme"
 
 export function applyStreamlitTheme(config: any, theme: Theme): any {
-  const hasLightBg = getLuminance(theme.colors.bgColor) > 0.5
   // This theming config contains multiple hard coded spacing values.
   // The reason is that we currently only have rem values in our spacing
   // definitions and vega lite requires numerical (pixel) values.
@@ -83,7 +81,7 @@ export function applyStreamlitTheme(config: any, theme: Theme): any {
       // TODO: Eventually, we might want to move those color schemes to our theme.
       // But For now, this is specifically defined for vega lite based charts.
       // Ramp & heatmap are both using the sequential color scheme.
-      ...(hasLightBg
+      ...(hasLightBackgroundColor(theme)
         ? {
             category: [
               "#0068C9",
@@ -200,7 +198,9 @@ export function applyStreamlitTheme(config: any, theme: Theme): any {
     },
     mark: {
       tooltip: true,
-      ...(hasLightBg ? { color: "#0068C9" } : { color: "#83C9FF" }),
+      ...(hasLightBackgroundColor(theme)
+        ? { color: "#0068C9" }
+        : { color: "#83C9FF" }),
     },
     bar: {
       binSpacing: 4,

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -20,8 +20,7 @@ import DeckGL from "deck.gl"
 import isEqual from "lodash/isEqual"
 import { MapContext, StaticMap, NavigationControl } from "react-map-gl"
 import { withTheme } from "@emotion/react"
-import { Theme } from "src/theme"
-import { getLuminance } from "color2k"
+import { hasLightBackgroundColor, Theme } from "src/theme"
 // We don't have Typescript defs for these imports, which makes ESLint unhappy
 /* eslint-disable import/no-extraneous-dependencies */
 import * as layers from "@deck.gl/layers"
@@ -150,8 +149,7 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
     // If unset, use either the Mapbox light or dark style based on Streamlit's theme
     // For Mapbox styles, see https://docs.mapbox.com/api/maps/styles/#mapbox-styles
     if (!notNullOrUndefined(json.mapStyle)) {
-      const hasLightBg = getLuminance(theme.colors.bgColor) > 0.5
-      const mapTheme = hasLightBg ? "light" : "dark"
+      const mapTheme = hasLightBackgroundColor(theme) ? "light" : "dark"
       json.mapStyle = `mapbox://styles/mapbox/${mapTheme}-v9`
     }
 

--- a/frontend/src/components/elements/Json/Json.tsx
+++ b/frontend/src/components/elements/Json/Json.tsx
@@ -16,14 +16,13 @@
  */
 
 import React, { ReactElement } from "react"
-import { getLuminance } from "color2k"
 import { useTheme } from "@emotion/react"
 import JSON5 from "json5"
 import ReactJson from "react-json-view"
 import ErrorElement from "src/components/shared/ErrorElement"
 
 import { Json as JsonProto } from "src/autogen/proto"
-import { Theme } from "src/theme"
+import { hasLightBackgroundColor, Theme } from "src/theme"
 import { ensureError } from "src/lib/ErrorHandling"
 
 export interface JsonProps {
@@ -56,8 +55,7 @@ export default function Json({ width, element }: JsonProps): ReactElement {
 
   // Try to pick a reasonable ReactJson theme based on whether the streamlit
   // theme's background is light or dark.
-  const hasLightBg = getLuminance(theme.colors.bgColor) > 0.5
-  const jsonTheme = hasLightBg ? "rjv-default" : "monokai"
+  const jsonTheme = hasLightBackgroundColor(theme) ? "rjv-default" : "monokai"
 
   return (
     <div data-testid="stJson" style={styleProp}>

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -38,6 +38,7 @@ import {
   getCachedTheme,
   removeCachedTheme,
   setCachedTheme,
+  hasLightBackgroundColor,
 } from "./utils"
 
 const matchMediaFillers = {
@@ -562,5 +563,42 @@ describe("bgColorToBaseString", () => {
 
   it("returns 'dark' for a dark background color", () => {
     expect(bgColorToBaseString("#000000")).toBe("dark")
+  })
+})
+
+describe("hasLightBackgroundColor", () => {
+  const testCases = [
+    {
+      description: "works for default light theme",
+      theme: lightTheme,
+      expectedResult: true,
+    },
+    {
+      description: "works for default dark theme",
+      theme: darkTheme,
+      expectedResult: false,
+    },
+    {
+      description: "works for custom light theme",
+      theme: createTheme(
+        CUSTOM_THEME_NAME,
+        new CustomThemeConfig({ backgroundColor: "yellow" })
+      ),
+      expectedResult: true,
+    },
+    {
+      description: "works for custom dark theme",
+      theme: createTheme(
+        CUSTOM_THEME_NAME,
+        new CustomThemeConfig({ backgroundColor: "navy" })
+      ),
+      expectedResult: false,
+    },
+  ]
+
+  testCases.forEach(({ description, theme, expectedResult }) => {
+    it(description, () => {
+      expect(hasLightBackgroundColor(theme.emotion)).toBe(expectedResult)
+    })
   })
 })


### PR DESCRIPTION
## 📚 Context

We added a new helper function in #5275. It doesn't save us many lines of code
compared to just importing and using getLuminance, but it does make it a bit
more clear what's going on.

This PR uses `hasLightBackgroundColor` in more places and also adds a few tests.

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: test additions

## 🧪 Testing Done

- [x] Added/Updated unit tests
