### PR TITLE
Test websocket reconnect behavior more rigorously

### DIFF
--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -14,20 +14,29 @@
  * limitations under the License.
  */
 
+const INCREMENTS_PER_DISCONNECT = 5;
+const NUM_DISCONNECTS = 20;
+
 describe("websocket reconnects", () => {
   beforeEach(() => {
     cy.loadApp("http://localhost:3000/");
   });
 
   it("persists session state when the websocket connection is dropped and reconnects", () => {
-    for (let i = 0; i < 5; i++) {
-      cy.get(".stButton button").contains("click me!").click();
-    }
+    let expectedCount = 0;
 
-    cy.window().then((win) => {
-      setTimeout(() => {
-        win.streamlitDebug.disconnectWebsocket();
-      }, 100);
+    for (let i = 0; i < NUM_DISCONNECTS; i++) {
+      expectedCount += INCREMENTS_PER_DISCONNECT;
+
+      for (let j = 0; j < INCREMENTS_PER_DISCONNECT; j++) {
+        cy.get(".stButton button").contains("click me!").click();
+      }
+
+      cy.window().then((win) => {
+        setTimeout(() => {
+          win.streamlitDebug.disconnectWebsocket();
+        }, 100);
+      });
 
       // Wait until we've disconnected.
       cy.get("[data-testid='stStatusWidget']").should(
@@ -37,7 +46,7 @@ describe("websocket reconnects", () => {
       // Wait until we've reconnected and rerun the script.
       cy.get("[data-testid='stStatusWidget']").should("not.exist");
 
-      cy.get(".stMarkdown").contains("count: 5");
-    });
+      cy.get(".stMarkdown").contains(`count: ${expectedCount}`);
+    }
   });
 });


### PR DESCRIPTION
## 📚 Context

We're debating whether to slightly defer the merge of #5856 to be more confident that we don't
introduce a low-probability heisenbug with websocket reconnects in a release. If we do choose
to do this, the plan would be to merge the feature branch immediately after the 1.18 cutoff so that
we'd get the additional testing of ~2 weeks of the websocket reconnects e2e test running in the nightly,
along with additional CI runs every time a PR gets merged into `develop`. The release of the feature
branch / bugfix would happen in 1.19.

Whether or not we choose to do this, it'd also be good to make the relevant e2e test a more rigorous
stress test. This PR does this by having the test repeatedly increment a value in session state 5 times
before disconnecting/reconnecting/verifying the value persists. It does this a total of 20 times before
the test ends.

## 🧪 Testing Done

- [x] Added/Updated e2e tests
