### PR TITLE
Fix issue with undefined children

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -124,32 +124,33 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
 const ChildRenderer = (props: BlockPropsWithWidth): ReactElement => {
   return (
     <>
-      {props.node.children.map(
-        (node: AppNode, index: number): ReactElement => {
-          // Base case: render a leaf node.
-          if (node instanceof ElementNode) {
-            // Put node in childProps instead of passing as a node={node} prop in React to
-            // guarantee it doesn't get overwritten by {...childProps}.
-            const childProps = { ...props, node: node as ElementNode }
+      {props.node.children &&
+        props.node.children.map(
+          (node: AppNode, index: number): ReactElement => {
+            // Base case: render a leaf node.
+            if (node instanceof ElementNode) {
+              // Put node in childProps instead of passing as a node={node} prop in React to
+              // guarantee it doesn't get overwritten by {...childProps}.
+              const childProps = { ...props, node: node as ElementNode }
 
-            const key = getElementWidgetID(node.element) || index
-            return <ElementNodeRenderer key={key} {...childProps} />
+              const key = getElementWidgetID(node.element) || index
+              return <ElementNodeRenderer key={key} {...childProps} />
+            }
+
+            // Recursive case: render a block, which can contain other blocks
+            // and elements.
+            if (node instanceof BlockNode) {
+              // Put node in childProps instead of passing as a node={node} prop in React to
+              // guarantee it doesn't get overwritten by {...childProps}.
+              const childProps = { ...props, node: node as BlockNode }
+
+              return <BlockNodeRenderer key={index} {...childProps} />
+            }
+
+            // We don't have any other node types!
+            throw new Error(`Unrecognized AppNode: ${node}`)
           }
-
-          // Recursive case: render a block, which can contain other blocks
-          // and elements.
-          if (node instanceof BlockNode) {
-            // Put node in childProps instead of passing as a node={node} prop in React to
-            // guarantee it doesn't get overwritten by {...childProps}.
-            const childProps = { ...props, node: node as BlockNode }
-
-            return <BlockNodeRenderer key={index} {...childProps} />
-          }
-
-          // We don't have any other node types!
-          throw new Error(`Unrecognized AppNode: ${node}`)
-        }
-      )}
+        )}
     </>
   )
 }


### PR DESCRIPTION
## 📚 Context

There is a strange frontend issue that only occurs very rarely - most likely related to tabs - that breaks the frontend :

<img width="797" alt="Screenshot 2022-10-06 at 02 51 50" src="https://user-images.githubusercontent.com/2852129/194293691-a7eefa4a-febc-42df-ab7c-32fb985d1fb0.png">

The issue gets triggered here, but I wasn't able to really determine the root cause:

https://github.com/streamlit/streamlit/blob/ccd945a61b097de494a856f2df9d07ae55079ceb/frontend/src/App.tsx#L956

## 🧠 Description of Changes

- Only call `map` if children are not `undefined`. This seems to prevent the issue without any apparent side effects.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
