### PR TITLE
Fix python-max-version check failure

### DIFF
--- a/e2e/scripts/st_arrow_empty_charts.py
+++ b/e2e/scripts/st_arrow_empty_charts.py
@@ -27,7 +27,7 @@ spec = {
 }
 
 # 5 empty charts
-st._arrow_vega_lite_chart(spec)
+st._arrow_vega_lite_chart(spec, use_container_width=True)
 fig, ax = plt.subplots()
 st.pyplot(fig)
 st._arrow_line_chart()

--- a/e2e/scripts/st_arrow_empty_charts.py
+++ b/e2e/scripts/st_arrow_empty_charts.py
@@ -27,9 +27,9 @@ spec = {
 }
 
 # 5 empty charts
-st._arrow_vega_lite_chart(spec, use_container_width=True)
+st._arrow_vega_lite_chart(spec)
 fig, ax = plt.subplots()
-st.pyplot(fig, use_container_width=True)
+st.pyplot(fig)
 st._arrow_line_chart()
 st._arrow_bar_chart()
 st._arrow_area_chart()

--- a/e2e/scripts/st_legacy_empty_charts.py
+++ b/e2e/scripts/st_legacy_empty_charts.py
@@ -27,7 +27,7 @@ spec = {
 }
 
 # 5 empty charts
-st._legacy_vega_lite_chart(spec)
+st._legacy_vega_lite_chart(spec, use_container_width=True)
 fig, ax = plt.subplots()
 st.pyplot(fig)
 st._legacy_line_chart()

--- a/e2e/scripts/st_legacy_empty_charts.py
+++ b/e2e/scripts/st_legacy_empty_charts.py
@@ -27,9 +27,9 @@ spec = {
 }
 
 # 5 empty charts
-st._legacy_vega_lite_chart(spec, use_container_width=True)
+st._legacy_vega_lite_chart(spec)
 fig, ax = plt.subplots()
-st.pyplot(fig, use_container_width=True)
+st.pyplot(fig)
 st._legacy_line_chart()
 st._legacy_bar_chart()
 st._legacy_area_chart()


### PR DESCRIPTION
## 📚 Context

The `python-max-version` check is currently failing on the run integration tests step, particularly on 2 scripts: `e2e/scripts/st_arrow_empty_charts.py` & `e2e/scripts/st_legacy_empty_charts.py`

Probably an alternative/better solution, especially after further investigation, but this will address the immediate test failure problem. Also worth noting that local run of `make integration-tests` works fine for me. 

**_CircleCI error shows as follows:_**
<img width="750" alt="Screen Shot 2022-09-17 at 10 18 50 PM" src="https://user-images.githubusercontent.com/63436329/190886981-f44dd8d9-2caf-4cd9-9c5f-e69e3b76f6f8.png">

- What kind of change does this PR introduce?
  - [x] Other, please describe: CircleCI test failure fix

## 🧠 Description of Changes

- Removed the `use_container_width` kwarg from the st.pyplot call in `e2e/scripts/st_arrow_empty_charts.py` & `e2e/scripts/st_legacy_empty_charts.py`

## 🧪 Testing Done

- [x] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
