### PR TITLE
Remove overflow tooltip from MPA sidebar

### DIFF
--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -89,7 +89,9 @@ describe("SidebarNav", () => {
   it("replaces underscores with spaces in pageName", () => {
     const wrapper = shallow(<SidebarNav {...getProps()} />)
 
-    const links = wrapper.find(StyledSidebarNavLink).find(StyledSidebarNavLink)
+    const links = wrapper
+      .find(StyledSidebarNavLink)
+      .find(StyledSidebarLinkText)
 
     expect(links.at(0).text()).toBe("streamlit app")
     expect(links.at(1).text()).toBe("my other page")

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -27,7 +27,6 @@ import { useIsOverflowing } from "src/lib/Hooks"
 import { mount, shallow } from "src/lib/test_util"
 import { BaseUriParts } from "src/lib/UriUtil"
 
-import { OverflowTooltip } from "src/components/shared/Tooltip"
 import SidebarNav, { Props } from "./SidebarNav"
 import {
   StyledSidebarNavItems,
@@ -90,10 +89,10 @@ describe("SidebarNav", () => {
   it("replaces underscores with spaces in pageName", () => {
     const wrapper = shallow(<SidebarNav {...getProps()} />)
 
-    const links = wrapper.find(StyledSidebarNavLink).find(OverflowTooltip)
+    const links = wrapper.find(StyledSidebarNavLink).find(StyledSidebarNavLink)
 
-    expect(links.at(0).props().content).toBe("streamlit app")
-    expect(links.at(1).props().content).toBe("my other page")
+    expect(links.at(0).text()).toBe("streamlit app")
+    expect(links.at(1).text()).toBe("my other page")
   })
 
   describe("page links", () => {

--- a/frontend/src/components/core/Sidebar/SidebarNav.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.tsx
@@ -22,7 +22,6 @@ import { ExpandMore, ExpandLess } from "@emotion-icons/material-outlined"
 
 import { IAppPage } from "src/autogen/proto"
 import AppContext from "src/components/core/AppContext"
-import { Placement, OverflowTooltip } from "src/components/shared/Tooltip"
 import Icon, { EmojiIcon } from "src/components/shared/Icon"
 import { useIsOverflowing } from "src/lib/Hooks"
 
@@ -141,12 +140,7 @@ const SidebarNav = ({
                       <EmojiIcon size="lg">{pageIcon}</EmojiIcon>
                     )}
                     <StyledSidebarLinkText isActive={isActive}>
-                      <OverflowTooltip
-                        content={tooltipContent}
-                        placement={Placement.AUTO}
-                      >
-                        {tooltipContent}
-                      </OverflowTooltip>
+                      {tooltipContent}
                     </StyledSidebarLinkText>
                   </StyledSidebarNavLink>
                 </StyledSidebarNavLinkContainer>

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -208,15 +208,9 @@ export const StyledSidebarNavLink = styled.a<StyledSidebarNavLinkProps>(
 export const StyledSidebarLinkText = styled.span<StyledSidebarNavLinkProps>(
   ({ isActive, theme }) => ({
     color: isActive ? theme.colors.bodyText : theme.colors.fadedText60,
-
-    // We only want it to to be truncated on desktop,
-    // where we can use the tooltip to show the whole content.
-    // On mobile, we'll let it wrap
-    [`@media (min-width: 768px)`]: {
-      overflow: "hidden",
-      whiteSpace: "nowrap",
-      textOverflow: "ellipsis",
-    },
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
     display: "table-cell",
   })
 )

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -208,6 +208,16 @@ export const StyledSidebarNavLink = styled.a<StyledSidebarNavLinkProps>(
 export const StyledSidebarLinkText = styled.span<StyledSidebarNavLinkProps>(
   ({ isActive, theme }) => ({
     color: isActive ? theme.colors.bodyText : theme.colors.fadedText60,
+
+    // We only want it to to be truncated on desktop,
+    // where we can use the tooltip to show the whole content.
+    // On mobile, we'll let it wrap
+    [`@media (min-width: 768px)`]: {
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+      textOverflow: "ellipsis",
+    },
+    display: "table-cell",
   })
 )
 


### PR DESCRIPTION
## 📚 Context

After some conversations with @jrieke on the recent changes introduced in https://github.com/streamlit/streamlit/pull/5445, it was decided that we'd ditch the `<OverflowTooltip>` component from the sidebar and only truncate the text. For context behind this decision, please see his video [here](https://www.notion.so/streamlit/Papercut-tooltip-in-multipage-app-nav-6445253c742947408e2e00048c1d4de1).

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Design change

## 🧠 Description of Changes

* Removed `<OverflowTooltip>` component from `SidebarNav`;
* Added styles to truncate text in `StyledSidebarLinkText`;
* Updated tests

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![Screen Shot 2022-10-13 at 1 22 56 PM](https://user-images.githubusercontent.com/34423371/195662562-d024ad64-b685-4463-924b-c3a2b0c64b4e.png)

![Screen Shot 2022-10-13 at 1 23 04 PM](https://user-images.githubusercontent.com/34423371/195662559-89cdff6f-5170-4976-97b0-3b7f2fa9affb.png)

**Current:**

![Screen Shot 2022-10-13 at 1 23 23 PM](https://user-images.githubusercontent.com/34423371/195662587-241ed244-dd26-460d-aaff-8ca2885b688c.png)

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- https://www.notion.so/streamlit/Papercut-tooltip-in-multipage-app-nav-6445253c742947408e2e00048c1d4de1

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
