### PR TITLE
Rename the confusingly named SessionState proto type

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -170,7 +170,7 @@ describe("App", () => {
         },
         sessionId: "sessionId",
         userInfo: {},
-        sessionState: {},
+        sessionStatus: {},
       },
     }
 
@@ -440,7 +440,7 @@ describe("App.handleNewSession", () => {
         streamlitVersion: "streamlitVersion",
         pythonVersion: "pythonVersion",
       },
-      sessionState: {
+      sessionStatus: {
         runOnSave: false,
         scriptIsRunning: false,
       },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,7 +66,7 @@ import {
   PageProfile,
   SessionEvent,
   WidgetStates,
-  SessionState,
+  SessionStatus,
   Config,
   IGitInfo,
   GitInfo,
@@ -444,8 +444,8 @@ export class App extends PureComponent<Props, State> {
       dispatchProto(msgProto, "type", {
         newSession: (newSessionMsg: NewSession) =>
           this.handleNewSession(newSessionMsg),
-        sessionStateChanged: (msg: SessionState) =>
-          this.handleSessionStateChanged(msg),
+        sessionStatusChanged: (msg: SessionStatus) =>
+          this.handleSessionStatusChanged(msg),
         sessionEvent: (evtMsg: SessionEvent) =>
           this.handleSessionEvent(evtMsg),
         delta: (deltaMsg: Delta) =>
@@ -573,17 +573,17 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Handler for ForwardMsg.sessionStateChanged messages
-   * @param stateChangeProto a SessionState protobuf
+   * Handler for ForwardMsg.sessionStatusChanged messages
+   * @param statusChangeProto a SessionStatus protobuf
    */
-  handleSessionStateChanged = (stateChangeProto: SessionState): void => {
+  handleSessionStatusChanged = (statusChangeProto: SessionStatus): void => {
     this.setState((prevState: State) => {
       // Determine our new ScriptRunState
       let { scriptRunState } = prevState
       let { dialog } = prevState
 
       if (
-        stateChangeProto.scriptIsRunning &&
+        statusChangeProto.scriptIsRunning &&
         prevState.scriptRunState !== ScriptRunState.STOP_REQUESTED
       ) {
         // If the script is running, we change our ScriptRunState only
@@ -599,7 +599,7 @@ export class App extends PureComponent<Props, State> {
           dialog = undefined
         }
       } else if (
-        !stateChangeProto.scriptIsRunning &&
+        !statusChangeProto.scriptIsRunning &&
         prevState.scriptRunState !== ScriptRunState.RERUN_REQUESTED &&
         prevState.scriptRunState !== ScriptRunState.COMPILATION_ERROR
       ) {
@@ -634,7 +634,7 @@ export class App extends PureComponent<Props, State> {
       return {
         userSettings: {
           ...prevState.userSettings,
-          runOnSave: Boolean(stateChangeProto.runOnSave),
+          runOnSave: Boolean(statusChangeProto.runOnSave),
         },
         dialog,
         scriptRunState,
@@ -799,7 +799,7 @@ export class App extends PureComponent<Props, State> {
       pythonVersion: SessionInfo.current.pythonVersion,
     })
 
-    this.handleSessionStateChanged(initialize.sessionState)
+    this.handleSessionStatusChanged(initialize.sessionStatus)
   }
 
   /**

--- a/frontend/src/lib/SessionInfo.test.ts
+++ b/frontend/src/lib/SessionInfo.test.ts
@@ -58,7 +58,7 @@ test("Can be initialized from a protobuf", () => {
         streamlitVersion: "streamlitVersion",
         pythonVersion: "pythonVersion",
       },
-      sessionState: {
+      sessionStatus: {
         runOnSave: false,
         scriptIsRunning: false,
       },

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -569,13 +569,13 @@ class AppSession:
         app_was_running = prev_state == AppSessionState.APP_IS_RUNNING
         app_is_running = self._state == AppSessionState.APP_IS_RUNNING
         if app_is_running != app_was_running:
-            self._enqueue_forward_msg(self._create_session_state_changed_message())
+            self._enqueue_forward_msg(self._create_session_status_changed_message())
 
-    def _create_session_state_changed_message(self) -> ForwardMsg:
-        """Create and return a session_state_changed ForwardMsg."""
+    def _create_session_status_changed_message(self) -> ForwardMsg:
+        """Create and return a session_status_changed ForwardMsg."""
         msg = ForwardMsg()
-        msg.session_state_changed.run_on_save = self._run_on_save
-        msg.session_state_changed.script_is_running = (
+        msg.session_status_changed.run_on_save = self._run_on_save
+        msg.session_status_changed.script_is_running = (
             self._state == AppSessionState.APP_IS_RUNNING
         )
         return msg
@@ -610,8 +610,8 @@ class AppSession:
         imsg.environment_info.streamlit_version = STREAMLIT_VERSION_STRING
         imsg.environment_info.python_version = ".".join(map(str, sys.version_info))
 
-        imsg.session_state.run_on_save = self._run_on_save
-        imsg.session_state.script_is_running = (
+        imsg.session_status.run_on_save = self._run_on_save
+        imsg.session_status.script_is_running = (
             self._state == AppSessionState.APP_IS_RUNNING
         )
 
@@ -710,7 +710,7 @@ class AppSession:
 
         """
         self._run_on_save = new_value
-        self._enqueue_forward_msg(self._create_session_state_changed_message())
+        self._enqueue_forward_msg(self._create_session_status_changed_message())
 
 
 def _populate_config_msg(msg: Config) -> None:

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -653,7 +653,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
                     ),
                     CLEAR_QUEUE,
                     session._create_new_session_message(page_script_hash=""),
-                    session._create_session_state_changed_message(),
+                    session._create_session_status_changed_message(),
                 ]
             )
 
@@ -663,7 +663,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
                     session._create_script_finished_message(
                         ForwardMsg.FINISHED_SUCCESSFULLY
                     ),
-                    session._create_session_state_changed_message(),
+                    session._create_session_status_changed_message(),
                     session._create_exception_message(FAKE_EXCEPTION),
                 ]
             )

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -25,7 +25,7 @@ import "streamlit/proto/PageProfile.proto";
 import "streamlit/proto/PageNotFound.proto";
 import "streamlit/proto/PagesChanged.proto";
 import "streamlit/proto/SessionEvent.proto";
-import "streamlit/proto/SessionState.proto";
+import "streamlit/proto/SessionStatus.proto";
 
 // A message sent from Proxy to the browser
 message ForwardMsg {
@@ -58,8 +58,8 @@ message ForwardMsg {
     GitInfo git_info_changed = 14;
     PageProfile page_profile = 18;
 
-    // State change and event messages.
-    SessionState session_state_changed = 9;
+    // Status change and event messages.
+    SessionStatus session_status_changed = 9;
     SessionEvent session_event = 10;
 
     // Other messages.

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -17,7 +17,7 @@
 syntax = "proto3";
 
 import "streamlit/proto/AppPage.proto";
-import "streamlit/proto/SessionState.proto";
+import "streamlit/proto/SessionStatus.proto";
 
 // This is the first message that is sent when a new session starts.
 message NewSession {
@@ -57,7 +57,7 @@ message NewSession {
   string page_script_hash = 9;
 }
 
-// Contains the session state that existed at the time the user connected.
+// Contains the session status that existed at the time the user connected.
 // The contents of this message don't change over the lifetime of the app by
 // definition.
 message Initialize {
@@ -65,8 +65,8 @@ message Initialize {
 
   EnvironmentInfo environment_info = 3;
 
-  // The session state at the time the connection was established
-  SessionState session_state = 4;
+  // The session status at the time the connection was established
+  SessionStatus session_status = 4;
 
   // the actual command line as a string
   string command_line = 5;

--- a/proto/streamlit/proto/SessionStatus.proto
+++ b/proto/streamlit/proto/SessionStatus.proto
@@ -16,9 +16,9 @@
 
 syntax = "proto3";
 
-// State for a session. Sent as part of the Initialize message, and also
-// on AppSession state change events.
-message SessionState {
+// Status for a session. Sent as part of the Initialize message, and also
+// on AppSession status change events.
+message SessionStatus {
   // If true, streamlit will re-run the script if it detects that the script
   // has been changed. This value comes from the server.runOnSave config.
   // The browser can change this option; it's sent here so that the browser


### PR DESCRIPTION
## 📚 Context

A recent [forum post](https://discuss.streamlit.io/t/hey-i-have-a-serious-issue-about-storing-things-in-the-session-state/35761) expressed concern that `st.session_state` is exposed to the client. While this isn't accurate,
it did lead me to investigate how this impression was formed.

Apparently we have a `SessionState` proto type that is unrelated to the `st.session_state` feature and predates it. The proto
message contains whether scripts should be rerun on file change as well as information related to whether a script is
currently running.

This PR changes its name to `SessionStatus` to avoid confusion. I don't love this name since it's not quite correct either
(suggestions for other names would be appreciated!), but it's definitely an improvement over being potentially confused
for an unrelated feature.