### PR TITLE
added setdefault override to session state proxy

### DIFF
--- a/lib/streamlit/runtime/state/session_state_proxy.py
+++ b/lib/streamlit/runtime/state/session_state_proxy.py
@@ -132,6 +132,11 @@ class SessionStateProxy(MutableMapping[Key, Any]):
     def to_dict(self) -> Dict[str, Any]:
         """Return a dict containing all session_state and keyed widget values."""
         return get_session_state().filtered_state
+    
+    def setdefault(self,key,default):
+        if key not in self:
+            self[key] = default
+        return self[key]
 
 
 def _missing_attr_error_message(attr_name: str) -> str:


### PR DESCRIPTION
## 📚 Context

setdefault is coming up as a completion in vscode so I'm guessing it exists, but it isn't implemented correctly causing the value not to be set. Hopefully this works. 

- Bugfix, keeps in line dictionary behaviour

## 🧠 Description of Changes

- impletements setdefault on session state proxy
  - [x] This is a visible (user-facing) change

**Current:**

```python 
def setdefault(self,key,default):
    if key not in self:
        self[key] = default
    return self[key]
```

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
