### PR TITLE
Fix pydoc command for streamlit package

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -23,6 +23,7 @@ from typing_extensions import Final
 
 import streamlit as st
 import streamlit.watcher.path_watcher
+from streamlit import runtime
 from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
@@ -243,7 +244,13 @@ class Secrets(Mapping[str, Any]):
             raise KeyError(_missing_key_error_message(key))
 
     def __repr__(self) -> str:
+        # If the runtime is NOT initialized, it is a method call outside
+        # the streamlit app, so we avoid reading the secrets file as it may not exist.
+        # If the runtime is initialized, display the contents of the file and
+        # the file must already exist.
         """A string representation of the contents of the dict. Thread-safe."""
+        if not runtime.exists():
+            return f"{self.__class__.__name__}(file_path={self._file_path!r})"
         return repr(self._parse(True))
 
     def __len__(self) -> int:

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -17,7 +17,9 @@
 import json
 import os
 import re
+import subprocess
 import sys
+import tempfile
 import textwrap
 import unittest
 from unittest.mock import patch
@@ -156,6 +158,19 @@ class StreamlitTest(unittest.TestCase):
                 "set_option",
             },
         )
+
+    def test_pydoc(self):
+        cwd = os.getcwd()
+        try:
+            os.chdir(tempfile.mkdtemp())
+            # Run the script as a separate process to make sure that
+            # the currently loaded modules do not affect the test result.
+            output = subprocess.check_output(
+                [sys.executable, "-m", "pydoc", "streamlit"]
+            ).decode()
+            self.assertIn("Help on package streamlit:", output)
+        finally:
+            os.chdir(cwd)
 
 
 class StreamlitAPITest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -160,6 +160,7 @@ class StreamlitTest(unittest.TestCase):
         )
 
     def test_pydoc(self):
+        """Test that we can run pydoc on the streamlit package"""
         cwd = os.getcwd()
         try:
             os.chdir(tempfile.mkdtemp())


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

The documentation generation fails because the secret file does not always exist.
```
FileNotFoundError: [Errno 2] No such file or directory: '/Users/kbregula/Snowflake/streamlit/streamlit/lib/.streamlit/secrets.toml'
```

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
