### PR TITLE
 Snowpark integration: Add support for uncollected dataframes in st.map and improve st.table data collection

### DIFF
--- a/e2e/scripts/st_arrow_unevaluated_snowpark_dataframe.py
+++ b/e2e/scripts/st_arrow_unevaluated_snowpark_dataframe.py
@@ -24,3 +24,5 @@ st.line_chart(snowpark_dataframe)
 st.bar_chart(snowpark_dataframe)
 
 st.area_chart(snowpark_dataframe)
+
+st.table(snowpark_dataframe)

--- a/e2e/scripts/st_map.py
+++ b/e2e/scripts/st_map.py
@@ -18,10 +18,20 @@ import numpy as np
 import pandas as pd
 
 import streamlit as st
+from tests.streamlit.snowpark_mocks import DataFrame as MockedSnowparkDataFrame
+from tests.streamlit.snowpark_mocks import Table as MockedSnowparkTable
 
 # Empty map.
 
 st.map()
+
+# st.map with unevaluated Snowpark DataFrame
+
+st.map(MockedSnowparkTable(is_map=True, num_of_rows=50000))
+
+# st.map with unevaluated Snowpark Table
+
+st.map(MockedSnowparkDataFrame(is_map=True, num_of_rows=50000))
 
 # Simple map.
 

--- a/e2e/specs/st_arrow_unevaluated_snowpark_dataframe.js
+++ b/e2e/specs/st_arrow_unevaluated_snowpark_dataframe.js
@@ -38,9 +38,14 @@ describe("st.DataFrame with unevaluated snowflake.snowpark.dataframe.DataFrame",
       .should("have.length", 1)
   });
 
