### PR TITLE
Add a new make target to only install build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,15 @@ all-devel: init develop pre-commit-install
 	@echo ""
 
 .PHONY: mini-devel
-# Get minimal dependencies and install Streamlit into Python environment -- but do not build the frontend.
+# Get minimal dependencies for development and install Streamlit into Python
+# environment -- but do not build the frontend.
 mini-devel: mini-init develop pre-commit-install
+
+.PHONY: build-deps
+# An even smaller installation than mini-devel. Installs the bare minimum
+# necessary to build Streamlit (by leaving out some dependencies necessary for
+# the development process). Does not build the frontend.
+build-deps: mini-init develop
 
 .PHONY: init
 # Install all Python and JS dependencies.
@@ -166,7 +173,7 @@ distribution:
 
 .PHONY: package
 # Build lib and frontend, and then run 'distribution'.
-package: mini-devel frontend distribution
+package: build-deps frontend distribution
 
 .PHONY: conda-distribution
 # Create conda distribution files in lib/conda-recipe/dist.
@@ -180,7 +187,7 @@ conda-distribution:
 
 .PHONY: conda-package
 # Build lib and frontend, and then run 'conda-distribution'
-conda-package: mini-devel frontend conda-distribution
+conda-package: build-deps frontend conda-distribution
 
 .PHONY: clean
 # Remove all generated files.


### PR DESCRIPTION
## 📚 Context

Some of our internal Snowpark conda builds of Streamlit ran into some issues installing `pre-commit`
on the machines that they run on. We really don't need pre-commit at all when *building* Streamlit (the
code has already gone through CI + code review at that point, so running pre-commit again is redundant),
so we might as well skip installing it completely.

This PR does this by adding a new make target: `make build-deps`, which works the same way as
`make mini-devel`, but intentionally omits the `pre-commit` installation. We also start using this target
in place of `mini-devel` in the `package` and `conda-package` targets. 

- What kind of change does this PR introduce?

  - [x] Other, please describe: new make target