### PR TITLE
Singleton: `ttl` and `max_entries` support

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -19,10 +19,12 @@ import contextlib
 import functools
 import hashlib
 import inspect
+import math
 import threading
 import types
 from abc import abstractmethod
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Callable, Iterator, Union
 
 from google.protobuf.message import Message
@@ -53,6 +55,17 @@ from streamlit.runtime.scriptrunner.script_run_context import (
 from streamlit.runtime.state.session_state import WidgetMetadata
 
 _LOGGER = get_logger(__name__)
+
+
+def ttl_to_seconds(ttl: float | timedelta | None) -> float:
+    """Convert a ttl value to a "seconds" float.
+    If ttl is None, return Infinity.
+    """
+    if ttl is None:
+        return math.inf
+    if isinstance(ttl, timedelta):
+        return ttl.total_seconds()
+    return ttl
 
 
 @runtime_checkable

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -21,6 +21,7 @@ import hashlib
 import inspect
 import math
 import threading
+import time
 import types
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -55,6 +56,10 @@ from streamlit.runtime.scriptrunner.script_run_context import (
 from streamlit.runtime.state.session_state import WidgetMetadata
 
 _LOGGER = get_logger(__name__)
+
+# The timer function we use with TTLCache. This is the default timer func, but
+# is exposed here as a constant so that it can be patched in unit tests.
+TTLCACHE_TIMER = time.monotonic
 
 
 def ttl_to_seconds(ttl: float | timedelta | None) -> float:

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -63,7 +63,7 @@ TTLCACHE_TIMER = time.monotonic
 
 
 def ttl_to_seconds(ttl: float | timedelta | None) -> float:
-    """Convert a ttl value to a "seconds" float.
+    """Convert a ttl value to a float representing "number of seconds".
     If ttl is None, return Infinity.
     """
     if ttl is None:

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -47,6 +47,7 @@ from streamlit.runtime.caching.cache_utils import (
     MsgData,
     MultiCacheResults,
     create_cache_wrapper,
+    ttl_to_seconds,
 )
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
@@ -77,7 +78,7 @@ class MemoizedFunction(CachedFunction):
         suppress_st_warning: bool,
         persist: str | None,
         max_entries: int | None,
-        ttl: float | None,
+        ttl: float | timedelta | None,
         allow_widgets: bool,
     ):
         super().__init__(func, show_spinner, suppress_st_warning, allow_widgets)
@@ -125,7 +126,7 @@ class MemoCaches(CacheStatsProvider):
         key: str,
         persist: str | None,
         max_entries: int | float | None,
-        ttl: int | float | None,
+        ttl: int | float | timedelta | None,
         display_name: str,
         allow_widgets: bool,
     ) -> MemoCache:
@@ -135,8 +136,9 @@ class MemoCaches(CacheStatsProvider):
         """
         if max_entries is None:
             max_entries = math.inf
-        if ttl is None:
-            ttl = math.inf
+
+        # Convert ttl to seconds
+        ttl_seconds = ttl_to_seconds(ttl)
 
         # Get the existing cache, if it exists, and validate that its params
         # haven't changed.
@@ -144,7 +146,7 @@ class MemoCaches(CacheStatsProvider):
             cache = self._function_caches.get(key)
             if (
                 cache is not None
-                and cache.ttl == ttl
+                and cache.ttl_seconds == ttl_seconds
                 and cache.max_entries == max_entries
                 and cache.persist == persist
             ):
@@ -162,7 +164,7 @@ class MemoCaches(CacheStatsProvider):
                 key=key,
                 persist=persist,
                 max_entries=max_entries,
-                ttl=ttl,
+                ttl_seconds=ttl_seconds,
                 display_name=display_name,
                 allow_widgets=allow_widgets,
             )
@@ -354,13 +356,6 @@ class MemoAPI:
                 f"Unsupported persist option '{persist}'. Valid values are 'disk' or None."
             )
 
-        ttl_seconds: float | None
-
-        if isinstance(ttl, timedelta):
-            ttl_seconds = ttl.total_seconds()
-        else:
-            ttl_seconds = ttl
-
         def wrapper(f):
             # We use wrapper function here instead of lambda function to be able to log
             # warning in case both persist="disk" and ttl parameters specified
