### PR TITLE
Remove `st._is_running_with_streamlit`

### DIFF
--- a/e2e/scripts/linked_sliders.py
+++ b/e2e/scripts/linked_sliders.py
@@ -15,7 +15,7 @@
 import streamlit as st
 from streamlit import runtime
 
-if runtime.is_running():
+if runtime.exists():
 
     to_celsius = lambda fahrenheit: (fahrenheit - 32) * 5.0 / 9.0
     to_fahrenheit = lambda celsius: 9.0 / 5.0 * celsius + 32

--- a/e2e/scripts/linked_sliders.py
+++ b/e2e/scripts/linked_sliders.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     to_celsius = lambda fahrenheit: (fahrenheit - 32) * 5.0 / 9.0
     to_fahrenheit = lambda celsius: 9.0 / 5.0 * celsius + 32

--- a/e2e/scripts/redisplayed_widgets.py
+++ b/e2e/scripts/redisplayed_widgets.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     if st.checkbox("checkbox 1"):
         if st.checkbox("checkbox 2"):

--- a/e2e/scripts/redisplayed_widgets.py
+++ b/e2e/scripts/redisplayed_widgets.py
@@ -15,7 +15,7 @@
 import streamlit as st
 from streamlit import runtime
 
-if runtime.is_running():
+if runtime.exists():
 
     if st.checkbox("checkbox 1"):
         if st.checkbox("checkbox 2"):

--- a/e2e/scripts/session_state_frontend_sync.py
+++ b/e2e/scripts/session_state_frontend_sync.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
     if "checkbox1" not in st.session_state:
         st.session_state.checkbox1 = True
 

--- a/e2e/scripts/session_state_frontend_sync.py
+++ b/e2e/scripts/session_state_frontend_sync.py
@@ -15,7 +15,7 @@
 import streamlit as st
 from streamlit import runtime
 
-if runtime.is_running():
+if runtime.exists():
     if "checkbox1" not in st.session_state:
         st.session_state.checkbox1 = True
 

--- a/e2e/scripts/st_button.py
+++ b/e2e/scripts/st_button.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 # st.session_state can only be used in streamlit
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_click(x, y):
         if "click_count" not in st.session_state:

--- a/e2e/scripts/st_button.py
+++ b/e2e/scripts/st_button.py
@@ -16,7 +16,7 @@ import streamlit as st
 from streamlit import runtime
 
 # st.session_state can only be used in streamlit
-if runtime.is_running():
+if runtime.exists():
 
     def on_click(x, y):
         if "click_count" not in st.session_state:

--- a/e2e/scripts/st_checkbox.py
+++ b/e2e/scripts/st_checkbox.py
@@ -24,7 +24,7 @@ st.write("value 2:", i2)
 i3 = st.checkbox("checkbox 3")
 st.write("value 3:", i3)
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.checkbox_clicked = True

--- a/e2e/scripts/st_checkbox.py
+++ b/e2e/scripts/st_checkbox.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 i1 = st.checkbox("checkbox 1", True)
 st.write("value 1:", i1)
@@ -23,7 +24,7 @@ st.write("value 2:", i2)
 i3 = st.checkbox("checkbox 3")
 st.write("value 3:", i3)
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.checkbox_clicked = True

--- a/e2e/scripts/st_date_input.py
+++ b/e2e/scripts/st_date_input.py
@@ -15,6 +15,7 @@
 from datetime import date, datetime
 
 import streamlit as st
+from streamlit import runtime
 
 d1 = st.date_input("Single date", date(1970, 1, 1), min_value=date(1970, 1, 1))
 st.write("Value 1:", d1)
@@ -44,7 +45,7 @@ d8 = st.date_input(
 )
 st.write("Value 8:", d8)
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.date_input_changed = True

--- a/e2e/scripts/st_date_input.py
+++ b/e2e/scripts/st_date_input.py
@@ -45,7 +45,7 @@ d8 = st.date_input(
 )
 st.write("Value 8:", d8)
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.date_input_changed = True

--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -25,7 +25,7 @@ else:
 # since we also run e2e python files in "bare Python mode" as part of our
 # Python tests, and this doesn't work in that circumstance
 # st.session_state can only be accessed while running with streamlit
