### PR TITLE
Refactor current session behavior into WebsocketSessionManager

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -558,7 +558,7 @@ class Runtime:
             # NOTE: We want to fully shut down sessions when the runtime stops for now,
             # but this may change in the future if/when our notion of a session is no
             # longer so tightly coupled to a browser tab.
-            for session_info in self._session_mgr.list_active_sessions():
+            for session_info in self._session_mgr.list_sessions():
                 self._session_mgr.close_session(session_info.session.id)
 
             self._set_state(RuntimeState.STOPPED)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -44,7 +44,7 @@ from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 from streamlit.type_util import ValueFieldName, is_array_value_field_name
 
 if TYPE_CHECKING:
-    from streamlit.runtime.session_manager import SessionInfo
+    from streamlit.runtime.session_manager import SessionManager
 
 
 T = TypeVar("T")
@@ -691,11 +691,11 @@ def require_valid_user_key(key: str) -> None:
 
 @dataclass
 class SessionStateStatProvider(CacheStatsProvider):
-    _session_info_by_id: Dict[str, "SessionInfo"]
+    _session_mgr: "SessionManager"
 
     def get_stats(self) -> List[CacheStat]:
         stats: List[CacheStat] = []
-        for session_info in self._session_info_by_id.values():
+        for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state
             stats.extend(session_state.get_stats())
         return stats

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -1,0 +1,97 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Dict, List, Optional
+
+from typing_extensions import Final
+
+from streamlit.logger import get_logger
+from streamlit.runtime.app_session import AppSession
+from streamlit.runtime.session_data import SessionData
+from streamlit.runtime.session_manager import (
+    SessionClient,
+    SessionInfo,
+    SessionManager,
+    SessionStorage,
+)
+from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+from streamlit.watcher import LocalSourcesWatcher
+
+LOGGER: Final = get_logger(__name__)
+
+
+class WebsocketSessionManager(SessionManager):
+    def __init__(
+        self,
+        session_storage: SessionStorage,
+        uploaded_file_manager: UploadedFileManager,
+        message_enqueued_callback: Optional[Callable[[], None]],
+    ) -> None:
+        # NOTE: We intentionally don't do anything with session_storage for now as we
+        # will initially implement WebsocketSessionManager so the current runtime
+        # session handling behavior is unchanged.
+        #
+        # A concrete session_storage class will be implemented and used in subsequent
+        # changes when we add session reuse on a websocket reconnect.
+        #
+        # Since we aren't worrying about session reconnects yet, we don't need to
+        # differentiate between active and inactive sessions and can provide the minimal
+        # implementation of a SessionManager below.
+
+        self._uploaded_file_mgr = uploaded_file_manager
+        self._message_enqueued_callback = message_enqueued_callback
+
+        # Mapping of AppSession.id -> SessionInfo.
+        self._session_info_by_id: Dict[str, SessionInfo] = {}
+
+    def connect_session(
+        self,
+        client: SessionClient,
+        session_data: SessionData,
+        user_info: Dict[str, Optional[str]],
+        existing_session_id: Optional[str] = None,  # unused for now
+    ) -> str:
+        session = AppSession(
+            session_data=session_data,
+            uploaded_file_manager=self._uploaded_file_mgr,
+            message_enqueued_callback=self._message_enqueued_callback,
+            local_sources_watcher=LocalSourcesWatcher(session_data.main_script_path),
+            user_info=user_info,
+        )
+
+        LOGGER.debug(
+            "Created new session for client %s. Session ID: %s", id(client), session.id
+        )
+
+        assert (
+            session.id not in self._session_info_by_id
+        ), f"session.id '{session.id}' registered multiple times!"
+
+        self._session_info_by_id[session.id] = SessionInfo(client, session)
+        return session.id
+
+    def close_session(self, session_id: str) -> None:
+        if session_id in self._session_info_by_id:
+            session_info = self._session_info_by_id[session_id]
+            del self._session_info_by_id[session_id]
+            session_info.session.shutdown()
+
+    def get_session_info(self, session_id: str) -> Optional[SessionInfo]:
+        return self._session_info_by_id.get(session_id, None)
+
+    def list_sessions(self) -> List[SessionInfo]:
+        # Shallow-clone our sessions into a list, so we can iterate
+        # over it and not worry about whether it's being changed
+        # outside this coroutine.
+        return list(self._session_info_by_id.values())

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -35,6 +35,7 @@ from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
+from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
@@ -176,6 +177,7 @@ class Server:
                 script_path=main_script_path,
                 command_line=command_line,
                 media_file_storage=media_file_storage,