@@ -376,7 +371,7 @@ class MemoAPI:
                     show_spinner=show_spinner,
                     suppress_st_warning=suppress_st_warning,
                     max_entries=max_entries,
-                    ttl=ttl_seconds,
+                    ttl=ttl,
                     allow_widgets=experimental_allow_widgets,
                 )
             )
@@ -393,7 +388,7 @@ class MemoAPI:
                 show_spinner=show_spinner,
                 suppress_st_warning=suppress_st_warning,
                 max_entries=max_entries,
-                ttl=ttl_seconds,
+                ttl=ttl,
                 allow_widgets=experimental_allow_widgets,
             )
         )
@@ -413,7 +408,7 @@ class MemoCache(Cache):
         key: str,
         persist: str | None,
         max_entries: float,
-        ttl: float,
+        ttl_seconds: float,
         display_name: str,
         allow_widgets: bool = False,
     ):
@@ -421,7 +416,7 @@ class MemoCache(Cache):
         self.display_name = display_name
         self.persist = persist
         self._mem_cache: TTLCache[str, bytes] = TTLCache(
-            maxsize=max_entries, ttl=ttl, timer=_TTLCACHE_TIMER
+            maxsize=max_entries, ttl=ttl_seconds, timer=_TTLCACHE_TIMER
         )
         self._mem_cache_lock = threading.Lock()
         self.allow_widgets = allow_widgets
@@ -431,7 +426,7 @@ class MemoCache(Cache):
         return cast(float, self._mem_cache.maxsize)
 
     @property
-    def ttl(self) -> float:
+    def ttl_seconds(self) -> float:
         return cast(float, self._mem_cache.ttl)
 
     def get_stats(self) -> list[CacheStat]:

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -20,7 +20,6 @@ import os
 import pickle
 import shutil
 import threading
-import time
 import types
 from datetime import timedelta
 from typing import Any, Callable, TypeVar, cast, overload
@@ -32,6 +31,7 @@ from streamlit import util
 from streamlit.errors import StreamlitAPIException
 from streamlit.file_util import get_streamlit_file_path, streamlit_read, streamlit_write
 from streamlit.logger import get_logger
+from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.cache_errors import (
     CacheError,
     CacheKeyNotFoundError,
@@ -54,10 +54,6 @@ from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 
 _LOGGER = get_logger(__name__)
-
-# The timer function we use with TTLCache. This is the default timer func, but
-# is exposed here as a constant so that it can be patched in unit tests.
-_TTLCACHE_TIMER = time.monotonic
 
 # Streamlit directory where persisted memoized items live.
 # (This is the same directory that @st.cache persisted items live. But memoized
@@ -416,7 +412,7 @@ class MemoCache(Cache):
         self.display_name = display_name
         self.persist = persist
         self._mem_cache: TTLCache[str, bytes] = TTLCache(
-            maxsize=max_entries, ttl=ttl_seconds, timer=_TTLCACHE_TIMER
+            maxsize=max_entries, ttl=ttl_seconds, timer=cache_utils.TTLCACHE_TIMER
         )
         self._mem_cache_lock = threading.Lock()
         self.allow_widgets = allow_widgets

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -133,7 +133,6 @@ class MemoCaches(CacheStatsProvider):
         if max_entries is None:
             max_entries = math.inf
 
-        # Convert ttl to seconds
         ttl_seconds = ttl_to_seconds(ttl)
 
         # Get the existing cache, if it exists, and validate that its params

--- a/lib/streamlit/runtime/caching/singleton_decorator.py
+++ b/lib/streamlit/runtime/caching/singleton_decorator.py
@@ -73,7 +73,6 @@ class SingletonCaches(CacheStatsProvider):
         if max_entries is None:
             max_entries = math.inf
 
-        # Convert ttl to seconds
         ttl_seconds = ttl_to_seconds(ttl)
 
         # Get the existing cache, if it exists, and validate that its params

--- a/lib/streamlit/runtime/caching/singleton_decorator.py
+++ b/lib/streamlit/runtime/caching/singleton_decorator.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import math
 import threading
-import time
 import types
 from datetime import timedelta
 from typing import Any, Callable, TypeVar, cast, overload
@@ -27,6 +26,7 @@ from pympler import asizeof
 
 import streamlit as st
 from streamlit.logger import get_logger
+from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.cache_errors import CacheKeyNotFoundError, CacheType
 from streamlit.runtime.caching.cache_utils import (
     Cache,
@@ -45,10 +45,6 @@ from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 
 _LOGGER = get_logger(__name__)
-
-# The timer function we use with TTLCache. This is the default timer func, but
-# is exposed here as a constant so that it can be patched in unit tests.
-_TTLCACHE_TIMER = time.monotonic
 
 
 SINGLETON_CALL_STACK = CacheWarningCallStack(CacheType.SINGLETON)
@@ -353,7 +349,7 @@ class SingletonCache(Cache):
         self.key = key
         self.display_name = display_name
         self._mem_cache: TTLCache[str, MultiCacheResults] = TTLCache(
-            maxsize=max_entries, ttl=ttl_seconds, timer=_TTLCACHE_TIMER
+            maxsize=max_entries, ttl=ttl_seconds, timer=cache_utils.TTLCACHE_TIMER
         )
         self._mem_cache_lock = threading.Lock()
         self.allow_widgets = allow_widgets

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -1,0 +1,35 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import unittest
+from datetime import timedelta
+from typing import Any
+
+from parameterized import parameterized
+
+from streamlit.runtime.caching.cache_utils import ttl_to_seconds
+
+
+class CacheUtilsTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("float", 3.5, 3.5),
+            ("timedelta", timedelta(minutes=3), 60 * 3),
+            ("None", None, math.inf),
+        ]
+    )
+    def test_ttl_to_seconds(self, _, input_value: Any, expected_seconds: float):
+        """Test the various types of input that ttl_to_seconds accepts."""
+        self.assertEqual(expected_seconds, ttl_to_seconds(input_value))

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -18,7 +18,7 @@ import threading
 import unittest
 from datetime import timedelta
 from typing import Any, List
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 
@@ -631,145 +631,123 @@ class CommonCacheTTLTest(unittest.TestCase):
         memo.clear()
         singleton.clear()
 
