### PR TITLE
Ignore broken protobuf version

### DIFF
--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -13,7 +13,8 @@ mypy-protobuf = ">=3.2"
 parameterized = "*"
 pipenv = "*"
 # Lower protobuf versions cause mypy issues during development builds
-protobuf = ">=3.19, <4"
+# protobuf 3.20.2 is broken: https://github.com/protocolbuffers/protobuf/issues/10571
+protobuf = ">=3.19, <4, !=3.20.2"
 pytest = "*"
 pytest-cov = "*"
 requests-mock = "*"

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -45,7 +45,8 @@ INSTALL_REQUIRES = [
     "packaging>=14.1",
     "pandas>=0.21.0",
     "pillow>=6.2.0",
-    "protobuf<4,>=3.12",
+    # protobuf 3.20.2 is broken: https://github.com/protocolbuffers/protobuf/issues/10571
+    "protobuf<4,>=3.12,!=3.20.2",
     "pyarrow>=4.0",
     "pydeck>=0.1.dev5",
     "pympler>=0.9",


### PR DESCRIPTION
## 📚 Context

Protobuf recently released a patch that seems broken: https://github.com/protocolbuffers/protobuf/issues/10571
It causes this error if you try to run a streamlit app with this protobuf version:

```
streamlit run app.py

Traceback (most recent call last):
  File "/private/tmp/tttt/.direnv/python-3.10.3/bin/streamlit", line 5, in <module>
    from streamlit.web.cli import main
  File "/private/tmp/tttt/.direnv/python-3.10.3/lib/python3.10/site-packages/streamlit/__init__.py", line 48, in <module>
    from streamlit.proto.RootContainer_pb2 import RootContainer
  File "/private/tmp/tttt/.direnv/python-3.10.3/lib/python3.10/site-packages/streamlit/proto/RootContainer_pb2.py", line 6, in <module>
    from google.protobuf import descriptor as _descriptor
  File "/private/tmp/tttt/.direnv/python-3.10.3/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 47, in <module>
    from google.protobuf.pyext import _message
ImportError: dlopen(/private/tmp/tttt/.direnv/python-3.10.3/lib/python3.10/site-packages/google/protobuf/pyext/_message.cpython-310-darwin.so, 0x0002): symbol not found in flat namespace (__ZN6google8protobuf15FieldDescriptor12TypeOnceInitEPKS1_)
```

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Ignore broken pipenv version (`3.20.2`) in Pipfile and setup.py.

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #5394

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
