### PR TITLE
memo_test/singleton_test: ensure ScriptRunCtx exists

### DIFF
--- a/lib/tests/streamlit/runtime/caching/singleton_test.py
+++ b/lib/tests/streamlit/runtime/caching/singleton_test.py
@@ -25,10 +25,12 @@ import streamlit as st
 from streamlit.runtime.caching import get_singleton_stats_provider, singleton_decorator
 from streamlit.runtime.caching.cache_errors import CacheType
 from streamlit.runtime.caching.cache_utils import MultiCacheResults
+from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.runtime.stats import CacheStat
 from tests.streamlit.runtime.caching.common_cache_test import (
     as_cached_result as _as_cached_result,
 )
+from tests.testutil import create_mock_script_run_ctx
 
 
 def as_cached_result(value: Any) -> MultiCacheResults:
@@ -36,6 +38,10 @@ def as_cached_result(value: Any) -> MultiCacheResults:
 
 
 class SingletonTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
     def tearDown(self):
         st.experimental_singleton.clear()
         # Some of these tests reach directly into _cache_info and twiddle it.
@@ -69,6 +75,9 @@ class SingletonStatsProviderTest(unittest.TestCase):
         # Guard against external tests not properly cache-clearing
         # in their teardowns.
         st.experimental_singleton.clear()
+
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
 
     def tearDown(self):
         st.experimental_singleton.clear()

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 def create_mock_script_run_ctx() -> ScriptRunContext:
-    """Create a ScriptRunContext for testing with."""
+    """Create a ScriptRunContext for use in tests."""
     return ScriptRunContext(
         session_id="mock_session_id",
         _enqueue=lambda msg: None,

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -19,10 +19,26 @@ from typing import TYPE_CHECKING, Any, Dict
 from unittest.mock import patch
 
 from streamlit import config
+from streamlit.runtime.scriptrunner import ScriptRunContext
+from streamlit.runtime.state import SafeSessionState, SessionState
+from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from tests.constants import SNOWFLAKE_CREDENTIAL_FILE
 
 if TYPE_CHECKING:
     from snowflake.snowpark import Session
+
+
+def create_mock_script_run_ctx() -> ScriptRunContext:
+    """Create a ScriptRunContext for testing with."""
+    return ScriptRunContext(
+        session_id="mock_session_id",
+        _enqueue=lambda msg: None,
+        query_string="mock_query_string",
+        session_state=SafeSessionState(SessionState()),
+        uploaded_file_mgr=UploadedFileManager(),
+        page_script_hash="mock_page_script_hash",
+        user_info={"email": "mock@test.com"},
+    )
 
 
 @contextmanager


### PR DESCRIPTION
Our new cache function "widget replay" functionality relies on a `ScriptRunContext` existing: without a `ScriptRunContext`, no values will be written to the cached function.

Some of our caching tests don't create a `ScriptRunContext`. Running these tests in isolation (outside of the full test suite) currently results in test failures due to a missing context. (When run as part of the full test suite, some other ScriptRunContext-creating test will run first, which is why they don't fail in that circumstance.)