-    @parameterized.expand(
-        [
-            ("memo", memo, "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER"),
-            (
-                "singleton",
-                singleton,
-                "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER",
-            ),
-        ]
-    )
-    def test_ttl(self, _, cache_decorator, timer_import: str):
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
+    @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
+    def test_ttl(self, _, cache_decorator, timer_patch: Mock):
         """Entries should expire after the given ttl."""
-        with patch(timer_import) as timer_patch:
-            one_day = 60 * 60 * 24
+        one_day = 60 * 60 * 24
 
-            # Create 2 cached functions to test that they don't interfere
-            # with each other.
-            foo_vals = []
+        # Create 2 cached functions to test that they don't interfere
+        # with each other.
+        foo_vals = []
 
-            @cache_decorator(ttl=one_day)
-            def foo(x):
-                foo_vals.append(x)
-                return x
+        @cache_decorator(ttl=one_day)
+        def foo(x):
+            foo_vals.append(x)
+            return x
 
-            bar_vals = []
+        bar_vals = []
 
-            @cache_decorator(ttl=one_day * 2)
-            def bar(x):
-                bar_vals.append(x)
-                return x
+        @cache_decorator(ttl=one_day * 2)
+        def bar(x):
+            bar_vals.append(x)
+            return x
 
-            # Store a value at time 0
-            timer_patch.return_value = 0
-            foo(0)
-            bar(0)
-            self.assertEqual([0], foo_vals)
-            self.assertEqual([0], bar_vals)
+        # Store a value at time 0
+        timer_patch.return_value = 0
+        foo(0)
+        bar(0)
+        self.assertEqual([0], foo_vals)
+        self.assertEqual([0], bar_vals)
 
-            # Advance our timer, but not enough to expire our value.
-            timer_patch.return_value = one_day * 0.5
-            foo(0)
-            bar(0)
-            self.assertEqual([0], foo_vals)
-            self.assertEqual([0], bar_vals)
+        # Advance our timer, but not enough to expire our value.
+        timer_patch.return_value = one_day * 0.5
+        foo(0)
+        bar(0)
+        self.assertEqual([0], foo_vals)
+        self.assertEqual([0], bar_vals)
 
