### PR TITLE
Move our list of allowed message origins into an endpoint

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -74,10 +74,11 @@ const getHostCommunicationProp = (
   extend?: Partial<HostCommunicationHOC>
 ): HostCommunicationHOC => ({
   connect: jest.fn(),
-  sendMessage: jest.fn(),
+  currentState: getHostCommunicationState({}),
   onModalReset: jest.fn(),
   onPageChanged: jest.fn(),
-  currentState: getHostCommunicationState({}),
+  sendMessage: jest.fn(),
+  setAllowedOrigins: jest.fn(),
   ...extend,
 })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -73,7 +73,6 @@ const getHostCommunicationState = (
 const getHostCommunicationProp = (
   extend?: Partial<HostCommunicationHOC>
 ): HostCommunicationHOC => ({
-  connect: jest.fn(),
   currentState: getHostCommunicationState({}),
   onModalReset: jest.fn(),
   onPageChanged: jest.fn(),
@@ -207,7 +206,6 @@ describe("App", () => {
   it("shows hostMenuItems", () => {
     const props = getProps({
       hostCommunication: getHostCommunicationProp({
-        connect: jest.fn(),
         sendMessage: jest.fn(),
         currentState: getHostCommunicationState({
           queryParams: "",
@@ -232,7 +230,6 @@ describe("App", () => {
   it("shows hostToolbarItems", () => {
     const props = getProps({
       hostCommunication: getHostCommunicationProp({
-        connect: jest.fn(),
         sendMessage: jest.fn(),
         currentState: getHostCommunicationState({
           queryParams: "",
@@ -321,11 +318,10 @@ describe("App", () => {
     expect(wrapper.find(Modal)).toHaveLength(1)
   })
 
-  it("sends initialization messages to the host when the app is first rendered", () => {
+  it("sends theme info to the host when the app is first rendered", () => {
     const props = getProps()
     shallow(<App {...props} />)
 
-    expect(props.hostCommunication.connect).toHaveBeenCalled()
     expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(lightTheme.emotion),

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -328,19 +328,6 @@ describe("App", () => {
     })
   })
 
-  it("sends WEBSOCKET_DISCONNECTED message to the host when the connection to the server is dropped", () => {
-    const props = getProps()
-    const wrapper = shallow(<App {...props} />)
-    const app = wrapper.instance() as App
-
-    app.handleConnectionStateChanged(ConnectionState.CONNECTED)
-    app.handleConnectionStateChanged(ConnectionState.PINGING_SERVER)
-
-    expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
-      type: "WEBSOCKET_DISCONNECTED",
-    })
-  })
-
   it("both sets theme locally and sends to host when setAndSendTheme is called", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,17 +368,6 @@ export class App extends PureComponent<Props, State> {
       `Connection state changed from ${this.state.connectionState} to ${newState}`
     )
 
-    const { connectionState: currState } = this.state
-
-    if (
-      currState === ConnectionState.CONNECTED &&
-      newState === ConnectionState.PINGING_SERVER
-    ) {
-      this.props.hostCommunication.sendMessage({
-        type: "WEBSOCKET_DISCONNECTED",
-      })
-    }
-
     this.setState({ connectionState: newState })
 
     if (newState === ConnectionState.CONNECTED) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -281,6 +281,7 @@ export class App extends PureComponent<Props, State> {
       onConnectionError: this.handleConnectionError,
       connectionStateChanged: this.handleConnectionStateChanged,
       getHostAuthToken: this.getHostAuthToken,
+      setHostAllowedOrigins: this.props.hostCommunication.setAllowedOrigins,
     })
 
     if (isEmbeddedInIFrame()) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -288,7 +288,6 @@ export class App extends PureComponent<Props, State> {
       document.body.classList.add("embedded")
     }
 
-    this.props.hostCommunication.connect()
     this.props.hostCommunication.sendMessage({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(this.props.theme.activeTheme.emotion),

--- a/frontend/src/ThemedApp.test.tsx
+++ b/frontend/src/ThemedApp.test.tsx
@@ -30,6 +30,8 @@ import {
 import AppWithScreencast from "./App"
 import ThemedApp from "./ThemedApp"
 
+jest.mock("src/lib/ConnectionManager")
+
 describe("ThemedApp", () => {
   beforeEach(() => {
     // sourced from:

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -151,9 +151,6 @@ export type IGuestToHostMessage =
       type: "UPDATE_HASH"
       hash: string
     }
-  | {
-      type: "WEBSOCKET_DISCONNECTED"
-    }
 
 export type VersionedMessage<Message> = {
   stCommVersion: number

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -85,6 +85,9 @@ describe("withHostCommunication HOC receiving messages", () => {
   let hostCommunication: any
 
   beforeEach(() => {
+    // We need to save and restore window.location.hash for each test because
+    // its value persists between tests otherwise, which may cause tests to
+    // interfere with each other.
     originalHash = window.location.hash
     dispatchEvent = mockEventListeners()
     wrapper = mount(<TestComponent />)

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -102,7 +102,7 @@ describe("withHostCommunication HOC receiving messages", () => {
       .prop("hostCommunication")
 
     act(() => {
-      hostCommunication.setAllowedOrigins(["devel.streamlit.test"])
+      hostCommunication.setAllowedOrigins(["http://devel.streamlit.test"])
     })
   })
 
@@ -280,7 +280,7 @@ describe("withHostCommunication HOC receiving messages", () => {
   describe("Test different origins", () => {
     it("exact pattern", () => {
       act(() => {
-        hostCommunication.setAllowedOrigins(["share.streamlit.io"])
+        hostCommunication.setAllowedOrigins(["http://share.streamlit.io"])
       })
 
       dispatchEvent(
@@ -300,7 +300,7 @@ describe("withHostCommunication HOC receiving messages", () => {
 
     it("wildcard pattern", () => {
       act(() => {
-        hostCommunication.setAllowedOrigins(["*.streamlitapp.com"])
+        hostCommunication.setAllowedOrigins(["http://*.streamlitapp.com"])
       })
 
       dispatchEvent(
@@ -320,7 +320,7 @@ describe("withHostCommunication HOC receiving messages", () => {
 
     it("ignores non-matching origins", () => {
       act(() => {
-        hostCommunication.setAllowedOrigins(["share.streamlit.io"])
+        hostCommunication.setAllowedOrigins(["http://share.streamlit.io"])
       })
 
       dispatchEvent(

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -27,8 +27,6 @@ import withHostCommunication, {
 const TestComponentNaked = (props: {
   hostCommunication: HostCommunicationHOC
 }): ReactElement => {
-  props.hostCommunication.connect()
-
   return <div>test</div>
 }
 
@@ -74,7 +72,14 @@ describe("withHostCommunication HOC", () => {
 
     window.addEventListener("message", listener)
 
-    shallow(<TestComponent />)
+    const wrapper = mount(<TestComponent />)
+    const hostCommunication: any = wrapper
+      .find(TestComponentNaked)
+      .prop("hostCommunication")
+
+    act(() => {
+      hostCommunication.setAllowedOrigins(["https://devel.streamlit.test"])
+    })
   })
 })
 

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -30,7 +30,6 @@ import {
 
 export interface HostCommunicationHOC {
   currentState: HostCommunicationState
-  connect: () => void
   sendMessage: (message: IGuestToHostMessage) => void
   onModalReset: () => void
   onPageChanged: () => void
@@ -148,7 +147,12 @@ function withHostCommunication(
         }
       }
 
+      if (!allowedOrigins.length) {
+        return () => {}
+      }
+
       window.addEventListener("message", receiveMessage)
+      sendMessageToHost({ type: "GUEST_READY" })
 
       return () => {
         window.removeEventListener("message", receiveMessage)
@@ -159,11 +163,6 @@ function withHostCommunication(
       <WrappedComponent
         hostCommunication={
           {
-            connect: () => {
-              sendMessageToHost({
-                type: "GUEST_READY",
-              })
-            },
             currentState: {
               authToken,
               forcedModalClose,

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -17,7 +17,7 @@
 import React, { ComponentType, useState, useEffect, ReactElement } from "react"
 import hoistNonReactStatics from "hoist-non-react-statics"
 
-import { isValidURL } from "src/lib/UriUtil"
+import { isValidOrigin } from "src/lib/UriUtil"
 
 import {
   IGuestToHostMessage,
@@ -73,16 +73,7 @@ function withHostCommunication(
 
     useEffect(() => {
       function receiveMessage(event: MessageEvent): void {
-        let origin: string
         const message: VersionedMessage<IHostToGuestMessage> | any = event.data
-
-        try {
-          const url = new URL(event.origin)
-
-          origin = url.hostname
-        } catch (e) {
-          origin = event.origin
-        }
 
         // Messages coming from the parent frame of a deployed Streamlit app
         // may not be coming from a trusted source (even if we've set the CSP
@@ -91,9 +82,8 @@ function withHostCommunication(
         // labeled as trusted here to lower the probability that we end up
         // processing malicious input.
         if (
-          !origin ||
           message.stCommVersion !== HOST_COMM_VERSION ||
-          !allowedOrigins.find(el => isValidURL(el, origin))
+          !allowedOrigins.find(allowed => isValidOrigin(allowed, event.origin))
         ) {
           return
         }

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -85,6 +85,12 @@ function withHostCommunication(
           origin = event.origin
         }
 
+        // Messages coming from the parent frame of a deployed Streamlit app
+        // may not be coming from a trusted source (even if we've set the CSP
+        // frame-anscestors header, it doesn't hurt to be extra safe). We avoid
+        // processing messages received from origins we haven't explicitly
+        // labeled as trusted here to lower the probability that we end up
+        // processing malicious input.
         if (
           !origin ||
           message.stCommVersion !== HOST_COMM_VERSION ||

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -50,6 +50,12 @@ interface Props {
    * relevant deployment scenario).
    */
   getHostAuthToken: () => string | undefined
+
+  /**
+   * Function to set the list of origins that this app should accept
+   * cross-origin messages from (if in a relevant deployment scenario).
+   */
+  setHostAllowedOrigins: (allowedOrigins: string[]) => void
 }
 
 /**
@@ -152,6 +158,7 @@ export class ConnectionManager {
       onConnectionStateChange: this.setConnectionState,
       onRetry: this.showRetryError,
       getHostAuthToken: this.props.getHostAuthToken,
+      setHostAllowedOrigins: this.props.setHostAllowedOrigins,
     })
   }
 }

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -167,6 +167,12 @@ export function buildMediaUri(
 /**
  * Check if the given origin follows the allowed origin pattern, which could
  * include wildcards.
+ *
+ * This function is used to check whether cross-origin messages received by the
+ * withHostCommunication component come from an origin that we've listed as
+ * trusted. If this function returns false against the origin being tested for
+ * all trusted origins in our whitelist, the cross-origin message should be
+ * ignored.
  */
 export function isValidOrigin(
   allowedOrigin: string,

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -166,7 +166,7 @@ export function buildMediaUri(
 
 /**
  * Check if the given origin follows the allowed origin pattern, which could
- * include a wildcard.
+ * include wildcards.
  */
 export function isValidOrigin(
   allowedOrigin: string,

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -462,6 +462,7 @@ describe("WebsocketConnection", () => {
     onConnectionStateChange: jest.fn(),
     onRetry: jest.fn(),
     getHostAuthToken: jest.fn(),
+    setHostAllowedOrigins: jest.fn(),
   }
 
   let client: WebsocketConnection
@@ -533,6 +534,7 @@ describe("WebsocketConnection auth token handling", () => {
     onConnectionStateChange: jest.fn(),
     onRetry: jest.fn(),
     getHostAuthToken: jest.fn(),
+    setHostAllowedOrigins: jest.fn(),
   }
 
   let websocketSpy: any

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -24,69 +24,99 @@ import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   StyledBashCode,
   WebsocketConnection,
-  doHealthPing,
+  doInitPings,
 } from "src/lib/WebsocketConnection"
 import { zip } from "lodash"
 
-describe("doHealthPing", () => {
+const MOCK_ALLOWED_ORIGINS_RESPONSE = {
+  data: {
+    allowedOrigins: ["list", "of", "allowed", "origins"],
+  },
+}
+
+describe("doInitPings", () => {
   const MOCK_PING_DATA = {
     uri: [
-      "https://not.a.real.host:3000/healthz",
-      "https://not.a.real.host:3001/healthz",
+      { host: "not.a.real.host", port: 3000, basePath: "/" },
+      { host: "not.a.real.host", port: 3001, basePath: "/" },
     ],
     timeoutMs: 10,
     maxTimeoutMs: 100,
-    retryCallback: () => {},
+    retryCallback: jest.fn(),
+    setHostAllowedOrigins: jest.fn(),
     userCommandLine: "streamlit run not-a-real-script.py",
   }
 
+  let originalAxiosGet: any
+  let originalPromiseAll: any
+
   beforeEach(() => {
+    originalAxiosGet = axios.get
+    axios.get = jest.fn()
     MOCK_PING_DATA.retryCallback = jest.fn()
+    MOCK_PING_DATA.setHostAllowedOrigins = jest.fn()
+    originalPromiseAll = Promise.all
   })
 
-  it("returns the uri index of the first successful ping (0)", async () => {
-    axios.get = jest.fn().mockResolvedValueOnce("")
+  afterEach(() => {
+    axios.get = originalAxiosGet
+    Promise.all = originalPromiseAll
+  })
 
-    const uriIndex = await doHealthPing(
+  it("returns the uri index and sets allowedOrigins for the first successful ping (0)", async () => {
+    Promise.all = jest
+      .fn()
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
+
+    const uriIndex = await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
+    expect(MOCK_PING_DATA.setHostAllowedOrigins).toHaveBeenCalledWith(
+      MOCK_ALLOWED_ORIGINS_RESPONSE.data.allowedOrigins
+    )
   })
 
-  it("returns the uri index of the first successful ping (1)", async () => {
-    axios.get = jest
+  it("returns the uri index and sets allowedOrigins for the first successful ping (1)", async () => {
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(new Error(""))
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    const uriIndex = await doHealthPing(
+    const uriIndex = await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(1)
+    expect(MOCK_PING_DATA.setHostAllowedOrigins).toHaveBeenCalledWith(
+      MOCK_ALLOWED_ORIGINS_RESPONSE.data.allowedOrigins
+    )
   })
 
   it("calls retry with the corresponding error message if there was an error", async () => {
     const TEST_ERROR_MESSAGE = "ERROR_MESSAGE"
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(new Error(TEST_ERROR_MESSAGE))
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -100,17 +130,18 @@ describe("doHealthPing", () => {
   it("calls retry with 'Connection timed out.' when the error code is `ECONNABORTED`", async () => {
     const TEST_ERROR = { code: "ECONNABORTED" }
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -128,17 +159,18 @@ describe("doHealthPing", () => {
       },
     }
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -154,17 +186,18 @@ describe("doHealthPing", () => {
       request: {},
     }
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -179,8 +212,8 @@ describe("doHealthPing", () => {
     const MOCK_PING_DATA_LOCALHOST = {
       ...MOCK_PING_DATA,
       uri: [
-        "https://localhost:3000/healthz",
-        "https://localhost:3001/healthz",
+        { host: "localhost", port: 3000, basePath: "/" },
+        { host: "localhost", port: 3001, basePath: "/" },
       ],
     }
 
@@ -204,17 +237,18 @@ describe("doHealthPing", () => {
       </Fragment>
     )
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA_LOCALHOST.uri,
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA_LOCALHOST.retryCallback,
+      MOCK_PING_DATA_LOCALHOST.setHostAllowedOrigins,
       MOCK_PING_DATA_LOCALHOST.userCommandLine
     )
 
@@ -243,17 +277,18 @@ describe("doHealthPing", () => {
       </Fragment>
     )
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -272,17 +307,18 @@ describe("doHealthPing", () => {
       },
     }
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -296,7 +332,7 @@ describe("doHealthPing", () => {
   it("calls retry with correct total tries", async () => {
     const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
@@ -304,13 +340,14 @@ describe("doHealthPing", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -320,7 +357,7 @@ describe("doHealthPing", () => {
   it("has increasing but capped retry backoff", async () => {
     const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
@@ -328,7 +365,7 @@ describe("doHealthPing", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
     const timeouts: number[] = []
     const callback = (
@@ -339,11 +376,12 @@ describe("doHealthPing", () => {
       timeouts.push(timeout)
     }
 
-    await doHealthPing(
-      ["https://not.a.real.host:3000/healthz"],
+    await doInitPings(
+      [{ host: "not.a.real.host", port: 3000, basePath: "/" }],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -362,7 +400,7 @@ describe("doHealthPing", () => {
   it("backs off independently for each target url", async () => {
     const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
@@ -370,7 +408,7 @@ describe("doHealthPing", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
     const timeouts: number[] = []
     const callback = (
@@ -381,11 +419,12 @@ describe("doHealthPing", () => {
       timeouts.push(timeout)
     }
 
-    await doHealthPing(
+    await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -399,16 +438,16 @@ describe("doHealthPing", () => {
   it("resets timeout each ping call", async () => {
     const TEST_ERROR_MESSAGE = "TEST_ERROR_MESSAGE"
 
-    axios.get = jest
+    Promise.all = jest
       .fn()
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
-      .mockResolvedValueOnce("")
-      // Reset for second doHealthPing call
+      // Reset after second doInitPings call
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
 
     const timeouts: number[] = []
     const callback = (
@@ -419,13 +458,15 @@ describe("doHealthPing", () => {
       timeouts.push(timeout)
     }
 
-    await doHealthPing(
-      ["https://not.a.real.host:3000/healthz"],
+    await doInitPings(
+      [{ host: "not.a.real.host", port: 3000, basePath: "/" }],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
+
     const timeouts2: number[] = []
     const callback2 = (
       _times: number,
@@ -435,11 +476,12 @@ describe("doHealthPing", () => {
       timeouts2.push(timeout)
     }
 
-    await doHealthPing(
-      ["https://not.a.real.host:3000/healthz"],
+    await doInitPings(
+      [{ host: "not.a.real.host", port: 3000, basePath: "/" }],
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
+      MOCK_PING_DATA.setHostAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -455,25 +497,40 @@ describe("WebsocketConnection", () => {
       {
         host: "localhost",
         port: 1234,
-        basePath: "",
+        basePath: "/",
       },
     ],
     onMessage: jest.fn(),
     onConnectionStateChange: jest.fn(),
     onRetry: jest.fn(),
-    getHostAuthToken: jest.fn(),
+    getHostAuthToken: () => undefined,
     setHostAllowedOrigins: jest.fn(),
   }
 
   let client: WebsocketConnection
   let server: WS
 
-  beforeEach(async () => {
+  let originalAxiosGet: any
+  let originalPromiseAll: any
+
+  beforeEach(() => {
     server = new WS("localhost:1234")
+
+    originalAxiosGet = axios.get
+    axios.get = jest.fn()
+
+    originalPromiseAll = Promise.all
+    Promise.all = jest
+      .fn()
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_ORIGINS_RESPONSE])
+
     client = new WebsocketConnection(MOCK_SOCKET_DATA)
   })
 
-  afterEach(async () => {
+  afterEach(() => {
+    axios.get = originalAxiosGet
+    Promise.all = originalPromiseAll
+
     // @ts-ignore
     client.websocket.close()
     server.close()
@@ -527,7 +584,7 @@ describe("WebsocketConnection auth token handling", () => {
       {
         host: "localhost",
         port: 1234,
-        basePath: "",
+        basePath: "/",
       },
     ],
     onMessage: jest.fn(),
@@ -537,15 +594,24 @@ describe("WebsocketConnection auth token handling", () => {
     setHostAllowedOrigins: jest.fn(),
   }
 
+  let originalAxiosGet: any
   let websocketSpy: any
 
   beforeEach(() => {
     websocketSpy = jest.spyOn(window, "WebSocket")
+
+    originalAxiosGet = axios.get
+    axios.get = jest.fn()
+  })
+
+  afterEach(() => {
+    axios.get = originalAxiosGet
   })
 
   it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", () => {
-    // eslint-disable-next-line no-new
-    new WebsocketConnection(MOCK_SOCKET_DATA)
+    const ws = new WebsocketConnection(MOCK_SOCKET_DATA)
+    // @ts-ignore
+    ws.connectToWebSocket()
 
     expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
       "streamlit",
@@ -553,11 +619,12 @@ describe("WebsocketConnection auth token handling", () => {
   })
 
   it("sets second Sec-WebSocket-Protocol option to value from getHostAuthToken", () => {
-    // eslint-disable-next-line no-new
-    new WebsocketConnection({
+    const ws = new WebsocketConnection({
       ...MOCK_SOCKET_DATA,
       getHostAuthToken: () => "iAmAnAuthToken",
     })
+    // @ts-ignore
+    ws.connectToWebSocket()
 
     expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
       "streamlit",

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -639,6 +639,13 @@ export function doInitPings(
       totalTries++
     }
 
+    // We fire off requests to the server's healthz and allowed message origins
+    // endpoints in parallel to avoid having to wait on too many sequential
+    // round trip network requests before we can try to establish a WebSocket
+    // connection. Technically, it would have been possible to implement a
+    // single "get server health and origins whitelist" endpoint, but we chose
+    // not to do so as it's semantically cleaner to not give the healthcheck
+    // endpoint additional responsibilities.
     Promise.all([
       axios.get(healthzUri, { timeout: minimumTimeoutMs }),
       axios.get(allowedOriginsUri, { timeout: minimumTimeoutMs }),

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -102,6 +102,12 @@ interface Args {
    * relevant deployment scenario).
    */
   getHostAuthToken: () => string | undefined
+
+  /**
+   * Function to set the list of origins that this app should accept
+   * cross-origin messages from (if in a relevant deployment scenario).
+   */
+  setHostAllowedOrigins: (allowedOrigins: string[]) => void
 }
 
 interface MessageQueue {

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -30,17 +30,3 @@ export const COMPONENT_DEVELOPER_URL =
 /** The URL we direct people to for troubleshooting camera permissions. */
 export const CAMERA_PERMISSION_URL =
   "https://docs.streamlit.io/knowledge-base/using-streamlit/enable-camera"
-
-export const CLOUD_COMM_WHITELIST = [
-  "devel.streamlit.test",
-  "share.streamlit.io",
-  "share-demo.streamlit.io",
-  "share-head.streamlit.io",
-  "share-staging.streamlit.io",
-  "*.demo.streamlit.run",
-  "*.head.streamlit.run",
-  "*.staging.streamlit.run",
-  "*.streamlitapp.test",
-  "*.streamlitapp.com",
-  "*.streamlit.run",
-]

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -183,6 +183,10 @@ ALLOWED_MESSAGE_ORIGINS = [
 
 class AllowedMessageOriginsHandler(_SpecialRequestHandler):
     def get(self) -> None:
+        # ALLOWED_MESSAGE_ORIGINS must be wrapped in a dictionary because Tornado
+        # disallows writing lists directly into responses due to potential XSS
+        # vulnerabilities.
+        # See https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write
         self.write({"allowedOrigins": ALLOWED_MESSAGE_ORIGINS})
         self.set_status(200)
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -178,6 +178,10 @@ ALLOWED_MESSAGE_ORIGINS = [
     "https://*.streamlitapp.test",
     "https://*.streamlitapp.com",
     "https://*.streamlit.run",
+    "https://*.demo.streamlit.app",
+    "https://*.head.streamlit.app",
+    "https://*.staging.streamlit.app",
+    "https://*.streamlit.app",
 ]
 
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -160,6 +160,33 @@ class HealthHandler(_SpecialRequestHandler):
             self.write(msg)
 
 
+# NOTE: We eventually want to get rid of this hard-coded list entirely as we don't want
+# to have links to Community Cloud live in the open source library in a way that affects
+# functionality (links advertising Community Cloud are probably okay 🙂). In the long
+# run, this list will most likely be replaced by a config option allowing us to more
+# granularly control what domains a Streamlit app should accept cross-origin iframe
+# messages from.
+ALLOWED_MESSAGE_ORIGINS = [
+    "devel.streamlit.test",
+    "share.streamlit.io",
+    "share-demo.streamlit.io",
+    "share-head.streamlit.io",
+    "share-staging.streamlit.io",
+    "*.demo.streamlit.run",
+    "*.head.streamlit.run",
+    "*.staging.streamlit.run",
+    "*.streamlitapp.test",
+    "*.streamlitapp.com",
+    "*.streamlit.run",
+]
+
+
+class AllowedMessageOriginsHandler(_SpecialRequestHandler):
+    def get(self) -> None:
+        self.write({"allowedOrigins": ALLOWED_MESSAGE_ORIGINS})
+        self.set_status(200)
+
+
 class MessageCacheHandler(tornado.web.RequestHandler):
     """Returns ForwardMsgs from our MessageCache"""
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -167,17 +167,17 @@ class HealthHandler(_SpecialRequestHandler):
 # granularly control what domains a Streamlit app should accept cross-origin iframe
 # messages from.
 ALLOWED_MESSAGE_ORIGINS = [
-    "devel.streamlit.test",
-    "share.streamlit.io",
-    "share-demo.streamlit.io",
-    "share-head.streamlit.io",
-    "share-staging.streamlit.io",
-    "*.demo.streamlit.run",
-    "*.head.streamlit.run",
-    "*.staging.streamlit.run",
-    "*.streamlitapp.test",
-    "*.streamlitapp.com",
-    "*.streamlit.run",
+    "https://devel.streamlit.test",
+    "https://share.streamlit.io",
+    "https://share-demo.streamlit.io",
+    "https://share-head.streamlit.io",
+    "https://share-staging.streamlit.io",
+    "https://*.demo.streamlit.run",
+    "https://*.head.streamlit.run",
+    "https://*.staging.streamlit.run",
+    "https://*.streamlitapp.test",
+    "https://*.streamlitapp.com",
+    "https://*.streamlit.run",
 ]
 
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -40,6 +40,7 @@ from streamlit.web.server.component_request_handler import ComponentRequestHandl
 from streamlit.web.server.media_file_handler import MediaFileHandler
 from streamlit.web.server.routes import (
     AddSlashHandler,
+    AllowedMessageOriginsHandler,
     AssetsFileHandler,
     HealthHandler,
     MessageCacheHandler,
@@ -233,6 +234,10 @@ class Server:
                 make_url_path_regex(base, "st-metrics"),
                 StatsRequestHandler,
                 dict(stats_manager=self._runtime.stats_mgr),
+            ),
+            (
+                make_url_path_regex(base, "st-allowed-message-origins"),
+                AllowedMessageOriginsHandler,
             ),
             (
                 make_url_path_regex(

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import tempfile
 from unittest.mock import MagicMock
@@ -25,7 +26,9 @@ from streamlit import config
 from streamlit.logger import get_logger
 from streamlit.runtime.forward_msg_cache import ForwardMsgCache, populate_hash_if_needed
 from streamlit.runtime.runtime_util import serialize_forward_msg
+from streamlit.web.server.routes import ALLOWED_MESSAGE_ORIGINS
 from streamlit.web.server.server import (
+    AllowedMessageOriginsHandler,
     HealthHandler,
     MessageCacheHandler,
     StaticFileHandler,
@@ -150,3 +153,22 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         for r in responses:
             assert r.code == 404
+
+
+class AllowedMessageOriginsHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/st-allowed-message-origins",
+                    AllowedMessageOriginsHandler,
+                )
+            ]
+        )
+
+    def test_allowed_message_origins(self):
+        response = self.fetch("/st-allowed-message-origins")
+        self.assertEqual(200, response.code)
+        self.assertEqual(
+            {"allowedOrigins": ALLOWED_MESSAGE_ORIGINS}, json.loads(response.body)
+        )


### PR DESCRIPTION
Notes:
* This PR is most easily reviewed commit-wise
* We'll need to wait on an approval from ProdSec before being able to click merge on this

## 📚 Context

This PR kicks off what will end up being the first phase of a two-phase project to eventually remove
the hard-coded whitelist we currently used to restrict which origins a deployed Streamlit app can
receive cross-origin messages from.

We want to do this for two main reasons

* It feels weird that the list is currently populated with only Streamlit Community Cloud origins. Ideally,
   we want people to be able to configure this as they'd like (even if we're the only users initially).
* In the Community Cloud and SiS worlds, we'd like to be able to set this value much more granularly
   than we currently do. In particular, in both of these worlds we know the unique subdomain that a
   Streamlit app is deployed to, so we want the message origins whitelist to be a singleton containing
   that exact origin (without needing to use wildcards).

In this stage of the project, we move the definition of this list into the server. The new endpoint that
can be hit to fetch the list is `/st-allowed-message-origins`, and the response body from this endpoint
is simply the whitelist as it was previously defined in the frontend code.

It turns out that this is already enough to satisfy our requirements for the various Streamlit deployment
environments that motivated this change: different hosting platforms should intercept requests to the
`/st-allowed-message-origins` endpoint and return an appropriate value.

For use-cases relying on the Tornado server (and not in Community Cloud), we'll eventually make the
message origin whitelist configurable via `config.toml`, but we'll do this in a future phase of this project
given that the amount of security overhead required to make this fully configurable will be significant.

- What kind of change does this PR introduce?

  - [x] Feature
  - [x] Refactoring


## 🧪 Testing Done

- [x] Added/Updated unit tests
