### PR TITLE
Tests: avoid unused params in @patched funcs

### DIFF
--- a/lib/tests/streamlit/components_test.py
+++ b/lib/tests/streamlit/components_test.py
@@ -374,7 +374,7 @@ class InvokeComponentTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.component_instance
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -110,7 +110,7 @@ class ArrowDataFrameProtoTest(testutil.DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.type_util.is_pandas_version_less_than",
-        new=MagicMock(return_value=True),
+        MagicMock(return_value=True),
     )
     @patch.object(Styler, "_translate")
     def test_pandas_version_below_1_3_0(self, mock_styler_translate):
@@ -123,7 +123,7 @@ class ArrowDataFrameProtoTest(testutil.DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.type_util.is_pandas_version_less_than",
-        new=MagicMock(return_value=False),
+        MagicMock(return_value=False),
     )
     @patch.object(Styler, "_translate")
     def test_pandas_version_1_3_0_and_above(self, mock_styler_translate):

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -14,7 +14,7 @@
 
 """Arrow DataFrame tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -108,9 +108,12 @@ class ArrowDataFrameProtoTest(testutil.DeltaGeneratorTestCase):
             bytes_to_data_frame(proto.styler.display_values), expected
         )
 
-    @patch("streamlit.type_util.is_pandas_version_less_than", return_value=True)
+    @patch(
+        "streamlit.type_util.is_pandas_version_less_than",
+        new=MagicMock(return_value=True),
+    )
     @patch.object(Styler, "_translate")
-    def test_pandas_version_below_1_3_0(self, mock_styler_translate, _):
+    def test_pandas_version_below_1_3_0(self, mock_styler_translate):
         """Tests that `styler._translate` is called without arguments in Pandas < 1.3.0"""
         df = mock_data_frame()
         styler = df.style.set_uuid("FAKE_UUID")
@@ -118,9 +121,12 @@ class ArrowDataFrameProtoTest(testutil.DeltaGeneratorTestCase):
         st._arrow_dataframe(styler)
         mock_styler_translate.assert_called_once_with()
 
-    @patch("streamlit.type_util.is_pandas_version_less_than", return_value=False)
+    @patch(
+        "streamlit.type_util.is_pandas_version_less_than",
+        new=MagicMock(return_value=False),
+    )
     @patch.object(Styler, "_translate")
-    def test_pandas_version_1_3_0_and_above(self, mock_styler_translate, _):
+    def test_pandas_version_1_3_0_and_above(self, mock_styler_translate):
         """Tests that `styler._translate` is called with correct arguments in Pandas >= 1.3.0"""
         df = mock_data_frame()
         styler = df.style.set_uuid("FAKE_UUID")

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -125,7 +125,7 @@ class ArrowTest(testutil.DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.type_util.is_pandas_version_less_than",
-        new=MagicMock(return_value=True),
+        MagicMock(return_value=True),
     )
     @patch.object(Styler, "_translate")
     def test_pandas_version_below_1_3_0(self, mock_styler_translate):
@@ -138,7 +138,7 @@ class ArrowTest(testutil.DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.type_util.is_pandas_version_less_than",
-        new=MagicMock(return_value=False),
+        MagicMock(return_value=False),
     )
     @patch.object(Styler, "_translate")
     def test_pandas_version_1_3_0_and_above(self, mock_styler_translate):

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -14,7 +14,7 @@
 
 """Arrow marshalling unit tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -123,9 +123,12 @@ class ArrowTest(testutil.DeltaGeneratorTestCase):
             bytes_to_data_frame(proto.styler.display_values), expected
         )
 
-    @patch("streamlit.type_util.is_pandas_version_less_than", return_value=True)
+    @patch(
+        "streamlit.type_util.is_pandas_version_less_than",
+        new=MagicMock(return_value=True),
+    )
     @patch.object(Styler, "_translate")
-    def test_pandas_version_below_1_3_0(self, mock_styler_translate, _):
+    def test_pandas_version_below_1_3_0(self, mock_styler_translate):
         """Tests that `styler._translate` is called without arguments in Pandas < 1.3.0"""
         df = mock_data_frame()
         styler = df.style.set_uuid("FAKE_UUID")
@@ -133,9 +136,12 @@ class ArrowTest(testutil.DeltaGeneratorTestCase):
         st._arrow_table(styler)
         mock_styler_translate.assert_called_once_with()
 