-            # Advance our timer enough to expire foo, but not bar.
-            timer_patch.return_value = one_day * 1.5
-            foo(0)
-            bar(0)
-            self.assertEqual([0, 0], foo_vals)
-            self.assertEqual([0], bar_vals)
+        # Advance our timer enough to expire foo, but not bar.
+        timer_patch.return_value = one_day * 1.5
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0], foo_vals)
+        self.assertEqual([0], bar_vals)
 
-            # Expire bar. Foo's second value was inserted at time=1.5 days,
-            # so it won't expire until time=2.5 days
-            timer_patch.return_value = (one_day * 2) + 1
-            foo(0)
-            bar(0)
-            self.assertEqual([0, 0], foo_vals)
-            self.assertEqual([0, 0], bar_vals)
+        # Expire bar. Foo's second value was inserted at time=1.5 days,
+        # so it won't expire until time=2.5 days
+        timer_patch.return_value = (one_day * 2) + 1
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0], foo_vals)
+        self.assertEqual([0, 0], bar_vals)
 
-            # Expire foo for a second time.
-            timer_patch.return_value = (one_day * 2.5) + 1
-            foo(0)
-            bar(0)
-            self.assertEqual([0, 0, 0], foo_vals)
-            self.assertEqual([0, 0], bar_vals)
+        # Expire foo for a second time.
+        timer_patch.return_value = (one_day * 2.5) + 1
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0, 0], foo_vals)
+        self.assertEqual([0, 0], bar_vals)
 
-    @parameterized.expand(
-        [
-            (
-                "memo",
-                st.experimental_memo,
-                "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER",
-            ),
-            (
-                "singleton",
-                st.experimental_singleton,
-                "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER",
-            ),
-        ]
-    )
-    def test_ttl_timedelta(self, _, cache_decorator, timer_import: str):
+    @parameterized.expand([("memo", memo), ("singleton", singleton)])
+    @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
+    def test_ttl_timedelta(self, _, cache_decorator, timer_patch: Mock):
         """Entries should expire after the given ttl."""
-        with patch(timer_import) as timer_patch:
-            one_day_seconds = 60 * 60 * 24
-            one_day_timedelta = timedelta(days=1)
-            two_days_timedelta = timedelta(days=2)
+        one_day_seconds = 60 * 60 * 24
+        one_day_timedelta = timedelta(days=1)
+        two_days_timedelta = timedelta(days=2)
 
-            # Create 2 cached functions to test that they don't interfere
-            # with each other.
-            foo_vals = []
+        # Create 2 cached functions to test that they don't interfere
+        # with each other.
+        foo_vals = []
 
-            @cache_decorator(ttl=one_day_timedelta)
-            def foo(x):
-                foo_vals.append(x)
-                return x
+        @cache_decorator(ttl=one_day_timedelta)
+        def foo(x):
+            foo_vals.append(x)
+            return x
 
-            bar_vals = []
+        bar_vals = []
 
-            @cache_decorator(ttl=two_days_timedelta)
-            def bar(x):
-                bar_vals.append(x)
-                return x
+        @cache_decorator(ttl=two_days_timedelta)
+        def bar(x):
+            bar_vals.append(x)
+            return x
 
-            # Store a value at time 0
-            timer_patch.return_value = 0
-            foo(0)
-            bar(0)
-            self.assertEqual([0], foo_vals)
-            self.assertEqual([0], bar_vals)
+        # Store a value at time 0
+        timer_patch.return_value = 0
+        foo(0)
+        bar(0)
+        self.assertEqual([0], foo_vals)
+        self.assertEqual([0], bar_vals)
 
-            # Advance our timer, but not enough to expire our value.
-            timer_patch.return_value = one_day_seconds * 0.5
-            foo(0)
-            bar(0)
-            self.assertEqual([0], foo_vals)
-            self.assertEqual([0], bar_vals)
+        # Advance our timer, but not enough to expire our value.
+        timer_patch.return_value = one_day_seconds * 0.5
+        foo(0)
+        bar(0)
+        self.assertEqual([0], foo_vals)
+        self.assertEqual([0], bar_vals)
 
