### PR TITLE
Make our custom snowpark build tweaks more obvious

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,4 +1,4 @@
-name: Conda Build Test
+name: Snowpark Conda Build Test
 
 on:
   push:
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_conda_package:
+  build_snowpark_conda_package:
     runs-on: ubuntu-latest
 
     defaults:
@@ -42,8 +42,8 @@ jobs:
           curl -sO "https://repo.anaconda.com/miniconda/${MINICONDA_RELEASE}.sh"
           bash "${MINICONDA_RELEASE}.sh" -b
           conda install conda-build
-      - name: Build Conda Package - Fast
+      - name: Build Snowpark Conda Package - Fast
         timeout-minutes: 120
         run: |
           sudo apt install rsync
-          BUILD_AS_FAST_AS_POSSIBLE=1 make conda-package
+          SNOWPARK_CONDA_BUILD=1 BUILD_AS_FAST_AS_POSSIBLE=1 make conda-package

--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,11 @@ conda-distribution:
 	# This can take upwards of 20 minutes to complete in a fresh conda installation! (Dependency solving is slow.)
 	# NOTE: Running the following command requires both conda and conda-build to
 	# be installed.
-	ST_CONDA_BUILD=1 GIT_HASH=$$(git rev-parse --short HEAD) conda build lib/conda-recipe --output-folder lib/conda-recipe/dist
+	GIT_HASH=$$(git rev-parse --short HEAD) conda build lib/conda-recipe --output-folder lib/conda-recipe/dist
 
 .PHONY: conda-package
 # Build lib and frontend, and then run 'conda-distribution'
 conda-package: mini-devel frontend conda-distribution
-
 
 .PHONY: clean
 # Remove all generated files.

--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -39,7 +39,7 @@ build:
     {% endfor %}
   script_env:
    - GIT_HASH
-   - ST_CONDA_BUILD
+   - SNOWPARK_CONDA_BUILD
 
 requirements:
   host:

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -55,28 +55,19 @@ INSTALL_REQUIRES = [
     "watchdog; platform_system != 'Darwin'",
 ]
 
-# We want to exclude some dependencies in our internal conda distribution of
+# We want to exclude some dependencies in our internal SnowPark conda distribution of
 # Streamlit. These dependencies will be installed normally for both regular conda builds
-# and PyPI builds.
-# NOTE: These packages are still installed normally when running
-#       `pip install streamlit` and `conda install -c conda-forge streamlit`
-# TODO(vdonato): Change the names CONDA_OPTIONAL_DEPENDENCIES and ST_CONDA_BUILD to be
-# more explicitly about internal SnowPark things so that it's less likely for someone to
-# accidentally/unknowingly create a tornado-less Streamlit package.
-CONDA_OPTIONAL_DEPENDENCIES = [
+# and PyPI builds (that is, for people installing streamlit using either
+# `pip install streamlit` or `conda install -c conda-forge streamlit`
+SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
     "gitpython!=3.1.19",
     "pydeck>=0.1.dev5",
     # 5.0 has a fix for etag header: https://github.com/tornadoweb/tornado/issues/2262
     "tornado>=5.0",
 ]
 
-# NOTE: ST_CONDA_BUILD is used here (even though CONDA_BUILD is set
-# automatically when using the `conda build` command) because the
-# `load_setup_py_data()` conda build helper function does not have the
-# CONDA_BUILD environment variable set when it runs to generate our build
-# recipe from meta.yaml.
-if not os.getenv("ST_CONDA_BUILD"):
-    INSTALL_REQUIRES.extend(CONDA_OPTIONAL_DEPENDENCIES)
+if not os.getenv("SNOWPARK_CONDA_BUILD"):
+    INSTALL_REQUIRES.extend(SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES)
 
 
 class VerifyVersionCommand(install):

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -55,10 +55,10 @@ INSTALL_REQUIRES = [
     "watchdog; platform_system != 'Darwin'",
 ]
 
-# We want to exclude some dependencies in our internal SnowPark conda distribution of
+# We want to exclude some dependencies in our internal Snowpark conda distribution of
 # Streamlit. These dependencies will be installed normally for both regular conda builds
 # and PyPI builds (that is, for people installing streamlit using either
-# `pip install streamlit` or `conda install -c conda-forge streamlit`
+# `pip install streamlit` or `conda install -c conda-forge streamlit`)
 SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
     "gitpython!=3.1.19",
     "pydeck>=0.1.dev5",


### PR DESCRIPTION
## 📚 Context

It previously wasn't clear what the `ST_CONDA_BUILD` environment variable was used for. This PR
renames the environment variable to `SNOWPARK_CONDA_BUILD` to make it obvious that it's for
Snowpark internal builds, which is preferable to having people accidentally building tornado-less
Streamlit builds (which are pretty useless everywhere else).

It also doesn't set the flag by default in the `make conda-package` target so that the `make` target
can be used as a generic conda one.

- What kind of change does this PR introduce?

  - [x] Refactoring
