### PR TITLE
Teach WebsocketConnection how to wait on an external auth token

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -57,6 +57,7 @@ jest.mock("src/lib/ConnectionManager")
 const getHostCommunicationState = (
   extend?: Partial<HostCommunicationState>
 ): HostCommunicationState => ({
+  authTokenPromise: Promise.resolve(undefined),
   forcedModalClose: false,
   hideSidebarNav: false,
   isOwner: true,
@@ -73,7 +74,6 @@ const getHostCommunicationState = (
 const getHostCommunicationProp = (
   extend?: Partial<HostCommunicationHOC>
 ): HostCommunicationHOC => ({
-  claimAuthToken: () => Promise.resolve(undefined),
   currentState: getHostCommunicationState({}),
   onModalReset: jest.fn(),
   onPageChanged: jest.fn(),

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -73,11 +73,13 @@ const getHostCommunicationState = (
 const getHostCommunicationProp = (
   extend?: Partial<HostCommunicationHOC>
 ): HostCommunicationHOC => ({
+  claimAuthToken: () => Promise.resolve(undefined),
   currentState: getHostCommunicationState({}),
   onModalReset: jest.fn(),
   onPageChanged: jest.fn(),
+  resetAuthToken: jest.fn(),
   sendMessage: jest.fn(),
-  setAllowedOrigins: jest.fn(),
+  setAllowedOriginsResp: jest.fn(),
   ...extend,
 })
 
@@ -406,30 +408,6 @@ describe("App", () => {
     expect(
       props.hostCommunication.currentState.requestedPageScriptHash
     ).toBeNull()
-  })
-
-  it("should return the auth token set in hostCommunication from getHostAuthToken", () => {
-    const props = getProps()
-    const wrapper = shallow(<App {...props} />)
-
-    // Use setProps (vs setting the auth token on component rendered) to
-    // simulate the auth token changing after the withHostCommunication hoc
-    // initially loads.
-    wrapper.setProps(
-      getProps({
-        hostCommunication: getHostCommunicationProp({
-          currentState: getHostCommunicationState({
-            authToken: "verySecureAuthToken",
-          }),
-        }),
-      })
-    )
-    wrapper.update()
-
-    const instance = wrapper.instance() as App
-
-    // @ts-ignore
-    expect(instance.getHostAuthToken()).toBe("verySecureAuthToken")
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -280,7 +280,8 @@ export class App extends PureComponent<Props, State> {
       onMessage: this.handleMessage,
       onConnectionError: this.handleConnectionError,
       connectionStateChanged: this.handleConnectionStateChanged,
-      claimHostAuthToken: this.props.hostCommunication.claimAuthToken,
+      claimHostAuthToken: () =>
+        this.props.hostCommunication.currentState.authTokenPromise,
       resetHostAuthToken: this.props.hostCommunication.resetAuthToken,
       setAllowedOriginsResp:
         this.props.hostCommunication.setAllowedOriginsResp,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -280,8 +280,10 @@ export class App extends PureComponent<Props, State> {
       onMessage: this.handleMessage,
       onConnectionError: this.handleConnectionError,
       connectionStateChanged: this.handleConnectionStateChanged,
-      getHostAuthToken: this.getHostAuthToken,
-      setHostAllowedOrigins: this.props.hostCommunication.setAllowedOrigins,
+      claimHostAuthToken: this.props.hostCommunication.claimAuthToken,
+      resetHostAuthToken: this.props.hostCommunication.resetAuthToken,
+      setAllowedOriginsResp:
+        this.props.hostCommunication.setAllowedOriginsResp,
     })
 
     if (isEmbeddedInIFrame()) {
@@ -1171,12 +1173,6 @@ export class App extends PureComponent<Props, State> {
       logError(`Not connected. Cannot send back message: ${msg}`)
     }
   }
-
-  /**
-   * Returns the authToken set by the withHostCommunication hoc.
-   */
-  private getHostAuthToken = (): string | undefined =>
-    this.props.hostCommunication.currentState.authToken
 
   /**
    * Updates the app body when there's a connection error.

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -28,7 +28,6 @@ export type DeployedAppMetadata = {
 }
 
 export interface HostCommunicationState {
-  authToken?: string
   deployedAppMetadata: DeployedAppMetadata
   forcedModalClose: boolean
   hideSidebarNav: boolean
@@ -155,3 +154,8 @@ export type IGuestToHostMessage =
 export type VersionedMessage<Message> = {
   stCommVersion: number
 } & Message
+
+export type IAllowedMessageOriginsResponse = {
+  allowedOrigins: string[]
+  useExternalAuthToken: boolean
+}

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -28,6 +28,7 @@ export type DeployedAppMetadata = {
 }
 
 export interface HostCommunicationState {
+  authTokenPromise: Promise<string | undefined>
   deployedAppMetadata: DeployedAppMetadata
   forcedModalClose: boolean
   hideSidebarNav: boolean

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -349,33 +349,31 @@ describe("withHostCommunication HOC external auth token handling", () => {
   it("resolves promise to undefined immediately if useExternalAuthToken is false", async () => {
     const wrapper = mount(<TestComponent />)
 
-    let authTokenPromise
     const hostCommunication = wrapper
       .find(TestComponentNaked)
       .prop("hostCommunication")
 
     act(() => {
-      authTokenPromise = hostCommunication.claimAuthToken()
       hostCommunication.setAllowedOriginsResp({
         allowedOrigins: ["http://devel.streamlit.test"],
         useExternalAuthToken: false,
       })
     })
 
-    await expect(authTokenPromise).resolves.toBe(undefined)
+    await expect(
+      hostCommunication.currentState.authTokenPromise
+    ).resolves.toBe(undefined)
   })
 
   it("waits to receive SET_AUTH_TOKEN message before resolving promise if useExternalAuthToken is true", async () => {
     const dispatchEvent = mockEventListeners()
     const wrapper = mount(<TestComponent />)
 
-    let authTokenPromise
     let hostCommunication = wrapper
       .find(TestComponentNaked)
       .prop("hostCommunication")
 
     act(() => {
-      authTokenPromise = hostCommunication.claimAuthToken()
       hostCommunication.setAllowedOriginsResp({
         allowedOrigins: ["http://devel.streamlit.test"],
         useExternalAuthToken: true,
@@ -398,7 +396,9 @@ describe("withHostCommunication HOC external auth token handling", () => {
       })
     })
 
-    await expect(authTokenPromise).resolves.toBe("i am an auth token")
+    await expect(
+      hostCommunication.currentState.authTokenPromise
+    ).resolves.toBe("i am an auth token")
 
     act(() => {
       hostCommunication.resetAuthToken()
@@ -413,7 +413,6 @@ describe("withHostCommunication HOC external auth token handling", () => {
     // withHostCommunication hoc's perspective is only seen as a new call to
     // setAllowedOriginsResp.
     act(() => {
-      authTokenPromise = hostCommunication.claimAuthToken()
       hostCommunication.setAllowedOriginsResp({
         allowedOrigins: ["http://devel.streamlit.test"],
         useExternalAuthToken: true,
@@ -436,6 +435,8 @@ describe("withHostCommunication HOC external auth token handling", () => {
       })
     })
 
-    await expect(authTokenPromise).resolves.toBe("i am a NEW auth token")
+    await expect(
+      hostCommunication.currentState.authTokenPromise
+    ).resolves.toBe("i am a NEW auth token")
   })
 })

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -373,6 +373,12 @@ describe("withHostCommunication HOC external auth token handling", () => {
       .find(TestComponentNaked)
       .prop("hostCommunication")
 
+    // Simulate receiving a response from the Streamlit server's
+    // `/st-allowed-message-origins` endpoint. Notably, the
+    // useExternalAuthToken field in the response body is set to true, which
+    // signals that the withHostCommunication hoc should wait to receive a
+    // SET_AUTH_TOKEN message before resolving authTokenPromise to the token
+    // in the message payload.
     act(() => {
       hostCommunication.setAllowedOriginsResp({
         allowedOrigins: ["http://devel.streamlit.test"],
@@ -380,6 +386,9 @@ describe("withHostCommunication HOC external auth token handling", () => {
       })
     })
 
+    // Asynchronously send a SET_AUTH_TOKEN message to the
+    // withHostCommunication hoc, which won't proceed past the `await`
+    // statement below until the message is received and handled.
     setTimeout(() => {
       act(() => {
         dispatchEvent(
@@ -400,6 +409,8 @@ describe("withHostCommunication HOC external auth token handling", () => {
       hostCommunication.currentState.authTokenPromise
     ).resolves.toBe("i am an auth token")
 
+    // Reset the auth token and do everything again to confirm that we don't
+    // incorrectly resolve to an old value after resetAuthToken is called.
     act(() => {
       hostCommunication.resetAuthToken()
     })

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.test.tsx
@@ -78,7 +78,10 @@ describe("withHostCommunication HOC", () => {
       .prop("hostCommunication")
 
     act(() => {
-      hostCommunication.setAllowedOrigins(["https://devel.streamlit.test"])
+      hostCommunication.setAllowedOriginsResp({
+        allowedOrigins: ["https://devel.streamlit.test"],
+        useExternalAuthToken: false,
+      })
     })
   })
 })
@@ -87,7 +90,6 @@ describe("withHostCommunication HOC receiving messages", () => {
   let dispatchEvent: any
   let originalHash: any
   let wrapper: any
-  let hostCommunication: any
 
   beforeEach(() => {
     // We need to save and restore window.location.hash for each test because
@@ -97,12 +99,15 @@ describe("withHostCommunication HOC receiving messages", () => {
     dispatchEvent = mockEventListeners()
     wrapper = mount(<TestComponent />)
 
-    hostCommunication = wrapper
+    const hostCommunication = wrapper
       .find(TestComponentNaked)
       .prop("hostCommunication")
 
     act(() => {
-      hostCommunication.setAllowedOrigins(["http://devel.streamlit.test"])
+      hostCommunication.setAllowedOriginsResp({
+        allowedOrigins: ["http://devel.streamlit.test"],
+        useExternalAuthToken: false,
+      })
     })
   })
 
@@ -256,31 +261,17 @@ describe("withHostCommunication HOC receiving messages", () => {
     )
   })
 
-  it("can process a received SET_AUTH_TOKEN message", () => {
-    act(() => {
-      dispatchEvent(
-        "message",
-        new MessageEvent("message", {
-          data: {
-            stCommVersion: HOST_COMM_VERSION,
-            type: "SET_AUTH_TOKEN",
-            authToken: "i am an auth token",
-          },
-          origin: "http://devel.streamlit.test",
-        })
-      )
-    })
-
-    wrapper.update()
-
-    const props = wrapper.find(TestComponentNaked).prop("hostCommunication")
-    expect(props.currentState.authToken).toBe("i am an auth token")
-  })
-
   describe("Test different origins", () => {
     it("exact pattern", () => {
+      const hostCommunication = wrapper
+        .find(TestComponentNaked)
+        .prop("hostCommunication")
+
       act(() => {
-        hostCommunication.setAllowedOrigins(["http://share.streamlit.io"])
+        hostCommunication.setAllowedOriginsResp({
+          allowedOrigins: ["http://share.streamlit.io"],
+          useExternalAuthToken: false,
+        })
       })
 
       dispatchEvent(
@@ -299,8 +290,15 @@ describe("withHostCommunication HOC receiving messages", () => {
     })
 
     it("wildcard pattern", () => {
+      const hostCommunication = wrapper
+        .find(TestComponentNaked)
+        .prop("hostCommunication")
+
       act(() => {
-        hostCommunication.setAllowedOrigins(["http://*.streamlitapp.com"])
+        hostCommunication.setAllowedOriginsResp({
+          allowedOrigins: ["http://*.streamlitapp.com"],
+          useExternalAuthToken: false,
+        })
       })
 
       dispatchEvent(
@@ -319,8 +317,15 @@ describe("withHostCommunication HOC receiving messages", () => {
     })
 
     it("ignores non-matching origins", () => {
+      const hostCommunication = wrapper
+        .find(TestComponentNaked)
+        .prop("hostCommunication")
+
       act(() => {
-        hostCommunication.setAllowedOrigins(["http://share.streamlit.io"])
+        hostCommunication.setAllowedOriginsResp({
+          allowedOrigins: ["http://share.streamlit.io"],
+          useExternalAuthToken: false,
+        })
       })
 
       dispatchEvent(
@@ -337,5 +342,100 @@ describe("withHostCommunication HOC receiving messages", () => {
 
       expect(window.location.hash).toEqual("")
     })
+  })
+})
+
+describe("withHostCommunication HOC external auth token handling", () => {
+  it("resolves promise to undefined immediately if useExternalAuthToken is false", async () => {
+    const wrapper = mount(<TestComponent />)
+
+    let authTokenPromise
+    const hostCommunication = wrapper
+      .find(TestComponentNaked)
+      .prop("hostCommunication")
+
+    act(() => {
+      authTokenPromise = hostCommunication.claimAuthToken()
+      hostCommunication.setAllowedOriginsResp({
+        allowedOrigins: ["http://devel.streamlit.test"],
+        useExternalAuthToken: false,
+      })
+    })
+
+    await expect(authTokenPromise).resolves.toBe(undefined)
+  })
+
+  it("waits to receive SET_AUTH_TOKEN message before resolving promise if useExternalAuthToken is true", async () => {
+    const dispatchEvent = mockEventListeners()
+    const wrapper = mount(<TestComponent />)
+
+    let authTokenPromise
+    let hostCommunication = wrapper
+      .find(TestComponentNaked)
+      .prop("hostCommunication")
+
+    act(() => {
+      authTokenPromise = hostCommunication.claimAuthToken()
+      hostCommunication.setAllowedOriginsResp({
+        allowedOrigins: ["http://devel.streamlit.test"],
+        useExternalAuthToken: true,
+      })
+    })
+
+    setTimeout(() => {
+      act(() => {
+        dispatchEvent(
+          "message",
+          new MessageEvent("message", {
+            data: {
+              stCommVersion: HOST_COMM_VERSION,
+              type: "SET_AUTH_TOKEN",
+              authToken: "i am an auth token",
+            },
+            origin: "http://devel.streamlit.test",
+          })
+        )
+      })
+    })
+
+    await expect(authTokenPromise).resolves.toBe("i am an auth token")
+
+    act(() => {
+      hostCommunication.resetAuthToken()
+    })
+    wrapper.update()
+
+    hostCommunication = wrapper
+      .find(TestComponentNaked)
+      .prop("hostCommunication")
+
+    // Simulate the browser tab disconnecting and reconnecting, which from the
+    // withHostCommunication hoc's perspective is only seen as a new call to
+    // setAllowedOriginsResp.
+    act(() => {
+      authTokenPromise = hostCommunication.claimAuthToken()
+      hostCommunication.setAllowedOriginsResp({
+        allowedOrigins: ["http://devel.streamlit.test"],
+        useExternalAuthToken: true,
+      })
+    })
+
+    setTimeout(() => {
+      act(() => {
+        dispatchEvent(
+          "message",
+          new MessageEvent("message", {
+            data: {
+              stCommVersion: HOST_COMM_VERSION,
+              type: "SET_AUTH_TOKEN",
+              authToken: "i am a NEW auth token",
+            },
+            origin: "http://devel.streamlit.test",
+          })
+        )
+      })
+    })
+
+    await expect(authTokenPromise).resolves.toBe("i am a NEW auth token")
   })
 })

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -30,7 +30,6 @@ import {
 } from "./types"
 
 export interface HostCommunicationHOC {
-  claimAuthToken: () => Promise<string | undefined>
   currentState: HostCommunicationState
   onModalReset: () => void
   onPageChanged: () => void
@@ -190,6 +189,7 @@ function withHostCommunication(
         hostCommunication={
           {
             currentState: {
+              authTokenPromise: deferredAuthToken.promise,
               forcedModalClose,
               hideSidebarNav,
               isOwner,
@@ -201,7 +201,6 @@ function withHostCommunication(
               deployedAppMetadata,
               toolbarItems,
             },
-            claimAuthToken: () => deferredAuthToken.promise,
             resetAuthToken: () => {
               setDeferredAuthToken(createDeferredValue())
             },

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -144,6 +144,11 @@ function withHostCommunication(
         }
 
         if (message.type === "SET_AUTH_TOKEN") {
+          // NOTE: The edge case (that should technically never happen) where
+          // useExternalAuthToken is false but we still receive this message
+          // type isn't an issue here because resolving a promise a second time
+          // is a no-op, and we already resolved the promise to undefined
+          // above.
           deferredAuthToken.resolve(message.authToken)
         }
 

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ReactNode } from "react"
 
 import { BackMsg, ForwardMsg } from "src/autogen/proto"
+import { IAllowedMessageOriginsResponse } from "src/hocs/withHostCommunication/types"
 import { BaseUriParts, getPossibleBaseUris } from "src/lib/UriUtil"
-import { ReactNode } from "react"
 
 import { ConnectionState } from "./ConnectionState"
 import { logError } from "./log"
@@ -52,13 +53,19 @@ interface Props {
    * Function to get the auth token set by the host of this app (if in a
    * relevant deployment scenario).
    */
-  getHostAuthToken: () => string | undefined
+  claimHostAuthToken: () => Promise<string | undefined>
+
+  /**
+   * Function to tell the withHostCommunication hoc that we've received
+   * the auth token set by the host of this app.
+   */
+  resetHostAuthToken: () => void
 
   /**
    * Function to set the list of origins that this app should accept
    * cross-origin messages from (if in a relevant deployment scenario).
    */
-  setHostAllowedOrigins: (allowedOrigins: string[]) => void
+  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void
 }
 
 /**
@@ -164,8 +171,9 @@ export class ConnectionManager {
       onMessage: this.props.onMessage,
       onConnectionStateChange: this.setConnectionState,
       onRetry: this.showRetryError,
-      getHostAuthToken: this.props.getHostAuthToken,
-      setHostAllowedOrigins: this.props.setHostAllowedOrigins,
+      claimHostAuthToken: this.props.claimHostAuthToken,
+      resetHostAuthToken: this.props.resetHostAuthToken,
+      setAllowedOriginsResp: this.props.setAllowedOriginsResp,
     })
   }
 }

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -56,8 +56,9 @@ interface Props {
   claimHostAuthToken: () => Promise<string | undefined>
 
   /**
-   * Function to tell the withHostCommunication hoc that we've received
-   * the auth token set by the host of this app.
+   * Function to clear the withHostCommunication hoc's auth token. This should
+   * be called after the promise returned by claimHostAuthToken successfully
+   * resolves.
    */
   resetHostAuthToken: () => void
 

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -31,6 +31,7 @@ import { zip } from "lodash"
 const MOCK_ALLOWED_ORIGINS_RESPONSE = {
   data: {
     allowedOrigins: ["list", "of", "allowed", "origins"],
+    useExternalAuthToken: false,
   },
 }
 
@@ -43,7 +44,7 @@ describe("doInitPings", () => {
     timeoutMs: 10,
     maxTimeoutMs: 100,
     retryCallback: jest.fn(),
-    setHostAllowedOrigins: jest.fn(),
+    setAllowedOriginsResp: jest.fn(),
     userCommandLine: "streamlit run not-a-real-script.py",
   }
 
@@ -54,7 +55,7 @@ describe("doInitPings", () => {
     originalAxiosGet = axios.get
     axios.get = jest.fn()
     MOCK_PING_DATA.retryCallback = jest.fn()
-    MOCK_PING_DATA.setHostAllowedOrigins = jest.fn()
+    MOCK_PING_DATA.setAllowedOriginsResp = jest.fn()
     originalPromiseAll = Promise.all
   })
 
@@ -80,12 +81,12 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
-    expect(MOCK_PING_DATA.setHostAllowedOrigins).toHaveBeenCalledWith(
-      MOCK_ALLOWED_ORIGINS_RESPONSE.data.allowedOrigins
+    expect(MOCK_PING_DATA.setAllowedOriginsResp).toHaveBeenCalledWith(
+      MOCK_ALLOWED_ORIGINS_RESPONSE.data
     )
   })
 
@@ -99,12 +100,12 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
-    expect(MOCK_PING_DATA.setHostAllowedOrigins).toHaveBeenCalledWith(
-      MOCK_ALLOWED_ORIGINS_RESPONSE.data.allowedOrigins
+    expect(MOCK_PING_DATA.setAllowedOriginsResp).toHaveBeenCalledWith(
+      MOCK_ALLOWED_ORIGINS_RESPONSE.data
     )
   })
 
@@ -119,12 +120,12 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(1)
-    expect(MOCK_PING_DATA.setHostAllowedOrigins).toHaveBeenCalledWith(
-      MOCK_ALLOWED_ORIGINS_RESPONSE.data.allowedOrigins
+    expect(MOCK_PING_DATA.setAllowedOriginsResp).toHaveBeenCalledWith(
+      MOCK_ALLOWED_ORIGINS_RESPONSE.data
     )
   })
 
@@ -142,7 +143,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -167,7 +168,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -196,7 +197,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -223,7 +224,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -274,7 +275,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA_LOCALHOST.retryCallback,
-      MOCK_PING_DATA_LOCALHOST.setHostAllowedOrigins,
+      MOCK_PING_DATA_LOCALHOST.setAllowedOriginsResp,
       MOCK_PING_DATA_LOCALHOST.userCommandLine
     )
 
@@ -314,7 +315,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -344,7 +345,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -373,7 +374,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -407,7 +408,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -450,7 +451,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -489,7 +490,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -507,7 +508,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
-      MOCK_PING_DATA.setHostAllowedOrigins,
+      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -529,8 +530,9 @@ describe("WebsocketConnection", () => {
     onMessage: jest.fn(),
     onConnectionStateChange: jest.fn(),
     onRetry: jest.fn(),
-    getHostAuthToken: () => undefined,
-    setHostAllowedOrigins: jest.fn(),
+    claimHostAuthToken: () => Promise.resolve(undefined),
+    resetHostAuthToken: jest.fn(),
+    setAllowedOriginsResp: jest.fn(),
   }
 
   let client: WebsocketConnection
@@ -616,8 +618,9 @@ describe("WebsocketConnection auth token handling", () => {
     onMessage: jest.fn(),
     onConnectionStateChange: jest.fn(),
     onRetry: jest.fn(),
-    getHostAuthToken: jest.fn(),
-    setHostAllowedOrigins: jest.fn(),
+    claimHostAuthToken: () => Promise.resolve(undefined),
+    resetHostAuthToken: jest.fn(),
+    setAllowedOriginsResp: jest.fn(),
   }
 
   let originalAxiosGet: any
@@ -634,27 +637,35 @@ describe("WebsocketConnection auth token handling", () => {
     axios.get = originalAxiosGet
   })
 
-  it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", () => {
-    const ws = new WebsocketConnection(MOCK_SOCKET_DATA)
+  it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", async () => {
+    const resetHostAuthToken = jest.fn()
+    const ws = new WebsocketConnection({
+      ...MOCK_SOCKET_DATA,
+      resetHostAuthToken,
+    })
     // @ts-ignore
-    ws.connectToWebSocket()
+    await ws.connectToWebSocket()
 
     expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
       "streamlit",
     ])
+    expect(resetHostAuthToken).toHaveBeenCalledTimes(1)
   })
 
-  it("sets second Sec-WebSocket-Protocol option to value from getHostAuthToken", () => {
+  it("sets second Sec-WebSocket-Protocol option to value from claimHostAuthToken", async () => {
+    const resetHostAuthToken = jest.fn()
     const ws = new WebsocketConnection({
       ...MOCK_SOCKET_DATA,
-      getHostAuthToken: () => "iAmAnAuthToken",
+      claimHostAuthToken: () => Promise.resolve("iAmAnAuthToken"),
+      resetHostAuthToken,
     })
     // @ts-ignore
-    ws.connectToWebSocket()
+    await ws.connectToWebSocket()
 
     expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
       "streamlit",
       "iAmAnAuthToken",
     ])
+    expect(resetHostAuthToken).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -373,6 +373,7 @@ export class WebsocketConnection {
     // to the frame containing the Streamlit app.
     return this.args.claimHostAuthToken().then(hostAuthToken => {
       this.args.resetHostAuthToken()
+      logMessage(LOG, "creating WebSocket")
 
       // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
       // parameter to the WebSocket constructor) here in a slightly unfortunate

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -15,9 +15,10 @@
  */
 
 import styled from "@emotion/styled"
-import { BackMsg, ForwardMsg, IBackMsg } from "src/autogen/proto"
-
 import axios from "axios"
+
+import { BackMsg, ForwardMsg, IBackMsg } from "src/autogen/proto"
+import { IAllowedMessageOriginsResponse } from "src/hocs/withHostCommunication/types"
 import { ConnectionState } from "src/lib/ConnectionState"
 import { ForwardMsgCache } from "src/lib/ForwardMessageCache"
 import { logError, logMessage, logWarning } from "src/lib/log"
@@ -106,13 +107,19 @@ interface Args {
    * Function to get the auth token set by the host of this app (if in a
    * relevant deployment scenario).
    */
-  getHostAuthToken: () => string | undefined
+  claimHostAuthToken: () => Promise<string | undefined>
+
+  /**
+   * Function to tell the withHostCommunication hoc that we've received
+   * the auth token set by the host of this app.
+   */
+  resetHostAuthToken: () => void
 
   /**
    * Function to set the list of origins that this app should accept
    * cross-origin messages from (if in a relevant deployment scenario).
    */
-  setHostAllowedOrigins: (allowedOrigins: string[]) => void
+  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void
 }
 
 interface MessageQueue {
@@ -342,14 +349,14 @@ export class WebsocketConnection {
       PING_MINIMUM_RETRY_PERIOD_MS,
       PING_MAXIMUM_RETRY_PERIOD_MS,
       this.args.onRetry,
-      this.args.setHostAllowedOrigins,
+      this.args.setAllowedOriginsResp,
       userCommandLine
     )
 
     this.stepFsm("SERVER_PING_SUCCEEDED")
   }
 
-  private connectToWebSocket(): void {
+  private connectToWebSocket(): Promise<void> {
     const uri = buildWsUri(
       this.args.baseUriPartsList[this.uriIndex],
       WEBSOCKET_STREAM_PATH
@@ -361,63 +368,67 @@ export class WebsocketConnection {
       throw new Error("Websocket already exists")
     }
 
-    logMessage(LOG, "creating WebSocket")
+    // claimHostAuthToken resolves to undefined immediately in deployment
+    // scenarios where we don't expect an external auth token to be passed down
+    // to the frame containing the Streamlit app.
+    return this.args.claimHostAuthToken().then(hostAuthToken => {
+      this.args.resetHostAuthToken()
 
-    // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
-    // parameter to the WebSocket constructor) here in a slightly unfortunate
-    // but necessary way. The browser WebSocket API doesn't allow us to set
-    // arbitrary HTTP headers, and this header is the only one where we have
-    // the ability to set it to arbitrary values. Thus, we use it to pass an
-    // auth token from client to server as the *second* value in the list.
-    //
-    // The reason why the auth token is set as the second value is that, when
-    // Sec-WebSocket-Protocol is set, many clients expect the server to respond
-    // with a selected subprotocol to use. We don't want that reply to be the
-    // auth token, so we just hard-code it to "streamlit".
-    const hostAuthToken = this.args.getHostAuthToken()
-    this.websocket = new WebSocket(uri, [
-      "streamlit",
-      ...(hostAuthToken ? [hostAuthToken] : []),
-    ])
-    this.websocket.binaryType = "arraybuffer"
+      // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
+      // parameter to the WebSocket constructor) here in a slightly unfortunate
+      // but necessary way. The browser WebSocket API doesn't allow us to set
+      // arbitrary HTTP headers, and this header is the only one where we have
+      // the ability to set it to arbitrary values. Thus, we use it to pass an
+      // auth token from client to server as the *second* value in the list.
+      //
+      // The reason why the auth token is set as the second value is that, when
+      // Sec-WebSocket-Protocol is set, many clients expect the server to respond
+      // with a selected subprotocol to use. We don't want that reply to be the
+      // auth token, so we just hard-code it to "streamlit".
+      this.websocket = new WebSocket(uri, [
+        "streamlit",
+        ...(hostAuthToken ? [hostAuthToken] : []),
+      ])
+      this.websocket.binaryType = "arraybuffer"
 
-    this.setConnectionTimeout(uri)
+      this.setConnectionTimeout(uri)
 
-    const localWebsocket = this.websocket
-    const checkWebsocket = (): boolean => localWebsocket === this.websocket
+      const localWebsocket = this.websocket
+      const checkWebsocket = (): boolean => localWebsocket === this.websocket
 
-    this.websocket.onmessage = (event: MessageEvent) => {
-      if (checkWebsocket()) {
-        this.handleMessage(event.data).catch(reason => {
-          const err = `Failed to process a Websocket message (${reason})`
-          logError(LOG, err)
-          this.stepFsm("FATAL_ERROR", err)
-        })
+      this.websocket.onmessage = (event: MessageEvent) => {
+        if (checkWebsocket()) {
+          this.handleMessage(event.data).catch(reason => {
+            const err = `Failed to process a Websocket message (${reason})`
+            logError(LOG, err)
+            this.stepFsm("FATAL_ERROR", err)
+          })
+        }
       }
-    }
 
-    this.websocket.onopen = () => {
-      if (checkWebsocket()) {
-        logMessage(LOG, "WebSocket onopen")
-        this.stepFsm("CONNECTION_SUCCEEDED")
+      this.websocket.onopen = () => {
+        if (checkWebsocket()) {
+          logMessage(LOG, "WebSocket onopen")
+          this.stepFsm("CONNECTION_SUCCEEDED")
+        }
       }
-    }
 
-    this.websocket.onclose = () => {
-      if (checkWebsocket()) {
-        logWarning(LOG, "WebSocket onclose")
-        this.cancelConnectionAttempt()
-        this.stepFsm("CONNECTION_CLOSED")
+      this.websocket.onclose = () => {
+        if (checkWebsocket()) {
+          logWarning(LOG, "WebSocket onclose")
+          this.cancelConnectionAttempt()
+          this.stepFsm("CONNECTION_CLOSED")
+        }
       }
-    }
 
-    this.websocket.onerror = () => {
-      if (checkWebsocket()) {
-        logError(LOG, "WebSocket onerror")
-        this.cancelConnectionAttempt()
-        this.stepFsm("CONNECTION_ERROR")
+      this.websocket.onerror = () => {
+        if (checkWebsocket()) {
+          logError(LOG, "WebSocket onerror")
+          this.cancelConnectionAttempt()
+          this.stepFsm("CONNECTION_ERROR")
+        }
       }
-    }
+    })
   }
 
   private setConnectionTimeout(uri: string): void {
@@ -558,7 +569,7 @@ export function doInitPings(
   minimumTimeoutMs: number,
   maximumTimeoutMs: number,
   retryCallback: OnRetry,
-  setHostAllowedOrigins: (allowedOrigins: string[]) => void,
+  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void,
   userCommandLine?: string
 ): Promise<number> {
   const resolver = new Resolver<number>()
@@ -665,7 +676,7 @@ export function doInitPings(
       axios.get(allowedOriginsUri, { timeout: minimumTimeoutMs }),
     ])
       .then(([_, originsResp]) => {
-        setHostAllowedOrigins(originsResp.data.allowedOrigins)
+        setAllowedOriginsResp(originsResp.data)
         resolver.resolve(uriNumber)
       })
       .catch(error => {

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -110,8 +110,9 @@ interface Args {
   claimHostAuthToken: () => Promise<string | undefined>
 
   /**
-   * Function to tell the withHostCommunication hoc that we've received
-   * the auth token set by the host of this app.
+   * Function to clear the withHostCommunication hoc's auth token. This should
+   * be called after the promise returned by claimHostAuthToken successfully
+   * resolves.
    */
   resetHostAuthToken: () => void
 
@@ -356,7 +357,7 @@ export class WebsocketConnection {
     this.stepFsm("SERVER_PING_SUCCEEDED")
   }
 
-  private connectToWebSocket(): Promise<void> {
+  private async connectToWebSocket(): Promise<void> {
     const uri = buildWsUri(
       this.args.baseUriPartsList[this.uriIndex],
       WEBSOCKET_STREAM_PATH
@@ -371,7 +372,7 @@ export class WebsocketConnection {
     // claimHostAuthToken resolves to undefined immediately in deployment
     // scenarios where we don't expect an external auth token to be passed down
     // to the frame containing the Streamlit app.
-    return this.args.claimHostAuthToken().then(hostAuthToken => {
+    await this.args.claimHostAuthToken().then(hostAuthToken => {
       this.args.resetHostAuthToken()
       logMessage(LOG, "creating WebSocket")
 

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -213,7 +213,12 @@ class AllowedMessageOriginsHandler(_SpecialRequestHandler):
             # disallows writing lists directly into responses due to potential XSS
             # vulnerabilities.
             # See https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write
-            self.write({"allowedOrigins": ALLOWED_MESSAGE_ORIGINS})
+            self.write(
+                {
+                    "allowedOrigins": ALLOWED_MESSAGE_ORIGINS,
+                    "useExternalAuthToken": False,
+                }
+            )
             self.set_status(200)
 
             if config.get_option("server.enableXsrfProtection"):

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -178,7 +178,8 @@ class AllowedMessageOriginsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         response = self.fetch("/st-allowed-message-origins")
         self.assertEqual(200, response.code)
         self.assertEqual(
-            {"allowedOrigins": ALLOWED_MESSAGE_ORIGINS}, json.loads(response.body)
+            {"allowedOrigins": ALLOWED_MESSAGE_ORIGINS, "useExternalAuthToken": False},
+            json.loads(response.body),
         )
 
     # NOTE: Temporary tests to verify this endpoint can also act as a healthcheck


### PR DESCRIPTION
## 📚 Context

There's currently a race condition that appears when using an external auth token passed to the
streamlit web client. The race is between the auth token actually making it to the iframed streamlit
app before it attempts to establish a websocket connection. What generally happens is that the first
attempt to establish the websocket connection is done without having received the token, which
results in a failed connection attempt. The next retry about 500ms later then succeeds (most
of the time, although the asynchronous nature of all of this makes it hard to guarantee when the
token is received), but both the extra round-trip and notable startup delay are annoying.

This PR fixes this problem by adding a new field to the `/st-allowed-message-origins` response body.
The `useExternalAuthToken` field (which for now will always be set to `False` in the pure open source
world) is used by the client to decide whether to wait for an auth token to be received from the parent
frame before attempting to establish a websocket connection to the Streamlit server.

If `useExternalAuthToken` is `False`, the client immediately attempts to establish a websocket
connection. Otherwise, it waits until a promise resolves to the auth token before proceeding.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests
