### PR TITLE
Selectbox wrapper class implementation for testing framework

### DIFF
--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -218,7 +218,7 @@ class SelectboxMixin:
         if help is not None:
             selectbox_proto.help = dedent(help)
 
-        serde = SelectboxSerde(opt, index)
+        serde = SelectboxSerde(selectbox_proto.options, index)
 
         widget_state = register_widget(
             "selectbox",

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -218,7 +218,7 @@ class SelectboxMixin:
         if help is not None:
             selectbox_proto.help = dedent(help)
 
-        serde = SelectboxSerde(selectbox_proto.options, index)
+        serde = SelectboxSerde(opt, index)
 
         widget_state = register_widget(
             "selectbox",

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -463,7 +463,7 @@ class Selectbox(Element, Widget, Generic[T]):
         return self.set_value(v)
 
     def select_index(self, index: int) -> Selectbox[T]:
-        return self.set_value(self.options[index])
+        return self.set_value(cast(T, self.options[index]))
 
     def widget_state(self) -> WidgetState:
         """Protobuf message representing the state of the widget, including

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -428,6 +428,8 @@ class Selectbox(Element, Widget, Generic[T]):
 
     @property
     def index(self) -> int:
+        if len(self.options) == 0:
+            return 0
         return self.options.index(str(self.value))
 
     @property

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -412,7 +412,7 @@ class Selectbox(Element, Widget, Generic[T]):
 
     root: ElementTree = field(repr=False)
 
-    def __init__(self, proto: MultiSelectProto, root: ElementTree):
+    def __init__(self, proto: SelectboxProto, root: ElementTree):
         self.proto = proto
         self.root = root
         self._value = None

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -371,6 +371,13 @@ class Multiselect(Element, Widget, Generic[T]):
         return [self.options.index(str(v)) for v in self.value]
 
     def set_value(self, v: list[T]) -> Multiselect[T]:
+        """
+        Set the value of the multiselect widget.
+        Implementation note: set_value not work correctly if `format_func` is also
+        passed to the multiselect. This is because we send options via proto with
+        applied `format_func`, but keep original values in session state
+        as widget value.
+        """
         self._value = v
         return self
 
@@ -443,11 +450,20 @@ class Selectbox(Element, Widget, Generic[T]):
             return cast(T, state[self.id])
 
     def set_value(self, v: T) -> Selectbox[T]:
+        """
+        Set the value of the selectbox.
+        Implementation note: set_value not work correctly if `format_func` is also
+        passed to the selectbox. This is because we send options via proto with applied
+        `format_func`, but keep original values in session state as widget value.
+        """
         self._value = v
         return self
 
     def select(self, v: T) -> Selectbox[T]:
         return self.set_value(v)
+
+    def select_index(self, index: int) -> Selectbox[T]:
+        return self.set_value(self.options[index])
 
     def widget_state(self) -> WidgetState:
         """Protobuf message representing the state of the widget, including

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -725,6 +725,10 @@ class Block:
         ...
 
     @overload
+    def get(self, element_type: Literal["selectbox"]) -> Sequence[Selectbox[Any]]:
+        ...
+
+    @overload
     def get(self, element_type: Literal["slider"]) -> Sequence[Slider[Any]]:
         ...
 
@@ -871,6 +875,8 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                 new_node = Checkbox(elt.checkbox, root=root)
             elif elt.WhichOneof("type") == "multiselect":
                 new_node = Multiselect(elt.multiselect, root=root)
+            elif elt.WhichOneof("type") == "selectbox":
+                new_node = Selectbox(elt.selectbox, root=root)
             elif elt.WhichOneof("type") == "slider":
                 if elt.slider.type == SliderProto.Type.SLIDER:
                     new_node = Slider(elt.slider, root=root)

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -324,3 +324,40 @@ class SelectSliderTest(InteractiveScriptTests):
         sr3 = sr2.get("select_slider")[1].set_range("yellow", "orange").run()
         assert sr3.get("select_slider")[0].value == "violet"
         assert sr3.get("select_slider")[1].value == ("orange", "yellow")
+
+
+@patch("streamlit.source_util._cached_pages", new=None)
+class Selectbox(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "select_slider_test.py",
+            """
+            import pandas as pd
+            import streamlit as st
+
+            options = ("male", "female")
+            st.selectbox("selectbox 1", options, 1)
+
+            st.selectbox("selectbox 2", options, 0, format_func=lambda x: x.capitalize())
+
+            st.selectbox("selectbox 3", [])
+
+            lst = ['Python', 'C', 'C++', 'Java', 'Scala', 'Lisp', 'JavaScript', 'Go']
+            df = pd.DataFrame(lst)
+            st.selectbox("selectbox 4", df)
+            """,
+        )
+        sr = script.run()
+        assert sr.get("selectbox")[0].value == "female"
+        assert sr.get("selectbox")[1].value == "Male"
+        assert sr.get("selectbox")[2].value is None
+        assert sr.get("selectbox")[3].value == "Python"
+
+        sr2 = sr.get("selectbox")[0].select("female").run()
+        sr3 = sr2.get("selectbox")[1].select("Female").run()
+        sr4 = sr3.get("selectbox")[3].select("JavaScript").run()
+
+        assert sr4.get("selectbox")[0].value == "female"
+        assert sr4.get("selectbox")[1].value == "Female"
+        assert sr4.get("selectbox")[2].value is None
+        assert sr4.get("selectbox")[3].value == "JavaScript"

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -359,3 +359,14 @@ class SelectboxTest(InteractiveScriptTests):
         assert sr4.get("selectbox")[1].value == "female"
         assert sr4.get("selectbox")[2].value is None
         assert sr4.get("selectbox")[3].value == "JavaScript"
+
+        sr5 = sr4.get("selectbox")[0].select_index(0).run()
+        sr6 = sr5.get("selectbox")[3].select_index(5).run()
+        assert sr6.get("selectbox")[0].value == "male"
+        assert sr6.get("selectbox")[3].value == "Lisp"
+
+        with pytest.raises(ValueError):
+            sr6.get("selectbox")[0].select("invalid").run()
+
+        with pytest.raises(IndexError):
+            sr6.get("selectbox")[0].select_index(42).run()

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -327,7 +327,7 @@ class SelectSliderTest(InteractiveScriptTests):
 
 
 @patch("streamlit.source_util._cached_pages", new=None)
-class Selectbox(InteractiveScriptTests):
+class SelectboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
             "select_slider_test.py",
@@ -337,9 +337,7 @@ class Selectbox(InteractiveScriptTests):
 
             options = ("male", "female")
             st.selectbox("selectbox 1", options, 1)
-
-            st.selectbox("selectbox 2", options, 0, format_func=lambda x: x.capitalize())
-
+            st.selectbox("selectbox 2", options, 0)
             st.selectbox("selectbox 3", [])
 
             lst = ['Python', 'C', 'C++', 'Java', 'Scala', 'Lisp', 'JavaScript', 'Go']
@@ -349,15 +347,15 @@ class Selectbox(InteractiveScriptTests):
         )
         sr = script.run()
         assert sr.get("selectbox")[0].value == "female"
-        assert sr.get("selectbox")[1].value == "Male"
+        assert sr.get("selectbox")[1].value == "male"
         assert sr.get("selectbox")[2].value is None
         assert sr.get("selectbox")[3].value == "Python"
 
         sr2 = sr.get("selectbox")[0].select("female").run()
-        sr3 = sr2.get("selectbox")[1].select("Female").run()
+        sr3 = sr2.get("selectbox")[1].select("female").run()
         sr4 = sr3.get("selectbox")[3].select("JavaScript").run()
 
         assert sr4.get("selectbox")[0].value == "female"
-        assert sr4.get("selectbox")[1].value == "Female"
+        assert sr4.get("selectbox")[1].value == "female"
         assert sr4.get("selectbox")[2].value is None
         assert sr4.get("selectbox")[3].value == "JavaScript"


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This PR implements class for interactions with Selectbox widget via testing framework

This implementation contains problems connected to the fact, that we send `options` via proto after apply `format_func`, and the state uses a row option list. 
I tried to illustrate that problems on the example of Multiselect widget (has same `format_func` behavior) in [this PR](https://github.com/streamlit/streamlit/pull/6000):  

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
