### PR TITLE
Docs: move note to `experimental_allow_widgets` param description

### DIFF
--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -280,13 +280,10 @@ class MemoAPI:
 
         experimental_allow_widgets : boolean
             Allow widgets to be used in the memoized function. Defaults to False.
-
-        .. note::
             Support for widgets in cached functions is currently experimental.
-            To enable it, set the parameter ``experimental_allow_widgets=True``
-            in ``@st.experimental_memo``. Note that this may lead to excessive memory
-            use since the widget value is treated as an additional input parameter
-            to the cache. We may remove support for this option at any time without notice.
+            Setting this parameter to True may lead to excessive memory use since the
+            widget value is treated as an additional input parameter to the cache.
+            We may remove support for this option at any time without notice.
 
         Example
         -------

--- a/lib/streamlit/runtime/caching/singleton_decorator.py
+++ b/lib/streamlit/runtime/caching/singleton_decorator.py
@@ -246,14 +246,10 @@ class SingletonAPI:
 
         experimental_allow_widgets : boolean
             Allow widgets to be used in the singleton function. Defaults to False.
-
-        .. note::
             Support for widgets in cached functions is currently experimental.
-            To enable it, set the parameter ``experimental_allow_widgets=True``
-            in ``@st.experimental_singleton``. Note that this may lead to excessive
-            memory use since the widget value is treated as an additional input
-            parameter to the cache. We may remove support for this option at any
-            time without notice.
+            Setting this parameter to True may lead to excessive memory use since the
+            widget value is treated as an additional input parameter to the cache.
+            We may remove support for this option at any time without notice.
 
         Example
         -------


### PR DESCRIPTION
## 📚 Context

The docstrings for memo and singleton include a note about the experimental nature of the `experimental_allow_widgets` parameter and how using it may lead to excessive memory usage. This PR moves the note into the parameter description of `experimental_allow_widgets`.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- This PR moves the note about the `experimental_allow_widgets` param from memo and singleton docstrings into the parameter description of `experimental_allow_widgets`.
- Note: this PR neither adds nor update any tests as the changes are merely a refactor of docstrings.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

<details open><summary><b>Revised:</b></summary>

![image](https://user-images.githubusercontent.com/20672874/207013981-5a05c272-7f5e-4026-b540-a4d473388443.png)
</details>

<details><summary><b>Current:</b></summary>

![image](https://user-images.githubusercontent.com/20672874/207014219-a40bf0cd-ec30-412c-8bd0-da6517ef5d2f.png)
</details>

## 🧪 Testing Done

- [s] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
