### PR TITLE
Image replay in cached functions

### DIFF
--- a/e2e/scripts/st_image_replay.py
+++ b/e2e/scripts/st_image_replay.py
@@ -1,0 +1,89 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+import streamlit as st
+
+
+def create_gif(size, frames=1):
+    # Create grayscale image.
+    im = Image.new("L", (size, size), "white")
+
+    images = []
+
+    # Make circle of a constant size with a number of frames, moving across the
+    # principal diagonal of a 64x64 image. The GIF will not loop and stops
+    # animating after frames x 100ms.
+    for i in range(0, frames):
+        frame = im.copy()
+        draw = ImageDraw.Draw(frame)
+        pos = (i, i)
+        circle_size = size / 2
+        draw.ellipse([pos, tuple(p + circle_size for p in pos)], "black")
+        images.append(frame.copy())
+
+    # Save the frames as an animated GIF
+    data = io.BytesIO()
+    images[0].save(
+        data,
+        format="GIF",
+        save_all=True,
+        append_images=images[1:],
+        duration=1,
+    )
+
+    return data.getvalue()
+
+
+img = np.repeat(0, 10000).reshape(100, 100)
+gif = create_gif(64, frames=32)
+
+
+# @st.experimental_memo
+def numpy_image():
+    st.image(img, caption="Black Square with no output format specified", width=100)
+
+
+numpy_image()
+numpy_image()
+
+
+# @st.experimental_memo
+def svg_image():
+    st.image(
+        """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+        <clipPath id="clipCircle">
+            <circle r="25" cx="25" cy="25"/>
+        </clipPath>
+        <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
+    </svg>
+    """
+    )
+
+
+svg_image()
+svg_image()
+
+
+# @st.experimental_memo
+def gif_image():
+    st.image(gif, width=100)
+
+
+gif_image()
+gif_image()

--- a/e2e/scripts/st_image_replay.py
+++ b/e2e/scripts/st_image_replay.py
@@ -87,3 +87,12 @@ def gif_image():
 
 gif_image()
 gif_image()
+
+
+@st.experimental_memo
+def url_image():
+    st.image("https://avatars.githubusercontent.com/anoctopus", width=200)
+
+
+url_image()
+url_image()

--- a/e2e/scripts/st_image_replay.py
+++ b/e2e/scripts/st_image_replay.py
@@ -54,7 +54,7 @@ img = np.repeat(0, 10000).reshape(100, 100)
 gif = create_gif(64, frames=32)
 
 
-# @st.experimental_memo
+@st.experimental_memo
 def numpy_image():
     st.image(img, caption="Black Square with no output format specified", width=100)
 
@@ -63,7 +63,7 @@ numpy_image()
 numpy_image()
 
 
