### PR TITLE
GHA: Update deprecated set-output syntax

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
           git config --global user.name "Streamlit Bot"
 
           TAG="$(./scripts/pypi_nightly_create_tag.py)"
-          echo "::set-output name=tag::$TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
           ./scripts/update_version.py $TAG
           ./scripts/update_name.py streamlit-nightly
@@ -89,12 +89,18 @@ jobs:
     if: ${{ always() }}
     # By default, jobs listed in needs must all complete successfully for the dependent job to run. always() conditional
     # added as we'd like this job to run whether or not tests pass & slack us regarding failing tests.
-    needs: [run-python-tests, run-javascript-tests, run-py-prod-deps-smoke-test, run-cypress-tests]
+    needs: [create-nightly-tag, run-python-tests, run-javascript-tests, run-py-prod-deps-smoke-test, run-cypress-tests]
 
     env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v3
+        with: 
+          ref: ${{ needs.create-nightly-tag.outputs.tag }}
+          persist-credentials: false
+          submodules: 'recursive'
       - if: ${{ needs.run-python-tests.result == 'failure' }}
         run: python scripts/slack_notifications.py nightly python
       - if: ${{ needs.run-javascript-tests.result == 'failure' }}
@@ -118,7 +124,7 @@ jobs:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
         with: 
-          ref: ${{needs.create-nightly-tag.outputs.tag}}
+          ref: ${{ needs.create-nightly-tag.outputs.tag }}
           persist-credentials: false
           submodules: 'recursive'
       - name: Set up Python 3.10
@@ -131,7 +137,7 @@ jobs:
         run: make develop
       - name: Verify git tag vs. version
         env:
-          TAG: ${{needs.create-nightly-tag.outputs.tag}}
+          TAG: ${{ needs.create-nightly-tag.outputs.tag }}
         run: |
           cd lib
           python setup.py verify

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -83,9 +83,9 @@ jobs:
 
           cd ../..
           # env variables don't carry over between gh action jobs
-          echo "::set-output name=enable-setup::${{ env.AWS_ACCESS_KEY_ID != '' }}"
-          echo "::set-output name=preview-branch::$PREVIEW_BRANCH"
-          echo "::set-output name=s3-url::https://core-previews.s3-us-west-2.amazonaws.com/${PREVIEW_BRANCH}/${WHEELFILE}"
+          echo "enable-setup=${{ env.AWS_ACCESS_KEY_ID != '' }}" >> $GITHUB_OUTPUT
+          echo "preview-branch=$PREVIEW_BRANCH" >> $GITHUB_OUTPUT
+          echo "s3-url=https://core-previews.s3-us-west-2.amazonaws.com/${PREVIEW_BRANCH}/${WHEELFILE}" >> $GITHUB_OUTPUT
 
   setup-preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📚 Context

Nightly Build run showed a warning on deprecation of the set-output syntax.
This PR fixes the syntax, which we use in pr-preview & nightly.

<img width=550 src=https://user-images.githubusercontent.com/63436329/197263003-f923ee29-4dc4-464d-9a57-383d07db66ed.png />



- What kind of change does this PR introduce?
  - [x] Refactoring
 
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.