### PR TITLE
Add padding to the bottom of the sidebar

### DIFF
--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -224,6 +224,7 @@ export const StyledSidebarUserContent =
     paddingTop: hasPageNavAbove
       ? theme.spacing.lg
       : theme.sizes.sidebarTopSpace,
+    paddingBottom: theme.spacing.lg,
     paddingLeft: theme.spacing.lg,
     paddingRight: theme.spacing.lg,
 


### PR DESCRIPTION
## 📚 Context

This is a very minor fix. When there is currently more user content than the sidebar height, the bottom component reaches the bottom of the screen, which doesn't look good.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

 I added a padding to the bottom of the sidebar to ensure that the sidebar has some bottom padding.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**
<img width="1280" alt="Schermafbeelding 2022-10-18 om 12 26 32" src="https://user-images.githubusercontent.com/25854734/196406710-d91d7871-6d4f-4768-a636-4fc733dac558.png">

**Current:**
<img width="1280" alt="Schermafbeelding 2022-10-18 om 12 26 05" src="https://user-images.githubusercontent.com/25854734/196406700-ff3a0453-f763-45d1-a4c4-6b239cd940f9.png">

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

No.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
