### PR TITLE
Remove unnecessary whitespace in legacy df test

### DIFF
--- a/lib/tests/streamlit/elements/legacy_data_frame_test.py
+++ b/lib/tests/streamlit/elements/legacy_data_frame_test.py
@@ -164,7 +164,7 @@ class LegacyDataFrameProtoTest(unittest.TestCase):
 
         # Period index
         df_period = pd.period_range(
-            start="2005-12-21 08:45 ", end="2005-12-21 11:55", freq="H"
+            start="2005-12-21 08:45", end="2005-12-21 11:55", freq="H"
         )
         proto = Index()
         with pytest.raises(NotImplementedError) as e:


### PR DESCRIPTION
## 📚 Context

There is an unnecessary whitespace in the legacy dataframe test causing some issues with Pandas 1.5.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Remove unnecessary whitespace

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
