### PR TITLE
Revert SCRIPT_RUN_FINISHED signal changes, add window.prerenderReady

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -26,6 +26,9 @@
 
     <title>Streamlit</title>
 
+    <!-- initialize window.prerenderReady to false and then set to true in React app when app is ready for indexing -->
+    <script> window.prerenderReady = false; </script>
+
     <!-- load via script to enable web workers -->
     <script
       src="%PUBLIC_URL%/vendor/viz/viz-1.8.0.min.js"

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -133,6 +133,8 @@ describe("App", () => {
       userMapboxToken: "mpt",
     } as SessionInfoArgs)
     MetricsManager.current = getMetricsManagerForTest()
+    // @ts-ignore
+    window.prerenderReady = false
   })
 
   afterEach(() => {
@@ -709,7 +711,7 @@ describe("App.handleNewSession", () => {
     expect(SessionInfo.isSet()).toBe(true)
   })
 
-  it("should send SCRIPT_RUN_FINISHED message on connection is established and running finished", () => {
+  it("should set window.prerenderReady to true after app script is run successfully first time", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
@@ -718,39 +720,33 @@ describe("App.handleNewSession", () => {
       connectionState: ConnectionState.CONNECTING,
     })
     wrapper.update()
-    expect(props.hostCommunication.sendMessage).not.toHaveBeenCalledWith({
-      type: "SCRIPT_RUN_FINISHED",
-    })
+    // @ts-ignore
+    expect(window.prerenderReady).toBe(false)
 
     wrapper.setState({
       scriptRunState: ScriptRunState.RUNNING,
       connectionState: ConnectionState.CONNECTED,
     })
     wrapper.update()
-    expect(props.hostCommunication.sendMessage).not.toHaveBeenCalledWith({
-      type: "SCRIPT_RUN_FINISHED",
-    })
+    // @ts-ignore
+    expect(window.prerenderReady).toBe(false)
 
     wrapper.setState({
       scriptRunState: ScriptRunState.NOT_RUNNING,
       connectionState: ConnectionState.CONNECTED,
     })
     wrapper.update()
-    expect(props.hostCommunication.sendMessage).toHaveBeenLastCalledWith({
-      type: "SCRIPT_RUN_FINISHED",
-    })
+    // @ts-ignore
+    expect(window.prerenderReady).toBe(true)
 
-    jest.clearAllMocks()
-
-    // message should not be called when App component simply re-rendered with same state
+    // window.prerenderReady is set to true after first
     wrapper.setState({
       scriptRunState: ScriptRunState.NOT_RUNNING,
       connectionState: ConnectionState.CONNECTED,
     })
     wrapper.update()
-    expect(props.hostCommunication.sendMessage).not.toHaveBeenLastCalledWith({
-      type: "SCRIPT_RUN_FINISHED",
-    })
+    // @ts-ignore
+    expect(window.prerenderReady).toBe(true)
   })
 
   it("plumbs appPages and currentPageScriptHash to the AppView component", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -321,9 +321,10 @@ export class App extends PureComponent<Props, State> {
       this.onPageChange(requestedPageScriptHash)
       this.props.hostCommunication.onPageChanged()
     }
-
-    if (this.isAppInReadyState(prevState)) {
-      this.props.hostCommunication.sendMessage({ type: "SCRIPT_RUN_FINISHED" })
+    // @ts-ignore
+    if (window.prerenderReady === false && this.isAppInReadyState(prevState)) {
+      // @ts-ignore
+      window.prerenderReady = true
     }
   }
 

--- a/frontend/src/hocs/withHostCommunication/types.ts
+++ b/frontend/src/hocs/withHostCommunication/types.ts
@@ -115,9 +115,6 @@ export type IGuestToHostMessage =
       type: "GUEST_READY"
     }
   | {
-      type: "SCRIPT_RUN_FINISHED"
-    }
-  | {
       type: "MENU_ITEM_CALLBACK"
       key: string
     }


### PR DESCRIPTION
Revert SCRIPT_RUN_FINISHED signal changes, add window.prerenderReady flag.

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

The cloud team asked to add a `window.prerenderReady` flag (based on a recommendation from here: https://docs.prerender.io/docs/11-best-practices we should do that as early as possible, that's why changes are added in an index.html)

This PR also reverts previous changes since based on feedback cloud team we didn't render streamlit app for indexing not inside iframe, so previous changes with communication to the parent iframe don't make sense.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
