### PR TITLE
Use get_running_loop instead of passing in the eventloop as an arg

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -74,7 +74,6 @@ class AppSession:
 
     def __init__(
         self,
-        event_loop: AbstractEventLoop,
         session_data: SessionData,
         uploaded_file_manager: UploadedFileManager,
         message_enqueued_callback: Optional[Callable[[], None]],
@@ -85,9 +84,6 @@ class AppSession:
 
         Parameters
         ----------
-        event_loop : AbstractEventLoop
-            The asyncio EventLoop that we're running on.
-
         session_data : SessionData
             Object storing parameters related to running a script
 
@@ -115,7 +111,7 @@ class AppSession:
         # Each AppSession has a unique string ID.
         self.id = str(uuid.uuid4())
 
-        self._event_loop = event_loop
+        self._event_loop = asyncio.get_running_loop()
         self._session_data = session_data
         self._uploaded_file_mgr = uploaded_file_manager
         self._message_enqueued_callback = message_enqueued_callback
@@ -451,7 +447,7 @@ class AppSession:
 
         assert (
             self._event_loop == asyncio.get_running_loop()
-        ), "This function must only be called on the eventloop thread"
+        ), "This function must only be called on the eventloop thread the AppSession was created on."
 
         if sender is not self._scriptrunner:
             # This event was sent by a non-current ScriptRunner; ignore it.

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -367,7 +367,6 @@ class Runtime:
         async_objs = self._get_async_objs()
 
         session = AppSession(
-            event_loop=async_objs.eventloop,
             session_data=SessionData(self._main_script_path, self._command_line or ""),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
@@ -497,7 +496,6 @@ class Runtime:
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
         session = AppSession(
-            event_loop=self._get_async_objs().eventloop,
             session_data=SessionData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,


### PR DESCRIPTION
## 📚 Context

It's a bit clunky having to pass an event loop into the `AppSession` constructor since we
already specify that functions that create `AppSession`s should only be run from the
`Runtime`'s eventloop thread. This PR makes this a bit better by instead using
`asyncio.get_running_loop` to get the currently running eventloop in `AppSession.__init__`.

- What kind of change does this PR introduce?

  - [x] Refactoring

## 🧪 Testing Done

- [x] Added/Updated e2e tests