-if runtime.is_running():
+if runtime.exists():
     st.write(repr(st.session_state.single) == repr(single_file))
 
 disabled = st.file_uploader(
@@ -36,7 +36,7 @@ if disabled is None:
 else:
     st.text(disabled.read())
 
-if runtime.is_running():
+if runtime.exists():
     st.write(repr(st.session_state.disabled) == repr(disabled))
 
 multiple_files = st.file_uploader(
@@ -51,7 +51,7 @@ else:
     files = [file.read().decode() for file in multiple_files]
     st.text("\n".join(files))
 
-if runtime.is_running():
+if runtime.exists():
     st.write(repr(st.session_state.multiple) == repr(multiple_files))
 
 with st.form("foo"):
@@ -74,7 +74,7 @@ if hidden_label is None:
 else:
     st.text(hidden_label.read())
 
-if runtime.is_running():
+if runtime.exists():
     st.write(repr(st.session_state.hidden_label) == repr(hidden_label))
 
 collapsed_label = st.file_uploader(
@@ -88,10 +88,10 @@ if collapsed_label is None:
 else:
     st.text(collapsed_label.read())
 
-if runtime.is_running():
+if runtime.exists():
     st.write(repr(st.session_state.collapsed_label) == repr(collapsed_label))
 
-if runtime.is_running():
+if runtime.exists():
     if not st.session_state.get("counter"):
         st.session_state["counter"] = 0
 

--- a/e2e/scripts/st_file_uploader.py
+++ b/e2e/scripts/st_file_uploader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 single_file = st.file_uploader("Drop a file:", type=["txt"], key="single")
 if single_file is None:
@@ -20,11 +21,11 @@ if single_file is None:
 else:
     st.text(single_file.read())
 
-# Here and throughout this file, we use if st._is_running_with_streamlit:
+# Here and throughout this file, we use `if runtime.is_running():`
 # since we also run e2e python files in "bare Python mode" as part of our
 # Python tests, and this doesn't work in that circumstance
 # st.session_state can only be accessed while running with streamlit
-if st._is_running_with_streamlit:
+if runtime.is_running():
     st.write(repr(st.session_state.single) == repr(single_file))
 
 disabled = st.file_uploader(
@@ -35,7 +36,7 @@ if disabled is None:
 else:
     st.text(disabled.read())
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
     st.write(repr(st.session_state.disabled) == repr(disabled))
 
 multiple_files = st.file_uploader(
@@ -50,7 +51,7 @@ else:
     files = [file.read().decode() for file in multiple_files]
     st.text("\n".join(files))
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
     st.write(repr(st.session_state.multiple) == repr(multiple_files))
 
 with st.form("foo"):
@@ -73,7 +74,7 @@ if hidden_label is None:
 else:
     st.text(hidden_label.read())
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
     st.write(repr(st.session_state.hidden_label) == repr(hidden_label))
 
 collapsed_label = st.file_uploader(
@@ -87,10 +88,10 @@ if collapsed_label is None:
 else:
     st.text(collapsed_label.read())
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
     st.write(repr(st.session_state.collapsed_label) == repr(collapsed_label))
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
     if not st.session_state.get("counter"):
         st.session_state["counter"] = 0
 

--- a/e2e/scripts/st_multiselect.py
+++ b/e2e/scripts/st_multiselect.py
@@ -15,6 +15,7 @@
 from typing import Any, List
 
 import streamlit as st
+from streamlit import runtime
 
 
 def set_multiselect_9_to_have_bad_state():
@@ -70,7 +71,7 @@ with st.form("my_max_selections_ms_in_form"):
     st.text(f"value 10: {i10}")
     submitted = st.form_submit_button("Submit")
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.multiselect_changed = True

--- a/e2e/scripts/st_multiselect.py
+++ b/e2e/scripts/st_multiselect.py
@@ -71,7 +71,7 @@ with st.form("my_max_selections_ms_in_form"):
     st.text(f"value 10: {i10}")
     submitted = st.form_submit_button("Submit")
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.multiselect_changed = True

--- a/e2e/scripts/st_number_input.py
+++ b/e2e/scripts/st_number_input.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 i1 = st.number_input("number input 1")
 st.write('value 1: "', i1, '"')
@@ -38,7 +39,7 @@ st.write('value 7: "', i7, '"')
 i8 = st.number_input("number input 8", label_visibility="collapsed")
 st.write('value 8: "', i8, '"')
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.number_input_changed = True

--- a/e2e/scripts/st_number_input.py
+++ b/e2e/scripts/st_number_input.py
@@ -39,7 +39,7 @@ st.write('value 7: "', i7, '"')
 i8 = st.number_input("number input 8", label_visibility="collapsed")
 st.write('value 8: "', i8, '"')
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.number_input_changed = True

--- a/e2e/scripts/st_radio.py
+++ b/e2e/scripts/st_radio.py
@@ -43,7 +43,7 @@ i8 = st.radio("radio 8", options, label_visibility="collapsed")
 st.write("value 8:", i8)
 
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.radio_changed = True

--- a/e2e/scripts/st_radio.py
+++ b/e2e/scripts/st_radio.py
@@ -15,6 +15,7 @@
 import pandas as pd
 
 import streamlit as st
+from streamlit import runtime
 
 options = ("female", "male")
 i1 = st.radio("radio 1", options, 1)
@@ -42,7 +43,7 @@ i8 = st.radio("radio 8", options, label_visibility="collapsed")
 st.write("value 8:", i8)
 
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.radio_changed = True

--- a/e2e/scripts/st_select_slider.py
+++ b/e2e/scripts/st_select_slider.py
@@ -75,7 +75,7 @@ w7 = st.select_slider(
 
 st.write("Value 7:", w7)
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.select_slider_changed = True

--- a/e2e/scripts/st_select_slider.py
+++ b/e2e/scripts/st_select_slider.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 import streamlit as st
+from streamlit import runtime
 
 w1 = st.select_slider(
     "Label 1",
@@ -74,7 +75,7 @@ w7 = st.select_slider(
 
 st.write("Value 7:", w7)
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.select_slider_changed = True

--- a/e2e/scripts/st_selectbox.py
+++ b/e2e/scripts/st_selectbox.py
@@ -51,7 +51,7 @@ st.write("value 6:", i6)
 i7 = st.selectbox("selectbox 7", options, label_visibility="collapsed")
 st.write("value 7:", i7)
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.selectbox_changed = True

--- a/e2e/scripts/st_selectbox.py
+++ b/e2e/scripts/st_selectbox.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 options = ("male", "female")
 i1 = st.selectbox("selectbox 1", options, 1)
@@ -50,7 +51,7 @@ st.write("value 6:", i6)
 i7 = st.selectbox("selectbox 7", options, label_visibility="collapsed")
 st.write("value 7:", i7)
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.selectbox_changed = True

--- a/e2e/scripts/st_session_state.py
+++ b/e2e/scripts/st_session_state.py
@@ -16,7 +16,7 @@ import streamlit as st
 from streamlit import runtime
 
 # st.session_state can only be accessed while running with streamlit
-if runtime.is_running():
+if runtime.exists():
     if "initialized" not in st.session_state:
         st.session_state["item_counter"] = 0
         st.session_state.attr_counter = 0

--- a/e2e/scripts/st_session_state.py
+++ b/e2e/scripts/st_session_state.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 # st.session_state can only be accessed while running with streamlit
-if st._is_running_with_streamlit:
+if runtime.is_running():
     if "initialized" not in st.session_state:
         st.session_state["item_counter"] = 0
         st.session_state.attr_counter = 0

--- a/e2e/scripts/st_slider.py
+++ b/e2e/scripts/st_slider.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 s1 = st.sidebar.slider("Label A", 0, 12345678, 12345678)
 st.sidebar.write("Value A:", s1)
@@ -45,7 +46,7 @@ st.write("Value 5:", w5)
 w6 = st.slider("Label 6", 0, 100, 36, label_visibility="collapsed")
 st.write("Value 6:", w6)
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.slider_changed = True

--- a/e2e/scripts/st_slider.py
+++ b/e2e/scripts/st_slider.py
@@ -46,7 +46,7 @@ st.write("Value 5:", w5)
 w6 = st.slider("Label 6", 0, 100, 36, label_visibility="collapsed")
 st.write("Value 6:", w6)
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.slider_changed = True

--- a/e2e/scripts/st_stop.py
+++ b/e2e/scripts/st_stop.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 st.text("Text before stop")
 
 # Since st.stop() throws an intentional exception, we want this to run
 # only in streamlit
-if st._is_running_with_streamlit:
+if runtime.is_running():
     st.stop()
 
 st.text("Text after stop")

--- a/e2e/scripts/st_stop.py
+++ b/e2e/scripts/st_stop.py
@@ -19,7 +19,7 @@ st.text("Text before stop")
 
 # Since st.stop() throws an intentional exception, we want this to run
 # only in streamlit
-if runtime.is_running():
+if runtime.exists():
     st.stop()
 
 st.text("Text after stop")

--- a/e2e/scripts/st_text_area.py
+++ b/e2e/scripts/st_text_area.py
@@ -42,7 +42,7 @@ st.write('value 8: "', i8, '"')
 i9 = st.text_area("text area 9", "default text", label_visibility="collapsed")
 st.write('value 9: "', i9, '"')
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.text_area_changed = True

--- a/e2e/scripts/st_text_area.py
+++ b/e2e/scripts/st_text_area.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 i1 = st.text_area("text area 1")
 st.write('value 1: "', i1, '"')
@@ -41,7 +42,7 @@ st.write('value 8: "', i8, '"')
 i9 = st.text_area("text area 9", "default text", label_visibility="collapsed")
 st.write('value 9: "', i9, '"')
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.text_area_changed = True

--- a/e2e/scripts/st_text_input.py
+++ b/e2e/scripts/st_text_input.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import streamlit as st
+from streamlit import runtime
 
 i1 = st.text_input("text input 1")
 st.write('value 1: "', i1, '"')
@@ -38,7 +39,7 @@ st.write('value 7: "', i7, '"')
 i8 = st.text_input("text input 8", "default text", label_visibility="collapsed")
 st.write('value 8: "', i8, '"')
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.text_input_changed = True

--- a/e2e/scripts/st_text_input.py
+++ b/e2e/scripts/st_text_input.py
@@ -39,7 +39,7 @@ st.write('value 7: "', i7, '"')
 i8 = st.text_input("text input 8", "default text", label_visibility="collapsed")
 st.write('value 8: "', i8, '"')
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.text_input_changed = True

--- a/e2e/scripts/st_time_input.py
+++ b/e2e/scripts/st_time_input.py
@@ -32,7 +32,7 @@ st.write("Value 4:", w4)
 w5 = st.time_input("Label 5", time(8, 45), label_visibility="collapsed")
 st.write("Value 5:", w5)
 
-if runtime.is_running():
+if runtime.exists():
 
     def on_change():
         st.session_state.time_input_changed = True

--- a/e2e/scripts/st_time_input.py
+++ b/e2e/scripts/st_time_input.py
@@ -15,6 +15,7 @@
 from datetime import datetime, time
 
 import streamlit as st
+from streamlit import runtime
 
 w1 = st.time_input("Label 1", time(8, 45))
 st.write("Value 1:", w1)
@@ -31,7 +32,7 @@ st.write("Value 4:", w4)
 w5 = st.time_input("Label 5", time(8, 45), label_visibility="collapsed")
 st.write("Value 5:", w5)
 
-if st._is_running_with_streamlit:
+if runtime.is_running():
 
     def on_change():
         st.session_state.time_input_changed = True

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -483,7 +483,7 @@ def _maybe_print_use_warning() -> None:
                 f"\n  {warning} to view a Streamlit app on a browser, use Streamlit in a file and\n  run it with the following command:\n\n    streamlit run [FILE_NAME] [ARGUMENTS]"
             )
 
-        elif not runtime.is_running() and _config.get_option(
+        elif not runtime.exists() and _config.get_option(
             "global.showWarningOnDirectExecution"
         ):
             script_name = _sys.argv[0]

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -94,11 +94,6 @@ from streamlit.runtime.caching import (
 
 cache = _gather_metrics(_cache)
 
-# This is set to True inside cli._main_run(), and is False otherwise.
-# If False, we should assume that DeltaGenerator functions are effectively
-# no-ops, and adapt gracefully.
-_is_running_with_streamlit: bool = False
-
 
 def _update_logger() -> None:
     _logger.set_log_level(_config.get_option("logger.level").upper())
@@ -476,6 +471,7 @@ def _maybe_print_use_warning() -> None:
     The warning is printed only once.
     """
     global _use_warning_has_been_displayed
+    from streamlit import runtime
 
     if not _use_warning_has_been_displayed:
         _use_warning_has_been_displayed = True
@@ -487,7 +483,7 @@ def _maybe_print_use_warning() -> None:
                 f"\n  {warning} to view a Streamlit app on a browser, use Streamlit in a file and\n  run it with the following command:\n\n    streamlit run [FILE_NAME] [ARGUMENTS]"
             )
 
-        elif not _is_running_with_streamlit and _config.get_option(
+        elif not runtime.is_running() and _config.get_option(
             "global.showWarningOnDirectExecution"
         ):
             script_name = _sys.argv[0]

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, BinaryIO, Optional, TextIO, Union, cast
 
 from typing_extensions import Final
 
-import streamlit
 from streamlit import runtime
 from streamlit.elements.form import current_form_id, is_in_form
 from streamlit.elements.utils import check_callback_rules, check_session_state_rules
@@ -328,7 +327,7 @@ class ButtonMixin:
         # every form). We throw an error to warn the user about this.
         # We omit this check for scripts running outside streamlit, because
         # they will have no script_run_ctx.
-        if streamlit._is_running_with_streamlit:
+        if runtime.is_running():
             if is_in_form(self.dg) and not is_form_submitter:
                 raise StreamlitAPIException(
                     f"`st.button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
@@ -408,7 +407,7 @@ def marshall_file(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    if streamlit._is_running_with_streamlit:
+    if runtime.is_running():
         file_url = runtime.get_instance().media_file_mgr.add(
             data_as_bytes,
             mimetype,

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -327,7 +327,7 @@ class ButtonMixin:
         # every form). We throw an error to warn the user about this.
         # We omit this check for scripts running outside streamlit, because
         # they will have no script_run_ctx.
-        if runtime.is_running():
+        if runtime.exists():
             if is_in_form(self.dg) and not is_form_submitter:
                 raise StreamlitAPIException(
                     f"`st.button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
@@ -407,7 +407,7 @@ def marshall_file(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    if runtime.is_running():
+    if runtime.exists():
         file_url = runtime.get_instance().media_file_mgr.add(
             data_as_bytes,
             mimetype,

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -16,6 +16,7 @@ import textwrap
 from typing import NamedTuple, Optional, cast
 
 import streamlit
+from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2
 from streamlit.runtime.metrics_util import gather_metrics
@@ -38,7 +39,7 @@ def _current_form(
     To find the current form, we walk up the dg_stack until we find
     a DeltaGenerator that has FormData.
     """
-    if not streamlit._is_running_with_streamlit:
+    if not runtime.is_running():
         return None
 
     if this_dg._form_data is not None:

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -39,7 +39,7 @@ def _current_form(
     To find the current form, we walk up the dg_stack until we find
     a DeltaGenerator that has FormData.
     """
-    if not runtime.is_running():
+    if not runtime.exists():
         return None
 
     if this_dg._form_data is not None:

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -380,7 +380,7 @@ def image_to_url(
     image_data = _ensure_image_size_and_format(image_data, width, image_format)
     mimetype = _get_image_format_mimetype(image_format)
 
-    if runtime.is_running():
+    if runtime.exists():
         return runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -30,7 +30,6 @@ import numpy as np
 from PIL import Image, ImageFile
 from typing_extensions import Final, Literal, TypeAlias
 
-import streamlit
 from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
@@ -381,7 +380,7 @@ def image_to_url(
     image_data = _ensure_image_size_and_format(image_data, width, image_format)
     mimetype = _get_image_format_mimetype(image_format)
 
-    if streamlit._is_running_with_streamlit:
+    if runtime.is_running():
         return runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 from typing_extensions import Final, TypeAlias
 from validators import url
 
-import streamlit
 from streamlit import runtime, type_util
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
@@ -208,7 +207,7 @@ def _marshall_av_media(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    if streamlit._is_running_with_streamlit:
+    if runtime.is_running():
         file_url = runtime.get_instance().media_file_mgr.add(
             data_or_filename, mimetype, coordinates
         )

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -207,7 +207,7 @@ def _marshall_av_media(
     else:
         raise RuntimeError("Invalid binary data format: %s" % type(data))
 
-    if runtime.is_running():
+    if runtime.exists():
         file_url = runtime.get_instance().media_file_mgr.add(
             data_or_filename, mimetype, coordinates
         )

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -41,7 +41,7 @@ def last_index_for_melted_dataframes(
 def check_callback_rules(
     dg: "DeltaGenerator", on_change: Optional[WidgetCallback]
 ) -> None:
-    if runtime.is_running() and is_in_form(dg) and on_change is not None:
+    if runtime.exists() and is_in_form(dg) and on_change is not None:
         raise StreamlitAPIException(
             "With forms, callbacks can only be defined on the `st.form_submit_button`."
             " Defining callbacks on other widgets inside a form is not allowed."
@@ -56,7 +56,7 @@ def check_session_state_rules(
 ) -> None:
     global _shown_default_value_warning
 
-    if key is None or not runtime.is_running():
+    if key is None or not runtime.exists():
         return
 
     session_state = get_session_state()

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -15,7 +15,7 @@
 from typing import TYPE_CHECKING, Any, Hashable, Optional, Union, cast
 
 import streamlit
-from streamlit import type_util
+from streamlit import runtime, type_util
 from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
@@ -41,11 +41,7 @@ def last_index_for_melted_dataframes(
 def check_callback_rules(
     dg: "DeltaGenerator", on_change: Optional[WidgetCallback]
 ) -> None:
-    if (
-        streamlit._is_running_with_streamlit
-        and is_in_form(dg)
-        and on_change is not None
-    ):
+    if runtime.is_running() and is_in_form(dg) and on_change is not None:
         raise StreamlitAPIException(
             "With forms, callbacks can only be defined on the `st.form_submit_button`."
             " Defining callbacks on other widgets inside a form is not allowed."
@@ -60,7 +56,7 @@ def check_session_state_rules(
 ) -> None:
     global _shown_default_value_warning
 
-    if key is None or not streamlit._is_running_with_streamlit:
+    if key is None or not runtime.is_running():
         return
 
     session_state = get_session_state()

--- a/lib/streamlit/runtime/__init__.py
+++ b/lib/streamlit/runtime/__init__.py
@@ -23,5 +23,18 @@ from streamlit.runtime.runtime import (
 
 
 def get_instance() -> Runtime:
-    """Return the singleton Runtime instance."""
+    """Return the singleton Runtime instance. Raise an Error if the
+    Runtime hasn't been created yet.
+    """
     return Runtime.instance()
+
+
+def is_running() -> bool:
+    """True if the singleton Runtime instance has been created.
+
+    When a Streamlit app is running in "raw mode" - that is, when the
+    app is run via `python app.py` instead of `streamlit run app.py` -
+    the Runtime will not exist, and various Streamlit functions need
+    to adapt.
+    """
+    return Runtime.is_running()

--- a/lib/streamlit/runtime/__init__.py
+++ b/lib/streamlit/runtime/__init__.py
@@ -29,7 +29,7 @@ def get_instance() -> Runtime:
     return Runtime.instance()
 
 
-def is_running() -> bool:
+def exists() -> bool:
     """True if the singleton Runtime instance has been created.
 
     When a Streamlit app is running in "raw mode" - that is, when the
@@ -37,4 +37,4 @@ def is_running() -> bool:
     the Runtime will not exist, and various Streamlit functions need
     to adapt.
     """
-    return Runtime.is_running()
+    return Runtime.exists()

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -157,6 +157,17 @@ class Runtime:
             raise RuntimeError("Runtime hasn't been created!")
         return cls._instance
 
+    @classmethod
+    def is_running(cls) -> bool:
+        """True if the singleton Runtime instance has been created.
+
+        When a Streamlit app is running in "raw mode" - that is, when the
+        app is run via `python app.py` instead of `streamlit run app.py` -
+        the Runtime will not exist, and various Streamlit functions need
+        to adapt.
+        """
+        return cls._instance is not None
+
     def __init__(self, config: RuntimeConfig):
         """Create a Runtime instance. It won't be started yet.
 

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -157,7 +157,7 @@ class Runtime:
         return cls._instance
 
     @classmethod
-    def is_running(cls) -> bool:
+    def exists(cls) -> bool:
         """True if the singleton Runtime instance has been created.
 
         When a Streamlit app is running in "raw mode" - that is, when the

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -22,7 +22,6 @@ from typing import Awaitable, Dict, NamedTuple, Optional, Tuple
 
 from typing_extensions import Final, Protocol
 
-import streamlit
 from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
@@ -287,7 +286,6 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        streamlit._is_running_with_streamlit = True
 
         # Create our AsyncObjects. We need to have a running eventloop to
         # instantiate our various synchronization primitives.

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -150,7 +150,7 @@ def get_script_run_ctx() -> Optional[ScriptRunContext]:
     ctx: Optional[ScriptRunContext] = getattr(
         thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None
     )
-    if ctx is None and runtime.is_running():
+    if ctx is None and runtime.exists():
         # Only warn about a missing ScriptRunContext if we were started
         # via `streamlit run`. Otherwise, the user is likely running a
         # script "bare", and doesn't need to be warned about streamlit

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -18,6 +18,7 @@ from typing import Callable, Dict, List, Optional, Set
 
 from typing_extensions import Final, TypeAlias
 
+from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -149,7 +150,7 @@ def get_script_run_ctx() -> Optional[ScriptRunContext]:
     ctx: Optional[ScriptRunContext] = getattr(
         thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None
     )
-    if ctx is None and streamlit._is_running_with_streamlit:
+    if ctx is None and runtime.is_running():
         # Only warn about a missing ScriptRunContext if we were started
         # via `streamlit run`. Otherwise, the user is likely running a
         # script "bare", and doesn't need to be warned about streamlit

--- a/lib/streamlit/runtime/state/session_state_proxy.py
+++ b/lib/streamlit/runtime/state/session_state_proxy.py
@@ -16,8 +16,8 @@ from typing import Any, Dict, Iterator, MutableMapping
 
 from typing_extensions import Final
 
-import streamlit as st
 from streamlit import logger as _logger
+from streamlit import runtime
 from streamlit.runtime.state.safe_session_state import SafeSessionState
 from streamlit.runtime.state.session_state import SessionState, require_valid_user_key
 from streamlit.type_util import Key
@@ -45,7 +45,7 @@ def get_session_state() -> SafeSessionState:
     if ctx is None:
         if not _state_use_warning_already_displayed:
             _state_use_warning_already_displayed = True
-            if not st._is_running_with_streamlit:
+            if not runtime.is_running():
                 LOGGER.warning(
                     "Session state does not function when running a script without `streamlit run`"
                 )

--- a/lib/streamlit/runtime/state/session_state_proxy.py
+++ b/lib/streamlit/runtime/state/session_state_proxy.py
@@ -45,7 +45,7 @@ def get_session_state() -> SafeSessionState:
     if ctx is None:
         if not _state_use_warning_already_displayed:
             _state_use_warning_already_displayed = True
-            if not runtime.is_running():
+            if not runtime.exists():
                 LOGGER.warning(
                     "Session state does not function when running a script without `streamlit run`"
                 )

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -232,9 +232,6 @@ def _main_run(file, args=None, flag_options=None):
 
     command_line = _get_command_line_as_string()
 
-    # Set a global flag indicating that we're "within" streamlit.
-    streamlit._is_running_with_streamlit = True
-
     check_credentials()
 
     bootstrap.run(file, command_line, args, flag_options)

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -374,7 +374,7 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.component_instance
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -374,8 +374,8 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.component_instance
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
-    def test_inside_form(self):
+    @patch("streamlit.runtime.is_running", return_value=True)
+    def test_inside_form(self, _):
         """Test that form id is marshalled correctly inside of a form."""
 
         with st.form("foo"):

--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -17,7 +17,7 @@ import os
 import unittest
 from typing import Any
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -374,8 +374,8 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.component_instance
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", return_value=True)
-    def test_inside_form(self, _):
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
         with st.form("foo"):

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -71,7 +71,7 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.checkbox
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -14,7 +14,7 @@
 
 """checkbox unit tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -71,8 +71,8 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.checkbox
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", return_value=True)
-    def test_inside_form(self, _):
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
         with st.form("form"):

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -71,8 +71,8 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.checkbox
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
-    def test_inside_form(self):
+    @patch("streamlit.runtime.is_running", return_value=True)
+    def test_inside_form(self, _):
         """Test that form id is marshalled correctly inside of a form."""
 
         with st.form("form"):

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -73,7 +73,7 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -14,7 +14,7 @@
 
 """color_picker unit test."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -73,7 +73,7 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -23,17 +23,17 @@ from streamlit.errors import StreamlitAPIException
 
 class ElementUtilsTest(unittest.TestCase):
     @patch("streamlit.elements.utils.is_in_form", return_value=False)
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_check_callback_rules_not_in_form(self, _):
         check_callback_rules(None, lambda x: x)
 
     @patch("streamlit.elements.utils.is_in_form", return_value=True)
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_check_callback_rules_in_form(self, _):
         check_callback_rules(None, None)
 
     @patch("streamlit.elements.utils.is_in_form", return_value=True)
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_check_callback_rules_error(self, _):
         with pytest.raises(StreamlitAPIException) as e:
             check_callback_rules(None, lambda x: x)
@@ -46,7 +46,7 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_val(
@@ -60,7 +60,7 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_state_val(
@@ -74,7 +74,7 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_prints_warning(
@@ -91,7 +91,7 @@ class ElementUtilsTest(unittest.TestCase):
         warning_msg = args[0]
         assert 'The widget with key "the key"' in warning_msg
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     def test_check_session_state_rules_writes_not_allowed(
         self, patched_get_session_state

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -23,18 +23,18 @@ from streamlit.errors import StreamlitAPIException
 
 class ElementUtilsTest(unittest.TestCase):
     @patch("streamlit.elements.utils.is_in_form", return_value=False)
-    @patch("streamlit.runtime.is_running", return_value=True)
-    def test_check_callback_rules_not_in_form(self, _1, _2):
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    def test_check_callback_rules_not_in_form(self, _):
         check_callback_rules(None, lambda x: x)
 
     @patch("streamlit.elements.utils.is_in_form", return_value=True)
-    @patch("streamlit.runtime.is_running", return_value=True)
-    def test_check_callback_rules_in_form(self, _1, _2):
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    def test_check_callback_rules_in_form(self, _):
         check_callback_rules(None, None)
 
     @patch("streamlit.elements.utils.is_in_form", return_value=True)
-    @patch("streamlit.runtime.is_running", return_value=True)
-    def test_check_callback_rules_error(self, _1, _2):
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    def test_check_callback_rules_error(self, _):
         with pytest.raises(StreamlitAPIException) as e:
             check_callback_rules(None, lambda x: x)
 
@@ -46,11 +46,11 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.is_running", return_value=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_val(
-        self, patched_st_warning, patched_get_session_state, _
+        self, patched_st_warning, patched_get_session_state
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True
@@ -60,11 +60,11 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.is_running", return_value=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_state_val(
-        self, patched_st_warning, patched_get_session_state, _
+        self, patched_st_warning, patched_get_session_state
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = False
@@ -74,11 +74,11 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.is_running", return_value=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_prints_warning(
-        self, patched_st_warning, patched_get_session_state, _
+        self, patched_st_warning, patched_get_session_state
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True
@@ -91,10 +91,10 @@ class ElementUtilsTest(unittest.TestCase):
         warning_msg = args[0]
         assert 'The widget with key "the key"' in warning_msg
 
-    @patch("streamlit.runtime.is_running", return_value=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     def test_check_session_state_rules_writes_not_allowed(
-        self, patched_get_session_state, _
+        self, patched_get_session_state
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -23,18 +23,18 @@ from streamlit.errors import StreamlitAPIException
 
 class ElementUtilsTest(unittest.TestCase):
     @patch("streamlit.elements.utils.is_in_form", return_value=False)
-    @patch("streamlit._is_running_with_streamlit", new=True)
-    def test_check_callback_rules_not_in_form(self, _):
+    @patch("streamlit.runtime.is_running", return_value=True)
+    def test_check_callback_rules_not_in_form(self, _1, _2):
         check_callback_rules(None, lambda x: x)
 
     @patch("streamlit.elements.utils.is_in_form", return_value=True)
-    @patch("streamlit._is_running_with_streamlit", new=True)
-    def test_check_callback_rules_in_form(self, _):
+    @patch("streamlit.runtime.is_running", return_value=True)
+    def test_check_callback_rules_in_form(self, _1, _2):
         check_callback_rules(None, None)
 
     @patch("streamlit.elements.utils.is_in_form", return_value=True)
-    @patch("streamlit._is_running_with_streamlit", new=True)
-    def test_check_callback_rules_error(self, _):
+    @patch("streamlit.runtime.is_running", return_value=True)
+    def test_check_callback_rules_error(self, _1, _2):
         with pytest.raises(StreamlitAPIException) as e:
             check_callback_rules(None, lambda x: x)
 
@@ -46,11 +46,11 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", return_value=True)
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_val(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_st_warning, patched_get_session_state, _
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True
@@ -60,11 +60,11 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", return_value=True)
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_state_val(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_st_warning, patched_get_session_state, _
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = False
@@ -74,11 +74,11 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", return_value=True)
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_prints_warning(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_st_warning, patched_get_session_state, _
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True
@@ -91,10 +91,10 @@ class ElementUtilsTest(unittest.TestCase):
         warning_msg = args[0]
         assert 'The widget with key "the key"' in warning_msg
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", return_value=True)
     @patch("streamlit.elements.utils.get_session_state")
     def test_check_session_state_rules_writes_not_allowed(
-        self, patched_get_session_state
+        self, patched_get_session_state, _
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -14,7 +14,7 @@
 
 """multiselect unit tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -220,7 +220,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.multiselect
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -220,7 +220,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.multiselect
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -220,7 +220,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
@@ -251,7 +251,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(number_input_proto.step, 1.0)
         self.assertEqual(number_input_proto.default, 0)
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     def test_no_warning_with_value_set_in_state(self, patched_get_session_state):
         mock_session_state = MagicMock()

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -220,7 +220,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
@@ -251,7 +251,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(number_input_proto.step, 1.0)
         self.assertEqual(number_input_proto.default, 0)
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     def test_no_warning_with_value_set_in_state(self, patched_get_session_state):
         mock_session_state = MagicMock()

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -157,7 +157,7 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.radio
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -14,7 +14,7 @@
 
 """radio unit tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -157,7 +157,7 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.radio
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -14,7 +14,7 @@
 
 """slider unit test."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -220,7 +220,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -220,7 +220,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -144,7 +144,7 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """selectbox unit tests."""
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -144,7 +144,7 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -15,7 +15,7 @@
 """slider unit test."""
 
 from datetime import date, datetime, time, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -216,7 +216,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -216,7 +216,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -15,7 +15,7 @@
 """text_area unit test."""
 
 import re
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -86,7 +86,7 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -86,7 +86,7 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -100,7 +100,7 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.text_input
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -15,7 +15,7 @@
 """text_input unit test."""
 
 import re
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -100,7 +100,7 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.text_input
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit._is_running_with_streamlit", new=True)
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -14,7 +14,7 @@
 
 """Form unit tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
@@ -24,7 +24,7 @@ from tests import testutil
 NO_FORM_ID = ""
 
 
-@patch("streamlit.runtime.is_running", return_value=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class FormAssociationTest(testutil.DeltaGeneratorTestCase):
     """Tests for every flavor of form/deltagenerator association."""
 
@@ -36,12 +36,12 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("checkbox", last_delta.new_element.WhichOneof("type"))
         return last_delta.new_element.checkbox.form_id
 
-    def test_no_form(self, _):
+    def test_no_form(self):
         """By default, an element doesn't belong to a form."""
         st.checkbox("widget")
         self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_implicit_form_parent(self, _):
+    def test_implicit_form_parent(self):
         """Within a `with form` statement, any `st.foo` element becomes
         part of that form."""
         with st.form("form"):
@@ -54,7 +54,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
             st.sidebar.checkbox("widget2")
         self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_deep_implicit_form_parent(self, _):
+    def test_deep_implicit_form_parent(self):
         """Within a `with form` statement, any `st.foo` element becomes
         part of that form, regardless of how deeply nested the element is."""
         with st.form("form"):
@@ -73,7 +73,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
                     st.sidebar.checkbox("widget2")
         self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_parent_created_inside_form(self, _):
+    def test_parent_created_inside_form(self):
         """If a parent DG is created inside a form, any children of
         that parent belong to the form."""
         with st.form("form"):
@@ -93,7 +93,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         form_col.checkbox("widget3")
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_parent_created_outside_form(self, _):
+    def test_parent_created_outside_form(self):
         """If our parent was created outside a form, any children of
         that parent have no form, regardless of where they're created."""
         no_form_col = st.columns(2)[0]
@@ -108,7 +108,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
                 st.checkbox("widget3")
                 self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_widget_created_directly_on_form_block(self, _):
+    def test_widget_created_directly_on_form_block(self):
         """Test that a widget can be created directly on a form block."""
 
         form = st.form("form")
@@ -116,7 +116,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_form_inside_columns(self, _):
+    def test_form_inside_columns(self):
         """Test that a form was successfully created inside a column."""
 
         col, _ = st.columns(2)
@@ -127,7 +127,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_form_in_sidebar(self, _):
+    def test_form_in_sidebar(self):
         """Test that a form was successfully created in the sidebar."""
 
         with st.sidebar.form("form"):
@@ -135,7 +135,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_dg_outside_form_but_element_inside(self, _):
+    def test_dg_outside_form_but_element_inside(self):
         """Test that a widget doesn't belong to a form if its DG was created outside it."""
 
         empty = st.empty()
@@ -145,7 +145,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         first_delta = self.get_delta_from_queue(0)
         self.assertEqual(NO_FORM_ID, first_delta.new_element.checkbox.form_id)
 
-    def test_dg_inside_form_but_element_outside(self, _):
+    def test_dg_inside_form_but_element_outside(self):
         """Test that a widget belongs to a form if its DG was created inside it."""
 
         with st.form("form"):
@@ -154,7 +154,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_dg_and_element_inside_form(self, _):
+    def test_dg_and_element_inside_form(self):
         """Test that a widget belongs to a form if its DG was created inside it and then replaced."""
 
         with st.form("form"):
@@ -164,11 +164,11 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
 
-@patch("streamlit.runtime.is_running", return_value=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
     """Test ability to marshall form protos."""
 
-    def test_marshall_form(self, _):
+    def test_marshall_form(self):
         """Creating a form should result in the expected protobuf data."""
 
         # Test with clear_on_submit=True
@@ -191,7 +191,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("bar", form_proto.form.form_id)
         self.assertEqual(False, form_proto.form.clear_on_submit)
 
-    def test_multiple_forms_same_key(self, _):
+    def test_multiple_forms_same_key(self):
         """Multiple forms with the same key are not allowed."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -202,7 +202,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
             "There are multiple identical forms with `key='foo'`", str(ctx.exception)
         )
 
-    def test_multiple_forms_same_labels_different_keys(self, _):
+    def test_multiple_forms_same_labels_different_keys(self):
         """Multiple forms with different keys are allowed."""
 
         try:
@@ -212,7 +212,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
         except Exception:
             self.fail("Forms with same labels and different keys failed to create.")
 
-    def test_form_in_form(self, _):
+    def test_form_in_form(self):
         """Test that forms cannot be nested in other forms."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -222,7 +222,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(str(ctx.exception), "Forms cannot be nested in other forms.")
 
-    def test_button_in_form(self, _):
+    def test_button_in_form(self):
         """Test that buttons are not allowed in forms."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -233,18 +233,18 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
             "`st.button()` can't be used in an `st.form()`", str(ctx.exception)
         )
 
-    def test_form_block_data(self, _):
+    def test_form_block_data(self):
         """Test that a form creates a block element with correct data."""
 
         form_data = st.form(key="bar")._form_data
         self.assertEqual("bar", form_data.form_id)
 
 
-@patch("streamlit.runtime.is_running", return_value=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
     """Test form submit button."""
 
-    def test_submit_button_outside_form(self, _):
+    def test_submit_button_outside_form(self):
         """Test that a submit button is not allowed outside a form."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -255,7 +255,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
             str(ctx.exception),
         )
 
-    def test_submit_button_inside_form(self, _):
+    def test_submit_button_inside_form(self):
         """Test that a submit button is allowed inside a form."""
 
         with st.form("foo"):
@@ -264,7 +264,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
         last_delta = self.get_delta_from_queue()
         self.assertEqual("foo", last_delta.new_element.button.form_id)
 
-    def test_submit_button_called_directly_on_form_block(self, _):
+    def test_submit_button_called_directly_on_form_block(self):
         """Test that a submit button can be called directly on a form block."""
 
         form = st.form("foo")
@@ -273,7 +273,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
         last_delta = self.get_delta_from_queue()
         self.assertEqual("foo", last_delta.new_element.button.form_id)
 
-    def test_return_false_when_not_submitted(self, _):
+    def test_return_false_when_not_submitted(self):
         with st.form("form1"):
             submitted = st.form_submit_button("Submit")
             self.assertEqual(submitted, False)
@@ -282,21 +282,21 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
         "streamlit.elements.button.register_widget",
         return_value=RegisterWidgetResult(True, False),
     )
-    def test_return_true_when_submitted(self, _1, _2):
+    def test_return_true_when_submitted(self, _):
         with st.form("form"):
             submitted = st.form_submit_button("Submit")
             self.assertEqual(submitted, True)
 
 
-@patch("streamlit.runtime.is_running", return_value=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
-    def test_exception_for_callbacks_on_widgets(self, _):
+    def test_exception_for_callbacks_on_widgets(self):
         with self.assertRaises(StreamlitAPIException):
             with st.form("form"):
                 st.radio("radio", ["a", "b", "c"], 0, on_change=lambda x: x)
                 st.form_submit_button()
 
-    def test_no_exception_for_callbacks_on_submit_button(self, _):
+    def test_no_exception_for_callbacks_on_submit_button(self):
         with st.form("form"):
             st.radio("radio", ["a", "b", "c"], 0)
             st.form_submit_button(on_click=lambda x: x)

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -24,7 +24,7 @@ from tests import testutil
 NO_FORM_ID = ""
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", return_value=True)
 class FormAssociationTest(testutil.DeltaGeneratorTestCase):
     """Tests for every flavor of form/deltagenerator association."""
 
@@ -36,12 +36,12 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("checkbox", last_delta.new_element.WhichOneof("type"))
         return last_delta.new_element.checkbox.form_id
 
-    def test_no_form(self):
+    def test_no_form(self, _):
         """By default, an element doesn't belong to a form."""
         st.checkbox("widget")
         self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_implicit_form_parent(self):
+    def test_implicit_form_parent(self, _):
         """Within a `with form` statement, any `st.foo` element becomes
         part of that form."""
         with st.form("form"):
@@ -54,7 +54,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
             st.sidebar.checkbox("widget2")
         self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_deep_implicit_form_parent(self):
+    def test_deep_implicit_form_parent(self, _):
         """Within a `with form` statement, any `st.foo` element becomes
         part of that form, regardless of how deeply nested the element is."""
         with st.form("form"):
@@ -73,7 +73,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
                     st.sidebar.checkbox("widget2")
         self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_parent_created_inside_form(self):
+    def test_parent_created_inside_form(self, _):
         """If a parent DG is created inside a form, any children of
         that parent belong to the form."""
         with st.form("form"):
@@ -93,7 +93,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         form_col.checkbox("widget3")
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_parent_created_outside_form(self):
+    def test_parent_created_outside_form(self, _):
         """If our parent was created outside a form, any children of
         that parent have no form, regardless of where they're created."""
         no_form_col = st.columns(2)[0]
@@ -108,7 +108,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
                 st.checkbox("widget3")
                 self.assertEqual(NO_FORM_ID, self._get_last_checkbox_form_id())
 
-    def test_widget_created_directly_on_form_block(self):
+    def test_widget_created_directly_on_form_block(self, _):
         """Test that a widget can be created directly on a form block."""
 
         form = st.form("form")
@@ -116,7 +116,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_form_inside_columns(self):
+    def test_form_inside_columns(self, _):
         """Test that a form was successfully created inside a column."""
 
         col, _ = st.columns(2)
@@ -127,7 +127,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_form_in_sidebar(self):
+    def test_form_in_sidebar(self, _):
         """Test that a form was successfully created in the sidebar."""
 
         with st.sidebar.form("form"):
@@ -135,7 +135,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_dg_outside_form_but_element_inside(self):
+    def test_dg_outside_form_but_element_inside(self, _):
         """Test that a widget doesn't belong to a form if its DG was created outside it."""
 
         empty = st.empty()
@@ -145,7 +145,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         first_delta = self.get_delta_from_queue(0)
         self.assertEqual(NO_FORM_ID, first_delta.new_element.checkbox.form_id)
 
-    def test_dg_inside_form_but_element_outside(self):
+    def test_dg_inside_form_but_element_outside(self, _):
         """Test that a widget belongs to a form if its DG was created inside it."""
 
         with st.form("form"):
@@ -154,7 +154,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
-    def test_dg_and_element_inside_form(self):
+    def test_dg_and_element_inside_form(self, _):
         """Test that a widget belongs to a form if its DG was created inside it and then replaced."""
 
         with st.form("form"):
@@ -164,11 +164,11 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", return_value=True)
 class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
     """Test ability to marshall form protos."""
 
-    def test_marshall_form(self):
+    def test_marshall_form(self, _):
         """Creating a form should result in the expected protobuf data."""
 
         # Test with clear_on_submit=True
@@ -191,7 +191,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("bar", form_proto.form.form_id)
         self.assertEqual(False, form_proto.form.clear_on_submit)
 
-    def test_multiple_forms_same_key(self):
+    def test_multiple_forms_same_key(self, _):
         """Multiple forms with the same key are not allowed."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -202,7 +202,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
             "There are multiple identical forms with `key='foo'`", str(ctx.exception)
         )
 
-    def test_multiple_forms_same_labels_different_keys(self):
+    def test_multiple_forms_same_labels_different_keys(self, _):
         """Multiple forms with different keys are allowed."""
 
         try:
@@ -212,7 +212,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
         except Exception:
             self.fail("Forms with same labels and different keys failed to create.")
 
-    def test_form_in_form(self):
+    def test_form_in_form(self, _):
         """Test that forms cannot be nested in other forms."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -222,7 +222,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
 
         self.assertEqual(str(ctx.exception), "Forms cannot be nested in other forms.")
 
-    def test_button_in_form(self):
+    def test_button_in_form(self, _):
         """Test that buttons are not allowed in forms."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -233,18 +233,18 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
             "`st.button()` can't be used in an `st.form()`", str(ctx.exception)
         )
 
-    def test_form_block_data(self):
+    def test_form_block_data(self, _):
         """Test that a form creates a block element with correct data."""
 
         form_data = st.form(key="bar")._form_data
         self.assertEqual("bar", form_data.form_id)
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", return_value=True)
 class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
     """Test form submit button."""
 
-    def test_submit_button_outside_form(self):
+    def test_submit_button_outside_form(self, _):
         """Test that a submit button is not allowed outside a form."""
 
         with self.assertRaises(StreamlitAPIException) as ctx:
@@ -255,7 +255,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
             str(ctx.exception),
         )
 
-    def test_submit_button_inside_form(self):
+    def test_submit_button_inside_form(self, _):
         """Test that a submit button is allowed inside a form."""
 
         with st.form("foo"):
@@ -264,7 +264,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
         last_delta = self.get_delta_from_queue()
         self.assertEqual("foo", last_delta.new_element.button.form_id)
 
-    def test_submit_button_called_directly_on_form_block(self):
+    def test_submit_button_called_directly_on_form_block(self, _):
         """Test that a submit button can be called directly on a form block."""
 
         form = st.form("foo")
@@ -273,7 +273,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
         last_delta = self.get_delta_from_queue()
         self.assertEqual("foo", last_delta.new_element.button.form_id)
 
-    def test_return_false_when_not_submitted(self):
+    def test_return_false_when_not_submitted(self, _):
         with st.form("form1"):
             submitted = st.form_submit_button("Submit")
             self.assertEqual(submitted, False)
@@ -282,21 +282,21 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
         "streamlit.elements.button.register_widget",
         return_value=RegisterWidgetResult(True, False),
     )
-    def test_return_true_when_submitted(self, _):
+    def test_return_true_when_submitted(self, _1, _2):
         with st.form("form"):
             submitted = st.form_submit_button("Submit")
             self.assertEqual(submitted, True)
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", return_value=True)
 class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
-    def test_exception_for_callbacks_on_widgets(self):
+    def test_exception_for_callbacks_on_widgets(self, _):
         with self.assertRaises(StreamlitAPIException):
             with st.form("form"):
                 st.radio("radio", ["a", "b", "c"], 0, on_change=lambda x: x)
                 st.form_submit_button()
 
-    def test_no_exception_for_callbacks_on_submit_button(self):
+    def test_no_exception_for_callbacks_on_submit_button(self, _):
         with st.form("form"):
             st.radio("radio", ["a", "b", "c"], 0)
             st.form_submit_button(on_click=lambda x: x)

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -24,7 +24,7 @@ from tests import testutil
 NO_FORM_ID = ""
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class FormAssociationTest(testutil.DeltaGeneratorTestCase):
     """Tests for every flavor of form/deltagenerator association."""
 
@@ -164,7 +164,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
     """Test ability to marshall form protos."""
 
@@ -240,7 +240,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("bar", form_data.form_id)
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
     """Test form submit button."""
 
@@ -288,7 +288,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(submitted, True)
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
     def test_exception_for_callbacks_on_widgets(self):
         with self.assertRaises(StreamlitAPIException):

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -80,11 +80,11 @@ class RuntimeSingletonTest(unittest.TestCase):
         _ = Runtime(MagicMock())
         instance = Runtime.instance()
 
-    def test_is_running(self):
-        """Runtime.is_running() returns True iff the Runtime singleton exists."""
-        self.assertFalse(Runtime.is_running())
+    def test_exists(self):
+        """Runtime.exists() returns True iff the Runtime singleton exists."""
+        self.assertFalse(Runtime.exists())
         _ = Runtime(MagicMock())
-        self.assertTrue(Runtime.is_running())
+        self.assertTrue(Runtime.exists())
 
 
 class RuntimeTest(RuntimeTestCase):

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -22,7 +22,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import streamlit
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -267,15 +267,6 @@ class RuntimeTest(RuntimeTestCase):
         with self.assertRaises(RuntimeStoppedError):
             self.runtime.handle_backmsg("not_a_session_id", MagicMock())
 
-    async def test_sets_is_running_with_streamlit_flag(self):
-        """Runtime should set streamlit._is_running_with_streamlit when it
-        starts.
-        """
-        # This will frequently be True from other tests
-        streamlit._is_running_with_streamlit = False
-        await self.runtime.start()
-        self.assertTrue(streamlit._is_running_with_streamlit)
-
     async def test_handle_session_client_disconnected(self):
         """Runtime should gracefully handle `SessionClient.write_forward_msg`
         raising a `SessionClientDisconnectedError`.

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -81,6 +81,12 @@ class RuntimeSingletonTest(unittest.TestCase):
         _ = Runtime(MagicMock())
         instance = Runtime.instance()
 
+    def test_is_running(self):
+        """Runtime.is_running() returns True iff the Runtime singleton exists."""
+        self.assertFalse(Runtime.is_running())
+        _ = Runtime(MagicMock())
+        self.assertTrue(Runtime.is_running())
+
 
 class RuntimeTest(RuntimeTestCase):
     async def test_start_stop(self):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -210,7 +210,7 @@ class WStateTests(unittest.TestCase):
         metadata.callback.assert_called_once_with(1, y=2)
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
     def test_widget_creation_updates_state(self):
         state = st.session_state
@@ -229,7 +229,7 @@ class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
         assert c == True
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class SessionStateTest(testutil.DeltaGeneratorTestCase):
     def test_widget_presence(self):
         state = st.session_state
@@ -295,7 +295,7 @@ def check_roundtrip(widget_id: str, value: Any) -> None:
     assert deserializer(serializer(value), "") == value
 
 
-@patch("streamlit._is_running_with_streamlit", new=True)
+@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
 class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
     def test_checkbox_serde(self):
         cb = st.checkbox("cb", key="cb")

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -210,7 +210,7 @@ class WStateTests(unittest.TestCase):
         metadata.callback.assert_called_once_with(1, y=2)
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
     def test_widget_creation_updates_state(self):
         state = st.session_state
@@ -229,7 +229,7 @@ class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
         assert c == True
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class SessionStateTest(testutil.DeltaGeneratorTestCase):
     def test_widget_presence(self):
         state = st.session_state
@@ -295,7 +295,7 @@ def check_roundtrip(widget_id: str, value: Any) -> None:
     assert deserializer(serializer(value), "") == value
 
 
-@patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
     def test_checkbox_serde(self):
         cb = st.checkbox("cb", key="cb")

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -82,7 +82,7 @@ class StreamlitTest(unittest.TestCase):
         with self.assertRaises(StreamlitAPIException):
             st.set_option("server.enableCORS", False)
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=False))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=False))
     def test_run_warning_presence(self):
         """Using Streamlit without `streamlit run` produces a warning."""
         with self.assertLogs(level=logging.WARNING) as logs:
@@ -92,7 +92,7 @@ class StreamlitTest(unittest.TestCase):
             # Warning produced exactly once
             self.assertEqual(len(re.findall(r"streamlit run", output)), 1)
 
-    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
     def test_run_warning_absence(self):
         """Using Streamlit through the CLI results in a Runtime being instantiated,
         so it produces no usage warning."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -22,7 +22,7 @@ import sys
 import textwrap
 import time
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -82,6 +82,7 @@ class StreamlitTest(unittest.TestCase):
         with self.assertRaises(StreamlitAPIException):
             st.set_option("server.enableCORS", False)
 
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=False))
     def test_run_warning_presence(self):
         """Using Streamlit without `streamlit run` produces a warning."""
         with self.assertLogs(level=logging.WARNING) as logs:
@@ -91,8 +92,10 @@ class StreamlitTest(unittest.TestCase):
             # Warning produced exactly once
             self.assertEqual(len(re.findall(r"streamlit run", output)), 1)
 
+    @patch("streamlit.runtime.is_running", new=MagicMock(return_value=True))
     def test_run_warning_absence(self):
-        """Using Streamlit through the CLI produces no usage warning."""
+        """Using Streamlit through the CLI results in a Runtime being instantiated,
+        so it produces no usage warning."""
         with self.assertLogs(level=logging.WARNING) as logs:
             st._use_warning_has_been_displayed = False
             st.write("Using delta generator")

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -96,7 +96,8 @@ class StreamlitTest(unittest.TestCase):
         with self.assertLogs(level=logging.WARNING) as logs:
             st._use_warning_has_been_displayed = False
             st.write("Using delta generator")
-            # assertLogs is being used as a context manager, but it also checks that some log output was captured, so we have to let it capture something
+            # assertLogs is being used as a context manager, but it also checks
+            # that some log output was captured, so we have to let it capture something
             get_logger("root").warning("irrelevant warning so assertLogs passes")
             self.assertNotRegex("".join(logs.output), r"streamlit run")
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -85,7 +85,6 @@ class StreamlitTest(unittest.TestCase):
     def test_run_warning_presence(self):
         """Using Streamlit without `streamlit run` produces a warning."""
         with self.assertLogs(level=logging.WARNING) as logs:
-            st._is_running_with_streamlit = False
             st._use_warning_has_been_displayed = False
             st.write("Using delta generator")
             output = "".join(logs.output)
@@ -95,7 +94,6 @@ class StreamlitTest(unittest.TestCase):
     def test_run_warning_absence(self):
         """Using Streamlit through the CLI produces no usage warning."""
         with self.assertLogs(level=logging.WARNING) as logs:
-            st._is_running_with_streamlit = True
             st._use_warning_has_been_displayed = False
             st.write("Using delta generator")
             # assertLogs is being used as a context manager, but it also checks that some log output was captured, so we have to let it capture something

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -46,7 +46,6 @@ class CliTest(unittest.TestCase):
 
         cli.name = "streamlit"
         self.runner = CliRunner()
-        streamlit._is_running_with_streamlit = False
 
         self.patches = [
             patch.object(config._on_config_parsed, "send"),
@@ -193,18 +192,6 @@ class CliTest(unittest.TestCase):
         with patch("click.get_current_context", return_value=mock_context):
             result = cli._get_command_line_as_string()
             self.assertIsNone(result)
-
-    def test_running_in_streamlit(self):
-        """Test that streamlit._running_in_streamlit is True after
-        calling `streamlit run...`, and false otherwise.
-        """
-        self.assertFalse(streamlit._is_running_with_streamlit)
-        with patch("streamlit.web.cli.bootstrap.run"), mock.patch(
-            "streamlit.runtime.credentials.Credentials._check_activated"
-        ), patch("streamlit.web.cli._get_command_line_as_string"):
-
-            cli._main_run("/not/a/file", None)
-            self.assertTrue(streamlit._is_running_with_streamlit)
 
     def test_convert_config_option_to_click_option(self):
         """Test that configurator_options adds dynamic commands based on a

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -19,11 +19,10 @@ from contextlib import contextmanager
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
 
-import streamlit
 from streamlit import config
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime import Runtime, media_file_manager
+from streamlit.runtime import Runtime
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.media_file_manager import MediaFileManager
@@ -113,16 +112,11 @@ class DeltaGeneratorTestCase(unittest.TestCase):
         mock_runtime.media_file_mgr = MediaFileManager(self.media_file_storage)
         Runtime._instance = mock_runtime
 
-        # Accessing the MediaFileManager requires that _is_running_with_streamlit
-        # is True.
-        streamlit._is_running_with_streamlit = True
-
     def tearDown(self):
         self.clear_queue()
         if self.override_root:
             add_script_run_ctx(threading.current_thread(), self.orig_report_ctx)
         Runtime._instance = None
-        streamlit._is_running_with_streamlit = False
 
     def get_message_from_queue(self, index=-1) -> ForwardMsg:
         """Get a ForwardMsg proto from the queue, by index."""


### PR DESCRIPTION
We currently use a "private" flag in Streamlit's `__init__.py` (scare quotes around "private" because it's actually accessed everywhere), called `_is_running_with_streamlit`, to test whether a Streamlit app was started via `streamlit run app.py` (`_is_running_with_streamlit=True`) or in "raw mode" via `python app.py` (`_is_running_with_streamlit=False`).

This is unfortunate for a number of reasons: 
- it means lots of code must do `import streamlit` (which can lead to circular import errors)
- it requires that we manually set the flag at the right times, even though we have other signals about whether Streamlit is actually running
- and it's just weird to have a private flag accessed so very publicly

But now that `streamlit.Runtime` is a singleton, we can ditch this flag and instead just check if the Runtime singleton exists or not!

This PR:
- Adds the `Runtime.is_running()` class method, which returns True if the Runtime singleton exists
- Also adds the convenience function `runtime.is_running()` directly in the `runtime` package
- Replaces all usage of `st._is_running_with_streamlit` with `runtime.is_running()`