### PR TITLE
fix slider jitter (#5546)

### DIFF
--- a/frontend/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.tsx
@@ -63,6 +63,8 @@ class Slider extends React.PureComponent<Props, State> {
 
   private sliderRef = React.createRef<HTMLDivElement>()
 
+  private thumbRef: React.MutableRefObject<HTMLDivElement> | undefined
+
   private thumbValueRef = React.createRef<HTMLDivElement>()
 
   private readonly commitWidgetValueDebounced: (source: Source) => void
@@ -202,20 +204,29 @@ class Slider extends React.PureComponent<Props, State> {
 
   private thumbValueAlignment(): void {
     const slider = this.sliderRef.current
-    const thumb = this.thumbValueRef.current
+    const thumb = this.thumbRef?.current
+    const thumbValue = this.thumbValueRef.current
 
-    if (slider && thumb) {
+    if (slider && thumb && thumbValue) {
       const sliderPosition = slider.getBoundingClientRect()
       const thumbPosition = thumb.getBoundingClientRect()
+      const thumbValuePosition = thumbValue.getBoundingClientRect()
 
-      thumb.style.left = thumbPosition.left < sliderPosition.left ? "0" : ""
-      thumb.style.right = thumbPosition.right > sliderPosition.right ? "0" : ""
+      const thumbMidpoint = thumbPosition.left + thumbPosition.width / 2
+      const thumbValueOverflowsLeft =
+        thumbMidpoint - thumbValuePosition.width / 2 < sliderPosition.left
+      const thumbValueOverflowsRight =
+        thumbMidpoint + thumbValuePosition.width / 2 > sliderPosition.right
+
+      thumbValue.style.left = thumbValueOverflowsLeft ? "0" : ""
+      thumbValue.style.right = thumbValueOverflowsRight ? "0" : ""
     }
   }
 
   // eslint-disable-next-line react/display-name
   private renderThumb = React.forwardRef<HTMLDivElement, SharedProps>(
     (props: SharedProps, ref): JSX.Element => {
+      this.thumbRef = ref as React.MutableRefObject<HTMLDivElement>
       const { $value, $thumbIndex } = props
       const formattedValue = $value
         ? this.formatValue($value[$thumbIndex as number])


### PR DESCRIPTION
## 📚 Context

Fixes #5546. Added a comment in that issue with context on why the bug is occurring.

This fix tweaks the original code from https://github.com/streamlit/streamlit/pull/4076 to prevent the jitter. The thumb value's current position cannot be used to determine if the thumb value's position needs to be clamped - because if we've already clamped it to be within the slider's bounds then it no longer overflows the slider.

Instead, we can use the thumb's position plus the thumb value's width to determine if the thumb value needs to be clamped. This calculation does not depend on the thumb value's position so it returns the same value before/after clamping the thumb value's position within the slider's bounds. This prevents the clamping from causing a jitter.


- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![afterFix](https://user-images.githubusercontent.com/1305608/198203054-18b53ee5-3544-4ad4-a771-46c27bbf9ac3.gif)


**Current:**

![beforeFix](https://user-images.githubusercontent.com/1305608/198203035-d3995eb6-d038-46dc-b9a8-98db5e0a225d.gif)


hovering on/off the thumb:

![hoverCausesJitter](https://user-images.githubusercontent.com/1305608/198205171-10ae8919-a1ef-4265-8e67-d0b9778dcb80.gif)



## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

This issue is tricky to add test coverage for since static tests (unit and e2e snapshot) will produce the same slider thumb value position with/without the code diff in this PR. The behavior only differs if React render is triggered multiple times in succession - that's what produces the jitter.

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #5546

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