-    @patch("streamlit.type_util.is_pandas_version_less_than", return_value=False)
+    @patch(
+        "streamlit.type_util.is_pandas_version_less_than",
+        new=MagicMock(return_value=False),
+    )
     @patch.object(Styler, "_translate")
-    def test_pandas_version_1_3_0_and_above(self, mock_styler_translate, _):
+    def test_pandas_version_1_3_0_and_above(self, mock_styler_translate):
         """Tests that `styler._translate` is called with correct arguments in Pandas >= 1.3.0"""
         df = mock_data_frame()
         styler = df.style.set_uuid("FAKE_UUID")

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -71,7 +71,7 @@ class CheckboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.checkbox
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -73,7 +73,7 @@ class ColorPickerTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -22,19 +22,19 @@ from streamlit.errors import StreamlitAPIException
 
 
 class ElementUtilsTest(unittest.TestCase):
-    @patch("streamlit.elements.utils.is_in_form", return_value=False)
+    @patch("streamlit.elements.utils.is_in_form", new=MagicMock(return_value=False))
     @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
-    def test_check_callback_rules_not_in_form(self, _):
+    def test_check_callback_rules_not_in_form(self):
         check_callback_rules(None, lambda x: x)
 
-    @patch("streamlit.elements.utils.is_in_form", return_value=True)
+    @patch("streamlit.elements.utils.is_in_form", new=MagicMock(return_value=True))
     @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
-    def test_check_callback_rules_in_form(self, _):
+    def test_check_callback_rules_in_form(self):
         check_callback_rules(None, None)
 
-    @patch("streamlit.elements.utils.is_in_form", return_value=True)
+    @patch("streamlit.elements.utils.is_in_form", new=MagicMock(return_value=True))
     @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
-    def test_check_callback_rules_error(self, _):
+    def test_check_callback_rules_error(self):
         with pytest.raises(StreamlitAPIException) as e:
             check_callback_rules(None, lambda x: x)
 

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -22,18 +22,18 @@ from streamlit.errors import StreamlitAPIException
 
 
 class ElementUtilsTest(unittest.TestCase):
-    @patch("streamlit.elements.utils.is_in_form", new=MagicMock(return_value=False))
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.elements.utils.is_in_form", MagicMock(return_value=False))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_check_callback_rules_not_in_form(self):
         check_callback_rules(None, lambda x: x)
 
-    @patch("streamlit.elements.utils.is_in_form", new=MagicMock(return_value=True))
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.elements.utils.is_in_form", MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_check_callback_rules_in_form(self):
         check_callback_rules(None, None)
 
-    @patch("streamlit.elements.utils.is_in_form", new=MagicMock(return_value=True))
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.elements.utils.is_in_form", MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_check_callback_rules_error(self):
         with pytest.raises(StreamlitAPIException) as e:
             check_callback_rules(None, lambda x: x)
