### PR TITLE
Allow cypress tests to run when calculations produce 0

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -72,21 +72,21 @@ jobs:
           js_specs=(e2e/specs/*)
 
           # get how many specs to be split up into $TOTAL_WORKERS runs
-          (( totalTests = ${#js_specs[@]} ))
-          (( testsPerWorker = totalTests / TOTAL_WORKERS ))
+          totalTests=$(( ${#js_specs[@]} ))
+          testsPerWorker=$(( totalTests / TOTAL_WORKERS ))
           # get the remainder of tests to be split up into the first $remainder workers
-          (( remainder = totalTests % TOTAL_WORKERS ))
+          remainder=$(( totalTests % TOTAL_WORKERS ))
 
           # We handle $CURRENT_RUN = 1 separately because bash interprets 0 as empty string in this case
           if [ "$CURRENT_RUN" -eq 1 ]; then
             startIndex=0
-            (( currentIntervalLength = testsPerWorker + (remainder > 0 ? 1 : 0) ))
+            currentIntervalLength=$(( testsPerWorker + (remainder > 0 ? 1 : 0) ))
           elif [ $CURRENT_RUN -le $remainder ]; then
-            (( startIndex = (CURRENT_RUN - 1) * (testsPerWorker + 1) ))
-            (( currentIntervalLength = testsPerWorker + 1 ))
+            startIndex=$(( (CURRENT_RUN - 1) * (testsPerWorker + 1) ))
+            currentIntervalLength=$(( testsPerWorker + 1 ))
           else
-            (( startIndex = remainder * (testsPerWorker + 1) + (CURRENT_RUN - remainder - 1) * testsPerWorker ))
-            (( currentIntervalLength = testsPerWorker ))
+            startIndex=$(( remainder * (testsPerWorker + 1) + (CURRENT_RUN - remainder - 1) * testsPerWorker ))
+            currentIntervalLength=$(( testsPerWorker ))
           fi
 
           # ensure no blank specs list (which causes every spec to run)


### PR DESCRIPTION
The remainder calculation was producing 0, which causes the expression's exit code to be 1 because bash is cursed. Assigning the result of arithmetic expansion, instead of doing "arithmetic assignment", avoids this issue.


## 📚 Context


- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

