### PR TITLE
Upgrade plotly to fix mapbox scatter

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
     "moment-timezone": "^0.5.33",
     "node-emoji": "^1.10.0",
     "numbro": "^2.3.1",
-    "plotly.js": "^2.16.0",
+    "plotly.js": "^2.17.0",
     "prismjs": "^1.27.0",
     "protobufjs": "^6.11.2",
     "query-string": "^6.13.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14039,10 +14039,10 @@ plist@^3.0.1:
     base64-js "^1.5.1"
     xmlbuilder "^9.0.7"
 
-plotly.js@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/plotly.js/-/plotly.js-2.16.0.tgz#cd1e3e8cfac391b4766095a5e9da60b21a1c3226"
-  integrity sha512-VmeGevBZdFRfi6SoBSK34ecXpOpBFS6klcmatRcvWWKresCACldnr4v3H2X2Ut04uyf026ifBMKWISkioPWHCg==
+plotly.js@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/plotly.js/-/plotly.js-2.17.0.tgz#677302875b968b537db228ae1883a356023291ae"
+  integrity sha512-YeSlcriGJFpLFrprhvMIjbJF1uH498enCKwZ9627/PkP9UXsbFMCHeetSmjkNUrJWhVRfo9LRg9kGPx1vSu2YQ==
   dependencies:
     "@plotly/d3" "3.8.0"
     "@plotly/d3-sankey" "0.7.2"


### PR DESCRIPTION
## 📚 Context

We upgraded Plotly, but it had a regression, so Streamlit therefore had a regression. Upgrade the dependency, ~save the world~ fix the bug.

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

- Upgrade plotly.js dependency

## 🧪 Testing Done

This one is a bit difficult to test because the slider is an advanced SVG and will be a flaky test in the end. We can assume this was an issue of our underlying dependency.

## 🌐 References

- **Issue**: Closes https://github.com/streamlit/streamlit/issues/5881

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
