### PR TITLE
SVG image from e2e tests render in Firefox

### DIFF
--- a/e2e/scripts/st_image.py
+++ b/e2e/scripts/st_image.py
@@ -77,9 +77,12 @@ col2.image(img, use_column_width=True)  # column
 
 col2.image(img800, use_column_width="auto")  # column
 
-st.image("""<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
-    <image href='https://avatars.githubusercontent.com/karriebear' width=50 height=50/>   
-      </svg> """)
+st.image(
+    """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
+</svg>
+"""
+)
       
 st.image(
     """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">

--- a/e2e/scripts/st_image.py
+++ b/e2e/scripts/st_image.py
@@ -77,6 +77,10 @@ col2.image(img, use_column_width=True)  # column
 
 col2.image(img800, use_column_width="auto")  # column
 
+st.image("""<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+    <image href='https://avatars.githubusercontent.com/karriebear' width=50 height=50/>   
+      </svg> """)
+      
 st.image(
     """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
     <clipPath id="clipCircle">

--- a/e2e/scripts/st_image.py
+++ b/e2e/scripts/st_image.py
@@ -77,19 +77,13 @@ col2.image(img, use_column_width=True)  # column
 
 col2.image(img800, use_column_width="auto")  # column
 
-st.image(
-    """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
-    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
-</svg>
-"""
-)
       
 st.image(
     """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
     <clipPath id="clipCircle">
         <circle r="25" cx="25" cy="25"/>
     </clipPath>
-    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
+    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clipPath="url(#clipCircle)"/>
 </svg>
 """
 )

--- a/test.py
+++ b/test.py
@@ -1,0 +1,1 @@
+print("hello")

--- a/test.py
+++ b/test.py
@@ -1,1 +1,0 @@
-print("hello")


### PR DESCRIPTION
Checklist

- [x]  I have searched the [existing issues](https://github.com/streamlit/streamlit/issues) for similar issues.

- [x]  I added a very descriptive title to this issue.
 

- [x] I have provided sufficient information below to help reproduce this issue.

Summary
The st.image cypress test renders an svg with a github avatar. The avatar appears as expected in chromium, but does not appear in firefox 100.

Reproducible Code Example
import streamlit as st

`st.image(
    """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
    <clipPath id="clipCircle">
        <circle r="25" cx="25" cy="25"/>
    </clipPath>
    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
</svg>
"""
)`

Expected Behavior
Avatar renders in all supported browsers