@@ -46,7 +46,7 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_val(
@@ -60,7 +60,7 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_no_state_val(
@@ -74,7 +74,7 @@ class ElementUtilsTest(unittest.TestCase):
 
         patched_st_warning.assert_not_called()
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     @patch("streamlit.warning")
     def test_check_session_state_rules_prints_warning(
@@ -91,7 +91,7 @@ class ElementUtilsTest(unittest.TestCase):
         warning_msg = args[0]
         assert 'The widget with key "the key"' in warning_msg
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     def test_check_session_state_rules_writes_not_allowed(
         self, patched_get_session_state

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -220,7 +220,7 @@ class Multiselectbox(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.multiselect
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -220,7 +220,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 
@@ -251,7 +251,7 @@ class NumberInputTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual(number_input_proto.step, 1.0)
         self.assertEqual(number_input_proto.default, 0)
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")
     def test_no_warning_with_value_set_in_state(self, patched_get_session_state):
         mock_session_state = MagicMock()

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -157,7 +157,7 @@ class RadioTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.radio
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -220,7 +220,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -144,7 +144,7 @@ class SelectboxTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -216,7 +216,7 @@ class SliderTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -86,7 +86,7 @@ class TextAreaTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.color_picker
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -100,7 +100,7 @@ class TextInputTest(testutil.DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.text_input
         self.assertEqual(proto.form_id, "")
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -280,9 +280,9 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.elements.button.register_widget",
-        return_value=RegisterWidgetResult(True, False),
+        new=MagicMock(return_value=RegisterWidgetResult(True, False)),
     )
-    def test_return_true_when_submitted(self, _):
+    def test_return_true_when_submitted(self):
         with st.form("form"):
             submitted = st.form_submit_button("Submit")
             self.assertEqual(submitted, True)

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -24,7 +24,7 @@ from tests import testutil
 NO_FORM_ID = ""
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class FormAssociationTest(testutil.DeltaGeneratorTestCase):
     """Tests for every flavor of form/deltagenerator association."""
 
@@ -164,7 +164,7 @@ class FormAssociationTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("form", self._get_last_checkbox_form_id())
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
     """Test ability to marshall form protos."""
 
@@ -240,7 +240,7 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual("bar", form_data.form_id)
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
     """Test form submit button."""
 
@@ -288,7 +288,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
             self.assertEqual(submitted, True)
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class FormStateInteractionTest(testutil.DeltaGeneratorTestCase):
     def test_exception_for_callbacks_on_widgets(self):
         with self.assertRaises(StreamlitAPIException):

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -280,7 +280,7 @@ class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.elements.button.register_widget",
-        new=MagicMock(return_value=RegisterWidgetResult(True, False)),
+        MagicMock(return_value=RegisterWidgetResult(True, False)),
     )
     def test_return_true_when_submitted(self):
         with st.form("form"):

--- a/lib/tests/streamlit/runtime/legacy_caching/caching_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/caching_test.py
@@ -15,7 +15,7 @@
 """st.caching unit tests."""
 import threading
 import types
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from parameterized import parameterized
 
@@ -261,9 +261,9 @@ class CacheTest(testutil.DeltaGeneratorTestCase):
         self.assertEqual([0, 1, 2], bar_vals)
 
     # Reduce the huge amount of logspam we get from hashing/caching
-    @patch("streamlit.runtime.legacy_caching.hashing._LOGGER.debug")
-    @patch("streamlit.runtime.legacy_caching.caching._LOGGER.debug")
-    def test_no_max_size(self, _1, _2):
+    @patch("streamlit.runtime.legacy_caching.hashing._LOGGER.debug", MagicMock())
+    @patch("streamlit.runtime.legacy_caching.caching._LOGGER.debug", MagicMock())
+    def test_no_max_size(self):
         """If max_size is None, the cache is unbounded."""
         called_values = []
 

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -133,18 +133,18 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_reject_null_files(self, _):
+    def test_reject_null_files(self):
         """MediaFileManager.add raises a TypeError if it's passed None."""
         with self.assertRaises(TypeError):
             self.media_file_manager.add(None, "media/any", random_coordinates())
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session",
+        new=MagicMock(return_value="mock_session"),
     )
-    def test_add_binary_files(self, _):
+    def test_add_binary_files(self):
         """Test that we can add binary files to the manager."""
         storage_load_spy = MagicMock(side_effect=self.storage.load_and_get_id)
         self.storage.load_and_get_id = storage_load_spy
@@ -176,14 +176,14 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session",
+        new=MagicMock(return_value="mock_session"),
     )
     @mock.patch(
         "streamlit.runtime.memory_media_file_storage.open",
         mock_open(read_data=b"mock_test_file"),
         create=True,
     )
-    def test_add_file_by_name(self, _1):
+    def test_add_file_by_name(self):
         """Test that we can add files by filename."""
         storage_load_spy = MagicMock(side_effect=self.storage.load_and_get_id)
         self.storage.load_and_get_id = storage_load_spy
@@ -207,9 +207,9 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_add_files_same_coord(self, _):
+    def test_add_files_same_coord(self):
         """We can add multiple files that share the same coordinate."""
         coord = random_coordinates()
 
@@ -239,9 +239,9 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_add_file_already_exists_same_coord(self, _):
+    def test_add_file_already_exists_same_coord(self):
         """Adding a file that already exists results in just a single file in
         the manager.
         """
@@ -263,9 +263,9 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_add_file_already_exists_different_coord(self, _):
+    def test_add_file_already_exists_different_coord(self):
         """Adding a file that already exists, but with different coordinates,
         results in just a single file in the manager.
         """
@@ -288,9 +288,9 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_remove_orphaned_files_in_empty_manager(self, _):
+    def test_remove_orphaned_files_in_empty_manager(self):
         """Calling clear_session_refs/remove_orphaned_files in an empty manager
         is a no-op.
         """

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -133,7 +133,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_reject_null_files(self):
         """MediaFileManager.add raises a TypeError if it's passed None."""
@@ -142,7 +142,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session"),
+        MagicMock(return_value="mock_session"),
     )
     def test_add_binary_files(self):
         """Test that we can add binary files to the manager."""
@@ -176,7 +176,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session"),
+        MagicMock(return_value="mock_session"),
     )
     @mock.patch(
         "streamlit.runtime.memory_media_file_storage.open",
@@ -207,7 +207,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_add_files_same_coord(self):
         """We can add multiple files that share the same coordinate."""
@@ -239,7 +239,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_add_file_already_exists_same_coord(self):
         """Adding a file that already exists results in just a single file in
@@ -263,7 +263,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_add_file_already_exists_different_coord(self):
         """Adding a file that already exists, but with different coordinates,
@@ -288,7 +288,7 @@ class MediaFileManagerTest(TestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_remove_orphaned_files_in_empty_manager(self):
         """Calling clear_session_refs/remove_orphaned_files in an empty manager

--- a/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_media_file_storage_test.py
@@ -16,7 +16,7 @@
 
 import unittest
 from unittest import mock
-from unittest.mock import mock_open
+from unittest.mock import MagicMock, mock_open
 
 from parameterized import parameterized
 
@@ -115,9 +115,10 @@ class MemoryMediaFileStorageTest(unittest.TestCase):
         self.assertNotEqual(file_id1, changed_filename)
 
     @mock.patch(
-        "streamlit.runtime.memory_media_file_storage.open", side_effect=Exception
+        "streamlit.runtime.memory_media_file_storage.open",
+        MagicMock(side_effect=Exception),
     )
-    def test_load_with_bad_path(self, _):
+    def test_load_with_bad_path(self):
         """Adding a file by path raises a MediaFileStorageError if the file can't be read."""
         with self.assertRaises(MediaFileStorageError):
             self.storage.load_and_get_id(

--- a/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
@@ -42,7 +42,7 @@ def _create_mock_session_state(
 
 @patch(
     "streamlit.runtime.state.session_state_proxy.get_session_state",
-    new=MagicMock(return_value=_create_mock_session_state({"foo": "bar"})),
+    MagicMock(return_value=_create_mock_session_state({"foo": "bar"})),
 )
 class SessionStateProxyTests(unittest.TestCase):
     reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
@@ -106,7 +106,7 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
+        MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
     def test_delattr(self):
         del self.session_state_proxy.foo
@@ -114,14 +114,14 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
+        MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
     def test_getattr(self):
         assert self.session_state_proxy.foo == "bar"
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
+        MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
     def test_getattr_error(self):
         with pytest.raises(AttributeError):
@@ -129,7 +129,7 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
+        MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
     def test_setattr(self):
         self.session_state_proxy.corge = "grault2"

--- a/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
@@ -16,7 +16,7 @@
 
 import unittest
 from typing import Any, Dict
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -42,7 +42,7 @@ def _create_mock_session_state(
 
 @patch(
     "streamlit.runtime.state.session_state_proxy.get_session_state",
-    return_value=_create_mock_session_state({"foo": "bar"}),
+    new=MagicMock(return_value=_create_mock_session_state({"foo": "bar"})),
 )
 class SessionStateProxyTests(unittest.TestCase):
     reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
@@ -50,46 +50,46 @@ class SessionStateProxyTests(unittest.TestCase):
     def setUp(self):
         self.session_state_proxy = SessionStateProxy()
 
-    def test_iter(self, _):
+    def test_iter(self):
         state_iter = iter(self.session_state_proxy)
         assert next(state_iter) == "foo"
         with pytest.raises(StopIteration):
             next(state_iter)
 
-    def test_len(self, _):
+    def test_len(self):
         assert len(self.session_state_proxy) == 1
 
-    def test_validate_key(self, _):
+    def test_validate_key(self):
         with pytest.raises(StreamlitAPIException) as e:
             require_valid_user_key(self.reserved_key)
         assert "are reserved" in str(e.value)
 
-    def test_to_dict(self, _):
+    def test_to_dict(self):
         assert self.session_state_proxy.to_dict() == {"foo": "bar"}
 
     # NOTE: We only test the error cases of {get, set, del}{item, attr} below
     # since the others are tested in another test class.
-    def test_getitem_reserved_key(self, _):
+    def test_getitem_reserved_key(self):
         with pytest.raises(StreamlitAPIException):
             _ = self.session_state_proxy[self.reserved_key]
 
-    def test_setitem_reserved_key(self, _):
+    def test_setitem_reserved_key(self):
         with pytest.raises(StreamlitAPIException):
             self.session_state_proxy[self.reserved_key] = "foo"
 
-    def test_delitem_reserved_key(self, _):
+    def test_delitem_reserved_key(self):
         with pytest.raises(StreamlitAPIException):
             del self.session_state_proxy[self.reserved_key]
 
-    def test_getattr_reserved_key(self, _):
+    def test_getattr_reserved_key(self):
         with pytest.raises(StreamlitAPIException):
             getattr(self.session_state_proxy, self.reserved_key)
 
-    def test_setattr_reserved_key(self, _):
+    def test_setattr_reserved_key(self):
         with pytest.raises(StreamlitAPIException):
             setattr(self.session_state_proxy, self.reserved_key, "foo")
 
-    def test_delattr_reserved_key(self, _):
+    def test_delattr_reserved_key(self):
         with pytest.raises(StreamlitAPIException):
             delattr(self.session_state_proxy, self.reserved_key)
 
@@ -106,31 +106,31 @@ class SessionStateProxyAttributeTests(unittest.TestCase):
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        return_value=SessionState(_new_session_state={"foo": "bar"}),
+        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
-    def test_delattr(self, _):
+    def test_delattr(self):
         del self.session_state_proxy.foo
         assert "foo" not in self.session_state_proxy
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        return_value=SessionState(_new_session_state={"foo": "bar"}),
+        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
-    def test_getattr(self, _):
+    def test_getattr(self):
         assert self.session_state_proxy.foo == "bar"
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        return_value=SessionState(_new_session_state={"foo": "bar"}),
+        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
-    def test_getattr_error(self, _):
+    def test_getattr_error(self):
         with pytest.raises(AttributeError):
             del self.session_state_proxy.nonexistent
 
     @patch(
         "streamlit.runtime.state.session_state_proxy.get_session_state",
-        return_value=SessionState(_new_session_state={"foo": "bar"}),
+        new=MagicMock(return_value=SessionState(_new_session_state={"foo": "bar"})),
     )
-    def test_setattr(self, _):
+    def test_setattr(self):
         self.session_state_proxy.corge = "grault2"
         assert self.session_state_proxy.corge == "grault2"

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -210,7 +210,7 @@ class WStateTests(unittest.TestCase):
         metadata.callback.assert_called_once_with(1, y=2)
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
     def test_widget_creation_updates_state(self):
         state = st.session_state
@@ -229,7 +229,7 @@ class SessionStateUpdateTest(testutil.DeltaGeneratorTestCase):
         assert c == True
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class SessionStateTest(testutil.DeltaGeneratorTestCase):
     def test_widget_presence(self):
         state = st.session_state
@@ -295,7 +295,7 @@ def check_roundtrip(widget_id: str, value: Any) -> None:
     assert deserializer(serializer(value), "") == value
 
 
-@patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+@patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
 class SessionStateSerdeTest(testutil.DeltaGeneratorTestCase):
     def test_checkbox_serde(self):
         cb = st.checkbox("cb", key="cb")

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -93,7 +93,7 @@ class PageHelperFunctionTests(unittest.TestCase):
     def test_page_icon_and_name(self, path_str, expected):
         assert source_util.page_icon_and_name(Path(path_str)) == expected
 
-    @patch("streamlit.source_util._on_pages_changed", new=MagicMock())
+    @patch("streamlit.source_util._on_pages_changed", MagicMock())
     @patch("streamlit.source_util._cached_pages", new="Some pages")
     def test_invalidate_pages_cache(self):
         source_util.invalidate_pages_cache()
@@ -101,7 +101,7 @@ class PageHelperFunctionTests(unittest.TestCase):
         assert source_util._cached_pages is None
         source_util._on_pages_changed.send.assert_called_once()
 
-    @patch("streamlit.source_util._on_pages_changed", new=MagicMock())
+    @patch("streamlit.source_util._on_pages_changed", MagicMock())
     def test_register_pages_changed_callback(self):
         callback = lambda: None
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -82,7 +82,7 @@ class StreamlitTest(unittest.TestCase):
         with self.assertRaises(StreamlitAPIException):
             st.set_option("server.enableCORS", False)
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=False))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=False))
     def test_run_warning_presence(self):
         """Using Streamlit without `streamlit run` produces a warning."""
         with self.assertLogs(level=logging.WARNING) as logs:
@@ -92,7 +92,7 @@ class StreamlitTest(unittest.TestCase):
             # Warning produced exactly once
             self.assertEqual(len(re.findall(r"streamlit run", output)), 1)
 
-    @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_run_warning_absence(self):
         """Using Streamlit through the CLI results in a Runtime being instantiated,
         so it produces no usage warning."""

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -41,7 +41,7 @@ def NOOP_CALLBACK(_filepath):
 
 
 @patch("streamlit.source_util._cached_pages", new=None)
-@patch("streamlit.file_util.file_in_pythonpath", return_value=False)
+@patch("streamlit.file_util.file_in_pythonpath", new=MagicMock(return_value=False))
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):
         modules = [
@@ -66,7 +66,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
                 pass
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_just_script(self, fob, _):
+    def test_just_script(self, fob):
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
@@ -85,13 +85,13 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(fob.call_count, 1)  # __init__.py
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_permission_error(self, fob, _):
+    def test_permission_error(self, fob):
         fob.side_effect = PermissionError("This error should be caught!")
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_script_and_2_modules_at_once(self, fob, _):
+    def test_script_and_2_modules_at_once(self, fob):
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
@@ -124,7 +124,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         self.assertEqual(fob.call_count, 0)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_script_and_2_modules_in_series(self, fob, _):
+    def test_script_and_2_modules_in_series(self, fob):
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
@@ -160,7 +160,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.LOGGER")
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_misbehaved_module(self, fob, patched_logger, _):
+    def test_misbehaved_module(self, fob, patched_logger):
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
@@ -177,7 +177,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         )
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_nested_module_parent_unloaded(self, fob, _):
+    def test_nested_module_parent_unloaded(self, fob):
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
@@ -201,7 +201,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             self.assertNotIn("NESTED_MODULE_PARENT", sys.modules)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_config_blacklist(self, fob, _):
+    def test_config_blacklist(self, fob):
         """Test server.folderWatchBlacklist"""
         prev_blacklist = config.get_option("server.folderWatchBlacklist")
 
