### PR TITLE
Do not show keyboard on `st.selectbox` on mobile if `options < 10`

### DIFF
--- a/frontend/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from "react"
+import { isMobile } from "react-device-detect"
 import { Select as UISelect, OnChangeParams, Option } from "baseui/select"
 import { logWarning } from "src/lib/log"
 import { VirtualDropdown } from "src/components/shared/Dropdown"
@@ -163,6 +164,10 @@ class Selectbox extends React.PureComponent<Props, State> {
       })
     )
 
+    // Check if we have more than 10 options in the selectbox.
+    // If that's true, we show the keyboard on mobile. If not, we hide it.
+    const showKeyboardOnMobile = options.length > 10
+
     return (
       <div className="row-widget stSelectbox" style={style}>
         <WidgetLabel
@@ -223,6 +228,13 @@ class Selectbox extends React.PureComponent<Props, State> {
             },
 
             Input: {
+              props: {
+                // Change the 'readonly' prop to hide the mobile keyboard if options < 10
+                readOnly:
+                  isMobile && showKeyboardOnMobile === false
+                    ? "readonly"
+                    : null,
+              },
               style: () => ({
                 lineHeight: 1.4,
               }),

--- a/frontend/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from "react"
+import { isMobile } from "react-device-detect"
 import without from "lodash/without"
 import { withTheme } from "@emotion/react"
 import { FormClearHelper } from "src/components/widgets/Form"
@@ -230,6 +231,10 @@ class Multiselect extends React.PureComponent<Props, State> {
       this.onFormCleared
     )
 
+    // Check if we have more than 10 options in the selectbox.
+    // If that's true, we show the keyboard on mobile. If not, we hide it.
+    const showKeyboardOnMobile = options.length > 10
+
     return (
       <div className="row-widget stMultiSelect" style={style}>
         <WidgetLabel
@@ -364,6 +369,15 @@ class Multiselect extends React.PureComponent<Props, State> {
                       },
                     },
                   },
+                },
+              },
+              Input: {
+                props: {
+                  // Change the 'readonly' prop to hide the mobile keyboard if options < 10
+                  readOnly:
+                    isMobile && showKeyboardOnMobile === false
+                      ? "readonly"
+                      : null,
                 },
               },
               Dropdown: { component: VirtualDropdown },


### PR DESCRIPTION
## 📚 Context

This PR enhances the UX of `st.selectbox` and `st.multiselect` on mobile by hiding the keyboard if you have few options. It was suggested by @jrieke [here](https://www.notion.so/streamlit/st-selectbox-Don-t-open-keyboard-on-mobile-4be50e3378c1429dac53f5768513fe46).

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

* Update the `readonly` prop in the `Input` field for the `<UISelect>` component, based on:
  * a. Whether or not the device accessing the app is a mobile device;
  * b. Whether or not the selectbox options are more than 10.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Hard to see on screenshots since keyboard is not present, but doing my best!_

![Screenshot 2023-01-19 at 1 27 05 PM](https://user-images.githubusercontent.com/103376966/213517314-db5eea4e-a550-4706-b915-c03637782433.png)

![Screenshot 2023-01-19 at 1 26 15 PM](https://user-images.githubusercontent.com/103376966/213517324-08325f1b-5c33-4a33-96e4-6dc209232f5a.png)

_Here's an example overriding the native component in Baseweb's site_

![WhatsApp Image 2023-01-19 at 14 39 39](https://user-images.githubusercontent.com/103376966/213519740-3db92687-272d-4d92-aecd-8e47647bd25e.jpeg)

**Current:**

![Screenshot 2023-01-19 at 2 34 19 PM](https://user-images.githubusercontent.com/103376966/213518421-1aa30e98-073b-4e19-9040-c192e0335093.png)

_Here's an example of how it currently works, regardless of the # of options_

![WhatsApp Image 2023-01-19 at 14 45 12](https://user-images.githubusercontent.com/103376966/213521394-c07f1033-cbfc-456e-9792-77b5b7baf422.jpeg)


## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- https://www.notion.so/streamlit/st-selectbox-Don-t-open-keyboard-on-mobile-4be50e3378c1429dac53f5768513fe46 (see comments)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
