### PR TITLE
Remove warning about unsafe HTML in element docstrings

### DIFF
--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -59,17 +59,6 @@ class MarkdownMixin:
 
             https://github.com/streamlit/streamlit/issues/152
 
-            *Also note that ``unsafe_allow_html`` is a temporary measure and may
-            be removed from Streamlit at any time.*
-
-            If you decide to turn on HTML anyway, we ask you to please tell us
-            your exact use case here:
-
-            https://discuss.streamlit.io/t/96
-
-            This will help us come up with safe APIs that allow you to do what
-            you want.
-
         Example
         -------
         >>> st.markdown('Streamlit is **_really_ cool**.')
@@ -139,16 +128,6 @@ class MarkdownMixin:
             security. For more information, see:
 
             https://github.com/streamlit/streamlit/issues/152
-
-            **Also note that `unsafe_allow_html` is a temporary measure and may be
-            removed from Streamlit at any time.**
-
-            If you decide to turn on HTML anyway, we ask you to please tell us your
-            exact use case here:
-            https://discuss.streamlit.io/t/96 .
-
-            This will help us come up with safe APIs that allow you to do what you
-            want.
 
         Example
         -------

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -94,16 +94,6 @@ class WriteMixin:
 
             https://github.com/streamlit/streamlit/issues/152
 
-            **Also note that `unsafe_allow_html` is a temporary measure and may be
-            removed from Streamlit at any time.**
-
-            If you decide to turn on HTML anyway, we ask you to please tell us your
-            exact use case here:
-            https://discuss.streamlit.io/t/96 .
-
-            This will help us come up with safe APIs that allow you to do what you
-            want.
-
         Example
         -------
 


### PR DESCRIPTION
## 📚 Context

It's safe to say that the `unsafe_allow_html` parameter is here to stay and will not be removed from `st.markdown`, `st.write`, and `st.caption`.  We should remove the warning in the docstrings of these elements that state:

> `unsafe_allow_html`` is a temporary measure and may be removed from Streamlit at any time.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

Removes the warning in the docstrings of these elements (`st.markdown`, `st.write`, and `st.caption`) that state:

_`unsafe_allow_html` is a temporary measure and may be removed from Streamlit at any time._

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change