### PR TITLE
iFrame resizer guest script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "gl-matrix": "^3.2.1",
     "hoist-non-react-statics": "^3.3.2",
     "humanize-string": "^2.1.0",
+    "iframe-resizer": "^4.3.2",
     "immer": "^9.0.6",
     "immutable": "^4.0.0-rc.12",
     "json5": "^2.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,7 @@ import {
   setCookie,
   hashString,
   isEmbeddedInIFrame,
+  isInChildFrame,
   notUndefined,
   getElementWidgetID,
 } from "src/lib/utils"
@@ -286,6 +287,11 @@ export class App extends PureComponent<Props, State> {
 
     if (isEmbeddedInIFrame()) {
       document.body.classList.add("embedded")
+    }
+
+    if (isInChildFrame()) {
+      // @ts-ignore
+      import("iframe-resizer/js/iframeResizer.contentWindow")
     }
 
     this.props.hostCommunication.sendMessage({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -290,6 +290,9 @@ export class App extends PureComponent<Props, State> {
     }
 
     if (isInChildFrame()) {
+      Object.assign(window, {
+        iFrameResizer: { heightCalculationMethod: "taggedElement" },
+      })
       // @ts-ignore
       import("iframe-resizer/js/iframeResizer.contentWindow")
     }

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -114,6 +114,7 @@ function AppView(props: AppViewProps): ReactElement {
         uploadClient={uploadClient}
         componentRegistry={componentRegistry}
         formsData={formsData}
+        main={node === elements.main}
       />
     </StyledAppViewBlockContainer>
   )

--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -24,6 +24,7 @@ import withExpandable from "src/hocs/withExpandable"
 import { Form } from "src/components/widgets/Form"
 import Tabs from "src/components/elements/Tabs"
 
+import AppContext from "src/components/core/AppContext"
 import {
   BaseBlockProps,
   isComponentStale,
@@ -34,6 +35,7 @@ import ElementNodeRenderer from "./ElementNodeRenderer"
 import {
   StyledColumn,
   StyledHorizontalBlock,
+  StyledIFrameResizerAnchor,
   StyledVerticalBlock,
   styledVerticalBlockWrapperStyles,
 } from "./styled-components"
@@ -42,6 +44,7 @@ const ExpandableLayoutBlock = withExpandable(LayoutBlock)
 
 export interface BlockPropsWithoutWidth extends BaseBlockProps {
   node: BlockNode
+  main?: boolean
 }
 
 interface BlockPropsWithWidth extends BaseBlockProps {
@@ -161,6 +164,9 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
   // Widths of children autosizes to container width (and therefore window width).
   // StyledVerticalBlocks are the only things that calculate their own widths. They should never use
   // the width value coming from the parent via props.
+  const { main } = props
+  const { embedded } = React.useContext(AppContext)
+
   return (
     <AutoSizer disableHeight={true} style={styledVerticalBlockWrapperStyles}>
       {({ width }) => {
@@ -169,6 +175,12 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
         return (
           <StyledVerticalBlock width={width} data-testid="stVerticalBlock">
             <ChildRenderer {...propsWithNewWidth} />
+            {main && (
+              <StyledIFrameResizerAnchor
+                isEmbedded={embedded}
+                data-iframe-height
+              />
+            )}
           </StyledVerticalBlock>
         )
       }}

--- a/frontend/src/components/core/Block/styled-components.ts
+++ b/frontend/src/components/core/Block/styled-components.ts
@@ -147,3 +147,18 @@ export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
     gap: theme.spacing.lg,
   })
 )
+
+/*
+Used by @npm/iframe-resizer to determine the page height
+*/
+export interface StyledIFrameResizerAnchorProps {
+  isEmbedded: boolean
+}
+
+export const StyledIFrameResizerAnchor =
+  styled.div<StyledIFrameResizerAnchorProps>(({ isEmbedded }) => ({
+    position: "absolute",
+    // 10rem: StyledAppViewBlockContainer padding-bottom
+    // 39px:  StyledAppViewFooter computed height
+    bottom: isEmbedded ? "-1rem" : "calc( -1 * (10rem + 39px))",
+  }))

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -54,11 +54,11 @@ export function isEmbeddedInIFrame(): boolean {
 }
 
 /**
- * Returns true if the frameElement and parent parameters indicate that we're in an
+ * Returns true if the parent parameter indicate that we're in an
  * iframe.
  */
 export function isInChildFrame(): boolean {
-  return window.parent !== window && !!window.frameElement
+  return window.parent !== window
 }
 
 /** Return an info Element protobuf with the given text. */

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10194,6 +10194,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+iframe-resizer@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.2.tgz#42dd88345d18b9e377b6044dddb98c664ab0ce6b"
+  integrity sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"


### PR DESCRIPTION
## 📚 Context

Enhance Streamlit apps embedding capabilities by making it "compatible" with the [iFrame Resizer](https://github.com/davidjbradshaw/iframe-resizer) library

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Dynamically load the iFrame resizer guest script on App startup if the app runs in an iFrame
- Place a no-op invisible anchor element at the bottom of the main app content
  - used by iFrame resizer to determine the current height of the running app

**Revised:**

https://user-images.githubusercontent.com/11795593/205446266-2b1a0cf2-5716-4018-b1c0-8cd0519d7ab0.mov

## 🧪 Testing Done

No test added

## 🌐 References

- Kind of following-up https://github.com/streamlit/streamlit/pull/5111
- iFrame Resizer library : https://github.com/davidjbradshaw/iframe-resizer

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
