### PR TITLE
Add me as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, that is.
-* @streamlit/core
+* @streamlit/core @LukasMasuch
 frontend/package.json @jroes @anoctopus @tconkling @kmcgrady
 lib/Pipfile @jroes @anoctopus @tconkling @kmcgrady
 lib/setup.py @jroes @anoctopus @tconkling @kmcgrady


### PR DESCRIPTION
## 📚 Context

I'm currently testing the new Github setup with Snowflake SSO. Thereby, I'm not anymore part of the `streamlit/core` team since outside collaborators cannot be added to organization teams. We might need to manually add all core developers here

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
