### PR TITLE
Sanitize streamlit/__init__.py

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -45,15 +45,12 @@ For more detailed info, see https://docs.streamlit.io.
 # Must be at the top, to avoid circular dependency.
 from streamlit import logger as _logger
 from streamlit import config as _config
-from streamlit.proto.RootContainer_pb2 import RootContainer
-from streamlit.runtime.secrets import Secrets, SECRETS_FILE_LOC
+from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STRING
 
 _LOGGER = _logger.get_logger("root")
 
 # Give the package a version.
-from importlib_metadata import version as _version
-
-__version__: str = _version("streamlit")
+__version__ = _STREAMLIT_VERSION_STRING
 
 from typing import Any, Dict, Iterator, List, NoReturn
 import contextlib as _contextlib
@@ -75,9 +72,16 @@ from streamlit.runtime.scriptrunner import (
     RerunException as _RerunException,
     RerunData as _RerunData,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException as _StreamlitAPIException
 from streamlit.proto import ForwardMsg_pb2 as _ForwardMsg_pb2
-from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer
+from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
+from streamlit.runtime.secrets import (
+    Secrets as _Secrets,
+    SECRETS_FILE_LOC as _SECRETS_FILE_LOC,
+)
+from streamlit.runtime.state import SessionStateProxy as _SessionStateProxy
+from streamlit.user_info import UserInfoProxy as _UserInfoProxy
 
 # Modules that the user should have access to. These are imported with "as"
 # syntax pass mypy checking with implicit_reexport disabled.
@@ -89,7 +93,7 @@ from streamlit.runtime.caching import (
     memo as experimental_memo,
 )
 
-cache = gather_metrics(_cache)
+cache = _gather_metrics(_cache)
 
 # This is set to True inside cli._main_run(), and is False otherwise.
 # If False, we should assume that DeltaGenerator functions are effectively
@@ -109,10 +113,10 @@ def _update_logger() -> None:
 _config.on_config_parsed(_update_logger, True)
 
 
-_main = _DeltaGenerator(root_container=RootContainer.MAIN)
-sidebar = _DeltaGenerator(root_container=RootContainer.SIDEBAR, parent=_main)
+_main = _DeltaGenerator(root_container=_RootContainer.MAIN)
+sidebar = _DeltaGenerator(root_container=_RootContainer.SIDEBAR, parent=_main)
 
-secrets = Secrets(SECRETS_FILE_LOC)
+secrets = _Secrets(_SECRETS_FILE_LOC)
 
 # DeltaGenerator methods:
 
@@ -199,22 +203,16 @@ get_option = _config.get_option
 from streamlit.commands.page_config import set_page_config as set_page_config
 
 # Session State
-
-from streamlit.runtime.state import SessionStateProxy
-from streamlit.user_info import UserInfoProxy
-
-session_state = SessionStateProxy()
-experimental_user = UserInfoProxy()
-
+session_state = _SessionStateProxy()
+experimental_user = _UserInfoProxy()
 
 # Beta APIs
+beta_container = _gather_metrics(_main.beta_container)
+beta_expander = _gather_metrics(_main.beta_expander)
+beta_columns = _gather_metrics(_main.beta_columns)
 
-beta_container = gather_metrics(_main.beta_container)
-beta_expander = gather_metrics(_main.beta_expander)
-beta_columns = gather_metrics(_main.beta_columns)
 
-
-@gather_metrics
+@_gather_metrics
 def set_option(key: str, value: Any) -> None:
     """Set config option.
 
@@ -240,21 +238,21 @@ def set_option(key: str, value: Any) -> None:
     try:
         opt = _config._config_options_template[key]
     except KeyError as ke:
-        raise StreamlitAPIException(
+        raise _StreamlitAPIException(
             "Unrecognized config option: {key}".format(key=key)
         ) from ke
     if opt.scriptable:
         _config.set_option(key, value)
         return
 
-    raise StreamlitAPIException(
+    raise _StreamlitAPIException(
         "{key} cannot be set on the fly. Set as command line option, e.g. streamlit run script.py --{key}, or in config.toml instead.".format(
             key=key
         )
     )
 
 
-@gather_metrics
+@_gather_metrics
 def experimental_show(*args: Any) -> None:
     """Write arguments and *argument names* to your app for debugging purposes.
 
@@ -336,7 +334,7 @@ def experimental_show(*args: Any) -> None:
         exception(exc)
 
 
-@gather_metrics
+@_gather_metrics
 def experimental_get_query_params() -> Dict[str, List[str]]:
     """Return the query parameters that is currently showing in the browser's URL bar.
 
@@ -367,7 +365,7 @@ def experimental_get_query_params() -> Dict[str, List[str]]:
     return _parse.parse_qs(ctx.query_string)
 
 
-@gather_metrics
+@_gather_metrics
 def experimental_set_query_params(**query_params: Any) -> None:
     """Set the query parameters that are shown in the browser's URL bar.
 
@@ -459,7 +457,7 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
                 message.empty()
 
 
-@gather_metrics
+@_gather_metrics
 def _transparent_write(*args: Any) -> Any:
     """This is just st.write, but returns the arguments you passed to it."""
     write(*args)

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -20,7 +20,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Dict, Optional, List, Union
 
 import streamlit.elements.exception as exception_utils
-from streamlit import __version__, config, source_util, secrets
+from streamlit import config, source_util, secrets
 from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
@@ -34,6 +34,7 @@ from streamlit.proto.NewSession_pb2 import (
     UserInfo,
 )
 from streamlit.proto.PagesChanged_pb2 import PagesChanged
+from streamlit.version import STREAMLIT_VERSION_STRING
 from streamlit.watcher import LocalSourcesWatcher
 from . import caching, legacy_caching
 from .credentials import Credentials
@@ -582,7 +583,7 @@ class AppSession:
 
         _populate_user_info_msg(imsg.user_info)
 
-        imsg.environment_info.streamlit_version = __version__
+        imsg.environment_info.streamlit_version = STREAMLIT_VERSION_STRING
         imsg.environment_info.python_version = ".".join(map(str, sys.version_info))
 
         imsg.session_state.run_on_save = self._run_on_save

--- a/lib/streamlit/version.py
+++ b/lib/streamlit/version.py
@@ -17,11 +17,12 @@ import random
 
 import packaging.version
 import requests
+from importlib_metadata import version as _version
+from typing_extensions import Final
 
-import streamlit as st
-from streamlit.logger import get_logger
+import streamlit.logger as logger
 
-LOGGER = get_logger(__name__)
+LOGGER = logger.get_logger(__name__)
 
 PYPI_STREAMLIT_URL = "https://pypi.org/pypi/streamlit/json"
 
@@ -30,12 +31,14 @@ PYPI_STREAMLIT_URL = "https://pypi.org/pypi/streamlit/json"
 # should_show_new_version_notice() is called.
 CHECK_PYPI_PROBABILITY = 0.10
 
+STREAMLIT_VERSION_STRING: Final[str] = _version("streamlit")
 
-def _version_str_to_obj(version_str):
+
+def _version_str_to_obj(version_str) -> packaging.version.Version:
     return packaging.version.Version(version_str)
 
 
-def _get_installed_streamlit_version():
+def _get_installed_streamlit_version() -> packaging.version.Version:
     """Return the streamlit version string from setup.py.
 
     Returns
@@ -44,8 +47,7 @@ def _get_installed_streamlit_version():
         The version string specified in setup.py.
 
     """
-    version_str = st.__version__
-    return _version_str_to_obj(version_str)
+    return _version_str_to_obj(STREAMLIT_VERSION_STRING)
 
 
 def _get_latest_streamlit_version(timeout=None):

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -24,13 +24,12 @@ import pytest
 
 import streamlit as st
 import streamlit.components.v1 as components
-from streamlit import StreamlitAPIException
 from streamlit.components.v1 import component_arrow
 from streamlit.components.v1.components import (
     ComponentRegistry,
     CustomComponent,
 )
-from streamlit.errors import DuplicateWidgetID
+from streamlit.errors import DuplicateWidgetID, StreamlitAPIException
 from streamlit.proto.Components_pb2 import SpecialArg
 from streamlit.type_util import to_bytes
 from tests import testutil

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -20,6 +20,8 @@ from typing import Callable
 import pytest
 import altair as alt
 import pandas as pd
+
+from streamlit.errors import StreamlitAPIException
 from tests import testutil
 from parameterized import parameterized
 
@@ -27,7 +29,6 @@ import streamlit as st
 from streamlit.elements import arrow_altair as altair
 from streamlit.elements.arrow_altair import ChartType
 from streamlit.type_util import bytes_to_data_frame
-from streamlit import StreamlitAPIException
 
 
 def _deep_get(dictionary, *keys):

--- a/lib/tests/streamlit/elements/media_test.py
+++ b/lib/tests/streamlit/elements/media_test.py
@@ -20,9 +20,9 @@ from unittest import mock
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit import RootContainer
 from streamlit.cursor import make_delta_path
 from streamlit.elements.media import MediaData
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from tests import testutil
 
 

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -20,11 +20,11 @@ import pandas as pd
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit import StreamlitAPIException
 from streamlit.elements.multiselect import (
     _get_default_count,
     _get_over_max_options_message,
 )
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from tests import testutil
 

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -18,7 +18,7 @@ import re
 from unittest.mock import patch
 from parameterized import parameterized
 
-from streamlit import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.TextInput_pb2 import TextInput
 from tests import testutil
 import streamlit as st

--- a/lib/tests/streamlit/layouts_test.py
+++ b/lib/tests/streamlit/layouts_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
-from streamlit import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException
 
 from tests import testutil
 

--- a/lib/tests/streamlit/message_mocks.py
+++ b/lib/tests/streamlit/message_mocks.py
@@ -14,11 +14,11 @@
 
 """Shared protobuf message mocking utilities."""
 
-from streamlit import RootContainer
 from streamlit.cursor import make_delta_path
 from streamlit.elements import legacy_data_frame
 from streamlit.elements.arrow import Data
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.proto.RootContainer_pb2 import RootContainer
 
 
 def create_dataframe_msg(df: Data, id: int = 1) -> ForwardMsg:

--- a/lib/tests/streamlit/runtime/caching/memo_test.py
+++ b/lib/tests/streamlit/runtime/caching/memo_test.py
@@ -20,7 +20,8 @@ import unittest
 from unittest.mock import patch, mock_open, MagicMock, Mock
 
 import streamlit as st
-from streamlit import StreamlitAPIException, file_util
+from streamlit import file_util
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.runtime.caching import memo_decorator
 from streamlit.runtime.caching.cache_errors import CacheError

--- a/lib/tests/streamlit/runtime/forward_msg_cache_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_cache_test.py
@@ -17,9 +17,10 @@
 import unittest
 from unittest.mock import MagicMock
 
-from streamlit import config, RootContainer
+from streamlit import config
 from streamlit.elements import legacy_data_frame as data_frame
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime import app_session
 from streamlit.runtime.forward_msg_cache import (
     ForwardMsgCache,

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -20,8 +20,8 @@ from typing import Tuple
 
 from parameterized import parameterized
 
-from streamlit import RootContainer
 from streamlit.cursor import make_delta_path
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.elements import legacy_data_frame
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -19,8 +19,8 @@ from unittest.mock import Mock, patch
 
 import matplotlib
 
-from streamlit import SECRETS_FILE_LOC
 from streamlit import config
+from streamlit.runtime.secrets import SECRETS_FILE_LOC
 from streamlit.runtime.session_data import SessionData
 from streamlit.web import bootstrap
 from streamlit.web.bootstrap import NEW_VERSION_TEXT


### PR DESCRIPTION
Our top-level `__init__.py` is complex (_too_ complex!), and we haven't been following best practices here:

1. Any import within `__init__.py` should be of the form

```
from foo import bar as _bar
```

so that these imports don't "escape" and accidentally become part of the Streamlit API.

2. Streamlit modules should generally never do `from streamlit import xyz` (edit: _for symbols imported in `__init__.py`_) because this form of import relies on `__init__.py` having been fully executed, which can quickly lead to circular imports.

This PR fixes (some) of these issues:

- `streamlit.__version__` is now defined in `version.py` (as `STREAMLIT_VERSION_STRING`), so modules that need to know the version string can import it from there.
- Lots of imports inside `__init__.py` are now imported as `from foo import bar as _bar` so that other modules don't accidentally do `from streamlit import bar`