### PR TITLE
Fix flaky legacy hashing test

### DIFF
--- a/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
@@ -234,16 +234,19 @@ class HashTest(unittest.TestCase):
             self.assertEqual(exc.find(code_msg) >= 0, True)
 
     def test_hash_funcs_acceptable_keys(self):
-        class C(object):
+        class C:
             def __init__(self):
                 self.x = (x for x in range(1))
 
         with self.assertRaises(UnhashableTypeError):
             get_hash(C())
 
+        # Assert that hashes are equivalent when hash_func key is supplied both as a
+        # type literal, and as a type name string.
+        c_result = C()
         self.assertEqual(
-            get_hash(C(), hash_funcs={types.GeneratorType: id}),
-            get_hash(C(), hash_funcs={"builtins.generator": id}),
+            get_hash(c_result, hash_funcs={types.GeneratorType: id}),
+            get_hash(c_result, hash_funcs={"builtins.generator": id}),
         )
 
     def test_hash_funcs_error(self):


### PR DESCRIPTION
Our legacy `HashTest.test_hash_funcs_acceptable_keys` is flaky. We create two instances of an unhashable type, and hash them with a custom `hash_func` that just uses the Python `id` builtin. 

`id` returns an object's unique identifier - two different objects will never share the same `id`. This particular hashing test seems to be failing with some regularity on Python 3.11, which is surprising: I would have expected the test to always fail on _all versions_ of Python (because we're hashing the IDs of two distinct objects).

This PR modifies the test to hash only a single instance of the given unhashable object; the test now passes on Python 3.11. (Why the test passed on earlier versions of Python remains a mystery!)