### PR TITLE
`streamlit hello`: use new cache primitives

### DIFF
--- a/lib/streamlit/hello/pages/2_Mapping_Demo.py
+++ b/lib/streamlit/hello/pages/2_Mapping_Demo.py
@@ -22,7 +22,7 @@ from streamlit.hello.utils import show_code
 
 
 def mapping_demo():
-    @st.cache
+    @st.cache_data
     def from_data_file(filename):
         url = (
             "http://raw.githubusercontent.com/streamlit/"

--- a/lib/streamlit/hello/pages/3_DataFrame_Demo.py
+++ b/lib/streamlit/hello/pages/3_DataFrame_Demo.py
@@ -22,7 +22,7 @@ from streamlit.hello.utils import show_code
 
 
 def data_frame_demo():
-    @st.cache
+    @st.cache_data
     def get_UN_data():
         AWS_BUCKET_URL = "http://streamlit-demo-data.s3-us-west-2.amazonaws.com"
         df = pd.read_csv(AWS_BUCKET_URL + "/agri.csv.gz")


### PR DESCRIPTION
Update `streamlit hello` to use `@st.cache_data` instead of `@st.cache`