### PR TITLE
Cached media (audio+video) replay

### DIFF
--- a/e2e/scripts/st_media_replay.py
+++ b/e2e/scripts/st_media_replay.py
@@ -1,0 +1,35 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+
+import streamlit as st
+
+
+@st.experimental_memo
+def audio():
+    url = "https://www.w3schools.com/html/horse.ogg"
+    file = requests.get(url).content
+    st.audio(file)
+
+
+@st.experimental_memo
+def video():
+    url = "https://www.w3schools.com/html/mov_bbb.mp4"
+    file = requests.get(url).content
+    st.video(file)
+
+
+audio()
+video()

--- a/e2e/specs/st_media_replay.spec.js
+++ b/e2e/specs/st_media_replay.spec.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Audio + video tests, but we rerun the page to ensure everything shows up
+// when the value is replayed from the cache
+
+describe("media replay", () => {
+  before(() => {
+    // Increasing timeout since we're requesting external files
+    Cypress.config("defaultCommandTimeout", 10000);
+    cy.loadApp("http://localhost:3000/");
+  });
+
+  it("displays an audio player", () => {
+    cy.get(".element-container .stAudio");
+    cy.rerunScript();
+    cy.waitForRerun();
+    cy.get(".element-container .stAudio");
+  });
+
+  it("has audio controls", () => {
+    cy.get(".element-container .stAudio").should("have.attr", "controls");
+    cy.rerunScript();
+    cy.waitForRerun();
+    cy.get(".element-container .stAudio").should("have.attr", "controls");
+  });
+
+  it("has audio src", () => {
+    cy.get(".element-container .stAudio").should("have.attr", "src");
+    cy.rerunScript();
+    cy.waitForRerun();
+    cy.get(".element-container .stAudio").should("have.attr", "src");
+  });
+
+  it("has audio", () => {
+    cy.get(".element-container .stAudio")
+      .should("have.prop", "tagName")
+      .and("eq", "AUDIO");
+    cy.rerunScript();
+    cy.waitForRerun();
+    cy.get(".element-container .stAudio")
+      .should("have.prop", "tagName")
+      .and("eq", "AUDIO");
+  });
+
+  it("displays a video player", () => {
+    cy.get(".element-container .stVideo").should("have.attr", "src");
+    cy.rerunScript();
+    cy.waitForRerun();
+    cy.get(".element-container .stVideo").should("have.attr", "src");
+  });
+});

--- a/lib/streamlit/elements/__init__.py
+++ b/lib/streamlit/elements/__init__.py
@@ -41,6 +41,7 @@ NONWIDGET_ELEMENTS = [
     "arrow_line_chart",
     "arrow_table",
     "arrow_vega_lite_chart",
+    "audio",
     "balloons",
     "bar_chart",
     "bokeh_chart",
@@ -68,9 +69,6 @@ NONWIDGET_ELEMENTS = [
     "table",
     "text",
     "vega_lite_chart",
-    "write",
-]
-FILESYSTEM_ELEMENTS = [
-    "audio",
     "video",
+    "write",
 ]

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -346,7 +346,7 @@ def image_to_url(
                 mimetype = "application/octet-stream"
 
             url = runtime.get_instance().media_file_mgr.add(image, mimetype, image_id)
-            caching.save_image_data(image, mimetype, image_id)
+            caching.save_media_data(image, mimetype, image_id)
             return url
 
     # PIL Images
@@ -396,7 +396,7 @@ def image_to_url(
 
     if runtime.exists():
         url = runtime.get_instance().media_file_mgr.add(image_data, mimetype, image_id)
-        caching.save_image_data(image_data, mimetype, image_id)
+        caching.save_media_data(image_data, mimetype, image_id)
         return url
     else:
         # When running in "raw mode", we can't access the MediaFileManager.

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -24,6 +24,7 @@ from streamlit import runtime, type_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
+from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
@@ -246,6 +247,7 @@ def _marshall_av_media(
         file_url = runtime.get_instance().media_file_mgr.add(
             data_or_filename, mimetype, coordinates
         )
+        caching.save_image_data(data_or_filename, mimetype, coordinates)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
         file_url = ""

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -247,7 +247,7 @@ def _marshall_av_media(
         file_url = runtime.get_instance().media_file_mgr.add(
             data_or_filename, mimetype, coordinates
         )
-        caching.save_image_data(data_or_filename, mimetype, coordinates)
+        caching.save_media_data(data_or_filename, mimetype, coordinates)
     else:
         # When running in "raw mode", we can't access the MediaFileManager.
         file_url = ""

--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -82,7 +82,7 @@ def save_widget_metadata(metadata: WidgetMetadata[Any]) -> None:
     SINGLETON_MESSAGE_CALL_STACK.save_widget_metadata(metadata)
 
 
-def save_image_data(
+def save_media_data(
     image_data: Union[bytes, str], mimetype: str, image_id: str
 ) -> None:
     MEMO_MESSAGE_CALL_STACK.save_image_data(image_data, mimetype, image_id)

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -263,7 +263,7 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         # Mock out save_image_data to avoid polluting the cache for later tests
         with mock.patch(
             "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_image_data"):
+        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_media_data"):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             result = image.image_to_url(

--- a/lib/tests/streamlit/elements/media_test.py
+++ b/lib/tests/streamlit/elements/media_test.py
@@ -56,7 +56,7 @@ class MediaTest(DeltaGeneratorTestCase):
         """
         with mock.patch(
             "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_image_data"):
+        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_media_data"):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             if media_kind is TestMediaKind.AUDIO:

--- a/lib/tests/streamlit/elements/media_test.py
+++ b/lib/tests/streamlit/elements/media_test.py
@@ -56,7 +56,7 @@ class MediaTest(DeltaGeneratorTestCase):
         """
         with mock.patch(
             "streamlit.runtime.media_file_manager.MediaFileManager.add"
-        ) as mock_mfm_add:
+        ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_image_data"):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
             if media_kind is TestMediaKind.AUDIO:


### PR DESCRIPTION
## 📚 Context

Element replay, for audio and video. 
- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Save audio/video data in cache
- Works almost exactly the same as image replay

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [x] Added/Updated e2e tests

