### PR TITLE
Move secrets singleton out of __init__.py

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -76,10 +76,7 @@ from streamlit.errors import StreamlitAPIException as _StreamlitAPIException
 from streamlit.proto import ForwardMsg_pb2 as _ForwardMsg_pb2
 from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
-from streamlit.runtime.secrets import (
-    Secrets as _Secrets,
-    SECRETS_FILE_LOC as _SECRETS_FILE_LOC,
-)
+from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
 from streamlit.runtime.state import SessionStateProxy as _SessionStateProxy
 from streamlit.user_info import UserInfoProxy as _UserInfoProxy
 
@@ -116,7 +113,7 @@ _config.on_config_parsed(_update_logger, True)
 _main = _DeltaGenerator(root_container=_RootContainer.MAIN)
 sidebar = _DeltaGenerator(root_container=_RootContainer.SIDEBAR, parent=_main)
 
-secrets = _Secrets(_SECRETS_FILE_LOC)
+secrets = _secrets_singleton
 
 # DeltaGenerator methods:
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -20,7 +20,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Dict, Optional, List, Union
 
 import streamlit.elements.exception as exception_utils
-from streamlit import config, source_util, secrets
+from streamlit import config, source_util
 from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
@@ -45,6 +45,7 @@ from .scriptrunner import (
     ScriptRunner,
     ScriptRunnerEvent,
 )
+from .secrets import secrets_singleton
 from .session_data import SessionData
 from .uploaded_file_manager import UploadedFileManager
 
@@ -142,7 +143,7 @@ class AppSession:
         )
 
         # The script should rerun when the `secrets.toml` file has been changed.
-        secrets._file_change_listener.connect(self._on_secrets_file_changed)
+        secrets_singleton._file_change_listener.connect(self._on_secrets_file_changed)
 
         self._run_on_save = config.get_option("server.runOnSave")
 
@@ -199,7 +200,9 @@ class AppSession:
                 self._stop_config_listener()
             if self._stop_pages_listener is not None:
                 self._stop_pages_listener()
-            secrets._file_change_listener.disconnect(self._on_secrets_file_changed)
+            secrets_singleton._file_change_listener.disconnect(
+                self._on_secrets_file_changed
+            )
 
     def _enqueue_forward_msg(self, msg: ForwardMsg) -> None:
         """Enqueue a new ForwardMsg to our browser queue.

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,10 +14,11 @@
 
 import os
 import threading
-from typing import Any, Mapping, Optional, Final
+from typing import Any, Mapping, Optional
 
 import toml
 from blinker import Signal
+from typing_extensions import Final
 
 import streamlit as st
 import streamlit.watcher.path_watcher

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,7 +14,7 @@
 
 import os
 import threading
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Final
 
 import toml
 from blinker import Signal
@@ -250,3 +250,6 @@ class Secrets(Mapping[str, Any]):
 
     def __iter__(self):
         return iter(self._parse(True))
+
+
+secrets_singleton: Final = Secrets(SECRETS_FILE_LOC)

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -82,7 +82,9 @@ class AppSessionTest(unittest.TestCase):
         super().tearDown()
         media_file_manager._media_file_manager = None
 
-    @patch("streamlit.runtime.app_session.secrets._file_change_listener.disconnect")
+    @patch(
+        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.disconnect"
+    )
     def test_shutdown(self, patched_disconnect):
         """Test that AppSession.shutdown behaves sanely."""
         session = _create_test_session()
@@ -143,7 +145,9 @@ class AppSessionTest(unittest.TestCase):
         clear_memo_cache.assert_called_once()
         clear_legacy_cache.assert_called_once()
 
-    @patch("streamlit.runtime.app_session.secrets._file_change_listener.connect")
+    @patch(
+        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.connect"
+    )
     def test_request_rerun_on_secrets_file_change(self, patched_connect):
         """AppSession should add a secrets listener on creation."""
         session = _create_test_session()


### PR DESCRIPTION
Our `secrets` singleton is currently declared inside Streamlit's `__init__.py`, which can lead to circular import issues.

This PR moves the secrets singleton creation to `secrets.py`. Other modules that need access to it should now do `from streamlit.runtime.secrets import secrets_singleton`, instead of `from streamlit import secrets`.

(The symbol is still called `secrets` inside `__init__.py`, so st.secrets functions as normal.)