@@ -224,7 +224,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         # Reset the config object.
         config.set_option("server.folderWatchBlacklist", prev_blacklist)
 
-    def test_config_watcherType(self, _):
+    def test_config_watcherType(self):
         """Test server.fileWatcherType"""
 
         config.set_option("server.fileWatcherType", "none")
@@ -260,14 +260,14 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             )
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher", new=NoOpPathWatcher)
-    def test_does_nothing_if_NoOpPathWatcher(self, _):
+    def test_does_nothing_if_NoOpPathWatcher(self):
         lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lsw.register_file_change_callback(NOOP_CALLBACK)
         lsw.update_watched_modules()
         self.assertEqual(len(lsw._watched_modules), 0)
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_namespace_package_unloaded(self, fob, _):
+    def test_namespace_package_unloaded(self, fob):
         import tests.streamlit.watcher.test_data.namespace_package as pkg
 
         pkg_path = os.path.abspath(pkg.__path__._path[0])
@@ -289,7 +289,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         del sys.modules["tests.streamlit.watcher.test_data.namespace_package"]
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_module_caching(self, _fob, _):
+    def test_module_caching(self, _fob):
         lso = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lso.register_file_change_callback(NOOP_CALLBACK)
 
@@ -332,7 +332,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         ),
     )
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_watches_all_page_scripts(self, fob, _):
+    def test_watches_all_page_scripts(self, fob):
         lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
         lsw.register_file_change_callback(NOOP_CALLBACK)
 
