### PR TITLE
Fix unevaluated dataframe exception formatting

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -368,16 +368,14 @@ def create_cache_wrapper(cached_func: CachedFunction) -> Callable[..., Any]:
                     ):
 
                         class UnevaluatedDataFrameError(StreamlitAPIException):
-                            def __init__(self):
-                                super().__init__(
-                                    self,
-                                    f"""
-                                    The function {get_cached_func_name_md(func)} is decorated with `st.experimental_memo` but it returns an unevaluated 
-                                    dataframe of type `snowflake.snowpark.DataFrame`. Please call `collect()` or `to_pandas()` on the 
-                                    dataframe before returning it, so `st.experimental_memo` can serialize and cache it.""",
-                                )
+                            pass
 
-                        raise UnevaluatedDataFrameError
+                        raise UnevaluatedDataFrameError(
+                            f"""
+                            The function {get_cached_func_name_md(func)} is decorated with `st.experimental_memo` but it returns an unevaluated dataframe 
+                            of type `snowflake.snowpark.DataFrame`. Please call `collect()` or `to_pandas()` on the dataframe before returning it, 
+                            so `st.experimental_memo` can serialize and cache it."""
+                        )
                     raise UnserializableReturnValueError(
                         return_value=return_value, func=cached_func.func
                     )


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

Currently `\n` are displayed when Streamlit throws `UnevaluatedDataFrameError` this PR fixes formatting for this exception, so `\n` are not visible and work properly.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Before:**
![image](https://user-images.githubusercontent.com/78742618/200301034-e9f711d8-083c-4074-9e91-fdfbad290d2c.png)


**Current:**

_Insert screenshot of existing UI/code here_

**This PR introduces:**
![image](https://user-images.githubusercontent.com/78742618/200301197-eecfd140-c817-4385-a859-d5e1aee6c440.png)


## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
