### PR TITLE
remove everything but the label from consideration when computing widget IDs

### DIFF
--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -345,5 +345,6 @@ def _get_widget_id(
     """
     h = hashlib.new("md5")
     h.update(element_type.encode("utf-8"))
-    h.update(element_proto.SerializeToString())
+    if hasattr(element_proto, "label"):
+        h.update(element_proto.label.encode("utf-8"))
     return f"{GENERATED_WIDGET_KEY_PREFIX}-{h.hexdigest()}-{user_key}"

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -74,7 +74,10 @@ class FileUploaderTest(DeltaGeneratorTestCase):
 
         for accept_multiple in [True, False]:
             return_val = st.file_uploader(
-                "label", type="png", accept_multiple_files=accept_multiple
+                "label",
+                type="png",
+                accept_multiple_files=accept_multiple,
+                key=str(accept_multiple),
             )
             c = self.get_delta_from_queue().new_element.file_uploader
             self.assertEqual(accept_multiple, c.multiple_files)
@@ -156,7 +159,7 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         ]
         get_file_recs_patch.return_value = file_recs
 
-        st.file_uploader("foo", accept_multiple_files=True)
+        st.file_uploader("foo", accept_multiple_files=True, key="1")
 
         args, kwargs = remove_orphaned_files_patch.call_args
         self.assertEqual(len(args), 0)
@@ -169,7 +172,7 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         get_file_recs_patch.return_value = []
         remove_orphaned_files_patch.reset_mock()
 
-        st.file_uploader("foo")
+        st.file_uploader("foo", key="2")
         remove_orphaned_files_patch.assert_not_called()
 
     @parameterized.expand(

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -34,11 +34,11 @@ class NumberInputTest(DeltaGeneratorTestCase):
         """Test that NumberInput.type is set to the proper
         NumberInput.DataType value
         """
-        st.number_input("Label", value=0)
+        st.number_input("Label", value=0, key="1")
         c = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(NumberInput.INT, c.data_type)
 
-        st.number_input("Label", value=0.5)
+        st.number_input("Label", value=0.5, key="2")
         c = self.get_delta_from_queue().new_element.number_input
         self.assertEqual(NumberInput.FLOAT, c.data_type)
 
@@ -138,7 +138,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         #       See https://github.com/streamlit/streamlit/pull/943
         SUPPORTED = "adifFeEgGuXxo"
         for char in SUPPORTED:
-            st.number_input("any label", format="%" + char)
+            st.number_input("any label", format="%" + char, key=char)
             c = self.get_delta_from_queue().new_element.number_input
             self.assertEqual(c.format, "%" + char)
 

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -54,7 +54,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
         proto_values = ["some str", "123", "None", "{}", ".*SomeObj.*"]
 
         for arg_value, proto_value in zip(arg_values, proto_values):
-            st.text_area("the label", arg_value)
+            st.text_area("the label", arg_value, key=arg_value)
 
             c = self.get_delta_from_queue().new_element.text_area
             self.assertEqual(c.label, "the label")

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -56,7 +56,7 @@ class TextInputTest(DeltaGeneratorTestCase):
         proto_values = ["some str", "123", "None", "{}", ".*SomeObj.*"]
 
         for arg_value, proto_value in zip(arg_values, proto_values):
-            st.text_input("the label", arg_value)
+            st.text_input("the label", arg_value, key=arg_value)
 
             c = self.get_delta_from_queue().new_element.text_input
             self.assertEqual(c.label, "the label")
@@ -67,7 +67,7 @@ class TextInputTest(DeltaGeneratorTestCase):
         type_strings = ["default", "password"]
         type_values = [TextInput.DEFAULT, TextInput.PASSWORD]
         for type_string, type_value in zip(type_strings, type_values):
-            st.text_input("label", type=type_string)
+            st.text_input("label", type=type_string, key=type_string)
 
             c = self.get_delta_from_queue().new_element.text_input
             self.assertEqual(type_value, c.type)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

This defect needs some discussion.  This PR is one possible solution.  We probably need some guidance from Product to determine if this is the direction we want to go.

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [x] This is a breaking API change
  - [ ] This is a visible (user-facing) change

Widgets IDs are determined by hashing the type of the widget together with an instance of the widget’s protobuf class.   The protobuf instance includes the label, default value, and other parameters provided to the widget when constructed.  

When the script is run the first time, all widgets IDs are created and sent to the Streamlit interface.  

When the user interacts with the Streamlit interface and causes the script to be re-run, widgets names are determined using this same scheme.  

If all parameters passed to create these widgets evaluate to a consistent set of values then the widget ID created will be the same.

Updates from the UI can then be mapped onto the associated widgets by their computed widget ID.  

However, if the set of values used to construct the widget varies when the script is re-run, a new widget is created and the previous widget is replaced.

The result of which being that the user observes that their input is lost.

Previous examples that exercise this behavior also have a feedback loop introduced by setting and getting the query parameters.  A simpler example that demonstrates this issue is as follows:

```python
import streamlit as st

if 'counter' not in st.session_state:
    st.session_state.counter = 1
else:
    st.session_state.counter = st.session_state.counter + 1

text = st.text_input("Your text:", value=st.session_state.counter)
text
```

Executing this example shows that regardless of what you try to change the text to in the text_input box, the user sees that it will always be set to the value of st.session_state.counter this is because every time the script is re-run a new widget is created to replace the previous widget as a result of the way widget IDs are computed.

The [documentation for st.text_input](https://docs.streamlit.io/library/api-reference/widgets/st.text_input) states the value parameter is “The text value of this widget when it first renders. This will be cast to str internally.”  It is possible that a customer could read this to mean that when a parameter is passed to value as part of a call to st.text_input that it will be ignored if this is not the first time that the script is run.  In this case the behavior above is clearly a defect.  Indeed this appears to be the behavior as long as the expression passed to value always evaluates to the same thing.  It works this way, though, because when we construct the name of the widget (using the evaluated value) we find that the widget already exists and we can then return the value set in the interface interaction. 

While we have options available in terms of a fix the following seem like the most appropriate in the current circumstances:

1. Consider this behavior to be “by design” and close as “won’t fix”.  -- Not really a great option as we clearly have some confusing behavior. 

2. Only use parameters that indicate a unique widget in generating the ID of the widget.  This means we will have a single widget for each type of widget unless a specific key is provided. In this way the script may change the label, the default value, and whatever other parameters associated with the widget as desired by the script’s developer when the script is re-run without causing a new widget to be created.  From our perspective, this is a small fix where we just remove the use of the protobuf instance from the process of creating a widget’s unique ID.  Customers who previously depended upon the label of a widget to uniquely identify that widget may now be shown the duplicate widget error.  Similarly, customers who have previously used the default value, or other parameters passed to a given widget, to uniquely identify that widget will also be shown the duplicate widget error.  Their fix is to introduce a unique key for each widget they create. This approach pushes the burden of tracking the widgets onto the script developer. -- This option seems like it goes too far.  Most customers probably think that the label is unique.

3. At least one other popular declarative GUI framework [Dear ImGui](https://github.com/ocornut/imgui) solves this problem by requiring labels to be unique, meaning that a change in the label results in a new widget instance.  They also introduce a scope stack so that a label need only be unique for a given point in the scope stack.  In this way if you require two widgets to have the same label you can still make their IDs unique by introducing new scope.  This change adopts the stance that the label is unique, meaning that a change in the label results in a new widget, similar to what is done in Dear ImGui.  While we don't have the scoping mechanism that is present in Dear ImGui our customers can attach a key if needed to ensure that their widget has a unique ID. -- This option is my recommendation.
 
4. Reconsider what the semantics of a script re-run are given that our widgets all seem to have something similar in their documentation that implies that at least one of the parameters are ignored when the script is re-run.  -- This option seems like it would require a lot of work and may be too high risk.  It is included here for completeness. 



## 🧪 Testing Done

- [ x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
