### PR TITLE
Add repo_meta.yaml

### DIFF
--- a/.github/repo_meta.yaml
+++ b/.github/repo_meta.yaml
@@ -1,0 +1,25 @@
+# point_of_contact: the owner of this repository, can be a GitHub user or GitHub team
+point_of_contact: @sfc-gh-kmcgrady
+
+# production: whether this repository meets the criteria for being "production"
+production: true
+
+# distributed: whether any source code in this repository is distributed directly to customers (e.g. driver and frontend software)
+distributed: true
+
+# modified: whether any open source dependencies in this repository have been modified
+modified: false
+
+# release_branches: list of release branch patterns, exact matches or regex is acceptable
+release_branches:
+  - develop
+  - release\/*
+
+# code_owners_file_present: whether there is a CODEOWNERS file in this repository
+code_owners_file_present: true
+
+# jira_project_issue_type: the jira issuetype used to raise issues related to this repository in the STREAMLIT Jira project
+jira_project_issue_type: Bug
+
+# jira_area: the jira area that raised issues should use
+jira_area: Streamlit


### PR DESCRIPTION
## 📚 Context

Repos within the broader Snowflake org are having `repo_meta.yaml` files added to them
to add metadata to them that's useful for security.

We technically haven't been asked to do this yet, but there's no harm in doing this early.

- What kind of change does this PR introduce?

  - [x] Other, please describe: security things