### PR TITLE
Send SCRIPT_RUN_FINISHED signal to parent

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -323,7 +323,7 @@ export class App extends PureComponent<Props, State> {
     }
 
     if (this.isAppInReadyState(prevState)) {
-      this.props.hostCommunication.sendMessage({ type: "APP_READY" })
+      this.props.hostCommunication.sendMessage({ type: "SCRIPT_RUN_FINISHED" })
     }
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -301,7 +301,10 @@ export class App extends PureComponent<Props, State> {
     MetricsManager.current.enqueue("viewReport")
   }
 
-  componentDidUpdate(prevProps: Readonly<Props>): void {
+  componentDidUpdate(
+    prevProps: Readonly<Props>,
+    prevState: Readonly<State>
+  ): void {
     if (
       prevProps.hostCommunication.currentState.queryParams !==
       this.props.hostCommunication.currentState.queryParams
@@ -317,6 +320,10 @@ export class App extends PureComponent<Props, State> {
     if (requestedPageScriptHash !== null) {
       this.onPageChange(requestedPageScriptHash)
       this.props.hostCommunication.onPageChanged()
+    }
+
+    if (this.isAppInReadyState(prevState)) {
+      this.props.hostCommunication.sendMessage({ type: "APP_READY" })
     }
   }
 
@@ -1044,6 +1051,15 @@ export class App extends PureComponent<Props, State> {
 
   onPageChange = (pageScriptHash: string): void => {
     this.sendRerunBackMsg(undefined, pageScriptHash)
+  }
+
+  isAppInReadyState = (prevState: Readonly<State>): boolean => {
+    return (
+      this.state.connectionState === ConnectionState.CONNECTED &&
+      this.state.scriptRunState === ScriptRunState.NOT_RUNNING &&
+      prevState.scriptRunState === ScriptRunState.RUNNING &&
+      prevState.connectionState === ConnectionState.CONNECTED
+    )
   }
 
   sendRerunBackMsg = (

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -115,6 +115,9 @@ export type IGuestToHostMessage =
       type: "GUEST_READY"
     }
   | {
+      type: "APP_READY"
+    }
+  | {
       type: "MENU_ITEM_CALLBACK"
       key: string
     }

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -115,7 +115,7 @@ export type IGuestToHostMessage =
       type: "GUEST_READY"
     }
   | {
-      type: "APP_READY"
+      type: "SCRIPT_RUN_FINISHED"
     }
   | {
       type: "MENU_ITEM_CALLBACK"


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Send SCRIPT_RUN_FINISHED signal to parent iframe when connection is established, and `scriptRunState` changed from `RUNNING` to `NOT_RUNNING`. 

Please note that this signal will be called each time after the normal script_rerun will be finished.   

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
