### PR TITLE
Add a config option to hide the hamburger menu

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -184,6 +184,7 @@ describe("App", () => {
 
     wrapper.setState({
       scriptName: "scriptName",
+      hideHamburgerMenu: false,
     })
 
     wrapper.find(MainMenu).props().screencastCallback()
@@ -221,6 +222,7 @@ describe("App", () => {
       }),
     })
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ hideHamburgerMenu: false })
 
     expect(wrapper.find(MainMenu).prop("hostMenuItems")).toStrictEqual([
       { type: "separator" },
@@ -360,6 +362,18 @@ describe("App", () => {
 
     expect(wrapper.find("WithTheme(StatusWidget)").exists()).toBe(true)
     expect(wrapper.find("ToolbarActions").exists()).toBe(true)
+  })
+
+  it("hides the hamburger menu if hideHamburgerMenu === true", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    // hideHamburgerMenu is true by default
+    expect(wrapper.find(MainMenu).exists()).toBe(false)
+  })
+
+  it("shows the hamburger menu if hideHamburgerMenu === false", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    wrapper.setState({ hideHamburgerMenu: false })
+    expect(wrapper.find(MainMenu).exists()).toBe(true)
   })
 
   it("updates state.appPages when it receives a PagesChanged msg", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,6 +140,7 @@ interface State {
   themeHash: string | null
   gitInfo: IGitInfo | null
   formsData: FormsData
+  hideHamburgerMenu: boolean
   hideTopBar: boolean
   hideSidebarNav: boolean
   appPages: IAppPage[]
@@ -211,12 +212,13 @@ export class App extends PureComponent<Props, State> {
       formsData: createFormsData(),
       appPages: [],
       currentPageScriptHash: "",
-      // We set hideTopBar to true by default because this information isn't
-      // available on page load (we get it when the script begins to run), so
-      // the user would see top bar elements for a few ms if this defaulted to
-      // false. hideSidebarNav doesn't have this issue (app pages and the value
-      // of the config option are received simultaneously), but we set it to
-      // true as well for consistency.
+      // We set hideHamburgerMenu and hideTopBar to true by default because this
+      // information isn't available on page load (we get it when the script
+      // begins to run), so the user would see the elements for a few ms if
+      // this defaulted to false. hideSidebarNav doesn't have this issue (app
+      // pages and the value of the config option are received simultaneously),
+      // but we set it to true as well for consistency.
+      hideHamburgerMenu: true,
       hideTopBar: true,
       hideSidebarNav: true,
       latestRunTime: performance.now(),
@@ -688,6 +690,7 @@ export class App extends PureComponent<Props, State> {
     this.setState(
       {
         allowRunOnSave: config.allowRunOnSave,
+        hideHamburgerMenu: config.hideHamburgerMenu,
         hideTopBar: config.hideTopBar,
         hideSidebarNav: config.hideSidebarNav,
         appPages: newSessionProto.appPages,
@@ -1280,6 +1283,7 @@ export class App extends PureComponent<Props, State> {
       scriptRunState,
       userSettings,
       gitInfo,
+      hideHamburgerMenu,
       hideTopBar,
       hideSidebarNav,
       currentPageScriptHash,
@@ -1353,31 +1357,34 @@ export class App extends PureComponent<Props, State> {
                   />
                 </>
               )}
-              <MainMenu
-                isServerConnected={this.isServerConnected()}
-                quickRerunCallback={this.rerunScript}
-                clearCacheCallback={this.openClearCacheDialog}
-                settingsCallback={this.settingsCallback}
-                aboutCallback={this.aboutCallback}
-                screencastCallback={this.screencastCallback}
-                screenCastState={this.props.screenCast.currentState}
-                hostMenuItems={
-                  this.props.hostCommunication.currentState.menuItems
-                }
-                hostIsOwner={this.props.hostCommunication.currentState.isOwner}
-                sendMessageToHost={this.props.hostCommunication.sendMessage}
-                gitInfo={gitInfo}
-                showDeployError={this.showDeployError}
-                closeDialog={this.closeDialog}
-                isDeployErrorModalOpen={
-                  this.state.dialog?.type === DialogType.DEPLOY_ERROR
-                }
-                loadGitInfo={this.sendLoadGitInfoBackMsg}
-                canDeploy={SessionInfo.isSet() && !SessionInfo.isHello}
-                menuItems={menuItems}
-              />
+              {!hideHamburgerMenu && (
+                <MainMenu
+                  isServerConnected={this.isServerConnected()}
+                  quickRerunCallback={this.rerunScript}
+                  clearCacheCallback={this.openClearCacheDialog}
+                  settingsCallback={this.settingsCallback}
+                  aboutCallback={this.aboutCallback}
+                  screencastCallback={this.screencastCallback}
+                  screenCastState={this.props.screenCast.currentState}
+                  hostMenuItems={
+                    this.props.hostCommunication.currentState.menuItems
+                  }
+                  hostIsOwner={
+                    this.props.hostCommunication.currentState.isOwner
+                  }
+                  sendMessageToHost={this.props.hostCommunication.sendMessage}
+                  gitInfo={gitInfo}
+                  showDeployError={this.showDeployError}
+                  closeDialog={this.closeDialog}
+                  isDeployErrorModalOpen={
+                    this.state.dialog?.type === DialogType.DEPLOY_ERROR
+                  }
+                  loadGitInfo={this.sendLoadGitInfoBackMsg}
+                  canDeploy={SessionInfo.isSet() && !SessionInfo.isHello}
+                  menuItems={menuItems}
+                />
+              )}
             </Header>
-
             <AppView
               elements={elements}
               scriptRunId={scriptRunId}

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -744,11 +744,14 @@ def _browser_server_port() -> int:
 
 # Config Section: UI #
 
-# NOTE: We currently hide the ui config section in the `streamlit config show`
-# output as all of its options are hidden. If a non-hidden option is eventually
-# added, the section should be unhidden by removing it from the `SKIP_SECTIONS`
-# set in config_util.show_config.
 _create_section("ui", "Configuration of UI elements displayed in the browser.")
+
+_create_option(
+    "ui.hideHamburgerMenu",
+    description="Flag to hide the hamburger menu found at the top-right of a Streamlit app.",
+    default_val=False,
+    type_=bool,
+)
 
 _create_option(
     "ui.hideTopBar",

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -42,7 +42,7 @@ def show_config(
     config_options: Dict[str, ConfigOption],
 ) -> None:
     """Print the given config sections/options to the terminal."""
-    SKIP_SECTIONS = {"_test", "ui"}
+    SKIP_SECTIONS = {"_test"}
 
     out = []
     out.append(

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -687,8 +687,11 @@ def _populate_config_msg(msg: Config) -> None:
     msg.max_cached_message_age = config.get_option("global.maxCachedMessageAge")
     msg.mapbox_token = config.get_option("mapbox.token")
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
-    msg.hide_top_bar = config.get_option("ui.hideTopBar")
-    msg.hide_sidebar_nav = config.get_option("ui.hideSidebarNav")
+
+    ui_opts = config.get_options_for_section("ui")
+    msg.hide_top_bar = ui_opts["hideTopBar"]
+    msg.hide_sidebar_nav = ui_opts["hideSidebarNav"]
+    msg.hide_hamburger_menu = ui_opts["hideHamburgerMenu"]
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -355,6 +355,7 @@ class ConfigTest(unittest.TestCase):
                 "server.runOnSave",
                 "server.maxUploadSize",
                 "server.maxMessageSize",
+                "ui.hideHamburgerMenu",
                 "ui.hideTopBar",
                 "ui.hideSidebarNav",
             ]

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -87,7 +87,7 @@ class ConfigUtilTest(unittest.TestCase):
         assert "port = 8501" in lines
 
     @patch("streamlit.config_util.click.echo")
-    def test_ui_section_hidden(self, patched_echo):
+    def test_ui_section(self, patched_echo):
         config_options = create_config_options({})
 
         config_util.show_config(CONFIG_SECTION_DESCRIPTIONS, config_options)
@@ -97,8 +97,10 @@ class ConfigUtilTest(unittest.TestCase):
         output = re.compile(r"\x1b[^m]*m").sub("", args[0])
         lines = set(output.split("\n"))
 
-        assert "[ui]" not in lines
+        assert "[ui]" in lines
+        assert "# hideHamburgerMenu = false" in lines
         assert "# hideTopBar = false" not in lines
+        assert "# hideSidebarNav = false" not in lines
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -389,10 +389,12 @@ def _mock_get_options_for_section(overrides=None) -> Callable[..., Any]:
     for k, v in overrides.items():
         theme_opts[k] = v
 
+    original_get_options_for_section = config.get_options_for_section
+
     def get_options_for_section(section):
         if section == "theme":
             return theme_opts
-        return config.get_options_for_section(section)
+        return original_get_options_for_section(section)
 
     return get_options_for_section
 
@@ -522,10 +524,6 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
                     sender=MagicMock(), event=ScriptRunnerEvent.SCRIPT_STARTED
                 )
 
-    @patch(
-        "streamlit.runtime.app_session.config.get_options_for_section",
-        MagicMock(side_effect=_mock_get_options_for_section()),
-    )
     @patch(
         "streamlit.runtime.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -98,6 +98,9 @@ message Config {
   // See config option "ui.hideSidebarNav".
   bool hide_sidebar_nav = 7;
 
+  // See config option "ui.hideHamburgerMenu".
+  bool hide_hamburger_menu = 8;
+
   reserved 1;
 }
 


### PR DESCRIPTION
NOTE: This shouldn't be merged until product has a chance to play around with it.

## 📚 Context

This PR adds a new config option `ui.hideHamburgerMenu` that, as its name suggests, removes the
hamburger menu at the top right of the screen.

Note that a mini product spec was technically supposed to have been written before actually working
on the code for this, but given that we already have a `ui` config option section used for toggling these
kinds of UI elements and the change itself is pretty trivial, I figured it wouldn't be too terrible of a crime
to skip some process since existing ways of toggling UI elements constrain the number of reasonable
ways we can implement this 🙂 

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Partially resolves #5141 
Closes #395
