### PR TITLE
Docs: Update docstring for `sample_rate` st.audio parameter

### DIFF
--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -56,9 +56,9 @@ class MediaMixin:
                 io.open().
             Raw audio data, filename, or a URL pointing to the file to load.
             Raw data formats must include all necessary file headers to match the file
-            format specified via `format`.
-            If `data` is a numpy array, it must either be a 1D array of the waveform
-            or a 2D array of shape `(num_channels, num_samples)` with waveforms
+            format specified via ``format``.
+            If ``data`` is a numpy array, it must either be a 1D array of the waveform
+            or a 2D array of shape ``(num_channels, num_samples)`` with waveforms
             for all channels. See the default channel order at
             http://msdn.microsoft.com/en-us/library/windows/hardware/dn653308(v=vs.85).aspx
         format : str
@@ -68,18 +68,30 @@ class MediaMixin:
             The time from which this element should start playing.
         sample_rate: int or None
             The sample rate of the audio data in samples per second. Only required if
-            `data` is a numpy array.
+            ``data`` is a numpy array.
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import numpy as np
         >>> audio_file = open('myaudio.ogg', 'rb')
         >>> audio_bytes = audio_file.read()
         >>>
         >>> st.audio(audio_bytes, format='audio/ogg')
+        >>>
+        >>> sample_rate = 44100  # 44100 samples per second
+        >>> seconds = 2  # Note duration of 2 seconds
+        >>> frequency_la = 440  # Our played note will be 440 Hz
+        >>> # Generate array with seconds*sample_rate steps, ranging between 0 and seconds
+        >>> t = np.linspace(0, seconds, seconds * sample_rate, False)
+        >>> # Generate a 440 Hz sine wave
+        >>> note_la = np.sin(frequency_la * t * 2 * np.pi)
+        >>>
+        >>> st.audio(note_la, sample_rate=sample_rate)
 
         .. output::
            https://doc-audio.streamlitapp.com/
-           height: 465px
+           height: 865px
 
         """
         audio_proto = AudioProto()


### PR DESCRIPTION
## 📚 Context

#5554 added an optional keyword-only `sample_rate` parameter to st.audio, that should be used only in case when data is NumPy array. The docstring could be improved with a simple example demonstrating the usage of `sample_rate`.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Adds a simple example demonstrating the usage of `sample_rate` in the `st.audio` docstring
- Fixes reStructuredText inline code bugs in the docstring
- Updated the associated [embedded app](https://doc-audio.streamlit.app/) to include the new example in the docs repo via https://github.com/streamlit/docs/pull/522

  - [x] This is a visible (user-facing) change