-            # Advance our timer enough to expire foo, but not bar.
-            timer_patch.return_value = one_day_seconds * 1.5
-            foo(0)
-            bar(0)
-            self.assertEqual([0, 0], foo_vals)
-            self.assertEqual([0], bar_vals)
+        # Advance our timer enough to expire foo, but not bar.
+        timer_patch.return_value = one_day_seconds * 1.5
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0], foo_vals)
+        self.assertEqual([0], bar_vals)
 
-            # Expire bar. Foo's second value was inserted at time=1.5 days,
-            # so it won't expire until time=2.5 days
-            timer_patch.return_value = (one_day_seconds * 2) + 1
-            foo(0)
-            bar(0)
-            self.assertEqual([0, 0], foo_vals)
-            self.assertEqual([0, 0], bar_vals)
+        # Expire bar. Foo's second value was inserted at time=1.5 days,
+        # so it won't expire until time=2.5 days
+        timer_patch.return_value = (one_day_seconds * 2) + 1
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0], foo_vals)
+        self.assertEqual([0, 0], bar_vals)
 
-            # Expire foo for a second time.
-            timer_patch.return_value = (one_day_seconds * 2.5) + 1
-            foo(0)
-            bar(0)
-            self.assertEqual([0, 0, 0], foo_vals)
-            self.assertEqual([0, 0], bar_vals)
+        # Expire foo for a second time.
+        timer_patch.return_value = (one_day_seconds * 2.5) + 1
+        foo(0)
+        bar(0)
+        self.assertEqual([0, 0, 0], foo_vals)
+        self.assertEqual([0, 0], bar_vals)
 
 
 class CommonCacheThreadingTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -633,11 +633,11 @@ class CommonCacheTTLTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("memo", memo, "streamlit.runtime.caching.memo_decorator._TTLCACHE_TIMER"),
+            ("memo", memo, "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER"),
             (
                 "singleton",
                 singleton,
-                "streamlit.runtime.caching.singleton_decorator._TTLCACHE_TIMER",
+                "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER",
             ),
         ]
     )
@@ -703,12 +703,12 @@ class CommonCacheTTLTest(unittest.TestCase):
             (
                 "memo",
                 st.experimental_memo,
-                "streamlit.runtime.caching.memo_decorator._TTLCACHE_TIMER",
+                "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER",
             ),
             (
                 "singleton",
                 st.experimental_singleton,
-                "streamlit.runtime.caching.singleton_decorator._TTLCACHE_TIMER",
+                "streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER",
             ),
         ]
     )

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -16,6 +16,7 @@
 
 import threading
 import unittest
+from datetime import timedelta
 from typing import Any, List
 from unittest.mock import patch
 
@@ -41,6 +42,7 @@ from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.exception_capturing_thread import ExceptionCapturingThread, call_on_threads
 from tests.streamlit.elements.image_test import create_image
+from tests.testutil import create_mock_script_run_ctx
 
 memo = st.experimental_memo
 singleton = st.experimental_singleton
@@ -618,6 +620,156 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
         function_with_spinner_empty_text(3)
         self.assertFalse(self.forward_msg_queue.is_empty())
