### PR TITLE
Update deploy app modal

### DIFF
--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from "react"
-import { ONLINE_DOCS_URL, TEAMS_URL } from "src/urls"
+import { ONLINE_DOCS_URL } from "src/urls"
 import { IDeployErrorDialog } from "./types"
 
 function NoRepositoryDetected(): IDeployErrorDialog {
@@ -40,13 +40,6 @@ function NoRepositoryDetected(): IDeployErrorDialog {
               our documentation
             </a>{" "}
             for more details.
-          </li>
-          <li>
-            If you'd like to deploy a private app,{" "}
-            <a href={TEAMS_URL} target="_blank" rel="noopener noreferrer">
-              sign up for Streamlit for Teams
-            </a>
-            .
           </li>
         </ul>
       </>

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/__snapshots__/NoRepositoryDetected.test.tsx.snap
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/__snapshots__/NoRepositoryDetected.test.tsx.snap
@@ -23,18 +23,6 @@ Object {
          
         for more details.
       </li>
-      <li>
-        If you'd like to deploy a private app,
-         
-        <a
-          href="https://streamlit.io/for-teams"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          sign up for Streamlit for Teams
-        </a>
-        .
-      </li>
     </ul>
   </React.Fragment>,
   "title": "Unable to deploy app",


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue reported by @blackary, where if you try to deploy an app that’s not yet on GitHub, you get a note that mentions trying Streamlit for Teams.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Wording change

## 🧠 Description of Changes

- Removed text in `NoRepositoryDetected.tsx`;
- Updated test

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![Screen Shot 2022-09-29 at 9 35 42 AM](https://user-images.githubusercontent.com/34423371/193034106-ed11e05b-a2c0-4128-80c5-c48b91bfccdf.png)

**Current:**

<img width="488" alt="Untitled" src="https://user-images.githubusercontent.com/34423371/193034166-ec54f7fa-160a-40e8-bdcc-5e2f2d95482d.png">

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- https://www.notion.so/streamlit/Deploy-modal-mentions-signing-up-for-Streamlit-for-Teams-ffc68f5dd2b143dca77103f919a4f986

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
