### PR TITLE
Implement real version of WebsocketSessionManager

### DIFF
--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -36,7 +36,7 @@ class MemorySessionStorage(SessionStorage):
     def __init__(
         self,
         maxsize: int = 128,
-        ttl_seconds: int = 5 * 60,  # 5 minutes
+        ttl_seconds: int = 2 * 60,  # 2 minutes
     ) -> None:
         """Instantiate a new MemorySessionStorage.
 
@@ -53,12 +53,6 @@ class MemorySessionStorage(SessionStorage):
             The time in seconds for an entry added to a MemorySessionStorage to live.
             After this amount of time has passed for a given entry, it becomes
             inaccessible and will be removed eventually.
-
-            TODO(vdonato): We'll have to do some testing to see what the TTLCache
-            documentation means by "eventually". It's possible that we'll want to add
-            our own mechanism to force cleanups of expired entries more frequently than
-            TTLCache does by default (which is easy to do with some of the methods that
-            TTLCache exposes).
         """
 
         self._cache: MutableMapping[str, SessionInfo] = TTLCache(

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -367,7 +367,7 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        self._session_mgr.close_session(session_id)
+        self._session_mgr.disconnect_session(session_id)
 
         if (
             self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -45,6 +45,7 @@ from streamlit.runtime.session_manager import (
     SessionClient,
     SessionClientDisconnectedError,
     SessionManager,
+    SessionStorage,
 )
 from streamlit.runtime.state import (
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
@@ -79,6 +80,9 @@ class RuntimeConfig(NamedTuple):
 
     # The SessionManager class to be used.
     session_manager_class: Type[SessionManager]
+
+    # The SessionStorage instance for the SessionManager to use.
+    session_storage: SessionStorage
 
 
 class RuntimeState(Enum):
@@ -170,12 +174,8 @@ class Runtime:
         self._uploaded_file_mgr.on_files_updated.connect(self._on_files_updated)
         self._media_file_mgr = MediaFileManager(storage=config.media_file_storage)
 
-        # Ignore the obviously incorrect type below where we pass None where a
-        # SessionStorage should be in the first argument. This is fine because we're
-        # not yet using the argument in the one class that currently implements
-        # SessionManager.
         self._session_mgr = config.session_manager_class(
-            session_storage=None,  # type: ignore
+            session_storage=config.session_storage,
             uploaded_file_manager=self._uploaded_file_mgr,
             message_enqueued_callback=self._enqueued_some_message,
         )

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -73,6 +73,10 @@ class SessionInfo:
 
     def to_active(self) -> ActiveSessionInfo:
         assert self.is_active(), "A SessionInfo with no client cannot be active!"
+
+        # NOTE: The cast here (rather than copying this SessionInfo's fields into a new
+        # ActiveSessionInfo) is important as the Runtime expects to be able to mutate
+        # what's returned from get_active_session_info to increment script_run_count.
         return cast(ActiveSessionInfo, self)
 
 

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, cast
 
 from typing_extensions import Final
 
@@ -20,6 +20,7 @@ from streamlit.logger import get_logger
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.session_data import SessionData
 from streamlit.runtime.session_manager import (
+    ActiveSessionInfo,
     SessionClient,
     SessionInfo,
     SessionManager,
@@ -32,36 +33,61 @@ LOGGER: Final = get_logger(__name__)
 
 
 class WebsocketSessionManager(SessionManager):
+    """A SessionManager used to manage sessions with lifecycles tied to those of a
+    browser tab's websocket connection.
+
+    WebsocketSessionManagers differentiate between "active" and "inactive" sessions.
+    Active sessions are those with a currently active websocket connection. Inactive
+    sessions are sessions without. Eventual cleanup of inactive sessions is a detail left
+    to the specific SessionStorage that a WebsocketSessionManager is instantiated with.
+
+    NOTE: The name of this class isn't finalized since there technically isn't any
+    mention of websockets in its implementation, but a more generic name like
+    DefaultSessionManager also feels weird with the concept of an active session being
+    so closely tied to websocket lifecycle. We'll figure out a final name for this
+    before the feature branch goes into `develop`.
+    """
+
     def __init__(
         self,
         session_storage: SessionStorage,
         uploaded_file_manager: UploadedFileManager,
         message_enqueued_callback: Optional[Callable[[], None]],
     ) -> None:
-        # NOTE: We intentionally don't do anything with session_storage for now as we
-        # will initially implement WebsocketSessionManager so the current runtime
-        # session handling behavior is unchanged.
-        #
-        # A concrete session_storage class will be implemented and used in subsequent
-        # changes when we add session reuse on a websocket reconnect.
-        #
-        # Since we aren't worrying about session reconnects yet, we don't need to
-        # differentiate between active and inactive sessions and can provide the minimal
-        # implementation of a SessionManager below.
-
+        self._session_storage = session_storage
         self._uploaded_file_mgr = uploaded_file_manager
         self._message_enqueued_callback = message_enqueued_callback
 
-        # Mapping of AppSession.id -> SessionInfo.
-        self._session_info_by_id: Dict[str, SessionInfo] = {}
+        # Mapping of AppSession.id -> ActiveSessionInfo.
+        self._active_session_info_by_id: Dict[str, ActiveSessionInfo] = {}
 
     def connect_session(
         self,
         client: SessionClient,
         session_data: SessionData,
         user_info: Dict[str, Optional[str]],
-        existing_session_id: Optional[str] = None,  # unused for now
+        existing_session_id: Optional[str] = None,
     ) -> str:
+        assert (
+            existing_session_id not in self._active_session_info_by_id
+        ), f"session with id '{existing_session_id}' is already connected!"
+
+        session_info = existing_session_id and self._session_storage.get(
+            existing_session_id
+        )
+        if session_info:
+            existing_session = session_info.session
+            existing_session.register_file_watchers()
+
+            self._active_session_info_by_id[existing_session.id] = ActiveSessionInfo(
+                client,
+                existing_session,
+                session_info.script_run_count,
+            )
+            self._session_storage.delete(existing_session.id)
+
+            return existing_session.id
+
         session = AppSession(
             session_data=session_data,
             uploaded_file_manager=self._uploaded_file_mgr,
@@ -75,23 +101,55 @@ class WebsocketSessionManager(SessionManager):
         )
 
         assert (
-            session.id not in self._session_info_by_id
+            session.id not in self._active_session_info_by_id
         ), f"session.id '{session.id}' registered multiple times!"
 
-        self._session_info_by_id[session.id] = SessionInfo(client, session)
+        self._active_session_info_by_id[session.id] = ActiveSessionInfo(client, session)
         return session.id
 
+    def disconnect_session(self, session_id: str) -> None:
+        if session_id in self._active_session_info_by_id:
+            active_session_info = self._active_session_info_by_id[session_id]
+            active_session_info.session.disconnect_file_watchers()
+
+            self._session_storage.save(
+                SessionInfo(
+                    client=None,
+                    session=active_session_info.session,
+                    script_run_count=active_session_info.script_run_count,
+                )
+            )
+            del self._active_session_info_by_id[session_id]
+
+    def get_active_session_info(self, session_id: str) -> Optional[ActiveSessionInfo]:
+        return self._active_session_info_by_id.get(session_id)
+
+    def is_active_session(self, session_id: str) -> bool:
+        return session_id in self._active_session_info_by_id
+
+    def list_active_sessions(self) -> List[ActiveSessionInfo]:
+        return list(self._active_session_info_by_id.values())
+
     def close_session(self, session_id: str) -> None:
-        if session_id in self._session_info_by_id:
-            session_info = self._session_info_by_id[session_id]
-            del self._session_info_by_id[session_id]
+        if session_id in self._active_session_info_by_id:
+            active_session_info = self._active_session_info_by_id[session_id]
+            del self._active_session_info_by_id[session_id]
+            active_session_info.session.shutdown()
+            return
+
+        session_info = self._session_storage.get(session_id)
+        if session_info:
+            self._session_storage.delete(session_id)
             session_info.session.shutdown()
 
     def get_session_info(self, session_id: str) -> Optional[SessionInfo]:
-        return self._session_info_by_id.get(session_id, None)
+        session_info = self.get_active_session_info(session_id)
+        if session_info:
+            return cast(SessionInfo, session_info)
+        return self._session_storage.get(session_id)
 
     def list_sessions(self) -> List[SessionInfo]:
-        # Shallow-clone our sessions into a list, so we can iterate
-        # over it and not worry about whether it's being changed
-        # outside this coroutine.
-        return list(self._session_info_by_id.values())
+        return (
+            cast(List[SessionInfo], self.list_active_sessions())
+            + self._session_storage.list()
+        )

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -34,6 +34,7 @@ from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
@@ -179,6 +180,7 @@ class Server:
                 command_line=command_line,
                 media_file_storage=media_file_storage,
                 session_manager_class=WebsocketSessionManager,
+                session_storage=MemorySessionStorage(),
             ),
         )
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -403,7 +403,7 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         session._local_sources_watcher = None
 
-        session._register_file_watchers()
+        session.register_file_watchers()
         self.assertIsNotNone(session._local_sources_watcher)
 
     @patch(
@@ -419,7 +419,7 @@ class AppSessionTest(unittest.TestCase):
         ) as patched_stop_config_listener, patch.object(
             session, "_stop_pages_listener"
         ) as patched_stop_pages_listener:
-            session._disconnect_file_watchers()
+            session.disconnect_file_watchers()
 
             patched_close_local_sources_watcher.assert_called_once()
             patched_stop_config_listener.assert_called_once()
@@ -433,7 +433,7 @@ class AppSessionTest(unittest.TestCase):
             self.assertIsNone(session._stop_pages_listener)
 
     def test_disconnect_file_watchers_removes_refs(self):
-        """Test that calling _disconnect_file_watchers on the AppSession
+        """Test that calling disconnect_file_watchers on the AppSession
         removes references to it so it is eligible to be garbage collected after the
         method is called.
         """
@@ -443,7 +443,7 @@ class AppSessionTest(unittest.TestCase):
         # handlers.
         self.assertGreater(len(gc.get_referrers(session)), 0)
 
-        session._disconnect_file_watchers()
+        session.disconnect_file_watchers()
         # Ensure that we don't count refs to session from an object that would have been
         # garbage collected along with it.
         gc.collect(2)

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -526,6 +526,7 @@ class ScriptCheckTest(RuntimeTestCase):
             command_line="mock command line",
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
             session_manager_class=MagicMock,
+            session_storage=MagicMock(),
         )
         self.runtime = Runtime(config)
         await self.runtime.start()

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -99,6 +99,7 @@ class RuntimeTestCase(IsolatedAsyncioTestCase):
             command_line="",
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
             session_manager_class=MockSessionManager,
+            session_storage=mock.MagicMock(),
         )
         self.runtime = Runtime(config)
 

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -49,6 +49,7 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                     "",
                     media_file_storage=MagicMock(),
                     session_manager_class=MagicMock(),
+                    session_storage=MagicMock(),
                 )
                 queue.put(Runtime(config))
             except BaseException as e:

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -16,3 +16,234 @@
 # waiting to merge these changes into `develop` until after we finish implementing
 # improved websocket reconnects, after which we would have to rewrite all of these tests
 # if we were to add some now.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.runtime.session_data import SessionData
+from streamlit.runtime.session_manager import SessionStorage
+from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
+
+
+class MockSessionStorage(SessionStorage):
+    """A simple SessionStorage implementation used for testing.
+
+    Essentially just a thin wrapper around a dict. This class exists so that we don't
+    accidentally have our WebsocketSessionManager tests rely on a real SessionStorage
+    implementation.
+    """
+
+    def __init__(self):
+        self._cache = {}
+
+    def get(self, session_id):
+        return self._cache.get(session_id, None)
+
+    def save(self, session_info):
+        self._cache[session_info.session.id] = session_info
+
+    def delete(self, session_id):
+        del self._cache[session_id]
+
+    def list(self):
+        return list(self._cache.values())
+
+
+@patch(
+    "streamlit.runtime.app_session.asyncio.get_running_loop",
+    new=MagicMock(),
+)
+@patch("streamlit.runtime.app_session.LocalSourcesWatcher", new=MagicMock())
+@patch("streamlit.runtime.app_session.ScriptRunner", new=MagicMock())
+class WebsocketSessionManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.session_mgr = WebsocketSessionManager(
+            session_storage=MockSessionStorage(),
+            uploaded_file_manager=MagicMock(),
+            message_enqueued_callback=MagicMock(),
+        )
+
+    def connect_session(self, existing_session_id=None):
+        return self.session_mgr.connect_session(
+            client=MagicMock(),
+            session_data=SessionData("/fake/script_path.py", "fake_command_line"),
+            user_info={},
+            existing_session_id=existing_session_id,
+        )
+
+    def test_connect_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr._active_session_info_by_id[session_id]
+
+        assert session_info.session.id == session_id
+
+    def test_connect_session_on_invalid_session_id(self):
+        """Test that connect_session gives us a new session if existing_session_id is invalid."""
+        session_id = self.connect_session(existing_session_id="not a valid session")
+        session_info = self.session_mgr._active_session_info_by_id[session_id]
+
+        assert session_info.session.id == session_id
+        assert session_info.session.id != "not a valid session"
+
+    def test_connect_session_explodes_if_already_connected(self):
+        session_id = self.connect_session()
+
+        with pytest.raises(AssertionError):
+            self.connect_session(existing_session_id=session_id)
+
+    def test_connect_session_explodes_if_ID_collission(self):
+        session_id = self.connect_session()
+        with pytest.raises(AssertionError):
+            with patch(
+                "streamlit.runtime.app_session.uuid.uuid4", return_value=session_id
+            ):
+                self.connect_session()
+
+    @patch(
+        "streamlit.runtime.app_session.AppSession.register_file_watchers",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
+        new=MagicMock(),
+    )
+    def test_disconnect_and_reconnect_session(self):
+        session_id = self.connect_session()
+        original_session_info = self.session_mgr.get_session_info(session_id)
+        original_client = original_session_info.client
+
+        # File watchers are registered on AppSession creation.
+        original_session_info.session.register_file_watchers.assert_called_once()
+
+        self.session_mgr.disconnect_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id in self.session_mgr._session_storage._cache
+        original_session_info.session.disconnect_file_watchers.assert_called_once()
+
+        # Call disconnect_session again to verify that disconnect_session is idempotent.
+        self.session_mgr.disconnect_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id in self.session_mgr._session_storage._cache
+        original_session_info.session.disconnect_file_watchers.assert_called_once()
+
+        # Reconnect to the existing session.
+        reconnected_session_id = self.connect_session(existing_session_id=session_id)
+        reconnected_session_info = self.session_mgr.get_session_info(
+            reconnected_session_id
+        )
+
+        assert reconnected_session_id == session_id
+        assert reconnected_session_info.session == original_session_info.session
+        assert reconnected_session_info != original_session_info
+        assert reconnected_session_info.client != original_client
+        # File watchers are registered on AppSession creation and again on AppSession
+        # reconnect.
+        assert reconnected_session_info.session.register_file_watchers.call_count == 2
+
+    def test_disconnect_session_on_invalid_session_id(self):
+        # Just check that no error is thrown.
+        self.session_mgr.disconnect_session("nonexistent_session")
+
+    def test_get_active_session_info(self):
+        session_id = self.connect_session()
+
+        active_session_info = self.session_mgr.get_active_session_info(session_id)
+        assert active_session_info.session.id == session_id
+
+    def test_get_active_session_info_on_invalid_session_id(self):
+        assert self.session_mgr.get_active_session_info("nonexistent_session") is None
+
+    def test_get_active_session_info_on_disconnected_session(self):
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        assert self.session_mgr.get_active_session_info(session_id) is None
+
+    def test_is_active_session(self):
+        session_id = self.connect_session()
+        assert self.session_mgr.is_active_session(session_id)
+
+    def test_is_active_session_on_invalid_session_id(self):
+        assert not self.session_mgr.is_active_session("nonexistent_session")
+
+    def test_is_active_session_on_disconnected_session(self):
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        assert not self.session_mgr.is_active_session(session_id)
+
+    def test_list_active_sessions(self):
+        session_ids = []
+        for _ in range(3):
+            session_ids.append(self.connect_session())
+
+        assert [
+            s.session.id for s in self.session_mgr.list_active_sessions()
+        ] == session_ids
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    def test_close_session_on_active_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr.get_session_info(session_id)
+        self.session_mgr.close_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id not in self.session_mgr._session_storage._cache
+        session_info.session.shutdown.assert_called_once()
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    def test_close_session_on_inactive_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr.get_session_info(session_id)
+        self.session_mgr.disconnect_session(session_id)
+
+        # Sanity check.
+        assert not self.session_mgr.is_active_session(session_id)
+
+        self.session_mgr.close_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id not in self.session_mgr._session_storage._cache
+        session_info.session.shutdown.assert_called_once()
+
+    def test_close_session_on_invalid_session_id(self):
+        self.session_mgr.close_session("nonexistent_session")
+
+    def test_get_session_info_on_active_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr.get_session_info(session_id)
+
+        assert session_info.session.id == session_id
+
+    def test_get_session_info_on_inactive_session(self):
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        # Sanity check.
+        assert not self.session_mgr.is_active_session(session_id)
+
+        session_info = self.session_mgr.get_session_info(session_id)
+        assert session_info.session.id == session_id
+
+    def test_get_session_info_on_invalid_session_id(self):
+        assert self.session_mgr.get_session_info("nonexistent_session") is None
+
+    def test_list_sessions(self):
+        session_ids = []
+        for _ in range(3):
+            session_ids.append(self.connect_session())
+
+        self.session_mgr.disconnect_session(session_ids[1])
+
+        # Sanity check.
+        assert self.session_mgr.is_active_session(session_ids[0])
+        assert not self.session_mgr.is_active_session(session_ids[1])
+        assert self.session_mgr.is_active_session(session_ids[2])
+
+        assert {s.session.id for s in self.session_mgr.list_sessions()} == set(
+            session_ids
+        )

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -110,10 +110,11 @@ class ServerTest(ServerTestCase):
             await asyncio.sleep(0.1)
             self.assertFalse(self.server.browser_is_connected)
 
-            # Ensure AppSession.shutdown() was called, and that our
-            # SessionInfo was cleared.
-            session_info.session.shutdown.assert_called_once()
+            # Ensure AppSession.disconnect_file_watchers() was called, and that our
+            # session exists but is no longer active.
+            session_info.session.disconnect_file_watchers.assert_called_once()
             self.assertEqual(0, self.server._runtime._session_mgr.num_active_sessions())
+            self.assertEqual(1, self.server._runtime._session_mgr.num_sessions())
 
     @tornado.testing.gen_test
     async def test_multiple_connections(self):


### PR DESCRIPTION
## 📚 Context

We previously wrote a stub implementation of `WebsocketSessionManager` that made
no behavioral changes while we were making the other changes necessary for us to be
able to actually implement our improved websocket reconnect behavior.

This PR implements a more complete version of `WebsocketSessionManager` that
understands how to disconnect from/reconnect to sessions using the `SessionStorage`
implementation provided to it.

Note that we don't take the final step of having the client attempt to reconnect to its last
session after a disconnect -- that will be done in the next PR.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests
