### PR TITLE
Add workflow to test that the conda build works

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,0 +1,40 @@
+name: Conda Build Test
+
+on:
+  push:
+    branches:
+      - "develop"
+      - "feature/**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Avoid duplicate workflows on same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli_test:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -ileo pipefail {0}
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+      - name: Build Conda Package - Fast
+        timeout-minutes: 120
+        run: |
+          sudo apt install rsync
+          BUILD_AS_FAST_AS_POSSIBLE=1 make conda-package

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cli_test:
+  build_conda_package:
     runs-on: ubuntu-latest
 
     defaults:
@@ -27,12 +27,21 @@ jobs:
         with:
           persist-credentials: false
           submodules: "recursive"
-      - name: Set up Python 3.10
+      # We need to install Python 3.9 here because it's the latest version
+      # supported by the miniconda installer as of 2022/10/11.
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Setup virtual env
         uses: ./.github/actions/make_init
+      - name: Install conda and conda-build
+        env:
+          MINICONDA_RELEASE: "Miniconda3-py39_4.12.0-Linux-x86_64"
+        run: |
+          curl -sO "https://repo.anaconda.com/miniconda/${MINICONDA_RELEASE}.sh"
+          bash "${MINICONDA_RELEASE}.sh" -b
+          conda install conda-build
       - name: Build Conda Package - Fast
         timeout-minutes: 120
         run: |


### PR DESCRIPTION
## 📚 Context

NOTE: This PR depends on #5520, which should be reviewed first.

This PR adds a workflow that simply tries to build the Streamlit conda package so that
we're more likely to catch when the conda build process gets broken.

I'm not sure if we want to run this for every PR as it may be slow enough to be disruptive
if we do so, but we can start off running it for every PR and change it to only run on merge
to `develop` if it gets too annoying.

- What kind of change does this PR introduce?

  - [x] Other, please describe: more tests
