### PR TITLE
Add and remove libraries for consistency

### DIFF
--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -59,7 +59,6 @@ class BokehMixin:
 
         Example
         -------
-        >>> import streamlit as st
         >>> from bokeh.plotting import figure
         >>>
         >>> x = [1, 2, 3, 4, 5]

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -77,6 +77,9 @@ class DataFrameSelectorMixin:
 
         Examples
         --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(50, 20),
         ...    columns=('col %d' % i for i in range(20)))
@@ -128,6 +131,9 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(10, 5),
         ...    columns=('col %d' % i for i in range(5)))
@@ -199,6 +205,9 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
@@ -282,6 +291,9 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
@@ -365,8 +377,11 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> chart_data = pd.DataFrame(
-        ...     np.random.randn(50, 3),
+        ...     np.random.randn(20, 3),
         ...     columns=["a", "b", "c"])
         ...
         >>> st.bar_chart(chart_data)
@@ -423,11 +438,11 @@ class DataFrameSelectorMixin:
         >>> import numpy as np
         >>> import altair as alt
         >>>
-        >>> df = pd.DataFrame(
-        ...     np.random.randn(200, 3),
+        >>> chart_data = pd.DataFrame(
+        ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
         ...
-        >>> c = alt.Chart(df).mark_circle().encode(
+        >>> c = alt.Chart(chart_data).mark_circle().encode(
         ...     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])
         >>>
         >>> st.altair_chart(c, use_container_width=True)
@@ -485,15 +500,14 @@ class DataFrameSelectorMixin:
 
         Example
         -------
-
         >>> import pandas as pd
         >>> import numpy as np
         >>>
-        >>> df = pd.DataFrame(
+        >>> chart_data = pd.DataFrame(
         ...     np.random.randn(200, 3),
         ...     columns=['a', 'b', 'c'])
         >>>
-        >>> st.vega_lite_chart(df, {
+        >>> st.vega_lite_chart(chart_data, {
         ...     'mark': {'type': 'circle', 'tooltip': True},
         ...     'encoding': {
         ...         'x': {'field': 'a', 'type': 'quantitative'},

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -69,7 +69,11 @@ class PydeckMixin:
         Here's a chart using a HexagonLayer and a ScatterplotLayer. It uses either the
         light or dark map style, based on which Streamlit theme is currently active:
 
-        >>> df = pd.DataFrame(
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> import pydeck as pdk
+        >>>
+        >>> chart_data = pd.DataFrame(
         ...    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],
         ...    columns=['lat', 'lon'])
         >>>
@@ -84,7 +88,7 @@ class PydeckMixin:
         ...     layers=[
         ...         pdk.Layer(
         ...            'HexagonLayer',
-        ...            data=df,
+        ...            data=chart_data,
         ...            get_position='[lon, lat]',
         ...            radius=200,
         ...            elevation_scale=4,
@@ -94,7 +98,7 @@ class PydeckMixin:
         ...         ),
         ...         pdk.Layer(
         ...             'ScatterplotLayer',
-        ...             data=df,
+        ...             data=chart_data,
         ...             get_position='[lon, lat]',
         ...             get_color='[200, 30, 0, 160]',
         ...             get_radius=200,

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -55,8 +55,6 @@ class GraphvizMixin:
 
         Example
         -------
-
-        >>> import streamlit as st
         >>> import graphviz
         >>>
         >>> # Create a graphlib graph object

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -114,10 +114,8 @@ class PlotlyMixin:
 
         The example below comes straight from the examples at
         https://plot.ly/python:
-
-        >>> import streamlit as st
-        >>> import plotly.figure_factory as ff
         >>> import numpy as np
+        >>> import plotly.figure_factory as ff
         >>>
         >>> # Add histogram data
         >>> x1 = np.random.randn(200) - 2


### PR DESCRIPTION
## 📚 Context
Currently, the package imports for the **Example** sections for the charts are inconsistent. Some call `import streamlit as st` such as [st.plotly_chart](https://docs.streamlit.io/library/api-reference/charts/st.plotly_chart) and [st.bokeh_chart](https://docs.streamlit.io/library/api-reference/charts/st.bokeh_chart) while all others do not. Some call `import numpy as np` such as [st.pyplot](https://docs.streamlit.io/library/api-reference/charts/st.pyplot) while many do not.  The standard for us seems to be we do not preface every call with `import streamlit as st`

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes
- Add pydeck import for st.pydeck_chart
- Add numpy and pandas imports for st.dataframe, st.table, st.line_chart, st.area_chart, st.bar_chart, st.deck_gl_json_chart
- Remove streamlit imports from st.plotly_chart, st.graphviz_chart, 
- Change `df` to `chart_data` for st.altair_chart and st.vega_lite_chart to be consistent with st.line_chart. 
- Make random data consistent with st.line_chart for st.altair_chart
  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

