### PR TITLE
`get_extension_for_mimetype` tests + clarification

### DIFF
--- a/e2e/specs/st_image.spec.js
+++ b/e2e/specs/st_image.spec.js
@@ -45,7 +45,7 @@ describe("st.image", () => {
     cy.get(".element-container [data-testid='stImage'] img")
       .eq(0)
       .should("have.attr", "src")
-      .should("match", /^.*\.jpeg$/);
+      .should("match", /^.*\.jpg$/);
   });
 
   it("displays a PNG image when specified", () => {
@@ -57,7 +57,7 @@ describe("st.image", () => {
   it("displays a JPEG image when not specified with no alpha channel", () => {
     cy.getIndexed(".element-container [data-testid='stImage'] img", 2)
       .should("have.attr", "src")
-      .should("match", /^.*\.jpeg$/);
+      .should("match", /^.*\.jpg$/);
   });
 
   it("displays a PNG image when not specified with alpha channel", () => {

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -18,7 +18,9 @@ import contextlib
 import hashlib
 import mimetypes
 import os.path
-from typing import Union, NamedTuple, Dict, Optional, List, Final
+from typing import Union, NamedTuple, Dict, Optional, List
+
+from typing_extensions import Final
 
 from streamlit.logger import get_logger
 from streamlit.runtime.media_file_storage import (

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -18,7 +18,7 @@ import contextlib
 import hashlib
 import mimetypes
 import os.path
-from typing import Union, NamedTuple, Dict, Optional, List
+from typing import Union, NamedTuple, Dict, Optional, List, Final
 
 from streamlit.logger import get_logger
 from streamlit.runtime.media_file_storage import (
@@ -30,8 +30,11 @@ from streamlit.runtime.stats import CacheStatsProvider, CacheStat
 
 LOGGER = get_logger(__name__)
 
-PREFERRED_MIMETYPE_EXTENSION_MAP = {
-    "image/jpeg": ".jpeg",
+# Mimetype -> filename extension map for the `get_extension_for_mimetype`
+# function. We use Python's `mimetypes.guess_extension` for most mimetypes,
+# but (as of Python 3.9) `mimetypes.guess_extension("audio/wav")` returns None,
+# so we handle it ourselves.
+PREFERRED_MIMETYPE_EXTENSION_MAP: Final = {
     "audio/wav": ".wav",
 }
 
@@ -61,15 +64,10 @@ def _calculate_file_id(
 
 
 def get_extension_for_mimetype(mimetype: str) -> str:
-    # Python mimetypes preference was changed in Python versions, so we specify
-    # a preference first and let Python's mimetypes library guess the rest.
-    # See https://bugs.python.org/issue4963
-    #
-    # Note: Removing Python 3.6 support would likely eliminate this code
     if mimetype in PREFERRED_MIMETYPE_EXTENSION_MAP:
         return PREFERRED_MIMETYPE_EXTENSION_MAP[mimetype]
 
-    extension = mimetypes.guess_extension(mimetype)
+    extension = mimetypes.guess_extension(mimetype, strict=False)
     if extension is None:
         return ""
 

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -55,10 +55,10 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
 
     def test_multiple_types(self):
         """Test that it can be called using an array for type parameter."""
-        st.file_uploader("the label", type=["png", ".svg", "jpeg"])
+        st.file_uploader("the label", type=["png", ".svg", "jpg"])
 
         c = self.get_delta_from_queue().new_element.file_uploader
-        self.assertEqual(c.type, [".png", ".svg", ".jpeg"])
+        self.assertEqual(c.type, [".png", ".svg", ".jpg"])
 
     @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_multiple_files(self, get_file_recs_patch):

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -55,10 +55,10 @@ class FileUploaderTest(testutil.DeltaGeneratorTestCase):
 
     def test_multiple_types(self):
         """Test that it can be called using an array for type parameter."""
-        st.file_uploader("the label", type=["png", ".svg", "jpg"])
+        st.file_uploader("the label", type=["png", ".svg", "jpeg"])
 
         c = self.get_delta_from_queue().new_element.file_uploader
-        self.assertEqual(c.type, [".png", ".svg", ".jpg"])
+        self.assertEqual(c.type, [".png", ".svg", ".jpeg"])
 
     @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_multiple_files(self, get_file_recs_patch):

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -110,7 +110,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
             (IMAGES["img_32_32_3_rgba"]["np"], "jpeg"),
         ]
     )
-    def test_marshall_images(self, data_in, format: str):
+    def test_marshall_images(self, data_in: image.AtomicImage, format: str):
         """Test streamlit.image.marshall_images.
         Need to test the following:
         * if list
@@ -152,7 +152,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         ]
     )
     def test_marshall_images_with_auto_output_format(
-        self, data_in, expected_extension: str
+        self, data_in: image.AtomicImage, expected_extension: str
     ):
         """Test streamlit.image.marshall_images.
         with auto output_format

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -30,6 +30,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.runtime.memory_media_file_storage import (
     _calculate_file_id,
+    get_extension_for_mimetype,
 )
 from streamlit.web.server.server import MEDIA_ENDPOINT
 from tests import testutil
@@ -109,7 +110,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
             (IMAGES["img_32_32_3_rgba"]["np"], "jpeg"),
         ]
     )
-    def test_marshall_images(self, data_in, format):
+    def test_marshall_images(self, data_in, format: str):
         """Test streamlit.image.marshall_images.
         Need to test the following:
         * if list
@@ -123,31 +124,36 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         * Path
         * Bytes
         """
+        mimetype = f"image/{format}"
         file_id = _calculate_file_id(
             _np_array_to_bytes(data_in, output_format=format),
-            mimetype="image/" + format,
+            mimetype=mimetype,
         )
 
         st.image(data_in, output_format=format)
         imglist = self.get_delta_from_queue().new_element.imgs
         self.assertEqual(len(imglist.imgs), 1)
         self.assertTrue(imglist.imgs[0].url.startswith(MEDIA_ENDPOINT))
-        self.assertTrue(imglist.imgs[0].url.endswith(f".{format}"))
+        self.assertTrue(
+            imglist.imgs[0].url.endswith(get_extension_for_mimetype(mimetype))
+        )
         self.assertTrue(file_id in imglist.imgs[0].url)
 
     @parameterized.expand(
         [
-            (IMAGES["img_32_32_3_rgb"]["np"], "jpeg"),
-            (IMAGES["img_32_32_3_bgr"]["np"], "jpeg"),
-            (IMAGES["img_64_64_rgb"]["np"], "jpeg"),
-            (IMAGES["img_32_32_3_rgba"]["np"], "png"),
-            (IMAGES["img_32_32_3_rgb"]["pil"], "jpeg"),
-            (IMAGES["img_32_32_3_bgr"]["pil"], "jpeg"),
-            (IMAGES["img_64_64_rgb"]["pil"], "jpeg"),
-            (IMAGES["img_32_32_3_rgba"]["pil"], "png"),
+            (IMAGES["img_32_32_3_rgb"]["np"], ".jpg"),
+            (IMAGES["img_32_32_3_bgr"]["np"], ".jpg"),
+            (IMAGES["img_64_64_rgb"]["np"], ".jpg"),
+            (IMAGES["img_32_32_3_rgba"]["np"], ".png"),
+            (IMAGES["img_32_32_3_rgb"]["pil"], ".jpg"),
+            (IMAGES["img_32_32_3_bgr"]["pil"], ".jpg"),
+            (IMAGES["img_64_64_rgb"]["pil"], ".jpg"),
+            (IMAGES["img_32_32_3_rgba"]["pil"], ".png"),
         ]
     )
-    def test_marshall_images_with_auto_output_format(self, data_in, expected_format):
+    def test_marshall_images_with_auto_output_format(
+        self, data_in, expected_extension: str
+    ):
         """Test streamlit.image.marshall_images.
         with auto output_format
         """
@@ -155,7 +161,7 @@ class ImageProtoTest(testutil.DeltaGeneratorTestCase):
         st.image(data_in, output_format="auto")
         imglist = self.get_delta_from_queue().new_element.imgs
         self.assertEqual(len(imglist.imgs), 1)
-        self.assertTrue(imglist.imgs[0].url.endswith(f".{expected_format}"))
+        self.assertTrue(imglist.imgs[0].url.endswith(expected_extension))
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
@@ -24,6 +24,7 @@ from streamlit.runtime.media_file_storage import MediaFileStorageError, MediaFil
 from streamlit.runtime.memory_media_file_storage import (
     MemoryMediaFileStorage,
     MemoryFile,
+    get_extension_for_mimetype,
 )
 
 
@@ -131,13 +132,11 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
             ("video/mp4", ".mp4"),
             ("audio/wav", ".wav"),
             ("image/png", ".png"),
-            ("image/jpeg", ".jpeg"),
+            ("image/jpeg", ".jpg"),
         ]
     )
     def test_get_url(self, mimetype, extension):
-        """URLs should be formatted correctly, and have the right extension for
-        the file's mimetype.
-        """
+        """URLs should be formatted correctly, and have the expected extension."""
         file_id = self.storage.load_and_get_id(
             b"mock_bytes", mimetype=mimetype, kind=MediaFileKind.MEDIA
         )
@@ -207,3 +206,19 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
             self.storage.delete_file(file_id)
 
         self.assertEqual(0, len(self.storage.get_stats()))
+
+
+class MemoryMediaFileStorageUtilTest(unittest.TestCase):
+    """Unit tests for utility functions in memory_media_file_storage.py"""
+
+    @parameterized.expand(
+        [
+            ("video/mp4", ".mp4"),
+            ("audio/wav", ".wav"),
+            ("image/png", ".png"),
+            ("image/jpeg", ".jpg"),
+        ]
+    )
+    def test_get_extension_for_mimetype(self, mimetype: str, extension: str):
+        result = get_extension_for_mimetype(mimetype)
+        self.assertEqual(extension, result)

--- a/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
@@ -219,6 +219,6 @@ class MemoryMediaFileStorageUtilTest(unittest.TestCase):
             ("image/jpeg", ".jpg"),
         ]
     )
-    def test_get_extension_for_mimetype(self, mimetype: str, extension: str):
+    def test_get_extension_for_mimetype(self, mimetype: str, expected_extension: str):
         result = get_extension_for_mimetype(mimetype)
-        self.assertEqual(extension, result)
+        self.assertEqual(expected_extension, result)


### PR DESCRIPTION
Update `get_extension_for_mimetype` mimetype mapping, docs, and tests:

- Remove the `get_extension_for_mimetype` comment referencing a Python bug that "might be fixed in Python 3.6", and that was forcing us to maintain an explicit mimetype:extension mapping for cases that Python didn't handle natively.
- Python now handles the "image/jpeg" mapping correctly (it returns ".jpg", which is as good or better an extension than ".jpeg", which we'd manually specified before). So remove this mapping.
- Add a note about why we keep the "audio/wav" mimetype mapping
- Pass `strict=False` to `mimetypes.guess_extension` (we'd rather have some result than no result).
- Add an explicit `test_get_extension_for_mimetype` unit test. (This behavior was already being indirectly tested via another MemoryMediaFileManager test, but this additional test adds clarity about what's being tested.)