### PR TITLE
Remove optional-checks from code that works with `SessionInfo`

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -457,6 +457,9 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
+        # NOTE: We create an AppSession directly here instead of using the
+        # SessionManager intentionally. This isn't a "real" session and is only being
+        # used to test that the script runs without error.
         session = AppSession(
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, cast
 
 from typing_extensions import Protocol
 
@@ -43,6 +43,19 @@ class SessionClient(Protocol):
 
 
 @dataclass
+class ActiveSessionInfo:
+    """Type containing data related to an active session.
+
+    This type is nearly identical to SessionInfo. The difference is that when using it,
+    we are guaranteed that SessionClient is not None.
+    """
+
+    client: SessionClient
+    session: AppSession
+    script_run_count: int = 0
+
+
+@dataclass
 class SessionInfo:
     """Type containing data related to an AppSession.
 
@@ -54,6 +67,13 @@ class SessionInfo:
     client: Optional[SessionClient]
     session: AppSession
     script_run_count: int = 0
+
+    def is_active(self) -> bool:
+        return self.client is not None
+
+    def to_active(self) -> ActiveSessionInfo:
+        assert self.is_active(), "A SessionInfo with no client cannot be active!"
+        return cast(ActiveSessionInfo, self)
 
 
 class SessionStorageError(Exception):
@@ -312,9 +332,9 @@ class SessionManager(Protocol):
         """
         self.close_session(session_id)
 
-    def get_active_session_info(self, session_id: str) -> Optional[SessionInfo]:
-        """Return the SessionInfo for the given id, or None if either no such session
-        exists or the session is not active.
+    def get_active_session_info(self, session_id: str) -> Optional[ActiveSessionInfo]:
+        """Return the ActiveSessionInfo for the given id, or None if either no such
+        session exists or the session is not active.
 
         Parameters
         ----------
@@ -323,9 +343,12 @@ class SessionManager(Protocol):
 
         Returns
         -------
-        SessionInfo or None
+        ActiveSessionInfo or None
         """
-        return self.get_session_info(session_id)
+        session = self.get_session_info(session_id)
+        if session is None or not session.is_active():
+            return None
+        return session.to_active()
 
     def is_active_session(self, session_id: str) -> bool:
         """Return True if the given session exists and is active, False otherwise.
@@ -336,14 +359,14 @@ class SessionManager(Protocol):
         """
         return self.get_active_session_info(session_id) is not None
 
-    def list_active_sessions(self) -> List[SessionInfo]:
-        """Return the SessionInfo for all active sessions tracked by this SessionManager.
+    def list_active_sessions(self) -> List[ActiveSessionInfo]:
+        """Return the session info for all active sessions tracked by this SessionManager.
 
         Returns
         -------
-        List[SessionInfo]
+        List[ActiveSessionInfo]
         """
-        return self.list_sessions()
+        return [s.to_active() for s in self.list_sessions()]
 
     def num_active_sessions(self) -> int:
         """Return the number of active sessions tracked by this SessionManager.


### PR DESCRIPTION
Note: This PR depends on #5451, which should be reviewed first.

## 📚 Context

In a previous change, I made the `client` field of the `SessionInfo` class optional, which
felt a bit bad since it seems tedious to have code that manipulates `SessionInfo` instances
have to check to see if `client is None` all the time.

This PR improves the situation by introducing a new `ActiveSessionInfo` class, which is nearly
identical to `SessionInfo` but has a non-optional `client` field. The active-session versions of
`SessionManager` methods now return the new type, and their default implementations assert
that all of the `SessionInfo` returned by the corresponding methods have their `client` fields set
before converting them from `SessionInfo` -> `ActiveSessionInfo`.

This should allow us to drop a bunch of the `None` checks while still having a high chance of catching
any mistakes -- they should only be possible when an active-session method falls back to the default
implementation, and potential mistakes in that scenario should be easily caught by unit tests.


- What kind of change does this PR introduce?

  - [x] Refactoring
  - [x] Other, please describe: type improvements
