### PR TITLE
Pass session ID back from frontend and use it to reconnect

### DIFF
--- a/e2e/scripts/websocket_reconnects.py
+++ b/e2e/scripts/websocket_reconnects.py
@@ -1,0 +1,29 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+from streamlit import runtime
+
+# st.session_state can only be accessed while running with streamlit
+if runtime.exists():
+    if "counter" not in st.session_state:
+        st.session_state.counter = 0
+
+    if st.button("click me!"):
+        st.session_state.counter += 1
+
+    st.write(f"count: {st.session_state.counter}")
+
+    # TODO(vdonato): Add st.file_uploader tests once we're able to teach the file uploader
+    # widget how to retrieve previously uploaded files after a session disconnect/reconnect.

--- a/e2e/scripts/websocket_reconnects.py
+++ b/e2e/scripts/websocket_reconnects.py
@@ -25,5 +25,6 @@ if runtime.exists():
 
     st.write(f"count: {st.session_state.counter}")
 
-    # TODO(vdonato): Add st.file_uploader tests once we're able to teach the file uploader
-    # widget how to retrieve previously uploaded files after a session disconnect/reconnect.
+    # TODO(vdonato): Add st.file_uploader and st.camera_input tests once we're able to
+    # teach those widgets how to retrieve previously uploaded files after a session
+    # disconnect/reconnect.

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("websocket reconnects", () => {
+  beforeEach(() => {
+    cy.loadApp("http://localhost:3000/");
+  });
+
+  it("persists session state when the websocket connection is dropped and reconnects", () => {
+    for (let i = 0; i < 5; i++) {
+      cy.get(".stButton button").contains("click me!").click();
+    }
+
+    cy.window().then((win) => {
+      win.streamlitDebug.disconnectWebsocket();
+
+      // Wait until we've reconnected and rerun the script.
+      cy.get("[data-testid='stStatusWidget']").should("not.exist");
+
+      cy.get(".stMarkdown").contains("count: 5");
+    });
+  });
+});

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -25,8 +25,15 @@ describe("websocket reconnects", () => {
     }
 
     cy.window().then((win) => {
-      win.streamlitDebug.disconnectWebsocket();
+      setTimeout(() => {
+        win.streamlitDebug.disconnectWebsocket();
+      }, 100);
 
+      // Wait until we've disconnected.
+      cy.get("[data-testid='stStatusWidget']").should(
+        "have.text",
+        "Connecting"
+      );
       // Wait until we've reconnected and rerun the script.
       cy.get("[data-testid='stStatusWidget']").should("not.exist");
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -145,6 +145,16 @@ describe("App", () => {
     expect(wrapper.html()).not.toBeNull()
   })
 
+  it("calls connectionManager.disconnect() when unmounting", () => {
+    const wrapper = getWrapper()
+    const instance = wrapper.instance() as App
+
+    wrapper.unmount()
+
+    // @ts-ignore
+    expect(instance.connectionManager.disconnect).toHaveBeenCalled()
+  })
+
   it("reloads when streamlit server version changes", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -321,6 +321,19 @@ export class App extends PureComponent<Props, State> {
   }
 
   componentWillUnmount(): void {
+    // Needing to disconnect our connection manager + websocket connection is
+    // only needed here to handle the case in dev mode where react hot-reloads
+    // the client as a result of a source code change. In this scenario, the
+    // previous websocket connection is still connected, and the client and
+    // server end up in a reconnect loop because the server rejects attempts to
+    // connect to an already-connected session.
+    //
+    // This situation doesn't exist outside of dev mode because the whole App
+    // unmounting is either a page refresh or the browser tab closing.
+    //
+    // The optional chaining on connectionManager is needed to make typescript
+    // happy since connectionManager's type is `ConnectionManager | null`,
+    // but at this point it should always be set.
     this.connectionManager?.disconnect()
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -320,6 +320,10 @@ export class App extends PureComponent<Props, State> {
     }
   }
 
+  componentWillUnmount(): void {
+    this.connectionManager?.disconnect()
+  }
+
   showError(title: string, errorNode: ReactNode): void {
     logError(errorNode)
     const newDialog: DialogProps = {

--- a/frontend/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.tsx
@@ -256,10 +256,15 @@ class CameraInput extends React.PureComponent<Props, State> {
   public componentDidUpdate = (prevProps: Props): void => {
     const { element, widgetMgr } = this.props
 
+    // TODO(vdonato): Rework this now that there's a short window where the app
+    // may reconnect to the server without losing its uploaded files. Just
+    // removing this seemed to work, but I'm not entirely sure if it's the
+    // correct fix.
+    //
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users
     // will lose access to the files they uploaded in their previous session.
-    // If we are reconnecting, reset the file uploader so that the widget is
+    // If we are reconnecting, reset the camera input so that the widget is
     // in sync with the new session.
     if (prevProps.disabled !== this.props.disabled && this.props.disabled) {
       this.reset()

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -145,6 +145,11 @@ class FileUploader extends React.PureComponent<Props, State> {
   public componentDidUpdate = (prevProps: Props): void => {
     const { element, widgetMgr } = this.props
 
+    // TODO(vdonato): Rework this now that there's a short window where the app
+    // may reconnect to the server without losing its uploaded files. Just
+    // removing this seemed to work, but I'm not entirely sure if it's the
+    // correct fix.
+    //
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users
     // will lose access to the files they uploaded in their previous session.

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -137,6 +137,10 @@ export class ConnectionManager {
     }
   }
 
+  disconnect(): void {
+    this.connection?.disconnect()
+  }
+
   private setConnectionState = (
     connectionState: ConnectionState,
     errMsg?: string
@@ -146,7 +150,7 @@ export class ConnectionManager {
       this.props.connectionStateChanged(connectionState)
     }
 
-    if (errMsg || connectionState === ConnectionState.DISCONNECTED_FOREVER) {
+    if (errMsg) {
       this.props.onConnectionError(errMsg || "unknown")
     }
   }

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -21,8 +21,8 @@ test("Throws an error when used before initialization", () => {
   expect(() => SessionInfo.current).toThrow()
 })
 
-test("Clears session info", () => {
-  SessionInfo.current = new SessionInfo({
+test("Saves SessionInfo.current to lastSessionInfo on clear", () => {
+  const sessionInfo = new SessionInfo({
     appId: "aid",
     sessionId: "sessionId",
     streamlitVersion: "sv",
@@ -35,13 +35,18 @@ test("Clears session info", () => {
     userMapboxToken: "mpt",
   })
 
+  // @ts-ignore
+  SessionInfo.lastSessionInfo = "some older value"
+
+  SessionInfo.current = sessionInfo
   expect(SessionInfo.isSet()).toBe(true)
-  expect(SessionInfo.lastSessionId).toBe(undefined)
+  // Also verify that lastSessionInfo is cleared when SessionInfo.current is
+  // set.
+  expect(SessionInfo.lastSessionInfo).toBe(undefined)
 
   SessionInfo.clearSession()
-
   expect(SessionInfo.isSet()).toBe(false)
-  expect(SessionInfo.lastSessionId).toBe("sessionId")
+  expect(SessionInfo.lastSessionInfo).toBe(sessionInfo)
 })
 
 test("Can be initialized from a protobuf", () => {

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -34,10 +34,14 @@ test("Clears session info", () => {
     commandLine: "command line",
     userMapboxToken: "mpt",
   })
+
   expect(SessionInfo.isSet()).toBe(true)
+  expect(SessionInfo.lastSessionId).toBe(undefined)
 
   SessionInfo.clearSession()
+
   expect(SessionInfo.isSet()).toBe(false)
+  expect(SessionInfo.lastSessionId).toBe("sessionId")
 })
 
 test("Can be initialized from a protobuf", () => {

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -41,6 +41,8 @@ export class SessionInfo {
   // Fields that don't change during the lifetime of a session (i.e. a browser tab).
   public readonly appId: string
 
+  public readonly sessionId: string
+
   public readonly streamlitVersion: string
 
   public readonly pythonVersion: string
@@ -72,28 +74,11 @@ export class SessionInfo {
    */
   private static singleton?: SessionInfo
 
-  private static sessionId?: string
-
   /**
-   * Return the sessionId of the last connected session, or undefined if a
-   * session is currently connected.
+   * Our last SessionInfo singleton if there is no currently active session, or
+   * undefined if there is one.
    */
-  public static get lastSessionId(): string | undefined {
-    return SessionInfo.isSet() ? undefined : SessionInfo.sessionId
-  }
-
-  /**
-   * Return the sessionId of the currently connected session.
-   */
-  // eslint-disable-next-line class-methods-use-this
-  public get sessionId(): string {
-    // We're guaranteed that SessionInfo._sessionId is set to the current
-    // session's ID here since there can be at most one SessionInfo object that
-    // exists at one time.
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return SessionInfo.sessionId!
-  }
+  public static lastSessionInfo?: SessionInfo
 
   public static get current(): SessionInfo {
     if (!SessionInfo.singleton) {
@@ -103,6 +88,7 @@ export class SessionInfo {
   }
 
   public static set current(sm: SessionInfo) {
+    SessionInfo.lastSessionInfo = undefined
     SessionInfo.singleton = sm
   }
 
@@ -115,6 +101,7 @@ export class SessionInfo {
   }
 
   public static clearSession(): void {
+    SessionInfo.lastSessionInfo = SessionInfo.singleton
     SessionInfo.singleton = undefined
   }
 
@@ -166,9 +153,8 @@ export class SessionInfo {
       throw new Error("SessionInfo arguments must be non-null")
     }
 
-    SessionInfo.sessionId = sessionId
-
     this.appId = appId
+    this.sessionId = sessionId
     this.streamlitVersion = streamlitVersion
     this.pythonVersion = pythonVersion
     this.installationId = installationId

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -41,8 +41,6 @@ export class SessionInfo {
   // Fields that don't change during the lifetime of a session (i.e. a browser tab).
   public readonly appId: string
 
-  public readonly sessionId: string
-
   public readonly streamlitVersion: string
 
   public readonly pythonVersion: string
@@ -73,6 +71,29 @@ export class SessionInfo {
    *   initialized.
    */
   private static singleton?: SessionInfo
+
+  private static sessionId?: string
+
+  /**
+   * Return the sessionId of the last connected session, or undefined if a
+   * session is currently connected.
+   */
+  public static get lastSessionId(): string | undefined {
+    return SessionInfo.isSet() ? undefined : SessionInfo.sessionId
+  }
+
+  /**
+   * Return the sessionId of the currently connected session.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  public get sessionId(): string {
+    // We're guaranteed that SessionInfo._sessionId is set to the current
+    // session's ID here since there can be at most one SessionInfo object that
+    // exists at one time.
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return SessionInfo.sessionId!
+  }
 
   public static get current(): SessionInfo {
     if (!SessionInfo.singleton) {
@@ -145,8 +166,9 @@ export class SessionInfo {
       throw new Error("SessionInfo arguments must be non-null")
     }
 
+    SessionInfo.sessionId = sessionId
+
     this.appId = appId
-    this.sessionId = sessionId
     this.streamlitVersion = streamlitVersion
     this.pythonVersion = pythonVersion
     this.installationId = installationId

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -649,8 +649,7 @@ describe("WebsocketConnection auth token handling", () => {
   afterEach(() => {
     axios.get = originalAxiosGet
 
-    // @ts-ignore
-    SessionInfo.sessionId = undefined
+    SessionInfo.lastSessionInfo = undefined
   })
 
   it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", async () => {
@@ -687,7 +686,7 @@ describe("WebsocketConnection auth token handling", () => {
 
   it("sets second Sec-WebSocket-Protocol option to lastSessionId", async () => {
     // @ts-ignore
-    SessionInfo.sessionId = "sessionId"
+    SessionInfo.lastSessionInfo = { sessionId: "sessionId" }
 
     const ws = new WebsocketConnection(MOCK_SOCKET_DATA)
 
@@ -702,7 +701,7 @@ describe("WebsocketConnection auth token handling", () => {
 
   it("prioritizes host provided auth token over lastSessionId if both set", async () => {
     // @ts-ignore
-    SessionInfo.sessionId = "sessionId"
+    SessionInfo.lastSessionInfo = { sessionId: "sessionId" }
 
     const resetHostAuthToken = jest.fn()
     const ws = new WebsocketConnection({

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -15,18 +15,19 @@
  */
 
 import axios from "axios"
-import React, { Fragment } from "react"
 import WS from "jest-websocket-mock"
+import { zip } from "lodash"
+import React, { Fragment } from "react"
 
 import { BackMsg } from "src/autogen/proto"
 import { ConnectionState } from "src/lib/ConnectionState"
+import { SessionInfo } from "src/lib/SessionInfo"
 import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   StyledBashCode,
   WebsocketConnection,
   doInitPings,
 } from "src/lib/WebsocketConnection"
-import { zip } from "lodash"
 
 const MOCK_ALLOWED_ORIGINS_RESPONSE = {
   data: {
@@ -560,8 +561,20 @@ describe("WebsocketConnection", () => {
     Promise.all = originalPromiseAll
 
     // @ts-ignore
-    client.websocket.close()
+    if (client.websocket) {
+      // @ts-ignore
+      client.websocket.close()
+    }
     server.close()
+  })
+
+  it("disconnect closes connection and sets state to DISCONNECTED_FOREVER", () => {
+    client.disconnect()
+
+    // @ts-ignore
+    expect(client.state).toBe(ConnectionState.DISCONNECTED_FOREVER)
+    // @ts-ignore
+    expect(client.websocket).toBe(undefined)
   })
 
   it("increments message cache run count", () => {
@@ -635,6 +648,9 @@ describe("WebsocketConnection auth token handling", () => {
 
   afterEach(() => {
     axios.get = originalAxiosGet
+
+    // @ts-ignore
+    SessionInfo.sessionId = undefined
   })
 
   it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", async () => {
@@ -659,6 +675,42 @@ describe("WebsocketConnection auth token handling", () => {
       claimHostAuthToken: () => Promise.resolve("iAmAnAuthToken"),
       resetHostAuthToken,
     })
+
+    // @ts-ignore
+    await ws.connectToWebSocket()
+
+    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
+      "streamlit",
+      "iAmAnAuthToken",
+    ])
+  })
+
+  it("sets second Sec-WebSocket-Protocol option to lastSessionId", async () => {
+    // @ts-ignore
+    SessionInfo.sessionId = "sessionId"
+
+    const ws = new WebsocketConnection(MOCK_SOCKET_DATA)
+
+    // @ts-ignore
+    await ws.connectToWebSocket()
+
+    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
+      "streamlit",
+      "sessionId",
+    ])
+  })
+
+  it("prioritizes host provided auth token over lastSessionId if both set", async () => {
+    // @ts-ignore
+    SessionInfo.sessionId = "sessionId"
+
+    const resetHostAuthToken = jest.fn()
+    const ws = new WebsocketConnection({
+      ...MOCK_SOCKET_DATA,
+      claimHostAuthToken: () => Promise.resolve("iAmAnAuthToken"),
+      resetHostAuthToken,
+    })
+
     // @ts-ignore
     await ws.connectToWebSocket()
 

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -144,7 +144,7 @@ interface MessageQueue {
  *   CONNECTED<───────────────────────────┘
  *
  *
- *                    on fatal error
+ *                    on fatal error or call to .disconnect()
  *                    :
  *   <ANY_STATE> ──────────────> DISCONNECTED_FOREVER
  */
@@ -225,6 +225,10 @@ export class WebsocketConnection {
       return this.args.baseUriPartsList[this.uriIndex]
     }
     return undefined
+  }
+
+  public disconnect(): void {
+    this.setFsmState(ConnectionState.DISCONNECTED_FOREVER)
   }
 
   // This should only be called inside stepFsm().
@@ -387,9 +391,11 @@ export class WebsocketConnection {
     // Sec-WebSocket-Protocol is set, many clients expect the server to respond
     // with a selected subprotocol to use. We don't want that reply to be the
     // auth token, so we just hard-code it to "streamlit".
+
+    const sessionToken = hostAuthToken || SessionInfo.lastSessionId
     this.websocket = new WebSocket(uri, [
       "streamlit",
-      ...(hostAuthToken ? [hostAuthToken] : []),
+      ...(sessionToken ? [sessionToken] : []),
     ])
     this.websocket.binaryType = "arraybuffer"
 

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -257,7 +257,7 @@ export class WebsocketConnection {
         break
 
       case ConnectionState.DISCONNECTED_FOREVER:
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         break
 
       default:
@@ -424,7 +424,7 @@ export class WebsocketConnection {
     this.websocket.onclose = () => {
       if (checkWebsocket()) {
         logWarning(LOG, "WebSocket onclose")
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("CONNECTION_CLOSED")
       }
     }
@@ -432,7 +432,7 @@ export class WebsocketConnection {
     this.websocket.onerror = () => {
       if (checkWebsocket()) {
         logError(LOG, "WebSocket onerror")
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("CONNECTION_ERROR")
       }
     }
@@ -462,21 +462,21 @@ export class WebsocketConnection {
         // This should never happen! The only place we call
         // setConnectionTimeout() should be immediately before setting
         // this.websocket.
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("FATAL_ERROR", "Null Websocket in setConnectionTimeout")
         return
       }
 
       if (this.websocket.readyState === 0 /* CONNECTING */) {
         logMessage(LOG, `${uri} timed out`)
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("CONNECTION_TIMED_OUT")
       }
     }, WEBSOCKET_TIMEOUT_MS)
     logMessage(LOG, `Set WS timeout ${this.wsConnectionTimeoutId}`)
   }
 
-  private cancelConnectionAttempt(): void {
+  private closeConnection(): void {
     // Need to make sure the websocket is closed in the same function that
     // cancels the connection timer. Otherwise, due to javascript's concurrency
     // model, when the onclose event fires it can get handled in between the

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -314,6 +314,7 @@ class Runtime:
         self,
         client: SessionClient,
         user_info: Dict[str, Optional[str]],
+        existing_session_id: Optional[str] = None,
     ) -> str:
         """Create a new session and return its unique ID.
 
@@ -346,6 +347,7 @@ class Runtime:
             client=client,
             session_data=SessionData(self._main_script_path, self._command_line),
             user_info=user_info,
+            existing_session_id=existing_session_id,
         )
         self._set_state(RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED)
         self._get_async_objs().has_connection.set()

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -63,16 +63,26 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         parts[0] = "ws"
         return urllib.parse.urlunparse(tuple(parts))
 
-    async def ws_connect(self) -> WebSocketClientConnection:
+    async def ws_connect(self, existing_session_id=None) -> WebSocketClientConnection:
         """Open a websocket connection to the server.
 
         Returns
         -------
         WebSocketClientConnection
             The connected websocket client.
-
         """
-        return await tornado.websocket.websocket_connect(self.get_ws_url("/stream"))
+
+        # See the comment in WebsocketConnection.tsx about how we repurpose the
+        # Sec-WebSocket-Protocol header for more information on how this works.
+        if existing_session_id is None:
+            subprotocols = ["streamlit"]
+        else:
+            subprotocols = ["streamlit", existing_session_id]
+
+        return await tornado.websocket.websocket_connect(
+            self.get_ws_url("/stream"),
+            subprotocols=subprotocols,
+        )
 
     async def read_forward_msg(
         self, ws_client: WebSocketClientConnection


### PR DESCRIPTION
## 📚 Context

This PR wraps up the websocket reconnect behavior improvements being implemented in this feature branch.
Now that the server knows how to accept an `existing_session_id` and reconnect to it due to the work done in
#5806, the last step is to pass the session ID that we want to reconnect to from the client when attempting to
reestablish a websocket connection.

There are still a few things related to reconnect improvements that I want to get done after this PR is merged:

* Within the feature branch,
  * Rename some methods/classes, such as `Runtime.create_session` -> `Runtime.connect_session` and
     `SessionData` -> something that doesn't sound so similar to `SessionInfo`.
  * Finalize and write docstrings for the thread safety semantics of `SessionManager` methods.
* As a followup project (after the feature branch is merged), fix `st.file_uploader` to be able to retain its files across
   websocket disconnects.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests
- [x] Added/Updated e2e tests
