### PR TITLE
Button 'type' parameter docstring fix

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -91,10 +91,10 @@ class ButtonMixin:
             An optional tuple of args to pass to the callback.
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
-        type (”primary” or “secondary”):
-            An optional string that specifies the button type. Can be “primary” for a
-            button with additional emphasis or “secondary” for a normal button. This
-            argument can only be supplied by keyword. Defaults to “secondary”.
+        type : "secondary" or "primary"
+            An optional string that specifies the button type. Can be "primary" for a
+            button with additional emphasis or "secondary" for a normal button. This
+            argument can only be supplied by keyword. Defaults to "secondary".
         disabled : bool
             An optional boolean, which disables the button if set to True. The
             default is False. This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -239,10 +239,10 @@ class FormMixin:
             An optional tuple of args to pass to the callback.
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
-        type (”primary” or “secondary”):
-            An optional string that specifies the button type. Can be “primary” for a
-            button with additional emphasis or “secondary” for a normal button. This
-            argument can only be supplied by keyword. Defaults to “secondary”.
+        type : "secondary" or "primary"
+            An optional string that specifies the button type. Can be "primary" for a
+            button with additional emphasis or "secondary" for a normal button. This
+            argument can only be supplied by keyword. Defaults to "secondary".
         disabled : bool
             An optional boolean, which disables the button if set to True. The
             default is False. This argument can only be supplied by keyword.


### PR DESCRIPTION
## 📚 Context

In docstrings: when a parameter can only assume one of a fixed set of values, those values are listed to the right of the colon appearing after the parameter name, with the default listed first. The docstrings for the `type` parameter in `st.button` and `st.form_submit_button` should follow the same convention, like the `label_visibility` parameter in `st.radio`:

https://github.com/streamlit/streamlit/blob/7c21b8d9355a6f37ebb45850a0ff36e5440fa3c4/lib/streamlit/elements/radio.py#L133 

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

Moves the parameter value choices for `type` in `st.button` and `st.form_submit_button` to the right of the colon appearing after the parameter name, with the default listed first.

  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/197466133-a6b61e45-b333-4bcb-9d4c-0bce335e0e60.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/197466211-4722ceb4-92da-4fd3-a5e8-40feaea84f7b.png)

## 🧪 Testing Done

- [x] Screenshots included

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
