### PR TITLE
Add CI job to enforce security assessments

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -12,7 +12,8 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: mheap/github-action-required-labels@v2
+      # v2=7b0461786d3bd0c6a8487e9b57814ba3e2c00227
+      - uses: mheap/github-action-required-labels@7b0461786d3bd0c6a8487e9b57814ba3e2c00227
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,0 +1,19 @@
+name: Pull Request Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "security-assessment-completed"


### PR DESCRIPTION
## 📚 Context

This PR adds a simple CI job that fails unless the `security-assessment-completed` label has been
added to the PR. The intention here is to simply ensure that we don't merge PRs without being reminded
to go through the security assessment process if the PR warrants it. The vast majority of our PRs likely
won't require an in-depth security review, but we do want to make sure that we don't prematurely merge
PRs that we should be getting security reviews for just because we forgot about the process.

NOTE: This security process is only something that maintainers will need to think about. Open source
contributors, of course, may be asked to make changes to their PRs in case that there is a security implication
that needs to be addressed, but the security process itself is a process internal to the Streamlit team.

- What kind of change does this PR introduce?

  - [x] Other, please describe: security process additions
