### PR TITLE
Update test-requirements comment to trigger CI cache invalidation

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -11,7 +11,7 @@ hypothesis = ">=6.17.4"
 mypy = ">=0.930"
 mypy-protobuf = ">=3.2"
 parameterized = "*"
-pipenv = "*"
+pipenv = "!=2022.9.20"
 # Lower protobuf versions cause mypy issues during development builds
 protobuf = ">=3.19, <4"
 pytest = "*"

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -11,7 +11,7 @@ hypothesis = ">=6.17.4"
 mypy = ">=0.930"
 mypy-protobuf = ">=3.2"
 parameterized = "*"
-pipenv = "!=2022.9.20"
+pipenv = "*"
 # Lower protobuf versions cause mypy issues during development builds
 protobuf = ">=3.19, <4"
 pytest = "*"

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -1,5 +1,5 @@
 # Packages used to test things users may do with Streamlit.
-# As of July 17, 2022, only the latest version of Bokeh (2.4.3) is supported.
+# As of September 21, 2022, only the latest version of Bokeh (2.4.3) is supported.
 # NOTE: Python Bokeh and BokehJS versions must always match.
 bokeh==2.4.3
 cffi>=1.14


### PR DESCRIPTION
## 📚 Context

The pipenv version `2022.9.20` is broken, a fix is already released. I applied a small update to the comments on `test-requirements.txt` to trigger a cache invalidation in our CI pipeline.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