@@ -343,7 +343,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         assert args2[0] == "streamlit_app2.py"
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
-    def test_passes_filepath_to_callback(self, fob, _):
+    def test_passes_filepath_to_callback(self, fob):
         saved_filepath = None
 
         def callback(filepath):

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -41,7 +41,7 @@ def NOOP_CALLBACK(_filepath):
 
 
 @patch("streamlit.source_util._cached_pages", new=None)
-@patch("streamlit.file_util.file_in_pythonpath", new=MagicMock(return_value=False))
+@patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):
         modules = [

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -64,16 +64,12 @@ class FakeStat(object):
 
 
 class PathModificationTimeTests(unittest.TestCase):
-    @patch(
-        "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
-    )
+    @patch("streamlit.watcher.util.os.stat", MagicMock(return_value=FakeStat(101.0)))
     @patch("streamlit.watcher.util.os.path.exists", MagicMock(return_value=True))
     def test_st_mtime_if_file_exists(self):
         assert util.path_modification_time("foo") == 101.0
 
-    @patch(
-        "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
-    )
+    @patch("streamlit.watcher.util.os.stat", MagicMock(return_value=FakeStat(101.0)))
     @patch("streamlit.watcher.util.os.path.exists", MagicMock(return_value=True))
     def test_st_mtime_if_file_exists_and_allow_nonexistent(self):
         assert util.path_modification_time("foo", allow_nonexistent=True) == 101.0

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -67,18 +67,18 @@ class PathModificationTimeTests(unittest.TestCase):
     @patch(
         "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
     )
-    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.watcher.util.os.path.exists", MagicMock(return_value=True))
     def test_st_mtime_if_file_exists(self):
         assert util.path_modification_time("foo") == 101.0
 
     @patch(
         "streamlit.watcher.util.os.stat", new=MagicMock(return_value=FakeStat(101.0))
     )
-    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=True))
+    @patch("streamlit.watcher.util.os.path.exists", MagicMock(return_value=True))
     def test_st_mtime_if_file_exists_and_allow_nonexistent(self):
         assert util.path_modification_time("foo", allow_nonexistent=True) == 101.0
 
