### PR TITLE
MediaFileManager threading tests

### DIFF
--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -42,7 +42,9 @@ class ExceptionCapturingThread(threading.Thread):
         Otherwise no-op.
         """
         if self._unhandled_exception is not None:
-            raise self._unhandled_exception
+            raise RuntimeError(
+                f"Unhandled exception in thread '{self.name}'"
+            ) from self._unhandled_exception
 
     def run(self) -> None:
         try:

--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -24,6 +24,11 @@ def call_on_threads(
 
     The function must take single `int` param, which will be the index of
     the thread it's being called on.
+
+    Note that a passing multi-threaded test does not generally guarantee that
+    the tested code is thread safe! Because threading issues tend to be
+    non-deterministic, a flaky test that fails only occasionally is a good
+    indicator of an underlying issue.
     """
     threads = [
         ExceptionCapturingThread(name=f"Thread {ii}", target=func, args=[ii])

--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -13,7 +13,29 @@
 # limitations under the License.
 
 import threading
-from typing import Optional
+from typing import Any, Callable, Optional
+
+
+def call_on_threads(
+    func: Callable[[int], Any], num_threads: int, timeout: Optional[float] = 0.25
+) -> None:
+    """Call a function on multiple threads simultaneously and assert that no
+    thread raises an unhandled exception.
+
+    The function must take single `int` param, which will be the index of
+    the thread it's being called on.
+    """
+    threads = [
+        ExceptionCapturingThread(name=f"Thread {ii}", target=func, args=[ii])
+        for ii in range(num_threads)
+    ]
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join(timeout=timeout)
+        thread.assert_no_unhandled_exception()
 
 
 class ExceptionCapturingThread(threading.Thread):

--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -1,0 +1,51 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from typing import Optional
+
+
+class ExceptionCapturingThread(threading.Thread):
+    """Thread subclass that captures unhandled exceptions."""
+
+    def __init__(
+        self, group=None, target=None, name=None, args=(), kwargs=None, *, daemon=None
+    ):
+        super().__init__(
+            group=group,
+            target=target,
+            name=name,
+            args=args,
+            kwargs=kwargs,
+            daemon=daemon,
+        )
+        self._unhandled_exception: Optional[BaseException] = None
+
+    @property
+    def unhandled_exception(self) -> Optional[BaseException]:
+        """The unhandled exception raised by the thread's target, if it raised one."""
+        return self._unhandled_exception
+
+    def assert_no_unhandled_exception(self):
+        """If the thread target raised an unhandled exception, re-raise it.
+        Otherwise no-op.
+        """
+        if self._unhandled_exception is not None:
+            raise self._unhandled_exception
+
+    def run(self) -> None:
+        try:
+            super().run()
+        except BaseException as e:
+            self._unhandled_exception = e

--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -59,7 +59,7 @@ class ExceptionCapturingThread(threading.Thread):
         """The unhandled exception raised by the thread's target, if it raised one."""
         return self._unhandled_exception
 
-    def assert_no_unhandled_exception(self):
+    def assert_no_unhandled_exception(self) -> None:
         """If the thread target raised an unhandled exception, re-raise it.
         Otherwise no-op.
         """

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -372,7 +372,7 @@ class MediaFileManagerTest(TestCase):
         )
 
 
-NUM_THREADS = 5
+NUM_THREADS = 15
 
 
 class MediaFileManagerThreadingTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -15,10 +15,12 @@
 """Unit tests for MediaFileManager"""
 
 import random
+import unittest
 from typing import Optional
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, call, mock_open
 
+from exception_capturing_thread import call_on_threads
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.media_file_storage import MediaFileKind
 from streamlit.runtime.memory_media_file_storage import (
@@ -368,3 +370,54 @@ class MediaFileManagerTest(TestCase):
         storage_delete_spy.assert_has_calls(
             [call(file_id) for file_id in file_ids], any_order=True
         )
+
+
+NUM_THREADS = 5
+
+
+class MediaFileManagerThreadingTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.storage = MemoryMediaFileStorage("/mock/endpoint")
+        self.media_file_manager = MediaFileManager(self.storage)
+        random.seed(1337)
+
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        MagicMock(return_value="mock_session_id"),
+    )
+    def test_add_file_multiple_threads(self):
+        """We can safely call `add` from multiple threads simultaneously."""
+
+        def add_file(ii: int) -> None:
+            coord = random_coordinates()
+            data = bytes(f"{ii}", "utf-8")
+            self.media_file_manager.add(data, "image/png", coord)
+
+        call_on_threads(add_file, num_threads=NUM_THREADS)
+        self.assertEqual(NUM_THREADS, len(self.media_file_manager._file_metadata))
+
+    @mock.patch(
+        "streamlit.runtime.media_file_manager._get_session_id",
+        MagicMock(return_value="mock_session_id"),
+    )
+    def test_clear_files_multiple_threads(self):
+        """We can safely clear session refs and remove orphaned files
+        from multiple threads simultaneously.
+        """
+        # Add a bunch of files
+        for sample in ALL_FIXTURES.values():
+            self.media_file_manager.add(
+                sample["content"], sample["mimetype"], random_coordinates()
+            )
+        self.assertEqual(len(ALL_FIXTURES), len(self.media_file_manager._file_metadata))
+
+        # Remove those files from multiple threads
+        def remove_files(_: int) -> None:
+            self.media_file_manager.clear_session_refs("mock_session_id")
+            self.media_file_manager.remove_orphaned_files()
+
+        call_on_threads(remove_files, num_threads=NUM_THREADS)
+
+        # Our files should be gone!
+        self.assertEqual(0, len(self.media_file_manager._file_metadata))

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -20,7 +20,6 @@ from typing import Optional
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, call, mock_open
 
-from exception_capturing_thread import call_on_threads
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.media_file_storage import MediaFileKind
 from streamlit.runtime.memory_media_file_storage import (
@@ -28,6 +27,7 @@ from streamlit.runtime.memory_media_file_storage import (
     MemoryMediaFileStorage,
     _calculate_file_id,
 )
+from tests.exception_capturing_thread import call_on_threads
 
 
 def random_coordinates():


### PR DESCRIPTION
- Adds `ExceptionCapturingThread`, a thread subclass for tests that captures uncaught exceptions
- And also `call_on_threads`, a convenience function for running a function on multiple threads simultaneously
- `MediaFileManagerThreadingTest` uses these to test thread safety for its functions

This is not a bulletproof approach to thread safety testing! The hope is that this may surface threading issues through "occasionally-flaky" tests (meaning: if a threading test usually succeeds but occasionally has an issue, we should pay very close attention to it).