### PR TITLE
Add heading type to elements list

### DIFF
--- a/lib/streamlit/elements/__init__.py
+++ b/lib/streamlit/elements/__init__.py
@@ -51,6 +51,7 @@ NONWIDGET_ELEMENTS = [
     "empty",
     "exception",
     "graphviz_chart",
+    "heading",
     "iframe",
     "json",
     "legacy_altair",


### PR DESCRIPTION
## 📚 Context

The newly introduced `heading` type (for `st.header`, `st.subheader`) is missing from the non-widgets elements list. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