-    @patch("streamlit.watcher.util.os.path.exists", new=MagicMock(return_value=False))
+    @patch("streamlit.watcher.util.os.path.exists", MagicMock(return_value=False))
     def test_zero_if_file_nonexistent_and_allow_nonexistent(self):
         assert util.path_modification_time("foo", allow_nonexistent=True) == 0.0
 

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import mock
+from unittest.mock import MagicMock
 
 import tornado.testing
 import tornado.web
@@ -42,9 +43,9 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_media_file(self, _) -> None:
+    def test_media_file(self) -> None:
         """Requests for media files in MediaFileManager should succeed."""
         # Add a media file and read it back
         url = self.media_file_manager.add(b"mock_data", "video/mp4", "mock_coords")
@@ -66,9 +67,9 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
     )
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        return_value="mock_session_id",
+        new=MagicMock(return_value="mock_session_id"),
     )
-    def test_downloadable_file(self, file_name, content_disposition_header, _) -> None:
+    def test_downloadable_file(self, file_name, content_disposition_header) -> None:
         """Downloadable files get an additional 'Content-Disposition' header
         that includes their user-specified filename.
         """

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -43,7 +43,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_media_file(self) -> None:
         """Requests for media files in MediaFileManager should succeed."""
@@ -67,7 +67,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
     )
     @mock.patch(
         "streamlit.runtime.media_file_manager._get_session_id",
-        new=MagicMock(return_value="mock_session_id"),
+        MagicMock(return_value="mock_session_id"),
     )
     def test_downloadable_file(self, file_name, content_disposition_header) -> None:
         """Downloadable files get an additional 'Content-Disposition' header


### PR DESCRIPTION
We have a number of tests that use the `@patch` decorator in such a way that the function accepts the `Mock` instance created by the patch, but then the function ignores the Mock param:

```python
@patch("foo", return_value="bar")
def test_the_thing(self, _):  # <-- this "_" param is unused
  ...
```

We can avoid these dummy params by instead passing the `Mock` instance to the `@patch` statement itself:

```python
@patch("foo", MagicMock(return_value="bar"))
def test_the_thing(self):  # <-- no extra param
  ...
```

From the patch docs: 

> If `patch` is used as a decorator and `new` is omitted, the created mock is passed in as an extra argument to the decorated function.


This PR just does the above transformation, and also removes a few unnecessary instances of the `new` keyword in the patch function that I added myself in a previous PR :) (`new` is the second argument to patch and isn't a keyword-only arg. Its meaning is clear in all these instances.)