### PR TITLE
Fix bash warnings in CI

### DIFF
--- a/.github/actions/branch/action.yml
+++ b/.github/actions/branch/action.yml
@@ -17,4 +17,4 @@ runs:
       env:
         BRANCH_NAME: ${{ inputs.branch }}
       run: echo "BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}

--- a/.github/actions/branch/action.yml
+++ b/.github/actions/branch/action.yml
@@ -17,4 +17,4 @@ runs:
       env:
         BRANCH_NAME: ${{ inputs.branch }}
       run: echo "BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         pip install pre-commit
         pre-commit install-hooks
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
@@ -27,7 +27,7 @@ runs:
         cache-dependency-path: '**/yarn.lock'
     - name: Initialize React
       run: make react-init
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}
     - name: Install Dependencies
       run: |
         echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/protobuf.list
@@ -39,7 +39,7 @@ runs:
             graphviz \
             libgvc6 \
             protobuf-compiler
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}
     # Combine hashes of the Python interpreter, Pipfile, and today's
     # date into a file whose hash will key the Python virtualenv.
     #
@@ -59,7 +59,7 @@ runs:
         md5sum lib/test-requirements-with-tensorflow.txt >> $GITHUB_WORKSPACE/python_cache_key.md5
         md5sum lib/setup.py >> $GITHUB_WORKSPACE/python_cache_key.md5
         date +%F >> $GITHUB_WORKSPACE/python_cache_key.md5
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}
     - if: inputs.use_cached_venv == 'true'
       name: Restore virtualenv from cache
       id: cache-virtualenv
@@ -76,10 +76,10 @@ runs:
         make setup
         make pipenv-install
         deactivate
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}
     - name: Activate virtualenv
       run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}
     - name: Generate Protobufs
       run: make protobuf
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}

--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         pip install pre-commit
         pre-commit install-hooks
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
@@ -27,7 +27,7 @@ runs:
         cache-dependency-path: '**/yarn.lock'
     - name: Initialize React
       run: make react-init
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}
     - name: Install Dependencies
       run: |
         echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/protobuf.list
@@ -39,7 +39,7 @@ runs:
             graphviz \
             libgvc6 \
             protobuf-compiler
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}
     # Combine hashes of the Python interpreter, Pipfile, and today's
     # date into a file whose hash will key the Python virtualenv.
     #
@@ -59,7 +59,7 @@ runs:
         md5sum lib/test-requirements-with-tensorflow.txt >> $GITHUB_WORKSPACE/python_cache_key.md5
         md5sum lib/setup.py >> $GITHUB_WORKSPACE/python_cache_key.md5
         date +%F >> $GITHUB_WORKSPACE/python_cache_key.md5
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}
     - if: inputs.use_cached_venv == 'true'
       name: Restore virtualenv from cache
       id: cache-virtualenv
@@ -76,10 +76,10 @@ runs:
         make setup
         make pipenv-install
         deactivate
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}
     - name: Activate virtualenv
       run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}
     - name: Generate Protobufs
       run: make protobuf
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}

--- a/.github/actions/preview_branch/action.yml
+++ b/.github/actions/preview_branch/action.yml
@@ -38,4 +38,4 @@ runs:
           fi
         )" >> $GITHUB_ENV
         echo "BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}

--- a/.github/actions/preview_branch/action.yml
+++ b/.github/actions/preview_branch/action.yml
@@ -38,4 +38,4 @@ runs:
           fi
         )" >> $GITHUB_ENV
         echo "BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}

--- a/.github/actions/tag_and_repo/action.yml
+++ b/.github/actions/tag_and_repo/action.yml
@@ -1,8 +1,8 @@
 name: "Set GIT_TAG & GH_REPO env variables"
 
-# Using an action to process user input (branch name) as an argument 
-# is the recommended approach for mitigating script injection attacks. 
-# It is not vulnerable to injection attacks, as the context value is not used 
+# Using an action to process user input (branch name) as an argument
+# is the recommended approach for mitigating script injection attacks.
+# It is not vulnerable to injection attacks, as the context value is not used
 # to generate a shell script, but is instead passed to the action as an argument
 # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks
 
@@ -22,4 +22,4 @@ runs:
       run: |
         echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
         echo "GH_REPO=$GH_REPO" >> $GITHUB_ENV
-      shell: bash -ileo pipefail {0}
+      shell: bash -eo pipefail {0}

--- a/.github/actions/tag_and_repo/action.yml
+++ b/.github/actions/tag_and_repo/action.yml
@@ -22,4 +22,4 @@ runs:
       run: |
         echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
         echo "GH_REPO=$GH_REPO" >> $GITHUB_ENV
-      shell: bash -eo pipefail {0}
+      shell: bash --login -eo pipefail {0}

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
 
 # Avoid duplicate workflows on same branch
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -19,12 +19,12 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           persist-credentials: false
           submodules: 'recursive'
       - name: Set up Python 3.10

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -19,7 +19,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -19,7 +19,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -19,7 +19,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 # Avoid duplicate workflows on same branch
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-cypress
   cancel-in-progress: true
 
@@ -25,17 +25,17 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     strategy:
       fail-fast: false
       matrix:
         specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
