### PR TITLE
`deprecation_util.py` (formerly `beta_util.py`)

### DIFF
--- a/lib/streamlit/beta_util.py
+++ b/lib/streamlit/beta_util.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+import functools
+from typing import Any, Callable, List, TypeVar, cast
 
 import streamlit
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 def _show_beta_warning(name: str, date: str) -> None:
@@ -24,7 +27,7 @@ def _show_beta_warning(name: str, date: str) -> None:
     )
 
 
-def function_beta_warning(func, date):
+def function_beta_warning(func: F, date: str) -> F:
     """Wrapper for functions that are no longer in beta.
 
     Wrapped functions will run as normal, but then proceed to show an st.warning
@@ -40,9 +43,8 @@ def function_beta_warning(func, date):
         support for the beta_ prefix.
     """
 
+    @functools.wraps(func)
     def wrapped_func(*args, **kwargs):
-        # Note: Since we use a wrapper, beta_ functions will not autocomplete
-        # correctly on VSCode.
         result = func(*args, **kwargs)
         _show_beta_warning(func.__name__, date)
         return result
@@ -50,10 +52,10 @@ def function_beta_warning(func, date):
     # Update the wrapped func's name & docstring so st.help does the right thing
     wrapped_func.__name__ = "beta_" + func.__name__
     wrapped_func.__doc__ = func.__doc__
-    return wrapped_func
+    return cast(F, wrapped_func)
 
 
-def object_beta_warning(obj, obj_name, date):
+def object_beta_warning(obj: object, obj_name: str, date: str) -> object:
     """Wrapper for objects that are no longer in beta.
 
     Wrapped objects will run as normal, but then proceed to show an st.warning

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -103,16 +103,16 @@ def object_prerelease_graduation_warning(
         support for the beta_ prefix.
     """
 
-    has_shown_grduation_warning = False
+    has_shown_graduation_warning = False
 
     def show_wrapped_obj_warning():
-        nonlocal has_shown_grduation_warning
-        if not has_shown_grduation_warning:
-            has_shown_grduation_warning = True
+        nonlocal has_shown_graduation_warning
+        if not has_shown_graduation_warning:
+            has_shown_graduation_warning = True
             _show_api_graduation_warning(api_type, obj_name, removal_date)
 
     class Wrapper:
