### PR TITLE
Improve error message when widgets of different types have the same key

### DIFF
--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -306,11 +306,10 @@ def _build_duplicate_widget_message(
     if user_key is not None:
         message = textwrap.dedent(
             """
-            There are multiple identical `st.{widget_type}` widgets with
-            `key='{user_key}'`.
+            There are multiple widgets with the same `key='{user_key}'`.
 
-            To fix this, please make sure that the `key` argument is unique for
-            each `st.{widget_type}` you create.
+            To fix this, please make sure that the `key` argument is unique for each
+            widget you create.
             """
         )
     else:


### PR DESCRIPTION
## 📚 Context

The message that we currently display to users when they give two widgets the same key
assumes that the two widgets have the same type, which is not necessarily the case.

It doesn't seem worth it to do the work (+add more complexity to this code) to include the
widget types in this message given that it should already be pretty easy to find the offending
widgets with the given stacktrace + key, so this PR just changes the message to not mention
the widget type.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change

## 🌐 References

Closes #5715