### PR TITLE
Change workers balancing logic for e2e tests to always cover all specs

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,6 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # In case of number of workers would change, update TOTAL_WORKERS env variable in "Cypress Tests" step.
         specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
 
     steps:
@@ -64,22 +65,32 @@ jobs:
       - name: Cypress Tests
         env:
           CURRENT_RUN: ${{matrix.specs}}
+          TOTAL_WORKERS: 22
         run: |
           js_specs=(e2e/specs/*)
-          # get how many specs to be split up into 21 runs
-          (( interval=(${#js_specs[@]})/21 ))
-          if [ "$CURRENT_RUN" -eq 1 ]
-          then
+
+          # get how many specs to be split up into $TOTAL_WORKERS runs
+          (( totalTests = ${#js_specs[@]} ))
+          (( testsPerWorker = totalTests / TOTAL_WORKERS ))
+          # get the remainder of tests to be split up into the first $remainder workers
+          (( remainder = totalTests % TOTAL_WORKERS ))
+
+          if [ "$CURRENT_RUN" -eq 1 ]; then
             startIndex=0
+            (( currentIntervalLength = testsPerWorker + 1 ))
+          elif [ $CURRENT_RUN -le $remainder ]; then
+            (( startIndex = (CURRENT_RUN - 1) * (testsPerWorker + 1) ))
+            (( currentIntervalLength = testsPerWorker + 1 ))
           else
-            (( startIndex = (${CURRENT_RUN} - 1) * ${interval} ))
+            (( startIndex = remainder * (testsPerWorker + 1) + (CURRENT_RUN - remainder - 1) * testsPerWorker ))
+            (( currentIntervalLength = testsPerWorker ))
           fi
+
           # ensure no blank specs list (which causes every spec to run)
-          if [[ "${js_specs[@]:${startIndex}:${interval}}" != "" ]]
-          then
+          if [[ "${js_specs[@]:${startIndex}:${currentIntervalLength}}" != "" ]]; then
             echo "Specs tested in this job:"
-            echo "${js_specs[@]:${startIndex}:${interval}}"
-            scripts/run_e2e_tests.py -a "${js_specs[@]:${startIndex}:${interval}}"
+            echo "${js_specs[@]:${startIndex}:${currentIntervalLength}}"
+            scripts/run_e2e_tests.py -a "${js_specs[@]:${startIndex}:${currentIntervalLength}}"
           fi
       - name: Check that all screenshot have been committed
         run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,6 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         # In case of number of workers would change, update TOTAL_WORKERS env variable in "Cypress Tests" step.
+        # Be aware that specs should be sequential integers starting from 1 without gaps
+        # based on logic in "Cypress Tests" step.
         specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
 
     steps:
@@ -75,9 +77,10 @@ jobs:
           # get the remainder of tests to be split up into the first $remainder workers
           (( remainder = totalTests % TOTAL_WORKERS ))
 
+          # We handle $CURRENT_RUN = 1 separately because bash interprets 0 as empty string in this case
           if [ "$CURRENT_RUN" -eq 1 ]; then
             startIndex=0
-            (( currentIntervalLength = testsPerWorker + 1 ))
+            (( currentIntervalLength = testsPerWorker + (remainder > 0 ? 1 : 0) ))
           elif [ $CURRENT_RUN -le $remainder ]; then
             (( startIndex = (CURRENT_RUN - 1) * (testsPerWorker + 1) ))
             (( currentIntervalLength = testsPerWorker + 1 ))


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Previous Cypress Tests implementation sometimes (depending on a number of e2e specs) not running tests at the end of the list of tests. E.g. `cypress22` job on the first commit of this PR not runs `e2e/specs/typography.spec.js`, `e2e/specs/widget_state_heavy_usage.spec.js` specs.

This PR changes the logic of calculation for a number of specs per worker, and should always run all e2e tests regardless of the number of tests. 

Based on the previous version if we have 135 test: the jobs will be divided equally between 22 workers by `135 / 21 = 6` test spec per job. And `6 * 22 = 132` will be not running. 

In the new implementation, we calculate the remainder `remainder=total_number_of_spec/22` and assign the first `#reminder` workers per one extra test spec. 

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [X] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [X] Added/Updated e2e tests 😅 

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
