### PR TITLE
Make UploadedFile hashable

### DIFF
--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -51,11 +51,15 @@ class UploadedFile(io.BytesIO):
         self.name = record.name
         self.type = record.type
         self.size = len(record.data)
+        self._record_hash = hash(record)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, UploadedFile):
             return NotImplemented
         return self.id == other.id
+
+    def __hash__(self) -> int:
+        return self._record_hash
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
@@ -17,7 +17,11 @@
 import unittest
 
 from streamlit.runtime.stats import CacheStat
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager, UploadedFileRec
+from streamlit.runtime.uploaded_file_manager import (
+    UploadedFile,
+    UploadedFileManager,
+    UploadedFileRec,
+)
 
 FILE_1 = UploadedFileRec(id=0, name="file1", type="type", data=b"file1")
 FILE_2 = UploadedFileRec(id=0, name="file2", type="type", data=b"file222")
@@ -38,6 +42,34 @@ class UploadedFileManagerTest(unittest.TestCase):
         f2 = self.mgr.add_file("session", "widget", FILE_1)
         self.assertNotEqual(FILE_1.id, f1.id)
         self.assertNotEqual(f1.id, f2.id)
+
+    def test_added_file_hash(self):
+        """The hash should be equal iff it's the same file."""
+        f1 = UploadedFile(self.mgr.add_file("session", "widget", FILE_1))
+        self.assertEqual(
+            hash(f1),
+            hash(
+                UploadedFile(
+                    UploadedFileRec(id=1, name="file1", type="type", data=b"file1")
+                )
+            ),
+        )
+        self.assertNotEqual(
+            hash(f1),
+            hash(
+                UploadedFile(
+                    UploadedFileRec(id=10, name="file1", type="type", data=b"file1")
+                )
+            ),
+        )
+        self.assertNotEqual(
+            hash(f1),
+            hash(
+                UploadedFile(
+                    UploadedFileRec(id=1, name="file1", type="type", data=b"other")
+                )
+            ),
+        )
 
     def test_added_file_properties(self):
         """An added file should maintain all its source properties


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Would be nice if we can use `@st.experimental_memo` with `UploadedFile`. So let's make this hashable.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Add `__hash__` function to `UploadedFile`
- Test this new hashing functionality

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

Does not apply here.

**Current:**

Does not apply here.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- No

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
