### PR TITLE
cache_data/resource: rearrange kwargs; remove `suppress_st_warning`

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -241,12 +241,12 @@ class CacheDataAPI:
     def __call__(
         self,
         *,
+        ttl: float | timedelta | None = None,
+        max_entries: int | None = None,
         persist: CachePersistType | bool = None,
         show_spinner: bool | str = True,
-        suppress_st_warning: bool = False,
-        max_entries: int | None = None,
-        ttl: float | timedelta | None = None,
         experimental_allow_widgets: bool = False,
+        suppress_st_warning: bool = False,
     ) -> Callable[[F], F]:
         ...
 
@@ -254,33 +254,33 @@ class CacheDataAPI:
         self,
         func: F | None = None,
         *,
+        ttl: float | timedelta | None = None,
+        max_entries: int | None = None,
         persist: CachePersistType | bool = None,
         show_spinner: bool | str = True,
-        suppress_st_warning: bool = False,
-        max_entries: int | None = None,
-        ttl: float | timedelta | None = None,
         experimental_allow_widgets: bool = False,
+        suppress_st_warning: bool = False,
     ):
         return self._decorator(
             func,
+            ttl=ttl,
+            max_entries=max_entries,
             persist=persist,
             show_spinner=show_spinner,
-            suppress_st_warning=suppress_st_warning,
-            max_entries=max_entries,
-            ttl=ttl,
             experimental_allow_widgets=experimental_allow_widgets,
+            suppress_st_warning=suppress_st_warning,
         )
 
     @staticmethod
     def _decorator(
         func: F | None = None,
         *,
-        persist: str | None = None,
-        show_spinner: bool | str = True,
-        suppress_st_warning: bool = False,
-        max_entries: int | None = None,
-        ttl: float | timedelta | None = None,
-        experimental_allow_widgets: bool = False,
+        ttl: float | timedelta | None,
+        max_entries: int | None,
+        persist: CachePersistType | bool,
+        show_spinner: bool | str,
+        experimental_allow_widgets: bool,
+        suppress_st_warning: bool,
     ):
         """Function decorator to cache function executions.
 
@@ -296,6 +296,17 @@ class CacheDataAPI:
         func : callable
             The function to cache. Streamlit hashes the function's source code.
 
+        ttl : float or timedelta or None
+            The maximum number of seconds to keep an entry in the cache, or
+            None if cache entries should not expire. The default is None.
+            Note that ttl is incompatible with `persist="disk"` - `ttl` will be
+            ignored if `persist` is specified.
+
+        max_entries : int or None
+            The maximum number of entries to keep in the cache, or None
+            for an unbounded cache. (When a new entry is added to a full cache,
+            the oldest cached entry will be removed.) The default is None.
+
         persist : str or boolean or None
             Optional location to persist cached data to. Passing "disk" (or True)
             will persist the cached data to the local disk. None (or False) will disable
@@ -305,27 +316,16 @@ class CacheDataAPI:
             Enable the spinner. Default is True to show a spinner when there is
             a cache miss.
 
-        suppress_st_warning : boolean
-            Suppress warnings about calling Streamlit commands from within
-            the cached function.
-
-        max_entries : int or None
-            The maximum number of entries to keep in the cache, or None
-            for an unbounded cache. (When a new entry is added to a full cache,
-            the oldest cached entry will be removed.) The default is None.
-
-        ttl : float or timedelta or None
-            The maximum number of seconds to keep an entry in the cache, or
-            None if cache entries should not expire. The default is None.
-            Note that ttl is incompatible with `persist="disk"` - `ttl` will be
-            ignored if `persist` is specified.
-
         experimental_allow_widgets : boolean
             Allow widgets to be used in the cached function. Defaults to False.
             Support for widgets in cached functions is currently experimental.
             Setting this parameter to True may lead to excessive memory use since the
             widget value is treated as an additional input parameter to the cache.
             We may remove support for this option at any time without notice.
+
+        suppress_st_warning : boolean
+            Suppress warnings about calling Streamlit commands from within
+            the cached function.
 
         Example
         -------

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -88,7 +88,6 @@ class CacheDataFunction(CachedFunction):
         super().__init__(
             func,
             show_spinner=show_spinner,
-            suppress_st_warning=False,
             allow_widgets=allow_widgets,
         )
         self.persist = persist

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -80,13 +80,17 @@ class CacheDataFunction(CachedFunction):
         self,
         func: types.FunctionType,
         show_spinner: bool | str,
-        suppress_st_warning: bool,
         persist: CachePersistType,
         max_entries: int | None,
         ttl: float | timedelta | None,
         allow_widgets: bool,
     ):
-        super().__init__(func, show_spinner, suppress_st_warning, allow_widgets)
+        super().__init__(
+            func,
+            show_spinner=show_spinner,
+            suppress_st_warning=False,
+            allow_widgets=allow_widgets,
+        )
         self.persist = persist
         self.max_entries = max_entries
         self.ttl = ttl
@@ -246,7 +250,6 @@ class CacheDataAPI:
         persist: CachePersistType | bool = None,
         show_spinner: bool | str = True,
         experimental_allow_widgets: bool = False,
-        suppress_st_warning: bool = False,
     ) -> Callable[[F], F]:
         ...
 
@@ -259,7 +262,6 @@ class CacheDataAPI:
         persist: CachePersistType | bool = None,
         show_spinner: bool | str = True,
         experimental_allow_widgets: bool = False,
-        suppress_st_warning: bool = False,
     ):
         return self._decorator(
             func,
@@ -268,7 +270,6 @@ class CacheDataAPI:
             persist=persist,
             show_spinner=show_spinner,
             experimental_allow_widgets=experimental_allow_widgets,
-            suppress_st_warning=suppress_st_warning,
         )
 
     @staticmethod
@@ -280,7 +281,6 @@ class CacheDataAPI:
         persist: CachePersistType | bool,
         show_spinner: bool | str,
         experimental_allow_widgets: bool,
-        suppress_st_warning: bool,
     ):
         """Function decorator to cache function executions.
 
