### PR TITLE
Upgrade codebase to Python 3 syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,10 @@ repos:
           # Configure Black to support only syntax supported by the minimum supported Python version in setup.py.
           - --target-version=py37
         files: \.py$|\.pyi$
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.2.2
+    hooks:
+    -   id: pyupgrade
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/e2e/scripts/st_magic.py
+++ b/e2e/scripts/st_magic.py
@@ -126,7 +126,7 @@ def docstrings():
         Should not be printed."""
         pass
 
-    class Foo(object):
+    class Foo:
         """Class docstring. Should not be printed."""
 
         pass

--- a/e2e/scripts/st_markdown.py
+++ b/e2e/scripts/st_markdown.py
@@ -28,7 +28,7 @@ st.markdown("[link](href)")
 
 st.markdown("[][]")
 
-st.markdown("Inline math with $\KaTeX$")
+st.markdown(r"Inline math with $\KaTeX$")
 
 st.markdown(
     """

--- a/e2e_flaky/scripts/st_bokeh_chart.py
+++ b/e2e_flaky/scripts/st_bokeh_chart.py
@@ -1,1 +1,15 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ../../e2e/scripts/st_bokeh_chart.py

--- a/e2e_flaky/scripts/st_empty.py
+++ b/e2e_flaky/scripts/st_empty.py
@@ -1,1 +1,15 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ../../e2e/scripts/st_empty.py

--- a/e2e_flaky/scripts/st_graphviz_chart.py
+++ b/e2e_flaky/scripts/st_graphviz_chart.py
@@ -1,1 +1,15 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ../../e2e/scripts/st_graphviz_chart.py

--- a/e2e_flaky/scripts/st_legacy_add_rows.py
+++ b/e2e_flaky/scripts/st_legacy_add_rows.py
@@ -1,1 +1,15 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ../../e2e/scripts/st_legacy_add_rows.py

--- a/e2e_flaky/scripts/st_pyplot_kwargs.py
+++ b/e2e_flaky/scripts/st_pyplot_kwargs.py
@@ -1,1 +1,15 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ../../e2e/scripts/st_pyplot_kwargs.py

--- a/examples/audio.py
+++ b/examples/audio.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import os
 import wave
 
@@ -94,7 +93,7 @@ fh.writeframes(sine_wave)
 
 fh.close()
 
-with io.open("sound.wav", "rb") as f:
+with open("sound.wav", "rb") as f:
     x.text("Sending wave...")
     x.audio(f)
 

--- a/examples/images.py
+++ b/examples/images.py
@@ -23,7 +23,7 @@ from PIL import Image, ImageDraw
 import streamlit as st
 
 
-class StreamlitImages(object):
+class StreamlitImages:
     def __init__(self, size=200, step=10):
         self._size = size
         self._step = step

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -79,7 +79,7 @@ class VerifyVersionCommand(install):
         tag = os.getenv("TAG")
 
         if tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
+            info = "Git tag: {} does not match the version of this app: {}".format(
                 tag, VERSION
             )
             sys.exit(info)

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -240,7 +240,7 @@ def _create_option(
     )
     assert (
         option.section in _section_descriptions
-    ), 'Section "%s" must be one of %s.' % (
+    ), 'Section "{}" must be one of {}.'.format(
         option.section,
         ", ".join(_section_descriptions.keys()),
     )
