### PR TITLE
Improve error message in st.experimental_memo when it returns an unevaluated dataframe

### DIFF
--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -24,7 +24,7 @@ from streamlit.errors import (
 )
 
 
-def _get_cached_func_name_md(func) -> str:
+def get_cached_func_name_md(func) -> str:
     """Get markdown representation of the function name."""
     if hasattr(func, "__name__"):
         return "`%s()`" % func.__name__
@@ -36,7 +36,7 @@ def _get_cached_func_name_md(func) -> str:
 def get_return_value_type(return_value) -> str:
     if hasattr(return_value, "__module__") and hasattr(type(return_value), "__name__"):
         return f"`{return_value.__module__}.{type(return_value).__name__}`"
-    return _get_cached_func_name_md(return_value)
+    return get_cached_func_name_md(return_value)
 
 
 class CacheType(enum.Enum):
@@ -141,7 +141,7 @@ class CacheReplayClosureError(StreamlitAPIException):
         cache_type: CacheType,
         cached_func: types.FunctionType,
     ):
-        func_name = _get_cached_func_name_md(cached_func)
+        func_name = get_cached_func_name_md(cached_func)
         decorator_name = (cache_type.value,)
 
         msg = (
@@ -165,7 +165,7 @@ class UnserializableReturnValueError(MarkdownFormattedException):
         MarkdownFormattedException.__init__(
             self,
             f"""
-            Cannot serialize the return value (of type {get_return_value_type(return_value)}) in {_get_cached_func_name_md(func)}.  
+            Cannot serialize the return value (of type {get_return_value_type(return_value)}) in {get_cached_func_name_md(func)}.  
             `st.experimental_memo` uses [pickle](https://docs.python.org/3/library/pickle.html) to 
             serialize the function’s return value and safely store it in the cache without mutating the original object. Please convert the return value to a pickle-serializable type.  
             If you want to cache unserializable objects such as database connections or Tensorflow 

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -38,9 +38,10 @@ from typing import (
 from google.protobuf.message import Message
 
 import streamlit as st
-from streamlit import util
+from streamlit import type_util, util
 from streamlit.elements import NONWIDGET_ELEMENTS
 from streamlit.elements.spinner import spinner
+from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Block_pb2 import Block
 from streamlit.runtime.caching.cache_errors import (
@@ -51,6 +52,7 @@ from streamlit.runtime.caching.cache_errors import (
     UnhashableParamError,
     UnhashableTypeError,
     UnserializableReturnValueError,
+    get_cached_func_name_md,
 )
 from streamlit.runtime.caching.hashing import update_hash
 
@@ -253,6 +255,21 @@ def create_cache_wrapper(cached_func: CachedFunction) -> Callable[..., Any]:
                 try:
                     cache.write_result(value_key, return_value, messages)
                 except TypeError:
+                    if type_util.is_type(
+                        return_value, "snowflake.snowpark.dataframe.DataFrame"
+                    ):
+
+                        class UnevaluatedDataFrameError(StreamlitAPIException):
+                            def __init__(self):
+                                super().__init__(
+                                    self,
+                                    f"""
+                                    The function {get_cached_func_name_md(func)} is decorated with `st.experimental_memo` but it returns an unevaluated 
+                                    dataframe of type `snowflake.snowpark.DataFrame`. Please call `collect()` or `to_pandas()` on the 
+                                    dataframe before returning it, so `st.experimental_memo` can serialize and cache it.""",
+                                )
+
+                        raise UnevaluatedDataFrameError
                     raise UnserializableReturnValueError(
                         return_value=return_value, func=cached_func.func
                     )


### PR DESCRIPTION
Tell the dev to call collect() or to_pandas() in st.memo when it's not serializable

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
Tell the dev to call collect() or to_pandas() in st.memo when it's not serializable

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
