### PR TITLE
Update issue labeling scheme to adopt new standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Submit a bug report to help us improve Streamlit
-labels: [bug, needs triage]
+labels: [type:bug, status:needs-triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a feature or enhancement for Streamlit
 title: ""
-labels: enhancement, needs triage
+labels: type:enhancement
 assignees: ""
 ---
 


### PR DESCRIPTION
Update the auto-labeling of our github issues.

Specifically:
* bug -> type:bug
* needs triage -> status:needs-triage
* enhancement -> type:enhancement
* enhancements will not have the needs-triage as upvoting will encourage attention.