### PR TITLE
Fix CORS acronym in docstring

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -646,7 +646,7 @@ _create_option(
 _create_option(
     "server.enableCORS",
     description="""
-    Enables support for Cross-Origin Request Sharing (CORS) protection, for added security.
+    Enables support for Cross-Origin Resource Sharing (CORS) protection, for added security.
 
     Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is on and
     `server.enableCORS` is off at the same time, we will prioritize `server.enableXsrfProtection`.


### PR DESCRIPTION
## 📚 Context

Quick fix to the streamlit config docstring for enableCORS option - we had the incorrect full name for CORS 
See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)

- What kind of change does this PR introduce?
  - [x] Bugfix

## 🧠 Description of Changes

- Updated to correct name
  - [x] This is a visible (user-facing) change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
