### PR TITLE
singleton/memo deprecation - take 2

### DIFF
--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -17,7 +17,6 @@ from typing import Any, Iterator, Union
 
 from google.protobuf.message import Message
 
-from streamlit.deprecation_util import deprecate_obj_name
 from streamlit.proto.Block_pb2 import Block
 from streamlit.runtime.caching.cache_data_api import (
     CACHE_DATA_CALL_STACK,
@@ -32,6 +31,9 @@ from streamlit.runtime.caching.cache_resource_api import (
     _resource_caches,
 )
 from streamlit.runtime.state.session_state import WidgetMetadata
+
+# TODO: replace this with the proper URL once it's ready from the docs team
+CACHE_DOCS_URL = "https://NEED.CACHE.DOCS.URL"
 
 
 def save_element_message(
@@ -110,15 +112,21 @@ cache_data = CacheDataAPI(decorator_metric_name="cache_data")
 cache_resource = CacheResourceAPI(decorator_metric_name="cache_resource")
 
 # Deprecated singletons
-experimental_memo = deprecate_obj_name(
-    CacheDataAPI(decorator_metric_name="experimental_memo"),
-    old_name="experimental_memo",
-    new_name="cache_data",
-    removal_date="2023.04.01",
+_MEMO_WARNING = (
+    f"`st.experimental_memo` is deprecated. Please use the new command `st.cache_data` instead, "
+    f"which has the same behavior. More information [in our docs]({CACHE_DOCS_URL})."
 )
-experimental_singleton = deprecate_obj_name(
-    CacheResourceAPI(decorator_metric_name="experimental_singleton"),
-    old_name="experimental_singleton",
-    new_name="cache_resource",
-    removal_date="2023.04.01",
+
+experimental_memo = CacheDataAPI(
+    decorator_metric_name="experimental_memo", deprecation_warning=_MEMO_WARNING
+)
+
+_SINGLETON_WARNING = (
+    f"`st.experimental_singleton` is deprecated. Please use the new command `st.cache_resource` instead, "
+    f"which has the same behavior. More information [in our docs]({CACHE_DOCS_URL})."
+)
+
+experimental_singleton = CacheResourceAPI(
+    decorator_metric_name="experimental_singleton",
+    deprecation_warning=_SINGLETON_WARNING,
 )

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -30,6 +30,7 @@ from typing_extensions import Literal, TypeAlias
 
 import streamlit as st
 from streamlit import util
+from streamlit.deprecation_util import show_deprecation_warning
 from streamlit.errors import StreamlitAPIException
 from streamlit.file_util import get_streamlit_file_path, streamlit_read, streamlit_write
 from streamlit.logger import get_logger
@@ -212,7 +213,9 @@ class CacheDataAPI:
     st.cache_data.clear().
     """
 
-    def __init__(self, decorator_metric_name: str):
+    def __init__(
+        self, decorator_metric_name: str, deprecation_warning: str | None = None
+    ):
         """Create a CacheDataAPI instance.
 
         Parameters
@@ -221,11 +224,15 @@ class CacheDataAPI:
             The metric name to record for decorator usage. `@st.experimental_memo` is
             deprecated, but we're still supporting it and tracking its usage separately
             from `@st.cache_data`.
+
+        deprecation_warning
+            An optional deprecation warning to show when the API is accessed.
         """
 
         # Parameterize the decorator metric name.
         # (Ignore spurious mypy complaints - https://github.com/python/mypy/issues/2427)
         self._decorator = gather_metrics(decorator_metric_name, self._decorator)  # type: ignore
+        self._deprecation_warning = deprecation_warning
 
     # Type-annotate the decorator function.
     # (See https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories)
@@ -268,8 +275,8 @@ class CacheDataAPI:
             experimental_allow_widgets=experimental_allow_widgets,
         )
 
-    @staticmethod
     def _decorator(
+        self,
         func: F | None = None,
         *,
         ttl: float | timedelta | None,
@@ -399,6 +406,8 @@ class CacheDataAPI:
                 f"Unsupported persist option '{persist}'. Valid values are 'disk' or None."
             )
 
+        self._maybe_show_deprecation_warning()
+
         def wrapper(f):
             # We use wrapper function here instead of lambda function to be able to log
             # warning in case both persist="disk" and ttl parameters specified
@@ -434,11 +443,18 @@ class CacheDataAPI:
             )
         )
 
-    @staticmethod
     @gather_metrics("clear_data_caches")
-    def clear() -> None:
+    def clear(self) -> None:
         """Clear all in-memory and on-disk data caches."""
+        self._maybe_show_deprecation_warning()
         _data_caches.clear_all()
+
+    def _maybe_show_deprecation_warning(self):
+        """If the API is being accessed with the deprecated `st.experimental_memo` name,
+        show a deprecation warning.
+        """
+        if self._deprecation_warning is not None:
+            show_deprecation_warning(self._deprecation_warning)
 
 
 class DataCache(Cache):

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -402,7 +402,7 @@ class CacheResourceAPI:
         _resource_caches.clear_all()
 
     def _maybe_show_deprecation_warning(self):
-        """If the API is being accessed with the deprecated `st.experimental_memo` name,
+        """If the API is being accessed with the deprecated `st.experimental_singleton` name,
         show a deprecation warning.
         """
         if self._deprecation_warning is not None:

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -49,6 +49,7 @@ from streamlit.elements.spinner import spinner
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIWarning
 from streamlit.logger import get_logger
+from streamlit.runtime.caching import CACHE_DOCS_URL
 from streamlit.runtime.caching.cache_type import CacheType, get_decorator_api_name
 from streamlit.runtime.legacy_caching.hashing import (
     HashFuncsDict,
@@ -126,9 +127,6 @@ NEW_CACHE_FUNC_RECOMMENDATIONS: Dict[str, CacheType] = {
     "transformers.TFPreTrainedModel": CacheType.RESOURCE,
     "transformers.FlaxPreTrainedModel": CacheType.RESOURCE,
 }
-
-# TODO: replace this with the proper URL once it's ready from the docs team
-CACHE_DOCS_URL = "https://NEED.CACHE.DOCS.URL"
 
 
 def _make_deprecation_warning(cached_value: Any) -> str:

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -103,8 +103,8 @@ class CacheDataTest(unittest.TestCase):
         self.assertEqual(r2, [0, 1])
 
     def test_multiple_api_names(self):
-        """`st.cache_data` is effectively an alias for `st.cache_data`, and we
-        support both APIs while cache_data is being deprecated.
+        """`st.experimental_memo` is effectively an alias for `st.cache_data`, and we
+        support both APIs while experimental_memo is being deprecated.
         """
         num_calls = [0]
 
@@ -112,9 +112,9 @@ class CacheDataTest(unittest.TestCase):
             num_calls[0] += 1
             return 42
 
-        # Annotate a function with both `cache_data` and `cache_data`.
+        # Annotate a function with both `cache_data` and `experimental_memo`.
         cache_data_func = st.cache_data(foo)
-        memo_func = st.cache_data(foo)
+        memo_func = st.experimental_memo(foo)
 
         # Call both versions of the function and assert the results.
         self.assertEqual(42, cache_data_func())

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -124,6 +124,41 @@ class CacheDataTest(unittest.TestCase):
         # results in just a single call to the decorated function.
         self.assertEqual(1, num_calls[0])
 
+    @parameterized.expand(
+        [
+            ("cache_data", st.cache_data, False),
+            ("experimental_memo", st.experimental_memo, True),
+        ]
+    )
+    @patch("streamlit.runtime.caching.cache_data_api.show_deprecation_warning")
+    def test_deprecation_warnings(
+        self, _, decorator: Any, should_show_warning: bool, show_warning_mock: Mock
+    ):
+        """We show deprecation warnings when using `@st.experimental_memo`, but not `@st.cache_data`."""
+        warning_str = (
+            "`st.experimental_memo` is deprecated. Please use the new command `st.cache_data` instead, "
+            "which has the same behavior. More information [in our docs](https://NEED.CACHE.DOCS.URL)."
+        )
+
+        # We show the deprecation warning at declaration time:
+        @decorator
+        def foo():
+            return 42
+
+        if should_show_warning:
+            show_warning_mock.assert_called_once_with(warning_str)
+        else:
+            show_warning_mock.assert_not_called()
+
+        # And also when clearing the cache:
+        show_warning_mock.reset_mock()
+        decorator.clear()
+
+        if should_show_warning:
+            show_warning_mock.assert_called_once_with(warning_str)
+        else:
+            show_warning_mock.assert_not_called()
+
 
 class CacheDataPersistTest(DeltaGeneratorTestCase):
     """st.cache_data disk persistence tests"""

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -84,11 +84,11 @@ class CacheResourceTest(unittest.TestCase):
 
         # Annotate a function with both `cache_resource` and `experimental_singleton`.
         cache_resource_func = st.cache_resource(foo)
-        memo_func = st.experimental_singleton(foo)
+        singleton_func = st.experimental_singleton(foo)
 
         # Call both versions of the function and assert the results.
         self.assertEqual(42, cache_resource_func())
-        self.assertEqual(42, memo_func())
+        self.assertEqual(42, singleton_func())
 
         # Because these decorators share the same cache, calling both functions
         # results in just a single call to the decorated function.


### PR DESCRIPTION
Our deprecation requirements for singleton/memo changed slightly: we now use a custom deprecation message.