### PR TITLE
Fix plotly docs example

### DIFF
--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -122,9 +122,6 @@ class PlotlyMixin:
 
         Example
         -------
-
-        The example below comes straight from the examples at
-        https://plot.ly/python:
         >>> import numpy as np
         >>> import plotly.figure_factory as ff
         >>>


### PR DESCRIPTION
## 📚 Context

The most recent update to the docs has introduced an extra newline which causes the example to not format correctly. This removes that new line. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Docs bug fix

## 🧠 Description of Changes

- Remove additional text that causes the example on the plotly streamlit docs page to render incorrectly. 

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

