### PR TITLE
Update error message and docstring in st.map

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -97,8 +97,11 @@ class MapMixin:
         Parameters
         ----------
         data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, pyspark.sql.DataFrame, snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table, Iterable, dict, or None
-            The data to be plotted. Must have columns called 'lat', 'lon',
-            'latitude', or 'longitude'.
+            The data to be plotted. Must have two columns:
+
+            - latitude called 'lat', 'latitude', 'LAT', 'LATITUDE'
+            - longitude called 'lon', 'longitude', 'LON', 'LONGITUDE'.
+
         zoom : int
             Zoom level as specified in
             https://wiki.openstreetmap.org/wiki/Zoom_levels
@@ -169,31 +172,27 @@ def to_deckgl_json(data: Data, zoom: Optional[int]) -> str:
     data = type_util.convert_anything_to_df(data)
     formmated_column_names = ", ".join(map(repr, list(data.columns)))
 
-    if "lat" in data:
-        lat = "lat"
-    elif "latitude" in data:
-        lat = "latitude"
-    elif "LAT" in data:
-        lat = "LAT"
-    elif "LATITUDE" in data:
-        lat = "LATITUDE"
-    else:
+    allowed_lat_columns = {"lat", "latitude", "LAT", "LATITUDE"}
+    lat = next((d for d in allowed_lat_columns if d in data), None)
+
+    if not lat:
+        formatted_allowed_column_name = ", ".join(
+            map(repr, sorted(allowed_lat_columns))
+        )
         raise StreamlitAPIException(
-            "Map data must contain a column named 'latitude' or 'lat'. "
+            f"Map data must contain a latitude column named: {formatted_allowed_column_name}. "
             f"Existing columns: {formmated_column_names}"
         )
 
-    if "lon" in data:
-        lon = "lon"
-    elif "longitude" in data:
-        lon = "longitude"
-    elif "LON" in data:
-        lon = "LON"
-    elif "LONGITUDE" in data:
-        lon = "LONGITUDE"
-    else:
+    allowed_lon_columns = {"lon", "longitude", "LON", "LONGITUDE"}
+    lon = next((d for d in allowed_lon_columns if d in data), None)
+
+    if not lon:
+        formatted_allowed_column_name = ", ".join(
+            map(repr, sorted(allowed_lon_columns))
+        )
         raise StreamlitAPIException(
-            "Map data must contain a column named 'longitude' or 'lon'. "
+            f"Map data must contain a longitude column named: {formatted_allowed_column_name}. "
             f"Existing columns: {formmated_column_names}"
         )
 

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -90,7 +90,8 @@ class StMapTest(DeltaGeneratorTestCase):
             st.map(df)
 
         self.assertEqual(
-            "Map data must contain a column named 'latitude' or 'lat'. Existing columns: 'notlat', 'lon'",
+            "Map data must contain a latitude column named: 'LAT', 'LATITUDE', 'lat', 'latitude'. "
+            "Existing columns: 'notlat', 'lon'",
             str(ctx.exception),
         )
 


### PR DESCRIPTION
## 📚 Context

The docstring for the `data` parameter of `st.map` could be better formatted and should include all the possible valid values of column names. Additionally, the st.map code includes many if-else blocks that could use refactoring.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Improves formatting of docstring for the `data` parameter of `st.map`
- Includes all the possible valid values of column names for the `data` parameter and also does so in the error message
- Refactors st.map code to replace multiple if-else blocks with iterators

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

<details open><summary><b>Revised:</b></summary>

![image](https://user-images.githubusercontent.com/20672874/205271475-a16389e2-850c-46c9-a2c2-cab73878c50c.png)
</details>

<details><summary><b>Current:</b></summary>

![image](https://user-images.githubusercontent.com/20672874/205271259-689b2e57-2208-4d4c-b86b-5780560cdc5d.png)
</details>


## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