@@ -322,10 +322,6 @@ class CacheDataAPI:
             Setting this parameter to True may lead to excessive memory use since the
             widget value is treated as an additional input parameter to the cache.
             We may remove support for this option at any time without notice.
-
-        suppress_st_warning : boolean
-            Suppress warnings about calling Streamlit commands from within
-            the cached function.
 
         Example
         -------
@@ -420,7 +416,6 @@ class CacheDataAPI:
                     func=f,
                     persist=persist_string,
                     show_spinner=show_spinner,
-                    suppress_st_warning=suppress_st_warning,
                     max_entries=max_entries,
                     ttl=ttl,
                     allow_widgets=experimental_allow_widgets,
@@ -437,7 +432,6 @@ class CacheDataAPI:
                 func=cast(types.FunctionType, func),
                 persist=persist_string,
                 show_spinner=show_spinner,
-                suppress_st_warning=suppress_st_warning,
                 max_entries=max_entries,
                 ttl=ttl,
                 allow_widgets=experimental_allow_widgets,

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -147,13 +147,17 @@ class CacheResourceFunction(CachedFunction):
         self,
         func: types.FunctionType,
         show_spinner: bool | str,
-        suppress_st_warning: bool,
         max_entries: int | None,
         ttl: float | timedelta | None,
         validate: ValidateFunc | None,
         allow_widgets: bool,
     ):
-        super().__init__(func, show_spinner, suppress_st_warning, allow_widgets)
+        super().__init__(
+            func,
+            show_spinner=show_spinner,
+            suppress_st_warning=False,
+            allow_widgets=allow_widgets,
+        )
         self.max_entries = max_entries
         self.ttl = ttl
         self.validate = validate
@@ -226,7 +230,6 @@ class CacheResourceAPI:
         show_spinner: bool | str = True,
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
-        suppress_st_warning: bool = False,
     ) -> Callable[[F], F]:
         ...
 
@@ -239,7 +242,6 @@ class CacheResourceAPI:
         show_spinner: bool | str = True,
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
-        suppress_st_warning: bool = False,
     ):
         return self._decorator(
             func,
@@ -248,7 +250,6 @@ class CacheResourceAPI:
             show_spinner=show_spinner,
             validate=validate,
             experimental_allow_widgets=experimental_allow_widgets,
-            suppress_st_warning=suppress_st_warning,
         )
 
     @staticmethod
@@ -260,7 +261,6 @@ class CacheResourceAPI:
         show_spinner: bool | str,
         validate: ValidateFunc | None,
         experimental_allow_widgets: bool,
-        suppress_st_warning: bool,
     ):
         """Function decorator to store cached resources.
 
@@ -306,10 +306,6 @@ class CacheResourceAPI:
             Setting this parameter to True may lead to excessive memory use since the
             widget value is treated as an additional input parameter to the cache.
             We may remove support for this option at any time without notice.
-
-        suppress_st_warning : boolean
-            Suppress warnings about calling Streamlit commands from within
-            the cache_resource function.
 
         Example
         -------
@@ -371,7 +367,6 @@ class CacheResourceAPI:
                 CacheResourceFunction(
                     func=f,
                     show_spinner=show_spinner,
-                    suppress_st_warning=suppress_st_warning,
                     max_entries=max_entries,
                     ttl=ttl,
                     validate=validate,
@@ -383,7 +378,6 @@ class CacheResourceAPI:
             CacheResourceFunction(
                 func=cast(types.FunctionType, func),
                 show_spinner=show_spinner,
-                suppress_st_warning=suppress_st_warning,
                 max_entries=max_entries,
                 ttl=ttl,
                 validate=validate,

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -221,12 +221,12 @@ class CacheResourceAPI:
     def __call__(
         self,
         *,
-        show_spinner: bool | str = True,
-        suppress_st_warning=False,
-        max_entries: int | None = None,
         ttl: float | timedelta | None = None,
+        max_entries: int | None = None,
+        show_spinner: bool | str = True,
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
+        suppress_st_warning: bool = False,
     ) -> Callable[[F], F]:
         ...
 
@@ -234,33 +234,33 @@ class CacheResourceAPI:
         self,
         func: F | None = None,
         *,
-        show_spinner: bool | str = True,
-        suppress_st_warning=False,
-        max_entries: int | None = None,
         ttl: float | timedelta | None = None,
+        max_entries: int | None = None,
+        show_spinner: bool | str = True,
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
+        suppress_st_warning: bool = False,
     ):
         return self._decorator(
             func,
-            show_spinner=show_spinner,
-            suppress_st_warning=suppress_st_warning,
-            max_entries=max_entries,
             ttl=ttl,
+            max_entries=max_entries,
+            show_spinner=show_spinner,
             validate=validate,
             experimental_allow_widgets=experimental_allow_widgets,
+            suppress_st_warning=suppress_st_warning,
         )
 
     @staticmethod
     def _decorator(
         func: F | None,
         *,
-        show_spinner: bool | str,
-        suppress_st_warning: bool,
-        max_entries: int | None,
         ttl: float | timedelta | None,
+        max_entries: int | None,
+        show_spinner: bool | str,
         validate: ValidateFunc | None,
         experimental_allow_widgets: bool,
+        suppress_st_warning: bool,
     ):
         """Function decorator to store cached resources.
 