@@ -1090,7 +1090,7 @@ def get_config_options(
             if not os.path.exists(filename):
                 continue
 
-            with open(filename, "r", encoding="utf-8") as input:
+            with open(filename, encoding="utf-8") as input:
                 file_contents = input.read()
 
             _update_config_with_toml(file_contents, filename)

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -293,5 +293,5 @@ class ConfigOption:
 
 
 def _parse_yyyymmdd_str(date_str: str) -> datetime.datetime:
-    year, month, day = [int(token) for token in date_str.split("-", 2)]
+    year, month, day = (int(token) for token in date_str.split("-", 2))
     return datetime.datetime(year, month, day)

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -346,9 +346,9 @@ class DeltaGenerator(
                         "`st.%(name)s()`?" % {"name": name}
                     )
             else:
-                message = "`%(name)s()` is not a valid Streamlit command." % {
-                    "name": name
-                }
+                message = "`{name}()` is not a valid Streamlit command.".format(
+                    name=name
+                )
 
             raise StreamlitAPIException(message)
 

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -167,7 +167,7 @@ def marshall(
 
 class PyplotGlobalUseWarning(StreamlitDeprecationWarning):
     def __init__(self) -> None:
-        super(PyplotGlobalUseWarning, self).__init__(
+        super().__init__(
             msg=self._get_message(), config_option="deprecation.showPyplotGlobalUse"
         )
 

--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -31,7 +31,7 @@ def _print_rich_exception(e: BaseException):
             box=box.Box("────\n    \n────\n    \n────\n────\n    \n────\n"),
             **kwargs,
         ):
-            super(ConfigurablePanel, self).__init__(renderable, box, **kwargs)
+            super().__init__(renderable, box, **kwargs)
 
     from rich import traceback as rich_traceback
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -79,7 +79,7 @@ class StreamlitAPIWarning(StreamlitAPIException, Warning):
     """
 
     def __init__(self, *args):
-        super(StreamlitAPIWarning, self).__init__(*args)
+        super().__init__(*args)
         import inspect
         import traceback
 

--- a/lib/streamlit/folder_black_list.py
+++ b/lib/streamlit/folder_black_list.py
@@ -34,7 +34,7 @@ DEFAULT_FOLDER_BLACKLIST = [
 ]
 
 
-class FolderBlackList(object):
+class FolderBlackList:
     """Implement a black list object with globbing.
 
     Note

--- a/lib/streamlit/js_number.py
+++ b/lib/streamlit/js_number.py
@@ -20,7 +20,7 @@ class JSNumberBoundsException(Exception):
     pass
 
 
-class JSNumber(object):
+class JSNumber:
     """
     Utility class. Exposes JavaScript Number constants.
     """
@@ -66,11 +66,11 @@ class JSNumber(object):
 
         if value < cls.MIN_SAFE_INTEGER:
             raise JSNumberBoundsException(
-                "%s (%s) must be >= -((1 << 53) - 1)" % (value_name, value)
+                "{} ({}) must be >= -((1 << 53) - 1)".format(value_name, value)
             )
         elif value > cls.MAX_SAFE_INTEGER:
             raise JSNumberBoundsException(
-                "%s (%s) must be <= (1 << 53) - 1" % (value_name, value)
+                "{} ({}) must be <= (1 << 53) - 1".format(value_name, value)
             )
 
     @classmethod
@@ -98,13 +98,13 @@ class JSNumber(object):
 
         if not isinstance(value, (numbers.Integral, float)):
             raise JSNumberBoundsException(
-                "%s (%s) is not a float" % (value_name, value)
+                "{} ({}) is not a float".format(value_name, value)
             )
         elif value < cls.MIN_NEGATIVE_VALUE:
             raise JSNumberBoundsException(
-                "%s (%s) must be >= -1.797e+308" % (value_name, value)
+                "{} ({}) must be >= -1.797e+308".format(value_name, value)
             )
         elif value > cls.MAX_VALUE:
             raise JSNumberBoundsException(
-                "%s (%s) must be <= 1.797e+308" % (value_name, value)
+                "{} ({}) must be <= 1.797e+308".format(value_name, value)
             )

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -610,7 +610,7 @@ class MemoCache(Cache):
             # Clean up file so we don't leave zero byte files.
             try:
                 os.remove(path)
-            except (FileNotFoundError, IOError, OSError):
+            except (FileNotFoundError, OSError):
                 # If we can't remove the file, it's not a big deal.
                 pass
             raise CacheError("Unable to write to cache") from e

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -46,7 +46,7 @@ _Activation = namedtuple(
 
 # IMPORTANT: Break the text below at 80 chars.
 _EMAIL_PROMPT = """
-  {0}%(welcome)s
+  {}%(welcome)s
 
   If you’d like to receive helpful onboarding emails, news, offers, promotions,
   and the occasional swag, please enter your email address below. Otherwise,
@@ -61,22 +61,22 @@ _EMAIL_PROMPT = """
 
 # IMPORTANT: Break the text below at 80 chars.
 _TELEMETRY_TEXT = """
-  You can find our privacy policy at %(link)s
+  You can find our privacy policy at {link}
 
   Summary:
   - This open source library collects usage statistics.
   - We cannot see and do not store information contained inside Streamlit apps,
     such as text, charts, images, etc.
   - Telemetry data is stored in servers in the United States.
-  - If you'd like to opt out, add the following to %(config)s,
+  - If you'd like to opt out, add the following to {config},
     creating that file if necessary:
 
     [browser]
     gatherUsageStats = false
-""" % {
-    "link": click.style("https://streamlit.io/privacy-policy", underline=True),
-    "config": click.style(_CONFIG_FILE_PATH),
-}
+""".format(
+    link=click.style("https://streamlit.io/privacy-policy", underline=True),
+    config=click.style(_CONFIG_FILE_PATH),
+)
 
 _TELEMETRY_HEADLESS_TEXT = """
 Collecting usage statistics. To deactivate, set browser.gatherUsageStats to False.
@@ -84,16 +84,16 @@ Collecting usage statistics. To deactivate, set browser.gatherUsageStats to Fals
 
 # IMPORTANT: Break the text below at 80 chars.
 _INSTRUCTIONS_TEXT = """
-  %(start)s
-  %(prompt)s %(hello)s
-""" % {
-    "start": click.style("Get started by typing:", fg="blue", bold=True),
-    "prompt": click.style("$", fg="blue"),
-    "hello": click.style("streamlit hello", bold=True),
-}
+  {start}
+  {prompt} {hello}
+""".format(
+    start=click.style("Get started by typing:", fg="blue", bold=True),
+    prompt=click.style("$", fg="blue"),
+    hello=click.style("streamlit hello", bold=True),
+)
 
 
-class Credentials(object):
+class Credentials:
     """Credentials class."""
 
     _singleton = None  # type: Optional[Credentials]
@@ -128,7 +128,7 @@ class Credentials(object):
             return
 
         try:
-            with open(self._conf_file, "r") as f:
+            with open(self._conf_file) as f:
                 data = toml.load(f).get("general")
             if data is None:
                 raise Exception

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -311,7 +311,7 @@ def _write_to_disk_cache(key: str, value: Any) -> None:
         # Clean up file so we don't leave zero byte files.
         try:
             os.remove(path)
-        except (FileNotFoundError, IOError, OSError):
+        except (FileNotFoundError, OSError):
             # If we can't remove the file, it's not a big deal.
             pass
         raise CacheError("Unable to write to cache: %s" % e)
@@ -582,7 +582,7 @@ def cache(
 
             # Avoid recomputing the body's hash by just appending the
             # previously-computed hash to the arg hash.
-            value_key = "%s-%s" % (value_key, cache_key)
+            value_key = "{}-{}".format(value_key, cache_key)
 
             _LOGGER.debug("Cache key: %s", value_key)
 
@@ -746,7 +746,7 @@ class CachedObjectMutationError(ValueError):
 class CachedStFunctionWarning(StreamlitAPIWarning):
     def __init__(self, st_func_name, cached_func):
         msg = self._get_message(st_func_name, cached_func)
-        super(CachedStFunctionWarning, self).__init__(msg)
+        super().__init__(msg)
 
     def _get_message(self, st_func_name, cached_func):
         args = {
@@ -772,7 +772,7 @@ to suppress the warning.
 class CachedObjectMutationWarning(StreamlitAPIWarning):
     def __init__(self, orig_exc):
         msg = self._get_message(orig_exc)
-        super(CachedObjectMutationWarning, self).__init__(msg)
+        super().__init__(msg)
 
     def _get_message(self, orig_exc):
         return (

--- a/lib/streamlit/runtime/legacy_caching/hashing.py
+++ b/lib/streamlit/runtime/legacy_caching/hashing.py
@@ -146,7 +146,7 @@ class _HashStack:
     def pretty_print(self):
         def to_str(v):
             try:
-                return "Object of type %s: %s" % (type_util.get_fqn_type(v), str(v))
+                return "Object of type {}: {}".format(type_util.get_fqn_type(v), str(v))
             except Exception:
                 return "<Unable to convert item to string>"
 
@@ -617,7 +617,7 @@ class _CodeHasher:
             if obj.__module__.startswith("streamlit"):
                 # Ignore streamlit modules even if they are in the CWD
                 # (e.g. during development).
-                return self.to_bytes("%s.%s" % (obj.__module__, obj.__name__))
+                return self.to_bytes("{}.{}".format(obj.__module__, obj.__name__))
 
             h = hashlib.new("md5")
 
@@ -790,7 +790,7 @@ class NoResult:
 class UnhashableTypeError(StreamlitAPIException):
     def __init__(self, orig_exc, failed_obj):
         msg = self._get_message(orig_exc, failed_obj)
-        super(UnhashableTypeError, self).__init__(msg)
+        super().__init__(msg)
         self.with_traceback(orig_exc.__traceback__)
 
     def _get_message(self, orig_exc, failed_obj):
@@ -840,7 +840,7 @@ class UserHashError(StreamlitAPIException):
         else:
             msg = self._get_message_from_code(orig_exc, cached_func_or_code, lineno)
 
-        super(UserHashError, self).__init__(msg)
+        super().__init__(msg)
         self.with_traceback(orig_exc.__traceback__)
 
     def _get_message_from_func(self, orig_exc, cached_func, hash_func):
@@ -912,7 +912,7 @@ class InternalHashError(MarkdownFormattedException):
 
     def __init__(self, orig_exc: BaseException, failed_obj: Any):
         msg = self._get_message(orig_exc, failed_obj)
-        super(InternalHashError, self).__init__(msg)
+        super().__init__(msg)
         self.with_traceback(orig_exc.__traceback__)
 
     def _get_message(self, orig_exc: BaseException, failed_obj: Any) -> str:

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -78,11 +78,11 @@ def _get_machine_id_v3() -> str:
 
     machine_id = str(uuid.getnode())
     if os.path.isfile(_ETC_MACHINE_ID_PATH):
-        with open(_ETC_MACHINE_ID_PATH, "r") as f:
+        with open(_ETC_MACHINE_ID_PATH) as f:
             machine_id = f.read()
 
     elif os.path.isfile(_DBUS_MACHINE_ID_PATH):
-        with open(_DBUS_MACHINE_ID_PATH, "r") as f:
+        with open(_DBUS_MACHINE_ID_PATH) as f:
             machine_id = f.read()
 
     return machine_id

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -27,7 +27,7 @@ class MessageSizeError(MarkdownFormattedException):
 
     def __init__(self, failed_msg_str: Any):
         msg = self._get_message(failed_msg_str)
-        super(MessageSizeError, self).__init__(msg)
+        super().__init__(msg)
 
     def _get_message(self, failed_msg_str: Any) -> str:
         # This needs to have zero indentation otherwise the markdown will render incorrectly.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -174,8 +174,7 @@ class WStates(MutableMapping[str, Any]):
         # For this and many other methods, we can't simply delegate to the
         # states field, because we need to invoke `__getitem__` for any
         # values, to handle deserialization and unwrapping of values.
-        for key in self.states:
-            yield key
+        yield from self.states
 
     def keys(self) -> KeysView[str]:
         return KeysView(self.states)

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -40,7 +40,7 @@ class CacheStat(NamedTuple):
     byte_length: int
 
     def to_metric_str(self) -> str:
-        return 'cache_memory_bytes{cache_type="%s",cache="%s"} %s' % (
+        return 'cache_memory_bytes{{cache_type="{}",cache="{}"}} {}'.format(
             self.category_name,
             self.cache_name,
             self.byte_length,

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -46,7 +46,7 @@ class UploadedFile(io.BytesIO):
         # the Python docs - possibly because it's a CPython-only optimization
         # and not guaranteed to be in other Python runtimes. But it's detailed
         # here: https://hg.python.org/cpython/rev/79a5fbe2c78f
-        super(UploadedFile, self).__init__(record.data)
+        super().__init__(record.data)
         self.id = record.id
         self.name = record.name
         self.type = record.type

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -41,7 +41,7 @@ def open_python_file(filename):
         # found, opens as utf-8.
         return tokenize.open(filename)
     else:
-        return open(filename, "r", encoding="utf-8")
+        return open(filename, encoding="utf-8")
 
 
 PAGE_FILENAME_REGEX = re.compile(r"([0-9]*)[_ -]*(.*)\.py")

--- a/lib/streamlit/temporary_directory.py
+++ b/lib/streamlit/temporary_directory.py
@@ -21,7 +21,7 @@ from streamlit import util
 # tempfile.mkdtemp
 
 
-class TemporaryDirectory(object):
+class TemporaryDirectory:
     """Temporary directory context manager.
 
     Creates a temporary directory that exists within the context manager scope.

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -22,9 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
-    List,
     NamedTuple,
-    Optional,
     Sequence,
     TypeVar,
     Union,
@@ -157,11 +155,11 @@ def is_type(
 
 
 @overload
-def is_type(obj: object, fqn_type_pattern: Union[str, re.Pattern[str]]) -> bool:
+def is_type(obj: object, fqn_type_pattern: str | re.Pattern[str]) -> bool:
     ...
 
 
-def is_type(obj: object, fqn_type_pattern: Union[str, re.Pattern[str]]) -> bool:
+def is_type(obj: object, fqn_type_pattern: str | re.Pattern[str]) -> bool:
     """Check type without importing expensive modules.
 
     Parameters
@@ -335,7 +333,7 @@ def is_keras_model(obj: object) -> bool:
     )
 
 
-def is_plotly_chart(obj: object) -> TypeGuard[Union[Figure, list[Any], dict[str, Any]]]:
+def is_plotly_chart(obj: object) -> TypeGuard[Figure | list[Any] | dict[str, Any]]:
     """True if input looks like a Plotly chart."""
     return (
         is_type(obj, "plotly.graph_objs._figure.Figure")
@@ -346,7 +344,7 @@ def is_plotly_chart(obj: object) -> TypeGuard[Union[Figure, list[Any], dict[str,
 
 def is_graphviz_chart(
     obj: object,
-) -> TypeGuard[Union[graphviz.Graph, graphviz.Digraph]]:
+) -> TypeGuard[graphviz.Graph | graphviz.Digraph]:
     """True if input looks like a GraphViz chart."""
     return (
         # GraphViz < 0.18
@@ -519,7 +517,7 @@ def ensure_iterable(obj: DataFrame) -> Iterable[Any]:
     ...
 
 
-def ensure_iterable(obj: Union[DataFrame, Iterable[V_co]]) -> Iterable[Any]:
+def ensure_iterable(obj: DataFrame | Iterable[V_co]) -> Iterable[Any]:
     """Try to convert different formats to something iterable. Most inputs
     are assumed to be iterable, but if we have a DataFrame, we can just
     select the first column to iterate over. If the input is not iterable,
@@ -600,7 +598,7 @@ def pyarrow_table_to_bytes(table: pa.Table) -> bytes:
     return cast(bytes, sink.getvalue().to_pybytes())
 
 
-def _is_colum_type_arrow_incompatible(column: Union[Series, Index]) -> bool:
+def _is_colum_type_arrow_incompatible(column: Series | Index) -> bool:
     """Return True if the column type is known to cause issues during Arrow conversion."""
 
     # Check all columns for mixed types and complex128 type
@@ -614,7 +612,7 @@ def _is_colum_type_arrow_incompatible(column: Union[Series, Index]) -> bool:
 
 
 def fix_arrow_incompatible_column_types(
-    df: DataFrame, selected_columns: Optional[List[str]] = None
+    df: DataFrame, selected_columns: list[str] | None = None
 ) -> DataFrame:
     """Fix column types that are not supported by Arrow table.
 
@@ -700,14 +698,14 @@ def to_key(key: Key) -> str:
     ...
 
 
-def to_key(key: Optional[Key]) -> Optional[str]:
+def to_key(key: Key | None) -> str | None:
     if key is None:
         return None
     else:
         return str(key)
 
 
-def maybe_raise_label_warnings(label: Optional[str], label_visibility: Optional[str]):
+def maybe_raise_label_warnings(label: str | None, label_visibility: str | None):
     if not label:
         _LOGGER.warning(
             "`label` got an empty value. This is discouraged for accessibility "

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -105,7 +105,7 @@ class EventBasedPathWatcher:
         path_watcher.stop_watching_path(self._path, self._on_changed)
 
 
-class _MultiPathWatcher(object):
+class _MultiPathWatcher:
     """Watches multiple paths."""
 
     _singleton: Optional["_MultiPathWatcher"] = None
@@ -127,7 +127,7 @@ class _MultiPathWatcher(object):
         """Constructor."""
         if _MultiPathWatcher._singleton is not None:
             raise RuntimeError("Use .get_singleton() instead")
-        return super(_MultiPathWatcher, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self) -> None:
         """Constructor."""
@@ -218,7 +218,7 @@ class _MultiPathWatcher(object):
             self._observer.join(timeout=5)
 
 
-class WatchedPath(object):
+class WatchedPath:
     """Emits notifications when a single path is modified."""
 
     def __init__(
@@ -254,7 +254,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
     """
 
     def __init__(self) -> None:
-        super(_FolderEventHandler, self).__init__()
+        super().__init__()
         self._watched_paths: Dict[str, WatchedPath] = {}
         self._lock = threading.Lock()  # for watched_paths mutations
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -38,19 +38,19 @@ LOGGER = get_logger(__name__)
 BROWSER_WAIT_TIMEOUT_SEC = 1
 
 NEW_VERSION_TEXT = """
-  %(new_version)s
+  {new_version}
 
   See what's new at https://discuss.streamlit.io/c/announcements
 
   Enter the following command to upgrade:
-  %(prompt)s %(command)s
-""" % {
-    "new_version": click.style(
+  {prompt} {command}
+""".format(
+    new_version=click.style(
         "A new version of Streamlit is available.", fg="blue", bold=True
     ),
-    "prompt": click.style("$", fg="blue"),
-    "command": click.style("pip install streamlit --upgrade", bold=True),
-}
+    prompt=click.style("$", fg="blue"),
+    command=click.style("pip install streamlit --upgrade", bold=True),
+)
 
 
 def _set_up_signal_handler(server: Server) -> None:

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -77,7 +77,7 @@ def _download_remote(main_script_path, url_path):
             resp.raise_for_status()
             fp.write(resp.content)
         except requests.exceptions.RequestException as e:
-            raise click.BadParameter(("Unable to fetch {}.\n{}".format(url_path, e)))
+            raise click.BadParameter("Unable to fetch {}.\n{}".format(url_path, e))
 
 
 @click.group(context_settings={"auto_envvar_prefix": "STREAMLIT"})

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -15,7 +15,6 @@
 import errno
 import logging
 import os
-import socket
 import sys
 from typing import Any, Awaitable, List, Optional
 
@@ -132,7 +131,7 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
             http_server.listen(port, address)
             break  # It worked! So let's break out of the loop.
 
-        except (OSError, socket.error) as e:
+        except OSError as e:
             if e.errno == errno.EADDRINUSE:
                 if server_port_is_manually_set():
                     LOGGER.error("Port %s is already in use", port)
@@ -295,14 +294,12 @@ class Server:
                         {
                             "path": "%s/" % static_path,
                             "default_filename": "index.html",
-                            "get_pages": lambda: set(
-                                [
+                            "get_pages": lambda: {
                                     page_info["page_name"]
                                     for page_info in source_util.get_pages(
                                         self.main_script_path
                                     ).values()
-                                ]
-                            ),
+                            },
                         },
                     ),
                     (make_url_path_regex(base, trailing_slash=False), AddSlashHandler),

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -14,7 +14,6 @@
 
 """st.audio unit tests"""
 
-import io
 import os
 from io import BytesIO
 
@@ -37,7 +36,7 @@ class AudioTest(DeltaGeneratorTestCase):
         """Test st.audio using fake audio bytes."""
 
         # Fake audio data: expect the resultant mimetype to be audio default.
-        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode()
 
         st.audio(fake_audio_data)
 
@@ -128,7 +127,7 @@ class AudioTest(DeltaGeneratorTestCase):
         """Test st.audio raises streamlit warning when sample_rate parameter provided,
         but data is not a numpy array."""
 
-        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode()
         sample_rate = 44100
 
         st.audio(fake_audio_data, sample_rate=sample_rate)
@@ -191,7 +190,7 @@ class AudioTest(DeltaGeneratorTestCase):
     def test_maybe_convert_to_wave_bytes_with_sample_rate(self):
         """Test _maybe_convert_to_wave_bytes works correctly with bytes."""
 
-        fake_audio_data_bytes = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        fake_audio_data_bytes = "\x11\x22\x33\x44\x55\x66".encode()
         sample_rate = 44100
 
         computed_bytes = _maybe_convert_to_wav_bytes(
@@ -221,7 +220,7 @@ class AudioTest(DeltaGeneratorTestCase):
 
         wavfile.write("test.wav", sample_rate, y)
 
-        with io.open("test.wav", "rb") as f:
+        with open("test.wav", "rb") as f:
             st.audio(f)
 
         el = self.get_delta_from_queue().new_element
@@ -254,13 +253,13 @@ class AudioTest(DeltaGeneratorTestCase):
     def test_st_audio_other_inputs(self):
         """Test that our other data types don't result in an error."""
         st.audio(b"bytes_data")
-        st.audio("str_data".encode("utf-8"))
+        st.audio(b"str_data")
         st.audio(BytesIO(b"bytesio_data"))
         st.audio(np.array([0, 1, 2, 3]), sample_rate=44100)
 
     def test_st_audio_options(self):
         """Test st.audio with options."""
-        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        fake_audio_data = "\x11\x22\x33\x44\x55\x66".encode()
         st.audio(fake_audio_data, format="audio/mp3", start_time=10)
 
         el = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -25,7 +25,7 @@ from streamlit.type_util import _LOGGER
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
-class SomeObj(object):
+class SomeObj:
     pass
 
 

--- a/lib/tests/streamlit/elements/echo_test.py
+++ b/lib/tests/streamlit/elements/echo_test.py
@@ -39,7 +39,7 @@ class EchoTest(DeltaGeneratorTestCase):
 
                 print(y)
 
-            class MyClass(object):
+            class MyClass:
                 def do_x(self):
                     pass
 

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -203,7 +203,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         """When the type of the object is type and no docs are defined,
         we expect docs are not available"""
 
-        class MyClass(object):
+        class MyClass:
             pass
 
         st.help(MyClass)

--- a/lib/tests/streamlit/elements/legacy_dataframe_styling_test.py
+++ b/lib/tests/streamlit/elements/legacy_dataframe_styling_test.py
@@ -217,7 +217,7 @@ class LegacyDataFrameStylingTest(DeltaGeneratorTestCase):
         for row in range(len(expected_styles)):
             proto_cell_style = get_cell_style(proto_df, col, row)
             # throw the `repeated CSSStyle styles` into a set of serialized strings
-            cell_styles = set((proto_to_str(css) for css in proto_cell_style.css))
+            cell_styles = {proto_to_str(css) for css in proto_cell_style.css}
             self.assertEqual(expected_styles[row], cell_styles)
 
 

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -163,5 +163,5 @@ This is a test
         )
 
 
-class SomeObj(object):
+class SomeObj:
     pass

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -30,7 +30,7 @@ class VideoTest(DeltaGeneratorTestCase):
         """Test st.video using fake bytes data."""
         # Make up some bytes to pretend we have a video.  The server should not vet
         # the video before sending it to the browser.
-        fake_video_data = "\x12\x10\x35\x44\x55\x66".encode("utf-8")
+        fake_video_data = "\x12\x10\x35\x44\x55\x66".encode()
 
         st.video(fake_video_data)
 
@@ -84,13 +84,13 @@ class VideoTest(DeltaGeneratorTestCase):
     def test_st_video_other_inputs(self):
         """Test that our other data types don't result in an error."""
         st.video(b"bytes_data")
-        st.video("str_data".encode("utf-8"))
+        st.video(b"str_data")
         st.video(BytesIO(b"bytesio_data"))
         st.video(np.array([0, 1, 2, 3]))
 
     def test_st_video_options(self):
         """Test st.video with options."""
-        fake_video_data = "\x11\x22\x33\x44\x55\x66".encode("utf-8")
+        fake_video_data = "\x11\x22\x33\x44\x55\x66".encode()
         st.video(fake_video_data, format="video/mp4", start_time=10)
 
         el = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -270,8 +270,8 @@ class HashTest(unittest.TestCase):
         temp1 = tempfile.NamedTemporaryFile()
         temp2 = tempfile.NamedTemporaryFile()
 
-        with open(__file__, "r") as f:
-            with open(__file__, "r") as g:
+        with open(__file__) as f:
+            with open(__file__) as g:
                 self.assertEqual(get_hash(f), get_hash(g))
 
             self.assertNotEqual(get_hash(f), get_hash(temp1))
@@ -280,7 +280,7 @@ class HashTest(unittest.TestCase):
         self.assertNotEqual(get_hash(temp1), get_hash(temp2))
 
     def test_file_position(self):
-        with open(__file__, "r") as f:
+        with open(__file__) as f:
             h1 = get_hash(f)
             self.assertEqual(h1, get_hash(f))
             f.readline()
@@ -368,7 +368,7 @@ class NotHashableTest(unittest.TestCase):
 
     def test_generator_not_hashable(self):
         with self.assertRaises(UnhashableTypeError):
-            get_hash((x for x in range(1)))
+            get_hash(x for x in range(1))
 
     def test_function_not_hashable(self):
         def foo():

--- a/lib/tests/streamlit/runtime/legacy_caching/caching_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/caching_test.py
@@ -570,7 +570,7 @@ Object of type tests.streamlit.runtime.legacy_caching.caching_test.NotHashable:
         self.assertEqual(list(hf_key_as_type()), list(hf_key_as_str()))
 
     def test_user_hash_error(self):
-        class MyObj(object):
+        class MyObj:
             pass
 
         def bad_hash_func(x):

--- a/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
@@ -181,15 +181,15 @@ class HashTest(unittest.TestCase):
         self.assertNotEqual(get_hash(d2), get_hash(d1))
 
     def test_reduce_(self):
-        class A(object):
+        class A:
             def __init__(self):
                 self.x = [1, 2, 3]
 
-        class B(object):
+        class B:
             def __init__(self):
                 self.x = [1, 2, 3]
 
-        class C(object):
+        class C:
             def __init__(self):
                 self.x = (x for x in range(1))
 
@@ -203,7 +203,7 @@ class HashTest(unittest.TestCase):
 
     def test_generator(self):
         with self.assertRaises(UnhashableTypeError):
-            get_hash((x for x in range(1)))
+            get_hash(x for x in range(1))
 
     def test_hashing_broken_code(self):
         import datetime
@@ -234,7 +234,7 @@ class HashTest(unittest.TestCase):
             self.assertEqual(exc.find(code_msg) >= 0, True)
 
     def test_hash_funcs_acceptable_keys(self):
-        class C(object):
+        class C:
             def __init__(self):
                 self.x = (x for x in range(1))
 
@@ -368,8 +368,8 @@ class HashTest(unittest.TestCase):
         temp1 = tempfile.NamedTemporaryFile()
         temp2 = tempfile.NamedTemporaryFile()
 
-        with open(__file__, "r") as f:
-            with open(__file__, "r") as g:
+        with open(__file__) as f:
+            with open(__file__) as g:
                 self.assertEqual(get_hash(f), get_hash(g))
 
             self.assertNotEqual(get_hash(f), get_hash(temp1))
@@ -378,7 +378,7 @@ class HashTest(unittest.TestCase):
         self.assertNotEqual(get_hash(temp1), get_hash(temp2))
 
     def test_file_position(self):
-        with open(__file__, "r") as f:
+        with open(__file__) as f:
             h1 = get_hash(f)
             self.assertEqual(h1, get_hash(f))
             f.readline()
@@ -590,24 +590,24 @@ class HashTest(unittest.TestCase):
 
         self.assertEqual(
             hash_engine(auth_url),
-            hash_engine("%s=%s" % (url, params_foo)),
+            hash_engine("{}={}".format(url, params_foo)),
         )
         self.assertNotEqual(
-            hash_engine("%s=%s" % (url, params_foo)),
-            hash_engine("%s=%s" % (url, params_bar)),
+            hash_engine("{}={}".format(url, params_foo)),
+            hash_engine("{}={}".format(url, params_bar)),
         )
 
         # Note: False negative because the ordering of the keys affects
         # the hash
         self.assertNotEqual(
-            hash_engine("%s=%s" % (url, params_foo)),
-            hash_engine("%s=%s" % (url, params_foo_order)),
+            hash_engine("{}={}".format(url, params_foo)),
+            hash_engine("{}={}".format(url, params_foo_order)),
         )
 
         # Note: False negative because the keys are case insensitive
         self.assertNotEqual(
-            hash_engine("%s=%s" % (url, params_foo)),
-            hash_engine("%s=%s" % (url, params_foo_caps)),
+            hash_engine("{}={}".format(url, params_foo)),
+            hash_engine("{}={}".format(url, params_foo_caps)),
         )
 
         # Note: False negative because `connect_args` doesn't affect the
@@ -780,7 +780,7 @@ class CodeHashTest(unittest.TestCase):
             print(12)
 
         def code_with_type():
-            type(12)
+            int
 
         self.assertNotEqual(get_hash(code_with_print), get_hash(code_with_type))
 

--- a/lib/tests/streamlit/runtime/media_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/media_file_manager_test.py
@@ -115,9 +115,7 @@ class MediaFileManagerTest(TestCase):
     def test_calculate_file_id(self):
         """Test that file_id generation from data works as expected."""
 
-        fake_bytes = "\x00\x00\xff\x00\x00\xff\x00\x00\xff\x00\x00\xff\x00".encode(
-            "utf-8"
-        )
+        fake_bytes = "\x00\x00\xff\x00\x00\xff\x00\x00\xff\x00\x00\xff\x00".encode()
         test_hash = "2ba850426b188d25adc5a37ad313080c346f5e88e069e0807d0cdb2b"
         self.assertEqual(test_hash, _calculate_file_id(fake_bytes, "media/any"))
 

--- a/lib/tests/streamlit/snowpark_mocks.py
+++ b/lib/tests/streamlit/snowpark_mocks.py
@@ -82,7 +82,7 @@ class DataFrame(_SnowparkDataLikeBaseClass):
     def __init__(
         self, is_map: bool = False, num_of_rows: int = 50000, num_of_cols: int = 4
     ):
-        super(DataFrame, self).__init__(
+        super().__init__(
             is_map=is_map, num_of_rows=num_of_rows, num_of_cols=num_of_cols
         )
 
@@ -97,7 +97,7 @@ class Table(_SnowparkDataLikeBaseClass):
     def __init__(
         self, is_map: bool = False, num_of_rows: int = 50000, num_of_cols: int = 4
     ):
-        super(Table, self).__init__(
+        super().__init__(
             is_map=is_map, num_of_rows=num_of_rows, num_of_cols=num_of_cols
         )
 

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -22,7 +22,7 @@ class PollingPathWatcherTest(unittest.TestCase):
     """Test PollingPathWatcher."""
 
     def setUp(self):
-        super(PollingPathWatcherTest, self).setUp()
+        super().setUp()
         self.util_patch = mock.patch("streamlit.watcher.polling_path_watcher.util")
         self.util_mock = self.util_patch.start()
 
@@ -44,7 +44,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         self.sleep_patch.start()
 
     def tearDown(self):
-        super(PollingPathWatcherTest, self).tearDown()
+        super().tearDown()
         self.util_patch.stop()
         self.executor_patch.stop()
         self.sleep_patch.stop()

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -56,7 +56,7 @@ class UtilTest(unittest.TestCase):
             m.assert_called_once_with("foo", "rb")
 
 
-class FakeStat(object):
+class FakeStat:
     """Emulates the output of os.stat()."""
 
     def __init__(self, mtime):

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -42,7 +42,7 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
     """Tests the /healthz endpoint"""
 
     def setUp(self):
-        super(HealthHandlerTest, self).setUp()
+        super().setUp()
         self._is_healthy = True
 
     async def is_healthy(self):
@@ -157,7 +157,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
 class AllowedMessageOriginsHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def setUp(self):
-        super(AllowedMessageOriginsHandlerTest, self).setUp()
+        super().setUp()
         self._is_healthy = True
 
     async def is_healthy(self):

--- a/lib/tests/streamlit/web/server/stats_handler_test.py
+++ b/lib/tests/streamlit/web/server/stats_handler_test.py
@@ -45,11 +45,11 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(200, response.code)
 
         expected_body = (
-            "# TYPE cache_memory_bytes gauge\n"
-            "# UNIT cache_memory_bytes bytes\n"
-            "# HELP Total memory consumed by a cache.\n"
-            "# EOF\n"
-        ).encode("utf-8")
+            b"# TYPE cache_memory_bytes gauge\n"
+            b"# UNIT cache_memory_bytes bytes\n"
+            b"# HELP Total memory consumed by a cache.\n"
+            b"# EOF\n"
+        )
 
         self.assertEqual(expected_body, response.body)
 
@@ -74,13 +74,13 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         )
 
         expected_body = (
-            "# TYPE cache_memory_bytes gauge\n"
-            "# UNIT cache_memory_bytes bytes\n"
-            "# HELP Total memory consumed by a cache.\n"
-            'cache_memory_bytes{cache_type="st.singleton",cache="foo"} 128\n'
-            'cache_memory_bytes{cache_type="st.memo",cache="bar"} 256\n'
-            "# EOF\n"
-        ).encode("utf-8")
+            b"# TYPE cache_memory_bytes gauge\n"
+            b"# UNIT cache_memory_bytes bytes\n"
+            b"# HELP Total memory consumed by a cache.\n"
+            b'cache_memory_bytes{cache_type="st.singleton",cache="foo"} 128\n'
+            b'cache_memory_bytes{cache_type="st.memo",cache="bar"} 256\n'
+            b"# EOF\n"
+        )
 
         self.assertEqual(expected_body, response.body)
 

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -45,7 +45,7 @@ class StreamlitWriteTest(unittest.TestCase):
     def test_repr_html(self):
         """Test st.write with an object that defines _repr_html_."""
 
-        class FakeHTMLable(object):
+        class FakeHTMLable:
             def _repr_html_(self):
                 return "<strong>hello world</strong>"
 
@@ -117,7 +117,7 @@ class StreamlitWriteTest(unittest.TestCase):
         """Test st.write with altair_chart."""
         is_type.side_effect = make_is_type_mock(type_util._ALTAIR_RE)
 
-        class FakeChart(object):
+        class FakeChart:
             pass
 
         with patch("streamlit.delta_generator.DeltaGenerator.altair_chart") as p:
@@ -130,7 +130,7 @@ class StreamlitWriteTest(unittest.TestCase):
         """Test st.write with matplotlib."""
         is_type.side_effect = make_is_type_mock("matplotlib.figure.Figure")
 
-        class FakePyplot(object):
+        class FakePyplot:
             pass
 
         with patch("streamlit.delta_generator.DeltaGenerator.pyplot") as p:
@@ -225,7 +225,7 @@ class StreamlitWriteTest(unittest.TestCase):
     def test_default_object(self):
         """Test st.write with default clause ie some object."""
 
-        class SomeObject(object):
+        class SomeObject:
             def __str__(self):
                 return "1 * 2 - 3 = 4 `ok` !"
 
@@ -239,7 +239,7 @@ class StreamlitWriteTest(unittest.TestCase):
     def test_class(self):
         """Test st.write with a class."""
 
-        class SomeClass(object):
+        class SomeClass:
             pass
 
         with patch("streamlit.delta_generator.DeltaGenerator.text") as p:

--- a/scripts/mypy
+++ b/scripts/mypy
@@ -52,7 +52,7 @@ class Module:
     @classmethod
     def header(cls) -> str:
         fmt = "%-*s  %-*s  %-*s  %-*s"
-        return ("%s\n%s" % (fmt, fmt)) % tuple(
+        return ("{}\n{}".format(fmt, fmt)) % tuple(
             itertools.chain(
                 *zip(cls._COLUMNS, cls._HEADERS),
                 *zip(cls._COLUMNS, ["-" * len(h) for h in cls._HEADERS]),

--- a/scripts/update_emojis.py
+++ b/scripts/update_emojis.py
@@ -33,7 +33,7 @@ emoji_unicodes = set(EMOJI_DATA.keys())
 
 generated_code = 'ALL_EMOJIS = {"' + '","'.join(sorted(emoji_unicodes)) + '"}'
 
-with open(EMOJIS_SCRIPT_PATH, "r") as file:
+with open(EMOJIS_SCRIPT_PATH) as file:
     script_content = file.read()
 
 updated_script_content = re.sub(EMOJI_SET_REGEX, generated_code, script_content)

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -103,7 +103,7 @@ def update_files(data, version):
             line = re.sub(regex, r"\g<pre>%s\g<post>" % version, line.rstrip())
             print(line)
         if not matched:
-            raise Exception('In file "%s", did not find regex "%s"' % (filename, regex))
+            raise Exception('In file "{}", did not find regex "{}"'.format(filename, regex))
 
 
 def main():


### PR DESCRIPTION
## 📚 Context

Updated Python code to Python 3 syntax (clean up leftover Python 2 code):
- utf-8 encoding is now the default ([PEP 3120](https://www.python.org/dev/peps/pep-3120/), Python 3.0+)
- Replace list comprehensions by Generator Expressions ([PEP 289](https://www.python.org/dev/peps/pep-0289/), Python 2.4+)
- Remove the default subclass `(object)` when defining a class
- Define sets with curly braces `{}` instead of `set()`
- Remove `"r"` parameter from open function, which is default

Used [pyupgrade](https://github.com/asottile/pyupgrade) 3.2.2 as starting point for this PR.

#### What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [x] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
