### PR TITLE
Docs: Add docs for label markdown feature

### DIFF
--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -77,6 +77,8 @@ class ButtonMixin:
         ----------
         label : str
             A short label explaining to the user what this button is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, and Emojis.
         key : str or int
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
@@ -168,6 +170,8 @@ class ButtonMixin:
         ----------
         label : str
             A short label explaining to the user what this button is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, and Emojis.
         data : str or bytes or file
             The contents of the file to be downloaded. See example below for
             caching techniques to avoid recomputing this data unnecessarily.

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -125,6 +125,9 @@ class CameraInputMixin:
         ----------
         label : str
             A short label explaining to the user what this widget is used for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -153,7 +156,7 @@ class CameraInputMixin:
             True. The default is False. This argument can only be supplied by
             keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -64,6 +64,8 @@ class CheckboxMixin:
         ----------
         label : str
             A short label explaining to the user what this checkbox is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
         value : bool
             Preselect the checkbox when it first renders. This will be
             cast to bool internally.
@@ -91,6 +93,7 @@ class CheckboxMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> agree = st.checkbox('I agree')
         >>>
         >>> if agree:

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -69,6 +69,9 @@ class ColorPickerMixin:
         ----------
         label : str
             A short label explaining to the user what this input is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -227,6 +227,9 @@ class FileUploaderMixin:
         ----------
         label : str
             A short label explaining to the user what this file uploader is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -264,7 +267,7 @@ class FileUploaderMixin:
             True. The default is False. This argument can only be supplied by
             keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -215,8 +215,11 @@ class LayoutsMixin:
         Parameters
         ----------
         tabs : list of strings
-            Creates a tab for each string in the list. The string is used as the name of the tab.
-            The first tab is selected by default.
+            Creates a tab for each string in the list. The first tab is selected by default.
+            The string is used as the name of the tab and can optionally contain Markdown,
+            supporting the following elements: Bold, Italics, Strikethroughs, Inline Code,
+            Emojis, and Links.
+
 
         Returns
         -------
@@ -302,7 +305,9 @@ class LayoutsMixin:
         Parameters
         ----------
         label : str
-            A string to use as the header for the expander.
+            A string to use as the header for the expander. The label can optionally
+            contain Markdown and supports the following elements: Bold, Italics,
+            Strikethroughs, Inline Code, Emojis, and Links.
         expanded : bool
             If True, initializes the expander in "expanded" state. Defaults to
             False (collapsed).

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -60,7 +60,9 @@ class MetricMixin:
         Parameters
         ----------
         label : str
-            The header or Title for the metric
+            The header or title for the metric. The label can optionally contain
+            Markdown and supports the following elements: Bold, Italics,
+            Strikethroughs, Inline Code, Emojis, and Links.
         value : int, float, str, or None
              Value of the metric. None is rendered as a long dash.
         delta : int, float, str, or None

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -166,6 +166,9 @@ class MultiSelectMixin:
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -197,7 +200,7 @@ class MultiSelectMixin:
             to True. The default is False. This argument can only be supplied
             by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -87,6 +87,9 @@ class NumberInputMixin:
         ----------
         label : str
             A short label explaining to the user what this input is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -125,7 +128,7 @@ class NumberInputMixin:
             True. The default is False. This argument can only be supplied by
             keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -95,6 +95,9 @@ class RadioMixin:
         ----------
         label : str
             A short label explaining to the user what this radio group is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -131,7 +134,7 @@ class RadioMixin:
             be supplied by keyword.
 
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -134,6 +134,9 @@ class SelectSliderMixin:
         ----------
         label : str
             A short label explaining to the user what this slider is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -168,7 +171,7 @@ class SelectSliderMixin:
             An optional boolean, which disables the select slider if set to True.
             The default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -90,6 +90,9 @@ class SelectboxMixin:
         ----------
         label : str
             A short label explaining to the user what this select widget is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -118,7 +121,7 @@ class SelectboxMixin:
             An optional boolean, which disables the selectbox if set to True.
             The default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -207,6 +207,9 @@ class SliderMixin:
         ----------
         label : str
             A short label explaining to the user what this slider is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -252,7 +255,7 @@ class SliderMixin:
             An optional boolean, which disables the slider if set to True. The
             default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -90,6 +90,9 @@ class TextWidgetsMixin:
         ----------
         label : str
             A short label explaining to the user what this input is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -127,7 +130,7 @@ class TextWidgetsMixin:
             An optional boolean, which disables the text input if set to True.
             The default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.
@@ -269,6 +272,9 @@ class TextWidgetsMixin:
         ----------
         label : str
             A short label explaining to the user what this input is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -300,7 +306,7 @@ class TextWidgetsMixin:
             An optional boolean, which disables the text area if set to True.
             The default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -229,6 +229,9 @@ class TimeWidgetsMixin:
         ----------
         label : str
             A short label explaining to the user what this time input is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -252,7 +255,7 @@ class TimeWidgetsMixin:
             An optional boolean, which disables the time input if set to True.
             The default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.
@@ -375,6 +378,9 @@ class TimeWidgetsMixin:
         ----------
         label : str
             A short label explaining to the user what this date input is for.
+            The label can optionally contain Markdown and supports the following
+            elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.
+
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
@@ -405,7 +411,7 @@ class TimeWidgetsMixin:
             An optional boolean, which disables the date input if set to True.
             The default is False. This argument can only be supplied by keyword.
         label_visibility : "visible" or "hidden" or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
             "visible". This argument can only be supplied by keyword.


### PR DESCRIPTION
## 📚 Context

#5651 added support for the use of limited markdown in labels for button/download button, widgets, expander, and tabs. The docstrings for the affected elements needs to be updated to reflect limited markdown support in the label parameter.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Updates the `label` parameter docstring of button/download button to include:
> The label can optionally contain Markdown and supports the following elements: Bold, Italics, Strikethroughs, and Emojis.

- Updates the `label` parameter docstring of widgets, expander, and tabs to include:
> The label can optionally contain Markdown and supports the following elements: Bold, Italics, Strikethroughs, Inline Code, Emojis, and Links.

  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/200799883-7d94c022-ea17-4278-bdd3-3aaa51c2bc33.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/200799967-1ab50241-ada9-4d82-9fa5-2c756836e130.png)

## 🧪 Testing Done

- [x] Screenshots included