### PR TITLE
Add test for different Enums with similar members

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -267,7 +267,7 @@ class _CacheFuncHasher:
             return self.to_bytes(dataclasses.asdict(obj))
 
         elif isinstance(obj, Enum):
-            return (str(obj._value_) + str(obj._name_)).encode()
+            return str(obj).encode()
 
         elif type_util.is_type(obj, "pandas.core.frame.DataFrame") or type_util.is_type(
             obj, "pandas.core.series.Series"

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -283,28 +283,31 @@ class HashTest(unittest.TestCase):
         assert get_hash(bar)
 
     def test_enum(self):
+        """The hashing function returns the same result when called with the same
+        Enum members."""
+
         class EnumClass(Enum):
             ENUM_1 = auto()
             ENUM_2 = auto()
 
-        enum_1 = EnumClass.ENUM_1
+        # Hash values should be stable
+        self.assertEqual(get_hash(EnumClass.ENUM_1), get_hash(EnumClass.ENUM_1))
 
-        assert get_hash(enum_1)
+        # Different enum values should produce different hashes
+        self.assertNotEqual(get_hash(EnumClass.ENUM_1), get_hash(EnumClass.ENUM_2))
 
     def test_different_enums(self):
+        """Different enum classes should have different hashes, even when the enum
+        values are the same."""
+
         class EnumClassA(Enum):
             ENUM_1 = "hello"
-            ENUM_2 = "world"
 
         class EnumClassB(Enum):
             ENUM_1 = "hello"
-            ENUM_2 = "world"
 
         enum_a = EnumClassA.ENUM_1
         enum_b = EnumClassB.ENUM_1
-
-        assert get_hash(enum_a)
-        assert get_hash(enum_b)
 
         self.assertNotEqual(get_hash(enum_a), get_hash(enum_b))
 

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -291,6 +291,23 @@ class HashTest(unittest.TestCase):
 
         assert get_hash(enum_1)
 
+    def test_different_enums(self):
+        class EnumClassA(Enum):
+            ENUM_1 = "hello"
+            ENUM_2 = "world"
+
+        class EnumClassB(Enum):
+            ENUM_1 = "hello"
+            ENUM_2 = "world"
+
+        enum_a = EnumClassA.ENUM_1
+        enum_b = EnumClassB.ENUM_1
+
+        assert get_hash(enum_a)
+        assert get_hash(enum_b)
+
+        self.assertNotEqual(get_hash(enum_a), get_hash(enum_b))
+
 
 class NotHashableTest(unittest.TestCase):
     """Tests for various unhashable types. Many of these types *are*


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Follow up PR for https://github.com/streamlit/streamlit/pull/5426 
Computing hash of enum member that way could potentially lead to similar values for different Enum members with same value and name. (Although test that check that scenario pass, but my experiments with python3.8 on replt.it shows that this could be a problem: https://replit.com/join/mcfyoealue-kajarenc

When `obj` is `Enum` member,  `str(obj)` returns `EnumClassName.MemberName` which should be unique. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [X] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
