### PR TITLE
Snowpark integration: Show an uncollected dataframe when using st.dataframe

### DIFF
--- a/e2e/scripts/st_arrow_unevaluated_snowpark_dataframe.py
+++ b/e2e/scripts/st_arrow_unevaluated_snowpark_dataframe.py
@@ -1,0 +1,26 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+from tests.streamlit.snowpark_mocks import DataFrame
+
+snowpark_dataframe = DataFrame(num_of_rows=50000)
+
+st.dataframe(snowpark_dataframe)
+
+st.line_chart(snowpark_dataframe)
+
+st.bar_chart(snowpark_dataframe)
+
+st.area_chart(snowpark_dataframe)

--- a/e2e/scripts/st_arrow_unevaluated_snowpark_dataframe.py
+++ b/e2e/scripts/st_arrow_unevaluated_snowpark_dataframe.py
@@ -15,7 +15,7 @@
 import streamlit as st
 from tests.streamlit.snowpark_mocks import DataFrame
 
-snowpark_dataframe = DataFrame(num_of_rows=50000)
+snowpark_dataframe = DataFrame(num_of_rows=50000, num_of_cols=4)
 
 st.dataframe(snowpark_dataframe)
 

--- a/e2e/specs/st_arrow_unevaluated_snowpark_dataframe.js
+++ b/e2e/specs/st_arrow_unevaluated_snowpark_dataframe.js
@@ -45,13 +45,13 @@ describe("st.DataFrame with unevaluated snowflake.snowpark.dataframe.DataFrame",
 
   it("warning about data being capped exists", () => {
     cy.getIndexed("div [data-testid='stCaptionContainer']", 0)
-      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+      .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
     cy.getIndexed("div [data-testid='stCaptionContainer']", 1)
-      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+      .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
     cy.getIndexed("div [data-testid='stCaptionContainer']", 2)
-      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+      .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
     cy.getIndexed("div [data-testid='stCaptionContainer']", 3)
-      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+      .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
   });
 
   it("displays a line chart", () => {

--- a/e2e/specs/st_arrow_unevaluated_snowpark_dataframe.js
+++ b/e2e/specs/st_arrow_unevaluated_snowpark_dataframe.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("st.DataFrame with unevaluated snowflake.snowpark.dataframe.DataFrame", () => {
+
+  before(() => {
+    // Increasing timeout since we're waiting for
+    // dataframes, and charts to be rendered.
+    var timeout = 300000
+    Cypress.config("defaultCommandTimeout", timeout)
+    cy.visit("http://localhost:3000/")
+    cy.get("[data-testid='stAppViewContainer']", { timeout: timeout }).should(
+      "not.contain",
+      "Please wait..."
+    )
+    // Wait until the script is no longer running.
+    cy.get("[data-testid='stStatusWidget']", { timeout: timeout }).should(
+      "not.exist"
+    )
+    cy.prepForElementSnapshots();
+  });
+
+  it("dataframe exists and is evaluated", () => {
+    cy.get(".stDataFrame")
+      .should("have.length", 1)
+  });
+
+  it("warning about data being capped exists", () => {
+    cy.get("div [data-testid='stCaptionContainer']")
+      .should("have.length", 4)
+  });
+
+  it("warning about data being capped exists", () => {
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 0)
+      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 1)
+      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 2)
+      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 3)
+      .should("contain", "Showing only 10k rows. Call collect() on the dataframe to show more.")
+  });
+
+  it("displays a line chart", () => {
+    cy.get(".element-container [data-testid='stArrowVegaLiteChart']")
+      .find("canvas")
+      .first()
+      .should("have.css", "height", "350px");
+  });
+
+  it("displays a bar chart", () => {
+    cy.get(".element-container [data-testid='stArrowVegaLiteChart']")
+      .find("canvas")
+      .first()
+      .should("have.css", "height", "350px");
+  });
+
+  it("displays an area chart", () => {
+    cy.get(".element-container [data-testid='stArrowVegaLiteChart']")
+      .find("canvas")
+      .first()
+      .should("have.css", "height", "350px");
+  });
+});

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -30,6 +30,7 @@ from numpy import ndarray
 from pandas import DataFrame
 from pandas.io.formats.style import Styler
 
+import streamlit as st
 from streamlit import type_util
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -54,7 +55,7 @@ class ArrowMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.DataFrame, Iterable, dict, or None
             The data to display.
 
             If 'data' is a pandas.Styler, it will be used to style its
@@ -93,6 +94,7 @@ class ArrowMixin:
         >>> st._arrow_dataframe(df.style.highlight_max(axis=0))
 
         """
+
         # If pandas.Styler uuid is not provided, a hash of the position
         # of the element will be used. This will cause a rerender of the table
         # when the position of the element is changed.
@@ -129,6 +131,7 @@ class ArrowMixin:
         >>> st._arrow_table(df)
 
         """
+
         # If pandas.Styler uuid is not provided, a hash of the position
         # of the element will be used. This will cause a rerender of the table
         # when the position of the element is changed.

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -195,6 +195,7 @@ class ArrowAltairMixin:
            height: 220px
 
         """
+
         proto = ArrowVegaLiteChartProto()
         chart = _generate_chart(ChartType.AREA, data, x, y, width, height)
         marshall(proto, chart, use_container_width)
@@ -264,6 +265,7 @@ class ArrowAltairMixin:
            height: 220px
 
         """