+                session_manager_class=WebsocketSessionManager,
             ),
         )
 

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -124,7 +124,9 @@ class RuntimeTest(RuntimeTestCase):
             session_id = self.runtime.create_session(
                 client=MockSessionClient(), user_info=MagicMock()
             )
-            app_session = self.runtime._get_session_info(session_id).session
+            app_session = self.runtime._session_mgr.get_active_session_info(
+                session_id
+            ).session
 
             # Close the session. AppSession.shutdown should be called.
             self.runtime.close_session(session_id)
@@ -194,7 +196,9 @@ class RuntimeTest(RuntimeTestCase):
                 session_id = self.runtime.create_session(
                     MockSessionClient(), MagicMock()
                 )
-                app_session = self.runtime._get_session_info(session_id).session
+                app_session = self.runtime._session_mgr.get_active_session_info(
+                    session_id
+                ).session
                 app_sessions.append(app_session)
 
             # Sanity check
@@ -221,7 +225,9 @@ class RuntimeTest(RuntimeTestCase):
             back_msg = MagicMock()
             self.runtime.handle_backmsg(session_id, back_msg)
 
-            app_session = self.runtime._get_session_info(session_id).session
+            app_session = self.runtime._session_mgr.get_active_session_info(
+                session_id
+            ).session
             app_session.handle_backmsg.assert_called_once_with(back_msg)
 
     async def test_handle_backmsg_invalid_session(self):
@@ -242,7 +248,9 @@ class RuntimeTest(RuntimeTestCase):
             exception = MagicMock()
             self.runtime.handle_backmsg_deserialization_exception(session_id, exception)
 
-            app_session = self.runtime._get_session_info(session_id).session
+            app_session = self.runtime._session_mgr.get_active_session_info(
+                session_id
+            ).session
             app_session.handle_backmsg_exception.assert_called_once_with(exception)
 
     async def test_handle_backmsg_exception_invalid_session(self):
@@ -514,6 +522,7 @@ class ScriptCheckTest(RuntimeTestCase):
             script_path=self._path,
             command_line="mock command line",
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
+            session_manager_class=MagicMock,
         )
         self.runtime = Runtime(config)
         await self.runtime.start()

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -185,6 +185,8 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.close_session(session_id)
         self.assertFalse(self.runtime.is_active_session(session_id))
 
+    # TODO(vdonato): Change this test to verify that *all* AppSessions (both active and
+    # inactive) are shut down when the Runtime stops.
     async def test_shutdown_appsessions_on_stop(self):
         """When the Runtime stops, it should shut down open AppSessions."""
         with self.patch_app_session():

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -45,7 +45,10 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                 # so that the main thread can retrieve it safely. If Runtime
                 # creation fails, we'll stick an Exception in the queue instead.
                 config = RuntimeConfig(
-                    "mock/script/path.py", "", media_file_storage=MagicMock()
+                    "mock/script/path.py",
+                    "",
+                    media_file_storage=MagicMock(),
+                    session_manager_class=MagicMock(),
                 )
                 queue.put(Runtime(config))
             except BaseException as e:

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -1,0 +1,18 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We intentionally neglect to write tests for this class for now as we'll be
+# waiting to merge these changes into `develop` until after we finish implementing
+# improved websocket reconnects, after which we would have to rewrite all of these tests
+# if we were to add some now.

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -38,7 +38,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get our connected BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler = session_info.client
             self.assertIsInstance(websocket_handler, BrowserWebSocketHandler)
 
@@ -70,8 +70,8 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.server.start()
             await self.ws_connect()
 
-            # Get our BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            # Get our connected BrowserWebSocketHandler
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler: BrowserWebSocketHandler = session_info.client
 
             mock_runtime = MagicMock(spec=Runtime)

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -102,8 +102,8 @@ class ServerTest(ServerTestCase):
             self.assertTrue(self.server.browser_is_connected)
 
             # Get this client's SessionInfo object
