### PR TITLE
Remove wildcard usage in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, that is.
-* @streamlit/core @LukasMasuch
 frontend/package.json @jroes @anoctopus @tconkling @kmcgrady
 lib/Pipfile @jroes @anoctopus @tconkling @kmcgrady
 lib/setup.py @jroes @anoctopus @tconkling @kmcgrady


### PR DESCRIPTION
## 📚 Context

Because of the transition to Snowflake SSO on the Github Org, we cannot make use of Github teams for our external accounts. Adding external accounts directly to the `CODEOWNERS` file will add the person explicitly as a reviewer for all files. That makes the reviewer feature quite unusable. Therefore, this PR removes the wildcard usage of in `CODEOWNERS` that applies to all files.

Previously we used `CODEOWNERS` to restrict who can merge into `develop` (protected branch) and who can approve our PRs. Removing this would result in the following change:

- All people with `maintain` or `admin` permission for the repo will be able to merge into `develop` (protected branch) [[SOURCE](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)]
- All people with `write` permission or higher will be able to approve pull requests into `develop` (protected branch) [[SOURCE](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews)]
-> Therefore, we should take care on maintaining the list of people with `write` (for approving PRs) and `maintain`  (for merging PRs) permission to `streamlit/streamlit`. The external accounts of the core developer team should be added with `maintain` permission.

## 🧠 Description of Changes

- Removing the wildcard usage of in CODEOWNERS that applies to all files.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
