### PR TITLE
Fix baseweb warnings

### DIFF
--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -21,7 +21,7 @@ import classNames from "classnames"
 import {
   StatelessAccordion as Accordion,
   Panel,
-  SharedProps,
+  SharedStylePropsArg,
 } from "baseui/accordion"
 import { useTheme } from "@emotion/react"
 import { StyledExpandableContainer } from "./styled-components"
@@ -72,7 +72,7 @@ function withExpandable(
           disabled={widgetsDisabled}
           overrides={{
             Content: {
-              style: ({ $expanded }: SharedProps) => ({
+              style: ({ $expanded }: SharedStylePropsArg) => ({
                 backgroundColor: colors.transparent,
                 marginLeft: spacing.none,
                 marginRight: spacing.none,
@@ -100,14 +100,14 @@ function withExpandable(
                 paddingRight: `${spacing.none} !important`,
                 paddingTop: `${spacing.none} !important`,
                 paddingBottom: `${spacing.none} !important`,
-                borderTop: "none !important",
-                borderBottom: "none !important",
-                borderRight: "none !important",
-                borderLeft: "none !important",
+                borderTopStyle: "none !important",
+                borderBottomStyle: "none !important",
+                borderRightStyle: "none !important",
+                borderLeftStyle: "none !important",
               }),
             },
             Header: {
-              style: ({ $disabled }: SharedProps) => ({
+              style: ({ $disabled }: SharedStylePropsArg) => ({
                 marginBottom: spacing.none,
                 marginLeft: spacing.none,
                 marginRight: spacing.none,
@@ -136,7 +136,7 @@ function withExpandable(
               },
             },
             ToggleIcon: {
-              style: ({ $disabled }: SharedProps) => ({
+              style: ({ $disabled }: SharedStylePropsArg) => ({
                 color: $disabled ? colors.disabled : colors.bodyText,
               }),
               // eslint-disable-next-line react/display-name


### PR DESCRIPTION
## 📚 Context

Basweb currently shows some warnings for `st.expander`, since the wrong properties are used.

<img width="897" alt="Screenshot 2022-10-06 at 05 00 34" src="https://user-images.githubusercontent.com/2852129/194204675-15220703-6ae6-4261-a042-3ab333b2de0e.png">

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Use the correct border style properties
- Replace deprecated `SharedProps` type.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
