### PR TITLE
Fix form while adding e2e tests and fixing e2e tests

### DIFF
--- a/e2e/scripts/st_multiselect.py
+++ b/e2e/scripts/st_multiselect.py
@@ -57,11 +57,18 @@ if "multiselect 9" in st.session_state and set_multiselect_9:
 i9 = st.multiselect("multiselect 9", options, max_selections=1, key="multiselect 9")
 st.text(f"value 9: {i9}")
 
+with st.form("my_max_selections_ms_in_form"):
+    i10 = st.multiselect(
+        "multiselect 10", options, max_selections=1, key="multiselect 10"
+    )
+    st.text(f"value 10: {i10}")
+    submitted = st.form_submit_button("Submit")
+
 if st._is_running_with_streamlit:
 
     def on_change():
         st.session_state.multiselect_changed = True
 
-    st.multiselect("multiselect 10", options, key="multiselect10", on_change=on_change)
-    st.text(f"value 10: {st.session_state.multiselect10}")
+    st.multiselect("multiselect 11", options, key="multiselect11", on_change=on_change)
+    st.text(f"value 11: {st.session_state.multiselect11}")
     st.text(f"multiselect changed: {'multiselect_changed' in st.session_state}")

--- a/e2e/specs/st_multiselect.spec.js
+++ b/e2e/specs/st_multiselect.spec.js
@@ -264,11 +264,6 @@ describe("st.multiselect", () => {
         .get("li")
         .eq(0)
         .click();
-      // Click one more option to have overMaxSelections message show
-      cy
-        .get("li")
-        .eq(0)
-        .click();
       cy.getIndexed(".stMultiSelect", 9).then(el => {
         cy
           .wrap(el)

--- a/e2e/specs/st_multiselect.spec.js
+++ b/e2e/specs/st_multiselect.spec.js
@@ -24,7 +24,7 @@ describe("st.multiselect", () => {
 
   describe("when first loaded", () => {
     it("should show widget correctly", () => {
-      cy.get(".stMultiSelect").should("have.length", 10);
+      cy.get(".stMultiSelect").should("have.length", 11);
 
       cy.get(".stMultiSelect").each((el, idx) => {
         return cy.wrap(el).matchThemedSnapshots("multiselect" + idx);
@@ -33,7 +33,6 @@ describe("st.multiselect", () => {
 
     it("should show the correct text", () => {
       cy.get("[data-testid='stText']")
-        .should("have.length", 11)
         .should(
           "have.text",
           "value 1: []" +
@@ -46,6 +45,7 @@ describe("st.multiselect", () => {
             "value 8: []" +
             "value 9: []" +
             "value 10: []" +
+            "value 11: []" +
             "multiselect changed: False"
         );
     });
@@ -135,20 +135,9 @@ describe("st.multiselect", () => {
 
     it("outputs the correct value", () => {
       cy.get("[data-testid='stText']")
-        .should("have.length", 11)
         .should(
-          "have.text",
-          "value 1: []" +
-            "value 2: ['female']" +
-            "value 3: []" +
-            "value 4: ['tea', 'water']" +
-            "value 5: []" +
-            "value 6: []" +
-            "value 7: []" +
-            "value 8: []" +
-            "value 9: []" +
-            "value 10: []" +
-            "multiselect changed: False"
+          "contain.text",
+            "value 2: ['female']"
         );
     });
 
@@ -157,20 +146,9 @@ describe("st.multiselect", () => {
 
       it("outputs the correct value", () => {
         cy.get("[data-testid='stText']")
-          .should("have.length", 11)
           .should(
-            "have.text",
-            "value 1: []" +
-              "value 2: ['female', 'male']" +
-              "value 3: []" +
-              "value 4: ['tea', 'water']" +
-              "value 5: []" +
-              "value 6: []" +
-              "value 7: []" +
-              "value 8: []" +
-              "value 9: []" +
-              "value 10: []" +
-              "multiselect changed: False"
+            "contain.text",
+              "value 2: ['female', 'male']"
           );
       });
 
@@ -183,20 +161,9 @@ describe("st.multiselect", () => {
         });
         it("outputs the correct value", () => {
           cy.get("[data-testid='stText']")
-            .should("have.length", 11)
             .should(
-              "have.text",
-              "value 1: []" +
-                "value 2: ['male']" +
-                "value 3: []" +
-                "value 4: ['tea', 'water']" +
-                "value 5: []" +
-                "value 6: []" +
-                "value 7: []" +
-                "value 8: []" +
-                "value 9: []" +
-                "value 10: []" +
-                "multiselect changed: False"
+              "contain.text",
+                "value 2: ['male']"
             );
         });
       });
@@ -209,7 +176,6 @@ describe("st.multiselect", () => {
         });
         it("outputs the correct value", () => {
           cy.get("[data-testid='stText']")
-            .should("have.length", 11)
             .should(
               "have.text",
               "value 1: []" +
@@ -222,6 +188,7 @@ describe("st.multiselect", () => {
                 "value 8: []" +
                 "value 9: []" +
                 "value 10: []" +
+                "value 11: []" +
                 "multiselect changed: False"
             );
         });
@@ -230,8 +197,7 @@ describe("st.multiselect", () => {
 
     it("calls callback if one is registered", () => {
       cy.get(".stMultiSelect")
-        .should("have.length", 10)
-        .last()
+        .eq(10)
         .find("input")
         .click();
       cy.get("li")
@@ -239,26 +205,16 @@ describe("st.multiselect", () => {
         .click();
 
       cy.get("[data-testid='stText']")
-        .should("have.length", 11)
         .should(
-          "have.text",
-          "value 1: []" +
-            "value 2: ['female']" +
-            "value 3: []" +
-            "value 4: ['tea', 'water']" +
-            "value 5: []" +
-            "value 6: []" +
-            "value 7: []" +
-            "value 8: []" +
-            "value 9: []" +
-            "value 10: ['male']" +
+          "contain.text",
+            "value 11: ['male']" +
             "multiselect changed: True"
         );
     });
   });
 
   describe("when using max_selections for st.multiselect", () => {
-    it("should show the correct text when maxSelections is reached", () => {
+    it("should show the correct text when maxSelections is reached regularly", () => {
       selectNthOptionForKthMultiselect(0, 8)
       cy.getIndexed(".stMultiSelect", 8).then(el => {
         cy
@@ -272,7 +228,6 @@ describe("st.multiselect", () => {
       });
     });
 
-
     it("should display an error when options > max selections set during session state", () => {
       cy.get(".stCheckbox")
         .first()
@@ -285,6 +240,43 @@ describe("st.multiselect", () => {
         "contain.text",
         `Multiselect has 2 options selected but max_selections\nis set to 1.`
       );
+    });
+
+    it("should show the correct text when maxSelections is reached in a form", () => {
+      selectNthOptionForKthMultiselect(0, 9)
+      cy.getIndexed(".stMultiSelect", 9).then(el => {
+        cy
+          .wrap(el)
+          // recheck that we have hit the limit
+          .find("input")
+          .click()
+          .get("li")
+          .first()
+          .should("have.text", "You can only select up to 1 option. Remove an option first.")
+      });
+    });
+
+    it("should show the correct text when maxSelections is reached in a form without closing after selecting", () => {
+      cy.getIndexed(".stMultiSelect", 9)
+        .find("input")
+        .click();
+      cy
+        .get("li")
+        .eq(0)
+        .click();
+      // Click one more option to have overMaxSelections message show
+      cy
+        .get("li")
+        .eq(0)
+        .click();
+      cy.getIndexed(".stMultiSelect", 9).then(el => {
+        cy
+          .wrap(el)
+          // recheck that we have hit the limit
+          .get("li")
+          .first()
+          .should("have.text", "You can only select up to 1 option. Remove an option first.")
+      });
     });
   })
 });

--- a/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -289,14 +289,13 @@ describe("Multiselect widget", () => {
     )
   })
   describe("properly invalidates going over max selections", () => {
-    it("has correct noResultsMsg when default.length < maxSelections", () => {
+    it("has correct noResultsMsg when maxSelections is not passed", () => {
       const props = getProps(
         MultiSelectProto.create({
           id: "1",
           label: "Label",
           default: [0],
           options: ["a", "b", "c"],
-          maxSelections: 2,
         })
       )
       const wrapper = mount(<Multiselect {...props} />)
@@ -309,7 +308,7 @@ describe("Multiselect widget", () => {
       ).toBe("No results")
     })
 
-    it("has correct noResultsMsg when default.length >= maxSelections", () => {
+    it("has correct noResultsMsg when maxSelections is passed", () => {
       const props = getProps(
         MultiSelectProto.create({
           id: "1",

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -59,7 +59,7 @@ interface MultiselectOption {
   value: string
 }
 
-class Multiselect extends React.PureComponent<Props, State> {
+class Multiselect extends React.Component<Props, State> {
   private readonly formClearHelper = new FormClearHelper()
 
   public state: State = {
@@ -69,7 +69,7 @@ class Multiselect extends React.PureComponent<Props, State> {
   public overMaxSelections(): boolean {
     return (
       this.props.element.maxSelections > 0 &&
-      this.initialValue.length >= this.props.element.maxSelections
+      this.state.value.length >= this.props.element.maxSelections
     )
   }
 

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -259,7 +259,7 @@ class Multiselect extends React.PureComponent<Props, State> {
             disabled={disabled}
             size={"compact"}
             noResultsMsg={
-              this.overMaxSelections() ? this.getNoResultsMsg() : "No results"
+              this.maxSelections !== 0 ? this.getNoResultsMsg() : "No results"
             }
             filterOptions={this.filterOptions}
             closeOnSelect={false}

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -258,7 +258,9 @@ class Multiselect extends React.PureComponent<Props, State> {
             disabled={disabled}
             size={"compact"}
             noResultsMsg={
-              this.maxSelections !== 0 ? this.getNoResultsMsg() : "No results"
+              this.props.element.maxSelections !== 0
+                ? this.getNoResultsMsg()
+                : "No results"
             }
             filterOptions={this.filterOptions}
             closeOnSelect={false}


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
Looks like when we just check if it's over the maxSelections, in a form, this will display "No results." because it is not rerendering with the new feature {onCloseSelect}={false}. Thus, we just need to check more explicitly if maxSelections was defined. Rest of tests should properly test form.

I have also deleted some st_multiselect.spec.js code because whenever you make a change to st_multiselect.spec.js, there are checks that are repetitive and irrelevant to the test so I have deleted such things so that when we go to write more code for st.multiselect, it's easier to write e2e multiselect tests.

In addition, looks like I debugged the issue with Ken and it looks like the pure component causes the multiselect to not update in form and the actual check for overMaxSelections has a bug.

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes
- Remove unnecessary st_multiselect.spec.js code
- add e2e for forms
- change check for correct noResultsMsg
- make multiselect.tsx a impure component
- fix bug for `overMaxSelections` method

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [x] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
