### PR TITLE
Add missing import statements to examples in docstrings

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -31,6 +31,8 @@ def stop() -> NoReturn:
 
     Example
     -------
+    >>> import streamlit as st
+    >>>
     >>> name = st.text_input('Name')
     >>> if not name:
     >>>   st.warning('Please input a name.')

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -163,6 +163,8 @@ def set_page_config(
 
     Example
     -------
+    >>> import streamlit as st
+    >>>
     >>> st.set_page_config(
     ...     page_title="Ex-stream-ly Cool App",
     ...     page_icon="🧊",

--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -36,6 +36,8 @@ def get_query_params() -> Dict[str, List[str]]:
     `http://localhost:8501/?show_map=True&selected=asia&selected=america`.
     Then, you can get the query parameters using the following:
 
+    >>> import streamlit as st
+    >>>
     >>> st.experimental_get_query_params()
     {"show_map": ["True"], "selected": ["asia", "america"]}
 
@@ -67,6 +69,8 @@ def set_query_params(**query_params: Any) -> None:
     "http://localhost:8501/?show_map=True&selected=asia&selected=america",
     you would do the following:
 
+    >>> import streamlit as st
+    >>>
     >>> st.experimental_set_query_params(
     ...     show_map=True,
     ...     selected=["asia", "america"],

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -641,6 +641,10 @@ class DeltaGenerator(
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df1 = pd.DataFrame(
         ...    np.random.randn(50, 20),
         ...    columns=('col %d' % i for i in range(20)))
@@ -751,6 +755,10 @@ class DeltaGenerator(
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df1 = pd.DataFrame(
         ...    np.random.randn(50, 20),
         ...    columns=('col %d' % i for i in range(20)))

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -37,7 +37,8 @@ def echo(code_location="above"):
 
     Example
     -------
-
+    >>> import streamlit as st
+    >>>
     >>> with st.echo():
     >>>     st.write('This code will be printed')
 

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -57,6 +57,8 @@ class AlertMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.error('This is an error', icon="🚨")
 
         """
@@ -87,6 +89,8 @@ class AlertMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.warning('This is a warning', icon="⚠️")
 
         """
@@ -117,6 +121,8 @@ class AlertMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.info('This is a purely informational message', icon="ℹ️")
 
         """
@@ -148,6 +154,8 @@ class AlertMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.success('This is a success message!', icon="✅")
 
         """

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -75,6 +75,10 @@ class ArrowMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(50, 20),
         ...    columns=('col %d' % i for i in range(20)))
@@ -123,6 +127,10 @@ class ArrowMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(10, 5),
         ...    columns=("col %d" % i for i in range(5)))

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -118,6 +118,10 @@ class ArrowAltairMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
@@ -186,6 +190,10 @@ class ArrowAltairMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
@@ -256,6 +264,10 @@ class ArrowAltairMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(50, 3),
         ...     columns=["a", "b", "c"])
@@ -295,7 +307,7 @@ class ArrowAltairMixin:
 
         Example
         -------
-
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>> import altair as alt

--- a/lib/streamlit/elements/arrow_vega_lite.py
+++ b/lib/streamlit/elements/arrow_vega_lite.py
@@ -72,7 +72,7 @@ class ArrowVegaLiteMixin:
 
         Example
         -------
-
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>

--- a/lib/streamlit/elements/balloons.py
+++ b/lib/streamlit/elements/balloons.py
@@ -28,6 +28,8 @@ class BalloonsMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.balloons()
 
         ...then watch your app and get ready for a celebration!

--- a/lib/streamlit/elements/bokeh_chart.py
+++ b/lib/streamlit/elements/bokeh_chart.py
@@ -59,6 +59,7 @@ class BokehMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> from bokeh.plotting import figure
         >>>
         >>> x = [1, 2, 3, 4, 5]

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -109,6 +109,8 @@ class ButtonMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> if st.button('Say hello'):
         ...     st.write('Why hello there')
         ... else:
@@ -213,6 +215,8 @@ class ButtonMixin:
         --------
         Download a large DataFrame as a CSV:
 
+        >>> import streamlit as st
+        >>>
         >>> @st.cache
         ... def convert_df(df):
         ...     # IMPORTANT: Cache the conversion to prevent computation on every rerun
@@ -229,17 +233,23 @@ class ButtonMixin:
 
         Download a string as a file:
 
+        >>> import streamlit as st
+        >>>
         >>> text_contents = '''This is some text'''
         >>> st.download_button('Download some text', text_contents)
 
         Download a binary file:
 
+        >>> import streamlit as st
+        >>>
         >>> binary_contents = b'example content'
         >>> # Defaults to 'application/octet-stream'
         >>> st.download_button('Download binary file', binary_contents)
 
         Download an image:
 
+        >>> import streamlit as st
+        >>>
         >>> with open("flower.png", "rb") as file:
         ...     btn = st.download_button(
         ...             label="Download image",

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -104,6 +104,7 @@ class CheckboxMixin:
         Example
         -------
         >>> import streamlit as st
+        >>>
         >>> agree = st.checkbox('I agree')
         >>>
         >>> if agree:

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -123,6 +123,8 @@ class ColorPickerMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> color = st.color_picker('Pick A Color', '#00f900')
         >>> st.write('The current color is', color)
 

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -78,6 +78,7 @@ class DataFrameSelectorMixin:
 
         Examples
         --------
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>
@@ -96,6 +97,10 @@ class DataFrameSelectorMixin:
         You can also pass a Pandas Styler object to change the style of
         the rendered DataFrame:
 
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(10, 20),
         ...    columns=('col %d' % i for i in range(20)))
@@ -132,6 +137,7 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>
@@ -206,6 +212,7 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>
@@ -292,6 +299,7 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>
@@ -378,6 +386,7 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>
@@ -435,6 +444,7 @@ class DataFrameSelectorMixin:
         Example
         -------
 
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>> import altair as alt
@@ -501,6 +511,7 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>
@@ -555,6 +566,10 @@ class DataFrameSelectorMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df1 = pd.DataFrame(
         ...    np.random.randn(50, 20),
         ...    columns=('col %d' % i for i in range(20)))

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -69,6 +69,7 @@ class PydeckMixin:
         Here's a chart using a HexagonLayer and a ScatterplotLayer. It uses either the
         light or dark map style, based on which Streamlit theme is currently active:
 
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>> import pydeck as pdk

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -57,11 +57,16 @@ class HelpMixin:
 
         Don't remember how to initialize a dataframe? Try this:
 
+        >>> import streamlit as st
+        >>> import pandas
+        >>>
         >>> st.help(pandas.DataFrame)
 
         Want to quickly check what datatype is output by a certain function?
         Try:
 
+        >>> import streamlit as st
+        >>>
         >>> x = my_poorly_documented_function()
         >>> st.help(x)
 

--- a/lib/streamlit/elements/empty.py
+++ b/lib/streamlit/elements/empty.py
@@ -36,6 +36,7 @@ class EmptyMixin:
         --------
         Overwriting elements in-place using "with" notation:
 
+        >>> import streamlit as st
         >>> import time
         >>>
         >>> with st.empty():
@@ -46,6 +47,8 @@ class EmptyMixin:
 
         Replacing several elements, then clearing them:
 
+        >>> import streamlit as st
+        >>>
         >>> placeholder = st.empty()
         >>>
         >>> # Replace the placeholder with some text:

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -58,6 +58,8 @@ class ExceptionMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> e = RuntimeError('This is an exception of type RuntimeError')
         >>> st.exception(e)
 

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -303,6 +303,10 @@ class FileUploaderMixin:
         --------
         Insert a file uploader that accepts a single file at a time:
 
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> from io import StringIO
+        >>>
         >>> uploaded_file = st.file_uploader("Choose a file")
         >>> if uploaded_file is not None:
         ...     # To read file as bytes:
@@ -323,6 +327,8 @@ class FileUploaderMixin:
 
         Insert a file uploader that accepts multiple files at a time:
 
+        >>> import streamlit as st
+        >>>
         >>> uploaded_files = st.file_uploader("Choose a CSV file", accept_multiple_files=True)
         >>> for uploaded_file in uploaded_files:
         ...     bytes_data = uploaded_file.read()

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -151,6 +151,8 @@ class FormMixin:
         --------
         Inserting elements using "with" notation:
 
+        >>> import streamlit as st
+        >>>
         >>> with st.form("my_form"):
         ...    st.write("Inside the form")
         ...    slider_val = st.slider("Form slider")
@@ -165,6 +167,8 @@ class FormMixin:
 
         Inserting elements out of order:
 
+        >>> import streamlit as st
+        >>>
         >>> form = st.form("my_form")
         >>> form.slider("Inside the form")
         >>> st.slider("Outside the form")

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -55,6 +55,7 @@ class GraphvizMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import graphviz
         >>>
         >>> # Create a graphlib graph object

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -56,6 +56,8 @@ class HeadingMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> st.header('This is a header')
         >>> st.header('A header with _italics_ :blue[colors] and emojis :sunglasses:')
 
@@ -99,6 +101,8 @@ class HeadingMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> st.subheader('This is a subheader')
         >>> st.subheader('A subheader with _italics_ :blue[colors] and emojis :sunglasses:')
 
@@ -146,6 +150,8 @@ class HeadingMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> st.title('This is a title')
         >>> st.title('A title with _italics_ :blue[colors] and emojis :sunglasses:')
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -122,7 +122,9 @@ class ImageMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> from PIL import Image
+        >>>
         >>> image = Image.open('sunrise.jpg')
         >>>
         >>> st.image(image, caption='Sunrise by the mountains')

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -55,6 +55,8 @@ class JsonMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.json({
         ...     'foo': 'bar',
         ...     'baz': 'boz',

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -42,6 +42,8 @@ class LayoutsMixin:
         --------
         Inserting elements using "with" notation:
 
+        >>> import streamlit as st
+        >>>
         >>> with st.container():
         ...    st.write("This is inside the container")
         ...
@@ -56,6 +58,8 @@ class LayoutsMixin:
 
         Inserting elements out of order:
 
+        >>> import streamlit as st
+        >>>
         >>> container = st.container()
         >>> container.write("This is inside the container")
         >>> st.write("This is outside the container")
@@ -115,6 +119,8 @@ class LayoutsMixin:
         --------
         You can use `with` notation to insert any element into a column:
 
+        >>> import streamlit as st
+        >>>
         >>> col1, col2, col3 = st.columns(3)
         >>>
         >>> with col1:
@@ -135,6 +141,9 @@ class LayoutsMixin:
 
         Or you can just call methods directly in the returned objects:
 
+        >>> import streamlit as st
+        >>> import numpy as np
+        >>>
         >>> col1, col2 = st.columns([3, 1])
         >>> data = np.random.randn(10, 1)
         >>>
@@ -228,6 +237,8 @@ class LayoutsMixin:
         --------
         You can use `with` notation to insert any element into a tab:
 
+        >>> import streamlit as st
+        >>>
         >>> tab1, tab2, tab3 = st.tabs(["Cat", "Dog", "Owl"])
         >>>
         >>> with tab1:
@@ -248,6 +259,9 @@ class LayoutsMixin:
 
         Or you can just call methods directly in the returned objects:
 
+        >>> import streamlit as st
+        >>> import numpy as np
+        >>>
         >>> tab1, tab2 = st.tabs(["📈 Chart", "🗃 Data"])
         >>> data = np.random.randn(10, 1)
         >>>
@@ -313,6 +327,8 @@ class LayoutsMixin:
         --------
         You can use `with` notation to insert any element into an expander
 
+        >>> import streamlit as st
+        >>>
         >>> st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
         >>>
         >>> with st.expander("See explanation"):
@@ -329,6 +345,8 @@ class LayoutsMixin:
 
         Or you can just call methods directly in the returned objects:
 
+        >>> import streamlit as st
+        >>>
         >>> st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
         >>>
         >>> expander = st.expander("See explanation")

--- a/lib/streamlit/elements/legacy_altair.py
+++ b/lib/streamlit/elements/legacy_altair.py
@@ -74,6 +74,10 @@ class LegacyAltairMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
@@ -130,6 +134,10 @@ class LegacyAltairMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(20, 3),
         ...     columns=['a', 'b', 'c'])
@@ -186,6 +194,10 @@ class LegacyAltairMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>>
         >>> chart_data = pd.DataFrame(
         ...     np.random.randn(50, 3),
         ...     columns=["a", "b", "c"])
@@ -225,6 +237,7 @@ class LegacyAltairMixin:
         Example
         -------
 
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>> import altair as alt

--- a/lib/streamlit/elements/legacy_data_frame.py
+++ b/lib/streamlit/elements/legacy_data_frame.py
@@ -72,6 +72,10 @@ class LegacyDataFrameMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(50, 20),
         ...    columns=('col %d' % i for i in range(20)))
@@ -87,6 +91,10 @@ class LegacyDataFrameMixin:
         You can also pass a Pandas Styler object to change the style of
         the rendered DataFrame:
 
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(10, 20),
         ...    columns=('col %d' % i for i in range(20)))
@@ -123,6 +131,10 @@ class LegacyDataFrameMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>>
         >>> df = pd.DataFrame(
         ...    np.random.randn(10, 5),
         ...    columns=('col %d' % i for i in range(5)))

--- a/lib/streamlit/elements/legacy_vega_lite.py
+++ b/lib/streamlit/elements/legacy_vega_lite.py
@@ -65,6 +65,7 @@ class LegacyVegaLiteMixin:
         Example
         -------
 
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>>

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -65,6 +65,8 @@ class MarkdownMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> st.markdown('Streamlit is **_really_ cool**.')
         >>> st.markdown(”This text is :red[colored red], and this is **:blue[colored]** and bold.”)
         >>> st.markdown(":green[$\sqrt{x^2+y^2}=1$] is a Pythagorean identity. :pencil:")
@@ -100,6 +102,8 @@ class MarkdownMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> code = '''def hello():
         ...     print("Hello, Streamlit!")'''
         >>> st.code(code, language='python')
@@ -152,6 +156,8 @@ class MarkdownMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> st.caption('This is a string that explains something above.')
         >>> st.caption('A caption with _italics_ :blue[colors] and emojis :sunglasses:')
 
@@ -181,6 +187,8 @@ class MarkdownMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.latex(r'''
         ...     a + ar + a r^2 + a r^3 + \cdots + a r^{n-1} =
         ...     \sum_{k=0}^{n-1} ar^k =

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -75,6 +75,7 @@ class MediaMixin:
         -------
         >>> import streamlit as st
         >>> import numpy as np
+        >>>
         >>> audio_file = open('myaudio.ogg', 'rb')
         >>> audio_bytes = audio_file.read()
         >>>
@@ -138,6 +139,8 @@ class MediaMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> video_file = open('myvideo.mp4', 'rb')
         >>> video_bytes = video_file.read()
         >>>

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -105,6 +105,8 @@ class MetricMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.metric(label="Temperature", value="70 °F", delta="1.2 °F")
 
         .. output::
@@ -113,6 +115,8 @@ class MetricMixin:
 
         ``st.metric`` looks especially nice in combination with ``st.columns``:
 
+        >>> import streamlit as st
+        >>>
         >>> col1, col2, col3 = st.columns(3)
         >>> col1.metric("Temperature", "70 °F", "1.2 °F")
         >>> col2.metric("Wind", "9 mph", "-8%")
@@ -124,6 +128,8 @@ class MetricMixin:
 
         The delta indicator color can also be inverted or turned off:
 
+        >>> import streamlit as st
+        >>>
         >>> st.metric(label="Gas price", value=4, delta=-0.5,
         ...     delta_color="inverse")
         >>>

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -229,6 +229,8 @@ class MultiSelectMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> options = st.multiselect(
         ...     'What are your favorite colors',
         ...     ['Green', 'Yellow', 'Red', 'Blue'],

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -155,6 +155,8 @@ class NumberInputMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> number = st.number_input('Insert a number')
         >>> st.write('The current number is ', number)
 

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -125,6 +125,8 @@ class PlotlyMixin:
 
         The example below comes straight from the examples at
         https://plot.ly/python:
+
+        >>> import streamlit as st
         >>> import numpy as np
         >>> import plotly.figure_factory as ff
         >>>

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -43,6 +43,7 @@ class ProgressMixin:
         -------
         Here is an example of a progress bar increasing over time:
 
+        >>> import streamlit as st
         >>> import time
         >>>
         >>> my_bar = st.progress(0)

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -66,6 +66,7 @@ class PyplotMixin:
 
         Example
         -------
+        >>> import streamlit as st
         >>> import matplotlib.pyplot as plt
         >>> import numpy as np
         >>>

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -160,6 +160,8 @@ class RadioMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> genre = st.radio(
         ...     "What\'s your favorite movie genre",
         ...     ('Comedy', 'Drama', 'Documentary'))

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -198,6 +198,8 @@ class SelectSliderMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> color = st.select_slider(
         ...     'Select a color of the rainbow',
         ...     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])
@@ -205,6 +207,8 @@ class SelectSliderMixin:
 
         And here's an example of a range select slider:
 
+        >>> import streamlit as st
+        >>>
         >>> start_color, end_color = st.select_slider(
         ...     'Select a range of color wavelength',
         ...     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'],

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -147,6 +147,8 @@ class SelectboxMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> option = st.selectbox(
         ...     'How would you like to be contacted?',
         ...     ('Email', 'Home phone', 'Mobile phone'))

--- a/lib/streamlit/elements/show.py
+++ b/lib/streamlit/elements/show.py
@@ -39,6 +39,9 @@ def show(*args: Any) -> None:
 
     Example
     -------
+    >>> import streamlit as st
+    >>> import pandas as pd
+    >>>
     >>> dataframe = pd.DataFrame({
     ...     'first column': [1, 2, 3, 4],
     ...     'second column': [10, 20, 30, 40],

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -283,11 +283,15 @@ class SliderMixin:
 
         Examples
         --------
+        >>> import streamlit as st
+        >>>
         >>> age = st.slider('How old are you?', 0, 130, 25)
         >>> st.write("I'm ", age, 'years old')
 
         And here's an example of a range slider:
 
+        >>> import streamlit as st
+        >>>
         >>> values = st.slider(
         ...     'Select a range of values',
         ...     0.0, 100.0, (25.0, 75.0))
@@ -295,7 +299,9 @@ class SliderMixin:
 
         This is a range time slider:
 
+        >>> import streamlit as st
         >>> from datetime import time
+        >>>
         >>> appointment = st.slider(
         ...     "Schedule your appointment:",
         ...     value=(time(11, 30), time(12, 45)))
@@ -303,7 +309,9 @@ class SliderMixin:
 
         Finally, a datetime slider:
 
+        >>> import streamlit as st
         >>> from datetime import datetime
+        >>>
         >>> start_time = st.slider(
         ...     "When do you start?",
         ...     value=datetime(2020, 1, 1, 9, 30),

--- a/lib/streamlit/elements/snow.py
+++ b/lib/streamlit/elements/snow.py
@@ -28,6 +28,8 @@ class SnowMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.snow()
 
         ...then watch your app and get ready for a cool celebration!

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -32,6 +32,9 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
     Example
     -------
 
+    >>> import time
+    >>> import streamlit as st
+    >>>
     >>> with st.spinner('Wait for it...'):
     >>>     time.sleep(5)
     >>> st.success('Done!')

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -35,6 +35,8 @@ class TextMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> st.text('This is some text.')
 
         """

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -156,6 +156,8 @@ class TextWidgetsMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> title = st.text_input('Movie title', 'Life of Brian')
         >>> st.write('The current movie title is', title)
 
@@ -346,6 +348,8 @@ class TextWidgetsMixin:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> txt = st.text_area('Text to analyze', '''
         ...     It was the best of times, it was the worst of times, it was
         ...     the age of wisdom, it was the age of foolishness, it was

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -281,6 +281,9 @@ class TimeWidgetsMixin:
 
         Example
         -------
+        >>> import datetime
+        >>> import streamlit as st
+        >>>
         >>> t = st.time_input('Set an alarm for', datetime.time(8, 45))
         >>> st.write('Alarm is set for', t)
 
@@ -451,6 +454,9 @@ class TimeWidgetsMixin:
 
         Example
         -------
+        >>> import datetime
+        >>> import streamlit as st
+        >>>
         >>> d = st.date_input(
         ...     "When\'s your birthday",
         ...     datetime.date(2019, 7, 6))

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -100,7 +100,9 @@ class WriteMixin:
         Its basic use case is to draw Markdown-formatted text, whenever the
         input is a string:
 
-        >>> write('Hello, *World!* :sunglasses:')
+        >>> import streamlit as st
+        >>>
+        >>> st.write('Hello, *World!* :sunglasses:')
 
         ..  output::
             https://doc-write1.streamlitapp.com/
@@ -109,6 +111,9 @@ class WriteMixin:
         As mentioned earlier, `st.write()` also accepts other data formats, such as
         numbers, data frames, styled data frames, and assorted objects:
 
+        >>> import streamlit as st
+        >>> import pandas as pd
+        >>>
         >>> st.write(1234)
         >>> st.write(pd.DataFrame({
         ...     'first column': [1, 2, 3, 4],
@@ -121,6 +126,8 @@ class WriteMixin:
 
         Finally, you can pass in multiple arguments to do things like:
 
+        >>> import streamlit as st
+        >>>
         >>> st.write('1 + 1 = ', 2)
         >>> st.write('Below is a DataFrame:', data_frame, 'Above is a dataframe.')
 
@@ -130,6 +137,7 @@ class WriteMixin:
 
         Oh, one more thing: `st.write` accepts chart objects too! For example:
 
+        >>> import streamlit as st
         >>> import pandas as pd
         >>> import numpy as np
         >>> import altair as alt

--- a/lib/streamlit/runtime/caching/memo_decorator.py
+++ b/lib/streamlit/runtime/caching/memo_decorator.py
@@ -287,6 +287,8 @@ class MemoAPI:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_memo
         ... def fetch_and_clean_data(url):
         ...     # Fetch data from URL here, and then clean it up.
@@ -305,6 +307,8 @@ class MemoAPI:
 
         To set the ``persist`` parameter, use this command as follows:
 
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_memo(persist="disk")
         ... def fetch_and_clean_data(url):
         ...     # Fetch data from URL here, and then clean it up.
@@ -314,6 +318,8 @@ class MemoAPI:
         Any parameter whose name begins with ``_`` will not be hashed. You can use
         this as an "escape hatch" for parameters that are not hashable:
 
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_memo
         ... def fetch_and_clean_data(_db_connection, num_rows):
         ...     # Fetch data from _db_connection here, and then clean it up.
@@ -332,6 +338,8 @@ class MemoAPI:
 
         A memoized function's cache can be procedurally cleared:
 
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_memo
         ... def fetch_and_clean_data(_db_connection, num_rows):
         ...     # Fetch data from _db_connection here, and then clean it up.

--- a/lib/streamlit/runtime/caching/singleton_decorator.py
+++ b/lib/streamlit/runtime/caching/singleton_decorator.py
@@ -253,6 +253,8 @@ class SingletonAPI:
 
         Example
         -------
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_singleton
         ... def get_database_session(url):
         ...     # Create a database session object that points to the URL.
@@ -273,6 +275,8 @@ class SingletonAPI:
         Any parameter whose name begins with ``_`` will not be hashed. You can use
         this as an "escape hatch" for parameters that are not hashable:
 
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_singleton
         ... def get_database_session(_sessionmaker, url):
         ...     # Create a database connection object that points to the URL.
@@ -289,6 +293,8 @@ class SingletonAPI:
 
         A singleton function's cache can be procedurally cleared:
 
+        >>> import streamlit as st
+        >>>
         >>> @st.experimental_singleton
         ... def get_database_session(_sessionmaker, url):
         ...     # Create a database connection object that points to the URL.

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -450,6 +450,8 @@ def cache(
 
     Example
     -------
+    >>> import streamlit as st
+    >>>
     >>> @st.cache
     ... def fetch_and_clean_data(url):
     ...     # Fetch data from URL here, and then clean it up.


### PR DESCRIPTION
## 📚 Context

Most docstrings in our public API include code examples. These examples are rendered as code blocks in the API reference that can be copied to clipboard. We want users to copy those examples from our docs and run them without running into errors. The most common error type is `NameError`, which occurs when users run copied code blocks with missing imports.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Adds import statements to all docstrings of `st.` commands that contain examples.
- Note: this PR neither adds nor updates any tests as the changes are a mere refactoring of docstrings.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
