### PR TITLE
Upgrade vega package to latest with vega-tooltip resolved to the latest version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -219,6 +219,7 @@
     "tar": "^6.1.9",
     "trim": "^0.0.3",
     "trim-newlines": "^3.0.1",
+    "vega-tooltip": "^0.30.0",
     "websocket-extensions": "^0.1.4",
     "ws": "^7.4.6",
     "y18n": "^4.0.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -18677,10 +18677,10 @@ vega-time@^2.0.3, vega-time@^2.0.4, vega-time@~2.0.4:
     d3-time "^2.0.0"
     vega-util "^1.15.2"
 
-vega-tooltip@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.28.0.tgz#8bae2601ffae5e67622de37108f53f284e9a978b"
-  integrity sha512-DbK0V5zzk+p9cphZZXV91ZGeKq0zr6JIS0VndUoGTisldzw4tRgmpGQcTfMjew53o7/voeTM2ELTnJAJRzX4tg==
+vega-tooltip@^0.28.0, vega-tooltip@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.30.0.tgz#b8a48a0d1be717b7410cf75021aaaff75818b212"
+  integrity sha512-dBuqp1HgNvxrc3MU4KAE3gU7AiD0AvCiyu7IMwubI6TQa0l9A5c+B+ZLjDZP2Ool0J9eAaGgVhqjXWaUjUAfAQ==
   dependencies:
     vega-util "^1.17.0"
 


### PR DESCRIPTION
## 📚 Context

`vega-tooltip` had an issue with `unsafe-inline` for a Content Security Policy (See https://github.com/vega/vega-tooltip/pull/714). This sets the resolution for `vega-tooltip` to ensure the latest version is used.

(We considered upgrading `vega`, but there were too many additional versions of d3 downloaded and we can save that for a specific project.)

- What kind of change does this PR introduce?

  - [x] Other, please describe: part bug fix/part feature to better support CSPs

## 🧪 Testing Done

No testing is needed beyond what we currently available. Our e2e tests will verify the output of the charts remain the same. See the following folders in the [snapshots directory](https://github.com/streamlit/streamlit/tree/develop/frontend/cypress/snapshots/linux/2x).

- st_arrow_altair_chart.spec.js
- st_arrow_vega_lite_chart.spec.js
- st_arrow_bar_chart.spec.js
- st_arrow_line_chart.spec.js
- st_arrow_area_chart.spec.js

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
