### PR TITLE
Allow auth token to be passed from parent to header when app is in an iframe

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -331,6 +331,19 @@ describe("App", () => {
     })
   })
 
+  it("sends WEBSOCKET_DISCONNECTED message to the host when the connection to the server is dropped", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+    const app = wrapper.instance() as App
+
+    app.handleConnectionStateChanged(ConnectionState.CONNECTED)
+    app.handleConnectionStateChanged(ConnectionState.PINGING_SERVER)
+
+    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
+      type: "WEBSOCKET_DISCONNECTED",
+    })
+  })
+
   it("both sets theme locally and sends to host when setAndSendTheme is called", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -320,11 +320,11 @@ describe("App", () => {
     expect(wrapper.find(Modal)).toHaveLength(1)
   })
 
-  it("sends the active theme to the host when the app is first rendered", () => {
+  it("sends initialization messages to the host when the app is first rendered", () => {
     const props = getProps()
     shallow(<App {...props} />)
 
-    // @ts-ignore
+    expect(props.hostCommunication.connect).toHaveBeenCalled()
     expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(lightTheme.emotion),
@@ -409,6 +409,30 @@ describe("App", () => {
     expect(
       props.hostCommunication.currentState.requestedPageScriptHash
     ).toBeNull()
+  })
+
+  it("should return the auth token set in hostCommunication from getHostAuthToken", () => {
+    const props = getProps()
+    const wrapper = shallow(<App {...props} />)
+
+    // Use setProps (vs setting the auth token on component rendered) to
+    // simulate the auth token changing after the withHostCommunication hoc
+    // initially loads.
+    wrapper.setProps(
+      getProps({
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({
+            authToken: "verySecureAuthToken",
+          }),
+        }),
+      })
+    )
+    wrapper.update()
+
+    const instance = wrapper.instance() as App
+
+    // @ts-ignore
+    expect(instance.getHostAuthToken()).toBe("verySecureAuthToken")
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -280,12 +280,17 @@ export class App extends PureComponent<Props, State> {
       onMessage: this.handleMessage,
       onConnectionError: this.handleConnectionError,
       connectionStateChanged: this.handleConnectionStateChanged,
+      // TODO(vdonato): Test for this function
+      getHostAuthToken: () =>
+        this.props.hostCommunication.currentState.authToken,
     })
 
     if (isEmbeddedInIFrame()) {
       document.body.classList.add("embedded")
     }
 
+    // TODO(vdonato): Test that this message is sent.
+    this.props.hostCommunication.connect() // TODO: Verify that this is safe to move here (I'm pretty sure it is)
     this.props.hostCommunication.sendMessage({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(this.props.theme.activeTheme.emotion),
@@ -760,7 +765,6 @@ export class App extends PureComponent<Props, State> {
       pythonVersion: SessionInfo.current.pythonVersion,
     })
 
-    this.props.hostCommunication.connect()
     this.handleSessionStateChanged(initialize.sessionState)
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,6 +368,17 @@ export class App extends PureComponent<Props, State> {
       `Connection state changed from ${this.state.connectionState} to ${newState}`
     )
 
+    const { connectionState: currState } = this.state
+
+    if (
+      currState === ConnectionState.CONNECTED &&
+      newState === ConnectionState.PINGING_SERVER
+    ) {
+      this.props.hostCommunication.sendMessage({
+        type: "WEBSOCKET_DISCONNECTED",
+      })
+    }
+
     this.setState({ connectionState: newState })
 
     if (newState === ConnectionState.CONNECTED) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -280,17 +280,14 @@ export class App extends PureComponent<Props, State> {
       onMessage: this.handleMessage,
       onConnectionError: this.handleConnectionError,
       connectionStateChanged: this.handleConnectionStateChanged,
-      // TODO(vdonato): Test for this function
-      getHostAuthToken: () =>
-        this.props.hostCommunication.currentState.authToken,
+      getHostAuthToken: this.getHostAuthToken,
     })
 
     if (isEmbeddedInIFrame()) {
       document.body.classList.add("embedded")
     }
 
-    // TODO(vdonato): Test that this message is sent.
-    this.props.hostCommunication.connect() // TODO: Verify that this is safe to move here (I'm pretty sure it is)
+    this.props.hostCommunication.connect()
     this.props.hostCommunication.sendMessage({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(this.props.theme.activeTheme.emotion),
@@ -1174,6 +1171,12 @@ export class App extends PureComponent<Props, State> {
       logError(`Not connected. Cannot send back message: ${msg}`)
     }
   }
+
+  /**
+   * Returns the authToken set by the withHostCommunication hoc.
+   */
+  private getHostAuthToken = (): string | undefined =>
+    this.props.hostCommunication.currentState.authToken
 
   /**
    * Updates the app body when there's a connection error.

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -28,6 +28,8 @@ export type DeployedAppMetadata = {
 }
 
 export interface HostCommunicationState {
+  authToken?: string
+  deployedAppMetadata: DeployedAppMetadata
   forcedModalClose: boolean
   hideSidebarNav: boolean
   isOwner: boolean
@@ -36,7 +38,6 @@ export interface HostCommunicationState {
   queryParams: string
   requestedPageScriptHash: string | null
   sidebarChevronDownshift: number
-  deployedAppMetadata: DeployedAppMetadata
   toolbarItems: IToolbarItem[]
 }
 
@@ -66,6 +67,10 @@ export type IHostToGuestMessage = {
   | {
       type: "REQUEST_PAGE_CHANGE"
       pageScriptHash: string
+    }
+  | {
+      type: "SET_AUTH_TOKEN"
+      authToken: string
     }
   | {
       type: "SET_IS_OWNER"

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -151,6 +151,9 @@ export type IGuestToHostMessage =
       type: "UPDATE_HASH"
       hash: string
     }
+  | {
+      type: "WEBSOCKET_DISCONNECTED"
+    }
 
 export type VersionedMessage<Message> = {
   stCommVersion: number

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -242,6 +242,30 @@ describe("withHostCommunication HOC", () => {
     )
   })
 
+  it("can process a received SET_AUTH_TOKEN message", () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    act(() => {
+      dispatchEvent(
+        "message",
+        new MessageEvent("message", {
+          data: {
+            stCommVersion: HOST_COMM_VERSION,
+            type: "SET_AUTH_TOKEN",
+            authToken: "i am an auth token",
+          },
+          origin: "http://devel.streamlit.test",
+        })
+      )
+    })
+
+    wrapper.update()
+
+    const props = wrapper.find(TestComponentNaked).prop("hostCommunication")
+    expect(props.currentState.authToken).toBe("i am an auth token")
+  })
+
   describe("Test different origins", () => {
     it("exact pattern", () => {
       const dispatchEvent = mockEventListeners()

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -62,8 +62,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("host should receive a GUEST_READY message", done => {
-    shallow(<TestComponent />)
-
     const listener = (event: MessageEvent): void => {
       expect(event.data).toStrictEqual({
         stCommVersion: HOST_COMM_VERSION,
@@ -75,13 +73,21 @@ describe("withHostCommunication HOC", () => {
     }
 
     window.addEventListener("message", listener)
+
+    shallow(<TestComponent />)
+  })
+})
+
+describe("withHostCommunication HOC receiving messages", () => {
+  let dispatchEvent: any
+  let wrapper: any
+
+  beforeEach(() => {
+    dispatchEvent = mockEventListeners()
+    wrapper = mount(<TestComponent />)
   })
 
   it("should respond to UPDATE_HASH message", () => {
-    const dispatchEvent = mockEventListeners()
-
-    mount(<TestComponent />)
-
     dispatchEvent(
       "message",
       new MessageEvent("message", {
@@ -98,9 +104,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("can process a received SET_TOOLBAR_ITEMS message", () => {
-    const dispatchEvent = mockEventListeners()
-    const wrapper = mount(<TestComponent />)
-
     act(() => {
       dispatchEvent(
         "message",
@@ -136,9 +139,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("can process a received SET_SIDEBAR_CHEVRON_DOWNSHIFT message", () => {
-    const dispatchEvent = mockEventListeners()
-    const wrapper = mount(<TestComponent />)
-
     act(() => {
       dispatchEvent(
         "message",
@@ -160,9 +160,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("can process a received SET_SIDEBAR_NAV_VISIBILITY message", () => {
-    const dispatchEvent = mockEventListeners()
-    const wrapper = mount(<TestComponent />)
-
     act(() => {
       dispatchEvent(
         "message",
@@ -184,9 +181,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("can process a received REQUEST_PAGE_CHANGE message", () => {
-    const dispatchEvent = mockEventListeners()
-    const wrapper = mount(<TestComponent />)
-
     act(() => {
       dispatchEvent(
         "message",
@@ -217,9 +211,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("can process a received SET_PAGE_LINK_BASE_URL message", () => {
-    const dispatchEvent = mockEventListeners()
-    const wrapper = mount(<TestComponent />)
-
     act(() => {
       dispatchEvent(
         "message",
@@ -243,9 +234,6 @@ describe("withHostCommunication HOC", () => {
   })
 
   it("can process a received SET_AUTH_TOKEN message", () => {
-    const dispatchEvent = mockEventListeners()
-    const wrapper = mount(<TestComponent />)
-
     act(() => {
       dispatchEvent(
         "message",
@@ -268,10 +256,6 @@ describe("withHostCommunication HOC", () => {
 
   describe("Test different origins", () => {
     it("exact pattern", () => {
-      const dispatchEvent = mockEventListeners()
-
-      mount(<TestComponent />)
-
       dispatchEvent(
         "message",
         new MessageEvent("message", {
@@ -286,11 +270,8 @@ describe("withHostCommunication HOC", () => {
 
       expect(window.location.hash).toEqual("#somehash")
     })
+
     it("wildcard pattern", () => {
-      const dispatchEvent = mockEventListeners()
-
-      mount(<TestComponent />)
-
       dispatchEvent(
         "message",
         new MessageEvent("message", {

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -54,7 +54,10 @@ function withHostCommunication(
 ): ComponentType<any> {
   function ComponentWithHostCommunication(props: any): ReactElement {
     // TODO(vdonato): Refactor this to use useReducer to make this less
-    // unwieldy.
+    // unwieldy. We may want to consider installing the redux-toolkit package
+    // even if we're not using redux just because it's so useful for reducing
+    // this type of boilerplate.
+    const [authToken, setAuthToken] = useState<string | undefined>(undefined)
     const [forcedModalClose, setForcedModalClose] = useState(false)
     const [hideSidebarNav, setHideSidebarNav] = useState(false)
     const [isOwner, setIsOwner] = useState(false)
@@ -95,6 +98,10 @@ function withHostCommunication(
 
         if (message.type === "REQUEST_PAGE_CHANGE") {
           setRequestedPageScriptHash(message.pageScriptHash)
+        }
+
+        if (message.type === "SET_AUTH_TOKEN") {
+          setAuthToken(message.authToken)
         }
 
         if (message.type === "SET_IS_OWNER") {
@@ -146,6 +153,7 @@ function withHostCommunication(
         hostCommunication={
           {
             currentState: {
+              authToken,
               forcedModalClose,
               hideSidebarNav,
               isOwner,

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -44,6 +44,12 @@ interface Props {
    * Called when our ConnectionState is changed.
    */
   connectionStateChanged: (connectionState: ConnectionState) => void
+
+  /**
+   * Function to get the auth token set by the host of this app (if in a
+   * relevant deployment scenario).
+   */
+  getHostAuthToken: () => string | undefined
 }
 
 /**
@@ -145,6 +151,7 @@ export class ConnectionManager {
       onMessage: this.props.onMessage,
       onConnectionStateChange: this.setConnectionState,
       onRetry: this.showRetryError,
+      getHostAuthToken: this.props.getHostAuthToken,
     })
   }
 }

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -461,6 +461,7 @@ describe("WebsocketConnection", () => {
     onMessage: jest.fn(),
     onConnectionStateChange: jest.fn(),
     onRetry: jest.fn(),
+    getHostAuthToken: jest.fn(),
   }
 
   let client: WebsocketConnection
@@ -516,5 +517,49 @@ describe("WebsocketConnection", () => {
     it("returns undefined when ConnectionState != Connected", () => {
       expect(client.getBaseUriParts()).toBeUndefined()
     })
+  })
+})
+
+describe("WebsocketConnection auth token handling", () => {
+  const MOCK_SOCKET_DATA = {
+    baseUriPartsList: [
+      {
+        host: "localhost",
+        port: 1234,
+        basePath: "",
+      },
+    ],
+    onMessage: jest.fn(),
+    onConnectionStateChange: jest.fn(),
+    onRetry: jest.fn(),
+    getHostAuthToken: jest.fn(),
+  }
+
+  let websocketSpy: any
+
+  beforeEach(() => {
+    websocketSpy = jest.spyOn(window, "WebSocket")
+  })
+
+  it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", () => {
+    // eslint-disable-next-line no-new
+    new WebsocketConnection(MOCK_SOCKET_DATA)
+
+    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
+      "streamlit",
+    ])
+  })
+
+  it("sets second Sec-WebSocket-Protocol option to value from getHostAuthToken", () => {
+    // eslint-disable-next-line no-new
+    new WebsocketConnection({
+      ...MOCK_SOCKET_DATA,
+      getHostAuthToken: () => "iAmAnAuthToken",
+    })
+
+    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
+      "streamlit",
+      "iAmAnAuthToken",
+    ])
   })
 })

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -353,7 +353,17 @@ export class WebsocketConnection {
 
     logMessage(LOG, "creating WebSocket")
 
-    // TODO(vdonato): Explanatory comment
+    // NOTE: We repurpose the Sec-WebSocket-Protocol header here in a slightly
+    // unfortunate (but necessary) way. The browser WebSocket API doesn't
+    // allow us to set arbitrary HTTP headers, and this header is the only one
+    // where we have the ability to set it to arbitrary values, so we use it
+    // to pass an auth token from client to server as the *second* value in the
+    // list.
+    //
+    // The reason why the auth token is set as the second value is that, when
+    // Sec-WebSocket-Protocol is set, many clients expect the server to respond
+    // with a selected subprotocol to use. We don't want that reply to be the
+    // auth token, so we just hard-code it to "streamlit".
     const hostAuthToken = this.args.getHostAuthToken()
     this.websocket = new WebSocket(uri, [
       "streamlit",

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -131,8 +131,8 @@ type Event =
   | "FATAL_ERROR" // Unrecoverable error. This should never happen!
 
 /**
- * This class is the "brother" of StaticConnection. The class connects to the
- * server and gets deltas over a websocket connection.
+ * This class connects to the server and gets deltas over a websocket connection.
+ *
  */
 export class WebsocketConnection {
   private readonly args: Args

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -353,12 +353,12 @@ export class WebsocketConnection {
 
     logMessage(LOG, "creating WebSocket")
 
-    // NOTE: We repurpose the Sec-WebSocket-Protocol header here in a slightly
-    // unfortunate (but necessary) way. The browser WebSocket API doesn't
-    // allow us to set arbitrary HTTP headers, and this header is the only one
-    // where we have the ability to set it to arbitrary values, so we use it
-    // to pass an auth token from client to server as the *second* value in the
-    // list.
+    // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
+    // parameter to the WebSocket constructor) here in a slightly unfortunate
+    // but necessary way. The browser WebSocket API doesn't allow us to set
+    // arbitrary HTTP headers, and this header is the only one where we have
+    // the ability to set it to arbitrary values. Thus, we use it to pass an
+    // auth token from client to server as the *second* value in the list.
     //
     // The reason why the auth token is set as the second value is that, when
     // Sec-WebSocket-Protocol is set, many clients expect the server to respond

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -96,6 +96,12 @@ interface Args {
    * Function called when we receive a new message.
    */
   onMessage: OnMessage
+
+  /**
+   * Function to get the auth token set by the host of this app (if in a
+   * relevant deployment scenario).
+   */
+  getHostAuthToken: () => string | undefined
 }
 
 interface MessageQueue {
@@ -346,7 +352,13 @@ export class WebsocketConnection {
     }
 
     logMessage(LOG, "creating WebSocket")
-    this.websocket = new WebSocket(uri)
+
+    // TODO(vdonato): Explanatory comment
+    const hostAuthToken = this.args.getHostAuthToken()
+    this.websocket = new WebSocket(uri, [
+      "streamlit",
+      ...(hostAuthToken ? [hostAuthToken] : []),
+    ])
     this.websocket.binaryType = "arraybuffer"
 
     this.setConnectionTimeout(uri)

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -15,7 +15,14 @@
 import base64
 import binascii
 import json
-from typing import Any, Awaitable, Dict, Optional, Union
+from typing import (
+    Any,
+    Awaitable,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 
 import tornado.concurrent
 import tornado.locks
@@ -60,6 +67,16 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             self.write_message(serialize_forward_msg(msg), binary=True)
         except tornado.websocket.WebSocketClosedError as e:
             raise SessionClientDisconnectedError from e
+
+    def select_subprotocol(self, subprotocols: List[str]) -> Optional[str]:
+        """Return the first subprotocol in the given list.
+
+        TODO: finish docstring and write test.
+        """
+        if subprotocols:
+            return subprotocols[0]
+
+        return None
 
     def open(self, *args, **kwargs) -> Optional[Awaitable[None]]:
         # Extract user info from the X-Streamlit-User header

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -15,14 +15,7 @@
 import base64
 import binascii
 import json
-from typing import (
-    Any,
-    Awaitable,
-    Dict,
-    List,
-    Optional,
-    Union,
-)
+from typing import Any, Awaitable, Dict, List, Optional, Union
 
 import tornado.concurrent
 import tornado.locks
@@ -71,7 +64,16 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
     def select_subprotocol(self, subprotocols: List[str]) -> Optional[str]:
         """Return the first subprotocol in the given list.
 
-        TODO: finish docstring and write test.
+        NOTE: We repurpose the Sec-WebSocket-Protocol header here in a slightly
+        unfortunate (but necessary) way. The browser WebSocket API doesn't allow us to
+        set arbitrary HTTP headers, and this header is the only one where we have the
+        ability to set it to arbitrary values, so we use it to pass an auth token from
+        client to server as the *second* value in the list.
+
+        The reason why the auth token is set as the second value is that, when
+        Sec-WebSocket-Protocol is set, many clients expect the server to respond with a
+        selected subprotocol to use. We don't want that reply to be the auth token, so
+        we just hard-code it to "streamlit".
         """
         if subprotocols:
             return subprotocols[0]

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -64,6 +64,9 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
     def select_subprotocol(self, subprotocols: List[str]) -> Optional[str]:
         """Return the first subprotocol in the given list.
 
+        This method is used by Tornado to select a protocol when the
+        Sec-WebSocket-Protocol header is set in an HTTP Upgrade request.
+
         NOTE: We repurpose the Sec-WebSocket-Protocol header here in a slightly
         unfortunate (but necessary) way. The browser WebSocket API doesn't allow us to
         set arbitrary HTTP headers, and this header is the only one where we have the


### PR DESCRIPTION
## 📚 Context

This PR makes the mildly hacky but unfortunately necessary change of repurposing
the `Sec-WebSocket-Protocol` header to optionally contain an auth token that can be
set by the parent frame of a Streamlit app when the app is embedded in an iframe.

Doing this will also allow us to soon improve reconnect behavior in the pure open source
world, where the header can be used to carry the ID of the `AppSession` that a
browser client is attempting to reconnect to.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests