### PR TITLE
cache_utils.get_decorator_api_name util

### DIFF
--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import enum
 import types
 from typing import Any, Optional
 
@@ -22,9 +21,10 @@ from streamlit.errors import (
     StreamlitAPIException,
     StreamlitAPIWarning,
 )
+from streamlit.runtime.caching.cache_utils import CacheType, get_decorator_api_name
 
 
-def get_cached_func_name_md(func) -> str:
+def get_cached_func_name_md(func: Any) -> str:
     """Get markdown representation of the function name."""
     if hasattr(func, "__name__"):
         return "`%s()`" % func.__name__
@@ -33,15 +33,10 @@ def get_cached_func_name_md(func) -> str:
     return f"`{type(func)}`"
 
 
-def get_return_value_type(return_value) -> str:
+def get_return_value_type(return_value: Any) -> str:
     if hasattr(return_value, "__module__") and hasattr(type(return_value), "__name__"):
         return f"`{return_value.__module__}.{type(return_value).__name__}`"
     return get_cached_func_name_md(return_value)
-
-
-class CacheType(enum.Enum):
-    MEMO = "experimental_memo"
-    SINGLETON = "experimental_singleton"
 
 
 class UnhashableTypeError(Exception):
@@ -81,7 +76,7 @@ To address this, you can tell Streamlit not to hash this argument by adding a
 leading underscore to the argument's name in the function signature:
 
 ```
-@st.{cache_type.value}
+@st.{get_decorator_api_name(cache_type)}
 def {func_name}({arg_replacement_name}, ...):
     ...
 ```
@@ -107,7 +102,7 @@ class CachedStFunctionWarning(StreamlitAPIWarning):
         args = {
             "st_func_name": f"`st.{st_func_name}()`",
             "func_name": self._get_cached_func_name_md(cached_func),
-            "decorator_name": cache_type.value,
+            "decorator_name": get_decorator_api_name(cache_type),
         }
 
         msg = (
@@ -142,7 +137,7 @@ class CacheReplayClosureError(StreamlitAPIException):
         cached_func: types.FunctionType,
     ):
         func_name = get_cached_func_name_md(cached_func)
-        decorator_name = (cache_type.value,)
+        decorator_name = get_decorator_api_name(cache_type)
 
         msg = (
             f"""

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import types
 from typing import Any, Optional
 
@@ -21,7 +22,22 @@ from streamlit.errors import (
     StreamlitAPIException,
     StreamlitAPIWarning,
 )
-from streamlit.runtime.caching.cache_utils import CacheType, get_decorator_api_name
+
+
+class CacheType(enum.Enum):
+    """The function cache types we implement."""
+
+    MEMO = "MEMO"
+    SINGLETON = "SINGLETON"
+
+
+def get_decorator_api_name(cache_type: CacheType) -> str:
+    """Return the name of the public decorator API for the given CacheType."""
+    if cache_type is CacheType.MEMO:
+        return "experimental_memo"
+    if cache_type is CacheType.SINGLETON:
+        return "experimental_singleton"
+    raise RuntimeError(f"Unrecognized CacheType '{cache_type}'")
 
 
 def get_cached_func_name_md(func: Any) -> str:

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -15,7 +15,6 @@
 """Common cache logic shared by st.memo and st.singleton."""
 
 import contextlib
-import enum
 import functools
 import hashlib
 import inspect
@@ -39,6 +38,7 @@ from streamlit.runtime.caching.cache_errors import (
     CachedStFunctionWarning,
     CacheKeyNotFoundError,
     CacheReplayClosureError,
+    CacheType,
     UnhashableParamError,
     UnhashableTypeError,
     UnserializableReturnValueError,
@@ -52,22 +52,6 @@ from streamlit.runtime.scriptrunner.script_run_context import (
 from streamlit.runtime.state.session_state import WidgetMetadata
 
 _LOGGER = get_logger(__name__)
-
-
-class CacheType(enum.Enum):
-    """The function cache types we implement."""
-
-    MEMO = "MEMO"
-    SINGLETON = "SINGLETON"
-
-
-def get_decorator_api_name(cache_type: CacheType) -> str:
-    """Return the name of the public decorator API for the given CacheType."""
-    if cache_type is CacheType.MEMO:
-        return "experimental_memo"
-    if cache_type is CacheType.SINGLETON:
-        return "experimental_singleton"
-    raise RuntimeError(f"Unrecognized CacheType '{cache_type}'")
 
 
 @runtime_checkable

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -15,6 +15,7 @@
 """Common cache logic shared by st.memo and st.singleton."""
 
 import contextlib
+import enum
 import functools
 import hashlib
 import inspect
@@ -38,7 +39,6 @@ from streamlit.runtime.caching.cache_errors import (
     CachedStFunctionWarning,
     CacheKeyNotFoundError,
     CacheReplayClosureError,
-    CacheType,
     UnhashableParamError,
     UnhashableTypeError,
     UnserializableReturnValueError,
@@ -52,6 +52,22 @@ from streamlit.runtime.scriptrunner.script_run_context import (
 from streamlit.runtime.state.session_state import WidgetMetadata
 
 _LOGGER = get_logger(__name__)
+
+
+class CacheType(enum.Enum):
+    """The function cache types we implement."""
+
+    MEMO = "MEMO"
+    SINGLETON = "SINGLETON"
+
+
+def get_decorator_api_name(cache_type: CacheType) -> str:
+    """Return the name of the public decorator API for the given CacheType."""
+    if cache_type is CacheType.MEMO:
+        return "experimental_memo"
+    if cache_type is CacheType.SINGLETON:
+        return "experimental_singleton"
+    raise RuntimeError(f"Unrecognized CacheType '{cache_type}'")
 
 
 @runtime_checkable


### PR DESCRIPTION
`CacheType.value` is currently implicitly used to store the name of the public API that the CacheType refers to. (That is, `CacheType.MEMO` has the value `"experimental_memo"`.) This isn't documented anywhere, and it's not intuitive.

This PR changes that:
- `CacheType.value` is now the stringified version of the enum name ("MEMO" and "SINGLETON" instead of "experimental_memo" and "experimental_singleton")
- A new function, `get_decorator_api_name`, returns the public API name for the given CacheType