-            self.assertEqual(1, len(self.server._runtime._session_info_by_id))
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            self.assertEqual(1, self.server._runtime._session_mgr.num_active_sessions())
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
 
             # Close the connection
             ws_client.close()
@@ -113,7 +113,7 @@ class ServerTest(ServerTestCase):
             # Ensure AppSession.shutdown() was called, and that our
             # SessionInfo was cleared.
             session_info.session.shutdown.assert_called_once()
-            self.assertEqual(0, len(self.server._runtime._session_info_by_id))
+            self.assertEqual(0, self.server._runtime._session_mgr.num_active_sessions())
 
     @tornado.testing.gen_test
     async def test_multiple_connections(self):
@@ -132,7 +132,7 @@ class ServerTest(ServerTestCase):
             self.assertTrue(self.server.browser_is_connected)
 
             # Assert that our session_infos are sane
-            session_infos = list(self.server._runtime._session_info_by_id.values())
+            session_infos = self.server._runtime._session_mgr.list_active_sessions()
             self.assertEqual(2, len(session_infos))
             self.assertNotEqual(
                 session_infos[0].session.id,
@@ -190,7 +190,7 @@ class ServerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get the server's socket and session for this client
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
 
             with patch.object(
                 session_info.session, "flush_browser_queue"
@@ -217,7 +217,9 @@ class ServerTest(ServerTestCase):
                 # Our session should have been removed from the server as
                 # a result of the WebSocketClosedError.
                 self.assertIsNone(
-                    self.server._runtime._get_session_info(session_info.session.id)
+                    self.server._runtime._session_mgr.get_active_session_info(
+                        session_info.session.id
+                    )
                 )
 
 

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -102,7 +102,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         """
 
         return mock.patch(
-            "streamlit.runtime.runtime.AppSession",
+            "streamlit.runtime.websocket_session_manager.AppSession",
             # new_callable must return a function, not an object, or else
             # there will only be a single AppSession mock. Hence the lambda.
             new_callable=lambda: self._create_mock_app_session,

--- a/lib/tests/streamlit/web/server/websocket_headers_test.py
+++ b/lib/tests/streamlit/web/server/websocket_headers_test.py
@@ -34,10 +34,12 @@ class WebSocketHeadersTest(ServerTestCase):
             await self.server.start()
             await self.ws_connect()
 
+            session_mgr = self.server._runtime._session_mgr
+
             # Get our client's session_id and some other stuff
-            self.assertEqual(1, len(self.server._runtime._session_info_by_id))
-            session_id = list(self.server._runtime._session_info_by_id.keys())[0]
-            session_info = self.server._runtime._session_info_by_id[session_id]
+            self.assertEqual(1, session_mgr.num_active_sessions())
+            session_info = session_mgr.list_active_sessions()[0]
+            session_id = session_info.session.id
             self.assertIsInstance(session_info.client, BrowserWebSocketHandler)
 
             # Mock get_script_run_ctx() to return our session_id


### PR DESCRIPTION
Note: This PR depends on #5486, which should be reviewed first.

## 📚 Context

This PR continues the work to replace our current session implementation, where the `Runtime`
manually manipulates sessions, with one where it defers much of the work to the new
`SessionManager` protocol.

In this step, we more or less just copy-paste the current implementation into a new
`WebsocketSessionManager` class with essentially no changes.

There's quite a bit omitted from the set of changes made in this PR which I plan to wrap up in
followup PRs (note this is all going into a feature branch). The TODOs are all contained in the code,
but I'll list them here for convenience: 

* We're currently just passing `None` as the first argument of the runtime's `SessionManager` (instead
  of a `SessionStorage` instance) since our current `WebsocketSessionManager` implementation doesn't
  do anything with its first arg. This should be fixed once we've implemented the `MemorySessionStore`
  class.
* Think through what the correct thread safety assumptions for `SessionManager` methods should be.
* Rename `Runtime.create_session` -> `Runtime.connect_session` for consistency with `SessionManager`
* Actually implement websocket reconnect improvements
* Write tests for `WebsocketConnectionManager` (no use writing any now since we'll be making a bunch
   of behavioral changes soon).
* Use a new `MockSessionManager` in runtime tests so that they don't depend on a concrete 
   `SessionManager` implementation

-----

- What kind of change does this PR introduce?

  - [x] Refactoring

## 🧪 Testing Done

- [x] Added/Updated unit tests
