### PR TITLE
Define the SessionManager protocol and improve our websocket reconnect behavior

### DIFF
--- a/e2e/scripts/websocket_reconnects.py
+++ b/e2e/scripts/websocket_reconnects.py
@@ -1,0 +1,30 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+from streamlit import runtime
+
+# st.session_state can only be accessed while running with streamlit
+if runtime.exists():
+    if "counter" not in st.session_state:
+        st.session_state.counter = 0
+
+    if st.button("click me!"):
+        st.session_state.counter += 1
+
+    st.write(f"count: {st.session_state.counter}")
+
+    # TODO(vdonato): Add st.file_uploader and st.camera_input tests once we're able to
+    # teach those widgets how to retrieve previously uploaded files after a session
+    # disconnect/reconnect.

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("websocket reconnects", () => {
+  beforeEach(() => {
+    cy.loadApp("http://localhost:3000/");
+  });
+
+  it("persists session state when the websocket connection is dropped and reconnects", () => {
+    for (let i = 0; i < 5; i++) {
+      cy.get(".stButton button").contains("click me!").click();
+    }
+
+    cy.window().then((win) => {
+      setTimeout(() => {
+        win.streamlitDebug.disconnectWebsocket();
+      }, 100);
+
+      // Wait until we've disconnected.
+      cy.get("[data-testid='stStatusWidget']").should(
+        "have.text",
+        "Connecting"
+      );
+      // Wait until we've reconnected and rerun the script.
+      cy.get("[data-testid='stStatusWidget']").should("not.exist");
+
+      cy.get(".stMarkdown").contains("count: 5");
+    });
+  });
+});

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -14,20 +14,29 @@
  * limitations under the License.
  */
 