+
         proto = ArrowVegaLiteChartProto()
         chart = _generate_chart(ChartType.BAR, data, x, y, width, height)
         marshall(proto, chart, use_container_width)

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -47,7 +47,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict, or None
             The data to display.
 
             If 'data' is a pandas.Styler, it will be used to style its
@@ -117,7 +117,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict, or None
             The table data.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -165,7 +165,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, dict or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict or None
             Data to be plotted.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -248,7 +248,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, or dict
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, or dict
             Data to be plotted.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -331,7 +331,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, or dict
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, or dict
             Data to be plotted.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -515,7 +515,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict, or None
             Table to concat. Optional.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -449,7 +449,7 @@ def convert_anything_to_df(df: Any) -> DataFrame:
         df = pd.DataFrame(df.take(MAX_UNEVALUATED_DF_ROWS))
         if df.shape[0] == MAX_UNEVALUATED_DF_ROWS:
             st.caption(
-                f"Showing only 10k rows. Call `collect()` on the dataframe to show more."
+                f"⚠️ Showing only 10k rows. Call `collect()` on the dataframe to show more."
             )
         return df
 

--- a/lib/tests/streamlit/dataframe_selector_test.py
+++ b/lib/tests/streamlit/dataframe_selector_test.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 import streamlit
 from streamlit.delta_generator import DeltaGenerator
+from tests.streamlit.snowpark_mocks import DataFrame as MockSnowparkDataFrame
 from tests.testutil import patch_config_options
 
 DATAFRAME = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
@@ -49,6 +50,19 @@ class DataFrameSelectorTest(unittest.TestCase):
         legacy_dataframe.assert_not_called()
         arrow_dataframe.assert_called_once_with(
             DATAFRAME, 100, 200, use_container_width=False
+        )
+
+    @patch.object(DeltaGenerator, "_legacy_dataframe")
+    @patch.object(DeltaGenerator, "_arrow_dataframe")
+    @patch_config_options({"global.dataFrameSerialization": "arrow"})
+    def test_arrow_dataframe_with_snowpark_dataframe(
+        self, arrow_dataframe, legacy_dataframe
+    ):
+        snowpark_df = MockSnowparkDataFrame()
+        streamlit.dataframe(snowpark_df, 100, 200)
+        legacy_dataframe.assert_not_called()
+        arrow_dataframe.assert_called_once_with(
+            snowpark_df, 100, 200, use_container_width=False
         )
 
     @patch.object(DeltaGenerator, "_legacy_table")

--- a/lib/tests/streamlit/snowpark_mocks.py
+++ b/lib/tests/streamlit/snowpark_mocks.py
@@ -24,7 +24,7 @@ class DataFrame:
 
     __module__ = "snowflake.snowpark.dataframe"
 
-    def __init__(self, num_of_rows: int = 10000, num_of_cols: int = 10):
+    def __init__(self, num_of_rows: int = 50000, num_of_cols: int = 4):
         self._data = None
         self._num_of_rows = num_of_rows
         self._num_of_cols = num_of_cols
@@ -47,6 +47,7 @@ class DataFrame:
     def _lazy_evaluation(self):
         """Sometimes we don't need data inside DataFrame class, so we populate it once and only when necessary"""
         if self._data is None:
+            random.seed(0)
             self._data = self._random_data()
 
     def _random_data(self) -> List[List[int]]:

--- a/lib/tests/streamlit/snowpark_mocks.py
+++ b/lib/tests/streamlit/snowpark_mocks.py
@@ -13,12 +13,53 @@
 # limitations under the License.
 
 
+import random
+from typing import List
+
+
 class DataFrame:
     """This is dummy DataFrame class,
-    which imitates snowflake.snowpark.dataframe.Dataframe class
+    which imitates snowflake.snowpark.dataframe.DataFrame class
     for testing purposes."""
 
     __module__ = "snowflake.snowpark.dataframe"
+
+    def __init__(self, num_of_rows: int = 10000, num_of_cols: int = 10):
+        self._data = None
+        self._num_of_rows = num_of_rows
+        self._num_of_cols = num_of_cols
+
+    def count(self) -> int:
+        return self._num_of_rows
+
+    def take(self, n: int):
+        """Returns n element of fake DataFrame, which imitates take of snowflake.snowpark.dataframe.DataFrame"""
+        self._lazy_evaluation()
+        if n > self._num_of_rows:
+            n = self._num_of_rows
+        return self._data[:n]
+
+    def collect(self) -> List[List[int]]:
+        """Returns fake DataFrame, which imitates collection of snowflake.snowpark.dataframe.DataFrame"""
+        self._lazy_evaluation()
+        return self._data
+
+    def _lazy_evaluation(self):
+        """Sometimes we don't need data inside DataFrame class, so we populate it once and only when necessary"""
+        if self._data is None:
+            self._data = self._random_data()
+
+    def _random_data(self) -> List[List[int]]:
+        data: List[List[int]] = []
+        for _ in range(0, self._num_of_rows):
+            data.append(self._random_row())
+        return data
+
+    def _random_row(self) -> List[int]:
+        row: List[int] = []
+        for _ in range(0, self._num_of_cols):
+            row.append(random.randint(1, 1000000))
+        return row
 
 
 class Row:


### PR DESCRIPTION
When using **unevaluated** `snowflake.snowpark.dataframe.DataFrame` Streamlit raises an exception.

This PR makes Streamlit take 10k rows from unevaluated snowpark DataFrame and shows an caption warning to user if we reach 10k rows.

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
