### PR TITLE
Fix: CI Check for no empty runners

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ]
+        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
     
     steps:
       - name: Checkout Streamlit code
@@ -67,16 +67,20 @@ jobs:
         run: |
           js_specs=(e2e/specs/*)
           # get how many specs to be split up into 21 runs
-          (( interval=(${#js_specs[@]}+21-1)/21 ))
+          (( interval=(${#js_specs[@]})/21 ))
           if [ "$CURRENT_RUN" -eq 1 ]
           then
             startIndex=0
           else
             (( startIndex = (${CURRENT_RUN} - 1) * ${interval} ))
           fi
-          echo "Specs tested in this job:"
-          echo "${js_specs[@]:${startIndex}:${interval}}"
-          scripts/run_e2e_tests.py -a "${js_specs[@]:${startIndex}:${interval}}"
+          # ensure no blank specs list (which causes every spec to run)
+          if [[ "${js_specs[@]:${startIndex}:${interval}}" != "" ]]
+          then
+            echo "Specs tested in this job:"
+            echo "${js_specs[@]:${startIndex}:${interval}}"
+            scripts/run_e2e_tests.py -a "${js_specs[@]:${startIndex}:${interval}}"
+          fi
       - name: Store Videos
         uses: actions/upload-artifact@v3
         if: always()


### PR DESCRIPTION
## 📚 Context

The formula to calculate relatively equal division of spec files across runners doesn't always work as expected.
Ex: 129 spec files in Amanda's PR puts 7 files in each runner, only requiring 19 runners - the 2 leftover runners then run ALL specs and as you can imagine that is painfully slow. 
This PR adds a check to ensure no runners run every spec file.

- What kind of change does this PR introduce?
  - [x] Other, please describe: CI Cypress fix

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
