### PR TITLE
Runtime.instance()

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -76,10 +76,7 @@ from streamlit.errors import StreamlitAPIException as _StreamlitAPIException
 from streamlit.proto import ForwardMsg_pb2 as _ForwardMsg_pb2
 from streamlit.proto.RootContainer_pb2 import RootContainer as _RootContainer
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
-from streamlit.runtime.secrets import (
-    Secrets as _Secrets,
-    SECRETS_FILE_LOC as _SECRETS_FILE_LOC,
-)
+from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
 from streamlit.runtime.state import SessionStateProxy as _SessionStateProxy
 from streamlit.user_info import UserInfoProxy as _UserInfoProxy
 
@@ -116,7 +113,7 @@ _config.on_config_parsed(_update_logger, True)
 _main = _DeltaGenerator(root_container=_RootContainer.MAIN)
 sidebar = _DeltaGenerator(root_container=_RootContainer.SIDEBAR, parent=_main)
 
-secrets = _Secrets(_SECRETS_FILE_LOC)
+secrets = _secrets_singleton
 
 # DeltaGenerator methods:
 

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -19,10 +19,10 @@ from textwrap import dedent
 from typing_extensions import Final
 
 import streamlit
+from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
-from streamlit.runtime.runtime import Runtime
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     register_widget,
@@ -409,7 +409,7 @@ def marshall_file(
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
     if streamlit._is_running_with_streamlit:
-        file_url = Runtime.instance().media_file_mgr.add(
+        file_url = runtime.get_instance().media_file_mgr.add(
             data_as_bytes,
             mimetype,
             coordinates,

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -21,8 +21,8 @@ from typing_extensions import Final
 import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Button_pb2 import Button as ButtonProto
-from streamlit.runtime.media_file_manager import get_media_file_manager
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
+from streamlit.runtime.runtime import Runtime
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     register_widget,
@@ -409,7 +409,7 @@ def marshall_file(
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
     if streamlit._is_running_with_streamlit:
-        file_url = get_media_file_manager().add(
+        file_url = Runtime.instance().media_file_mgr.add(
             data_as_bytes,
             mimetype,
             coordinates,

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -31,11 +31,11 @@ from PIL import Image, ImageFile
 from typing_extensions import Final, Literal, TypeAlias
 
 import streamlit
+from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.runtime import Runtime
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -332,7 +332,7 @@ def image_to_url(
             mimetype, _ = mimetypes.guess_type(image)
             if mimetype is None:
                 mimetype = "application/octet-stream"
-            return Runtime.instance().media_file_mgr.add(image, mimetype, image_id)
+            return runtime.get_instance().media_file_mgr.add(image, mimetype, image_id)
 
     # PIL Images
     elif isinstance(image, (ImageFile.ImageFile, Image.Image)):
@@ -380,7 +380,7 @@ def image_to_url(
     mimetype = _get_image_format_mimetype(image_format)
 
     if streamlit._is_running_with_streamlit:
-        return Runtime.instance().media_file_mgr.add(image_data, mimetype, image_id)
+        return runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
         return ""

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -34,8 +34,8 @@ import streamlit
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
-from streamlit.runtime.media_file_manager import get_media_file_manager
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.runtime import Runtime
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -332,7 +332,7 @@ def image_to_url(
             mimetype, _ = mimetypes.guess_type(image)
             if mimetype is None:
                 mimetype = "application/octet-stream"
-            return get_media_file_manager().add(image, mimetype, image_id)
+            return Runtime.instance().media_file_mgr.add(image, mimetype, image_id)
 
     # PIL Images
     elif isinstance(image, (ImageFile.ImageFile, Image.Image)):
@@ -380,7 +380,7 @@ def image_to_url(
     mimetype = _get_image_format_mimetype(image_format)
 
     if streamlit._is_running_with_streamlit:
-        return get_media_file_manager().add(image_data, mimetype, image_id)
+        return Runtime.instance().media_file_mgr.add(image_data, mimetype, image_id)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
         return ""

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -20,11 +20,10 @@ from typing_extensions import Final, TypeAlias
 from validators import url
 
 import streamlit
-from streamlit import type_util
+from streamlit import type_util, runtime
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.runtime import Runtime
 
 if TYPE_CHECKING:
     from typing import Any
@@ -210,7 +209,7 @@ def _marshall_av_media(
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
     if streamlit._is_running_with_streamlit:
-        file_url = Runtime.instance().media_file_mgr.add(
+        file_url = runtime.get_instance().media_file_mgr.add(
             data_or_filename, mimetype, coordinates
         )
     else:

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -23,8 +23,8 @@ import streamlit
 from streamlit import type_util
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
-from streamlit.runtime.media_file_manager import get_media_file_manager
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.runtime import Runtime
 
 if TYPE_CHECKING:
     from typing import Any
@@ -210,7 +210,9 @@ def _marshall_av_media(
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
     if streamlit._is_running_with_streamlit:
-        file_url = get_media_file_manager().add(data_or_filename, mimetype, coordinates)
+        file_url = Runtime.instance().media_file_mgr.add(
+            data_or_filename, mimetype, coordinates
+        )
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
         file_url = ""

--- a/lib/streamlit/runtime/__init__.py
+++ b/lib/streamlit/runtime/__init__.py
@@ -11,3 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Explicitly re-export public symbols from runtime.py
+from .runtime import (
+    Runtime as Runtime,
+    RuntimeState as RuntimeState,
+    SessionClient as SessionClient,
+    SessionClientDisconnectedError as SessionClientDisconnectedError,
+    RuntimeConfig as RuntimeConfig,
+)
+
+
+def get_instance() -> Runtime:
+    """Return the singleton Runtime instance."""
+    return Runtime.instance()

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -20,7 +20,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Dict, Optional, List, Union
 
 import streamlit.elements.exception as exception_utils
-from streamlit import config, source_util, secrets
+from streamlit import config, source_util
 from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
@@ -45,6 +45,7 @@ from .scriptrunner import (
     ScriptRunner,
     ScriptRunnerEvent,
 )
+from .secrets import secrets_singleton
 from .session_data import SessionData
 from .uploaded_file_manager import UploadedFileManager
 
@@ -142,7 +143,7 @@ class AppSession:
         )
 
         # The script should rerun when the `secrets.toml` file has been changed.
-        secrets._file_change_listener.connect(self._on_secrets_file_changed)
+        secrets_singleton._file_change_listener.connect(self._on_secrets_file_changed)
 
         self._run_on_save = config.get_option("server.runOnSave")
 
@@ -199,7 +200,9 @@ class AppSession:
                 self._stop_config_listener()
             if self._stop_pages_listener is not None:
                 self._stop_pages_listener()
-            secrets._file_change_listener.disconnect(self._on_secrets_file_changed)
+            secrets_singleton._file_change_listener.disconnect(
+                self._on_secrets_file_changed
+            )
 
     def _enqueue_forward_msg(self, msg: ForwardMsg) -> None:
         """Enqueue a new ForwardMsg to our browser queue.

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -38,8 +38,8 @@ from streamlit.version import STREAMLIT_VERSION_STRING
 from streamlit.watcher import LocalSourcesWatcher
 from . import caching, legacy_caching
 from .credentials import Credentials
-from .media_file_manager import get_media_file_manager
 from .metrics_util import Installation
+from .runtime import Runtime
 from .scriptrunner import (
     RerunData,
     ScriptRunner,
@@ -184,8 +184,8 @@ class AppSession:
             # Clear any unused session files in upload file manager and media
             # file manager
             self._uploaded_file_mgr.remove_session_files(self.id)
-            get_media_file_manager().clear_session_refs(self.id)
-            get_media_file_manager().remove_orphaned_files()
+            Runtime.instance().media_file_mgr.clear_session_refs(self.id)
+            Runtime.instance().media_file_mgr.remove_orphaned_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
@@ -530,7 +530,7 @@ class AppSession:
             if self._state == AppSessionState.SHUTDOWN_REQUESTED:
                 # Only clear media files if the script is done running AND the
                 # session is actually shutting down.
-                get_media_file_manager().clear_session_refs(self.id)
+                Runtime.instance().media_file_mgr.clear_session_refs(self.id)
 
             self._client_state = client_state
             self._scriptrunner = None

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Dict, Optional, List, Union
 
 import streamlit.elements.exception as exception_utils
+import streamlit.runtime as runtime
 from streamlit import config, source_util
 from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
@@ -39,7 +40,6 @@ from streamlit.watcher import LocalSourcesWatcher
 from . import caching, legacy_caching
 from .credentials import Credentials
 from .metrics_util import Installation
-from .runtime import Runtime
 from .scriptrunner import (
     RerunData,
     ScriptRunner,
@@ -185,8 +185,8 @@ class AppSession:
             # Clear any unused session files in upload file manager and media
             # file manager
             self._uploaded_file_mgr.remove_session_files(self.id)
-            Runtime.instance().media_file_mgr.clear_session_refs(self.id)
-            Runtime.instance().media_file_mgr.remove_orphaned_files()
+            runtime.get_instance().media_file_mgr.clear_session_refs(self.id)
+            runtime.get_instance().media_file_mgr.remove_orphaned_files()
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
@@ -533,7 +533,7 @@ class AppSession:
             if self._state == AppSessionState.SHUTDOWN_REQUESTED:
                 # Only clear media files if the script is done running AND the
                 # session is actually shutting down.
-                Runtime.instance().media_file_mgr.clear_session_refs(self.id)
+                runtime.get_instance().media_file_mgr.clear_session_refs(self.id)
 
             self._client_state = client_state
             self._scriptrunner = None

--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -228,28 +228,3 @@ class MediaFileManager:
             self._files_by_session_and_coord[session_id][coordinates] = file_id
 
             return self._storage.get_url(file_id)
-
-
-# Singleton MediaFileManager instance. The Runtime initializes
-# this during startup.
-_media_file_manager: Optional[MediaFileManager] = None
-
-
-def set_media_file_manager(manager: MediaFileManager) -> None:
-    """Set the singleton MediaFileManager instance."""
-    global _media_file_manager
-    if _media_file_manager is not None:
-        raise RuntimeError("MediaFileManager singleton already exists!")
-    _media_file_manager = manager
-
-
-def get_media_file_manager() -> MediaFileManager:
-    """Return the singleton MediaFileManager instance. Raise an error
-    if it hasn't been instantiated yet.
-    """
-    global _media_file_manager
-
-    if _media_file_manager is None:
-        raise RuntimeError("MediaFileManager hasn't been created!")
-
-    return _media_file_manager

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -210,10 +210,11 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def gather_metrics(callable: F) -> F:
+    # Avoid circular import
+    from streamlit.runtime.scriptrunner import get_script_run_ctx
+
     @wraps(callable)
     def wrap(*args, **kwargs):
-        # Avoid circular import
-        from streamlit.runtime.scriptrunner import get_script_run_ctx
 
         ctx = get_script_run_ctx()
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -30,7 +30,6 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.PageProfile_pb2 import Argument, Command
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 LOGGER = get_logger(__name__)
 
@@ -213,6 +212,9 @@ F = TypeVar("F", bound=Callable[..., Any])
 def gather_metrics(callable: F) -> F:
     @wraps(callable)
     def wrap(*args, **kwargs):
+        # Avoid circular import
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+
         ctx = get_script_run_ctx()
 
         tracking_activated = (

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -30,6 +30,8 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.PageProfile_pb2 import Argument, Command
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+
 
 LOGGER = get_logger(__name__)
 
@@ -210,9 +212,6 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def gather_metrics(callable: F) -> F:
-    # Avoid circular import
-    from streamlit.runtime.scriptrunner import get_script_run_ctx
-
     @wraps(callable)
     def wrap(*args, **kwargs):
 

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -29,7 +29,7 @@ from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.runtime_util import is_cacheable_msg
 from streamlit.watcher import LocalSourcesWatcher
-import streamlit.runtime.app_session as app_session
+from .app_session import AppSession
 from .caching import get_memo_stats_provider, get_singleton_stats_provider
 from .forward_msg_cache import (
     ForwardMsgCache,
@@ -91,7 +91,7 @@ class SessionInfo:
     the ForwardMsgCache.
     """
 
-    def __init__(self, client: SessionClient, session: app_session.AppSession):
+    def __init__(self, client: SessionClient, session: AppSession):
         """Initialize a SessionInfo instance.
 
         Parameters
@@ -344,7 +344,7 @@ class Runtime:
 
         async_objs = self._get_async_objs()
 
-        session = app_session.AppSession(
+        session = AppSession(
             event_loop=async_objs.eventloop,
             session_data=SessionData(self._main_script_path, self._command_line or ""),
             uploaded_file_manager=self._uploaded_file_mgr,
@@ -474,7 +474,7 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        session = app_session.AppSession(
+        session = AppSession(
             event_loop=self._get_async_objs().eventloop,
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -144,14 +144,17 @@ class Runtime:
 
     @classmethod
     def instance(cls) -> "Runtime":
+        """Return the singleton Runtime instance. Raise an Error if the
+        Runtime hasn't been created yet.
+        """
         if cls._instance is None:
             raise RuntimeError("Runtime hasn't been created!")
         return cls._instance
 
     def __init__(self, config: RuntimeConfig):
-        """Create a StreamlitRuntime. It won't be started yet.
+        """Create a Runtime instance. It won't be started yet.
 
-        StreamlitRuntime is *not* thread-safe. Its public methods are generally
+        Runtime is *not* thread-safe. Its public methods are generally
         safe to call only on the same thread that its event loop runs on.
 
         Parameters

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -29,7 +29,7 @@ from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.runtime_util import is_cacheable_msg
 from streamlit.watcher import LocalSourcesWatcher
-from .app_session import AppSession
+import streamlit.runtime.app_session as app_session
 from .caching import get_memo_stats_provider, get_singleton_stats_provider
 from .forward_msg_cache import (
     ForwardMsgCache,
@@ -37,7 +37,7 @@ from .forward_msg_cache import (
     create_reference_msg,
 )
 from .legacy_caching.caching import _mem_caches
-from .media_file_manager import MediaFileManager, set_media_file_manager
+from .media_file_manager import MediaFileManager
 from .media_file_storage import MediaFileStorage
 from .session_data import SessionData
 from .state import SessionStateStatProvider, SCRIPT_RUN_WITHOUT_ERRORS_KEY
@@ -91,7 +91,7 @@ class SessionInfo:
     the ForwardMsgCache.
     """
 
-    def __init__(self, client: SessionClient, session: AppSession):
+    def __init__(self, client: SessionClient, session: app_session.AppSession):
         """Initialize a SessionInfo instance.
 
         Parameters
@@ -140,6 +140,14 @@ class AsyncObjects(NamedTuple):
 
 
 class Runtime:
+    _instance: Optional["Runtime"] = None
+
+    @classmethod
+    def instance(cls) -> "Runtime":
+        if cls._instance is None:
+            raise RuntimeError("Runtime hasn't been created!")
+        return cls._instance
+
     def __init__(self, config: RuntimeConfig):
         """Create a StreamlitRuntime. It won't be started yet.
 
@@ -151,6 +159,10 @@ class Runtime:
         config
             Config options.
         """
+        if self._instance is not None:
+            raise RuntimeError("Runtime instance already exists!")
+        self._instance = self
+
         # Will be created when we start.
         self._async_objs: Optional[AsyncObjects] = None
 
@@ -170,8 +182,7 @@ class Runtime:
         self._message_cache = ForwardMsgCache()
         self._uploaded_file_mgr = UploadedFileManager()
         self._uploaded_file_mgr.on_files_updated.connect(self._on_files_updated)
-        self._media_file_manager = MediaFileManager(storage=config.media_file_storage)
-        set_media_file_manager(self._media_file_manager)
+        self._media_file_mgr = MediaFileManager(storage=config.media_file_storage)
 
         self._stats_mgr = StatsManager()
         self._stats_mgr.register_provider(get_memo_stats_provider())
@@ -194,6 +205,10 @@ class Runtime:
     @property
     def uploaded_file_mgr(self) -> UploadedFileManager:
         return self._uploaded_file_mgr
+
+    @property
+    def media_file_mgr(self) -> MediaFileManager:
+        return self._media_file_mgr
 
     @property
     def stats_mgr(self) -> StatsManager:
@@ -329,7 +344,7 @@ class Runtime:
 
         async_objs = self._get_async_objs()
 
-        session = AppSession(
+        session = app_session.AppSession(
             event_loop=async_objs.eventloop,
             session_data=SessionData(self._main_script_path, self._command_line or ""),
             uploaded_file_manager=self._uploaded_file_mgr,
@@ -459,7 +474,7 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        session = AppSession(
+        session = app_session.AppSession(
             event_loop=self._get_async_objs().eventloop,
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -159,9 +159,9 @@ class Runtime:
         config
             Config options.
         """
-        if self._instance is not None:
+        if Runtime._instance is not None:
             raise RuntimeError("Runtime instance already exists!")
-        self._instance = self
+        Runtime._instance = self
 
         # Will be created when we start.
         self._async_objs: Optional[AsyncObjects] = None

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -23,14 +23,11 @@ from typing import Dict, Optional, Callable
 
 from blinker import Signal
 
-from streamlit import config
-from streamlit import source_util
-from streamlit import util
+from streamlit import config, runtime, source_util, util
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-import streamlit.runtime.runtime as runtime
 from streamlit.runtime.state import (
     SessionState,
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
@@ -413,7 +410,7 @@ class ScriptRunner:
         start_time: float = timer()
 
         # Reset DeltaGenerators, widgets, media files.
-        runtime.Runtime.instance().media_file_mgr.clear_session_refs()
+        runtime.get_instance().media_file_mgr.clear_session_refs()
 
         main_script_path = self._main_script_path
         pages = source_util.get_pages(main_script_path)
@@ -625,7 +622,7 @@ class ScriptRunner:
 
         # Remove orphaned files now that the script has run and files in use
         # are marked as active.
-        runtime.Runtime.instance().media_file_mgr.remove_orphaned_files()
+        runtime.get_instance().media_file_mgr.remove_orphaned_files()
 
         # Force garbage collection to run, to help avoid memory use building up
         # This is usually not an issue, but sometimes GC takes time to kick in and

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -30,7 +30,7 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.media_file_manager import get_media_file_manager
+import streamlit.runtime.runtime as runtime
 from streamlit.runtime.state import (
     SessionState,
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
@@ -413,7 +413,7 @@ class ScriptRunner:
         start_time: float = timer()
 
         # Reset DeltaGenerators, widgets, media files.
-        get_media_file_manager().clear_session_refs()
+        runtime.Runtime.instance().media_file_mgr.clear_session_refs()
 
         main_script_path = self._main_script_path
         pages = source_util.get_pages(main_script_path)
@@ -625,7 +625,7 @@ class ScriptRunner:
 
         # Remove orphaned files now that the script has run and files in use
         # are marked as active.
-        get_media_file_manager().remove_orphaned_files()
+        runtime.Runtime.instance().media_file_mgr.remove_orphaned_files()
 
         # Force garbage collection to run, to help avoid memory use building up
         # This is usually not an issue, but sometimes GC takes time to kick in and

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,10 +14,11 @@
 
 import os
 import threading
-from typing import Any, Mapping, Optional, Final
+from typing import Any, Mapping, Optional
 
 import toml
 from blinker import Signal
+from typing_extensions import Final
 
 import streamlit as st
 import streamlit.watcher.path_watcher

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,7 +14,7 @@
 
 import os
 import threading
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Final
 
 import toml
 from blinker import Signal
@@ -250,3 +250,6 @@ class Secrets(Mapping[str, Any]):
 
     def __iter__(self):
         return iter(self._parse(True))
+
+
+secrets_singleton: Final = Secrets(SECRETS_FILE_LOC)

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,7 +14,7 @@
 
 import os
 import threading
-from typing import Any, Mapping, Optional, Final
+from typing import Any, Mapping, Optional
 
 import toml
 from blinker import Signal

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -35,7 +35,7 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.runtime import (
+from streamlit.runtime import (
     Runtime,
     SessionClient,
     SessionClientDisconnectedError,

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -36,7 +36,7 @@ from streamlit.components.v1.components import ComponentRegistry
 from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
-from streamlit.runtime.runtime import (
+from streamlit.runtime import (
     Runtime,
     RuntimeConfig,
     RuntimeState,

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -26,7 +26,7 @@ from streamlit import config
 from streamlit.proto.AppPage_pb2 import AppPage
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime import media_file_manager
+from streamlit.runtime import Runtime
 from streamlit.runtime.app_session import AppSession, AppSessionState
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.media_file_manager import MediaFileManager
@@ -74,13 +74,15 @@ def _create_test_session(event_loop: Optional[AbstractEventLoop] = None) -> AppS
 class AppSessionTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
-        media_file_manager._media_file_manager = MediaFileManager(
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime.media_file_mgr = MediaFileManager(
             MemoryMediaFileStorage("/mock/media")
         )
+        Runtime._instance = mock_runtime
 
     def tearDown(self) -> None:
         super().tearDown()
-        media_file_manager._media_file_manager = None
+        Runtime._instance = None
 
     @patch("streamlit.runtime.app_session.secrets._file_change_listener.disconnect")
     def test_shutdown(self, patched_disconnect):

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -82,7 +82,9 @@ class AppSessionTest(unittest.TestCase):
         super().tearDown()
         media_file_manager._media_file_manager = None
 
-    @patch("streamlit.runtime.app_session.secrets._file_change_listener.disconnect")
+    @patch(
+        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.disconnect"
+    )
     def test_shutdown(self, patched_disconnect):
         """Test that AppSession.shutdown behaves sanely."""
         session = _create_test_session()
@@ -143,7 +145,9 @@ class AppSessionTest(unittest.TestCase):
         clear_memo_cache.assert_called_once()
         clear_legacy_cache.assert_called_once()
 
-    @patch("streamlit.runtime.app_session.secrets._file_change_listener.connect")
+    @patch(
+        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.connect"
+    )
     def test_request_rerun_on_secrets_file_change(self, patched_connect):
         """AppSession should add a secrets listener on creation."""
         session = _create_test_session()

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
 import datetime
 import unittest
+from typing import Callable
 from unittest.mock import patch, mock_open, MagicMock
-from parameterized import parameterized
+
 import pandas as pd
+from parameterized import parameterized
 
 import streamlit
 from streamlit.runtime import metrics_util
-
+from streamlit.runtime.scriptrunner import get_script_run_ctx
 from tests import testutil
 
 MAC = "mac"
@@ -183,7 +184,7 @@ class PageTelemetryTest(testutil.DeltaGeneratorTestCase):
     def test_gather_metrics_decorator(self):
         """Test gather_metrics decorator"""
 
-        ctx = metrics_util.get_script_run_ctx()
+        ctx = get_script_run_ctx()
         ctx.reset()
         ctx.gather_usage_stats = True
 

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 import shutil
 import tempfile
+import unittest
 from typing import List
 from unittest.mock import MagicMock, patch
 
@@ -52,6 +53,33 @@ class MockSessionClient(SessionClient):
 
     def write_forward_msg(self, msg: ForwardMsg) -> None:
         self.forward_msgs.append(msg)
+
+
+class RuntimeSingletonTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        Runtime._instance = None
+
+    def test_runtime_constructor_sets_instance(self):
+        """Creating a Runtime instance sets Runtime.instance"""
+        self.assertIsNone(Runtime._instance)
+        _ = Runtime(MagicMock())
+        self.assertIsNotNone(Runtime._instance)
+
+    def test_multiple_runtime_error(self):
+        """Creating multiple Runtimes raises an error."""
+        r1 = Runtime(MagicMock())
+        with self.assertRaises(RuntimeError):
+            r2 = Runtime(MagicMock())
+
+    def test_instance_class_method(self):
+        """Runtime.instance() returns our singleton instance."""
+        with self.assertRaises(RuntimeError):
+            # No Runtime: error
+            instance = Runtime.instance()
+
+        # Runtime instantiated: no error
+        _ = Runtime(MagicMock())
+        instance = Runtime.instance()
 
 
 class RuntimeTest(RuntimeTestCase):

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -493,6 +493,8 @@ class ScriptCheckTest(RuntimeTestCase):
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
         )
         self.runtime = Runtime(config)
+        Runtime._instance = self.runtime
+
         await self.runtime.start()
 
     def tearDown(self) -> None:

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -521,8 +521,6 @@ class ScriptCheckTest(RuntimeTestCase):
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
         )
         self.runtime = Runtime(config)
-        Runtime._instance = self.runtime
-
         await self.runtime.start()
 
     def tearDown(self) -> None:

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -16,9 +16,9 @@ import asyncio
 from unittest import mock
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
-from streamlit.runtime.runtime import Runtime, RuntimeConfig, RuntimeState
 from tests.isolated_asyncio_test_case import IsolatedAsyncioTestCase
 
 

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -16,10 +16,9 @@ import asyncio
 from unittest import mock
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime import media_file_manager
 from streamlit.runtime.app_session import AppSession
-from streamlit.runtime.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.runtime import Runtime, RuntimeConfig, RuntimeState
 from tests.isolated_asyncio_test_case import IsolatedAsyncioTestCase
 
 
@@ -35,13 +34,14 @@ class RuntimeTestCase(IsolatedAsyncioTestCase):
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
         )
         self.runtime = Runtime(config)
+        Runtime._instance = self.runtime
 
     async def asyncTearDown(self):
         # Stop the runtime, and return when it's stopped
         if self.runtime.state != RuntimeState.INITIAL:
             self.runtime.stop()
             await self.runtime.stopped
-        media_file_manager._media_file_manager = None
+        Runtime._instance = None
 
     @staticmethod
     async def tick_runtime_loop() -> None:

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -34,7 +34,6 @@ class RuntimeTestCase(IsolatedAsyncioTestCase):
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
         )
         self.runtime = Runtime(config)
-        Runtime._instance = self.runtime
 
     async def asyncTearDown(self):
         # Stop the runtime, and return when it's stopped

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -17,7 +17,7 @@ import threading
 from queue import Queue
 from unittest.mock import MagicMock
 
-from streamlit.runtime.runtime import Runtime, RuntimeConfig
+from streamlit.runtime import Runtime, RuntimeConfig
 from tests.isolated_asyncio_test_case import IsolatedAsyncioTestCase
 
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -31,7 +31,7 @@ from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.Element_pb2 import Element
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.WidgetStates_pb2 import WidgetStates, WidgetState
-from streamlit.runtime import media_file_manager
+from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.legacy_caching import caching
 from streamlit.runtime.media_file_manager import MediaFileManager
@@ -81,13 +81,15 @@ def _is_control_event(event: ScriptRunnerEvent) -> bool:
 class ScriptRunnerTest(AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
-        media_file_manager._media_file_manager = MediaFileManager(
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime.media_file_mgr = MediaFileManager(
             MemoryMediaFileStorage("/mock/media")
         )
+        Runtime._instance = mock_runtime
 
     def tearDown(self) -> None:
         super().tearDown()
-        media_file_manager._media_file_manager = None
+        Runtime._instance = None
 
     def test_startup_shutdown(self):
         """Test that we can create and shut down a ScriptRunner."""

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -21,7 +21,7 @@ import tornado.web
 import tornado.websocket
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.runtime import SessionClientDisconnectedError, Runtime
+from streamlit.runtime import SessionClientDisconnectedError, Runtime
 from streamlit.web.server.server import BrowserWebSocketHandler
 from .server_test_case import ServerTestCase
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -31,8 +31,7 @@ import streamlit.web.server.server
 from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime import media_file_manager
-from streamlit.runtime.runtime import RuntimeState, Runtime
+from streamlit.runtime import RuntimeState, Runtime
 from streamlit.web.server.server import (
     MAX_PORT_SEARCH_RETRIES,
     RetriesExceeded,

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -32,7 +32,7 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import media_file_manager
-from streamlit.runtime.runtime import RuntimeState
+from streamlit.runtime.runtime import RuntimeState, Runtime
 from streamlit.web.server.server import (
     MAX_PORT_SEARCH_RETRIES,
     RetriesExceeded,
@@ -346,7 +346,7 @@ class ScriptCheckEndpointExistsTest(tornado.testing.AsyncHTTPTestCase):
 
     def tearDown(self):
         config._set_option("server.scriptHealthCheckEnabled", self._old_config, "test")
-        media_file_manager._media_file_manager = None
+        Runtime._instance = None
         super().tearDown()
 
     def get_app(self):
@@ -374,7 +374,7 @@ class ScriptCheckEndpointDoesNotExistTest(tornado.testing.AsyncHTTPTestCase):
 
     def tearDown(self):
         config._set_option("server.scriptHealthCheckEnabled", self._old_config, "test")
-        media_file_manager._media_file_manager = None
+        Runtime._instance = None
         super().tearDown()
 
     def get_app(self):

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -21,7 +21,7 @@ import tornado.websocket
 from tornado.websocket import WebSocketClientConnection
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime import media_file_manager
+from streamlit.runtime import Runtime
 from streamlit.runtime.app_session import AppSession
 from streamlit.web.server import Server
 
@@ -41,10 +41,10 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
 
     def tearDown(self) -> None:
         super().tearDown()
-        # Server._create_app() will create the MediaFileManager singleton.
+        # Server._create_app() will create the Runtime singleton.
         # We null it out in tearDown() so that it doesn't interfere with
         # future tests.
-        media_file_manager._media_file_manager = None
+        Runtime._instance = None
 
     def get_app(self) -> tornado.web.Application:
         self.server = Server(


### PR DESCRIPTION
- Runtime is now a singleton, and its singleton instance is accessed via `Runtime.instance()`
- This means we no longer access the MediaFileManager via `get_media_file_manager()`. Instead, this manager (and all other Runtime-owned public managers) should be accessed from the Runtime instance itself: `Runtime.instance().media_file_mgr`
- The runtime package now has an `__init__.py` that re-exports the public symbols of `runtime/runtime.py`. This means that awkward imports like `from streamlit.runtime.runtime import Runtime` are now `from streamlit.runtime import Runtime`
- The runtime package also exports a `get_instance()` convenience function that just calls `Runtime.instance()`. This means you can do `from streamlit import runtime`, and then `runtime.get_instance()` to get the Runtime instance