### PR TITLE
Memo/singleton threading tests

### DIFF
--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 
 import contextlib
-from typing import TYPE_CHECKING, Iterator
+from typing import Iterator
 
 from google.protobuf.message import Message
 
 from streamlit.proto.Block_pb2 import Block
-
-if TYPE_CHECKING:
-    from streamlit.delta_generator import DeltaGenerator
-
 from streamlit.runtime.caching.memo_decorator import (
     MEMO_CALL_STACK,
     MEMO_MESSAGES_CALL_STACK,

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -33,6 +33,7 @@ from streamlit.runtime.scriptrunner import (
 )
 from streamlit.runtime.state import SessionState
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.exception_capturing_thread import ExceptionCapturingThread
 
 memo = st.experimental_memo
 singleton = st.experimental_singleton
@@ -652,9 +653,10 @@ class CommonCacheThreadingTest(unittest.TestCase):
             set_counter(55)
             values_in_thread.append(get_counter())
 
-        thread = threading.Thread(target=thread_test)
+        thread = ExceptionCapturingThread(target=thread_test)
         thread.start()
         thread.join()
+        thread.assert_no_unhandled_exception()
 
         self.assertEqual([0, 55], values_in_thread)
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -593,6 +593,7 @@ class CommonCacheThreadingTest(unittest.TestCase):
         def call_foo(_: int) -> None:
             self.assertEqual(42, foo())
 
+        # Call foo from multiple threads and assert no errors.
         call_on_threads(call_foo, self.NUM_THREADS)
 
         # We don't currently guarantee that the cached function will only be called
@@ -611,13 +612,16 @@ class CommonCacheThreadingTest(unittest.TestCase):
         def foo():
             return 42
 
+        # Populate the cache
         foo()
 
         def clear_caches(_: int) -> None:
             clear_cache_func()
 
+        # Clear the cache from a bunch of threads and assert no errors.
         call_on_threads(clear_caches, self.NUM_THREADS)
 
+        # Sanity check: ensure we can still call our cached function.
         self.assertEqual(42, foo())
 
     @parameterized.expand([("memo", memo), ("singleton", singleton)])
@@ -628,13 +632,16 @@ class CommonCacheThreadingTest(unittest.TestCase):
         def foo():
             return 42
 
+        # Populate the cache
         foo()
 
         def clear_foo(_: int) -> None:
             foo.clear()
 
+        # Clear it from a bunch of threads and assert no errors.
         call_on_threads(clear_foo, self.NUM_THREADS)
 
+        # Sanity check: ensure we can still call our cached function.
         self.assertEqual(42, foo())
 
     @parameterized.expand(

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -268,12 +268,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
             add_script_run_ctx(threading.current_thread(), orig_report_ctx)
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay(self, _, cache_decorator):
         @cache_decorator
         def foo(i):
@@ -288,12 +283,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
         assert text == ["1", "---", "1"]
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay_nested(self, _, cache_decorator):
         @cache_decorator
         def inner(i):
@@ -329,12 +319,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
             "3",
         ]
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay_outer_blocks(self, _, cache_decorator):
         @cache_decorator
         def foo(i):
@@ -349,12 +334,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         text = self.get_text_delta_contents()
         assert text == ["1", "---", "1"]
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay_sidebar(self, _, cache_decorator):
         @cache_decorator(show_spinner=False)
         def foo(i):
@@ -379,12 +359,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         ]
         assert paths == [[1, 0], [0, 0], [1, 1]]
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay_inner_blocks(self, _, cache_decorator):
         @cache_decorator(show_spinner=False)
         def foo(i):
@@ -420,12 +395,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
             [0, 5, 0],
         ]
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay_inner_direct(self, _, cache_decorator):
         @cache_decorator(show_spinner=False)
         def foo(i):
@@ -447,12 +417,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         ]
         assert paths == [[0, 0], [0, 0, 0], [0, 1], [0, 2], [0, 2, 0]]
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay_outer_direct(self, _, cache_decorator):
         cont = st.container()
 
@@ -535,12 +500,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         self.assertEqual(2, foo_call_count[0])
         self.assertEqual(1, bar_call_count[0])
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_without_spinner(self, _, cache_decorator):
         """If the show_spinner flag is not set, the report queue should be
         empty.
@@ -553,12 +513,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         function_without_spinner(3)
         self.assertTrue(self.forward_msg_queue.is_empty())
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_with_spinner(self, _, cache_decorator):
         """If the show_spinner flag is set, there should be one element in the
         report queue.
@@ -571,12 +526,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         function_with_spinner(3)
         self.assertFalse(self.forward_msg_queue.is_empty())
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_with_custom_text_spinner(self, _, cache_decorator):
         """If the show_spinner flag is set, there should be one element in the
         report queue.
@@ -589,12 +539,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
         function_with_spinner_custom_text(3)
         self.assertFalse(self.forward_msg_queue.is_empty())
 
-    @parameterized.expand(
-        [
-            ("memo", memo),
-            ("singleton", singleton),
-        ]
-    )
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_with_empty_text_spinner(self, _, cache_decorator):
         """If the show_spinner flag is set, even if it is empty text,
         there should be one element in the report queue.


### PR DESCRIPTION
`CommonCacheThreadingTest`, with unit tests for populating and clearing our singleton/memo caches from multiple threads simultaneously.