### PR TITLE
Improve alert elements docstrings

### DIFF
--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -47,12 +47,12 @@ class AlertMixin:
 
         Parameters
         ----------
+        body : str
+            The error text to display.
         icon : None
             An optional parameter, that adds an emoji to the alert.
             The default is None.
             This argument can only be supplied by keyword.
-        body : str
-            The error text to display.
 
         Example
         -------

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -49,10 +49,11 @@ class AlertMixin:
         ----------
         body : str
             The error text to display.
-        icon : None
-            An optional parameter, that adds an emoji to the alert.
-            The default is None.
-            This argument can only be supplied by keyword.
+        icon : str or None
+            An optional, keyword-only argument that specifies an emoji to use as
+            the icon for the alert. Shortcodes are not allowed, please use a
+            single character instead. E.g. "🚨", "🔥", "🤖", etc.
+            Defaults to None, which means no icon is displayed.
 
         Example
         -------
@@ -78,10 +79,11 @@ class AlertMixin:
         ----------
         body : str
             The warning text to display.
-        icon : None
-            An optional parameter, that adds an emoji to the alert.
-            The default is None.
-            This argument can only be supplied by keyword.
+        icon : str or None
+            An optional, keyword-only argument that specifies an emoji to use as
+            the icon for the alert. Shortcodes are not allowed, please use a
+            single character instead. E.g. "🚨", "🔥", "🤖", etc.
+            Defaults to None, which means no icon is displayed.
 
         Example
         -------
@@ -107,10 +109,11 @@ class AlertMixin:
         ----------
         body : str
             The info text to display.
-        icon : None
-            An optional parameter, that adds an emoji to the alert.
-            The default is None.
-            This argument can only be supplied by keyword.
+        icon : str or None
+            An optional, keyword-only argument that specifies an emoji to use as
+            the icon for the alert. Shortcodes are not allowed, please use a
+            single character instead. E.g. "🚨", "🔥", "🤖", etc.
+            Defaults to None, which means no icon is displayed.
 
         Example
         -------
@@ -137,10 +140,11 @@ class AlertMixin:
         ----------
         body : str
             The success text to display.
-        icon : None
-            An optional parameter, that adds an emoji to the alert.
-            The default is None.
-            This argument can only be supplied by keyword.
+        icon : str or None
+            An optional, keyword-only argument that specifies an emoji to use as
+            the icon for the alert. Shortcodes are not allowed, please use a
+            single character instead. E.g. "🚨", "🔥", "🤖", etc.
+            Defaults to None, which means no icon is displayed.
 
         Example
         -------


### PR DESCRIPTION
## 📚 Context

The docstring for `icon` arg in st.warning, st.info, etc, is unclear. From its docstring, I can’t tell how to use the `icon` keyword. The type annotation also seems to be wrong (it says `None`, which would mean it only accepts`None` — incorrect).

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Changes the type of `icon` keyword in alert element docstrings from `None` to `str or None`.
- Explains how to use the `icon` keyword, states what's not allowed, and describes the default behavior.
- Reorders the `st.error` parameters in the docstring to be consistent with the order of params in the function signature.

Note: This PR does not update or add any tests as it is merely refactoring/updating the docstring text.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/205647818-c34eb50c-f760-44db-a2f7-ab5768926b8a.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/205647915-d2bc28a6-4f08-45c5-b655-2eb04c1c006c.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests
