### PR TITLE
Docs: Add docstrings for `experimental_allow_widgets`

### DIFF
--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -265,7 +265,7 @@ class MemoAPI:
             a cache miss.
 
         suppress_st_warning : boolean
-            Suppress warnings about calling Streamlit functions from within
+            Suppress warnings about calling Streamlit commands from within
             the cached function.
 
         max_entries : int or None
@@ -278,6 +278,16 @@ class MemoAPI:
             None if cache entries should not expire. The default is None.
             Note that ttl is incompatible with `persist="disk"` - `ttl` will be
             ignored if `persist` is specified.
+
+        experimental_allow_widgets : boolean
+            Allow widgets to be used in the memoized function. Defaults to False.
+
+        .. note::
+            Support for widgets in cached functions is currently experimental.
+            To enable it, set the parameter ``experimental_allow_widgets=True``
+            in ``@st.experimental_memo``. Note that this may lead to excessive memory
+            use since the widget value is treated as an additional input parameter
+            to the cache. We may remove support for this option at any time without notice.
 
         Example
         -------

--- a/lib/streamlit/runtime/caching/singleton_decorator.py
+++ b/lib/streamlit/runtime/caching/singleton_decorator.py
@@ -191,8 +191,19 @@ class SingletonAPI:
             value of show_spinner param will be used for spinner text.
 
         suppress_st_warning : boolean
-            Suppress warnings about calling Streamlit functions from within
+            Suppress warnings about calling Streamlit commands from within
             the singleton function.
+
+        experimental_allow_widgets : boolean
+            Allow widgets to be used in the singleton function. Defaults to False.
+
+        .. note::
+            Support for widgets in cached functions is currently experimental.
+            To enable it, set the parameter ``experimental_allow_widgets=True``
+            in ``@st.experimental_singleton``. Note that this may lead to excessive
+            memory use since the widget value is treated as an additional input
+            parameter to the cache. We may remove support for this option at any
+            time without notice.
 
         Example
         -------

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -429,7 +429,7 @@ def cache(
         a cache miss.
 
     suppress_st_warning : boolean
-        Suppress warnings about calling Streamlit functions from within
+        Suppress warnings about calling Streamlit commands from within
         the cached function.
 
     hash_funcs : dict or None


### PR DESCRIPTION
## 📚 Context

#5298 added a new boolean `experimental_allow_widgets` parameter to the experimental cache primitives. This parameter is undocumented.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Adds documentation for `experimental_allow_widgets` in the experimental cache primitives docstrings.

  - [x] This is a visible (user-facing) change