### PR TITLE
Add pinning for pandas version <= 1.4.4 since 1.5.0 has breaking changes

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -20,3 +20,4 @@ setuptools<50.0.0
 sqlalchemy>=1.4.25
 watchdog==2.1.5
 rich>=11.2.0
+pandas<=1.4.4

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -10,6 +10,7 @@ graphviz>=0.17
 matplotlib>=3.3.4
 mysqlclient>=2.0.3
 opencv-python>=4.5.3
+pandas<=1.4.4
 plotly>=5.3.1
 psycopg2-binary>=2.9.1
 pydot>=1.4.2
@@ -20,4 +21,3 @@ setuptools<50.0.0
 sqlalchemy>=1.4.25
 watchdog==2.1.5
 rich>=11.2.0
-pandas<=1.4.4


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
Looks like Pandas just released a breaking change for 1.5.0 and as a result, our legacy dataframe tests are failing. We are going to temporarily put pin on the pandas version in order for tests to pass and look at this in the future and fix the failure likely.

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: pinning pandas version in order for pytest to pass.

## 🧠 Description of Changes
Add a pin in test-requirements.txt

## 🌐 References

https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#what-s-new-in-1-5-0-september-19-2022

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
