### PR TITLE
Update S3 URL conditional

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -93,27 +93,11 @@ jobs:
           echo "enable-setup=${{ env.AWS_ACCESS_KEY_ID != '' }}" >> $GITHUB_OUTPUT
           echo "preview-branch=$PREVIEW_BRANCH" >> $GITHUB_OUTPUT
           echo "s3-url=${S3_URL}" >> $GITHUB_OUTPUT
-
-  s3_url:
-    runs-on: ubuntu-latest
-
-    needs: upload-whl
-
-    if: needs.upload-whl.outputs.enable-setup == 'true' && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
-
-    permissions:
-      contents: read # This is required for actions/checkout
-      statuses: write # This is required for "Set S3 URL as Github status" step
-
-    defaults:
-      run:
-        shell: bash --login -eo pipefail {0}
-
-    steps:
-      - name: "Set S3 URL as Github status"
+      - if: steps.exports.outputs.enable-setup == 'true' && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
+        name: Set S3 URL as Github Status
         uses: actions/github-script@v6
         env:
-          S3_URL: ${{ needs.upload-whl.outputs.s3-url }}
+          S3_URL: ${{ steps.exports.outputs.s3-url }}
         with:
           script: |
             const { sha } = context.payload.pull_request.head
@@ -121,7 +105,7 @@ jobs:
             // https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
             await github.request(`POST /repos/streamlit/streamlit/statuses/{sha}`, {
               owner: 'streamlit',
-              repor: 'streamlit',
+              repo: 'streamlit',
               sha,
               state: 'success',
               target_url: process.env.S3_URL,

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -94,11 +94,26 @@ jobs:
           echo "preview-branch=$PREVIEW_BRANCH" >> $GITHUB_OUTPUT
           echo "s3-url=${S3_URL}" >> $GITHUB_OUTPUT
 
+  s3_url:
+    runs-on: ubuntu-latest
+
+    needs: upload-whl
+
+    if: needs.upload-whl.outputs.enable-setup == 'true' && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
+
+    permissions:
+      contents: read # This is required for actions/checkout
+      statuses: write # This is required for "Set S3 URL as Github status" step
+
+    defaults:
+      run:
+        shell: bash --login -eo pipefail {0}
+
+    steps:
       - name: "Set S3 URL as Github status"
-        if: ${{ env.S3_URL != '' }} && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
         uses: actions/github-script@v6
         env:
-          S3_URL: ${{ steps.exports.outputs.s3-url }}
+          S3_URL: ${{ needs.upload-whl.outputs.s3-url }}
         with:
           script: |
             const { sha } = context.payload.pull_request.head
@@ -106,7 +121,7 @@ jobs:
             // https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
             await github.request(`POST /repos/streamlit/streamlit/statuses/{sha}`, {
               owner: 'streamlit',
-              repo: 'streamlit',
+              repor: 'streamlit',
               sha,
               state: 'success',
               target_url: process.env.S3_URL,

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -95,7 +95,7 @@ jobs:
           echo "s3-url=${S3_URL}" >> $GITHUB_OUTPUT
 
       - name: "Set S3 URL as Github status"
-        if: ${{ env.AWS_ACCESS_KEY_ID != '' }} && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
+        if: ${{ env.S3_URL != '' }} && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
         uses: actions/github-script@v6
         env:
           S3_URL: ${{ steps.exports.outputs.s3-url }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -95,7 +95,7 @@ jobs:
           echo "s3-url=${S3_URL}" >> $GITHUB_OUTPUT
 
       - name: "Set S3 URL as Github status"
-        if: success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }} && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request' && github.event.sender.type == 'User'
         uses: actions/github-script@v6
         env:
           S3_URL: ${{ steps.exports.outputs.s3-url }}
@@ -106,7 +106,7 @@ jobs:
             // https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
             await github.request(`POST /repos/streamlit/streamlit/statuses/{sha}`, {
               owner: 'streamlit',
-              repor: 'streamlit',
+              repo: 'streamlit',
               sha,
               state: 'success',
               target_url: process.env.S3_URL,


### PR DESCRIPTION
## 📚 Context

PR Preview's `upload-whl` test (particularly the **Set S3 URL as Github status** job) is failing for all forked PRs because it is trying to post the S3 URL that doesn't exist. To satisfy security requirements we don't share our AWS S3 creds (or other secrets) with forks. This PR updates the `upload-whl` test to skip this step if Upload whl to S3 is skipped.

- What kind of change does this PR introduce?
  - [x] Refactoring
 
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