-    
+
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: 'recursive'
@@ -58,7 +58,7 @@ jobs:
           echo '[mapbox]' >  ~/.streamlit/config.toml
           MAPBOX_TOKEN=$(curl -sS https://data.streamlit.io/tokens.json | jq -r '.["mapbox-localhost"]') \
             && echo 'token = "'$MAPBOX_TOKEN'"' >> ~/.streamlit/config.toml
-          
+
           echo '[general]' >  ~/.streamlit/credentials.toml
           echo 'email = "test@streamlit.io"' >> ~/.streamlit/credentials.toml
       - name: Cypress Tests
@@ -103,7 +103,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Check Cypress test matrix status

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     strategy:
       fail-fast: false
@@ -103,7 +103,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Check Cypress test matrix status

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash --login -eo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 # Avoid duplicate workflows on same branch
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-javascript
   cancel-in-progress: true
 
@@ -25,12 +25,12 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: 'recursive'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     permissions:
       # Additional permission needed to generate tag
@@ -118,7 +118,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     permissions:
       # Additional permission needed to generate tag
@@ -55,7 +55,7 @@ jobs:
           git push origin $TAG
       - if: ${{ failure() }}
         name: Nightly Tag Failure Slack Message
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py nightly tag
 
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ needs.create-nightly-tag.outputs.tag }}
           persist-credentials: false
           submodules: 'recursive'
@@ -109,21 +109,21 @@ jobs:
         run: python scripts/slack_notifications.py nightly py_prod
       - if: ${{ needs.run-cypress-tests.result == 'failure' }}
         run: python scripts/slack_notifications.py nightly cypress
-  
+
   create-nightly-build:
     runs-on: ubuntu-latest
 
-    # Tag creation & tests must all complete successfully for nightly build job to run. 
+    # Tag creation & tests must all complete successfully for nightly build job to run.
     needs: [create-nightly-tag, run-python-tests, run-javascript-tests, run-py-prod-deps-smoke-test, run-cypress-tests]
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ needs.create-nightly-tag.outputs.tag }}
           persist-credentials: false
           submodules: 'recursive'
@@ -154,6 +154,6 @@ jobs:
           make distribute
       - if: ${{ failure() }}
         name: Nightly Build Failure Slack Message
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py nightly build

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -19,7 +19,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     outputs:
       enable-setup: ${{ steps.exports.outputs.enable-setup }}
@@ -95,7 +95,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Core Previews Repo

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
 
 # Avoid duplicate workflows on same branch
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -19,7 +19,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     outputs:
       enable-setup: ${{ steps.exports.outputs.enable-setup }}
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           persist-credentials: false
           submodules: 'recursive'
       - name: Set up Python 3.10
@@ -95,14 +95,14 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
-    
+        shell: bash -eo pipefail {0}
+
     steps:
       - name: Checkout Core Previews Repo
         uses: actions/checkout@v3
-        with: 
+        with:
           repository: streamlit/core-previews
-          # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo. 
+          # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
           # Accessing streamlit/core-previews repo requires a separate auth token.
           token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
       - name: Setup preview repo

--- a/.github/workflows/py-prod-deps-smoke-test.yml
+++ b/.github/workflows/py-prod-deps-smoke-test.yml
@@ -25,7 +25,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/py-prod-deps-smoke-test.yml
+++ b/.github/workflows/py-prod-deps-smoke-test.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 # Avoid duplicate workflows on same branch
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-py_prod
   cancel-in-progress: true
 
@@ -25,12 +25,12 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: 'recursive'

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -25,7 +25,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -25,7 +25,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/cypress.yml
     with:
       ref: ${{ github.ref_name }}
-      
+
   build-release-candidate:
     runs-on: ubuntu-latest
 
@@ -32,12 +32,12 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ github.ref_name }}
           persist-credentials: false
           submodules: 'recursive'
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "DESIRED_VERSION=$(echo "${BRANCH}" | sed 's/release\///')" >> $GITHUB_ENV
       - name: Set final versions for pre-release and update version
-        env: 
+        env:
           DESIRED_VERSION: ${{ env.DESIRED_VERSION }}
         run: |
           LATEST_MATCHING_RC=$(python scripts/get_latest_release_candidate.py)
@@ -87,11 +87,11 @@ jobs:
           make distribute
       - name: Successful Release Candidate Slack Message
         if: ${{ success() }}
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py candidate success
       - name: Failed Release Candidate Slack Message
         if: ${{ failure() }}
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py candidate failure

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -32,7 +32,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Build Release
 
-on: 
+on:
   # Manual Trigger GH CLI -> gh workflow run release.yml --ref <tag>
   workflow_dispatch:
 
@@ -10,9 +10,9 @@ jobs:
 
     defaults:
       run:
-        shell: bash -ileo pipefail {0}
+        shell: bash -eo pipefail {0}
 
-    permissions: 
+    permissions:
     # Additional permission needed to generate release
       contents: write
 
@@ -41,7 +41,7 @@ jobs:
           pip install requests
           echo "GH_PR_BRANCH=$(python scripts/get_release_branch.py)" >> $GITHUB_ENV
       - name: Ensure that version tag matches branch version
-        env: 
+        env:
           GH_PR_BRANCH: ${{ env.GH_PR_BRANCH }}
         run: |
           BRANCH_VERSION=$(echo "$GH_PR_BRANCH" | sed 's/release\///' )
@@ -102,11 +102,11 @@ jobs:
           python scripts/create_release.py
       - name: Successful Release Slack Message
         if: ${{ success() }}
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py release success
       - name: Failed Release Slack Message
         if: ${{ failure() }}
-        env: 
+        env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: python scripts/slack_notifications.py release failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -eo pipefail {0}
+        shell: bash --login -eo pipefail {0}
 
     permissions:
     # Additional permission needed to generate release


### PR DESCRIPTION
Remove the `-i` ("interactive") option from our bash invocations in CI jobs. 

This fixes the "bash: cannot set terminal process group: Inappropriate ioctl for device" warning printed in all of our workflow jobs.

(The PR also trims whitespace at the end of lines in our CI yaml files.)