### PR TITLE
Replace closeConnection with shutdownRuntime and disconnectWebsocket

### DIFF
--- a/e2e/specs/st_disabled.spec.js
+++ b/e2e/specs/st_disabled.spec.js
@@ -30,8 +30,11 @@ describe("disable widgets", () => {
 
     cy.get(".stMarkdown").should("have.text", "Value 1: 25");
 
-    cy.window().then(win => {
-      win.streamlitDebug.closeConnection();
+    cy.window().then((win) => {
+      // We shut down the runtime entirely rather than just close the websocket
+      // connection as the client will immediately reconnect if we just do the
+      // latter.
+      win.streamlitDebug.shutdownRuntime();
 
       cy.get(".stButton button").should("be.disabled");
 
@@ -50,10 +53,7 @@ describe("disable widgets", () => {
       cy.get(".stTimeInput input").should("be.disabled");
 
       // slider doesn't have a `disabled` attribute
-      cy.get('.stSlider [role="slider"]')
-        .first()
-        .parent()
-        .click();
+      cy.get('.stSlider [role="slider"]').first().parent().click();
 
       cy.get(".stMarkdown").should("have.text", "Value 1: 25");
 

--- a/e2e/specs/st_disconnect.spec.js
+++ b/e2e/specs/st_disconnect.spec.js
@@ -24,8 +24,11 @@ describe("kill server", () => {
   it("disconnects the client", () => {
     cy.get("[data-testid='stConnectionStatus']").should("not.exist");
 
-    cy.window().then(win => {
-      win.streamlitDebug.closeConnection();
+    cy.window().then((win) => {
+      // We shut down the runtime entirely rather than just close the websocket
+      // connection as the client will immediately reconnect if we just do the
+      // latter.
+      win.streamlitDebug.shutdownRuntime();
 
       cy.get("[data-testid='stConnectionStatus'] label").should(
         "have.text",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -246,8 +246,10 @@ export class App extends PureComponent<Props, State> {
     this.pendingElementsTimerRunning = false
     this.pendingElementsBuffer = this.state.elements
 
-    window.streamlitDebug = {}
-    window.streamlitDebug.closeConnection = this.closeConnection.bind(this)
+    window.streamlitDebug = {
+      disconnectWebsocket: this.debugDisconnectWebsocket,
+      shutdownRuntime: this.debugShutdownRuntime,
+    }
   }
 
   /**
@@ -964,12 +966,23 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Used by e2e tests to test disabling widgets
+   * Used by e2e tests to test disabling widgets.
    */
-  closeConnection(): void {
+  debugShutdownRuntime = (): void => {
     if (this.isServerConnected()) {
-      const backMsg = new BackMsg({ closeConnection: true })
-      backMsg.type = "closeConnection"
+      const backMsg = new BackMsg({ debugShutdownRuntime: true })
+      backMsg.type = "debugShutdownRuntime"
+      this.sendBackMsg(backMsg)
+    }
+  }
+
+  /**
+   * Used by e2e tests to test reconnect behavior.
+   */
+  debugDisconnectWebsocket = (): void => {
+    if (this.isServerConnected()) {
+      const backMsg = new BackMsg({ debugDisconnectWebsocket: true })
+      backMsg.type = "debugDisconnectWebsocket"
       this.sendBackMsg(backMsg)
     }
   }

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -145,14 +145,22 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             self._runtime.handle_backmsg_deserialization_exception(self._session_id, ex)
             return
 
-        if msg.WhichOneof("type") == "close_connection":
-            # "close_connection" is a special developmentMode-only
-            # message used in e2e tests to test disabling widgets.
+        # "debug_disconnect_websocket" and "debug_shutdown_runtime" are special
+        # developmentMode-only messages used in e2e tests to test reconnect handling and
+        # disabling widgets.
+        if msg.WhichOneof("type") == "debug_disconnect_websocket":
+            if config.get_option("global.developmentMode"):
+                self.close()
+            else:
+                _LOGGER.warning(
+                    "Client tried to disconnect websocket when not in development mode."
+                )
+        elif msg.WhichOneof("type") == "debug_shutdown_runtime":
             if config.get_option("global.developmentMode"):
                 self._runtime.stop()
             else:
                 _LOGGER.warning(
-                    "Client tried to close connection when " "not in development mode"
+                    "Client tried to shut down runtime when not in development mode."
                 )
         else:
             # AppSession handles all other BackMsg types.

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -46,12 +46,22 @@ message BackMsg {
     // DEPRECATED. This is now inside ClientState.
     // WidgetStates update_widgets = 9;
 
-    // Set to true to ask the server to close the connection
-    bool close_connection = 10;
+    // DEPRECATED. Set to true to ask the server to close the connection
+    // bool close_connection = 10;
 
     ClientState rerun_script = 11;
 
     bool load_git_info = 12;
+
+    // Test and dev-mode only field used to ask the server to disconnect the
+    // client's websocket connection. This message is IGNORED unless the
+    // runtime is configured with global.developmentMode = True.
+    bool debug_disconnect_websocket = 14;
+
+    // Test and dev-mode only field used to ask the server to shut down the
+    // runtime. This message is IGNORED unless the runtime is configured with
+    // global.developmentMode = True.
+    bool debug_shutdown_runtime = 15;
   }
 
   // An ID used to associate this BackMsg with the corresponding ForwardMsgs
@@ -59,5 +69,7 @@ message BackMsg {
   // should only be used for testing.
   string debug_last_backmsg_id = 13;
 
-  reserved 1, 2, 3, 4, 8, 9;
+  reserved 1, 2, 3, 4, 8, 9, 10;
+
+  // Next: 16
 }


### PR DESCRIPTION
## 📚 Context

This is another change that's being made because we need it for the `feature/session-manager` branch
but is being made straight to `develop` to keep the final diff size down.

The special test-only `closeConnection` proto message type has a pretty misleading name because what
it really does is shut down the runtime entirely. Because we need a way to test reconnect behavior (and thus
a way to close *only* the browser websocket connection without nuking the entire Streamlit server), we replace
this proto type with `debugShutdownRuntime` and `debugDisconnectWebsocket`, which do what their names
suggest.

## 🧪 Testing Done

- [x] Added/Updated e2e tests