### PR TITLE
_get_websocket_headers()

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -222,6 +222,19 @@ class Runtime:
         """A Future that completes when the Runtime's run loop has exited."""
         return self._get_async_objs().stopped
 
+    def get_client(self, session_id: str) -> Optional[SessionClient]:
+        """Get the SessionClient for the given session_id, or None
+        if no such session exists.
+
+        Notes
+        -----
+        Threading: SAFE. May be called on any thread.
+        """
+        session_info = self._get_session_info(session_id)
+        if session_info is None:
+            return None
+        return session_info.client
+
     def _on_files_updated(self, session_id: str) -> None:
         """Event handler for UploadedFileManager.on_file_added.
         Ensures that uploaded files from stale sessions get deleted.

--- a/lib/streamlit/web/server/websocket_headers.py
+++ b/lib/streamlit/web/server/websocket_headers.py
@@ -15,10 +15,12 @@
 from streamlit import runtime
 from typing import Optional, Dict
 
+from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
 
 
+@gather_metrics
 def _get_websocket_headers() -> Optional[Dict[str, str]]:
     """Return a copy of the HTTP request headers for the current session's
     WebSocket connection. If there's no active session, return None instead.

--- a/lib/streamlit/web/server/websocket_headers.py
+++ b/lib/streamlit/web/server/websocket_headers.py
@@ -21,7 +21,7 @@ from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandl
 
 def _get_websocket_headers() -> Optional[Dict[str, str]]:
     """Return a copy of the HTTP request headers for the current session's
-    WebSocket connection.
+    WebSocket connection. If there's no active session, return None instead.
 
     Raise an error if the server is not running.
 

--- a/lib/streamlit/web/server/websocket_headers.py
+++ b/lib/streamlit/web/server/websocket_headers.py
@@ -1,0 +1,45 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit import runtime
+from typing import Optional, Dict
+
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
+
+
+def _get_websocket_headers() -> Optional[Dict[str, str]]:
+    """Return a copy of the HTTP request headers for the current session's
+    WebSocket connection.
+
+    Raise an error if the server is not running.
+
+    Note to the intrepid: this is an UNSUPPORTED, INTERNAL API. (We don't have plans
+    to remove it without a replacement, but we don't consider this a production-ready
+    function, and its signature may change without a deprecation warning.)
+    """
+    ctx = get_script_run_ctx()
+    if ctx is None:
+        return None
+
+    session_client = runtime.get_instance().get_client(ctx.session_id)
+    if session_client is None:
+        return None
+
+    if not isinstance(session_client, BrowserWebSocketHandler):
+        raise RuntimeError(
+            f"SessionClient is not a BrowserWebSocketHandler! ({session_client})"
+        )
+
+    return dict(session_client.request.headers)

--- a/lib/tests/streamlit/web/server/websocket_headers_test.py
+++ b/lib/tests/streamlit/web/server/websocket_headers_test.py
@@ -53,7 +53,7 @@ class WebSocketHeadersTest(ServerTestCase):
                 self.assertEqual(headers, dict(session_info.client.request.headers))
 
                 # Assert the presence of some (arbitrary) headers that should always
-                # be present in a WebSocket request.
+                # be in a WebSocket request.
                 self.assertIn("Host", headers)
                 self.assertIn("Upgrade", headers)
                 self.assertIn("Connection", headers)

--- a/lib/tests/streamlit/web/server/websocket_headers_test.py
+++ b/lib/tests/streamlit/web/server/websocket_headers_test.py
@@ -1,0 +1,59 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+import tornado.testing
+import tornado.websocket
+
+from streamlit.runtime.scriptrunner import ScriptRunContext
+from streamlit.web.server import websocket_headers
+from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
+from .server_test_case import ServerTestCase
+
+
+class WebSocketHeadersTest(ServerTestCase):
+    @tornado.testing.gen_test
+    async def test_get_websocket_headers(self):
+        """`get_websocket_headers()` returns the current session's
+        `BrowserWebSocketHandler.request.headers`.
+        """
+        with self._patch_app_session():
+            await self.server.start()
+            await self.ws_connect()
+
+            # Get our client's session_id and some other stuff
+            self.assertEqual(1, len(self.server._runtime._session_info_by_id))
+            session_id = list(self.server._runtime._session_info_by_id.keys())[0]
+            session_info = self.server._runtime._session_info_by_id[session_id]
+            self.assertIsInstance(session_info.client, BrowserWebSocketHandler)
+
+            # Mock get_script_run_ctx() to return our session_id
+            mock_script_run_ctx = MagicMock(spec=ScriptRunContext)
+            mock_script_run_ctx.session_id = session_id
+            with mock.patch(
+                "streamlit.web.server.websocket_headers.get_script_run_ctx",
+                return_value=mock_script_run_ctx,
+            ):
+                # Assert that our headers are equal to our BrowserWebSocketHandler's
+                # request headers.
+                headers = websocket_headers._get_websocket_headers()
+                self.assertEqual(headers, dict(session_info.client.request.headers))
+
+                # Assert the presence of some (arbitrary) headers that should always
+                # be present in a WebSocket request.
+                self.assertIn("Host", headers)
+                self.assertIn("Upgrade", headers)
+                self.assertIn("Connection", headers)


### PR DESCRIPTION
Adds a new "internal" (i.e.: subject to change without deprecation!) API:

```python
import streamlit as st
from streamlit.web.server.websocket_headers import _get_websocket_headers

headers = _get_websocket_headers()
access_token = headers.get("X-Access-Token")
if access_token is not None:
  # authenticate the user or whatever
  ...
```

This function returns a copy of the headers from the current session's incoming WebSocket request. This unblocks users that were previously relying on a hack, involving the (since removed) server singleton instance, to retrieve the headers for auth purposes (see https://github.com/streamlit/streamlit/issues/5166).

This function is underscore-prefixed to make it clear that this is _not_ an official part of the Streamlit API. We have a unit test running against it so that we don't accidentally break it, but it doesn't currently meet the product standards of even our "experimental" APIs (so we're not going to broadcast its existence).

Closes https://github.com/streamlit/streamlit/issues/5166 (but NOT https://github.com/streamlit/streamlit/issues/1083, which will only be closed when we have an official API to do this).