### PR TITLE
Remove broken Pipenv '--sequential' flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,9 +616,9 @@ jobs:
           <<: *generate_protobufs
 
       - run:
-          name: Run make develop
+          name: Run make init develop
           command: |
-            make develop
+            make init develop
 
       - run:
           name: CLI smoke tests

--- a/Makefile
+++ b/Makefile
@@ -51,15 +51,11 @@ pipenv-install: pipenv-dev-install py-test-install
 .PHONY: pipenv-dev-install
 pipenv-dev-install: lib/Pipfile
 	# Run pipenv install; don't update the Pipfile.lock.
-	# We use `--sequential` here to ensure our results are...
-	# "more deterministic", per pipenv's documentation.
-	# (Omitting this flag is causing incorrect dependency version
-	# resolution on CircleCI.)
 	# The lockfile is created to force resolution of all dependencies at once,
 	# but we don't actually want to use the lockfile.
 	cd lib; \
 		rm Pipfile.lock; \
-		pipenv install --dev --sequential
+		pipenv install --dev
 
 SHOULD_INSTALL_TENSORFLOW := $(shell python scripts/should_install_tensorflow.py)
 .PHONY: py-test-install
@@ -159,7 +155,7 @@ install:
 # Install Streamlit as links in your Python environment, pointing to local workspace.
 develop:
 	cd lib; \
-		pipenv install --skip-lock --sequential
+		pipenv install --skip-lock
 
 .PHONY: distribution
 # Create Python distribution files in dist/.

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -101,7 +101,7 @@ COPY --chown=$USER lib/setup.py ./lib/
 
 # install python modules
 # This would be `make pipenv-install`, but lockfile creation somehow breaks it
-RUN IS_DOCKER=true CIRCLECI=true cd ./lib/ && pipenv install --dev --sequential --skip-lock && cd -
+RUN IS_DOCKER=true CIRCLECI=true cd ./lib/ && pipenv install --dev --skip-lock && cd -
 RUN IS_DOCKER=true CIRCLECI=true make py-test-install
 
 # copy streamlit code


### PR DESCRIPTION
Remove obsolete (and now broken!) --sequential flag from `pipenv install`

(Pipenv now incorrectly parses this flag as a package name, and throws an error when it can't install it.)

https://github.com/pypa/pipenv/pull/5348

We originally added the flag because Pipenv stated it "increased determinism" (and we were having issues with dependencies being resolved non-deterministically).