+
+
+class CommonCacheTTLTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+    def tearDown(self):
+        memo.clear()
+        singleton.clear()
+
+    @parameterized.expand(
+        [
+            ("memo", memo, "streamlit.runtime.caching.memo_decorator._TTLCACHE_TIMER"),
+            (
+                "singleton",
+                singleton,
+                "streamlit.runtime.caching.singleton_decorator._TTLCACHE_TIMER",
+            ),
+        ]
+    )
+    def test_ttl(self, _, cache_decorator, timer_import: str):
+        """Entries should expire after the given ttl."""
+        with patch(timer_import) as timer_patch:
+            one_day = 60 * 60 * 24
+
+            # Create 2 cached functions to test that they don't interfere
+            # with each other.
+            foo_vals = []
+
+            @cache_decorator(ttl=one_day)
+            def foo(x):
+                foo_vals.append(x)
+                return x
+
+            bar_vals = []
+
+            @cache_decorator(ttl=one_day * 2)
+            def bar(x):
+                bar_vals.append(x)
+                return x
+
+            # Store a value at time 0
+            timer_patch.return_value = 0
+            foo(0)
+            bar(0)
+            self.assertEqual([0], foo_vals)
+            self.assertEqual([0], bar_vals)
+
+            # Advance our timer, but not enough to expire our value.
+            timer_patch.return_value = one_day * 0.5
+            foo(0)
+            bar(0)
+            self.assertEqual([0], foo_vals)
+            self.assertEqual([0], bar_vals)
+
+            # Advance our timer enough to expire foo, but not bar.
+            timer_patch.return_value = one_day * 1.5
+            foo(0)
+            bar(0)
+            self.assertEqual([0, 0], foo_vals)
+            self.assertEqual([0], bar_vals)
+
+            # Expire bar. Foo's second value was inserted at time=1.5 days,
+            # so it won't expire until time=2.5 days
+            timer_patch.return_value = (one_day * 2) + 1
+            foo(0)
+            bar(0)
+            self.assertEqual([0, 0], foo_vals)
+            self.assertEqual([0, 0], bar_vals)
+
+            # Expire foo for a second time.
+            timer_patch.return_value = (one_day * 2.5) + 1
+            foo(0)
+            bar(0)
+            self.assertEqual([0, 0, 0], foo_vals)
+            self.assertEqual([0, 0], bar_vals)
+
+    @parameterized.expand(
+        [
+            (
+                "memo",
+                st.experimental_memo,
+                "streamlit.runtime.caching.memo_decorator._TTLCACHE_TIMER",
+            ),
+            (
+                "singleton",
+                st.experimental_singleton,
+                "streamlit.runtime.caching.singleton_decorator._TTLCACHE_TIMER",
+            ),
+        ]
+    )
+    def test_ttl_timedelta(self, _, cache_decorator, timer_import: str):
+        """Entries should expire after the given ttl."""
+        with patch(timer_import) as timer_patch:
+            one_day_seconds = 60 * 60 * 24
+            one_day_timedelta = timedelta(days=1)
+            two_days_timedelta = timedelta(days=2)
+
+            # Create 2 cached functions to test that they don't interfere
+            # with each other.
+            foo_vals = []
+
+            @cache_decorator(ttl=one_day_timedelta)
+            def foo(x):
+                foo_vals.append(x)
+                return x
+
+            bar_vals = []
+
+            @cache_decorator(ttl=two_days_timedelta)
+            def bar(x):
+                bar_vals.append(x)
+                return x
+
+            # Store a value at time 0
+            timer_patch.return_value = 0
+            foo(0)
+            bar(0)
+            self.assertEqual([0], foo_vals)
+            self.assertEqual([0], bar_vals)
+
+            # Advance our timer, but not enough to expire our value.
+            timer_patch.return_value = one_day_seconds * 0.5
+            foo(0)
+            bar(0)
+            self.assertEqual([0], foo_vals)
+            self.assertEqual([0], bar_vals)
+
+            # Advance our timer enough to expire foo, but not bar.
+            timer_patch.return_value = one_day_seconds * 1.5
+            foo(0)
+            bar(0)
+            self.assertEqual([0, 0], foo_vals)
+            self.assertEqual([0], bar_vals)
+
+            # Expire bar. Foo's second value was inserted at time=1.5 days,
+            # so it won't expire until time=2.5 days
+            timer_patch.return_value = (one_day_seconds * 2) + 1
+            foo(0)
+            bar(0)
+            self.assertEqual([0, 0], foo_vals)
+            self.assertEqual([0, 0], bar_vals)
+
+            # Expire foo for a second time.
+            timer_patch.return_value = (one_day_seconds * 2.5) + 1
+            foo(0)
+            bar(0)
+            self.assertEqual([0, 0, 0], foo_vals)
+            self.assertEqual([0, 0], bar_vals)
 
 
 class CommonCacheThreadingTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/caching/memo_test.py
+++ b/lib/tests/streamlit/runtime/caching/memo_test.py
@@ -18,9 +18,10 @@ import pickle
 import re
 import threading
 import unittest
-from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, Mock, mock_open, patch
+
+from parameterized import parameterized
 
 import streamlit as st
 from streamlit import file_util
@@ -97,122 +98,6 @@ class MemoTest(unittest.TestCase):
 
         self.assertEqual(r1, [1, 1])
         self.assertEqual(r2, [0, 1])
