### PR TITLE
Apply automatic column type fixes for additional errors

### DIFF
--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -380,7 +380,7 @@ def _melt_data(
 
     # Arrow has problems with object types after melting two different dtypes
     # pyarrow.lib.ArrowTypeError: "Expected a <TYPE> object, got a object"
-    data_df = type_util.fix_unsupported_column_types(
+    data_df = type_util.fix_arrow_incompatible_column_types(
         data_df, selected_columns=[x_column, color_column, y_column]
     )
 

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -380,7 +380,7 @@ def _melt_data(
 
     # Arrow has problems with object types after melting two different dtypes
     # pyarrow.lib.ArrowTypeError: "Expected a <TYPE> object, got a object"
-    data_df = type_util.convert_mixed_columns_to_string(
+    data_df = type_util.fix_unsupported_column_types(
         data_df, selected_columns=[x_column, color_column, y_column]
     )
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -73,10 +73,6 @@ class DuplicateWidgetID(StreamlitAPIException):
     pass
 
 
-class NumpyDtypeException(StreamlitAPIException):
-    pass
-
-
 class StreamlitAPIWarning(StreamlitAPIException, Warning):
     """Used to display a warning.
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -564,7 +564,7 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
     try:
         table = pa.Table.from_pandas(df)
     except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError):
-        _LOGGER.warning(
+        _LOGGER.info(
             "Applying automatic fixes for column types to make the dataframe Arrow-compatible."
         )
         df = fix_unsupported_column_types(df)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -540,10 +540,9 @@ def _is_colum_type_unsupported(column: Union[Series, Index]) -> bool:
     # values can be determined via the infer_dtype function:
     # https://pandas.pydata.org/docs/reference/api/pandas.api.types.infer_dtype.html
 
-    if (
+    return (
         column.dtype == "object" and infer_dtype(column) in ["mixed", "mixed-integer"]
-    ) or column.dtype == "complex128":
-        return True
+    ) or column.dtype == "complex128"
 
 
 def fix_unsupported_column_types(

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -544,9 +544,9 @@ def fix_unsupported_column_types(
 
     # Fix the index in case it uses mixed type
     if not selected_columns and (
-        df.index.dtype == "object"
+        not isinstance(df.index, MultiIndex)
+        and df.index.dtype == "object"
         and infer_dtype(df.index).startswith("mixed")
-        and not isinstance(df.index, MultiIndex)
     ):
         df.index = df.index.astype(str)
     return df

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -20,7 +20,6 @@ import pandas as pd
 import plotly.graph_objs as go
 
 from streamlit import type_util
-from streamlit.errors import NumpyDtypeException
 from streamlit.type_util import data_frame_to_bytes, is_bytes_like, to_bytes
 
 
@@ -95,5 +94,7 @@ class TypeUtilTest(unittest.TestCase):
         df1 = pd.DataFrame(["foo", "bar"])
         df2 = pd.DataFrame(df1.dtypes)
 
-        with self.assertRaises(NumpyDtypeException):
+        try:
             data_frame_to_bytes(df2)
+        except Exception as ex:
+            self.fail(f"Converting dtype dataframes to Arrow should not fail: {ex}")

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -114,7 +114,8 @@ class TypeUtilTest(unittest.TestCase):
                 "integer": [1, 2, 3],
                 "float": [1.0, 2.1, 3.2],
                 "string": ["foo", "bar", None],
-            }
+            },
+            index=[1.0, "foo", 3],
         )
 
         fixed_df = fix_unsupported_column_types(df)
@@ -125,6 +126,8 @@ class TypeUtilTest(unittest.TestCase):
         self.assertEqual(infer_dtype(fixed_df["integer"]), "integer")
         self.assertEqual(infer_dtype(fixed_df["float"]), "floating")
         self.assertEqual(infer_dtype(fixed_df["string"]), "string")
+        self.assertEqual(infer_dtype(fixed_df.index), "string")
+
         self.assertEqual(
             str(fixed_df.dtypes),
             """mixed-integer     object
@@ -145,7 +148,8 @@ dtype: object""",
                 "integer": [1, 2, 3],
                 "float": [1.0, 2.1, 3.2],
                 "string": ["foo", "bar", None],
-            }
+            },
+            index=[1.0, "foo", 3],
         )
 
         try:

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -23,7 +23,7 @@ from pandas.api.types import infer_dtype
 from streamlit import type_util
 from streamlit.type_util import (
     data_frame_to_bytes,
-    fix_unsupported_column_types,
+    fix_arrow_incompatible_column_types,
     is_bytes_like,
     to_bytes,
 )
@@ -119,11 +119,11 @@ class TypeUtilTest(unittest.TestCase):
 
         self.assertEqual(infer_dtype(df["complex"]), "complex")
 
-        fixed_df = fix_unsupported_column_types(df)
+        fixed_df = fix_arrow_incompatible_column_types(df)
         self.assertEqual(infer_dtype(fixed_df["complex"]), "string")
 
     def test_fix_mixed_column_types(self):
-        """Test that `fix_unsupported_column_types` correctly fixes
+        """Test that `fix_arrow_incompatible_column_types` correctly fixes
         columns containing mixed types by converting them to string.
         """
         df = pd.DataFrame(
@@ -137,7 +137,7 @@ class TypeUtilTest(unittest.TestCase):
             index=[1.0, "foo", 3],
         )
 
-        fixed_df = fix_unsupported_column_types(df)
+        fixed_df = fix_arrow_incompatible_column_types(df)
 
         self.assertEqual(infer_dtype(fixed_df["mixed-integer"]), "string")
         self.assertEqual(infer_dtype(fixed_df["mixed"]), "string")

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -135,3 +135,23 @@ float            float64
 string            object
 dtype: object""",
         )
+
+    def test_data_frame_with_unsupported_column_types(self):
+        df = pd.DataFrame(
+            {
+                "mixed-integer": [1, "foo", 3],
+                "mixed": [1.0, "foo", 3],
+                "complex": [1 + 2j, 3 + 4j, 5 + 6 * 1j],
+                "integer": [1, 2, 3],
+                "float": [1.0, 2.1, 3.2],
+                "string": ["foo", "bar", None],
+            }
+        )
+
+        try:
+            data_frame_to_bytes(df)
+        except Exception as ex:
+            self.fail(
+                "No exception should have been thrown here. "
+                f"Unsupported types of this dataframe should have been automatically fixed: {ex}"
+            )

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -106,6 +106,9 @@ class TypeUtilTest(unittest.TestCase):
             self.fail(f"Converting dtype dataframes to Arrow should not fail: {ex}")
 
     def test_fix_complex_column_type(self):
+        """Test that `fix_unsupported_column_types` correctly fixes
+        columns containing complex types by converting them to string.
+        """
         df = pd.DataFrame(
             {
                 "complex": [1 + 2j, 3 + 4j, 5 + 6 * 1j],
@@ -120,6 +123,9 @@ class TypeUtilTest(unittest.TestCase):
         self.assertEqual(infer_dtype(fixed_df["complex"]), "string")
 
     def test_fix_mixed_column_types(self):
+        """Test that `fix_unsupported_column_types` correctly fixes
+        columns containing mixed types by converting them to string.
+        """
         df = pd.DataFrame(
             {
                 "mixed-integer": [1, "foo", 3],
@@ -151,6 +157,9 @@ dtype: object""",
         )
 
     def test_data_frame_with_unsupported_column_types(self):
+        """Test that `data_frame_to_bytes` correctly handles dataframes
+        with unsupported column types by converting those types to string.
+        """
         df = pd.DataFrame(
             {
                 "mixed-integer": [1, "foo", 3],

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -105,12 +105,25 @@ class TypeUtilTest(unittest.TestCase):
         except Exception as ex:
             self.fail(f"Converting dtype dataframes to Arrow should not fail: {ex}")
 
-    def test_fix_unsupported_column_types(self):
+    def test_fix_complex_column_type(self):
+        df = pd.DataFrame(
+            {
+                "complex": [1 + 2j, 3 + 4j, 5 + 6 * 1j],
+                "integer": [1, 2, 3],
+                "string": ["foo", "bar", None],
+            }
+        )
+
+        self.assertEqual(infer_dtype(df["complex"]), "complex")
+
+        fixed_df = fix_unsupported_column_types(df)
+        self.assertEqual(infer_dtype(fixed_df["complex"]), "string")
+
+    def test_fix_mixed_column_types(self):
         df = pd.DataFrame(
             {
                 "mixed-integer": [1, "foo", 3],
                 "mixed": [1.0, "foo", 3],
-                "complex": [1 + 2j, 3 + 4j, 5 + 6 * 1j],
                 "integer": [1, 2, 3],
                 "float": [1.0, 2.1, 3.2],
                 "string": ["foo", "bar", None],
@@ -122,7 +135,6 @@ class TypeUtilTest(unittest.TestCase):
 
         self.assertEqual(infer_dtype(fixed_df["mixed-integer"]), "string")
         self.assertEqual(infer_dtype(fixed_df["mixed"]), "string")
-        self.assertEqual(infer_dtype(fixed_df["complex"]), "string")
         self.assertEqual(infer_dtype(fixed_df["integer"]), "integer")
         self.assertEqual(infer_dtype(fixed_df["float"]), "floating")
         self.assertEqual(infer_dtype(fixed_df["string"]), "string")
@@ -132,7 +144,6 @@ class TypeUtilTest(unittest.TestCase):
             str(fixed_df.dtypes),
             """mixed-integer     object
 mixed             object
-complex           object
 integer            int64
 float            float64
 string            object


### PR DESCRIPTION
## 📚 Context

We already transform some dataframe column types (`mixed` columns) that are unsupported by Arrow into strings. This PR extends this to additional error types to resolve various issues. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Extend the automatic column fixes to additional Arrow error types.
- Support fixes for index columns.
- Add support for `complex128` type.
- Remove unnecessary error message
- Do not catch and wrap errors into `StreamlitAPIException`. The original Arrow error types make it easier to interpret the issue.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: 
	- Closes #1361
	- Closes #4094
	- Closes #4058
	- Closes #3696
	- Closes #4454

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
