### PR TITLE
Improve st.experimental_memo exception on Snowpark/PySpark integration

### DIFF
--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -182,3 +182,9 @@ class UnserializableReturnValueError(MarkdownFormattedException):
             If you want to cache unserializable objects such as database connections or Tensorflow
             sessions, use `st.experimental_singleton` instead (see [our docs](https://docs.streamlit.io/library/advanced-features/experimental-cache-primitives) for differences).""",
         )
+
+
+class UnevaluatedDataFrameError(StreamlitAPIException):
+    """Used to display a message about uncollected dataframe being used"""
+
+    pass

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -387,7 +387,10 @@ def create_cache_wrapper(cached_func: CachedFunction) -> Callable[..., Any]:
                 messages = cached_func.message_call_stack._most_recent_messages
                 try:
                     cache.write_result(value_key, return_value, messages)
-                except (TypeError, RuntimeError, CacheError):
+                except (
+                    CacheError,
+                    RuntimeError,
+                ):  # RuntimeError will be raised by Apache Spark, if we do not collect dataframe before using st.experimental_memo
                     if True in [
                         type_util.is_type(return_value, type_name)
                         for type_name in UNEVALUATED_DATAFRAME_TYPES

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -32,14 +32,15 @@ import streamlit as st
 from streamlit import runtime, type_util, util
 from streamlit.elements import NONWIDGET_ELEMENTS, WIDGETS
 from streamlit.elements.spinner import spinner
-from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Block_pb2 import Block
 from streamlit.runtime.caching.cache_errors import (
     CachedStFunctionWarning,
+    CacheError,
     CacheKeyNotFoundError,
     CacheReplayClosureError,
     CacheType,
+    UnevaluatedDataFrameError,
     UnhashableParamError,
     UnhashableTypeError,
     UnserializableReturnValueError,
@@ -53,6 +54,15 @@ from streamlit.runtime.scriptrunner.script_run_context import (
 from streamlit.runtime.state.session_state import WidgetMetadata
 
 _LOGGER = get_logger(__name__)
+
+
+# We show a special "UnevaluatedDataFrame" warning for cached funcs
+# that attempt to return one of these unserializable types:
+UNEVALUATED_DATAFRAME_TYPES = (
+    "snowflake.snowpark.table.Table",
+    "snowflake.snowpark.dataframe.DataFrame",
+    "pyspark.sql.dataframe.DataFrame",
+)
 
 
 @runtime_checkable
@@ -377,18 +387,15 @@ def create_cache_wrapper(cached_func: CachedFunction) -> Callable[..., Any]:
                 messages = cached_func.message_call_stack._most_recent_messages
                 try:
                     cache.write_result(value_key, return_value, messages)
-                except TypeError:
-                    if type_util.is_type(
-                        return_value, "snowflake.snowpark.dataframe.DataFrame"
-                    ):
-
-                        class UnevaluatedDataFrameError(StreamlitAPIException):
-                            pass
-
+                except (TypeError, RuntimeError, CacheError):
+                    if True in [
+                        type_util.is_type(return_value, type_name)
+                        for type_name in UNEVALUATED_DATAFRAME_TYPES
+                    ]:
                         raise UnevaluatedDataFrameError(
                             f"""
                             The function {get_cached_func_name_md(func)} is decorated with `st.experimental_memo` but it returns an unevaluated dataframe
-                            of type `snowflake.snowpark.DataFrame`. Please call `collect()` or `to_pandas()` on the dataframe before returning it,
+                            of type `{type_util.get_fqn_type(return_value)}`. Please call `collect()` or `to_pandas()` on the dataframe before returning it,
                             so `st.experimental_memo` can serialize and cache it."""
                         )
                     raise UnserializableReturnValueError(

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -526,7 +526,7 @@ class MemoCache(Cache):
 
         try:
             pickled_entry = pickle.dumps(multi_cache_results)
-        except pickle.PicklingError as exc:
+        except (pickle.PicklingError, TypeError) as exc:
             raise CacheError(f"Failed to pickle {key}") from exc
 
         self._write_to_mem_cache(key, pickled_entry)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

This PR shows custom `st.experimental_memo` exception for `snowflake.snowpark.table.Table` and `pyspark.sql.dataframe.DataFrame`, additionally to `snowflake.snowpark.dataframe.DataFrame`.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
