### PR TITLE
Remove `make pycoverage`

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 # Avoid duplicate workflows on same branch
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-python
   cancel-in-progress: true
 
@@ -26,16 +26,16 @@ jobs:
     defaults:
       run:
         shell: bash -ileo pipefail {0}
-    
+
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.10"]
-    
+
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: 'recursive'
@@ -53,7 +53,7 @@ jobs:
       - name: Run Type Checkers
         run: scripts/mypy --report
       - name: Run Python Tests
-        run: make pycoverage
+        run: make pytest
       - name: Run Integration Tests
         run: make integration-tests
       - name: CLI Smoke Tests

--- a/Makefile
+++ b/Makefile
@@ -109,36 +109,11 @@ pyformat:
 .PHONY: pytest
 # Run Python unit tests.
 pytest:
-	# Just testing. No code coverage.
 	cd lib; \
 		PYTHONPATH=. \
 		pytest -v \
 			--junitxml=test-reports/pytest/junit.xml \
 			-l tests/ \
-			$(PYTHON_MODULES)
-
-.PHONY: pycoverage
-# Show Python test coverage.
-pycoverage:
-	# testing + code coverage
-	cd lib; \
-		PYTHONPATH=. \
-		pytest -v \
-			--junitxml=test-reports/pytest/junit.xml \
-			-l $(foreach dir,$(PYTHON_MODULES),--cov=$(dir)) \
-			--cov-report=term-missing tests/ \
-			$(PYTHON_MODULES)
-
-.PHONY: pycoverage_html
-# Generate HTML report of Python test coverage.
-pycoverage_html:
-	# testing + code coverage
-	cd lib; \
-		PYTHONPATH=. \
-		pytest -v \
-			--junitxml=test-reports/pytest/junit.xml \
-			-l $(foreach dir,$(PYTHON_MODULES),--cov=$(dir)) \
-			--cov-report=html tests/ \
 			$(PYTHON_MODULES)
 
 .PHONY: mypy


### PR DESCRIPTION
Remove `make pycoverage` and `make pycoverage_html` from our Makefile. We haven't used test coverage data literally ever, so this is essentially just noise. (We can always resurrect these commands if we plan to use them.)

Github Actions now calls `make pytest` to run python unit tests.