### PR TITLE
FIX: Support hashing for Enum classes

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -15,6 +15,7 @@
 """Hashing for st.memo and st.singleton."""
 import collections
 import dataclasses
+from enum import Enum
 import functools
 import hashlib
 import inspect
@@ -264,6 +265,9 @@ class _CacheFuncHasher:
 
         elif dataclasses.is_dataclass(obj):
             return self.to_bytes(dataclasses.asdict(obj))
+
+        elif isinstance(obj, Enum):
+            return (str(obj._value_) + str(obj._name_)).encode()
 
         elif type_util.is_type(obj, "pandas.core.frame.DataFrame") or type_util.is_type(
             obj, "pandas.core.series.Series"

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -14,6 +14,7 @@
 
 """st.memo/singleton hashing tests."""
 
+from enum import Enum, auto
 import functools
 import hashlib
 import os
@@ -280,6 +281,15 @@ class HashTest(unittest.TestCase):
         bar = Data("bar")
 
         assert get_hash(bar)
+
+    def test_enum(self):
+        class EnumClass(Enum):
+            ENUM_1 = auto()
+            ENUM_2 = auto()
+
+        enum_1 = EnumClass.ENUM_1
+
+        assert get_hash(enum_1)
 
 
 class NotHashableTest(unittest.TestCase):


### PR DESCRIPTION
## 📚 Context

In our project, we heavily rely on `Enum` classes in order to enumerate and classify types of things. However, currently they are not supported by Streamlit for caching with `st.experimental_memo` because they are not correctly hashed.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Support for `Enum` class hashing for `st.experimental_memo`

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #4417 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
