### PR TITLE
Fix snowpark integration test workflow

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -64,9 +64,8 @@ jobs:
 
     # Won't run if PR from fork or by dependabot, since that PR wouldn't have secrets access
     # See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-    if: | 
+    if: |
         github.repository == 'streamlit/streamlit' && (
-        
         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') ||
         (github.event_name == 'push') ||
         (github.event_name == 'workflow_dispatch')

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -62,7 +62,8 @@ jobs:
   py_snowflake:
     runs-on: ubuntu-latest
 
-    if: github.repository == 'streamlit/streamlit'
+    # Won't run if PR from fork, since that PR wouldn't have secrets access
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Won't run if PR from fork, since that PR wouldn't have secrets access
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Won't run if PR from fork, since that PR wouldn't have secrets access
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository == 'streamlit/streamlit' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository ) }}
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -62,8 +62,15 @@ jobs:
   py_snowflake:
     runs-on: ubuntu-latest
 
-    # Won't run if PR from fork, since that PR wouldn't have secrets access
-    if: ${{ github.repository == 'streamlit/streamlit' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository ) }}
+    # Won't run if PR from fork or by dependabot, since that PR wouldn't have secrets access
+    # See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+    if: | 
+        github.repository == 'streamlit/streamlit' && (
+        
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') ||
+        (github.event_name == 'push') ||
+        (github.event_name == 'workflow_dispatch')
+        )
 
     steps:
       - name: Checkout Streamlit code


### PR DESCRIPTION
## 📚 Context

The snowpark integration test in `python-versons.yml` will fail for all forks because forks don't have secrets access - necessary for the `Decrypt credentials` step in `py_snowpark`. This adjusts the if statement to check if the PR is coming from a fork.

- What kind of change does this PR introduce?
  - [x] Other, please describe: Test Fix

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
