### PR TITLE
Stop installing pip-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ frontend: react-build
 
 .PHONY: setup
 setup:
-	pip install pip-tools pipenv ;
+	pip install pipenv
 
 .PHONY: pipenv-install
 pipenv-install: pipenv-dev-install py-test-install


### PR DESCRIPTION
## 📚 Context

It looks like the most recent CI failures affecting the release are caused by the `pip-tools` package.
This package stopped being used years ago (the last commit removing the usage of `pip-compile`
is from Jan 2019), and I'm fairly certain that it only stuck around in our `Makefile` afterwards because
we forgot to remove it.