-# @st.experimental_memo
+@st.experimental_memo
 def svg_image():
     st.image(
         """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
@@ -80,7 +80,7 @@ svg_image()
 svg_image()
 
 
-# @st.experimental_memo
+@st.experimental_memo
 def gif_image():
     st.image(gif, width=100)
 

--- a/e2e/scripts/st_image_replay_old_image.py
+++ b/e2e/scripts/st_image_replay_old_image.py
@@ -1,0 +1,28 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import streamlit as st
+
+img = np.repeat(0, 10000).reshape(100, 100)
+
+
+@st.experimental_memo
+def image():
+    st.image(img)
+
+
+if st.checkbox("show image", True):
+    image()

--- a/e2e/specs/st_image_replay.spec.js
+++ b/e2e/specs/st_image_replay.spec.js
@@ -50,12 +50,12 @@ describe("st.image replay", () => {
 
 
   it("displays a GIF image twice", () => {
-    cy.getIndexed(".element-container [data-testid='stImage'] img", 4)
+    cy.getIndexed(".element-container [data-testid='stImage'] img", 2)
       .should("have.css", "height", "100px")
       .should("have.css", "width", "100px")
       .should("have.attr", "src")
       .should("match", /^.*\.gif$/);
-    cy.getIndexed(".element-container [data-testid='stImage'] img", 5)
+    cy.getIndexed(".element-container [data-testid='stImage'] img", 3)
       .should("have.css", "height", "100px")
       .should("have.css", "width", "100px")
       .should("have.attr", "src")

--- a/e2e/specs/st_image_replay.spec.js
+++ b/e2e/specs/st_image_replay.spec.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("st.image replay", () => {
+  before(() => {
+    cy.loadApp("http://localhost:3000/");
+
+  });
+
+  it("displays an image", () => {
+    cy.get(".element-container [data-testid='stImage'] img")
+      .should("have.css", "height", "100px")
+      .should("have.css", "width", "100px");
+  });
+
+  it("displays a caption for both calls", () => {
+    cy.getIndexed(
+      ".element-container [data-testid='stImage'] [data-testid='caption']", 0
+    )
+      .should("contain", "Black Square")
+      .should("have.css", "width", "100px");
+    cy.getIndexed(
+      ".element-container [data-testid='stImage'] [data-testid='caption']", 1
+    )
+      .should("contain", "Black Square")
+      .should("have.css", "width", "100px");
+  });
+
+
+  it("displays SVG images that load external images", () => {
+    cy.getIndexed("[data-testid='stImage'] svg", 0)
+      .matchImageSnapshot("karriebear-avatar");
+
+    cy.getIndexed("[data-testid='stImage'] svg", 1)
+      .matchImageSnapshot("karriebear-avatar");
+  });
+
+
+  it("displays a GIF image twice", () => {
+    cy.getIndexed(".element-container [data-testid='stImage'] img", 4)
+      .should("have.css", "height", "100px")
+      .should("have.css", "width", "100px")
+      .should("have.attr", "src")
+      .should("match", /^.*\.gif$/);
+    cy.getIndexed(".element-container [data-testid='stImage'] img", 5)
+      .should("have.css", "height", "100px")
+      .should("have.css", "width", "100px")
+      .should("have.attr", "src")
+      .should("match", /^.*\.gif$/);
+  });
+
+});

--- a/e2e/specs/st_image_replay.spec.js
+++ b/e2e/specs/st_image_replay.spec.js
@@ -62,4 +62,12 @@ describe("st.image replay", () => {
       .should("match", /^.*\.gif$/);
   });
 
+  it("displays from URL twice", () => {
+    cy.getIndexed(".element-container [data-testid='stImage'] img", 4)
+      .should("have.css", "width", "200px")
+    cy.getIndexed(".element-container [data-testid='stImage'] img", 5)
+      .should("have.css", "width", "200px")
+
+  })
+
 });

--- a/e2e/specs/st_image_replay.spec.js
+++ b/e2e/specs/st_image_replay.spec.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// This tests that images replay as expected. We assume that caching working
+// overall is covered by other tests.
+
 describe("st.image replay", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");

--- a/e2e/specs/st_image_replay_old_image.spec.js
+++ b/e2e/specs/st_image_replay_old_image.spec.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("st.image replay", () => {
+  before(() => {
+    cy.loadApp("http://localhost:3000/");
+
+  });
+
+  it("shows a cached image that was not rendered in previous script run", () => {
+    // Displays the image initially
+    cy.get(".element-container [data-testid='stImage'] img")
+      .should("have.css", "height", "100px")
+      .should("have.css", "width", "100px");
+
+    // Uncheck checkbox to hide image
+    cy.get(".stCheckbox")
+      .first()
+      .click({ multiple: true });
+    cy.get(".element-container [data-testid='stImage'] img")
+      .should("not.exist");
+
+    // Cached image renders again
+    cy.get(".stCheckbox")
+      .first()
+      .click({ multiple: true });
+    cy.get(".element-container [data-testid='stImage'] img")
+      .should("have.css", "height", "100px")
+      .should("have.css", "width", "100px");
+  })
+})

--- a/lib/streamlit/elements/__init__.py
+++ b/lib/streamlit/elements/__init__.py
@@ -53,6 +53,7 @@ NONWIDGET_ELEMENTS = [
     "graphviz_chart",
     "heading",
     "iframe",
+    "imgs",
     "json",
     "legacy_altair",
     "legacy_data_frame",
@@ -71,6 +72,6 @@ NONWIDGET_ELEMENTS = [
 ]
 FILESYSTEM_ELEMENTS = [
     "audio",
-    "imgs",
+    # "imgs",
     "video",
 ]

--- a/lib/streamlit/elements/__init__.py
+++ b/lib/streamlit/elements/__init__.py
@@ -72,6 +72,5 @@ NONWIDGET_ELEMENTS = [
 ]
 FILESYSTEM_ELEMENTS = [
     "audio",
-    # "imgs",
     "video",
 ]

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -344,6 +344,7 @@ def image_to_url(
             mimetype, _ = mimetypes.guess_type(image)
             if mimetype is None:
                 mimetype = "application/octet-stream"
+            caching.save_image_data(image, mimetype, image_id)
             return runtime.get_instance().media_file_mgr.add(image, mimetype, image_id)
 
     # PIL Images

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -34,6 +34,7 @@ from streamlit import runtime
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
+from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
@@ -391,6 +392,7 @@ def image_to_url(
     mimetype = _get_image_format_mimetype(image_format)
 
     if runtime.exists():
+        caching.save_image_data(image_data, mimetype, image_id)
         return runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
@@ -505,6 +507,8 @@ def marshall_images(
                 else:
                     proto_img.url = f"data:image/svg+xml,{image}"
                 is_svg = True
+
+        # TODO save image data when the image is an svg
         if not is_svg:
             proto_img.url = image_to_url(
                 image, width, clamp, channels, output_format, image_id

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -344,8 +344,10 @@ def image_to_url(
             mimetype, _ = mimetypes.guess_type(image)
             if mimetype is None:
                 mimetype = "application/octet-stream"
+
+            url = runtime.get_instance().media_file_mgr.add(image, mimetype, image_id)
             caching.save_image_data(image, mimetype, image_id)
-            return runtime.get_instance().media_file_mgr.add(image, mimetype, image_id)
+            return url
 
     # PIL Images
     elif isinstance(image, (ImageFile.ImageFile, Image.Image)):
@@ -393,8 +395,9 @@ def image_to_url(
     mimetype = _get_image_format_mimetype(image_format)
 
     if runtime.exists():
+        url = runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
         caching.save_image_data(image_data, mimetype, image_id)
-        return runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
+        return url
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
         return ""

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -508,7 +508,6 @@ def marshall_images(
                     proto_img.url = f"data:image/svg+xml,{image}"
                 is_svg = True
 
-        # TODO save image data when the image is an svg
         if not is_svg:
             proto_img.url = image_to_url(
                 image, width, clamp, channels, output_format, image_id

--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import contextlib
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, Union
 
 from google.protobuf.message import Message
 
@@ -80,6 +80,13 @@ def save_widget_metadata(metadata: WidgetMetadata[Any]) -> None:
     """
     MEMO_MESSAGE_CALL_STACK.save_widget_metadata(metadata)
     SINGLETON_MESSAGE_CALL_STACK.save_widget_metadata(metadata)
+
+
+def save_image_data(
+    image_data: Union[bytes, str], mimetype: str, image_id: str
+) -> None:
+    MEMO_MESSAGE_CALL_STACK.save_image_data(image_data, mimetype, image_id)
+    SINGLETON_MESSAGE_CALL_STACK.save_image_data(image_data, mimetype, image_id)
 
 
 def maybe_show_cached_st_function_warning(dg, st_func_name: str) -> None:

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -567,7 +567,7 @@ class CacheMessagesCallStack(threading.local):
         self._seen_dg_stack: List[Set[str]] = []
         self._most_recent_messages: List[MsgData] = []
         self._registered_metadata: Optional[WidgetMetadata[Any]] = None
-        self._image_data: Optional[List[MediaMsgData]] = None
+        self._image_data: List[MediaMsgData] = []
         self._cache_type = cache_type
         self._allow_widgets: int = 0
 
@@ -617,7 +617,7 @@ class CacheMessagesCallStack(threading.local):
                 widget_meta = None
 
             image_data = self._image_data
-            self._image_data = None
+            self._image_data = []
 
             if self._allow_widgets or widget_meta is None:
                 msgs.append(
@@ -667,9 +667,6 @@ class CacheMessagesCallStack(threading.local):
     def save_image_data(
         self, image_data: Union[bytes, str], mimetype: str, image_id: str
     ) -> None:
-        if self._image_data is None:
-            self._image_data = []
-
         self._image_data.append(MediaMsgData(image_data, mimetype, image_id))
 
     @contextlib.contextmanager

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -612,12 +612,10 @@ class CacheMessagesCallStack(threading.local):
                 widget_meta = WidgetMsgMetadata(
                     wid, None, metadata=self._registered_metadata
                 )
-                self._registered_metadata = None
             else:
                 widget_meta = None
 
             image_data = self._image_data
-            self._image_data = []
 
             if self._allow_widgets or widget_meta is None:
                 msgs.append(
@@ -630,6 +628,11 @@ class CacheMessagesCallStack(threading.local):
                         image_data,
                     )
                 )
+
+            # Reset instance state, now that it has been used for the
+            # associated element.
+            self._image_data = []
+            self._registered_metadata = None
         for s in self._seen_dg_stack:
             s.add(returned_dg_id)
 

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -71,6 +71,13 @@ class WidgetMsgMetadata:
 
 
 @dataclass(frozen=True)
+class MediaMsgData:
+    image_data: Union[bytes, str]
+    mimetype: str
+    image_id: str
+
+
+@dataclass(frozen=True)
 class ElementMsgData:
     """An element's message and related metadata for
     replaying that element's function call.
@@ -83,6 +90,7 @@ class ElementMsgData:
     id_of_dg_called_on: str
     returned_dgs_id: str
     widget_metadata: Optional[WidgetMsgMetadata] = None
+    media_data: Optional[List[MediaMsgData]] = None
 
 
 @dataclass(frozen=True)
@@ -291,6 +299,12 @@ def replay_result_messages(
                         None,
                         msg.delta_type,
                     )
+                if msg.media_data is not None:
+                    for data in msg.media_data:
+                        _LOGGER.debug(data)
+                        runtime.get_instance().media_file_mgr.add(
+                            data.image_data, data.mimetype, data.image_id
+                        )
                 dg = returned_dgs[msg.id_of_dg_called_on]
                 maybe_dg = dg._enqueue(msg.delta_type, msg.message)
                 if isinstance(maybe_dg, DeltaGenerator):
@@ -554,6 +568,7 @@ class CacheMessagesCallStack(threading.local):
         self._seen_dg_stack: List[Set[str]] = []
         self._most_recent_messages: List[MsgData] = []
         self._registered_metadata: Optional[WidgetMetadata[Any]] = None
+        self._image_data: Optional[List[MediaMsgData]] = None
         self._cache_type = cache_type
         self._allow_widgets: int = 0
 
@@ -602,6 +617,9 @@ class CacheMessagesCallStack(threading.local):
             else:
                 widget_meta = None
 
+            image_data = self._image_data
+            self._image_data = None
+
             if self._allow_widgets or widget_meta is None:
                 msgs.append(
                     ElementMsgData(
@@ -610,6 +628,7 @@ class CacheMessagesCallStack(threading.local):
                         id_to_save,
                         returned_dg_id,
                         widget_meta,
+                        image_data,
                     )
                 )
         for s in self._seen_dg_stack:
@@ -645,6 +664,14 @@ class CacheMessagesCallStack(threading.local):
 
     def save_widget_metadata(self, metadata: WidgetMetadata[Any]) -> None:
         self._registered_metadata = metadata
+
+    def save_image_data(
+        self, image_data: Union[bytes, str], mimetype: str, image_id: str
+    ) -> None:
+        if self._image_data is None:
+            self._image_data = []
+
+        self._image_data.append(MediaMsgData(image_data, mimetype, image_id))
 
     @contextlib.contextmanager
     def allow_widgets(self) -> Iterator[None]:

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -301,7 +301,6 @@ def replay_result_messages(
                     )
                 if msg.media_data is not None:
                     for data in msg.media_data:
-                        _LOGGER.debug(data)
                         runtime.get_instance().media_file_mgr.add(
                             data.image_data, data.mimetype, data.image_id
                         )

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -260,11 +260,10 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         storage backend that's able to open the file, so it's up to the manager -
         and not image_to_url - to throw an error.)
         """
+        # Mock out save_image_data to avoid polluting the cache for later tests
         with mock.patch(
             "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add, mock.patch(
-            "streamlit.runtime.caching.save_image_data"
-        ) as save_data:
+        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_image_data"):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             result = image.image_to_url(

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -262,7 +262,9 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         """
         with mock.patch(
             "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add:
+        ) as mock_mfm_add, mock.patch(
+            "streamlit.runtime.caching.save_image_data"
+        ) as save_data:
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             result = image.image_to_url(

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -458,7 +458,6 @@ class CommonCacheTest(DeltaGeneratorTestCase):
             cont.text(i)
             return i
 
-        # TODO make exception more specific
         with self.assertRaises(CacheReplayClosureError):
             foo(1)
             st.text("---")
@@ -466,6 +465,11 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
     @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_image_replay(self, _, cache_decorator):
+        """Basic sanity check that nothing blows up. This test assumes that
+        actual caching/replay functionality are covered by e2e tests that
+        can more easily test them.
+        """
+
         @cache_decorator
         def img_fn():
             st.image(create_image(10))

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -303,13 +303,13 @@ class CommonCacheTest(DeltaGeneratorTestCase):
     @parameterized.expand([("memo", memo), ("singleton", singleton)])
     def test_cached_st_function_replay(self, _, cache_decorator):
         @cache_decorator
-        def foo(i):
+        def foo_replay(i):
             st.text(i)
             return i
 
-        foo(1)
+        foo_replay(1)
         st.text("---")
-        foo(1)
+        foo_replay(1)
 
         text = self.get_text_delta_contents()
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -40,6 +40,7 @@ from streamlit.runtime.state import SafeSessionState, SessionState
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.exception_capturing_thread import ExceptionCapturingThread, call_on_threads
+from tests.streamlit.elements.image_test import create_image
 
 memo = st.experimental_memo
 singleton = st.experimental_singleton
@@ -462,6 +463,22 @@ class CommonCacheTest(DeltaGeneratorTestCase):
             foo(1)
             st.text("---")
             foo(1)
+
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
+    def test_cached_st_image_replay(self, _, cache_decorator):
+        @cache_decorator
+        def img_fn():
+            st.image(create_image(10))
+
+        img_fn()
+        img_fn()
+
+        @cache_decorator
+        def img_fn_multi():
+            st.image([create_image(5), create_image(15), create_image(1)])
+
+        img_fn_multi()
+        img_fn_multi()
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## 📚 Context

Replay of media elements, part 1: images

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Store image data in cache
- Use stored image data to add image to MediaFileManager when replaying element

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [x] Added/Updated e2e tests