@@ -279,23 +279,19 @@ class CacheResourceAPI:
             The function that creates the cached resource. Streamlit hashes the
             function's source code.
 
-        show_spinner : boolean or string
-            Enable the spinner. Default is True to show a spinner when there is
-            a "cache miss" and the cached resource is being created. If string,
-            value of show_spinner param will be used for spinner text.
-
-        suppress_st_warning : boolean
-            Suppress warnings about calling Streamlit commands from within
-            the cache_resource function.
+        ttl : float or timedelta or None
+            The maximum number of seconds to keep an entry in the cache, or
+            None if cache entries should not expire. The default is None.
 
         max_entries : int or None
             The maximum number of entries to keep in the cache, or None
             for an unbounded cache. (When a new entry is added to a full cache,
             the oldest cached entry will be removed.) The default is None.
 
-        ttl : float or timedelta or None
-            The maximum number of seconds to keep an entry in the cache, or
-            None if cache entries should not expire. The default is None.
+        show_spinner : boolean or string
+            Enable the spinner. Default is True to show a spinner when there is
+            a "cache miss" and the cached resource is being created. If string,
+            value of show_spinner param will be used for spinner text.
 
         validate : callable or None
             An optional validation function for cached data. `validate` is
@@ -310,6 +306,10 @@ class CacheResourceAPI:
             Setting this parameter to True may lead to excessive memory use since the
             widget value is treated as an additional input parameter to the cache.
             We may remove support for this option at any time without notice.
+
+        suppress_st_warning : boolean
+            Suppress warnings about calling Streamlit commands from within
+            the cache_resource function.
 
         Example
         -------

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -155,7 +155,6 @@ class CacheResourceFunction(CachedFunction):
         super().__init__(
             func,
             show_spinner=show_spinner,
-            suppress_st_warning=False,
             allow_widgets=allow_widgets,
         )
         self.max_entries = max_entries

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -266,12 +266,10 @@ class CachedFunction:
         self,
         func: types.FunctionType,
         show_spinner: bool | str,
-        suppress_st_warning: bool,
         allow_widgets: bool,
     ):
         self.func = func
         self.show_spinner = show_spinner
-        self.suppress_st_warning = suppress_st_warning
         self.allow_widgets = allow_widgets
 
     @property
@@ -395,10 +393,7 @@ def create_cache_wrapper(cached_func: CachedFunction) -> Callable[..., Any]:
                             with cached_func.message_call_stack.maybe_allow_widgets(
                                 cached_func.allow_widgets
                             ):
-                                with cached_func.warning_call_stack.maybe_suppress_cached_st_function_warning(
-                                    cached_func.suppress_st_warning
-                                ):
-                                    return_value = func(*args, **kwargs)
+                                return_value = func(*args, **kwargs)
 
                 messages = cached_func.message_call_stack._most_recent_messages
                 try:

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -244,15 +244,6 @@ class CommonCacheTest(DeltaGeneratorTestCase):
             st.text("foo")
             warning.assert_not_called()
 
-            # Test warning suppression
-            @cache_decorator(suppress_st_warning=True)
-            def suppressed_cached_func():
-                st.text("No warnings here!")
-
-            suppressed_cached_func()
-
-            warning.assert_not_called()
-
             # Test nested st.cache functions
             @cache_decorator
             def outer():


### PR DESCRIPTION
- Rearrange `cache_data` and `cache_resource` kwargs based on importance:
  - `cache_data`: `ttl`, `max_entries`, `persist`, `show_spinner`, `experimental_allow_widgets`
  - `cache_resource`: `ttl`, `max_entries`, `validate`, `show_spinner`, `experimental_allow_widgets`
- Remove `suppress_st_warnings` option from both decorators. We support almost all `st.foo` commands inside cached functions now, and we're ok always showing the warning for the few we don't support.