+  it("table exists and is evaluated", () => {
+    cy.get("div [data-testid='stTable']")
+      .should("have.length", 1)
+  });
+
   it("warning about data being capped exists", () => {
     cy.get("div [data-testid='stCaptionContainer']")
-      .should("have.length", 4)
+      .should("have.length", 5)
   });
 
   it("warning about data being capped exists", () => {
@@ -52,6 +57,8 @@ describe("st.DataFrame with unevaluated snowflake.snowpark.dataframe.DataFrame",
       .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
     cy.getIndexed("div [data-testid='stCaptionContainer']", 3)
       .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 4)
+      .should("contain", "⚠️ Showing only 100 rows. Call collect() on the dataframe to show more.")
   });
 
   it("displays a line chart", () => {

--- a/e2e/specs/st_map.spec.js
+++ b/e2e/specs/st_map.spec.js
@@ -19,16 +19,29 @@ describe("st.map", () => {
     cy.loadApp("http://localhost:3000/");
   });
 
-  it("displays 3 maps", () => {
-    cy.get(".element-container .stDeckGlJsonChart").should("have.length", 3)
+  it("displays 5 maps", () => {
+    cy.get(".element-container .stDeckGlJsonChart").should("have.length", 5)
   });
   
-  it("displays 3 zoom buttons", () => {
-    cy.get(".element-container .zoomButton").should("have.length", 3)
+  it("displays 5 zoom buttons", () => {
+    cy.get(".element-container .zoomButton").should("have.length", 5)
+  })
+
+  it("warning about data being capped exists", () => {
+    cy.get("div [data-testid='stCaptionContainer']")
+      .should("have.length", 2)
+  })
+
+  it("warning about data being capped has proper message value", () => {
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 0)
+      .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
+    cy.getIndexed("div [data-testid='stCaptionContainer']", 1)
+      .should("contain", "⚠️ Showing only 10k rows. Call collect() on the dataframe to show more.")
   })
 
   it("displays the correct snapshot", () => {
     cy.get(".mapboxgl-canvas")
     cy.get(".element-container", { waitForAnimations: true }).last().matchThemedSnapshots("stDeckGlJsonChart")
   })
+
 });

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -134,7 +134,7 @@ class ArrowMixin:
 
         # Check if data is uncollected, and collect it but with 100 rows max, instead of 10k rows, which is done in all other cases.
         # Avoid this and use 100 rows in st.table, because large tables render slowly, take too much screen space, and can crush the app.
-        if type_util.is_snowpark_dataframe(data):
+        if type_util.is_snowpark_data_object(data):
             data = type_util.convert_anything_to_df(data, max_unevaluated_rows=100)
 
         # If pandas.Styler uuid is not provided, a hash of the position

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -132,6 +132,11 @@ class ArrowMixin:
 
         """
 
+        # Check if data is uncollected, and collect it but with 100 rows max, instead of 10k rows, which is done in all other cases.
+        # Avoid this and use 100 rows in st.table, because large tables render slowly, take too much screen space, and can crush the app.
+        if type_util.is_snowpark_dataframe(data):
+            data = type_util.convert_anything_to_df(data, max_unevaluated_rows=100)
+
         # If pandas.Styler uuid is not provided, a hash of the position
         # of the element will be used. This will cause a rerender of the table
         # when the position of the element is changed.

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -47,7 +47,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, dict, or None
             The data to display.
 
             If 'data' is a pandas.Styler, it will be used to style its
@@ -117,7 +117,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, dict, or None
             The table data.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -165,7 +165,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, dict or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, dict or None
             Data to be plotted.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -248,7 +248,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, or dict
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, or dict
             Data to be plotted.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).
@@ -331,7 +331,7 @@ class DataFrameSelectorMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, Iterable, or dict
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, or dict
             Data to be plotted.
             Pyarrow tables are not supported by Streamlit's legacy DataFrame serialization
             (i.e. with `config.dataFrameSerialization = "legacy"`).

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -167,8 +167,7 @@ def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
     if hasattr(data, "empty") and data.empty:  # type: ignore
         return json.dumps(_DEFAULT_MAP)
 
-    if type_util.is_snowpark_dataframe(data):
-        data = type_util.convert_anything_to_df(data)
+    data = type_util.convert_anything_to_df(data)
 
     if "lat" in data:
         lat = "lat"
@@ -190,8 +189,6 @@ def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
 
     if data[lon].isnull().values.any() or data[lat].isnull().values.any():
         raise StreamlitAPIException("Latitude and longitude data must be numeric.")
-
-    data = pd.DataFrame(data)
 
     min_lat = data[lat].min()
     max_lat = data[lat].max()

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -161,13 +161,11 @@ def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
     if data is None:
         return json.dumps(_DEFAULT_MAP)
 
-    if hasattr(data, "empty"):
-        # TODO(harahu): The ignore statement here is because iterables don't have
-        #  the empty attribute. This is either a bug, or the documented data type
-        #  is too broad. One or the other should be addressed, and the ignore
-        #  statement removed.
-        if data.empty:  # type: ignore[union-attr]
-            return json.dumps(_DEFAULT_MAP)
+    # TODO(harahu): The ignore statement here is because iterables don't have
+    #  the empty attribute. This is either a bug, or the documented data type
+    #  is too broad. One or the other should be addressed, and the ignore
+    if hasattr(data, "empty") and data.empty:  # type: ignore
+        return json.dumps(_DEFAULT_MAP)
 
     if type_util.is_snowpark_dataframe(data):
         data = type_util.convert_anything_to_df(data)

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -96,7 +96,7 @@ class MapMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, dict,
             or None
             The data to be plotted. Must have columns called 'lat', 'lon',
             'latitude', or 'longitude'.

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -22,6 +22,7 @@ import pandas as pd
 from typing_extensions import Final, TypeAlias
 
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
+from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as DeckGlJsonChartProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -157,12 +158,19 @@ def _get_zoom_level(distance: float) -> int:
 
 
 def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
-    # TODO(harahu): The ignore statement here is because iterables don't have
-    #  the empty attribute. This is either a bug, or the documented data type
-    #  is too broad. One or the other should be addressed, and the ignore
-    #  statement removed.
-    if data is None or data.empty:  # type: ignore[union-attr]
+    if data is None:
         return json.dumps(_DEFAULT_MAP)
+
+    if hasattr(data, "empty"):
+        # TODO(harahu): The ignore statement here is because iterables don't have
+        #  the empty attribute. This is either a bug, or the documented data type
+        #  is too broad. One or the other should be addressed, and the ignore
+        #  statement removed.
+        if data.empty:  # type: ignore[union-attr]
+            return json.dumps(_DEFAULT_MAP)
+
+    if type_util.is_snowpark_dataframe(data):
+        data = type_util.convert_anything_to_df(data)
 
     if "lat" in data:
         lat = "lat"
@@ -186,7 +194,7 @@ def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
     #  the empty attribute. This is either a bug, or the documented data type
     #  is too broad. One or the other should be addressed, and the ignore
     #  statement removed.
-    if data[lon].isnull().values.any() or data[lat].isnull().values.any():  # type: ignore[index]
+    if data[lon].isnull().values.any() or data[lat].isnull().values.any():
         raise StreamlitAPIException("Latitude and longitude data must be numeric.")
 
     data = pd.DataFrame(data)

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -188,10 +188,6 @@ def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
             'Map data must contain a column called "longitude" or "lon".'
         )
 
-    # TODO(harahu): The ignore statement here is because iterables don't have
-    #  the empty attribute. This is either a bug, or the documented data type
-    #  is too broad. One or the other should be addressed, and the ignore
-    #  statement removed.
     if data[lon].isnull().values.any() or data[lat].isnull().values.any():
         raise StreamlitAPIException("Latitude and longitude data must be numeric.")
 

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -181,7 +181,7 @@ class WriteMixin:
             # Order matters!
             if isinstance(arg, str):
                 string_buffer.append(arg)
-            elif type_util.is_snowpark_dataframe(arg):
+            elif type_util.is_snowpark_data_object(arg):
                 flush_buffer()
                 self.dg.dataframe(arg)
             elif type_util.is_dataframe_like(arg):

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -144,3 +144,16 @@ def generate_download_filename_from_title(title_string: str) -> str:
     file_name_string = clean_filename(title_string)
     title_string = snake_case_to_camel_case(file_name_string)
     return append_date_time_to_string(title_string)
+
+
+def simplify_number(num: int) -> str:
+    """Simplifies number into Human readable format, returns str"""
+    num_converted = float("{:.2g}".format(num))
+    magnitude = 0
+    while abs(num_converted) >= 1000:
+        magnitude += 1
+        num_converted /= 1000.0
+    return "{}{}".format(
+        "{:f}".format(num_converted).rstrip("0").rstrip("."),
+        ["", "k", "m", "b", "t"][magnitude],
+    )

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -39,8 +39,8 @@ from typing_extensions import Final, Literal, Protocol, TypeAlias, TypeGuard, ge
 
 import streamlit as st
 from streamlit import errors
-from streamlit import string_util
 from streamlit import logger as _logger
+from streamlit import string_util
 
 if TYPE_CHECKING:
     import graphviz

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -429,8 +429,9 @@ def convert_anything_to_df(
     ----------
     df : ndarray, Iterable, dict, DataFrame, Styler, pa.Table, None, dict, list, or any
 
-    max_unevaluated_rows: int, If unevaluated data is detected this func will evaluate it,
-                            taking max_unevaluated_rows, defaults to 10k and 100 for st.table
+    max_unevaluated_rows: int
+        If unevaluated data is detected this func will evaluate it,
+        taking max_unevaluated_rows, defaults to 10k and 100 for st.table
 
     Returns
     -------
@@ -459,7 +460,7 @@ def convert_anything_to_df(
         if df.shape[0] == max_unevaluated_rows:
             st.caption(
                 f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
-                f"Call `collect()` on the dataframe to show more."
+                "Call `collect()` on the dataframe to show more."
             )
         return df
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -242,7 +242,7 @@ def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
     return any(is_type(obj, t) for t in _DATAFRAME_LIKE_TYPES)
 
 
-def is_snowpark_dataframe(obj: object) -> bool:
+def is_snowpark_data_object(obj: object) -> bool:
     """True if obj is of type snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table or
     True when obj is a list which contains snowflake.snowpark.row.Row,
     False otherwise"""
@@ -509,7 +509,7 @@ def ensure_iterable(obj: Union[DataFrame, Iterable[V_co]]) -> Iterable[Any]:
     iterable
 
     """
-    if is_snowpark_dataframe(obj):
+    if is_snowpark_data_object(obj):
         obj = convert_anything_to_df(obj)
 
     if is_dataframe(obj):

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -39,6 +39,7 @@ from typing_extensions import Final, Literal, Protocol, TypeAlias, TypeGuard, ge
 
 import streamlit as st
 from streamlit import errors
+from streamlit import string_util
 from streamlit import logger as _logger
 
 if TYPE_CHECKING:
@@ -453,15 +454,11 @@ def convert_anything_to_df(
     if is_type(df, "numpy.ndarray") and len(df.shape) == 0:
         return pd.DataFrame([])
 
-    if (
-        is_type(df, _SNOWPARK_DF_TYPE_STR)
-        and not isinstance(df, list)
-        or is_type(df, _SNOWPARK_TABLE_TYPE_STR)
-    ):
+    if is_type(df, _SNOWPARK_DF_TYPE_STR) or is_type(df, _SNOWPARK_TABLE_TYPE_STR):
         df = pd.DataFrame(df.take(max_unevaluated_rows))
         if df.shape[0] == max_unevaluated_rows:
             st.caption(
-                f"⚠️ Showing only {'10k' if max_unevaluated_rows == MAX_UNEVALUATED_DF_ROWS else str(max_unevaluated_rows)} rows. "
+                f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
                 f"Call `collect()` on the dataframe to show more."
             )
         return df

--- a/lib/tests/streamlit/dataframe_selector_test.py
+++ b/lib/tests/streamlit/dataframe_selector_test.py
@@ -23,6 +23,7 @@ import pandas as pd
 import streamlit
 from streamlit.delta_generator import DeltaGenerator
 from tests.streamlit.snowpark_mocks import DataFrame as MockSnowparkDataFrame
+from tests.streamlit.snowpark_mocks import Table as MockSnowparkTable
 from tests.testutil import patch_config_options
 
 DATAFRAME = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
@@ -63,6 +64,19 @@ class DataFrameSelectorTest(unittest.TestCase):
         legacy_dataframe.assert_not_called()
         arrow_dataframe.assert_called_once_with(
             snowpark_df, 100, 200, use_container_width=False
+        )
+
+    @patch.object(DeltaGenerator, "_legacy_dataframe")
+    @patch.object(DeltaGenerator, "_arrow_dataframe")
+    @patch_config_options({"global.dataFrameSerialization": "arrow"})
+    def test_arrow_dataframe_with_snowpark_table(
+        self, arrow_dataframe, legacy_dataframe
+    ):
+        snowpark_table = MockSnowparkTable()
+        streamlit.dataframe(snowpark_table, 100, 200)
+        legacy_dataframe.assert_not_called()
+        arrow_dataframe.assert_called_once_with(
+            snowpark_table, 100, 200, use_container_width=False
         )
 
     @patch.object(DeltaGenerator, "_legacy_table")

--- a/lib/tests/streamlit/snowpark_mocks.py
+++ b/lib/tests/streamlit/snowpark_mocks.py
@@ -16,16 +16,16 @@
 import random
 from typing import List
 
+import numpy as np
+import pandas as pd
 
-class DataFrame:
-    """This is dummy DataFrame class,
-    which imitates snowflake.snowpark.dataframe.DataFrame class
-    for testing purposes."""
 
-    __module__ = "snowflake.snowpark.dataframe"
-
-    def __init__(self, num_of_rows: int = 50000, num_of_cols: int = 4):
+class _SnowparkDataLikeBaseClass:
+    def __init__(
+        self, is_map: bool = False, num_of_rows: int = 50000, num_of_cols: int = 4
+    ):
         self._data = None
+        self._is_map = is_map
         self._num_of_rows = num_of_rows
         self._num_of_cols = num_of_cols
 
@@ -33,22 +33,31 @@ class DataFrame:
         return self._num_of_rows
 
     def take(self, n: int):
-        """Returns n element of fake DataFrame, which imitates take of snowflake.snowpark.dataframe.DataFrame"""
+        """Returns n element of fake Data like, which imitates take of snowflake.snowpark.dataframe.DataFrame"""
         self._lazy_evaluation()
         if n > self._num_of_rows:
             n = self._num_of_rows
         return self._data[:n]
 
     def collect(self) -> List[List[int]]:
-        """Returns fake DataFrame, which imitates collection of snowflake.snowpark.dataframe.DataFrame"""
+        """Returns fake Data like, which imitates collection of snowflake.snowpark.dataframe.DataFrame"""
         self._lazy_evaluation()
         return self._data
 
     def _lazy_evaluation(self):
-        """Sometimes we don't need data inside DataFrame class, so we populate it once and only when necessary"""
+        """Sometimes we don't need data inside Data like class, so we populate it once and only when necessary"""
         if self._data is None:
-            random.seed(0)
-            self._data = self._random_data()
+            if self._is_map:
+                self._data = pd.DataFrame(
+                    (
+                        np.random.randn(self._num_of_rows, 2) / [50, 50]
+                        + [37.76, -122.4]
+                    ),
+                    columns=["lat", "lon"],
+                )
+            else:
+                random.seed(0)
+                self._data = self._random_data()
 
     def _random_data(self) -> List[List[int]]:
         data: List[List[int]] = []
@@ -61,6 +70,36 @@ class DataFrame:
         for _ in range(0, self._num_of_cols):
             row.append(random.randint(1, 1000000))
         return row
+
+
+class DataFrame(_SnowparkDataLikeBaseClass):
+    """This is dummy DataFrame class,
+    which imitates snowflake.snowpark.dataframe.DataFrame class
+    for testing purposes."""
+
+    __module__ = "snowflake.snowpark.dataframe"
+
+    def __init__(
+        self, is_map: bool = False, num_of_rows: int = 50000, num_of_cols: int = 4
+    ):
+        super(DataFrame, self).__init__(
+            is_map=is_map, num_of_rows=num_of_rows, num_of_cols=num_of_cols
+        )
+
+
+class Table(_SnowparkDataLikeBaseClass):
+    """This is dummy Table class,
+    which imitates snowflake.snowpark.dataframe.DataFrame class
+    for testing purposes."""
+
+    __module__ = "snowflake.snowpark.table"
+
+    def __init__(
+        self, is_map: bool = False, num_of_rows: int = 50000, num_of_cols: int = 4
+    ):
+        super(Table, self).__init__(
+            is_map=is_map, num_of_rows=num_of_rows, num_of_cols=num_of_cols
+        )
 
 
 class Row:

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -101,3 +101,16 @@ class StringUtilTest(unittest.TestCase):
                 "Аптека, улица, фонарь"
             ).startswith("АптекаУлицаФонарь")
         )
+
+    def test_simplify_number(self):
+        """Test streamlit.string_util.simplify_number."""
+
+        self.assertEqual(string_util.simplify_number(100), "100")
+
+        self.assertEqual(string_util.simplify_number(10000), "10k")
+
+        self.assertEqual(string_util.simplify_number(1000000), "1m")
+
+        self.assertEqual(string_util.simplify_number(1000000000), "1b")
+
+        self.assertEqual(string_util.simplify_number(1000000000000), "1t")

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -25,7 +25,7 @@ from streamlit.type_util import (
     data_frame_to_bytes,
     fix_arrow_incompatible_column_types,
     is_bytes_like,
-    is_snowpark_dataframe,
+    is_snowpark_data_object,
     to_bytes,
 )
 from tests.streamlit.snowpark_mocks import DataFrame, Row
@@ -196,47 +196,47 @@ dtype: object""",
         )
 
         # pandas dataframe should not be SnowparkDataFrame
-        self.assertFalse(is_snowpark_dataframe(df))
+        self.assertFalse(is_snowpark_data_object(df))
 
-        # if snowflake.snowpark.dataframe.DataFrame def is_snowpark_dataframe should return true
-        self.assertTrue(is_snowpark_dataframe(DataFrame()))
+        # if snowflake.snowpark.dataframe.DataFrame def is_snowpark_data_object should return true
+        self.assertTrue(is_snowpark_data_object(DataFrame()))
 
         # any object should not be snowpark dataframe
-        self.assertFalse(is_snowpark_dataframe("any text"))
-        self.assertFalse(is_snowpark_dataframe(123))
+        self.assertFalse(is_snowpark_data_object("any text"))
+        self.assertFalse(is_snowpark_data_object(123))
 
         class DummyClass:
             """DummyClass for testing purposes"""
 
-        self.assertFalse(is_snowpark_dataframe(DummyClass()))
+        self.assertFalse(is_snowpark_data_object(DummyClass()))
 
         # empty list should not be snowpark dataframe
-        self.assertFalse(is_snowpark_dataframe(list()))
+        self.assertFalse(is_snowpark_data_object(list()))
 
         # list with items should not be snowpark dataframe
         self.assertFalse(
-            is_snowpark_dataframe(
+            is_snowpark_data_object(
                 [
                     "any text",
                 ]
             )
         )
         self.assertFalse(
-            is_snowpark_dataframe(
+            is_snowpark_data_object(
                 [
                     123,
                 ]
             )
         )
         self.assertFalse(
-            is_snowpark_dataframe(
+            is_snowpark_data_object(
                 [
                     DummyClass(),
                 ]
             )
         )
         self.assertFalse(
-            is_snowpark_dataframe(
+            is_snowpark_data_object(
                 [
                     df,
                 ]
@@ -245,7 +245,7 @@ dtype: object""",
 
         # list with SnowparkRow should be SnowparkDataframe
         self.assertTrue(
-            is_snowpark_dataframe(
+            is_snowpark_data_object(
                 [
                     Row(),
                 ]


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This PR improves Snowpark integration in Streamlit, it introduces changes like:
* adds support for uncollected Snowpark dataframes and tables in `st.map` component
* adds support for Snowpark table auto-collection (`snowflake.snowpark.table.Table`) in Streamlit components, before only unevaluated Dataframes were collected
* Limits auto-collection for `st.table` to 100 rows, instead of 10k rows. When 10k in `st.table` was collected it was buggy, page took long to load, app sometimes crashed and the page was very very long (it was discussed with @jrieke)

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
