### PR TITLE
Reworke AttrDict for st.secrets to explicitly disallow item and attribute assignment

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -72,6 +72,12 @@ class AttrDict(UserDict):  # type: ignore[type-arg]
         except KeyError:
             raise KeyError(_missing_key_error_message(key))
 
+    def __setattr__(self, key, value):
+        raise NotImplemented
+
+    def __setitem__(self, key, value):
+        raise NotImplemented
+
 
 class Secrets(Mapping[str, Any]):
     """A dict-like class that stores secrets.

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,7 +14,16 @@
 
 import os
 import threading
-from typing import Any, ItemsView, Iterator, KeysView, Mapping, Optional, ValuesView
+from typing import (
+    Any,
+    ItemsView,
+    Iterator,
+    KeysView,
+    Mapping,
+    NoReturn,
+    Optional,
+    ValuesView,
+)
 
 import toml
 from blinker import Signal
@@ -83,10 +92,10 @@ class AttrDict(Mapping[str, Any]):
     def __repr__(self):
         return repr(self.__nested_secrets__)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value) -> NoReturn:
         raise TypeError("Secrets does not support item assignment.")
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, key, value) -> NoReturn:
         raise TypeError("Secrets does not support attribute assignment.")
 
 

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -17,7 +17,8 @@
 import os
 import unittest
 from collections.abc import Mapping as MappingABC
-from typing import Mapping
+from collections.abc import MutableMapping as MutableMappingABC
+from typing import Mapping, MutableMapping
 from unittest.mock import MagicMock, mock_open, patch
 
 from toml import TomlDecodeError
@@ -134,6 +135,8 @@ class SecretsTest(unittest.TestCase):
         """Verify that AttrDict implements Mapping, but not built-in Dict"""
         self.assertTrue(isinstance(self.secrets.subsection, Mapping))
         self.assertTrue(isinstance(self.secrets.subsection, MappingABC))
+        self.assertFalse(isinstance(self.secrets.subsection, MutableMapping))
+        self.assertFalse(isinstance(self.secrets.subsection, MutableMappingABC))
         self.assertFalse(isinstance(self.secrets.subsection, dict))
 
     @patch("streamlit.watcher.path_watcher.watch_file")

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -129,8 +129,8 @@ class SecretsTest(unittest.TestCase):
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
-    def test_attr_dict_is_mapping_but_not_build_in_dict(self, *mocks):
-        """Verify that AttrDict is implements Mapping, but not build-in Dict"""
+    def test_attr_dict_is_mapping_but_not_built_in_dict(self, *mocks):
+        """Verify that AttrDict is implements Mapping, but not built-in Dict"""
         self.assertTrue(isinstance(self.secrets.subsection, Mapping))
         self.assertFalse(isinstance(self.secrets.subsection, dict))
 

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -130,7 +130,7 @@ class SecretsTest(unittest.TestCase):
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_attr_dict_is_mapping_but_not_built_in_dict(self, *mocks):
-        """Verify that AttrDict is implements Mapping, but not built-in Dict"""
+        """Verify that AttrDict implements Mapping, but not built-in Dict"""
         self.assertTrue(isinstance(self.secrets.subsection, Mapping))
         self.assertFalse(isinstance(self.secrets.subsection, dict))
 

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -16,6 +16,7 @@
 
 import os
 import unittest
+from collections.abc import Mapping as MappingABC
 from typing import Mapping
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -132,6 +133,7 @@ class SecretsTest(unittest.TestCase):
     def test_attr_dict_is_mapping_but_not_built_in_dict(self, *mocks):
         """Verify that AttrDict implements Mapping, but not built-in Dict"""
         self.assertTrue(isinstance(self.secrets.subsection, Mapping))
+        self.assertTrue(isinstance(self.secrets.subsection, MappingABC))
         self.assertFalse(isinstance(self.secrets.subsection, dict))
 
     @patch("streamlit.watcher.path_watcher.watch_file")

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -16,6 +16,7 @@
 
 import os
 import unittest
+from typing import Mapping
 from unittest.mock import MagicMock, mock_open, patch
 
 from toml import TomlDecodeError
@@ -115,6 +116,23 @@ class SecretsTest(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             self.secrets.subsection.nonexistent_secret
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_getattr_raises_exception_on_attr_dict(self, *mocks):
+        """Verify that assignment to nested secrets raises TypeError."""
+        with self.assertRaises(TypeError):
+            self.secrets.subsection["new_secret"] = "123"
+
+        with self.assertRaises(TypeError):
+            self.secrets.subsection.new_secret = "123"
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_attr_dict_is_mapping_but_not_build_in_dict(self, *mocks):
+        """Verify that AttrDict is implements Mapping, but not build-in Dict"""
+        self.assertTrue(isinstance(self.secrets.subsection, Mapping))
+        self.assertFalse(isinstance(self.secrets.subsection, dict))
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_
We implement `AttrDict` as `Mapping` instead of inheriting directly from `UserDict` to prevent unwanted item or attribute assignments for instances of `AttrDict`.  Also, the goal is to be more specific about the types and protocols and keep it consistent with the Secret object itself.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [X] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #5617

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
