### PR TITLE
Force explicit subclasses of MediaFileStorage to implement its methods

### DIFF
--- a/lib/streamlit/runtime/media_file_storage.py
+++ b/lib/streamlit/runtime/media_file_storage.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import abstractmethod
 from enum import Enum
 from typing import Union, Optional
 
@@ -39,6 +40,7 @@ class MediaFileStorageError(Exception):
 
 
 class MediaFileStorage(Protocol):
+    @abstractmethod
     def load_and_get_id(
         self,
         path_or_data: Union[str, bytes],
@@ -80,7 +82,9 @@ class MediaFileStorage(Protocol):
             path is invalid).
 
         """
+        raise NotImplementedError
 
+    @abstractmethod
     def get_url(self, file_id: str) -> str:
         """Return a URL for a file in the manager.
 
@@ -101,7 +105,9 @@ class MediaFileStorage(Protocol):
             Raised if the manager doesn't contain an object with the given ID.
 
         """
+        raise NotImplementedError
 
+    @abstractmethod
     def delete_file(self, file_id: str) -> None:
         """Delete a file from the manager.
 
@@ -134,3 +140,4 @@ class MediaFileStorage(Protocol):
             deletion usually occurs on session disconnect).
 
         """
+        raise NotImplementedError


### PR DESCRIPTION
## 📚 Context

The `MediaFileStorage` protocol is currently useful to ensure that static code
analysis catches when a class that doesn't inherit from `MediaFileStorage` (but
is meant to implement the Protocol structurally) is missing some required
methods.

However, there are still a few ways that mistakes can slip by. Namely, a class
that inherits from `MediaFileStorage` but doesn't implement any of its methods
isn't flagged by mypy because the methods in `MediaFileStorage` itself are
considered default implementations, so the subclass inherits all of them, and
the inherited implementations are all no-ops (due to how they're defined in the
protocol).

To prevent this, we use the `abc` module's `@abstractmethod` decorator so that
mypy complains loudly when a subclass of `MediaFileStorage` doesn't implement
the methods. This also causes Python to throw a `TypeError` when attempting to
instantiate a `MediaFileStorage` instance without providing a concrete
implementation, which is nice for scenarios where no static type checker is
being used.

Finally, we have the default implementation raise a `NotImplementedError`, which
isn't strictly required, but the PEP defining protocols does this in its example
code, and it makes it more clear to the subclass implementer that the method
must be defined.

- What kind of change does this PR introduce?

  - [x] Other, please describe: make protocols more strict
