### PR TITLE
Don't run the nightly on forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   create-nightly-tag:
+    if: github.repository == 'streamlit/streamlit'
     runs-on: ubuntu-latest
 
     defaults:
@@ -53,7 +54,7 @@ jobs:
           git push origin $TAG
       - if: ${{ failure() }}
         name: Nightly Tag Failure Slack Message
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py nightly tag
 
@@ -101,11 +102,11 @@ jobs:
         run: python scripts/slack_notifications.py nightly py_prod
       - if: ${{ needs.run-cypress-tests.result == 'failure' }}
         run: python scripts/slack_notifications.py nightly cypress
-  
+
   create-nightly-build:
     runs-on: ubuntu-latest
 
-    # Tag creation & tests must all complete successfully for nightly build job to run. 
+    # Tag creation & tests must all complete successfully for nightly build job to run.
     needs: [create-nightly-tag, run-python-tests, run-javascript-tests, run-py-prod-deps-smoke-test, run-cypress-tests]
 
     defaults:
@@ -115,7 +116,7 @@ jobs:
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{needs.create-nightly-tag.outputs.tag}}
           persist-credentials: false
           submodules: 'recursive'
@@ -146,6 +147,6 @@ jobs:
           make distribute
       - if: ${{ failure() }}
         name: Nightly Build Failure Slack Message
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py nightly build


### PR DESCRIPTION
## 📚 Context

GitHub Actions is weird and for some reason runs scheduled workflows on forks,
which means that the nightly build is being run for up-to-date contributor
forks. This isn't a big deal, but it does result in an annoying workflow failed
email being sent daily.

This PR adds an if check that avoids running the job on repos that aren't the
streamlit/streamlit repo. The way this is done isn't ideal, but as far as I can
tell it's the only supported way of excluding non-upstream repos.

- What kind of change does this PR introduce?

  - [x] Bugfix
