### PR TITLE
DeltaGeneratorTestCase: remove unused setup param

### DIFF
--- a/lib/tests/delta_generator_test_case.py
+++ b/lib/tests/delta_generator_test_case.py
@@ -42,9 +42,8 @@ class FakeAppSession(AppSession):
 
 
 class DeltaGeneratorTestCase(unittest.TestCase):
-    def setUp(self, override_root=True):
+    def setUp(self):
         self.forward_msg_queue = ForwardMsgQueue()
-        self.override_root = override_root
         self.orig_report_ctx = None
         self.new_script_run_ctx = ScriptRunContext(
             session_id="test session id",
@@ -56,9 +55,8 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             user_info={"email": "test@test.com"},
         )
 
-        if self.override_root:
-            self.orig_report_ctx = get_script_run_ctx()
-            add_script_run_ctx(threading.current_thread(), self.new_script_run_ctx)
+        self.orig_report_ctx = get_script_run_ctx()
+        add_script_run_ctx(threading.current_thread(), self.new_script_run_ctx)
 
         self.app_session = FakeAppSession()
 
@@ -72,8 +70,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.clear_queue()
-        if self.override_root:
-            add_script_run_ctx(threading.current_thread(), self.orig_report_ctx)
+        add_script_run_ctx(threading.current_thread(), self.orig_report_ctx)
         Runtime._instance = None
 
     def get_message_from_queue(self, index=-1) -> ForwardMsg:

--- a/lib/tests/streamlit/elements/pyplot_test.py
+++ b/lib/tests/streamlit/elements/pyplot_test.py
@@ -26,8 +26,8 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
 class PyplotTest(DeltaGeneratorTestCase):
-    def setUp(self, override_root=True):
-        super().setUp(override_root)
+    def setUp(self):
+        super().setUp()
         if matplotlib.get_backend().lower() != "agg":
             plt.switch_backend("agg")
 

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -98,7 +98,7 @@ class MetricsUtilTest(unittest.TestCase):
 
 class PageTelemetryTest(DeltaGeneratorTestCase):
     def setUp(self):
-        super().setUp(self)
+        super().setUp()
         ctx = get_script_run_ctx()
         ctx.reset()
         ctx.gather_usage_stats = True


### PR DESCRIPTION
`setUp` is an override called internally by `unittest.TestCase`, so it can't have any additional parameters. (Nobody is attempting to set this param to `False`, so removing it has no effect on existing tests.)