### PR TITLE
Fix py_snowflake for Nightly, Release Candidate & Release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,6 +64,8 @@ jobs:
     uses: ./.github/workflows/python-versions.yml
     with:
       ref: ${{needs.create-nightly-tag.outputs.tag}}
+    secrets:
+      PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
 
   run-javascript-tests:
     needs: create-nightly-tag

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -13,6 +13,10 @@ on:
       ref:
         required: true
         type: string
+    secrets:
+      PARAMETER_PASSWORD:
+        description: 'Token passed from caller workflows for snowflake integration tests'
+        required: true
 
 # Avoid duplicate workflows on same branch
 concurrency:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -9,6 +9,8 @@ jobs:
     uses: ./.github/workflows/python-versions.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets:
+      PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
 
   run-javascript-tests:
     uses: ./.github/workflows/js-tests.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     uses: ./.github/workflows/python-versions.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets:
+      PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
 
   run-javascript-tests:
     uses: ./.github/workflows/js-tests.yml


### PR DESCRIPTION
## 📚 Context

`python_versions.yml` when triggered from a `workflow_dispatch` event (Nightly, Release Candidate, Release) does not have secrets access unless the workflow is specifically passed the secret(s). The PR passes the `PARAMETER_PASSWORD` necessary for `py_snowflake` test.

Docs used as reference [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow).

- What kind of change does this PR introduce?
  - [x] Bugfix

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
