### PR TITLE
Make specifying session related RuntimeConfig params optional

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -16,6 +16,7 @@ import asyncio
 import sys
 import time
 import traceback
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Awaitable, Dict, NamedTuple, Optional, Tuple, Type
 
@@ -38,6 +39,7 @@ from streamlit.runtime.forward_msg_cache import (
 from streamlit.runtime.legacy_caching.caching import _mem_caches
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.media_file_storage import MediaFileStorage
+from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import is_cacheable_msg
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.session_manager import (
@@ -53,6 +55,7 @@ from streamlit.runtime.state import (
 )
 from streamlit.runtime.stats import StatsManager
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.watcher import LocalSourcesWatcher
 
 # Wait for the script run result for 60s and if no result is available give up
@@ -65,7 +68,8 @@ class RuntimeStoppedError(Exception):
     """Raised by operations on a Runtime instance that is stopped."""
 
 
-class RuntimeConfig(NamedTuple):
+@dataclass(frozen=True)
+class RuntimeConfig:
     """Config options for StreamlitRuntime."""
 
     # The filesystem path of the Streamlit script to run.
@@ -79,10 +83,10 @@ class RuntimeConfig(NamedTuple):
     media_file_storage: MediaFileStorage
 
     # The SessionManager class to be used.
-    session_manager_class: Type[SessionManager]
+    session_manager_class: Type[SessionManager] = WebsocketSessionManager
 
     # The SessionStorage instance for the SessionManager to use.
-    session_storage: SessionStorage
+    session_storage: SessionStorage = field(default_factory=MemorySessionStorage)
 
 
 class RuntimeState(Enum):

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -34,9 +34,7 @@ from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
-from streamlit.runtime.memory_session_storage import MemorySessionStorage
 from streamlit.runtime.runtime_util import get_max_message_size_bytes
-from streamlit.runtime.websocket_session_manager import WebsocketSessionManager
 from streamlit.web.server.browser_websocket_handler import BrowserWebSocketHandler
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
 from streamlit.web.server.media_file_handler import MediaFileHandler
@@ -179,8 +177,6 @@ class Server:
                 script_path=main_script_path,
                 command_line=command_line,
                 media_file_storage=media_file_storage,
-                session_manager_class=WebsocketSessionManager,
-                session_storage=MemorySessionStorage(),
             ),
         )
 

--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -48,7 +48,7 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                     "mock/script/path.py",
                     "",
                     media_file_storage=MagicMock(),
-                    session_manager_class=MagicMock(),
+                    session_manager_class=MagicMock,
                     session_storage=MagicMock(),
                 )
                 queue.put(Runtime(config))


### PR DESCRIPTION
It's currently necessary to specify all fields in a `RuntimeConfig`, but this can be a bit cumbersome as
well as backwards incompatible for use cases where the Streamlit runtime is initialized by something 
other than the Tornado server (as things work in the OS world).

This PR addresses this by
* Changing `RuntimeConfig` into a frozen dataclass
* Making `WebsocketSessionManager` and `MemorySessionStorage` the default fields for their
  respective config options.