### PR TITLE
Surround labels in quotes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Submit a bug report to help us improve Streamlit
-labels: [type:bug, status:needs-triage]
+labels: ["type:bug", "status:needs-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
YAML does not allow colons, so wrapped the labels in quotes 🤦.