### PR TITLE
Add disabled param to st.form_submit_button

### DIFF
--- a/frontend/src/components/shared/Button/Button.test.tsx
+++ b/frontend/src/components/shared/Button/Button.test.tsx
@@ -44,6 +44,20 @@ describe("Button element", () => {
           .exists()
       ).toBeTruthy()
     })
+
+    it(`renders disabled ${kind} correctly`, () => {
+      const wrapper = shallow(
+        <Button {...getProps({ kind, disabled: true })}>Hello</Button>
+      )
+
+      expect(
+        wrapper
+          .find(
+            `Styled${kind.charAt(0).toUpperCase()}${kind.substring(1)}Button`
+          )
+          .prop("disabled")
+      ).toBe(true)
+    })
   })
 
   Object.keys(Size).forEach(key => {

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -208,6 +208,8 @@ class FormMixin:
         on_click=None,
         args=None,
         kwargs=None,
+        *,  # keyword-only arguments:
+        disabled: bool = False,
     ) -> bool:
         """Display a form submit button.
 
@@ -234,6 +236,9 @@ class FormMixin:
             An optional tuple of args to pass to the callback.
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
+        disabled : bool
+            An optional boolean, which disables the button if set to True. The
+            default is False. This argument can only be supplied by keyword.
 
         Returns
         -------
@@ -247,6 +252,7 @@ class FormMixin:
             on_click=on_click,
             args=args,
             kwargs=kwargs,
+            disabled=disabled,
             ctx=ctx,
         )
 
@@ -257,6 +263,8 @@ class FormMixin:
         on_click=None,
         args=None,
         kwargs=None,
+        *,  # keyword-only arguments:
+        disabled: bool = False,
         ctx: Optional[ScriptRunContext] = None,
     ) -> bool:
         form_id = current_form_id(self.dg)
@@ -269,6 +277,7 @@ class FormMixin:
             on_click=on_click,
             args=args,
             kwargs=kwargs,
+            disabled=disabled,
             ctx=ctx,
         )
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -244,6 +244,15 @@ class FormMarshallingTest(testutil.DeltaGeneratorTestCase):
 class FormSubmitButtonTest(testutil.DeltaGeneratorTestCase):
     """Test form submit button."""
 
+    def test_disabled_submit_button(self):
+        """Test that a submit button can be disabled."""
+
+        with st.form("foo"):
+            st.form_submit_button(disabled=True)
+
+        last_delta = self.get_delta_from_queue()
+        self.assertEqual(True, last_delta.new_element.button.disabled)
+
     def test_submit_button_outside_form(self):
         """Test that a submit button is not allowed outside a form."""
 


### PR DESCRIPTION
## 📚 Context

Noticed the `st.form_submit_button` doesn't have the disabled param, but think it should. Ran it by Johannes, who agreed we should implement.

- What kind of change does this PR introduce?
  - [x] Feature

## 🧠 Description of Changes

- Added disabled kw-only param to `st.form_submit_button` consistent with other buttons

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