+const INCREMENTS_PER_DISCONNECT = 5;
+const NUM_DISCONNECTS = 20;
+
 describe("websocket reconnects", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
   });
 
   it("persists session state when the websocket connection is dropped and reconnects", () => {
-    for (let i = 0; i < 5; i++) {
-      cy.get(".stButton button").contains("click me!").click();
-    }
+    let expectedCount = 0;
 
-    cy.window().then((win) => {
-      setTimeout(() => {
-        win.streamlitDebug.disconnectWebsocket();
-      }, 100);
+    for (let i = 0; i < NUM_DISCONNECTS; i++) {
+      expectedCount += INCREMENTS_PER_DISCONNECT;
+
+      for (let j = 0; j < INCREMENTS_PER_DISCONNECT; j++) {
+        cy.get(".stButton button").contains("click me!").click();
+      }
+
+      cy.window().then((win) => {
+        setTimeout(() => {
+          win.streamlitDebug.disconnectWebsocket();
+        }, 100);
+      });
 
       // Wait until we've disconnected.
       cy.get("[data-testid='stStatusWidget']").should(
@@ -37,7 +46,7 @@ describe("websocket reconnects", () => {
       // Wait until we've reconnected and rerun the script.
       cy.get("[data-testid='stStatusWidget']").should("not.exist");
 
-      cy.get(".stMarkdown").contains("count: 5");
-    });
+      cy.get(".stMarkdown").contains(`count: ${expectedCount}`);
+    }
   });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -148,6 +148,16 @@ describe("App", () => {
     expect(wrapper.html()).not.toBeNull()
   })
 
+  it("calls connectionManager.disconnect() when unmounting", () => {
+    const wrapper = getWrapper()
+    const instance = wrapper.instance() as App
+
+    wrapper.unmount()
+
+    // @ts-ignore
+    expect(instance.connectionManager.disconnect).toHaveBeenCalled()
+  })
+
   it("reloads when streamlit server version changes", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -352,6 +352,23 @@ export class App extends PureComponent<Props, State> {
     }
   }
 
+  componentWillUnmount(): void {
+    // Needing to disconnect our connection manager + websocket connection is
+    // only needed here to handle the case in dev mode where react hot-reloads
+    // the client as a result of a source code change. In this scenario, the
+    // previous websocket connection is still connected, and the client and
+    // server end up in a reconnect loop because the server rejects attempts to
+    // connect to an already-connected session.
+    //
+    // This situation doesn't exist outside of dev mode because the whole App
+    // unmounting is either a page refresh or the browser tab closing.
+    //
+    // The optional chaining on connectionManager is needed to make typescript
+    // happy since connectionManager's type is `ConnectionManager | null`,
+    // but at this point it should always be set.
+    this.connectionManager?.disconnect()
+  }
+
   showError(title: string, errorNode: ReactNode): void {
     logError(errorNode)
     const newDialog: DialogProps = {

--- a/frontend/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.tsx
@@ -258,8 +258,9 @@ class CameraInput extends React.PureComponent<Props, State> {
 
     // TODO(vdonato): Rework this now that there's a short window where the app
     // may reconnect to the server without losing its uploaded files. Just
-    // removing this seemed to work, but I'm not entirely sure if it's the
-    // correct fix.
+    // removing the if statement below (to avoid resetting widget state on a
+    // disconnect) seemed to work, but I'm not entirely sure if it's a complete
+    // fix.
     //
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users

--- a/frontend/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.tsx
@@ -256,10 +256,15 @@ class CameraInput extends React.PureComponent<Props, State> {
   public componentDidUpdate = (prevProps: Props): void => {
     const { element, widgetMgr } = this.props
 
+    // TODO(vdonato): Rework this now that there's a short window where the app
+    // may reconnect to the server without losing its uploaded files. Just
+    // removing this seemed to work, but I'm not entirely sure if it's the
+    // correct fix.
+    //
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users
     // will lose access to the files they uploaded in their previous session.
-    // If we are reconnecting, reset the file uploader so that the widget is
+    // If we are reconnecting, reset the camera input so that the widget is
     // in sync with the new session.
     if (prevProps.disabled !== this.props.disabled && this.props.disabled) {
       this.reset()

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -147,8 +147,9 @@ class FileUploader extends React.PureComponent<Props, State> {
 
     // TODO(vdonato): Rework this now that there's a short window where the app
     // may reconnect to the server without losing its uploaded files. Just
-    // removing this seemed to work, but I'm not entirely sure if it's the
-    // correct fix.
+    // removing the if statement below (to avoid resetting widget state on a
+    // disconnect) seemed to work, but I'm not entirely sure if it's a complete
+    // fix.
     //
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users

--- a/frontend/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.tsx
@@ -145,6 +145,11 @@ class FileUploader extends React.PureComponent<Props, State> {
   public componentDidUpdate = (prevProps: Props): void => {
     const { element, widgetMgr } = this.props
 
+    // TODO(vdonato): Rework this now that there's a short window where the app
+    // may reconnect to the server without losing its uploaded files. Just
+    // removing this seemed to work, but I'm not entirely sure if it's the
+    // correct fix.
+    //
     // Widgets are disabled if the app is not connected anymore.
     // If the app disconnects from the server, a new session is created and users
     // will lose access to the files they uploaded in their previous session.

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -137,6 +137,10 @@ export class ConnectionManager {
     }
   }
 
+  disconnect(): void {
+    this.connection?.disconnect()
+  }
+
   private setConnectionState = (
     connectionState: ConnectionState,
     errMsg?: string
@@ -146,7 +150,7 @@ export class ConnectionManager {
       this.props.connectionStateChanged(connectionState)
     }
 
-    if (errMsg || connectionState === ConnectionState.DISCONNECTED_FOREVER) {
+    if (errMsg) {
       this.props.onConnectionError(errMsg || "unknown")
     }
   }

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -21,8 +21,8 @@ test("Throws an error when used before initialization", () => {
   expect(() => SessionInfo.current).toThrow()
 })
 
-test("Clears session info", () => {
-  SessionInfo.current = new SessionInfo({
+test("Saves SessionInfo.current to lastSessionInfo on clear", () => {
+  const sessionInfo = new SessionInfo({
     appId: "aid",
     sessionId: "sessionId",
     streamlitVersion: "sv",
@@ -34,10 +34,19 @@ test("Clears session info", () => {
     commandLine: "command line",
     userMapboxToken: "mpt",
   })
+
+  // @ts-ignore
+  SessionInfo.lastSessionInfo = "some older value"
+
+  SessionInfo.current = sessionInfo
   expect(SessionInfo.isSet()).toBe(true)
+  // Also verify that lastSessionInfo is cleared when SessionInfo.current is
+  // set.
+  expect(SessionInfo.lastSessionInfo).toBe(undefined)
 
   SessionInfo.clearSession()
   expect(SessionInfo.isSet()).toBe(false)
+  expect(SessionInfo.lastSessionInfo).toBe(sessionInfo)
 })
 
 test("Can be initialized from a protobuf", () => {

--- a/frontend/src/lib/SessionInfo.ts
+++ b/frontend/src/lib/SessionInfo.ts
@@ -74,6 +74,12 @@ export class SessionInfo {
    */
   private static singleton?: SessionInfo
 
+  /**
+   * Our last SessionInfo singleton if there is no currently active session, or
+   * undefined if there is one.
+   */
+  public static lastSessionInfo?: SessionInfo
+
   public static get current(): SessionInfo {
     if (!SessionInfo.singleton) {
       throw new Error("Tried to use SessionInfo before it was initialized")
@@ -82,6 +88,7 @@ export class SessionInfo {
   }
 
   public static set current(sm: SessionInfo) {
+    SessionInfo.lastSessionInfo = undefined
     SessionInfo.singleton = sm
   }
 
@@ -94,6 +101,7 @@ export class SessionInfo {
   }
 
   public static clearSession(): void {
+    SessionInfo.lastSessionInfo = SessionInfo.singleton
     SessionInfo.singleton = undefined
   }
 

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -15,18 +15,19 @@
  */
 
 import axios from "axios"
-import React, { Fragment } from "react"
 import WS from "jest-websocket-mock"
+import { zip } from "lodash"
+import React, { Fragment } from "react"
 
 import { BackMsg } from "src/autogen/proto"
 import { ConnectionState } from "src/lib/ConnectionState"
+import { SessionInfo } from "src/lib/SessionInfo"
 import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   StyledBashCode,
   WebsocketConnection,
   doInitPings,
 } from "src/lib/WebsocketConnection"
-import { zip } from "lodash"
 
 const MOCK_ALLOWED_ORIGINS_RESPONSE = {
   data: {
@@ -561,8 +562,20 @@ describe("WebsocketConnection", () => {
     Promise.all = originalPromiseAll
 
     // @ts-ignore
-    client.websocket.close()
+    if (client.websocket) {
+      // @ts-ignore
+      client.websocket.close()
+    }
     server.close()
+  })
+
+  it("disconnect closes connection and sets state to DISCONNECTED_FOREVER", () => {
+    client.disconnect()
+
+    // @ts-ignore
+    expect(client.state).toBe(ConnectionState.DISCONNECTED_FOREVER)
+    // @ts-ignore
+    expect(client.websocket).toBe(undefined)
   })
 
   it("increments message cache run count", () => {
@@ -636,6 +649,8 @@ describe("WebsocketConnection auth token handling", () => {
 
   afterEach(() => {
     axios.get = originalAxiosGet
+
+    SessionInfo.lastSessionInfo = undefined
   })
 
   it("always sets first Sec-WebSocket-Protocol option to 'streamlit'", async () => {
@@ -661,6 +676,42 @@ describe("WebsocketConnection auth token handling", () => {
       claimHostAuthToken: () => Promise.resolve("iAmAnAuthToken"),
       resetHostAuthToken,
     })
+
+    // @ts-ignore
+    await ws.connectToWebSocket()
+
+    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
+      "streamlit",
+      "iAmAnAuthToken",
+    ])
+  })
+
+  it("sets second Sec-WebSocket-Protocol option to lastSessionId", async () => {
+    // @ts-ignore
+    SessionInfo.lastSessionInfo = { sessionId: "sessionId" }
+
+    const ws = new WebsocketConnection(MOCK_SOCKET_DATA)
+
+    // @ts-ignore
+    await ws.connectToWebSocket()
+
+    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
+      "streamlit",
+      "sessionId",
+    ])
+  })
+
+  it("prioritizes host provided auth token over lastSessionId if both set", async () => {
+    // @ts-ignore
+    SessionInfo.lastSessionInfo = { sessionId: "sessionId" }
+
+    const resetHostAuthToken = jest.fn()
+    const ws = new WebsocketConnection({
+      ...MOCK_SOCKET_DATA,
+      claimHostAuthToken: () => Promise.resolve("iAmAnAuthToken"),
+      resetHostAuthToken,
+    })
+
     // @ts-ignore
     await ws.connectToWebSocket()
 

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -680,10 +680,10 @@ describe("WebsocketConnection auth token handling", () => {
     // @ts-ignore
     await ws.connectToWebSocket()
 
-    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
-      "streamlit",
-      "iAmAnAuthToken",
-    ])
+    expect(websocketSpy).toHaveBeenCalledWith(
+      "ws://localhost:1234/_stcore/stream",
+      ["streamlit", "iAmAnAuthToken"]
+    )
   })
 
   it("sets second Sec-WebSocket-Protocol option to lastSessionId", async () => {
@@ -695,10 +695,10 @@ describe("WebsocketConnection auth token handling", () => {
     // @ts-ignore
     await ws.connectToWebSocket()
 
-    expect(websocketSpy).toHaveBeenCalledWith("ws://localhost:1234/stream", [
-      "streamlit",
-      "sessionId",
-    ])
+    expect(websocketSpy).toHaveBeenCalledWith(
+      "ws://localhost:1234/_stcore/stream",
+      ["streamlit", "sessionId"]
+    )
   })
 
   it("prioritizes host provided auth token over lastSessionId if both set", async () => {

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -144,7 +144,7 @@ interface MessageQueue {
  *   CONNECTED<───────────────────────────┘
  *
  *
- *                    on fatal error
+ *                    on fatal error or call to .disconnect()
  *                    :
  *   <ANY_STATE> ──────────────> DISCONNECTED_FOREVER
  */
@@ -227,6 +227,10 @@ export class WebsocketConnection {
     return undefined
   }
 
+  public disconnect(): void {
+    this.setFsmState(ConnectionState.DISCONNECTED_FOREVER)
+  }
+
   // This should only be called inside stepFsm().
   private setFsmState(state: ConnectionState, errMsg?: string): void {
     logMessage(LOG, `New state: ${state}`)
@@ -253,7 +257,7 @@ export class WebsocketConnection {
         break
 
       case ConnectionState.DISCONNECTED_FOREVER:
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         break
 
       default:
@@ -357,6 +361,28 @@ export class WebsocketConnection {
     this.stepFsm("SERVER_PING_SUCCEEDED")
   }
 
+  /**
+   * Get the session token to use to initialize a WebSocket connection.
+   *
+   * There are two scenarios that are considered here:
+   *   1. If this Streamlit is embedded in a page that will be passing an
+   *      external, opaque auth token to it, we get it using claimHostAuthToken
+   *      and return it. This only occurs in deployment environments where
+   *      we're not connecting to the usual Tornado server, so we don't have to
+   *      worry about what this token actually is/does.
+   *   2. Otherwise, claimHostAuthToken will resolve immediately to undefined,
+   *      in which case we return the sessionId of the last session this
+   *      browser tab connected to (or undefined if this is the first time this
+   *      tab has connected to the Streamlit server). This sessionId is used to
+   *      attempt to reconnect to an existing session to handle transient
+   *      disconnects.
+   */
+  private async getSessionToken(): Promise<string | undefined> {
+    const hostAuthToken = await this.args.claimHostAuthToken()
+    this.args.resetHostAuthToken()
+    return hostAuthToken || SessionInfo.lastSessionInfo?.sessionId
+  }
+
   private async connectToWebSocket(): Promise<void> {
     const uri = buildWsUri(
       this.args.baseUriPartsList[this.uriIndex],
@@ -369,11 +395,6 @@ export class WebsocketConnection {
       throw new Error("Websocket already exists")
     }
 
-    // claimHostAuthToken resolves to undefined immediately in deployment
-    // scenarios where we don't expect an external auth token to be passed down
-    // to the frame containing the Streamlit app.
-    const hostAuthToken = await this.args.claimHostAuthToken()
-    this.args.resetHostAuthToken()
     logMessage(LOG, "creating WebSocket")
 
     // NOTE: We repurpose the Sec-WebSocket-Protocol header (set via the second
@@ -387,9 +408,10 @@ export class WebsocketConnection {
     // Sec-WebSocket-Protocol is set, many clients expect the server to respond
     // with a selected subprotocol to use. We don't want that reply to be the
     // auth token, so we just hard-code it to "streamlit".
+    const sessionToken = await this.getSessionToken()
     this.websocket = new WebSocket(uri, [
       "streamlit",
-      ...(hostAuthToken ? [hostAuthToken] : []),
+      ...(sessionToken ? [sessionToken] : []),
     ])
     this.websocket.binaryType = "arraybuffer"
 
@@ -418,7 +440,7 @@ export class WebsocketConnection {
     this.websocket.onclose = () => {
       if (checkWebsocket()) {
         logWarning(LOG, "WebSocket onclose")
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("CONNECTION_CLOSED")
       }
     }
@@ -426,7 +448,7 @@ export class WebsocketConnection {
     this.websocket.onerror = () => {
       if (checkWebsocket()) {
         logError(LOG, "WebSocket onerror")
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("CONNECTION_ERROR")
       }
     }
@@ -456,21 +478,21 @@ export class WebsocketConnection {
         // This should never happen! The only place we call
         // setConnectionTimeout() should be immediately before setting
         // this.websocket.
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("FATAL_ERROR", "Null Websocket in setConnectionTimeout")
         return
       }
 
       if (this.websocket.readyState === 0 /* CONNECTING */) {
         logMessage(LOG, `${uri} timed out`)
-        this.cancelConnectionAttempt()
+        this.closeConnection()
         this.stepFsm("CONNECTION_TIMED_OUT")
       }
     }, WEBSOCKET_TIMEOUT_MS)
     logMessage(LOG, `Set WS timeout ${this.wsConnectionTimeoutId}`)
   }
 
-  private cancelConnectionAttempt(): void {
+  private closeConnection(): void {
     // Need to make sure the websocket is closed in the same function that
     // cancels the connection timer. Otherwise, due to javascript's concurrency
     // model, when the onclose event fires it can get handled in between the

--- a/lib/streamlit/runtime/__init__.py
+++ b/lib/streamlit/runtime/__init__.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Explicitly re-export public symbols from runtime.py
+# Explicitly re-export public symbols from runtime.py and session_manager.py
 from streamlit.runtime.runtime import Runtime as Runtime
 from streamlit.runtime.runtime import RuntimeConfig as RuntimeConfig
 from streamlit.runtime.runtime import RuntimeState as RuntimeState
-from streamlit.runtime.runtime import SessionClient as SessionClient
-from streamlit.runtime.runtime import (
+from streamlit.runtime.session_manager import SessionClient as SessionClient
+from streamlit.runtime.session_manager import (
     SessionClientDisconnectedError as SessionClientDisconnectedError,
 )
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -87,7 +87,7 @@ class AppSession:
             Object storing parameters related to running a script
 
         uploaded_file_manager : UploadedFileManager
-            The server's UploadedFileManager.
+            Used to manage files uploaded by users via the Streamlit web client.
 
         message_enqueued_callback : Callable[[], None]
             After enqueuing a message, this callable notification will be invoked.

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -132,7 +132,7 @@ class AppSession:
         self._stop_config_listener: Optional[Callable[[], bool]] = None
         self._stop_pages_listener: Optional[Callable[[], bool]] = None
 
-        self._register_file_watchers()
+        self.register_file_watchers()
 
         self._run_on_save = config.get_option("server.runOnSave")
 
@@ -152,7 +152,20 @@ class AppSession:
         """Ensure that we call shutdown() when an AppSession is garbage collected."""
         self.shutdown()
 
-    def _register_file_watchers(self) -> None:
+    def register_file_watchers(self) -> None:
+        """Register handlers to be called when various files are changed.
+
+        Files that we watch include:
+          * source files that already exist (for edits)
+          * `.py` files in the the main script's `pages/` directory (for file additions
+            and deletions)
+          * project and user-level config.toml files
+          * the project-level secrets.toml files
+
+        This method is called automatically on AppSession construction, but it may be
+        called again in the case when a session is disconnected and is being reconnect
+        to.
+        """
         if self._local_sources_watcher is None:
             self._local_sources_watcher = LocalSourcesWatcher(
                 self._script_data.main_script_path
@@ -169,7 +182,8 @@ class AppSession:
         )
         secrets_singleton._file_change_listener.connect(self._on_secrets_file_changed)
 
-    def _disconnect_file_watchers(self) -> None:
+    def disconnect_file_watchers(self) -> None:
+        """Disconnect the file watcher handlers registered by register_file_watchers."""
         if self._local_sources_watcher is not None:
             self._local_sources_watcher.close()
         if self._stop_config_listener is not None:
@@ -226,7 +240,7 @@ class AppSession:
 
             # Disconnect all file watchers if we haven't already, although we will have
             # generally already done so by the time we get here.
-            self._disconnect_file_watchers()
+            self.disconnect_file_watchers()
 
     def _enqueue_forward_msg(self, msg: ForwardMsg) -> None:
         """Enqueue a new ForwardMsg to our browser queue.

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -36,7 +36,7 @@ class MemorySessionStorage(SessionStorage):
     def __init__(
         self,
         maxsize: int = 128,
-        ttl_seconds: int = 5 * 60,  # 5 minutes
+        ttl_seconds: int = 2 * 60,  # 2 minutes
     ) -> None:
         """Instantiate a new MemorySessionStorage.
 
@@ -53,12 +53,6 @@ class MemorySessionStorage(SessionStorage):
             The time in seconds for an entry added to a MemorySessionStorage to live.
             After this amount of time has passed for a given entry, it becomes
             inaccessible and will be removed eventually.
-
-            TODO(vdonato): We'll have to do some testing to see what the TTLCache
-            documentation means by "eventually". It's possible that we'll want to add
-            our own mechanism to force cleanups of expired entries more frequently than
-            TTLCache does by default (which is easy to do with some of the methods that
-            TTLCache exposes).
         """
 
         self._cache: MutableMapping[str, SessionInfo] = TTLCache(

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -1,0 +1,78 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, MutableMapping, Optional
+
+from cachetools import TTLCache
+
+from streamlit.runtime.session_manager import SessionInfo, SessionStorage
+
+
+class MemorySessionStorage(SessionStorage):
+    """A SessionStorage that stores sessions in memory.
+
+    At most maxsize sessions are stored with a TTL of ttl seconds. This class is really
+    just a thin wrapper around cachetools.TTLCache that complies with the SessionStorage
+    protocol.
+    """
+
+    # NOTE: The defaults for maxsize and ttl are chosen arbitrarily for now. These
+    # numbers are reasonable as the main problems we're trying to solve at the moment are
+    # caused by transient disconnects that are usually just short network blips. In the
+    # future, we may want to increase both to support use cases such as saving state for
+    # much longer periods of time. For example, we may want session state to persist if
+    # a user closes their laptop lid and comes back to an app hours later.
+    def __init__(
+        self,
+        maxsize: int = 128,
+        ttl_seconds: int = 5 * 60,  # 5 minutes
+    ) -> None:
+        """Instantiate a new MemorySessionStorage.
+
+        Parameters
+        ----------
+        maxsize
+            The maximum number of sessions we allow to be stored in this
+            MemorySessionStorage. If an entry needs to be removed because we have
+            exceeded this number, either
+              * an expired entry is removed, or
+              * the least recently used entry is removed (if no entries have expired).
+
+        ttl_seconds
+            The time in seconds for an entry added to a MemorySessionStorage to live.
+            After this amount of time has passed for a given entry, it becomes
+            inaccessible and will be removed eventually.
+
+            TODO(vdonato): We'll have to do some testing to see what the TTLCache
+            documentation means by "eventually". It's possible that we'll want to add
+            our own mechanism to force cleanups of expired entries more frequently than
+            TTLCache does by default (which is easy to do with some of the methods that
+            TTLCache exposes).
+        """
+
+        self._cache: MutableMapping[str, SessionInfo] = TTLCache(
+            maxsize=maxsize, ttl=ttl_seconds
+        )
+
+    def get(self, session_id: str) -> Optional[SessionInfo]:
+        return self._cache.get(session_id, None)
+
+    def save(self, session_info: SessionInfo) -> None:
+        self._cache[session_info.session.id] = session_info
+
+    def delete(self, session_id: str) -> None:
+        del self._cache[session_id]
+
+    def list(self) -> List[SessionInfo]:
+        return list(self._cache.values())

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -17,7 +17,7 @@ import sys
 import time
 import traceback
 from enum import Enum
-from typing import Awaitable, Dict, NamedTuple, Optional, Tuple
+from typing import Awaitable, Dict, NamedTuple, Optional, Tuple, Type
 
 from typing_extensions import Final
 
@@ -44,6 +44,7 @@ from streamlit.runtime.session_manager import (
     SessionClient,
     SessionClientDisconnectedError,
     SessionInfo,
+    SessionManager,
 )
 from streamlit.runtime.state import (
     SCRIPT_RUN_WITHOUT_ERRORS_KEY,
@@ -75,6 +76,9 @@ class RuntimeConfig(NamedTuple):
 
     # The storage backend for Streamlit's MediaFileManager.
     media_file_storage: MediaFileStorage
+
+    # The SessionManager class to be used.
+    session_manager_class: Type[SessionManager]
 
 
 class RuntimeState(Enum):
@@ -158,9 +162,6 @@ class Runtime:
         self._main_script_path = config.script_path
         self._command_line = config.command_line or ""
 
-        # Mapping of AppSession.id -> SessionInfo.
-        self._session_info_by_id: Dict[str, SessionInfo] = {}
-
         self._state = RuntimeState.INITIAL
 
         # Initialize managers
@@ -169,15 +170,23 @@ class Runtime:
         self._uploaded_file_mgr.on_files_updated.connect(self._on_files_updated)
         self._media_file_mgr = MediaFileManager(storage=config.media_file_storage)
 
+        # Ignore the obviously incorrect type below where we pass None where a
+        # SessionStorage should be in the first argument. This is fine because we're
+        # not yet using the argument in the one class that currently implements
+        # SessionManager.
+        self._session_mgr = config.session_manager_class(
+            session_storage=None,  # type: ignore
+            uploaded_file_manager=self._uploaded_file_mgr,
+            message_enqueued_callback=self._enqueued_some_message,
+        )
+
         self._stats_mgr = StatsManager()
         self._stats_mgr.register_provider(get_data_cache_stats_provider())
         self._stats_mgr.register_provider(get_resource_cache_stats_provider())
         self._stats_mgr.register_provider(_mem_caches)
         self._stats_mgr.register_provider(self._message_cache)
         self._stats_mgr.register_provider(self._uploaded_file_mgr)
-        self._stats_mgr.register_provider(
-            SessionStateStatProvider(self._session_info_by_id)
-        )
+        self._stats_mgr.register_provider(SessionStateStatProvider(self._session_mgr))
 
     @property
     def state(self) -> RuntimeState:
@@ -212,7 +221,7 @@ class Runtime:
         -----
         Threading: SAFE. May be called on any thread.
         """
-        session_info = self._get_session_info(session_id)
+        session_info = self._session_mgr.get_active_session_info(session_id)
         if session_info is None:
             return None
         return session_info.client
@@ -225,22 +234,11 @@ class Runtime:
         -----
         Threading: SAFE. May be called on any thread.
         """
-        session_info = self._get_session_info(session_id)
+        session_info = self._session_mgr.get_active_session_info(session_id)
         if session_info is None:
-            # If an uploaded file doesn't belong to an existing session,
+            # If an uploaded file doesn't belong to an active session,
             # remove it so it doesn't stick around forever.
             self._uploaded_file_mgr.remove_session_files(session_id)
-
-    def _get_session_info(self, session_id: str) -> Optional[SessionInfo]:
-        """Return the SessionInfo with the given id, or None if no such
-        session exists.
-
-        Notes
-        -----
-        Threading: SAFE. May be called on any thread. (But note that SessionInfo
-        mutations are not thread-safe!)
-        """
-        return self._session_info_by_id.get(session_id, None)
 
     async def start(self) -> None:
         """Start the runtime. This must be called only once, before
@@ -304,8 +302,13 @@ class Runtime:
         -----
         Threading: SAFE. May be called on any thread.
         """
-        # Dictionary membership is atomic in CPython, so this is thread-safe.
-        return session_id in self._session_info_by_id
+        # TODO(vdonato): Work out any thread safety issues caused by this function now
+        # being delegated to self._session_mgr. We'll have to reconsider the assumption
+        # that's stated in the SessionManager docstring that SessionManager methods
+        # should only be called from the eventloop thread. This shouldn't be an issue
+        # in practice while sessions still live in memory but will likely end up
+        # becoming problematic in the far future once that's no longer true.
+        return self._session_mgr.is_active_session(session_id)
 
     def create_session(
         self,
@@ -339,29 +342,15 @@ class Runtime:
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             raise RuntimeStoppedError(f"Can't create_session (state={self._state})")
 
-        async_objs = self._get_async_objs()
-
-        session = AppSession(
+        session_id = self._session_mgr.connect_session(
+            client=client,
             script_data=ScriptData(self._main_script_path, self._command_line or ""),
-            uploaded_file_manager=self._uploaded_file_mgr,
-            message_enqueued_callback=self._enqueued_some_message,
-            local_sources_watcher=LocalSourcesWatcher(self._main_script_path),
             user_info=user_info,
         )
-
-        LOGGER.debug(
-            "Created new session for client %s. Session ID: %s", id(client), session.id
-        )
-
-        assert (
-            session.id not in self._session_info_by_id
-        ), f"session.id '{session.id}' registered multiple times!"
-
-        self._session_info_by_id[session.id] = SessionInfo(client, session)
         self._set_state(RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED)
-        async_objs.has_connection.set()
+        self._get_async_objs().has_connection.set()
 
-        return session.id
+        return session_id
 
     def close_session(self, session_id: str) -> None:
         """Close a session. It will stop producing ForwardMsgs.
@@ -378,20 +367,17 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        if session_id in self._session_info_by_id:
-            session_info = self._session_info_by_id[session_id]
-            del self._session_info_by_id[session_id]
-            session_info.session.shutdown()
+        self._session_mgr.close_session(session_id)
 
         if (
             self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED
-            and len(self._session_info_by_id) == 0
+            and self._session_mgr.num_active_sessions() == 0
         ):
             self._get_async_objs().has_connection.clear()
             self._set_state(RuntimeState.NO_SESSIONS_CONNECTED)
 
     def handle_backmsg(self, session_id: str, msg: BackMsg) -> None:
-        """Send a BackMsg to a connected session.
+        """Send a BackMsg to an active session.
 
         Parameters
         ----------
@@ -407,7 +393,7 @@ class Runtime:
         if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
             raise RuntimeStoppedError(f"Can't handle_backmsg (state={self._state})")
 
-        session_info = self._session_info_by_id.get(session_id)
+        session_info = self._session_mgr.get_active_session_info(session_id)
         if session_info is None:
             LOGGER.debug(
                 "Discarding BackMsg for disconnected session (id=%s)", session_id
@@ -437,7 +423,7 @@ class Runtime:
                 f"Can't handle_backmsg_deserialization_exception (state={self._state})"
             )
 
-        session_info = self._session_info_by_id.get(session_id)
+        session_info = self._session_mgr.get_active_session_info(session_id)
         if session_info is None:
             LOGGER.debug(
                 "Discarding BackMsg Exception for disconnected session (id=%s)",
@@ -538,18 +524,15 @@ class Runtime:
                 elif self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
                     async_objs.need_send_data.clear()
 
-                    # Shallow-clone our sessions into a list, so we can iterate
-                    # over it and not worry about whether it's being changed
-                    # outside this coroutine.
-                    session_infos = list(self._session_info_by_id.values())
-
-                    for session_info in session_infos:
+                    for session_info in self._session_mgr.list_active_sessions():
                         msg_list = session_info.session.flush_browser_queue()
                         for msg in msg_list:
                             try:
                                 self._send_message(session_info, msg)
                             except SessionClientDisconnectedError:
-                                self.close_session(session_info.session.id)
+                                self._session_mgr.disconnect_session(
+                                    session_info.session.id
+                                )
 
                             # Yield for a tick after sending a message.
                             await asyncio.sleep(0)
@@ -570,9 +553,12 @@ class Runtime:
                     return_when=asyncio.FIRST_COMPLETED,
                 )
 
-            # Shut down all AppSessions
-            for session_info in list(self._session_info_by_id.values()):
-                session_info.session.shutdown()
+            # Shut down all AppSessions.
+            # NOTE: We want to fully shut down sessions when the runtime stops for now,
+            # but this may change in the future if/when our notion of a session is no
+            # longer so tightly coupled to a browser tab.
+            for session_info in self._session_mgr.list_sessions():
+                self._session_mgr.close_session(session_info.session.id)
 
             self._set_state(RuntimeState.STOPPED)
             async_objs.stopped.set_result(None)

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -16,6 +16,7 @@ import asyncio
 import sys
 import time
 import traceback
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Awaitable, Dict, NamedTuple, Optional, Tuple, Type
 
@@ -38,6 +39,7 @@ from streamlit.runtime.forward_msg_cache import (
 from streamlit.runtime.legacy_caching.caching import _mem_caches
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.media_file_storage import MediaFileStorage
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import is_cacheable_msg
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import (
@@ -53,6 +55,7 @@ from streamlit.runtime.state import (
 )
 from streamlit.runtime.stats import StatsManager
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.watcher import LocalSourcesWatcher
 
 # Wait for the script run result for 60s and if no result is available give up
@@ -65,7 +68,8 @@ class RuntimeStoppedError(Exception):
     """Raised by operations on a Runtime instance that is stopped."""
 
 
-class RuntimeConfig(NamedTuple):
+@dataclass(frozen=True)
+class RuntimeConfig:
     """Config options for StreamlitRuntime."""
 
     # The filesystem path of the Streamlit script to run.
@@ -79,10 +83,10 @@ class RuntimeConfig(NamedTuple):
     media_file_storage: MediaFileStorage
 
     # The SessionManager class to be used.
-    session_manager_class: Type[SessionManager]
+    session_manager_class: Type[SessionManager] = WebsocketSessionManager
 
     # The SessionStorage instance for the SessionManager to use.
-    session_storage: SessionStorage
+    session_storage: SessionStorage = field(default_factory=MemorySessionStorage)
 
 
 class RuntimeState(Enum):

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -314,6 +314,7 @@ class Runtime:
         self,
         client: SessionClient,
         user_info: Dict[str, Optional[str]],
+        existing_session_id: Optional[str] = None,
     ) -> str:
         """Create a new session and return its unique ID.
 
@@ -346,6 +347,7 @@ class Runtime:
             client=client,
             script_data=ScriptData(self._main_script_path, self._command_line or ""),
             user_info=user_info,
+            existing_session_id=existing_session_id,
         )
         self._set_state(RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED)
         self._get_async_objs().has_connection.set()

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -41,9 +41,9 @@ from streamlit.runtime.media_file_storage import MediaFileStorage
 from streamlit.runtime.runtime_util import is_cacheable_msg
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import (
+    ActiveSessionInfo,
     SessionClient,
     SessionClientDisconnectedError,
-    SessionInfo,
     SessionManager,
 )
 from streamlit.runtime.state import (
@@ -456,6 +456,9 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
+        # NOTE: We create an AppSession directly here instead of using the
+        # SessionManager intentionally. This isn't a "real" session and is only being
+        # used to test that the script runs without error.
         session = AppSession(
             script_data=ScriptData(self._main_script_path, self._command_line),
             uploaded_file_manager=self._uploaded_file_mgr,
@@ -524,14 +527,14 @@ class Runtime:
                 elif self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
                     async_objs.need_send_data.clear()
 
-                    for session_info in self._session_mgr.list_active_sessions():
-                        msg_list = session_info.session.flush_browser_queue()
+                    for active_session_info in self._session_mgr.list_active_sessions():
+                        msg_list = active_session_info.session.flush_browser_queue()
                         for msg in msg_list:
                             try:
-                                self._send_message(session_info, msg)
+                                self._send_message(active_session_info, msg)
                             except SessionClientDisconnectedError:
                                 self._session_mgr.disconnect_session(
-                                    session_info.session.id
+                                    active_session_info.session.id
                                 )
 
                             # Yield for a tick after sending a message.
@@ -554,10 +557,10 @@ class Runtime:
                 )
 
             # Shut down all AppSessions.
-            # NOTE: We want to fully shut down sessions when the runtime stops for now,
-            # but this may change in the future if/when our notion of a session is no
-            # longer so tightly coupled to a browser tab.
             for session_info in self._session_mgr.list_sessions():
+                # NOTE: We want to fully shut down sessions when the runtime stops for
+                # now, but this may change in the future if/when our notion of a session
+                # is no longer so tightly coupled to a browser tab.
                 self._session_mgr.close_session(session_info.session.id)
 
             self._set_state(RuntimeState.STOPPED)
@@ -572,7 +575,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 """
             )
 
-    def _send_message(self, session_info: SessionInfo, msg: ForwardMsg) -> None:
+    def _send_message(self, session_info: ActiveSessionInfo, msg: ForwardMsg) -> None:
         """Send a message to a client.
 
         If the client is likely to have already cached the message, we may
@@ -581,8 +584,8 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
 
         Parameters
         ----------
-        session_info : SessionInfo
-            The SessionInfo associated with websocket
+        session_info : ActiveSessionInfo
+            The ActiveSessionInfo associated with websocket
         msg : ForwardMsg
             The message to send to the client
 
@@ -628,9 +631,6 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
                 session_info.session, session_info.script_run_count
             )
 
-        assert (
-            session_info.client is not None
-        ), "SessionClient should never be None here!"
         # Ship it off!
         session_info.client.write_forward_msg(msg_to_send)
 

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -22,7 +22,6 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
-from streamlit.watcher import LocalSourcesWatcher
 
 
 class SessionClientDisconnectedError(Exception):

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -1,0 +1,346 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from typing_extensions import Protocol
+
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.app_session import AppSession
+
+if TYPE_CHECKING:
+    from streamlit.runtime import Runtime
+
+
+class SessionClientDisconnectedError(Exception):
+    """Raised by operations on a disconnected SessionClient."""
+
+
+class SessionClient(Protocol):
+    """Interface for sending data to a session's client."""
+
+    @abstractmethod
+    def write_forward_msg(self, msg: ForwardMsg) -> None:
+        """Deliver a ForwardMsg to the client.
+
+        If the SessionClient has been disconnected, it should raise a
+        SessionClientDisconnectedError.
+        """
+        raise NotImplementedError
+
+
+# TODO(vdonato): We may want to consider either coming up with a better name for this or
+# consolidating it with the SessionData class since the two names are similar enough
+# to be confusing right now.
+@dataclass
+class SessionInfo:
+    """Type containing data related to an AppSession.
+
+    For each AppSession, the Runtime tracks that session's
+    script_run_count. This is used to track the age of messages in
+    the ForwardMsgCache.
+    """
+
+    client: Optional[SessionClient]
+    session: AppSession
+    script_run_count: int = 0
+
+
+class SessionStorageError(Exception):
+    """Exception class for errors raised by SessionStorage.
+
+    The original error that causes a SessionStorageError to be (re)raised will generally
+    be an I/O error specific to the concrete SessionStorage implementation.
+    """
+
+
+class SessionStorage(Protocol):
+    @abstractmethod
+    def get(self, session_id: str) -> Optional[SessionInfo]:
+        """Return the SessionInfo corresponding to session_id, or None if one does not
+        exist.
+
+        Parameters
+        ----------
+        session_id
+            The unique ID of the session being fetched.
+
+        Returns
+        -------
+        SessionInfo or None
+
+        Raises
+        ------
+        SessionStorageError
+            Raised if an error occurs while attempting to fetch the session. This will
+            generally happen if there is an error with the underlying storage backend
+            (e.g. if we lose our connection to it).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def save(self, session_info: SessionInfo) -> None:
+        """Save the given session.
+
+        Parameters
+        ----------
+        session_info
+            The SessionInfo being saved.
+
+        Raises
+        ------
+        SessionStorageError
+            Raised if an error occurs while saving the given session.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete(self, session_id: str) -> None:
+        """Mark the session corresponding to session_id for deletion and stop tracking
+        it.
+
+        Note that:
+          * Calling delete on an ID corresponding to a nonexistent session is a no-op.
+          * Calling delete on an ID should cause the given session to no longer be
+            tracked by this SessionStorage, but exactly when and how the session's data
+            is eventually cleaned up is a detail left up to the implementation.
+
+        Parameters
+        ----------
+        session_id
+            The unique ID of the session to delete.
+
+        Raises
+        ------
+        SessionStorageError
+            Raised if an error occurs while attempting to delete the session.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def list(self) -> List[SessionInfo]:
+        """List all sessions tracked by this SessionStorage.
+
+        Returns
+        -------
+        List[SessionInfo]
+
+        Raises
+        ------
+        SessionStorageError
+            Raised if an error occurs while attempting to list sessions.
+        """
+        raise NotImplementedError
+
+
+class SessionManager(Protocol):
+    """SessionManagers are responsible for encapsulating all session lifecycle behavior
+    that the Streamlit Runtime may care about.
+
+    A SessionManager must define the following required methods:
+      * __init__
+      * connect_session
+      * close_session
+      * get_session_info
+      * list_sessions
+
+    SessionManager implementations may also choose to define the notions of active and
+    inactive sessions. The precise definitions of active/inactive are left to the
+    concrete implementation. SessionManagers that wish to differentiate between active
+    and inactive sessions should have the required methods listed above operate on *all*
+    sessions. Additionally, they should define the following methods for working with
+    active sessions:
+      * disconnect_session
+      * get_active_session_info
+      * is_active_session
+      * list_active_sessions
+
+    When active session-related methods are left undefined, their default
+    implementations are the naturally corresponding required methods.
+
+    The Runtime, unless there's a good reason to do otherwise, should generally work
+    with the active-session versions of a SessionManager's methods. There isn't currently
+    a need for us to be able to operate on inactive sessions stored in SessionStorage
+    outside of the SessionManager itself. However, it's highly likely that we'll
+    eventually have to do so, which is why the abstractions allow for this now.
+
+    Notes
+    -----
+    Threading: All SessionManager methods are *not* threadsafe -- they must be called
+    from the runtime's eventloop thread.
+    """
+
+    @abstractmethod
+    def __init__(self, session_storage: SessionStorage, runtime: "Runtime") -> None:
+        """Initialize a SessionManager with the given SessionStorage.
+
+        Parameters
+        ----------
+        session_storage
+            The SessionStorage instance backing this SessionManager.
+        runtime
+            A backpointer to the Runtime that owns this SessionManager.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def connect_session(
+        self,
+        client: SessionClient,
+        user_info: Dict[str, Optional[str]],
+        existing_session_id: Optional[str] = None,
+    ) -> str:
+        """Create a new session or connect to an existing one.
+
+        Parameters
+        ----------
+        client
+            A concrete SessionClient implementation for communicating with
+            the session's client.
+        user_info
+            A dict that contains information about the session's user. For now,
+            it only (optionally) contains the user's email address.
+
+            {
+                "email": "example@example.com"
+            }
+        existing_session_id
+            The ID of an existing session to reconnect to. If one is not provided, a new
+            session is created. Note that whether a SessionManager supports reconnection
+            to an existing session is left up to the concrete SessionManager
+            implementation. Those that do not support reconnection should simply ignore
+            this argument.
+
+        Returns
+        -------
+        str
+            The session's unique string ID.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def close_session(self, session_id: str) -> None:
+        """Close and completely delete the session with the given id.
+
+        This function may be called multiple times for the same session,
+        which is not an error. (Subsequent calls just no-op.)
+
+        Parameters
+        ----------
+        session_id
+            The session's unique ID.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_session_info(self, session_id: str) -> Optional[SessionInfo]:
+        """Return the SessionInfo for the given id, or None if no such session
+        exists.
+
+        Parameters
+        ----------
+        session_id
+            The session's unique ID.
+
+        Returns
+        -------
+        SessionInfo or None
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_sessions(self) -> List[SessionInfo]:
+        """Return the SessionInfo for all sessions managed by this SessionManager.
+
+        Returns
+        -------
+        List[SessionInfo]
+        """
+        raise NotImplementedError
+
+    def num_sessions(self) -> int:
+        """Return the number of sessions tracked by this SessionManager.
+
+        Subclasses of SessionManager shouldn't provide their own implementation of this
+        method without a *very* good reason.
+
+        Returns
+        -------
+        int
+        """
+        return len(self.list_sessions())
+
+    # NOTE: The following methods only need to be overwritten when a concrete
+    # SessionManager implementation has a notion of active vs inactive sessions.
+    # If left unimplemented in a subclass, the default implementations of these methods
+    # call corresponding SessionManager methods in a natural way.
+
+    def disconnect_session(self, session_id: str) -> None:
+        """Disconnect the given session.
+
+        This method should be idempotent.
+
+        Parameters
+        ----------
+        session_id
+            The session's unique ID.
+        """
+        self.close_session(session_id)
+
+    def get_active_session_info(self, session_id: str) -> Optional[SessionInfo]:
+        """Return the SessionInfo for the given id, or None if either no such session
+        exists or the session is not active.
+
+        Parameters
+        ----------
+        session_id
+            The active session's unique ID.
+
+        Returns
+        -------
+        SessionInfo or None
+        """
+        return self.get_session_info(session_id)
+
+    def is_active_session(self, session_id: str) -> bool:
+        """Return True if the given session exists and is active, False otherwise.
+
+        Returns
+        -------
+        bool
+        """
+        return self.get_active_session_info(session_id) is not None
+
+    def list_active_sessions(self) -> List[SessionInfo]:
+        """Return the SessionInfo for all active sessions tracked by this SessionManager.
+
+        Returns
+        -------
+        List[SessionInfo]
+        """
+        return self.list_sessions()
+
+    def num_active_sessions(self) -> int:
+        """Return the number of active sessions tracked by this SessionManager.
+
+        Subclasses of SessionManager shouldn't provide their own implementation of this
+        method without a *very* good reason.
+
+        Returns
+        -------
+        int
+        """
+        return len(self.list_active_sessions())

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -73,6 +73,10 @@ class SessionInfo:
 
     def to_active(self) -> ActiveSessionInfo:
         assert self.is_active(), "A SessionInfo with no client cannot be active!"
+
+        # NOTE: The cast here (rather than copying this SessionInfo's fields into a new
+        # ActiveSessionInfo) is important as the Runtime expects to be able to mutate
+        # what's returned from get_active_session_info to increment script_run_count.
         return cast(ActiveSessionInfo, self)
 
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -43,7 +43,7 @@ from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 from streamlit.type_util import ValueFieldName, is_array_value_field_name
 
 if TYPE_CHECKING:
-    from streamlit.runtime.runtime import SessionInfo
+    from streamlit.runtime.session_manager import SessionInfo
 
 
 T = TypeVar("T")

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -43,7 +43,7 @@ from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 from streamlit.type_util import ValueFieldName, is_array_value_field_name
 
 if TYPE_CHECKING:
-    from streamlit.runtime.session_manager import SessionInfo
+    from streamlit.runtime.session_manager import SessionManager
 
 
 T = TypeVar("T")
@@ -699,11 +699,11 @@ def require_valid_user_key(key: str) -> None:
 
 @dataclass
 class SessionStateStatProvider(CacheStatsProvider):
-    _session_info_by_id: dict[str, "SessionInfo"]
+    _session_mgr: "SessionManager"
 
     def get_stats(self) -> list[CacheStat]:
         stats: list[CacheStat] = []
-        for session_info in self._session_info_by_id.values():
+        for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state
             stats.extend(session_state.get_stats())
         return stats

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, cast
 
 from typing_extensions import Final
 
@@ -20,6 +20,7 @@ from streamlit.logger import get_logger
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import (
+    ActiveSessionInfo,
     SessionClient,
     SessionInfo,
     SessionManager,
@@ -32,36 +33,61 @@ LOGGER: Final = get_logger(__name__)
 
 
 class WebsocketSessionManager(SessionManager):
+    """A SessionManager used to manage sessions with lifecycles tied to those of a
+    browser tab's websocket connection.
+
+    WebsocketSessionManagers differentiate between "active" and "inactive" sessions.
+    Active sessions are those with a currently active websocket connection. Inactive
+    sessions are sessions without. Eventual cleanup of inactive sessions is a detail left
+    to the specific SessionStorage that a WebsocketSessionManager is instantiated with.
+
+    NOTE: The name of this class isn't finalized since there technically isn't any
+    mention of websockets in its implementation, but a more generic name like
+    DefaultSessionManager also feels weird with the concept of an active session being
+    so closely tied to websocket lifecycle. We'll figure out a final name for this
+    before the feature branch goes into `develop`.
+    """
+
     def __init__(
         self,
         session_storage: SessionStorage,
         uploaded_file_manager: UploadedFileManager,
         message_enqueued_callback: Optional[Callable[[], None]],
     ) -> None:
-        # NOTE: We intentionally don't do anything with session_storage for now as we
-        # will initially implement WebsocketSessionManager so the current runtime
-        # session handling behavior is unchanged.
-        #
-        # A concrete session_storage class will be implemented and used in subsequent
-        # changes when we add session reuse on a websocket reconnect.
-        #
-        # Since we aren't worrying about session reconnects yet, we don't need to
-        # differentiate between active and inactive sessions and can provide the minimal
-        # implementation of a SessionManager below.
-
+        self._session_storage = session_storage
         self._uploaded_file_mgr = uploaded_file_manager
         self._message_enqueued_callback = message_enqueued_callback
 
-        # Mapping of AppSession.id -> SessionInfo.
-        self._session_info_by_id: Dict[str, SessionInfo] = {}
+        # Mapping of AppSession.id -> ActiveSessionInfo.
+        self._active_session_info_by_id: Dict[str, ActiveSessionInfo] = {}
 
     def connect_session(
         self,
         client: SessionClient,
         script_data: ScriptData,
         user_info: Dict[str, Optional[str]],
-        existing_session_id: Optional[str] = None,  # unused for now
+        existing_session_id: Optional[str] = None,
     ) -> str:
+        assert (
+            existing_session_id not in self._active_session_info_by_id
+        ), f"session with id '{existing_session_id}' is already connected!"
+
+        session_info = existing_session_id and self._session_storage.get(
+            existing_session_id
+        )
+        if session_info:
+            existing_session = session_info.session
+            existing_session.register_file_watchers()
+
+            self._active_session_info_by_id[existing_session.id] = ActiveSessionInfo(
+                client,
+                existing_session,
+                session_info.script_run_count,
+            )
+            self._session_storage.delete(existing_session.id)
+
+            return existing_session.id
+
         session = AppSession(
             script_data=script_data,
             uploaded_file_manager=self._uploaded_file_mgr,
@@ -75,23 +101,55 @@ class WebsocketSessionManager(SessionManager):
         )
 
         assert (
-            session.id not in self._session_info_by_id
+            session.id not in self._active_session_info_by_id
         ), f"session.id '{session.id}' registered multiple times!"
 
-        self._session_info_by_id[session.id] = SessionInfo(client, session)
+        self._active_session_info_by_id[session.id] = ActiveSessionInfo(client, session)
         return session.id
 
+    def disconnect_session(self, session_id: str) -> None:
+        if session_id in self._active_session_info_by_id:
+            active_session_info = self._active_session_info_by_id[session_id]
+            active_session_info.session.disconnect_file_watchers()
+
+            self._session_storage.save(
+                SessionInfo(
+                    client=None,
+                    session=active_session_info.session,
+                    script_run_count=active_session_info.script_run_count,
+                )
+            )
+            del self._active_session_info_by_id[session_id]
+
+    def get_active_session_info(self, session_id: str) -> Optional[ActiveSessionInfo]:
+        return self._active_session_info_by_id.get(session_id)
+
+    def is_active_session(self, session_id: str) -> bool:
+        return session_id in self._active_session_info_by_id
+
+    def list_active_sessions(self) -> List[ActiveSessionInfo]:
+        return list(self._active_session_info_by_id.values())
+
     def close_session(self, session_id: str) -> None:
-        if session_id in self._session_info_by_id:
-            session_info = self._session_info_by_id[session_id]
-            del self._session_info_by_id[session_id]
+        if session_id in self._active_session_info_by_id:
+            active_session_info = self._active_session_info_by_id[session_id]
+            del self._active_session_info_by_id[session_id]
+            active_session_info.session.shutdown()
+            return
+
+        session_info = self._session_storage.get(session_id)
+        if session_info:
+            self._session_storage.delete(session_id)
             session_info.session.shutdown()
 
     def get_session_info(self, session_id: str) -> Optional[SessionInfo]:
-        return self._session_info_by_id.get(session_id, None)
+        session_info = self.get_active_session_info(session_id)
+        if session_info:
+            return cast(SessionInfo, session_info)
+        return self._session_storage.get(session_id)
 
     def list_sessions(self) -> List[SessionInfo]:
-        # Shallow-clone our sessions into a list, so we can iterate
-        # over it and not worry about whether it's being changed
-        # outside this coroutine.
-        return list(self._session_info_by_id.values())
+        return (
+            cast(List[SessionInfo], self.list_active_sessions())
+            + self._session_storage.list()
+        )

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -40,12 +40,6 @@ class WebsocketSessionManager(SessionManager):
     Active sessions are those with a currently active websocket connection. Inactive
     sessions are sessions without. Eventual cleanup of inactive sessions is a detail left
     to the specific SessionStorage that a WebsocketSessionManager is instantiated with.
-
-    NOTE: The name of this class isn't finalized since there technically isn't any
-    mention of websockets in its implementation, but a more generic name like
-    DefaultSessionManager also feels weird with the concept of an active session being
-    so closely tied to websocket lifecycle. We'll figure out a final name for this
-    before the feature branch goes into `develop`.
     """
 
     def __init__(

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -1,0 +1,97 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Dict, List, Optional
+
+from typing_extensions import Final
+
+from streamlit.logger import get_logger
+from streamlit.runtime.app_session import AppSession
+from streamlit.runtime.script_data import ScriptData
+from streamlit.runtime.session_manager import (
+    SessionClient,
+    SessionInfo,
+    SessionManager,
+    SessionStorage,
+)
+from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+from streamlit.watcher import LocalSourcesWatcher
+
+LOGGER: Final = get_logger(__name__)
+
+
+class WebsocketSessionManager(SessionManager):
+    def __init__(
+        self,
+        session_storage: SessionStorage,
+        uploaded_file_manager: UploadedFileManager,
+        message_enqueued_callback: Optional[Callable[[], None]],
+    ) -> None:
+        # NOTE: We intentionally don't do anything with session_storage for now as we
+        # will initially implement WebsocketSessionManager so the current runtime
+        # session handling behavior is unchanged.
+        #
+        # A concrete session_storage class will be implemented and used in subsequent
+        # changes when we add session reuse on a websocket reconnect.
+        #
+        # Since we aren't worrying about session reconnects yet, we don't need to
+        # differentiate between active and inactive sessions and can provide the minimal
+        # implementation of a SessionManager below.
+
+        self._uploaded_file_mgr = uploaded_file_manager
+        self._message_enqueued_callback = message_enqueued_callback
+
+        # Mapping of AppSession.id -> SessionInfo.
+        self._session_info_by_id: Dict[str, SessionInfo] = {}
+
+    def connect_session(
+        self,
+        client: SessionClient,
+        script_data: ScriptData,
+        user_info: Dict[str, Optional[str]],
+        existing_session_id: Optional[str] = None,  # unused for now
+    ) -> str:
+        session = AppSession(
+            script_data=script_data,
+            uploaded_file_manager=self._uploaded_file_mgr,
+            message_enqueued_callback=self._message_enqueued_callback,
+            local_sources_watcher=LocalSourcesWatcher(script_data.main_script_path),
+            user_info=user_info,
+        )
+
+        LOGGER.debug(
+            "Created new session for client %s. Session ID: %s", id(client), session.id
+        )
+
+        assert (
+            session.id not in self._session_info_by_id
+        ), f"session.id '{session.id}' registered multiple times!"
+
+        self._session_info_by_id[session.id] = SessionInfo(client, session)
+        return session.id
+
+    def close_session(self, session_id: str) -> None:
+        if session_id in self._session_info_by_id:
+            session_info = self._session_info_by_id[session_id]
+            del self._session_info_by_id[session_id]
+            session_info.session.shutdown()
+
+    def get_session_info(self, session_id: str) -> Optional[SessionInfo]:
+        return self._session_info_by_id.get(session_id, None)
+
+    def list_sessions(self) -> List[SessionInfo]:
+        # Shallow-clone our sessions into a list, so we can iterate
+        # over it and not worry about whether it's being changed
+        # outside this coroutine.
+        return list(self._session_info_by_id.values())

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -120,7 +120,7 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             # extract it from the Sec-Websocket-Protocol header.
             pass
 
-        self._session_id = self._runtime.create_session(
+        self._session_id = self._runtime.connect_session(
             client=self,
             user_info=user_info,
             existing_session_id=existing_session_id,
@@ -130,7 +130,7 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
     def on_close(self) -> None:
         if not self._session_id:
             return
-        self._runtime.close_session(self._session_id)
+        self._runtime.disconnect_session(self._session_id)
         self._session_id = None
 
     def get_compression_options(self) -> Optional[Dict[Any, Any]]:

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -70,13 +70,15 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         NOTE: We repurpose the Sec-WebSocket-Protocol header here in a slightly
         unfortunate (but necessary) way. The browser WebSocket API doesn't allow us to
         set arbitrary HTTP headers, and this header is the only one where we have the
-        ability to set it to arbitrary values, so we use it to pass an auth token from
-        client to server as the *second* value in the list.
+        ability to set it to arbitrary values, so we use it to pass tokens (in this
+        case, the previous session ID to allow us to reconnect to it) from client to
+        server as the *second* value in the list.
 
         The reason why the auth token is set as the second value is that, when
         Sec-WebSocket-Protocol is set, many clients expect the server to respond with a
-        selected subprotocol to use. We don't want that reply to be the auth token, so
-        we just hard-code it to "streamlit".
+        selected subprotocol to use. We don't want that reply to be the token, so we
+        by convention have the client always set the first protocol to "streamlit" and
+        select that.
         """
         if subprotocols:
             return subprotocols[0]
@@ -102,7 +104,27 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         else:
             user_info["email"] = email
 
-        self._session_id = self._runtime.create_session(self, user_info)
+        existing_session_id = None
+        try:
+            ws_protocols = [
+                p.strip()
+                for p in self.request.headers["Sec-Websocket-Protocol"].split(",")
+            ]
+
+            if len(ws_protocols) > 1:
+                # See the NOTE in the docstring of the select_subprotocol method above
+                # for a detailed explanation of why this is done.
+                existing_session_id = ws_protocols[1]
+        except KeyError:
+            # Just let existing_session_id=None if we run into any error while trying to
+            # extract it from the Sec-Websocket-Protocol header.
+            pass
+
+        self._session_id = self._runtime.create_session(
+            client=self,
+            user_info=user_info,
+            existing_session_id=existing_session_id,
+        )
         return None
 
     def on_close(self) -> None:

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -35,6 +35,7 @@ from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
+from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
@@ -184,6 +185,7 @@ class Server:
                 script_path=main_script_path,
                 command_line=command_line,
                 media_file_storage=media_file_storage,
+                session_manager_class=WebsocketSessionManager,
             ),
         )
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -34,9 +34,7 @@ from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
-from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
-from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
@@ -186,8 +184,6 @@ class Server:
                 script_path=main_script_path,
                 command_line=command_line,
                 media_file_storage=media_file_storage,
-                session_manager_class=WebsocketSessionManager,
-                session_storage=MemorySessionStorage(),
             ),
         )
 

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -34,6 +34,7 @@ from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
@@ -186,6 +187,7 @@ class Server:
                 command_line=command_line,
                 media_file_storage=media_file_storage,
                 session_manager_class=WebsocketSessionManager,
+                session_storage=MemorySessionStorage(),
             ),
         )
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -403,7 +403,7 @@ class AppSessionTest(unittest.TestCase):
         session = _create_test_session()
         session._local_sources_watcher = None
 
-        session._register_file_watchers()
+        session.register_file_watchers()
         self.assertIsNotNone(session._local_sources_watcher)
 
     @patch(
@@ -419,7 +419,7 @@ class AppSessionTest(unittest.TestCase):
         ) as patched_stop_config_listener, patch.object(
             session, "_stop_pages_listener"
         ) as patched_stop_pages_listener:
-            session._disconnect_file_watchers()
+            session.disconnect_file_watchers()
 
             patched_close_local_sources_watcher.assert_called_once()
             patched_stop_config_listener.assert_called_once()
@@ -433,7 +433,7 @@ class AppSessionTest(unittest.TestCase):
             self.assertIsNone(session._stop_pages_listener)
 
     def test_disconnect_file_watchers_removes_refs(self):
-        """Test that calling _disconnect_file_watchers on the AppSession
+        """Test that calling disconnect_file_watchers on the AppSession
         removes references to it so it is eligible to be garbage collected after the
         method is called.
         """
@@ -443,7 +443,7 @@ class AppSessionTest(unittest.TestCase):
         # handlers.
         self.assertGreater(len(gc.get_referrers(session)), 0)
 
-        session._disconnect_file_watchers()
+        session.disconnect_file_watchers()
         # Ensure that we don't count refs to session from an object that would have been
         # garbage collected along with it.
         gc.collect(2)

--- a/lib/tests/streamlit/runtime/memory_session_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_session_storage_test.py
@@ -1,0 +1,69 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+from cachetools import TTLCache
+
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
+
+
+class MemorySessionStorageTest(unittest.TestCase):
+    """Test MemorySessionStorage.
+
+    These tests are intentionally extremely simple to ensure that we don't just end up
+    testing cachetools.TTLCache. We try to just verify that we've wrapped TTLCache
+    correctly, and in particular we avoid testing cache expiry functionality.
+    """
+
+    def test_uses_ttl_cache(self):
+        """Verify that the backing cache of a MemorySessionStorage is a TTLCache.
+
+        We do this because we're intentionally avoiding writing tests around cache
+        expiry because the cachetools library should do this for us. In the case
+        that the backing cache for a MemorySessionStorage ever changes, we'll likely be
+        responsible for adding our own tests.
+        """
+        store = MemorySessionStorage()
+        self.assertIsInstance(store._cache, TTLCache)
+
+    def test_get(self):
+        store = MemorySessionStorage()
+        store._cache["foo"] = "bar"
+
+        self.assertEqual(store.get("foo"), "bar")
+        self.assertEqual(store.get("baz"), None)
+
+    def test_save(self):
+        store = MemorySessionStorage()
+        session_info = MagicMock()
+        session_info.session.id = "foo"
+
+        store.save(session_info)
+        self.assertEqual(store.get("foo"), session_info)
+
+    def test_delete(self):
+        store = MemorySessionStorage()
+        store._cache["foo"] = "bar"
+
+        store.delete("foo")
+        self.assertEqual(store.get("foo"), None)
+
+    def test_list(self):
+        store = MemorySessionStorage()
+        store._cache["foo"] = "bar"
+        store._cache["baz"] = "qux"
+
+        self.assertEqual(store.list(), ["bar", "qux"])

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -101,21 +101,21 @@ class RuntimeTest(RuntimeTestCase):
         await self.runtime.stopped
         self.assertEqual(RuntimeState.STOPPED, self.runtime.state)
 
-    async def test_create_session(self):
+    async def test_connect_session(self):
         """We can create and remove a single session."""
         await self.runtime.start()
 
-        session_id = self.runtime.create_session(
+        session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
         self.assertEqual(
             RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED, self.runtime.state
         )
 
-        self.runtime.close_session(session_id)
+        self.runtime.disconnect_session(session_id)
         self.assertEqual(RuntimeState.NO_SESSIONS_CONNECTED, self.runtime.state)
 
-    async def test_create_session_existing_session_id_plumbing(self):
+    async def test_connect_session_existing_session_id_plumbing(self):
         """The existing_session_id parameter is plumbed to _session_mgr.connect_session."""
         await self.runtime.start()
 
@@ -126,7 +126,7 @@ class RuntimeTest(RuntimeTestCase):
             user_info = MagicMock()
             existing_session_id = "some_session_id"
 
-            session_id = self.runtime.create_session(
+            session_id = self.runtime.connect_session(
                 client=client,
                 user_info=user_info,
                 existing_session_id=existing_session_id,
@@ -139,20 +139,61 @@ class RuntimeTest(RuntimeTestCase):
                 existing_session_id=existing_session_id,
             )
 
-    async def test_close_session_disconnects_appsession(self):
-        """Closing a session should shutdown its associated AppSession."""
+    @patch("streamlit.runtime.runtime.LOGGER")
+    async def test_create_session_alias(self, patched_logger):
+        """Test that create_session defers to connect_session and logs a warning."""
         await self.runtime.start()
 
-        # Create a session and get its associated AppSession object.
-        session_id = self.runtime.create_session(
+        client = MockSessionClient()
+        user_info = MagicMock()
+
+        with patch.object(
+            self.runtime, "connect_session", new=MagicMock()
+        ) as patched_connect_session:
+
+            self.runtime.create_session(client=client, user_info=user_info)
+
+            patched_connect_session.assert_called_with(
+                client=client,
+                user_info=user_info,
+                existing_session_id=None,
+            )
+            patched_logger.warning.assert_called_with(
+                "create_session is deprecated! Use connect_session instead."
+            )
+
+    async def test_disconnect_session_disconnects_appsession(self):
+        """Closing a session should disconnect its associated AppSession."""
+        await self.runtime.start()
+
+        session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
 
         with patch.object(
             self.runtime._session_mgr, "disconnect_session", new=MagicMock()
-        ) as patched_disconnect_session:
-            self.runtime.close_session(session_id)
+        ) as patched_disconnect_session, patch.object(
+            self.runtime, "_on_session_disconnected", new=MagicMock()
+        ) as patched_on_session_disconnected:
+            self.runtime.disconnect_session(session_id)
             patched_disconnect_session.assert_called_with(session_id)
+            patched_on_session_disconnected.assert_called_once()
+
+    async def test_close_session_closes_appsession(self):
+        await self.runtime.start()
+
+        session_id = self.runtime.connect_session(
+            client=MockSessionClient(), user_info=MagicMock()
+        )
+
+        with patch.object(
+            self.runtime._session_mgr, "close_session", new=MagicMock()
+        ) as patched_close_session, patch.object(
+            self.runtime, "_on_session_disconnected", new=MagicMock()
+        ) as patched_on_session_disconnected:
+            self.runtime.close_session(session_id)
+            patched_close_session.assert_called_with(session_id)
+            patched_on_session_disconnected.assert_called_once()
 
     async def test_multiple_sessions(self):
         """Multiple sessions can be connected."""
@@ -160,7 +201,7 @@ class RuntimeTest(RuntimeTestCase):
 
         session_ids = []
         for _ in range(3):
-            session_id = self.runtime.create_session(
+            session_id = self.runtime.connect_session(
                 client=MockSessionClient(),
                 user_info=MagicMock(),
             )
@@ -171,7 +212,7 @@ class RuntimeTest(RuntimeTestCase):
             session_ids.append(session_id)
 
         for i in range(len(session_ids)):
-            self.runtime.close_session(session_ids[i])
+            self.runtime.disconnect_session(session_ids[i])
             expected_state = (
                 RuntimeState.NO_SESSIONS_CONNECTED
                 if i == len(session_ids) - 1
@@ -181,6 +222,20 @@ class RuntimeTest(RuntimeTestCase):
 
         self.assertEqual(RuntimeState.NO_SESSIONS_CONNECTED, self.runtime.state)
 
+    async def test_disconnect_invalid_session(self):
+        """Disconnecting a session that doesn't exist is a no-op: no error raised."""
+        await self.runtime.start()
+
+        # Close a session that never existed
+        self.runtime.disconnect_session("no_such_session")
+
+        # Close a valid session twice
+        session_id = self.runtime.connect_session(
+            client=MockSessionClient(), user_info=MagicMock()
+        )
+        self.runtime.disconnect_session(session_id)
+        self.runtime.disconnect_session(session_id)
+
     async def test_close_invalid_session(self):
         """Closing a session that doesn't exist is a no-op: no error raised."""
         await self.runtime.start()
@@ -189,7 +244,7 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.close_session("no_such_session")
 
         # Close a valid session twice
-        session_id = self.runtime.create_session(
+        session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
         self.runtime.close_session(session_id)
@@ -198,13 +253,13 @@ class RuntimeTest(RuntimeTestCase):
     async def test_is_active_session(self):
         """`is_active_session` should work as expected."""
         await self.runtime.start()
-        session_id = self.runtime.create_session(
+        session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
         self.assertTrue(self.runtime.is_active_session(session_id))
         self.assertFalse(self.runtime.is_active_session("not_a_session_id"))
 
-        self.runtime.close_session(session_id)
+        self.runtime.disconnect_session(session_id)
         self.assertFalse(self.runtime.is_active_session(session_id))
 
     async def test_closes_app_sessions_on_stop(self):
@@ -214,7 +269,7 @@ class RuntimeTest(RuntimeTestCase):
         # Create a few sessions
         app_sessions = []
         for _ in range(3):
-            session_id = self.runtime.create_session(MockSessionClient(), MagicMock())
+            session_id = self.runtime.connect_session(MockSessionClient(), MagicMock())
             app_session = self.runtime._session_mgr.get_active_session_info(
                 session_id
             ).session
@@ -236,7 +291,7 @@ class RuntimeTest(RuntimeTestCase):
     async def test_handle_backmsg(self):
         """BackMsgs should be delivered to the appropriate AppSession."""
         await self.runtime.start()
-        session_id = self.runtime.create_session(
+        session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
 
@@ -262,7 +317,7 @@ class RuntimeTest(RuntimeTestCase):
         appropriate AppSession.
         """
         await self.runtime.start()
-        session_id = self.runtime.create_session(
+        session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
 
@@ -282,14 +337,14 @@ class RuntimeTest(RuntimeTestCase):
             "not_a_session_id", MagicMock()
         )
 
-    async def test_create_session_after_stop(self):
-        """After Runtime.stop is called, `create_session` is an error."""
+    async def test_connect_session_after_stop(self):
+        """After Runtime.stop is called, `connect_session` is an error."""
         await self.runtime.start()
         self.runtime.stop()
         await self.tick_runtime_loop()
 
         with self.assertRaises(RuntimeStoppedError):
-            self.runtime.create_session(MagicMock(), MagicMock())
+            self.runtime.connect_session(MagicMock(), MagicMock())
 
     async def test_handle_backmsg_after_stop(self):
         """After Runtime.stop is called, `handle_backmsg` is an error."""
@@ -307,7 +362,7 @@ class RuntimeTest(RuntimeTestCase):
         await self.runtime.start()
 
         client = MagicMock(spec=SessionClient)
-        session_id = self.runtime.create_session(client, MagicMock())
+        session_id = self.runtime.connect_session(client, MagicMock())
 
         # Send the client a message. All should be well.
         self.enqueue_forward_msg(session_id, create_dataframe_msg([1, 2, 3]))
@@ -331,7 +386,7 @@ class RuntimeTest(RuntimeTestCase):
         await self.runtime.start()
 
         client = MockSessionClient()
-        session_id = self.runtime.create_session(client=client, user_info=MagicMock())
+        session_id = self.runtime.connect_session(client=client, user_info=MagicMock())
 
         # Create a message and ensure its hash is unset; we're testing
         # that _send_message adds the hash before it goes out.
@@ -349,7 +404,7 @@ class RuntimeTest(RuntimeTestCase):
         await self.runtime.start()
 
         client = MockSessionClient()
-        session_id = self.runtime.create_session(client=client, user_info=MagicMock())
+        session_id = self.runtime.connect_session(client=client, user_info=MagicMock())
 
         with patch_config_options({"global.minCachedMessageSize": 0}):
             cacheable_msg = create_dataframe_msg([1, 2, 3])
@@ -375,7 +430,7 @@ class RuntimeTest(RuntimeTestCase):
             await self.runtime.start()
 
             client = MockSessionClient()
-            session_id = self.runtime.create_session(
+            session_id = self.runtime.connect_session(
                 client=client, user_info=MagicMock()
             )
 
@@ -412,7 +467,7 @@ class RuntimeTest(RuntimeTestCase):
             await self.runtime.start()
 
             client = MockSessionClient()
-            session_id = self.runtime.create_session(
+            session_id = self.runtime.connect_session(
                 client=client, user_info=MagicMock()
             )
 
@@ -472,7 +527,7 @@ class RuntimeTest(RuntimeTestCase):
         await self.runtime.start()
 
         client = MockSessionClient()
-        session_id = self.runtime.create_session(client=client, user_info=MagicMock())
+        session_id = self.runtime.connect_session(client=client, user_info=MagicMock())
 
         file = UploadedFileRec(0, "file.txt", "type", b"123")
 
@@ -490,7 +545,7 @@ class RuntimeTest(RuntimeTestCase):
         )
 
         # Disconnect the session. The file should be deleted.
-        self.runtime.close_session(session_id)
+        self.runtime.disconnect_session(session_id)
         self.assertEqual(
             self.runtime._uploaded_file_mgr.get_all_files(session_id, "widget_id"),
             [],

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -23,17 +23,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
-from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
-from streamlit.runtime.runtime import (
-    AsyncObjects,
+from streamlit.runtime import (
     Runtime,
     RuntimeConfig,
     RuntimeState,
-    RuntimeStoppedError,
     SessionClient,
     SessionClientDisconnectedError,
 )
+from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
+from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.runtime import AsyncObjects, RuntimeStoppedError
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.watcher import event_based_path_watcher
 from tests.streamlit.message_mocks import (

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -526,6 +526,7 @@ class ScriptCheckTest(RuntimeTestCase):
             command_line="mock command line",
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
             session_manager_class=MagicMock,
+            session_storage=MagicMock(),
         )
         self.runtime = Runtime(config)
         await self.runtime.start()

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -134,7 +134,7 @@ class RuntimeTest(RuntimeTestCase):
 
             patched_connect_session.assert_called_with(
                 client=client,
-                session_data=ANY,
+                script_data=ANY,
                 user_info=user_info,
                 existing_session_id=existing_session_id,
             )

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -20,9 +20,9 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import (
     SessionClient,
-    SessionData,
     SessionInfo,
     SessionManager,
     SessionStorage,
@@ -53,7 +53,7 @@ class MockSessionManager(SessionManager):
     def connect_session(
         self,
         client: SessionClient,
-        session_data: SessionData,
+        script_data: ScriptData,
         user_info: Dict[str, Optional[str]],
         existing_session_id: Optional[str] = None,
     ) -> str:
@@ -61,7 +61,7 @@ class MockSessionManager(SessionManager):
             "streamlit.runtime.scriptrunner.ScriptRunner", new=mock.MagicMock()
         ):
             session = AppSession(
-                session_data=session_data,
+                script_data=script_data,
                 uploaded_file_manager=self._uploaded_file_mgr,
                 message_enqueued_callback=self._message_enqueued_callback,
                 local_sources_watcher=mock.MagicMock(),

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -99,6 +99,7 @@ class RuntimeTestCase(IsolatedAsyncioTestCase):
             command_line="",
             media_file_storage=MemoryMediaFileStorage("/mock/media"),
             session_manager_class=MockSessionManager,
+            session_storage=mock.MagicMock(),
         )
         self.runtime = Runtime(config)
 

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -49,6 +49,7 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                     "",
                     media_file_storage=MagicMock(),
                     session_manager_class=MagicMock(),
+                    session_storage=MagicMock(),
                 )
                 queue.put(Runtime(config))
             except BaseException as e:

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -48,7 +48,7 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                     "mock/script/path.py",
                     "",
                     media_file_storage=MagicMock(),
-                    session_manager_class=MagicMock(),
+                    session_manager_class=MagicMock,
                     session_storage=MagicMock(),
                 )
                 queue.put(Runtime(config))

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -45,7 +45,10 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                 # so that the main thread can retrieve it safely. If Runtime
                 # creation fails, we'll stick an Exception in the queue instead.
                 config = RuntimeConfig(
-                    "mock/script/path.py", "", media_file_storage=MagicMock()
+                    "mock/script/path.py",
+                    "",
+                    media_file_storage=MagicMock(),
+                    session_manager_class=MagicMock(),
                 )
                 queue.put(Runtime(config))
             except BaseException as e:

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -1,0 +1,18 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We intentionally neglect to write tests for this class for now as we'll be
+# waiting to merge these changes into `develop` until after we finish implementing
+# improved websocket reconnects, after which we would have to rewrite all of these tests
+# if we were to add some now.

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE: We intentionally neglect to write tests for this class for now as we'll be
-# waiting to merge these changes into `develop` until after we finish implementing
-# improved websocket reconnects, after which we would have to rewrite all of these tests
-# if we were to add some now.
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -16,3 +16,234 @@
 # waiting to merge these changes into `develop` until after we finish implementing
 # improved websocket reconnects, after which we would have to rewrite all of these tests
 # if we were to add some now.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.runtime.session_data import SessionData
+from streamlit.runtime.session_manager import SessionStorage
+from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
+
+
+class MockSessionStorage(SessionStorage):
+    """A simple SessionStorage implementation used for testing.
+
+    Essentially just a thin wrapper around a dict. This class exists so that we don't
+    accidentally have our WebsocketSessionManager tests rely on a real SessionStorage
+    implementation.
+    """
+
+    def __init__(self):
+        self._cache = {}
+
+    def get(self, session_id):
+        return self._cache.get(session_id, None)
+
+    def save(self, session_info):
+        self._cache[session_info.session.id] = session_info
+
+    def delete(self, session_id):
+        del self._cache[session_id]
+
+    def list(self):
+        return list(self._cache.values())
+
+
+@patch(
+    "streamlit.runtime.app_session.asyncio.get_running_loop",
+    new=MagicMock(),
+)
+@patch("streamlit.runtime.app_session.LocalSourcesWatcher", new=MagicMock())
+@patch("streamlit.runtime.app_session.ScriptRunner", new=MagicMock())
+class WebsocketSessionManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.session_mgr = WebsocketSessionManager(
+            session_storage=MockSessionStorage(),
+            uploaded_file_manager=MagicMock(),
+            message_enqueued_callback=MagicMock(),
+        )
+
+    def connect_session(self, existing_session_id=None):
+        return self.session_mgr.connect_session(
+            client=MagicMock(),
+            session_data=SessionData("/fake/script_path.py", "fake_command_line"),
+            user_info={},
+            existing_session_id=existing_session_id,
+        )
+
+    def test_connect_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr._active_session_info_by_id[session_id]
+
+        assert session_info.session.id == session_id
+
+    def test_connect_session_on_invalid_session_id(self):
+        """Test that connect_session gives us a new session if existing_session_id is invalid."""
+        session_id = self.connect_session(existing_session_id="not a valid session")
+        session_info = self.session_mgr._active_session_info_by_id[session_id]
+
+        assert session_info.session.id == session_id
+        assert session_info.session.id != "not a valid session"
+
+    def test_connect_session_explodes_if_already_connected(self):
+        session_id = self.connect_session()
+
+        with pytest.raises(AssertionError):
+            self.connect_session(existing_session_id=session_id)
+
+    def test_connect_session_explodes_if_ID_collission(self):
+        session_id = self.connect_session()
+        with pytest.raises(AssertionError):
+            with patch(
+                "streamlit.runtime.app_session.uuid.uuid4", return_value=session_id
+            ):
+                self.connect_session()
+
+    @patch(
+        "streamlit.runtime.app_session.AppSession.register_file_watchers",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
+        new=MagicMock(),
+    )
+    def test_disconnect_and_reconnect_session(self):
+        session_id = self.connect_session()
+        original_session_info = self.session_mgr.get_session_info(session_id)
+        original_client = original_session_info.client
+
+        # File watchers are registered on AppSession creation.
+        original_session_info.session.register_file_watchers.assert_called_once()
+
+        self.session_mgr.disconnect_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id in self.session_mgr._session_storage._cache
+        original_session_info.session.disconnect_file_watchers.assert_called_once()
+
+        # Call disconnect_session again to verify that disconnect_session is idempotent.
+        self.session_mgr.disconnect_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id in self.session_mgr._session_storage._cache
+        original_session_info.session.disconnect_file_watchers.assert_called_once()
+
+        # Reconnect to the existing session.
+        reconnected_session_id = self.connect_session(existing_session_id=session_id)
+        reconnected_session_info = self.session_mgr.get_session_info(
+            reconnected_session_id
+        )
+
+        assert reconnected_session_id == session_id
+        assert reconnected_session_info.session == original_session_info.session
+        assert reconnected_session_info != original_session_info
+        assert reconnected_session_info.client != original_client
+        # File watchers are registered on AppSession creation and again on AppSession
+        # reconnect.
+        assert reconnected_session_info.session.register_file_watchers.call_count == 2
+
+    def test_disconnect_session_on_invalid_session_id(self):
+        # Just check that no error is thrown.
+        self.session_mgr.disconnect_session("nonexistent_session")
+
+    def test_get_active_session_info(self):
+        session_id = self.connect_session()
+
+        active_session_info = self.session_mgr.get_active_session_info(session_id)
+        assert active_session_info.session.id == session_id
+
+    def test_get_active_session_info_on_invalid_session_id(self):
+        assert self.session_mgr.get_active_session_info("nonexistent_session") is None
+
+    def test_get_active_session_info_on_disconnected_session(self):
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        assert self.session_mgr.get_active_session_info(session_id) is None
+
+    def test_is_active_session(self):
+        session_id = self.connect_session()
+        assert self.session_mgr.is_active_session(session_id)
+
+    def test_is_active_session_on_invalid_session_id(self):
+        assert not self.session_mgr.is_active_session("nonexistent_session")
+
+    def test_is_active_session_on_disconnected_session(self):
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        assert not self.session_mgr.is_active_session(session_id)
+
+    def test_list_active_sessions(self):
+        session_ids = []
+        for _ in range(3):
+            session_ids.append(self.connect_session())
+
+        assert [
+            s.session.id for s in self.session_mgr.list_active_sessions()
+        ] == session_ids
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    def test_close_session_on_active_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr.get_session_info(session_id)
+        self.session_mgr.close_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id not in self.session_mgr._session_storage._cache
+        session_info.session.shutdown.assert_called_once()
+
+    @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
+    def test_close_session_on_inactive_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr.get_session_info(session_id)
+        self.session_mgr.disconnect_session(session_id)
+
+        # Sanity check.
+        assert not self.session_mgr.is_active_session(session_id)
+
+        self.session_mgr.close_session(session_id)
+
+        assert session_id not in self.session_mgr._active_session_info_by_id
+        assert session_id not in self.session_mgr._session_storage._cache
+        session_info.session.shutdown.assert_called_once()
+
+    def test_close_session_on_invalid_session_id(self):
+        self.session_mgr.close_session("nonexistent_session")
+
+    def test_get_session_info_on_active_session(self):
+        session_id = self.connect_session()
+        session_info = self.session_mgr.get_session_info(session_id)
+
+        assert session_info.session.id == session_id
+
+    def test_get_session_info_on_inactive_session(self):
+        session_id = self.connect_session()
+        self.session_mgr.disconnect_session(session_id)
+
+        # Sanity check.
+        assert not self.session_mgr.is_active_session(session_id)
+
+        session_info = self.session_mgr.get_session_info(session_id)
+        assert session_info.session.id == session_id
+
+    def test_get_session_info_on_invalid_session_id(self):
+        assert self.session_mgr.get_session_info("nonexistent_session") is None
+
+    def test_list_sessions(self):
+        session_ids = []
+        for _ in range(3):
+            session_ids.append(self.connect_session())
+
+        self.session_mgr.disconnect_session(session_ids[1])
+
+        # Sanity check.
+        assert self.session_mgr.is_active_session(session_ids[0])
+        assert not self.session_mgr.is_active_session(session_ids[1])
+        assert self.session_mgr.is_active_session(session_ids[2])
+
+        assert {s.session.id for s in self.session_mgr.list_sessions()} == set(
+            session_ids
+        )

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from streamlit.runtime.session_data import SessionData
+from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import SessionStorage
 from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 
@@ -68,7 +68,7 @@ class WebsocketSessionManagerTests(unittest.TestCase):
     def connect_session(self, existing_session_id=None):
         return self.session_mgr.connect_session(
             client=MagicMock(),
-            session_data=SessionData("/fake/script_path.py", "fake_command_line"),
+            script_data=ScriptData("/fake/script_path.py", "fake_command_line"),
             user_info={},
             existing_session_id=existing_session_id,
         )

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -36,12 +36,12 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_connect_with_no_session_id(self):
         with self._patch_app_session(), patch.object(
-            self.server._runtime, "create_session"
-        ) as patched_create_session:
+            self.server._runtime, "connect_session"
+        ) as patched_connect_session:
             await self.server.start()
             await self.ws_connect()
 
-            patched_create_session.assert_called_with(
+            patched_connect_session.assert_called_with(
                 client=ANY,
                 user_info=ANY,
                 existing_session_id=None,
@@ -50,12 +50,12 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
     @tornado.testing.gen_test
     async def test_connect_with_session_id(self):
         with self._patch_app_session(), patch.object(
-            self.server._runtime, "create_session"
-        ) as patched_create_session:
+            self.server._runtime, "connect_session"
+        ) as patched_connect_session:
             await self.server.start()
             await self.ws_connect(existing_session_id="session_id")
 
-            patched_create_session.assert_called_with(
+            patched_connect_session.assert_called_with(
                 client=ANY,
                 user_info=ANY,
                 existing_session_id="session_id",

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -98,7 +98,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get our BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler: BrowserWebSocketHandler = session_info.client
 
             websocket_handler.on_message(
@@ -115,7 +115,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get our BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler: BrowserWebSocketHandler = session_info.client
 
             websocket_handler.on_message(
@@ -132,7 +132,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get our BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler: BrowserWebSocketHandler = session_info.client
 
             with patch.object(
@@ -152,7 +152,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get our BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler: BrowserWebSocketHandler = session_info.client
 
             with patch.object(

--- a/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
+++ b/lib/tests/streamlit/web/server/browser_websocket_handler_test.py
@@ -45,7 +45,7 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get our connected BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler = session_info.client
             self.assertIsInstance(websocket_handler, BrowserWebSocketHandler)
 
@@ -77,8 +77,8 @@ class BrowserWebSocketHandlerTest(ServerTestCase):
             await self.server.start()
             await self.ws_connect()
 
-            # Get our BrowserWebSocketHandler
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            # Get our connected BrowserWebSocketHandler
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
             websocket_handler: BrowserWebSocketHandler = session_info.client
 
             mock_runtime = MagicMock(spec=Runtime)

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -103,8 +103,8 @@ class ServerTest(ServerTestCase):
             self.assertTrue(self.server.browser_is_connected)
 
             # Get this client's SessionInfo object
-            self.assertEqual(1, len(self.server._runtime._session_info_by_id))
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            self.assertEqual(1, self.server._runtime._session_mgr.num_active_sessions())
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
 
             # Close the connection
             ws_client.close()
@@ -114,7 +114,7 @@ class ServerTest(ServerTestCase):
             # Ensure AppSession.shutdown() was called, and that our
             # SessionInfo was cleared.
             session_info.session.shutdown.assert_called_once()
-            self.assertEqual(0, len(self.server._runtime._session_info_by_id))
+            self.assertEqual(0, self.server._runtime._session_mgr.num_active_sessions())
 
     @tornado.testing.gen_test
     async def test_multiple_connections(self):
@@ -133,7 +133,7 @@ class ServerTest(ServerTestCase):
             self.assertTrue(self.server.browser_is_connected)
 
             # Assert that our session_infos are sane
-            session_infos = list(self.server._runtime._session_info_by_id.values())
+            session_infos = self.server._runtime._session_mgr.list_active_sessions()
             self.assertEqual(2, len(session_infos))
             self.assertNotEqual(
                 session_infos[0].session.id,
@@ -191,7 +191,7 @@ class ServerTest(ServerTestCase):
             await self.ws_connect()
 
             # Get the server's socket and session for this client
-            session_info = list(self.server._runtime._session_info_by_id.values())[0]
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
 
             with patch.object(
                 session_info.session, "flush_browser_queue"
@@ -218,7 +218,9 @@ class ServerTest(ServerTestCase):
                 # Our session should have been removed from the server as
                 # a result of the WebSocketClosedError.
                 self.assertIsNone(
-                    self.server._runtime._get_session_info(session_info.session.id)
+                    self.server._runtime._session_mgr.get_active_session_info(
+                        session_info.session.id
+                    )
                 )
 
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -111,10 +111,11 @@ class ServerTest(ServerTestCase):
             await asyncio.sleep(0.1)
             self.assertFalse(self.server.browser_is_connected)
 
-            # Ensure AppSession.shutdown() was called, and that our
-            # SessionInfo was cleared.
-            session_info.session.shutdown.assert_called_once()
+            # Ensure AppSession.disconnect_file_watchers() was called, and that our
+            # session exists but is no longer active.
+            session_info.session.disconnect_file_watchers.assert_called_once()
             self.assertEqual(0, self.server._runtime._session_mgr.num_active_sessions())
+            self.assertEqual(1, self.server._runtime._session_mgr.num_sessions())
 
     @tornado.testing.gen_test
     async def test_multiple_connections(self):

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -118,6 +118,48 @@ class ServerTest(ServerTestCase):
             self.assertEqual(1, self.server._runtime._session_mgr.num_sessions())
 
     @tornado.testing.gen_test
+    async def test_websocket_connect_to_nonexistent_session(self):
+        with _patch_local_sources_watcher(), self._patch_app_session():
+            await self.server.start()
+
+            ws_client = await self.ws_connect(existing_session_id="nonexistent_session")
+
+            session_info = self.server._runtime._session_mgr.list_active_sessions()[0]
+
+            self.assertNotEqual(session_info.session.id, "nonexistent_session")
+
+            ws_client.close()
+            await asyncio.sleep(0.1)
+
+    @tornado.testing.gen_test
+    async def test_websocket_disconnect_and_reconnect(self):
+        with _patch_local_sources_watcher(), self._patch_app_session():
+            await self.server.start()
+
+            ws_client = await self.ws_connect()
+            original_session_info = (
+                self.server._runtime._session_mgr.list_active_sessions()[0]
+            )
+
+            # Disconnect, reconnect with the same session_id, and confirm that the
+            # session was reused.
+            ws_client.close()
+            await asyncio.sleep(0.1)
+
+            ws_client = await self.ws_connect(
+                existing_session_id=original_session_info.session.id
+            )
+
+            self.assertEqual(self.server._runtime._session_mgr.num_active_sessions(), 1)
+            new_session_info = self.server._runtime._session_mgr.list_active_sessions()[
+                0
+            ]
+            self.assertEqual(new_session_info.session, original_session_info.session)
+
+            ws_client.close()
+            await asyncio.sleep(0.1)
+
+    @tornado.testing.gen_test
     async def test_multiple_connections(self):
         """Test multiple websockets can connect simultaneously."""
         with _patch_local_sources_watcher(), self._patch_app_session():

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -63,17 +63,24 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         parts[0] = "ws"
         return urllib.parse.urlunparse(tuple(parts))
 
-    async def ws_connect(self) -> WebSocketClientConnection:
+    async def ws_connect(self, existing_session_id=None) -> WebSocketClientConnection:
         """Open a websocket connection to the server.
 
         Returns
         -------
         WebSocketClientConnection
             The connected websocket client.
-
         """
+        # See the comment in WebsocketConnection.tsx about how we repurpose the
+        # Sec-WebSocket-Protocol header for more information on how this works.
+        if existing_session_id is None:
+            subprotocols = ["streamlit"]
+        else:
+            subprotocols = ["streamlit", existing_session_id]
+
         return await tornado.websocket.websocket_connect(
             self.get_ws_url("/_stcore/stream")
+            subprotocols=subprotocols,
         )
 
     async def read_forward_msg(

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -104,7 +104,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         """
 
         return mock.patch(
-            "streamlit.runtime.runtime.AppSession",
+            "streamlit.runtime.websocket_session_manager.AppSession",
             # new_callable must return a function, not an object, or else
             # there will only be a single AppSession mock. Hence the lambda.
             new_callable=lambda: self._create_mock_app_session,

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -79,7 +79,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
             subprotocols = ["streamlit", existing_session_id]
 
         return await tornado.websocket.websocket_connect(
-            self.get_ws_url("/_stcore/stream")
+            self.get_ws_url("/_stcore/stream"),
             subprotocols=subprotocols,
         )
 

--- a/lib/tests/streamlit/web/server/websocket_headers_test.py
+++ b/lib/tests/streamlit/web/server/websocket_headers_test.py
@@ -34,10 +34,12 @@ class WebSocketHeadersTest(ServerTestCase):
             await self.server.start()
             await self.ws_connect()
 
+            session_mgr = self.server._runtime._session_mgr
+
             # Get our client's session_id and some other stuff
-            self.assertEqual(1, len(self.server._runtime._session_info_by_id))
-            session_id = list(self.server._runtime._session_info_by_id.keys())[0]
-            session_info = self.server._runtime._session_info_by_id[session_id]
+            self.assertEqual(1, session_mgr.num_active_sessions())
+            session_info = session_mgr.list_active_sessions()[0]
+            session_id = session_info.session.id
             self.assertIsInstance(session_info.client, BrowserWebSocketHandler)
 
             # Mock get_script_run_ctx() to return our session_id


### PR DESCRIPTION
Notes:
* All of the code in this PR was already reviewed before being merged into the feature branch, so very careful/thorough
  review of this code isn't necessary, although it'd be good to still read through the full PR and sanity-check everything
  being done.
* While we fix the issue with session state immediately being dropped when the browser tab's websocket disconnects,
   some followup changes will be required to teach `st.file_uploader` and `st.camera_input` to benefit from these changes.
   The frontend pieces of these widgets were originally written assuming that files are gone forever once the websocket
   connection is lost (see some TODOs left in the code). These fixes can be tackled as followup projects.

## 📚 Context

This PR is the final merge for the `feature/session-manager` branch into `develop`. It aims to accomplish three main goals:

1. Define new `SessionManager` and `SessionStorage` abstractions, which will soon be useful for being able to
    configure how Streamlit runs across various different environments. Right now, our notion of a "session" is
    very closely tied to the life of a browser's websocket connection, and we also assume that Streamlit servers
    are long-lived + that server shutdowns cause us to lose data that isn't explicitly persisted outside of Streamlit.
    In the future, it's possible that many of these assumptions will be changing, so we want to define suitable
    abstractions to guide how we think about these changes. Note that we don't expect to get these abstractions
    perfectly correct on the first try, but we have some leeway here to make adjustments until we have a few
    implementations of `SessionManager` / `SessionStorage` aside from the ones used by default by the OS lib.
2. Write our first concrete implementations of `SessionManager` and `SessionStorage`: `WebsocketSessionManager`
    and `MemorySessionStorage`. These implementations retain most of the behavior that exists today, with one
    exception described below. 
3. Use `WebsocketSessionManager` to fix a source of nondeterministic bugs where a browser tab's session state
    is immediately cleared when its websocket disconnects. To fix this, we teach `WebsocketSessionManager` to
    avoid immediately deleting a session's state/uploaded files/etc on websocket disconnect and instead defer
    the cleanup for a few minutes. This allows browser tabs that only transient disconnected (due to a network
    blip, load balancer timeout, etc.) to avoid losing all of their state.

---

Closes #4297