### PR TITLE
Enlarge bottom padding in sidebar

### DIFF
--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -224,7 +224,7 @@ export const StyledSidebarUserContent =
     paddingTop: hasPageNavAbove
       ? theme.spacing.lg
       : theme.sizes.sidebarTopSpace,
-    paddingBottom: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
     paddingLeft: theme.spacing.lg,
     paddingRight: theme.spacing.lg,
 

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -224,7 +224,7 @@ export const StyledSidebarUserContent =
     paddingTop: hasPageNavAbove
       ? theme.spacing.lg
       : theme.sizes.sidebarTopSpace,
-    paddingBottom: theme.spacing.xl,
+    paddingBottom: theme.spacing.twoXL,
     paddingLeft: theme.spacing.lg,
     paddingRight: theme.spacing.lg,
 


### PR DESCRIPTION
## 📚 Context

This PR is a follow-up to https://github.com/streamlit/streamlit/pull/5559 (thanks for fixing, @RubenVanEldik!). We're increasing padding a bit more per Andreas Braendhaugen's request [here](https://www.notion.so/streamlit/Sidebar-needs-more-bottom-padding-to-indicate-end-of-scrollable-area-056283969c91404bb91ec5f76b48d90d), to make it more apparent it's the end of the scrollable area.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Design change

## 🧠 Description of Changes

* Updated `paddingBottom` in `StyledSidebarUserContent` from `1rem` to `1.5rem`;

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![Screen Shot 2022-10-24 at 3 37 07 PM](https://user-images.githubusercontent.com/34423371/197624309-da6e2a44-73a1-4a38-8009-137a9624a5f3.png)


**Current:**

<img width="1597" alt="Untitled" src="https://user-images.githubusercontent.com/34423371/197624576-32eec6d5-1ffd-455e-b7c9-ea564e11d47c.png">

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- https://www.notion.so/streamlit/Sidebar-needs-more-bottom-padding-to-indicate-end-of-scrollable-area-056283969c91404bb91ec5f76b48d90d

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