-        def __init__(self, obj):
+        def __init__(self, obj: object):
             self._obj = obj
 
             # Override all the Wrapped object's magic functions

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -37,7 +37,7 @@ def _get_function_name_prefix(api_type: PrereleaseAPIType) -> str:
 
 
 def _show_api_graduation_warning(
-    name: str, api_type: PrereleaseAPIType, removal_date: str
+    api_type: PrereleaseAPIType, name: str, removal_date: str
 ) -> None:
     prefix = _get_function_name_prefix(api_type)
     streamlit.warning(
@@ -47,7 +47,7 @@ def _show_api_graduation_warning(
 
 
 def function_prerelease_graduation_warning(
-    func: TFunc, api_type: PrereleaseAPIType, removal_date: str
+    api_type: PrereleaseAPIType, func: TFunc, removal_date: str
 ) -> TFunc:
     """Wrapper for functions that have "graduated" from pre-release.
 
@@ -56,11 +56,11 @@ def function_prerelease_graduation_warning(
 
     Parameters
     ----------
-    func: callable
-        The `st.` function that has graduated from beta/experimental.
-
     api_type : PrereleaseAPIType
         The type of prerelease API that's graduating to release.
+
+    func: callable
+        The `st.` function that has graduated from beta/experimental.
 
     removal_date: str
         A date like "2020-01-01", indicating the last day we'll guarantee
@@ -70,7 +70,7 @@ def function_prerelease_graduation_warning(
     @functools.wraps(func)
     def wrapped_func(*args, **kwargs):
         result = func(*args, **kwargs)
-        _show_api_graduation_warning(func.__name__, api_type, removal_date)
+        _show_api_graduation_warning(api_type, func.__name__, removal_date)
         return result
 
     # Update the wrapped func's name & docstring so st.help does the right thing
@@ -80,7 +80,7 @@ def function_prerelease_graduation_warning(
 
 
 def object_prerelease_graduation_warning(
-    obj: TObj, obj_name: str, api_type: PrereleaseAPIType, removal_date: str
+    api_type: PrereleaseAPIType, obj: TObj, obj_name: str, removal_date: str
 ) -> TObj:
     """Wrapper for objects that have "graduated" from pre-release.
 
@@ -109,7 +109,7 @@ def object_prerelease_graduation_warning(
         nonlocal has_shown_grduation_warning
         if not has_shown_grduation_warning:
             has_shown_grduation_warning = True
-            _show_api_graduation_warning(obj_name, api_type, removal_date)
+            _show_api_graduation_warning(api_type, obj_name, removal_date)
 
     class Wrapper:
         def __init__(self, obj):

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -20,14 +20,14 @@ import streamlit
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def _show_beta_warning(name: str, date: str) -> None:
+def _show_beta_warning(name: str, removal_date: str) -> None:
     streamlit.warning(
         f"Please replace `st.beta_{name}` with `st.{name}`.\n\n"
-        f"`st.beta_{name}` will be removed after {date}."
+        f"`st.beta_{name}` will be removed after {removal_date}."
     )
 
 
-def function_beta_warning(func: F, date: str) -> F:
+def function_beta_warning(func: F, removal_date: str) -> F:
     """Wrapper for functions that are no longer in beta.
 
     Wrapped functions will run as normal, but then proceed to show an st.warning
@@ -38,7 +38,7 @@ def function_beta_warning(func: F, date: str) -> F:
     func: callable
         The `st.` function that used to be in beta.
 
-    date: str
+    removal_date: str
         A date like "2020-01-01", indicating the last day we'll guarantee
         support for the beta_ prefix.
     """
@@ -46,7 +46,7 @@ def function_beta_warning(func: F, date: str) -> F:
     @functools.wraps(func)
     def wrapped_func(*args, **kwargs):
         result = func(*args, **kwargs)
-        _show_beta_warning(func.__name__, date)
+        _show_beta_warning(func.__name__, removal_date)
         return result
 
     # Update the wrapped func's name & docstring so st.help does the right thing
@@ -55,7 +55,7 @@ def function_beta_warning(func: F, date: str) -> F:
     return cast(F, wrapped_func)
 
 
-def object_beta_warning(obj: object, obj_name: str, date: str) -> object:
+def object_beta_warning(obj: object, obj_name: str, removal_date: str) -> object:
     """Wrapper for objects that are no longer in beta.
 
     Wrapped objects will run as normal, but then proceed to show an st.warning
@@ -69,7 +69,7 @@ def object_beta_warning(obj: object, obj_name: str, date: str) -> object:
     obj_name: str
         The name of the object within __init__.py
 
-    date: str
+    removal_date: str
         A date like "2020-01-01", indicating the last day we'll guarantee
         support for the beta_ prefix.
     """
@@ -80,7 +80,7 @@ def object_beta_warning(obj: object, obj_name: str, date: str) -> object:
         nonlocal has_shown_beta_warning
         if not has_shown_beta_warning:
             has_shown_beta_warning = True
-            _show_beta_warning(obj_name, date)
+            _show_beta_warning(obj_name, removal_date)
 
     class Wrapper:
         def __init__(self, obj):

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -14,7 +14,7 @@
 
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 
-from streamlit.beta_util import function_beta_warning
+from streamlit.deprecation_util import function_beta_warning
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -14,7 +14,10 @@
 
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 
-from streamlit.deprecation_util import function_beta_warning
+from streamlit.deprecation_util import (
+    PrereleaseAPIType,
+    function_prerelease_graduation_warning,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -367,6 +370,12 @@ class LayoutsMixin:
         return cast("DeltaGenerator", self)
 
     # Deprecated beta_ functions
-    beta_container = function_beta_warning(container, "2021-11-02")
-    beta_expander = function_beta_warning(expander, "2021-11-02")
-    beta_columns = function_beta_warning(columns, "2021-11-02")
+    beta_container = function_prerelease_graduation_warning(
+        container, PrereleaseAPIType.BETA, "2021-11-02"
+    )
+    beta_expander = function_prerelease_graduation_warning(
+        expander, PrereleaseAPIType.BETA, "2021-11-02"
+    )
+    beta_columns = function_prerelease_graduation_warning(
+        columns, PrereleaseAPIType.BETA, "2021-11-02"
+    )

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -371,11 +371,11 @@ class LayoutsMixin:
 
     # Deprecated beta_ functions
     beta_container = function_prerelease_graduation_warning(
-        container, PrereleaseAPIType.BETA, "2021-11-02"
+        PrereleaseAPIType.BETA, container, "2021-11-02"
     )
     beta_expander = function_prerelease_graduation_warning(
-        expander, PrereleaseAPIType.BETA, "2021-11-02"
+        PrereleaseAPIType.BETA, expander, "2021-11-02"
     )
     beta_columns = function_prerelease_graduation_warning(
-        columns, PrereleaseAPIType.BETA, "2021-11-02"
+        PrereleaseAPIType.BETA, columns, "2021-11-02"
     )

--- a/lib/tests/streamlit/deprecation_util_test.py
+++ b/lib/tests/streamlit/deprecation_util_test.py
@@ -47,7 +47,7 @@ class DeprecationUtilTest(unittest.TestCase):
             return a * b
 
         prerelease_multiply = function_prerelease_graduation_warning(
-            multiply, api_type, "1980-01-01"
+            api_type, multiply, "1980-01-01"
         )
 
         self.assertEqual(prerelease_multiply(3, 2), 6)
@@ -76,7 +76,7 @@ class DeprecationUtilTest(unittest.TestCase):
                 return a * b
 
         prerelease_multiplier = object_prerelease_graduation_warning(
-            Multiplier(), "multiplier", api_type, "1980-01-01"
+            api_type, Multiplier(), "multiplier", "1980-01-01"
         )
 
         self.assertEqual(prerelease_multiplier.multiply(3, 2), 6)
@@ -109,7 +109,7 @@ class DeprecationUtilTest(unittest.TestCase):
             pass
 
         beta_dict = object_prerelease_graduation_warning(
-            DictClass(), "my_dict", api_type, "1980-01-01"
+            api_type, DictClass(), "my_dict", "1980-01-01"
         )
 
         beta_dict["foo"] = "bar"

--- a/lib/tests/streamlit/deprecation_util_test.py
+++ b/lib/tests/streamlit/deprecation_util_test.py
@@ -15,10 +15,10 @@
 import unittest
 from unittest.mock import patch
 
-from streamlit.beta_util import function_beta_warning, object_beta_warning
+from streamlit.deprecation_util import function_beta_warning, object_beta_warning
 
 
-class BetaUtilTest(unittest.TestCase):
+class DeprecationUtilTest(unittest.TestCase):
     @patch("streamlit.warning")
     def test_function_beta_warning(self, mock_warning):
         def multiply(a, b):


### PR DESCRIPTION
- Renames `beta_util` to `deprecation_util`
- adds support for deprecating `experimental_` methods
- Adds proper type annotations to the deprecation wrapper functions, which should help with IDE autocomplete