### PR TITLE
Replace assertEquals->assertEqual to silence deprecation warnings

### DIFF
--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -100,7 +100,7 @@ class PageConfigTest(DeltaGeneratorTestCase):
     def test_set_page_config_sidebar_invalid(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.set_page_config(initial_sidebar_state="INVALID")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             '`initial_sidebar_state` must be "auto" or "expanded" or "collapsed" (got "INVALID")',
         )
@@ -130,7 +130,7 @@ class PageConfigTest(DeltaGeneratorTestCase):
         with self.assertRaises(StreamlitAPIException) as e:
             menu_items = {"report a bug": "", "GET HELP": "", "about": ""}
             st.set_page_config(menu_items=menu_items)
-        self.assertEquals(str(e.exception), '"" is a not a valid URL!')
+        self.assertEqual(str(e.exception), '"" is a not a valid URL!')
 
     def test_set_page_config_menu_items_none(self):
         menu_items = {"report a bug": None, "GET HELP": None, "about": None}
@@ -144,7 +144,7 @@ class PageConfigTest(DeltaGeneratorTestCase):
         with self.assertRaises(StreamlitAPIException) as e:
             menu_items = {"invalid": "fdsa"}
             st.set_page_config(menu_items=menu_items)
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             'We only accept the keys: "Get help", "Report a bug", and "About" '
             '("invalid" is not a valid key.)',

--- a/lib/tests/streamlit/elements/camera_input_test.py
+++ b/lib/tests/streamlit/elements/camera_input_test.py
@@ -58,7 +58,7 @@ class CameraInputTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.camera_input("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -105,7 +105,7 @@ class ColorPickerTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.color_picker("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -205,7 +205,7 @@ class DateInputTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.date_input("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -189,7 +189,7 @@ class FileUploaderTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.file_uploader("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -269,7 +269,7 @@ class Multiselectbox(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.multiselect("the label", ("m", "f"), label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -285,7 +285,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.number_input("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -207,7 +207,7 @@ class RadioTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.radio("the label", ("m", "f"), label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -257,7 +257,7 @@ class SliderTest(DeltaGeneratorTestCase):
             st.select_slider(
                 "the label", options=["red", "orange"], label_visibility="wrong_value"
             )
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -175,7 +175,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.selectbox("the label", ("m", "f"), label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -262,7 +262,7 @@ class SliderTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.slider("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -131,7 +131,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.text_area("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -163,7 +163,7 @@ class TextInputTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.text_input("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -92,7 +92,7 @@ class TimeInputTest(DeltaGeneratorTestCase):
     def test_label_visibility_wrong_value(self):
         with self.assertRaises(StreamlitAPIException) as e:
             st.time_input("the label", label_visibility="wrong_value")
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             "Unsupported label_visibility option 'wrong_value'. Valid values are "
             "'visible', 'hidden' or 'collapsed'.",


### PR DESCRIPTION
## 📚 Context

I started noticing some deprecation warnings for using `self.assertEquals` in unit tests.
This PR just changes those calls to `self.assertEqual`.

- What kind of change does this PR introduce?
  - [x] Refactoring
  - [x] Other, please describe: deprecation tweaks

## 🧪 Testing Done

- [x] Added/Updated unit tests
