### PR TITLE
Rename withS4ACommunication -> withHostCommunication

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -29,12 +29,12 @@ import {
   PageNotFound,
   PagesChanged,
 } from "src/autogen/proto"
-import { S4ACommunicationHOC } from "src/hocs/withS4ACommunication/withS4ACommunication"
+import { HostCommunicationHOC } from "src/hocs/withHostCommunication"
 import {
   IMenuItem,
   IToolbarItem,
-  S4ACommunicationState,
-} from "src/hocs/withS4ACommunication/types"
+  HostCommunicationState,
+} from "src/hocs/withHostCommunication/types"
 import { ConnectionState } from "src/lib/ConnectionState"
 import { MetricsManager } from "src/lib/MetricsManager"
 import { getMetricsManagerForTest } from "src/lib/MetricsManagerTestUtils"
@@ -54,9 +54,9 @@ import ToolbarActions from "./components/core/ToolbarActions"
 
 jest.mock("src/lib/ConnectionManager")
 
-const getS4ACommunicationState = (
-  extend?: Partial<S4ACommunicationState>
-): S4ACommunicationState => ({
+const getHostCommunicationState = (
+  extend?: Partial<HostCommunicationState>
+): HostCommunicationState => ({
   forcedModalClose: false,
   hideSidebarNav: false,
   isOwner: true,
@@ -65,19 +65,19 @@ const getS4ACommunicationState = (
   queryParams: "",
   requestedPageScriptHash: null,
   sidebarChevronDownshift: 0,
-  streamlitShareMetadata: {},
+  deployedAppMetadata: {},
   toolbarItems: [],
   ...extend,
 })
 
-const getS4ACommunicationProp = (
-  extend?: Partial<S4ACommunicationHOC>
-): S4ACommunicationHOC => ({
+const getHostCommunicationProp = (
+  extend?: Partial<HostCommunicationHOC>
+): HostCommunicationHOC => ({
   connect: jest.fn(),
   sendMessage: jest.fn(),
   onModalReset: jest.fn(),
   onPageChanged: jest.fn(),
-  currentState: getS4ACommunicationState({}),
+  currentState: getHostCommunicationState({}),
   ...extend,
 })
 
@@ -88,7 +88,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
     startRecording: jest.fn(),
     stopRecording: jest.fn(),
   },
-  s4aCommunication: getS4ACommunicationProp({}),
+  hostCommunication: getHostCommunicationProp({}),
   theme: {
     activeTheme: lightTheme,
     availableThemes: [],
@@ -206,12 +206,12 @@ describe("App", () => {
     expect(props.screenCast.stopRecording).toBeCalled()
   })
 
-  it("shows s4aMenuItems", () => {
+  it("shows hostMenuItems", () => {
     const props = getProps({
-      s4aCommunication: getS4ACommunicationProp({
+      hostCommunication: getHostCommunicationProp({
         connect: jest.fn(),
         sendMessage: jest.fn(),
-        currentState: getS4ACommunicationState({
+        currentState: getHostCommunicationState({
           queryParams: "",
           menuItems: [
             {
@@ -226,17 +226,17 @@ describe("App", () => {
     })
     const wrapper = shallow(<App {...props} />)
 
-    expect(wrapper.find(MainMenu).prop("s4aMenuItems")).toStrictEqual([
+    expect(wrapper.find(MainMenu).prop("hostMenuItems")).toStrictEqual([
       { type: "separator" },
     ])
   })
 
-  it("shows s4aToolbarItems", () => {
+  it("shows hostToolbarItems", () => {
     const props = getProps({
-      s4aCommunication: getS4ACommunicationProp({
+      hostCommunication: getHostCommunicationProp({
         connect: jest.fn(),
         sendMessage: jest.fn(),
-        currentState: getS4ACommunicationState({
+        currentState: getHostCommunicationState({
           queryParams: "",
           toolbarItems: [
             {
@@ -250,14 +250,14 @@ describe("App", () => {
     const wrapper = shallow(<App {...props} />)
     wrapper.setState({ hideTopBar: false })
 
-    expect(wrapper.find(ToolbarActions).prop("s4aToolbarItems")).toStrictEqual(
-      [
-        {
-          key: "favorite",
-          icon: "star.svg",
-        },
-      ]
-    )
+    expect(
+      wrapper.find(ToolbarActions).prop("hostToolbarItems")
+    ).toStrictEqual([
+      {
+        key: "favorite",
+        icon: "star.svg",
+      },
+    ])
   })
 
   it("closes modals when the modal closure message has been received", () => {
@@ -271,8 +271,8 @@ describe("App", () => {
     const onModalReset = jest.fn()
     wrapper.setProps(
       getProps({
-        s4aCommunication: getS4ACommunicationProp({
-          currentState: getS4ACommunicationState({ forcedModalClose: true }),
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({ forcedModalClose: true }),
           onModalReset,
         }),
       })
@@ -286,8 +286,8 @@ describe("App", () => {
     const wrapper = shallow(
       <App
         {...getProps({
-          s4aCommunication: getS4ACommunicationProp({
-            currentState: getS4ACommunicationState({
+          hostCommunication: getHostCommunicationProp({
+            currentState: getHostCommunicationState({
               menuItems: [],
               queryParams: "",
               forcedModalClose: false,
@@ -300,8 +300,8 @@ describe("App", () => {
     )
     wrapper.setProps(
       getProps({
-        s4aCommunication: getS4ACommunicationProp({
-          currentState: getS4ACommunicationState({ forcedModalClose: true }),
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({ forcedModalClose: true }),
           onModalReset,
         }),
       })
@@ -309,8 +309,8 @@ describe("App", () => {
     expect(onModalReset).toBeCalled()
     wrapper.setProps(
       getProps({
-        s4aCommunication: getS4ACommunicationProp({
-          currentState: getS4ACommunicationState({ forcedModalClose: false }),
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({ forcedModalClose: false }),
           onModalReset,
         }),
       })
@@ -328,7 +328,7 @@ describe("App", () => {
     shallow(<App {...props} />)
 
     // @ts-ignore
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(lightTheme.emotion),
     })
@@ -346,7 +346,7 @@ describe("App", () => {
     expect(props.theme.setTheme).toHaveBeenCalledWith(mockThemeConfig)
 
     // @ts-ignore
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(darkTheme.emotion),
     })
@@ -385,7 +385,7 @@ describe("App", () => {
     instance.handleMessage(msg)
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
 
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_APP_PAGES",
       appPages,
     })
@@ -399,8 +399,8 @@ describe("App", () => {
 
     wrapper.setProps(
       getProps({
-        s4aCommunication: getS4ACommunicationProp({
-          currentState: getS4ACommunicationState({
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({
             requestedPageScriptHash: "hash1",
           }),
         }),
@@ -410,7 +410,7 @@ describe("App", () => {
 
     expect(instance.onPageChange).toHaveBeenCalledWith("hash1")
     expect(
-      props.s4aCommunication.currentState.requestedPageScriptHash
+      props.hostCommunication.currentState.requestedPageScriptHash
     ).toBeNull()
   })
 })
@@ -737,11 +737,11 @@ describe("App.handleNewSession", () => {
       "hash1"
     )
     expect(document.title).toBe("page1 · Streamlit")
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_APP_PAGES",
       appPages,
     })
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_CURRENT_PAGE_NAME",
       currentPageName: "",
       currentPageScriptHash: "hash1",
@@ -780,7 +780,7 @@ describe("App.handleNewSession", () => {
     expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
-  it("sets hideSidebarNav based on the server config option and s4a setting", () => {
+  it("sets hideSidebarNav based on the server config option and host setting", () => {
     const wrapper = shallow(<App {...getProps()} />)
 
     // hideSidebarNav initializes to true.
@@ -791,11 +791,11 @@ describe("App.handleNewSession", () => {
     instance.handleNewSession(new NewSession(NEW_SESSION_JSON))
     expect(wrapper.find("AppView").prop("hideSidebarNav")).toEqual(false)
 
-    // Have s4a override the server config option.
+    // Have the host override the server config option.
     wrapper.setProps(
       getProps({
-        s4aCommunication: getS4ACommunicationProp({
-          currentState: getS4ACommunicationState({
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({
             hideSidebarNav: true,
           }),
         }),
@@ -1108,7 +1108,7 @@ describe("App.handlePageNotFound", () => {
       "Page not found",
       expect.stringMatching("You have requested page /nonexistentPage")
     )
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_CURRENT_PAGE_NAME",
       currentPageName: "",
       currentPageScriptHash: "page_hash",
@@ -1136,7 +1136,7 @@ describe("App.handlePageNotFound", () => {
         "The page that you have requested does not seem to exist"
       )
     )
-    expect(props.s4aCommunication.sendMessage).toHaveBeenCalledWith({
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_CURRENT_PAGE_NAME",
       currentPageName: "",
       currentPageScriptHash: "page_hash",
@@ -1158,8 +1158,8 @@ describe("Test Main Menu shortcut functionality", () => {
 
   it("Tests dev menu shortcuts cannot be accessed as a viewer", () => {
     const props = getProps({
-      s4aCommunication: getS4ACommunicationProp({
-        currentState: getS4ACommunicationState({
+      hostCommunication: getHostCommunicationProp({
+        currentState: getHostCommunicationState({
           isOwner: false,
         }),
         sendMessage: jest.fn(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,9 +98,9 @@ import {
 
 import { StyledApp } from "./styled-components"
 
-import withS4ACommunication, {
-  S4ACommunicationHOC,
-} from "./hocs/withS4ACommunication/withS4ACommunication"
+import withHostCommunication, {
+  HostCommunicationHOC,
+} from "./hocs/withHostCommunication"
 
 import withScreencast, {
   ScreenCastHOC,
@@ -112,7 +112,7 @@ import { ensureError } from "./lib/ErrorHandling"
 
 export interface Props {
   screenCast: ScreenCastHOC
-  s4aCommunication: S4ACommunicationHOC
+  hostCommunication: HostCommunicationHOC
   theme: {
     activeTheme: ThemeConfig
     availableThemes: ThemeConfig[]
@@ -266,7 +266,7 @@ export class App extends PureComponent<Props, State> {
       this.rerunScript()
     },
     CLEAR_CACHE: () => {
-      if (isLocalhost() || this.props.s4aCommunication.currentState.isOwner) {
+      if (isLocalhost() || this.props.hostCommunication.currentState.isOwner) {
         this.openClearCacheDialog()
       }
     },
@@ -286,7 +286,7 @@ export class App extends PureComponent<Props, State> {
       document.body.classList.add("embedded")
     }
 
-    this.props.s4aCommunication.sendMessage({
+    this.props.hostCommunication.sendMessage({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(this.props.theme.activeTheme.emotion),
     })
@@ -296,21 +296,21 @@ export class App extends PureComponent<Props, State> {
 
   componentDidUpdate(prevProps: Readonly<Props>): void {
     if (
-      prevProps.s4aCommunication.currentState.queryParams !==
-      this.props.s4aCommunication.currentState.queryParams
+      prevProps.hostCommunication.currentState.queryParams !==
+      this.props.hostCommunication.currentState.queryParams
     ) {
       this.sendRerunBackMsg()
     }
-    if (this.props.s4aCommunication.currentState.forcedModalClose) {
+    if (this.props.hostCommunication.currentState.forcedModalClose) {
       this.closeDialog()
     }
 
     const {
       requestedPageScriptHash,
-    } = this.props.s4aCommunication.currentState
+    } = this.props.hostCommunication.currentState
     if (requestedPageScriptHash !== null) {
       this.onPageChange(requestedPageScriptHash)
-      this.props.s4aCommunication.onPageChanged()
+      this.props.hostCommunication.onPageChanged()
     }
   }
 
@@ -453,7 +453,7 @@ export class App extends PureComponent<Props, State> {
     })
 
     if (title) {
-      this.props.s4aCommunication.sendMessage({
+      this.props.hostCommunication.sendMessage({
         type: "SET_PAGE_TITLE",
         title,
       })
@@ -491,7 +491,7 @@ export class App extends PureComponent<Props, State> {
       document.location.pathname + (queryString ? `?${queryString}` : "")
     window.history.pushState({}, "", targetUrl)
 
-    this.props.s4aCommunication.sendMessage({
+    this.props.hostCommunication.sendMessage({
       type: "SET_QUERY_PARAM",
       queryParams: queryString ? `?${queryString}` : "",
     })
@@ -506,7 +506,7 @@ export class App extends PureComponent<Props, State> {
 
     const currentPageScriptHash = this.state.appPages[0]?.pageScriptHash || ""
     this.setState({ currentPageScriptHash }, () => {
-      this.props.s4aCommunication.sendMessage({
+      this.props.hostCommunication.sendMessage({
         type: "SET_CURRENT_PAGE_NAME",
         currentPageName: "",
         currentPageScriptHash,
@@ -517,7 +517,7 @@ export class App extends PureComponent<Props, State> {
   handlePagesChanged = (pagesChangedMsg: PagesChanged): void => {
     const { appPages } = pagesChangedMsg
     this.setState({ appPages }, () => {
-      this.props.s4aCommunication.sendMessage({
+      this.props.hostCommunication.sendMessage({
         type: "SET_APP_PAGES",
         appPages,
       })
@@ -698,12 +698,12 @@ export class App extends PureComponent<Props, State> {
         latestRunTime: performance.now(),
       },
       () => {
-        this.props.s4aCommunication.sendMessage({
+        this.props.hostCommunication.sendMessage({
           type: "SET_APP_PAGES",
           appPages: newSessionProto.appPages,
         })
 
-        this.props.s4aCommunication.sendMessage({
+        this.props.hostCommunication.sendMessage({
           type: "SET_CURRENT_PAGE_NAME",
           currentPageName: viewingMainPage ? "" : newPageName,
           currentPageScriptHash: newPageScriptHash,
@@ -726,7 +726,7 @@ export class App extends PureComponent<Props, State> {
     )
 
     MetricsManager.current.setMetadata(
-      this.props.s4aCommunication.currentState.streamlitShareMetadata
+      this.props.hostCommunication.currentState.deployedAppMetadata
     )
     MetricsManager.current.setAppHash(newSessionHash)
     MetricsManager.current.clearDeltaCounter()
@@ -765,7 +765,7 @@ export class App extends PureComponent<Props, State> {
       pythonVersion: SessionInfo.current.pythonVersion,
     })
 
-    this.props.s4aCommunication.connect()
+    this.props.hostCommunication.connect()
     this.handleSessionStateChanged(initialize.sessionState)
   }
 
@@ -774,7 +774,7 @@ export class App extends PureComponent<Props, State> {
    */
   setAndSendTheme = (themeConfig: ThemeConfig): void => {
     this.props.theme.setTheme(themeConfig)
-    this.props.s4aCommunication.sendMessage({
+    this.props.hostCommunication.sendMessage({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(themeConfig.emotion),
     })
@@ -916,7 +916,7 @@ export class App extends PureComponent<Props, State> {
    */
   closeDialog = (): void => {
     this.setState({ dialog: undefined })
-    this.props.s4aCommunication.onModalReset()
+    this.props.hostCommunication.onModalReset()
   }
 
   /**
@@ -1247,7 +1247,7 @@ export class App extends PureComponent<Props, State> {
       : undefined
 
   getQueryString = (): string => {
-    const { queryParams } = this.props.s4aCommunication.currentState
+    const { queryParams } = this.props.hostCommunication.currentState
 
     const queryString =
       queryParams && queryParams.length > 0
@@ -1277,8 +1277,8 @@ export class App extends PureComponent<Props, State> {
     } = this.state
 
     const {
-      hideSidebarNav: s4AHideSidebarNav,
-    } = this.props.s4aCommunication.currentState
+      hideSidebarNav: hostHideSidebarNav,
+    } = this.props.hostCommunication.currentState
 
     const outerDivClass = classNames("stApp", {
       "streamlit-embedded": isEmbeddedInIFrame(),
@@ -1311,7 +1311,7 @@ export class App extends PureComponent<Props, State> {
           availableThemes: this.props.theme.availableThemes,
           setTheme: this.setAndSendTheme,
           addThemes: this.props.theme.addThemes,
-          sidebarChevronDownshift: this.props.s4aCommunication.currentState
+          sidebarChevronDownshift: this.props.hostCommunication.currentState
             .sidebarChevronDownshift,
           getBaseUriParts: this.getBaseUriParts,
         }}
@@ -1336,10 +1336,12 @@ export class App extends PureComponent<Props, State> {
                     allowRunOnSave={allowRunOnSave}
                   />
                   <ToolbarActions
-                    s4aToolbarItems={
-                      this.props.s4aCommunication.currentState.toolbarItems
+                    hostToolbarItems={
+                      this.props.hostCommunication.currentState.toolbarItems
                     }
-                    sendS4AMessage={this.props.s4aCommunication.sendMessage}
+                    sendMessageToHost={
+                      this.props.hostCommunication.sendMessage
+                    }
                   />
                 </>
               )}
@@ -1351,11 +1353,11 @@ export class App extends PureComponent<Props, State> {
                 aboutCallback={this.aboutCallback}
                 screencastCallback={this.screencastCallback}
                 screenCastState={this.props.screenCast.currentState}
-                s4aMenuItems={
-                  this.props.s4aCommunication.currentState.menuItems
+                hostMenuItems={
+                  this.props.hostCommunication.currentState.menuItems
                 }
-                s4aIsOwner={this.props.s4aCommunication.currentState.isOwner}
-                sendS4AMessage={this.props.s4aCommunication.sendMessage}
+                hostIsOwner={this.props.hostCommunication.currentState.isOwner}
+                sendMessageToHost={this.props.hostCommunication.sendMessage}
                 gitInfo={gitInfo}
                 showDeployError={this.showDeployError}
                 closeDialog={this.closeDialog}
@@ -1380,9 +1382,9 @@ export class App extends PureComponent<Props, State> {
               appPages={this.state.appPages}
               onPageChange={this.onPageChange}
               currentPageScriptHash={currentPageScriptHash}
-              hideSidebarNav={hideSidebarNav || s4AHideSidebarNav}
+              hideSidebarNav={hideSidebarNav || hostHideSidebarNav}
               pageLinkBaseUrl={
-                this.props.s4aCommunication.currentState.pageLinkBaseUrl
+                this.props.hostCommunication.currentState.pageLinkBaseUrl
               }
             />
             {renderedDialog}
@@ -1393,4 +1395,4 @@ export class App extends PureComponent<Props, State> {
   }
 }
 
-export default withS4ACommunication(withScreencast(App))
+export default withHostCommunication(withScreencast(App))

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -23,7 +23,7 @@ import { ScriptRunState } from "src/lib/ScriptRunState"
 import { FormsData, WidgetStateManager } from "src/lib/WidgetStateManager"
 import { FileUploadClient } from "src/lib/FileUploadClient"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent"
-import { sendS4AMessage } from "src/hocs/withS4ACommunication/withS4ACommunication"
+import { sendMessageToHost } from "src/hocs/withHostCommunication"
 
 import AppContext from "src/components/core/AppContext"
 import { BlockNode, AppRoot } from "src/lib/AppNode"
@@ -88,7 +88,7 @@ function AppView(props: AppViewProps): ReactElement {
 
   React.useEffect(() => {
     const listener = (): void => {
-      sendS4AMessage({
+      sendMessageToHost({
         type: "UPDATE_HASH",
         hash: window.location.hash,
       })

--- a/frontend/src/components/core/MainMenu/MainMenu.test.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.test.tsx
@@ -17,7 +17,7 @@
 import React from "react"
 
 import { mount } from "src/lib/test_util"
-import { IMenuItem } from "src/hocs/withS4ACommunication/types"
+import { IMenuItem } from "src/hocs/withHostCommunication/types"
 
 import { GitInfo, IGitInfo } from "src/autogen/proto"
 import { IDeployErrorDialog } from "src/components/core/StreamlitDialog/DeployErrorDialogs/types"
@@ -39,10 +39,10 @@ const getProps = (extend?: Partial<Props>): Props => ({
   clearCacheCallback: jest.fn(),
   isServerConnected: true,
   quickRerunCallback: jest.fn(),
-  s4aMenuItems: [],
+  hostMenuItems: [],
   screencastCallback: jest.fn(),
   screenCastState: "",
-  sendS4AMessage: jest.fn(),
+  sendMessageToHost: jest.fn(),
   settingsCallback: jest.fn(),
   isDeployErrorModalOpen: false,
   showDeployError: jest.fn(),
@@ -50,7 +50,7 @@ const getProps = (extend?: Partial<Props>): Props => ({
   closeDialog: jest.fn(),
   canDeploy: true,
   menuItems: {},
-  s4aIsOwner: false,
+  hostIsOwner: false,
   gitInfo: null,
   ...extend,
 })
@@ -63,7 +63,7 @@ describe("App", () => {
     expect(wrapper).toBeDefined()
   })
 
-  it("should render s4a menu items", () => {
+  it("should render host menu items", () => {
     const items: IMenuItem[] = [
       {
         type: "separator",
@@ -83,7 +83,7 @@ describe("App", () => {
       },
     ]
     const props = getProps({
-      s4aMenuItems: items,
+      hostMenuItems: items,
     })
     const wrapper = mount(<MainMenu {...props} />)
     const popoverContent = wrapper.find("StatefulPopover").prop("content")
@@ -385,7 +385,7 @@ describe("App", () => {
     ])
   })
 
-  it("should not render dev menu when s4aIsOwner is false and not on localhost", () => {
+  it("should not render dev menu when hostIsOwner is false and not on localhost", () => {
     // set isLocalhost to false by deleting window.location.
     // Source: https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
     // @ts-ignore

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -42,7 +42,7 @@ import Icon from "src/components/shared/Icon"
 import {
   IGuestToHostMessage,
   IMenuItem,
-} from "src/hocs/withS4ACommunication/types"
+} from "src/hocs/withHostCommunication/types"
 import { GitInfo, IGitInfo, PageConfig } from "src/autogen/proto"
 import { MetricsManager } from "src/lib/MetricsManager"
 import {
@@ -95,9 +95,9 @@ export interface Props {
 
   screenCastState: string
 
-  s4aMenuItems: IMenuItem[]
+  hostMenuItems: IMenuItem[]
 
-  sendS4AMessage: (message: IGuestToHostMessage) => void
+  sendMessageToHost: (message: IGuestToHostMessage) => void
 
   gitInfo: IGitInfo | null
 
@@ -115,7 +115,7 @@ export interface Props {
 
   menuItems?: PageConfig.IMenuItems | null
 
-  s4aIsOwner?: boolean
+  hostIsOwner?: boolean
 }
 
 const getOpenInWindowCallback = (url: string) => (): void => {
@@ -452,7 +452,7 @@ function MainMenu(props: Props): ReactElement {
     },
   }
 
-  const S4AMenuItems = props.s4aMenuItems.map(item => {
+  const hostMenuItems = props.hostMenuItems.map(item => {
     if (item.type === "separator") {
       return coreMenuItems.DIVIDER
     }
@@ -471,7 +471,7 @@ function MainMenu(props: Props): ReactElement {
 
     return {
       onClick: () =>
-        props.sendS4AMessage({
+        props.sendMessageToHost({
           type: "MENU_ITEM_CALLBACK",
           key: item.key,
         }),
@@ -479,8 +479,8 @@ function MainMenu(props: Props): ReactElement {
     }
   }, [] as any[])
 
-  const shouldShowS4AMenu = !!S4AMenuItems.length
-  const showDeploy = isLocalhost() && !shouldShowS4AMenu && props.canDeploy
+  const shouldShowHostMenu = !!hostMenuItems.length
+  const showDeploy = isLocalhost() && !shouldShowHostMenu && props.canDeploy
   const preferredMenuOrder: any[] = [
     coreMenuItems.rerun,
     coreMenuItems.settings,
@@ -489,7 +489,7 @@ function MainMenu(props: Props): ReactElement {
     coreMenuItems.DIVIDER,
     coreMenuItems.report,
     coreMenuItems.community,
-    ...(shouldShowS4AMenu ? S4AMenuItems : [coreMenuItems.DIVIDER]),
+    ...(shouldShowHostMenu ? hostMenuItems : [coreMenuItems.DIVIDER]),
     coreMenuItems.about,
   ]
 
@@ -536,7 +536,7 @@ function MainMenu(props: Props): ReactElement {
     }
   }
 
-  const { s4aIsOwner } = props
+  const { hostIsOwner } = props
 
   return (
     <StatefulPopover
@@ -550,7 +550,7 @@ function MainMenu(props: Props): ReactElement {
       content={({ close }) => (
         <>
           <SubMenu menuItems={menuItems} closeMenu={close} isDevMenu={false} />
-          {(s4aIsOwner || isLocalhost()) && (
+          {(hostIsOwner || isLocalhost()) && (
             <StyledUl>
               <SubMenu
                 menuItems={devMenuItems}

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.test.tsx
@@ -69,11 +69,11 @@ describe("ToolbarActions", () => {
   const getProps = (
     extended?: Partial<ToolbarActionsProps>
   ): ToolbarActionsProps => ({
-    s4aToolbarItems: [
+    hostToolbarItems: [
       { key: "favorite", icon: "star.svg" },
       { key: "share", label: "Share" },
     ],
-    sendS4AMessage: jest.fn(),
+    sendMessageToHost: jest.fn(),
     ...extended,
   })
 
@@ -82,7 +82,7 @@ describe("ToolbarActions", () => {
     expect(wrapper).toMatchSnapshot()
   })
 
-  it("calls sendS4AMessage with correct args when clicked", () => {
+  it("calls sendMessageToHost with correct args when clicked", () => {
     const props = getProps()
     const wrapper = shallow(<ToolbarActions {...props} />)
 
@@ -90,7 +90,7 @@ describe("ToolbarActions", () => {
       .find(ActionButton)
       .at(0)
       .simulate("click")
-    expect(props.sendS4AMessage).toHaveBeenLastCalledWith({
+    expect(props.sendMessageToHost).toHaveBeenLastCalledWith({
       type: "TOOLBAR_ITEM_CALLBACK",
       key: "favorite",
     })
@@ -99,7 +99,7 @@ describe("ToolbarActions", () => {
       .find(ActionButton)
       .at(1)
       .simulate("click")
-    expect(props.sendS4AMessage).toHaveBeenLastCalledWith({
+    expect(props.sendMessageToHost).toHaveBeenLastCalledWith({
       type: "TOOLBAR_ITEM_CALLBACK",
       key: "share",
     })

--- a/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/src/components/core/ToolbarActions/ToolbarActions.tsx
@@ -20,7 +20,7 @@ import Button, { Kind } from "src/components/shared/Button"
 import {
   IGuestToHostMessage,
   IToolbarItem,
-} from "src/hocs/withS4ACommunication/types"
+} from "src/hocs/withHostCommunication/types"
 import {
   StyledActionButtonContainer,
   StyledActionButtonIcon,
@@ -52,24 +52,24 @@ export function ActionButton({
 }
 
 export interface ToolbarActionsProps {
-  sendS4AMessage: (message: IGuestToHostMessage) => void
-  s4aToolbarItems: IToolbarItem[]
+  sendMessageToHost: (message: IGuestToHostMessage) => void
+  hostToolbarItems: IToolbarItem[]
 }
 
 function ToolbarActions({
-  sendS4AMessage,
-  s4aToolbarItems,
+  sendMessageToHost,
+  hostToolbarItems,
 }: ToolbarActionsProps): ReactElement {
   return (
     <>
-      {s4aToolbarItems.map(({ borderless, key, label, icon }) => (
+      {hostToolbarItems.map(({ borderless, key, label, icon }) => (
         <ActionButton
           key={key}
           label={label}
           icon={icon}
           borderless={borderless}
           onClick={() =>
-            sendS4AMessage({
+            sendMessageToHost({
               type: "TOOLBAR_ITEM_CALLBACK",
               key,
             })

--- a/frontend/src/components/core/ToolbarActions/styled-components.ts
+++ b/frontend/src/components/core/ToolbarActions/styled-components.ts
@@ -34,7 +34,7 @@ export const StyledActionButtonIcon = styled.div<StyledActionButtonIconProps>(
 
     // NOTE: We intentionally don't use any of the preset theme iconSizes here
     // so that icon scaling is unchanged from what we receive from the
-    // withS4ACommunication hoc.
+    // withHostCommunication hoc.
     width: "1rem",
     height: "1rem",
   })

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -17,7 +17,7 @@
 import nodeEmoji from "node-emoji"
 import { BaseUriParts, buildMediaUri } from "src/lib/UriUtil"
 import { grabTheRightIcon } from "src/vendor/twemoji"
-import { sendS4AMessage } from "src/hocs/withS4ACommunication/withS4ACommunication"
+import { sendMessageToHost } from "src/hocs/withHostCommunication"
 
 /**
  * Set the provided url/emoji as the page favicon.
@@ -44,7 +44,7 @@ export function handleFavicon(
 
   overwriteFavicon(imageUrl)
 
-  sendS4AMessage({
+  sendMessageToHost({
     type: "SET_PAGE_FAVICON",
     favicon: imageUrl,
   })

--- a/frontend/src/hocs/withHostCommunication/index.tsx
+++ b/frontend/src/hocs/withHostCommunication/index.tsx
@@ -14,4 +14,7 @@
  * limitations under the License.
  */
 
-export { default } from "./withS4ACommunication"
+import { HostCommunicationHOC as _HostCommunicationHOC } from "./withHostCommunication"
+
+export { default, sendMessageToHost } from "./withHostCommunication"
+export type HostCommunicationHOC = _HostCommunicationHOC

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -17,7 +17,7 @@
 import { IAppPage } from "src/autogen/proto"
 import { ExportedTheme } from "src/theme"
 
-export type StreamlitShareMetadata = {
+export type DeployedAppMetadata = {
   hostedAt?: string
   creatorId?: string
   owner?: string
@@ -27,7 +27,7 @@ export type StreamlitShareMetadata = {
   isOwner?: boolean
 }
 
-export interface S4ACommunicationState {
+export interface HostCommunicationState {
   forcedModalClose: boolean
   hideSidebarNav: boolean
   isOwner: boolean
@@ -36,7 +36,7 @@ export interface S4ACommunicationState {
   queryParams: string
   requestedPageScriptHash: string | null
   sidebarChevronDownshift: number
-  streamlitShareMetadata: StreamlitShareMetadata
+  deployedAppMetadata: DeployedAppMetadata
   toolbarItems: IToolbarItem[]
 }
 
@@ -77,7 +77,7 @@ export type IHostToGuestMessage = {
     }
   | {
       type: "SET_METADATA"
-      metadata: StreamlitShareMetadata
+      metadata: DeployedAppMetadata
     }
   | {
       type: "SET_PAGE_LINK_BASE_URL"

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -19,20 +19,20 @@ import { act } from "react-dom/test-utils"
 
 import { shallow, mount } from "src/lib/test_util"
 
-import withS4ACommunication, {
-  S4ACommunicationHOC,
-  S4A_COMM_VERSION,
-} from "./withS4ACommunication"
+import withHostCommunication, {
+  HostCommunicationHOC,
+  HOST_COMM_VERSION,
+} from "./withHostCommunication"
 
 const TestComponentNaked = (props: {
-  s4aCommunication: S4ACommunicationHOC
+  hostCommunication: HostCommunicationHOC
 }): ReactElement => {
-  props.s4aCommunication.connect()
+  props.hostCommunication.connect()
 
   return <div>test</div>
 }
 
-const TestComponent = withS4ACommunication(TestComponentNaked)
+const TestComponent = withHostCommunication(TestComponentNaked)
 
 function mockEventListeners(): (type: string, event: any) => void {
   const listeners: { [name: string]: ((event: Event) => void)[] } = {}
@@ -47,26 +47,26 @@ function mockEventListeners(): (type: string, event: any) => void {
   return dispatchEvent
 }
 
-describe("withS4ACommunication HOC", () => {
+describe("withHostCommunication HOC", () => {
   it("renders without crashing", () => {
     const wrapper = shallow(<TestComponent />)
 
     expect(wrapper.html()).not.toBeNull()
   })
 
-  it("wrapped component should have s4aCommunication prop", () => {
+  it("wrapped component should have hostCommunication prop", () => {
     const wrapper = shallow(<TestComponent />)
     expect(
-      wrapper.find(TestComponentNaked).prop("s4aCommunication")
+      wrapper.find(TestComponentNaked).prop("hostCommunication")
     ).toBeDefined()
   })
 
-  it("s4a should receive a GUEST_READY message", done => {
+  it("host should receive a GUEST_READY message", done => {
     shallow(<TestComponent />)
 
     const listener = (event: MessageEvent): void => {
       expect(event.data).toStrictEqual({
-        stCommVersion: S4A_COMM_VERSION,
+        stCommVersion: HOST_COMM_VERSION,
         type: "GUEST_READY",
       })
 
@@ -86,7 +86,7 @@ describe("withS4ACommunication HOC", () => {
       "message",
       new MessageEvent("message", {
         data: {
-          stCommVersion: S4A_COMM_VERSION,
+          stCommVersion: HOST_COMM_VERSION,
           type: "UPDATE_HASH",
           hash: "#somehash",
         },
@@ -106,7 +106,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "SET_TOOLBAR_ITEMS",
             items: [
               {
@@ -124,7 +124,7 @@ describe("withS4ACommunication HOC", () => {
 
     wrapper.update()
 
-    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    const props = wrapper.find(TestComponentNaked).prop("hostCommunication")
     expect(props.currentState.toolbarItems).toEqual([
       {
         borderless: true,
@@ -144,7 +144,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "SET_SIDEBAR_CHEVRON_DOWNSHIFT",
             sidebarChevronDownshift: 50,
           },
@@ -155,7 +155,7 @@ describe("withS4ACommunication HOC", () => {
 
     wrapper.update()
 
-    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    const props = wrapper.find(TestComponentNaked).prop("hostCommunication")
     expect(props.currentState.sidebarChevronDownshift).toBe(50)
   })
 
@@ -168,7 +168,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "SET_SIDEBAR_NAV_VISIBILITY",
             hidden: true,
           },
@@ -179,7 +179,7 @@ describe("withS4ACommunication HOC", () => {
 
     wrapper.update()
 
-    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    const props = wrapper.find(TestComponentNaked).prop("hostCommunication")
     expect(props.currentState.hideSidebarNav).toBe(true)
   })
 
@@ -192,7 +192,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "REQUEST_PAGE_CHANGE",
             pageScriptHash: "hash1",
           },
@@ -203,16 +203,16 @@ describe("withS4ACommunication HOC", () => {
     wrapper.update()
 
     const innerComponent = wrapper.find(TestComponentNaked)
-    const props = innerComponent.prop("s4aCommunication")
+    const props = innerComponent.prop("hostCommunication")
     expect(props.currentState.requestedPageScriptHash).toBe("hash1")
 
     act(() => {
-      innerComponent.prop("s4aCommunication").onPageChanged()
+      innerComponent.prop("hostCommunication").onPageChanged()
     })
     wrapper.update()
 
     const innerComponent2 = wrapper.find(TestComponentNaked)
-    const props2 = innerComponent2.prop("s4aCommunication")
+    const props2 = innerComponent2.prop("hostCommunication")
     expect(props2.currentState.requestedPageScriptHash).toBe(null)
   })
 
@@ -225,7 +225,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "SET_PAGE_LINK_BASE_URL",
             pageLinkBaseUrl: "https://share.streamlit.io/vdonato/foo/bar",
           },
@@ -236,7 +236,7 @@ describe("withS4ACommunication HOC", () => {
 
     wrapper.update()
 
-    const props = wrapper.find(TestComponentNaked).prop("s4aCommunication")
+    const props = wrapper.find(TestComponentNaked).prop("hostCommunication")
     expect(props.currentState.pageLinkBaseUrl).toBe(
       "https://share.streamlit.io/vdonato/foo/bar"
     )
@@ -252,7 +252,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "UPDATE_HASH",
             hash: "#somehash",
           },
@@ -271,7 +271,7 @@ describe("withS4ACommunication HOC", () => {
         "message",
         new MessageEvent("message", {
           data: {
-            stCommVersion: S4A_COMM_VERSION,
+            stCommVersion: HOST_COMM_VERSION,
             type: "UPDATE_HASH",
             hash: "#somehash",
           },

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -26,33 +26,33 @@ import {
   IMenuItem,
   IToolbarItem,
   VersionedMessage,
-  S4ACommunicationState,
+  HostCommunicationState,
 } from "./types"
 
-export interface S4ACommunicationHOC {
-  currentState: S4ACommunicationState
+export interface HostCommunicationHOC {
+  currentState: HostCommunicationState
   connect: () => void
   sendMessage: (message: IGuestToHostMessage) => void
   onModalReset: () => void
   onPageChanged: () => void
 }
 
-export const S4A_COMM_VERSION = 1
+export const HOST_COMM_VERSION = 1
 
-export function sendS4AMessage(message: IGuestToHostMessage): void {
+export function sendMessageToHost(message: IGuestToHostMessage): void {
   window.parent.postMessage(
     {
-      stCommVersion: S4A_COMM_VERSION,
+      stCommVersion: HOST_COMM_VERSION,
       ...message,
     } as VersionedMessage<IGuestToHostMessage>,
     "*"
   )
 }
 
-function withS4ACommunication(
+function withHostCommunication(
   WrappedComponent: ComponentType<any>
 ): ComponentType<any> {
-  function ComponentWithS4ACommunication(props: any): ReactElement {
+  function ComponentWithHostCommunication(props: any): ReactElement {
     // TODO(vdonato): Refactor this to use useReducer to make this less
     // unwieldy.
     const [forcedModalClose, setForcedModalClose] = useState(false)
@@ -65,7 +65,7 @@ function withS4ACommunication(
       string | null
     >(null)
     const [sidebarChevronDownshift, setSidebarChevronDownshift] = useState(0)
-    const [streamlitShareMetadata, setStreamlitShareMetadata] = useState({})
+    const [deployedAppMetadata, setDeployedAppMetadata] = useState({})
     const [toolbarItems, setToolbarItems] = useState<IToolbarItem[]>([])
 
     useEffect(() => {
@@ -83,7 +83,7 @@ function withS4ACommunication(
 
         if (
           !origin ||
-          message.stCommVersion !== S4A_COMM_VERSION ||
+          message.stCommVersion !== HOST_COMM_VERSION ||
           !CLOUD_COMM_WHITELIST.find(el => isValidURL(el, origin))
         ) {
           return
@@ -106,7 +106,7 @@ function withS4ACommunication(
         }
 
         if (message.type === "SET_METADATA") {
-          setStreamlitShareMetadata(message.metadata)
+          setDeployedAppMetadata(message.metadata)
         }
 
         if (message.type === "SET_PAGE_LINK_BASE_URL") {
@@ -143,7 +143,7 @@ function withS4ACommunication(
 
     return (
       <WrappedComponent
-        s4aCommunication={
+        hostCommunication={
           {
             currentState: {
               forcedModalClose,
@@ -154,11 +154,11 @@ function withS4ACommunication(
               queryParams,
               requestedPageScriptHash,
               sidebarChevronDownshift,
-              streamlitShareMetadata,
+              deployedAppMetadata,
               toolbarItems,
             },
             connect: () => {
-              sendS4AMessage({
+              sendMessageToHost({
                 type: "GUEST_READY",
               })
             },
@@ -168,20 +168,20 @@ function withS4ACommunication(
             onPageChanged: () => {
               setRequestedPageScriptHash(null)
             },
-            sendMessage: sendS4AMessage,
-          } as S4ACommunicationHOC
+            sendMessage: sendMessageToHost,
+          } as HostCommunicationHOC
         }
         {...props}
       />
     )
   }
 
-  ComponentWithS4ACommunication.displayName = `withS4ACommunication(${WrappedComponent.displayName ||
+  ComponentWithHostCommunication.displayName = `withHostCommunication(${WrappedComponent.displayName ||
     WrappedComponent.name})`
 
   // Static methods must be copied over
   // https://en.reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
-  return hoistNonReactStatics(ComponentWithS4ACommunication, WrappedComponent)
+  return hoistNonReactStatics(ComponentWithHostCommunication, WrappedComponent)
 }
 
-export default withS4ACommunication
+export default withHostCommunication

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -17,7 +17,7 @@
 import { pick } from "lodash"
 import { SessionInfo } from "src/lib/SessionInfo"
 import { initializeSegment } from "src/vendor/Segment"
-import { StreamlitShareMetadata } from "src/hocs/withS4ACommunication/types"
+import { DeployedAppMetadata } from "src/hocs/withHostCommunication/types"
 import { IS_DEV_ENV } from "./baseconsts"
 import { logAlways } from "./log"
 
@@ -80,7 +80,7 @@ export class MetricsManager {
    */
   private appHash = "Not initialized"
 
-  private metadata: StreamlitShareMetadata = {}
+  private metadata: DeployedAppMetadata = {}
 
   /**
    * Singleton MetricsManager object. The reason we're using a singleton here
@@ -231,12 +231,12 @@ export class MetricsManager {
     }
   }
 
-  public setMetadata(metadata: StreamlitShareMetadata): void {
+  public setMetadata(metadata: DeployedAppMetadata): void {
     this.metadata = metadata
   }
 
-  // Use the tracking data injected by S4A if the app is hosted there
-  private getHostTrackingData(): StreamlitShareMetadata {
+  // Use the tracking data injected by the host of the app if included.
+  private getHostTrackingData(): DeployedAppMetadata {
     if (this.metadata) {
       return pick(this.metadata, [
         "hostedAt",


### PR DESCRIPTION
## 📚 Context

This PR renames the withS4ACommunication hoc to withHostCommunication, which
we've wanted to do for awhile now, but it was far from urgent so easy to keep
pushing back until recently.

We wanted to do this for a few reasons

- It feels a bit wrong to have references to a non-open-source product in the
  open source library
  - We still have some shameless plugs to deploy your app via Streamlit
    Community Cloud in other places, but now that we've shifted gears to having
    it be an always-free/never-monetized service for the community, this seems a
    bit more forgivable (especially because the remaining references are more or
    less just links to Community Cloud).
- In theory, the hoc to communicate with a Streamlit's parent iframe could be
  used in a non-Streamlit-Cloud deployment, so its current name is overly
  specific.

When you combine the pre-existing reasons above with the facts that

- we're starting look at improving the Streamlit deployment story in general
- we're working toward a non-Community-Cloud Streamlit deployment environment,

it's probably time to finally rename the component.

- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: component rename

## 🧪 Testing Done

- [x] Added/Updated unit tests
