### PR TITLE
Add ability to hash PIL images in st.memo and st.singleton

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -291,7 +291,7 @@ class _CacheFuncHasher:
         elif type_util.is_type(obj, "PIL.Image.Image"):
             import numpy as np
 
-            np_array = np.array(obj)
+            np_array = np.frombuffer(obj.tobytes(), dtype="uint8")
             return self.to_bytes(np_array)
 
         elif inspect.isbuiltin(obj):

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -36,16 +36,13 @@ from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 _LOGGER = get_logger(__name__)
 
-
 # If a dataframe has more than this many rows, we consider it large and hash a sample.
 _PANDAS_ROWS_LARGE = 100000
 _PANDAS_SAMPLE_SIZE = 10000
 
-
 # Similar to dataframes, we also sample large numpy arrays.
 _NP_SIZE_LARGE = 1000000
 _NP_SAMPLE_SIZE = 100000
-
 
 # Arbitrary item to denote where we found a cycle in a hashed object.
 # This allows us to hash self-referencing lists, dictionaries, etc.
@@ -291,6 +288,11 @@ class _CacheFuncHasher:
 
             self.update(h, obj.tobytes())
             return h.digest()
+        elif type_util.is_type(obj, "PIL.Image.Image"):
+            import numpy as np
+
+            np_array = np.array(obj)
+            return self.to_bytes(np_array)
 
         elif inspect.isbuiltin(obj):
             return bytes(obj.__name__.encode())

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -291,6 +291,8 @@ class _CacheFuncHasher:
         elif type_util.is_type(obj, "PIL.Image.Image"):
             import numpy as np
 
+            # we don't just hash the results of obj.tobytes() because we want to use
+            # the sampling logic for numpy data
             np_array = np.frombuffer(obj.tobytes(), dtype="uint8")
             return self.to_bytes(np_array)
 

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -221,8 +221,8 @@ class HashTest(unittest.TestCase):
         self.assertNotEqual(get_hash(im1), get_hash(im2))
 
         # Check for big PIL images, they converted to numpy array with size
-        # bigger than _NP_SIZE_LARGE = 1_000_000
-        # 1000 * 1000 * 3 = 3_000_000 > _NP_SIZE_LARGE
+        # bigger than _NP_SIZE_LARGE
+        # 1000 * 1000 * 3 = 3_000_000 > _NP_SIZE_LARGE = 1_000_000
         im4 = Image.new("RGB", (1000, 1000), (100, 20, 60))
         im5 = Image.new("RGB", (1000, 1000), (100, 20, 60))
 

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -220,9 +220,11 @@ class HashTest(unittest.TestCase):
         self.assertEqual(get_hash(im1), get_hash(im3))
         self.assertNotEqual(get_hash(im1), get_hash(im2))
 
-        # ADD EXPLANATORY COMMENT
-        im4 = Image.new("RGB", (500, 500), (100, 20, 60))
-        im5 = Image.new("RGB", (500, 500), (100, 20, 60))
+        # Check for big PIL images, they converted to numpy array with size
+        # bigger than _NP_SIZE_LARGE = 1_000_000
+        # 1000 * 1000 * 3 = 3_000_000 > _NP_SIZE_LARGE
+        im4 = Image.new("RGB", (1000, 1000), (100, 20, 60))
+        im5 = Image.new("RGB", (1000, 1000), (100, 20, 60))
 
         self.assertEqual(get_hash(im4), get_hash(im5))
 

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -225,8 +225,13 @@ class HashTest(unittest.TestCase):
         # 1000 * 1000 * 3 = 3_000_000 > _NP_SIZE_LARGE = 1_000_000
         im4 = Image.new("RGB", (1000, 1000), (100, 20, 60))
         im5 = Image.new("RGB", (1000, 1000), (100, 20, 60))
+        im6 = Image.new("RGB", (1000, 1000), (101, 21, 61))
+
+        im4_np_array = np.frombuffer(im4.tobytes(), dtype="uint8")
+        self.assertGreater(im4_np_array.size, _NP_SIZE_LARGE)
 
         self.assertEqual(get_hash(im4), get_hash(im5))
+        self.assertNotEqual(get_hash(im5), get_hash(im6))
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -30,6 +30,7 @@ import cffi
 import numpy as np
 import pandas as pd
 from parameterized import parameterized
+from PIL import Image
 
 from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.hashing import (
@@ -210,6 +211,20 @@ class HashTest(unittest.TestCase):
         np5 = np.zeros(_NP_SIZE_LARGE)
 
         self.assertEqual(get_hash(np4), get_hash(np5))
+
+    def test_PIL_image(self):
+        im1 = Image.new("RGB", (50, 50), (220, 20, 60))
+        im2 = Image.new("RGB", (50, 50), (30, 144, 255))
+        im3 = Image.new("RGB", (50, 50), (220, 20, 60))
+
+        self.assertEqual(get_hash(im1), get_hash(im3))
+        self.assertNotEqual(get_hash(im1), get_hash(im2))
+
+        # ADD EXPLANATORY COMMENT
+        im4 = Image.new("RGB", (500, 500), (100, 20, 60))
+        im5 = Image.new("RGB", (500, 500), (100, 20, 60))
+
+        self.assertEqual(get_hash(im4), get_hash(im5))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
