### PR TITLE
Wrap type in quotes to support lower versions of protobuf

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -39,7 +39,7 @@ INSTALL_REQUIRES = [
     "packaging>=14.1",
     "pandas>=0.21.0",
     "pillow>=6.2.0",
-    "protobuf<4,>=3.12",
+    "protobuf<4,>=3.20.0",
     "pyarrow>=4.0",
     "pympler>=0.9",
     "python-dateutil",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -39,7 +39,7 @@ INSTALL_REQUIRES = [
     "packaging>=14.1",
     "pandas>=0.21.0",
     "pillow>=6.2.0",
-    "protobuf<4,>=3.20.0",
+    "protobuf<4,>=3.12",
     "pyarrow>=4.0",
     "pympler>=0.9",
     "python-dateutil",

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -79,7 +79,7 @@ def check_session_state_rules(
 
 def get_label_visibility_proto_value(
     label_visibility_string: type_util.LabelVisibility,
-) -> LabelVisibilityMessage.LabelVisibilityOptions.ValueType:
+) -> "LabelVisibilityMessage.LabelVisibilityOptions.ValueType":
     """Returns one of LabelVisibilityMessage enum constants.py based on string value."""
 
     if label_visibility_string == "visible":


### PR DESCRIPTION
We seemingly broke streamlit in 1.15.0 in https://github.com/streamlit/streamlit/issues/5742 and https://discuss.streamlit.io/t/version-1-15-returns-error/33523/10 and https://discuss.streamlit.io/t/streamlit-1-15-0-hello-run-error/33571 and likely more. 

It looks like the bug is being caused by protobuf versions from my debugging since I don't see that ValueType in 3.19.6. https://github.com/protocolbuffers/protobuf/blob/v3.19.6/python/google/protobuf/internal/enum_type_wrapper.py. I also tested it out and my theory holds true if u install protobuf==3.19.6 and run streamlit --version. 

I think we should add dependency changes to make sure they have the correct protobuf version. 

UPDATE: We just need to change the return type as a string