-
-    @patch("streamlit.runtime.caching.memo_decorator._TTLCACHE_TIMER")
-    def test_ttl(self, timer_patch):
-        """Entries should expire after the given ttl."""
-        one_day = 60 * 60 * 24
-
-        # Create 2 cached functions to test that they don't interfere
-        # with each other.
-        foo_vals = []
-
-        @st.experimental_memo(ttl=one_day)
-        def foo(x):
-            foo_vals.append(x)
-            return x
-
-        bar_vals = []
-
-        @st.experimental_memo(ttl=one_day * 2)
-        def bar(x):
-            bar_vals.append(x)
-            return x
-
-        # Store a value at time 0
-        timer_patch.return_value = 0
-        foo(0)
-        bar(0)
-        self.assertEqual([0], foo_vals)
-        self.assertEqual([0], bar_vals)
-
-        # Advance our timer, but not enough to expire our value.
-        timer_patch.return_value = one_day * 0.5
-        foo(0)
-        bar(0)
-        self.assertEqual([0], foo_vals)
-        self.assertEqual([0], bar_vals)
-
-        # Advance our timer enough to expire foo, but not bar.
-        timer_patch.return_value = one_day * 1.5
-        foo(0)
-        bar(0)
-        self.assertEqual([0, 0], foo_vals)
-        self.assertEqual([0], bar_vals)
-
-        # Expire bar. Foo's second value was inserted at time=1.5 days,
-        # so it won't expire until time=2.5 days
-        timer_patch.return_value = (one_day * 2) + 1
-        foo(0)
-        bar(0)
-        self.assertEqual([0, 0], foo_vals)
-        self.assertEqual([0, 0], bar_vals)
-
-        # Expire foo for a second time.
-        timer_patch.return_value = (one_day * 2.5) + 1
-        foo(0)
-        bar(0)
-        self.assertEqual([0, 0, 0], foo_vals)
-        self.assertEqual([0, 0], bar_vals)
-
-    @patch("streamlit.runtime.caching.memo_decorator._TTLCACHE_TIMER")
-    def test_ttl_timedelta(self, timer_patch):
-        """Entries should expire after the given ttl."""
-        one_day_seconds = 60 * 60 * 24
-        one_day_timedelta = timedelta(days=1)
-        two_days_timedelta = timedelta(days=2)
-
-        # Create 2 cached functions to test that they don't interfere
-        # with each other.
-        foo_vals = []
-
-        @st.experimental_memo(ttl=one_day_timedelta)
-        def foo(x):
-            foo_vals.append(x)
-            return x
-
-        bar_vals = []
-
-        @st.experimental_memo(ttl=two_days_timedelta)
-        def bar(x):
-            bar_vals.append(x)
-            return x
-
-        # Store a value at time 0
-        timer_patch.return_value = 0
-        foo(0)
-        bar(0)
-        self.assertEqual([0], foo_vals)
-        self.assertEqual([0], bar_vals)
-
-        # Advance our timer, but not enough to expire our value.
-        timer_patch.return_value = one_day_seconds * 0.5
-        foo(0)
-        bar(0)
-        self.assertEqual([0], foo_vals)
-        self.assertEqual([0], bar_vals)
-
-        # Advance our timer enough to expire foo, but not bar.
-        timer_patch.return_value = one_day_seconds * 1.5
-        foo(0)
-        bar(0)
-        self.assertEqual([0, 0], foo_vals)
-        self.assertEqual([0], bar_vals)
-
-        # Expire bar. Foo's second value was inserted at time=1.5 days,
-        # so it won't expire until time=2.5 days
-        timer_patch.return_value = (one_day_seconds * 2) + 1
-        foo(0)
-        bar(0)
-        self.assertEqual([0, 0], foo_vals)
-        self.assertEqual([0, 0], bar_vals)
-
-        # Expire foo for a second time.
-        timer_patch.return_value = (one_day_seconds * 2.5) + 1
-        foo(0)
-        bar(0)
-        self.assertEqual([0, 0, 0], foo_vals)
-        self.assertEqual([0, 0], bar_vals)
 
 
 class MemoPersistTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
Adds `ttl` and `max_entries` support to `@st.experimental_singleton`.

This is primarily just copied from the existing support in `memo`, which means that `singleton` now uses a `cachetools.TTLCache` instance for its storage.

There are a few new common utilities and tests where appropriate.