### PR TITLE
Update source_util.get_pages

### DIFF
--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -135,7 +135,7 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
 
         pages_dir = main_script_path.parent / "pages"
         page_scripts = sorted(
-            [f for f in pages_dir.glob("*.py") if not f.name.startswith(".")],
+            [f for f in pages_dir.glob("*.py") if not f.name.startswith(".") and not f.name == "__init__.py"],
             key=page_sort_key,
         )
 

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -135,7 +135,11 @@ def get_pages(main_script_path_str: str) -> Dict[str, Dict[str, str]]:
 
         pages_dir = main_script_path.parent / "pages"
         page_scripts = sorted(
-            [f for f in pages_dir.glob("*.py") if not f.name.startswith(".") and not f.name == "__init__.py"],
+            [
+                f
+                for f in pages_dir.glob("*.py")
+                if not f.name.startswith(".") and not f.name == "__init__.py"
+            ],
             key=page_sort_key,
         )
 

--- a/lib/tests/streamlit/source_util_test.py
+++ b/lib/tests/streamlit/source_util_test.py
@@ -135,6 +135,8 @@ def test_get_pages(tmpdir):
         "page.py",
         # This file shouldn't appear as a page because it's hidden.
         ".hidden_file.py",
+        # This file shouldn't appear as a page because it's __init__.py, so also hidden.
+        "__init__.py",
         # This shouldn't appear because it's not a Python file.
         "not_a_page.rs",
     ]


### PR DESCRIPTION
don't add `__init__.py` to the list of pages

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - This is a visible (user-facing) change
  - `pages/__init__.py` is no longer included in the list of pages to display

**Revised:**

Could not get the local version to run, but it will not contain the empty `init` page

**Current:**

![image](https://user-images.githubusercontent.com/29500178/209537178-02a9af93-1dbe-44e7-a3fa-9c1ebe7ce3b2.png)


## 🧪 Testing Done
 
- Could not get the local env to run dev streamlit, but relying on the automated tests. Regardless, this single line change should not break anything

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

No

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
