### PR TITLE
Implement the MemorySessionStorage class

### DIFF
--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -1,0 +1,55 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, MutableMapping, Optional
+
+from cachetools import TTLCache
+
+from streamlit.runtime.session_manager import SessionInfo, SessionStorage
+
+
+class MemorySessionStorage(SessionStorage):
+    """A SessionStorage that stores sessions in memory.
+
+    At most maxsize sessions are stored with a TTL of ttl seconds. This class is really
+    just a thin wrapper around cachetools.TTLCache that complies with the SessionStorage
+    protocol.
+    """
+
+    # NOTE: The defaults for maxsize and ttl are chosen arbitrarily for now. These
+    # numbers are reasonable as the main problems we're trying to solve at the moment are
+    # caused by transient disconnects that are usually just short network blips. In the
+    # future, we may want to increase both to support use cases such as saving state for
+    # much longer periods of time. For example, we may want session state to persist if
+    # a user closes their laptop lid and comes back to an app hours later.
+    def __init__(
+        self,
+        maxsize: int = 128,
+        ttl: int = 5 * 60,  # 5 minutes
+    ) -> None:
+        self._cache: MutableMapping[str, SessionInfo] = TTLCache(
+            maxsize=maxsize, ttl=ttl
+        )
+
+    def get(self, session_id: str) -> Optional[SessionInfo]:
+        return self._cache.get(session_id, None)
+
+    def save(self, session_info: SessionInfo) -> None:
+        self._cache[session_info.session.id] = session_info
+
+    def delete(self, session_id: str) -> None:
+        del self._cache[session_id]
+
+    def list(self) -> List[SessionInfo]:
+        return list(self._cache.values())

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -36,10 +36,33 @@ class MemorySessionStorage(SessionStorage):
     def __init__(
         self,
         maxsize: int = 128,
-        ttl: int = 5 * 60,  # 5 minutes
+        ttl_seconds: int = 5 * 60,  # 5 minutes
     ) -> None:
+        """Instantiate a new MemorySessionStorage.
+
+        Parameters
+        ----------
+        maxsize
+            The maximum number of sessions we allow to be stored in this
+            MemorySessionStorage. If an entry needs to be removed because we have
+            exceeded this number, either
+              * an expired entry is removed, or
+              * the least recently used entry is removed (if no entries have expired).
+
+        ttl_seconds
+            The time in seconds for an entry added to a MemorySessionStorage to live.
+            After this amount of time has passed for a given entry, it becomes
+            inaccessible and will be removed eventually.
+
+            TODO(vdonato): We'll have to do some testing to see what the TTLCache
+            documentation means by "eventually". It's possible that we'll want to add
+            our own mechanism to force cleanups of expired entries more frequently than
+            TTLCache does by default (which is easy to do with some of the methods that
+            TTLCache exposes).
+        """
+
         self._cache: MutableMapping[str, SessionInfo] = TTLCache(
-            maxsize=maxsize, ttl=ttl
+            maxsize=maxsize, ttl=ttl_seconds
         )
 
     def get(self, session_id: str) -> Optional[SessionInfo]:

--- a/lib/tests/streamlit/runtime/memory_session_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_session_storage_test.py
@@ -15,6 +15,8 @@
 import unittest
 from unittest.mock import MagicMock
 
+from cachetools import TTLCache
+
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
 
 
@@ -25,6 +27,17 @@ class MemorySessionStorageTest(unittest.TestCase):
     testing cachetools.TTLCache. We try to just verify that we've wrapped TTLCache
     correctly, and in particular we avoid testing cache expiry functionality.
     """
+
+    def test_uses_ttl_cache(self):
+        """Verify that the backing cache of a MemorySessionStorage is a TTLCache.
+
+        We do this because we're intentionally avoiding writing tests around cache
+        expiry because the cachetools library should do this for us. In the case
+        that the backing cache for a MemorySessionStorage ever changes, we'll likely be
+        responsible for adding our own tests.
+        """
+        store = MemorySessionStorage()
+        self.assertIsInstance(store._cache, TTLCache)
 
     def test_get(self):
         store = MemorySessionStorage()

--- a/lib/tests/streamlit/runtime/memory_session_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_session_storage_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
+
+
+class MemorySessionStorageTest(unittest.TestCase):
+    """Test MemorySessionStorage.
+
+    These tests are intentionally extremely simple to ensure that we don't just end up
+    testing cachetools.TTLCache. We try to just verify that we've wrapped TTLCache
+    correctly, and in particular we avoid testing cache expiry functionality.
+    """
+
+    def test_get(self):
+        store = MemorySessionStorage()
+        store._cache["foo"] = "bar"
+
+        self.assertEqual(store.get("foo"), "bar")
+        self.assertEqual(store.get("baz"), None)
+
+    def test_save(self):
+        store = MemorySessionStorage()
+        session_info = MagicMock()
+        session_info.session.id = "foo"
+
+        store.save(session_info)
+        self.assertEqual(store.get("foo"), session_info)
+
+    def test_delete(self):
+        store = MemorySessionStorage()
+        store._cache["foo"] = "bar"
+
+        store.delete("foo")
+        self.assertEqual(store.get("foo"), None)
+
+    def test_list(self):
+        store = MemorySessionStorage()
+        store._cache["foo"] = "bar"
+        store._cache["baz"] = "qux"
+
+        self.assertEqual(store.list(), ["bar", "qux"])


### PR DESCRIPTION
## 📚 Context

This PR implements `MemorySessionStorage`, which is our first concrete implementation of
the `SessionStorage` protocol and under the hood is really just a thin wrapper around
`cachetools.TTLCache`.

For now, we make it so that an instance of this class holds at most 128 disconnected sessions
for at most 5 minutes. This is reasonable while we're only trying to solve the transient disconnect
issue (the numbers are actually quite generous for solving this problem), but we leave the
`maxsize` and `ttl` parameters configurable in case we later want to save more sessions for a
longer period of time.

We don't actually use `MemorySessionStorage` yet, that'll be done in a subsequent PR.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests
