### PR TITLE
Improve the error message when using st.memo with Snowpark session

### DIFF
--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -24,7 +24,7 @@ from streamlit.errors import (
 )
 
 
-def _get_cached_func_name_md(func: object) -> str:
+def _get_cached_func_name_md(func) -> str:
     """Get markdown representation of the function name."""
     if hasattr(func, "__name__"):
         return "`%s()`" % func.__name__
@@ -33,7 +33,7 @@ def _get_cached_func_name_md(func: object) -> str:
     return f"`{type(func)}`"
 
 
-def get_return_value_type(return_value: object) -> str:
+def get_return_value_type(return_value) -> str:
     if hasattr(return_value, "__module__") and hasattr(type(return_value), "__name__"):
         return f"`{return_value.__module__}.{type(return_value).__name__}`"
     return _get_cached_func_name_md(return_value)

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -17,7 +17,19 @@ import types
 from typing import Any, Optional
 
 from streamlit import type_util
-from streamlit.errors import StreamlitAPIException, StreamlitAPIWarning
+from streamlit.errors import (
+    MarkdownFormattedException,
+    StreamlitAPIException,
+    StreamlitAPIWarning,
+)
+
+
+def _get_cached_func_name_md(func: types.FunctionType) -> str:
+    """Get markdown representation of the function name."""
+    if hasattr(func, "__name__"):
+        return "`%s()`" % func.__name__
+    else:
+        return "a cached function"
 
 
 class CacheType(enum.Enum):
@@ -122,7 +134,7 @@ class CacheReplayClosureError(StreamlitAPIException):
         cache_type: CacheType,
         cached_func: types.FunctionType,
     ):
-        func_name = self._get_cached_func_name_md(cached_func)
+        func_name = _get_cached_func_name_md(cached_func)
         decorator_name = (cache_type.value,)
 
         msg = (
@@ -140,10 +152,23 @@ How to fix this:
 
         super().__init__(msg)
 
+
+class UnserializableReturnValueError(MarkdownFormattedException):
+    def __init__(self, func: types.FunctionType, return_value: types.FunctionType):
+        MarkdownFormattedException.__init__(
+            self,
+            f"""
+            Cannot serialize the return value (of type {self._get_return_value_type(return_value)}) in {_get_cached_func_name_md(func)}.  
+            `st.experimental_memo` uses [pickle](https://docs.python.org/3/library/pickle.html) to 
+            serialize the function’s return value and safely store it in the cache without mutating the original object. Please convert the return value to a pickle-serializable type.  
+            If you want to cache unserializable objects such as database connections or Tensorflow 
+            sessions, use `st.experimental_singleton` instead (see [our docs](https://docs.streamlit.io/library/advanced-features/experimental-cache-primitives) for differences).""",
+        )
+
     @staticmethod
-    def _get_cached_func_name_md(func: types.FunctionType) -> str:
-        """Get markdown representation of the function name."""
-        if hasattr(func, "__name__"):
-            return "`%s()`" % func.__name__
-        else:
-            return "a cached function"
+    def _get_return_value_type(return_value: types.FunctionType) -> str:
+        if hasattr(return_value, "__module__") and hasattr(
+            type(return_value), "__name__"
+        ):
+            return f"`{return_value.__module__}.{type(return_value).__name__}`"
+        return f"`{type(return_value)}`"

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -49,6 +49,7 @@ from streamlit.runtime.caching.cache_errors import (
     CacheType,
     UnhashableParamError,
     UnhashableTypeError,
+    UnserializableReturnValueError,
 )
 from streamlit.runtime.caching.hashing import update_hash
 
@@ -248,7 +249,12 @@ def create_cache_wrapper(cached_func: CachedFunction) -> Callable[..., Any]:
                         return_value = func(*args, **kwargs)
 
                 messages = cached_func.message_call_stack._most_recent_messages
-                cache.write_result(value_key, return_value, messages)
+                try:
+                    cache.write_result(value_key, return_value, messages)
+                except TypeError:
+                    raise UnserializableReturnValueError(
+                        return_value=return_value, func=cached_func.func
+                    )
 
             return return_value
 

--- a/lib/tests/streamlit/runtime/caching/cache_errors_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_errors_test.py
@@ -17,7 +17,10 @@ import threading
 import streamlit as st
 from streamlit.elements import exception
 from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
-from streamlit.runtime.caching.cache_errors import UnhashableParamError
+from streamlit.runtime.caching.cache_errors import (
+    UnhashableParamError,
+    UnserializableReturnValueError,
+)
 from tests import testutil
 
 
@@ -63,5 +66,31 @@ def unhashable_type_func(_lock, ...):
         )
         # Stack trace doesn't show in test :(
         # self.assertNotEqual(len(ep.stack_trace), 0)
+        self.assertEqual(ep.message_is_markdown, True)
+        self.assertEqual(ep.is_warning, False)
+
+    def test_unserializable_return_value_error(self):
+        @st.experimental_memo
+        def unserializable_return_value_func():
+            return threading.Lock()
+
+        with self.assertRaises(UnserializableReturnValueError) as cm:
+            unserializable_return_value_func()
+
+        ep = ExceptionProto()
+        exception.marshall(ep, cm.exception)
+
+        self.assertEqual(ep.type, "UnserializableReturnValueError")
+
+        expected_message = f"""
+            Cannot serialize the return value (of type `<class '_thread.lock'>`) in `unserializable_return_value_func()`.  
+            `st.experimental_memo` uses [pickle](https://docs.python.org/3/library/pickle.html) to 
+            serialize the function’s return value and safely store it in the cache without mutating the original object. Please convert the return value to a pickle-serializable type.  
+            If you want to cache unserializable objects such as database connections or Tensorflow 
+            sessions, use `st.experimental_singleton` instead (see [our docs](https://docs.streamlit.io/library/advanced-features/experimental-cache-primitives) for differences)."""
+
+        self.assertEqual(
+            testutil.normalize_md(expected_message), testutil.normalize_md(ep.message)
+        )
         self.assertEqual(ep.message_is_markdown, True)
         self.assertEqual(ep.is_warning, False)

--- a/lib/tests/streamlit/runtime/caching/cache_errors_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_errors_test.py
@@ -20,6 +20,7 @@ from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
 from streamlit.runtime.caching.cache_errors import (
     UnhashableParamError,
     UnserializableReturnValueError,
+    get_return_value_type,
 )
 from tests import testutil
 
@@ -34,6 +35,8 @@ class CacheErrorsTest(testutil.DeltaGeneratorTestCase):
 
     TODO: parameterize these tests for both memo + singleton
     """
+
+    maxDiff = None
 
     def test_unhashable_type(self):
         @st.experimental_memo
@@ -83,7 +86,7 @@ def unhashable_type_func(_lock, ...):
         self.assertEqual(ep.type, "UnserializableReturnValueError")
 
         expected_message = f"""
-            Cannot serialize the return value (of type `<class '_thread.lock'>`) in `unserializable_return_value_func()`.  
+            Cannot serialize the return value (of type {get_return_value_type(return_value=threading.Lock())}) in `unserializable_return_value_func()`.  
             `st.experimental_memo` uses [pickle](https://docs.python.org/3/library/pickle.html) to 
             serialize the function’s return value and safely store it in the cache without mutating the original object. Please convert the return value to a pickle-serializable type.  
             If you want to cache unserializable objects such as database connections or Tensorflow 


### PR DESCRIPTION
Improve the error message when using st.memo with Snowpark session. Tell the dev to use st.singleton instead.

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
