### PR TITLE
Bring back the "Is Streamlit still running?" dialog

### DIFF
--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -25,9 +25,12 @@ import { ensureError } from "./ErrorHandling"
 
 /**
  * When the websocket connection retries this many times, we show a dialog
- * letting the user know we're having problems connecting.
+ * letting the user know we're having problems connecting. This happens
+ * after about 15 seconds as, before the 6th retry, we've set timeouts for
+ * a total of approximately 0.5 + 1 + 2 + 4 + 8 = 15.5 seconds (+/- some
+ * due to jitter).
  */
-const RETRY_COUNT_FOR_WARNING = 30 // around 15s
+const RETRY_COUNT_FOR_WARNING = 6
 
 interface Props {
   /**
@@ -142,7 +145,11 @@ export class ConnectionManager {
 
   private showRetryError = (
     totalRetries: number,
-    latestError: ReactNode
+    latestError: ReactNode,
+    // The last argument of this function is unused and exists because the
+    // WebsocketConnection.OnRetry type allows a third argument to be set to be
+    // used in tests.
+    _retryTimeout: number
   ): void => {
     if (totalRetries === RETRY_COUNT_FOR_WARNING) {
       this.props.onConnectionError(latestError)

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -122,8 +122,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      TEST_ERROR_MESSAGE
+      TEST_ERROR_MESSAGE,
+      expect.anything()
     )
   })
 
@@ -147,8 +147,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      "Connection timed out."
+      "Connection timed out.",
+      expect.anything()
     )
   })
 
@@ -176,8 +176,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      "Connection failed with status 0."
+      "Connection failed with status 0.",
+      expect.anything()
     )
   })
 
@@ -203,8 +203,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      "Connection failed with status 0."
+      "Connection failed with status 0.",
+      expect.anything()
     )
   })
 
@@ -254,8 +254,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA_LOCALHOST.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      NoResponse
+      NoResponse,
+      expect.anything()
     )
   })
 
@@ -294,8 +294,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      Forbidden
+      Forbidden,
+      expect.anything()
     )
   })
 
@@ -324,8 +324,8 @@ describe("doInitPings", () => {
 
     expect(MOCK_PING_DATA.retryCallback).toHaveBeenCalledWith(
       1,
-      expect.anything(),
-      `Connection failed with status ${TEST_ERROR.response.status}, and response "${TEST_ERROR.response.data}".`
+      `Connection failed with status ${TEST_ERROR.response.status}, and response "${TEST_ERROR.response.data}".`,
+      expect.anything()
     )
   })
 
@@ -370,8 +370,8 @@ describe("doInitPings", () => {
     const timeouts: number[] = []
     const callback = (
       _times: number,
-      timeout: number,
-      _errorNode: React.ReactNode
+      _errorNode: React.ReactNode,
+      timeout: number
     ): void => {
       timeouts.push(timeout)
     }
@@ -413,8 +413,8 @@ describe("doInitPings", () => {
     const timeouts: number[] = []
     const callback = (
       _times: number,
-      timeout: number,
-      _errorNode: React.ReactNode
+      _errorNode: React.ReactNode,
+      timeout: number
     ): void => {
       timeouts.push(timeout)
     }
@@ -452,8 +452,8 @@ describe("doInitPings", () => {
     const timeouts: number[] = []
     const callback = (
       _times: number,
-      timeout: number,
-      _errorNode: React.ReactNode
+      _errorNode: React.ReactNode,
+      timeout: number
     ): void => {
       timeouts.push(timeout)
     }
@@ -470,8 +470,8 @@ describe("doInitPings", () => {
     const timeouts2: number[] = []
     const callback2 = (
       _times: number,
-      timeout: number,
-      _errorNode: React.ReactNode
+      _errorNode: React.ReactNode,
+      timeout: number
     ): void => {
       timeouts2.push(timeout)
     }

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -74,8 +74,8 @@ type OnConnectionStateChange = (
 ) => void
 type OnRetry = (
   totalTries: number,
-  retryTimeout: number,
-  errorNode: React.ReactNode
+  errorNode: React.ReactNode,
+  retryTimeout: number
 ) => void
 
 interface Args {
@@ -588,7 +588,7 @@ export function doInitPings(
         : minimumTimeoutMs * 2 ** (totalTries - 1) * (1 + jitter)
     const retryTimeout = Math.min(maximumTimeoutMs, timeoutMs)
 
-    retryCallback(totalTries, retryTimeout, errorNode)
+    retryCallback(totalTries, errorNode, retryTimeout)
 
     window.setTimeout(retryImmediately, retryTimeout)
   }


### PR DESCRIPTION
## 📚 Context

A few months ago, we had the Streamlit client backoff exponentially (with jitter) when attempting to
reconnect to help spread out load from a thundering herd when clients reconnect after an outage with
the hosting service (we were mainly thinking of Community Cloud when making this change, but this
should benefit all Streamlit deployments).

This inadvertently effectively broke the "Is Streamlit still running?" dialog because we decide to display
the dialog after retrying a given number of times. This number was previously 30 (we retried every 500ms).
With the exponential backoff, 30 retries ends up being closer to half an hour than the original 15 seconds that we
wanted to display the dialog after. This PR changes the number of retries so that the dialog displays after roughly
15 seconds again.

Note this is hard to test because the way that cypress re-throws errors (when it's rerouting requests it
receives to another service) seems to change the error code we receive, which causes us to display the
wrong dialog 😢 

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests