### PR TITLE
Fix multipage apps e2e test describe block

### DIFF
--- a/e2e/specs/multipage_apps.spec.js
+++ b/e2e/specs/multipage_apps.spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-describe("st.map", () => {
+describe("multipage apps", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
   });


### PR DESCRIPTION
I noticed the top-level `describe` for the multipage e2e tests is labeled as `st.map`, probably
because I copy-pasted the `describe` block and forgot to change the title, then it managed to
slip by in code review.
