### PR TITLE
Unbreak conda builds

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -88,11 +88,21 @@ class VerifyVersionCommand(install):
             sys.exit(info)
 
 
+readme_path = THIS_DIRECTORY / ".." / "README.md"
+if readme_path.exists():
+    long_description = readme_path.read_text()
+else:
+    # In some build environments (specifically in conda), we may not have the README file
+    # readily available. In these cases, just let long_description be the empty string.
+    # Note that long_description isn't used at all in these build environments, so it
+    # being missing isn't problematic.
+    long_description = ""
+
 setuptools.setup(
     name=NAME,
     version=VERSION,
     description="The fastest way to build data apps in Python",
-    long_description=(THIS_DIRECTORY / ".." / "README.md").read_text(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://streamlit.io",
     project_urls={


### PR DESCRIPTION
## 📚 Context

In #5406, we accidentally broke the `make conda-package` target. This happened because,
in conda builds, we don't have the README available since it lives in the root directory of the
repo, and only the contents of `lib` are copied into the temporary conda directory used in the
build process. To fix this, I changed `setup.py` to be able to handle the README being missing.
We just set `long_description` to the empty string in this case, but that's fine since the field
isn't used in conda builds anyway.

To make situations like this more unlikely in the future, we should really add a CI workflow
that builds the conda version of the package to ensure that the build process doesn't get
randomly broken. I'll work on this later this week when I have some spare time.

- What kind of change does this PR introduce?

  - [x] Bugfix