### PR TITLE
Add CI tests to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  run-python-tests:
+    uses: ./.github/workflows/python-versions.yml
+    with:
+      ref: ${{ github.ref_name }}
+
+  run-javascript-tests:
+    uses: ./.github/workflows/js-tests.yml
+    with:
+      ref: ${{ github.ref_name }}
+
+  run-py-prod-deps-smoke-test:
+    uses: ./.github/workflows/py-prod-deps-smoke-test.yml
+    with:
+      ref: ${{ github.ref_name }}
+
+  run-cypress-tests:
+    uses: ./.github/workflows/cypress.yml
+    with:
+      ref: ${{ github.ref_name }}
+
   build-release:
     runs-on: ubuntu-latest
+
+    needs: [run-python-tests, run-javascript-tests, run-py-prod-deps-smoke-test, run-cypress-tests]
 
     defaults:
       run:


### PR DESCRIPTION
## 📚 Context

Revised release process will not always include a release candidate prior, so adding the checks to the release workflow as well. Previously, we specifically decided to only include the required CI checks on the release candidate. 

- What kind of change does this PR introduce?
  - [x] Refactoring

## 🧠 Description of Changes

- Add required CI checks for merge to `release.yml`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
