### PR TITLE
Use specialized assertion functions

### DIFF
--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -417,9 +417,9 @@ class ConfigTest(unittest.TestCase):
         with self.assertLogs(logger="streamlit.config", level="WARNING") as cm:
             config._set_option("not.defined", "no.value", "test")
         # cm.output is a list of messages and there shouldn't be any other messages besides one created by this test
-        self.assertTrue(
-            '"not.defined" is not a valid config option. If you previously had this config option set, it may have been removed.'
-            in cm.output[0]
+        self.assertIn(
+            '"not.defined" is not a valid config option. If you previously had this config option set, it may have been removed.',
+            cm.output[0],
         )
 
         config._set_option("client.caching", "test", "test")

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -87,7 +87,7 @@ class StMapTest(DeltaGeneratorTestCase):
         with self.assertRaises(Exception) as ctx:
             st.map(df)
 
-        self.assertTrue("Map data must contain a column named" in str(ctx.exception))
+        self.assertIn("Map data must contain a column named", str(ctx.exception))
 
     def test_nan_exception(self):
         """Test st.map with NaN in data."""
@@ -95,7 +95,7 @@ class StMapTest(DeltaGeneratorTestCase):
         with self.assertRaises(Exception) as ctx:
             st.map(df)
 
-        self.assertTrue("data must be numeric." in str(ctx.exception))
+        self.assertIn("data must be numeric.", str(ctx.exception))
 
     def test_unevaluated_snowpark_table(self):
         """Test st.map with unevaluated Snowpark Table"""

--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -35,10 +35,10 @@ class GitUtilTest(unittest.TestCase):
 
     def test_ssh_url_check(self):
         # standard ssh url
-        self.assertTrue("git@github.com:username/repo.git", GITHUB_SSH_URL)
+        self.assertRegex("git@github.com:username/repo.git", GITHUB_SSH_URL)
 
         # no .git
-        self.assertTrue("git@github.com:username/repo", GITHUB_SSH_URL)
+        self.assertRegex("git@github.com:username/repo", GITHUB_SSH_URL)
 
     def test_git_repo_invalid(self):
         with patch("git.Repo") as mock:

--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 import unittest
 from unittest.mock import patch
 
@@ -24,30 +23,22 @@ from streamlit.git_util import GITHUB_HTTP_URL, GITHUB_SSH_URL, GitRepo
 class GitUtilTest(unittest.TestCase):
     def test_https_url_check(self):
         # standard https url with and without .git
-        self.assertTrue(
-            re.search(GITHUB_HTTP_URL, "https://github.com/username/repo.git")
-        )
-        self.assertTrue(re.search(GITHUB_HTTP_URL, "https://github.com/username/repo"))
+        self.assertRegex("https://github.com/username/repo.git", GITHUB_HTTP_URL)
+        self.assertRegex("https://github.com/username/repo", GITHUB_HTTP_URL)
 
         # with www with and without .git
-        self.assertTrue(
-            re.search(GITHUB_HTTP_URL, "https://www.github.com/username/repo.git")
-        )
-        self.assertTrue(
-            re.search(GITHUB_HTTP_URL, "https://www.github.com/username/repo")
-        )
+        self.assertRegex("https://www.github.com/username/repo.git", GITHUB_HTTP_URL)
+        self.assertRegex("https://www.github.com/username/repo", GITHUB_HTTP_URL)
 
         # not http
-        self.assertFalse(
-            re.search(GITHUB_HTTP_URL, "http://www.github.com/username/repo.git")
-        )
+        self.assertNotRegex("http://www.github.com/username/repo.git", GITHUB_HTTP_URL)
 
     def test_ssh_url_check(self):
         # standard ssh url
-        self.assertTrue(re.search(GITHUB_SSH_URL, "git@github.com:username/repo.git"))
+        self.assertTrue("git@github.com:username/repo.git", GITHUB_SSH_URL)
 
         # no .git
-        self.assertTrue(re.search(GITHUB_SSH_URL, "git@github.com:username/repo"))
+        self.assertTrue("git@github.com:username/repo", GITHUB_SSH_URL)
 
     def test_git_repo_invalid(self):
         with patch("git.Repo") as mock:

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -155,11 +155,11 @@ class SecretsTest(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_attr_dict_is_mapping_but_not_built_in_dict(self, *mocks):
         """Verify that AttrDict implements Mapping, but not built-in Dict"""
-        self.assertTrue(isinstance(self.secrets.subsection, Mapping))
-        self.assertTrue(isinstance(self.secrets.subsection, MappingABC))
-        self.assertFalse(isinstance(self.secrets.subsection, MutableMapping))
-        self.assertFalse(isinstance(self.secrets.subsection, MutableMappingABC))
-        self.assertFalse(isinstance(self.secrets.subsection, dict))
+        self.assertIsInstance(self.secrets.subsection, Mapping)
+        self.assertIsInstance(self.secrets.subsection, MappingABC)
+        self.assertNotIsInstance(self.secrets.subsection, MutableMapping)
+        self.assertNotIsInstance(self.secrets.subsection, MutableMappingABC)
+        self.assertNotIsInstance(self.secrets.subsection, dict)
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -85,11 +85,9 @@ class WidgetManagerTests(unittest.TestCase):
         session_state = SessionState()
         session_state._set_widget_metadata(create_metadata("fake_widget_id", ""))
 
-        self.assertTrue(
-            isinstance(
-                session_state._new_widget_state.widget_metadata["fake_widget_id"],
-                WidgetMetadata,
-            )
+        self.assertIsInstance(
+            session_state._new_widget_state.widget_metadata["fake_widget_id"],
+            WidgetMetadata,
         )
 
     def test_call_callbacks(self):

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -110,7 +110,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         call_args_list = sort_args_list(fob.call_args_list)
 
         args, _ = call_args_list[0]
-        self.assertTrue("__init__.py" in args[0])
+        self.assertIn("__init__.py", args[0])
         args, _ = call_args_list[1]
         self.assertEqual(args[0], DUMMY_MODULE_1_FILE)
         self.assertEqual(type(args[1]), method_type)
@@ -142,7 +142,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         call_args_list = sort_args_list(fob.call_args_list)
 
         args, _ = call_args_list[0]
-        self.assertTrue("__init__.py" in args[0])
+        self.assertIn("__init__.py", args[0])
 
         args, _ = call_args_list[1]
         self.assertEqual(args[0], DUMMY_MODULE_1_FILE)

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -92,10 +92,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(True)
 
         out = sys.stdout.getvalue()
-        self.assertTrue(
-            "Welcome to Streamlit. Check out our demo in your browser." in out
-        )
-        self.assertTrue("URL: http://the-address" in out)
+        self.assertIn("Welcome to Streamlit. Check out our demo in your browser.", out)
+        self.assertIn("URL: http://the-address", out)
 
     def test_print_new_version_message(self):
         with patch(
@@ -118,8 +116,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("You can now view your Streamlit app in your browser." in out)
-        self.assertTrue("URL: http://the-address" in out)
+        self.assertIn("You can now view your Streamlit app in your browser.", out)
+        self.assertIn("URL: http://the-address", out)
 
     @patch("streamlit.net_util.get_external_ip")
     @patch("streamlit.net_util.get_internal_ip")
@@ -140,8 +138,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Network URL: http://internal-ip" in out)
-        self.assertTrue("External URL: http://external-ip" in out)
+        self.assertIn("Network URL: http://internal-ip", out)
+        self.assertIn("External URL: http://external-ip", out)
 
     @patch("streamlit.net_util.get_external_ip")
     @patch("streamlit.net_util.get_internal_ip")
@@ -164,8 +162,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Network URL: http://internal-ip" in out)
-        self.assertTrue("External URL: http://external-ip" not in out)
+        self.assertIn("Network URL: http://internal-ip", out)
+        self.assertNotIn("External URL: http://external-ip", out)
 
     @patch("streamlit.net_util.get_external_ip")
     @patch("streamlit.net_util.get_internal_ip")
@@ -188,8 +186,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Network URL: http://internal-ip" not in out)
-        self.assertTrue("External URL: http://external-ip" in out)
+        self.assertNotIn("Network URL: http://internal-ip", out)
+        self.assertIn("External URL: http://external-ip", out)
 
     @patch("streamlit.net_util.get_internal_ip")
     def test_print_urls_local(self, mock_get_internal_ip):
@@ -208,8 +206,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Local URL: http://localhost" in out)
-        self.assertTrue("Network URL: http://internal-ip" in out)
+        self.assertIn("Local URL: http://localhost", out)
+        self.assertIn("Network URL: http://internal-ip", out)
 
     @patch("streamlit.net_util.get_internal_ip")
     def test_print_urls_port(self, mock_get_internal_ip):
@@ -232,8 +230,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Local URL: http://localhost:9988" in out)
-        self.assertTrue("Network URL: http://internal-ip:9988" in out)
+        self.assertIn("Local URL: http://localhost:9988", out)
+        self.assertIn("Network URL: http://internal-ip:9988", out)
 
     @patch("streamlit.net_util.get_internal_ip")
     def test_print_urls_base(self, mock_get_internal_ip):
@@ -257,8 +255,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Local URL: http://localhost:8501/foo" in out)
-        self.assertTrue("Network URL: http://internal-ip:8501/foo" in out)
+        self.assertIn("Local URL: http://localhost:8501/foo", out)
+        self.assertIn("Network URL: http://internal-ip:8501/foo", out)
 
     @patch("streamlit.net_util.get_internal_ip")
     def test_print_urls_base_no_internal(self, mock_get_internal_ip):
@@ -282,8 +280,8 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        self.assertTrue("Local URL: http://localhost:8501/foo" in out)
-        self.assertTrue("Network URL: http://internal-ip:8501/foo" not in out)
+        self.assertIn("Local URL: http://localhost:8501/foo", out)
+        self.assertNotIn("Network URL: http://internal-ip:8501/foo", out)
 
     def test_print_socket(self):
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(
@@ -312,9 +310,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
 
         bootstrap._maybe_print_old_git_warning("main_script_path")
         out = sys.stdout.getvalue()
-        self.assertTrue(
-            "Streamlit requires Git 2.7.0 or later, but you have 1.2.3." in out
-        )
+        self.assertIn("Streamlit requires Git 2.7.0 or later, but you have 1.2.3.", out)
 
     @patch("streamlit.config.get_config_options")
     def test_load_config_options(self, patched_get_config_options):

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -86,7 +86,7 @@ class CliTest(unittest.TestCase):
 
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertNotEqual(0, result.exit_code)
-        self.assertTrue("File does not exist" in result.output)
+        self.assertIn("File does not exist", result.output)
 
     def test_run_not_allowed_file_extension(self):
         """streamlit run should fail if a not allowed file extension is passed."""
@@ -94,8 +94,8 @@ class CliTest(unittest.TestCase):
         result = self.runner.invoke(cli, ["run", "file_name.doc"])
 
         self.assertNotEqual(0, result.exit_code)
-        self.assertTrue(
-            "Streamlit requires raw Python (.py) files, not .doc." in result.output
+        self.assertIn(
+            "Streamlit requires raw Python (.py) files, not .doc.", result.output
         )
 
     @tempdir()
@@ -132,7 +132,7 @@ class CliTest(unittest.TestCase):
                 result = self.runner.invoke(cli, ["run", "http://url/app.py"])
 
         self.assertNotEqual(0, result.exit_code)
-        self.assertTrue("Unable to fetch" in result.output)
+        self.assertIn("Unable to fetch", result.output)
 
     def test_run_arguments(self):
         """The correct command line should be passed downstream."""


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
I was working on the tests for `st.map` and saw that the `assertTrue` function was used there. This makes the error message not very helpful.

Here is the difference:
```diff
-E       AssertionError: False is not true
+E       AssertionError: 'Map data must contain a column named' not found in 'Invalid exception'
```

Hopefully we'll start using [plain assert-statements](https://docs.pytest.org/en/7.1.x/how-to/assert.html#assert) instead of `self.assert*` functions someday, and then similar problems won't happen.

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [X] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
