### PR TITLE
Fix reStructuredText issues in cache_data and cache_resource docstrings

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -285,18 +285,17 @@ class CacheDataAPI:
         persist: CachePersistType | bool,
         experimental_allow_widgets: bool,
     ):
-        """Decorator to cache functions that return data (e.g. dataframe transforms,
-        database queries, ML inference).
+        """Decorator to cache functions that return data (e.g. dataframe transforms, database queries, ML inference).
 
         Cached objects are stored in "pickled" form, which means that the return
         value of a cached function must be pickleable. Each caller of the cached
         function gets its own copy of the cached data.
 
-        You can clear a function's cache with `func.clear()` or clear the entire
-        cache with `st.cache_data.clear()`.
+        You can clear a function's cache with ``func.clear()`` or clear the entire
+        cache with ``st.cache_data.clear()``.
 
-        To cache global resources, use `st.cache_resource` instead.
-        Learn more about caching at [https://docs.streamlit.io/library/advanced-features/caching](https://docs.streamlit.io/library/advanced-features/caching)
+        To cache global resources, use ``st.cache_resource`` instead. Learn more
+        about caching at https://docs.streamlit.io/library/advanced-features/caching.
 
         Parameters
         ----------
@@ -306,8 +305,8 @@ class CacheDataAPI:
         ttl : float or timedelta or None
             The maximum number of seconds to keep an entry in the cache, or
             None if cache entries should not expire. The default is None.
-            Note that ttl is incompatible with `persist="disk"` - `ttl` will be
-            ignored if `persist` is specified.
+            Note that ttl is incompatible with ``persist="disk"`` - ``ttl`` will be
+            ignored if ``persist`` is specified.
 
         max_entries : int or None
             The maximum number of entries to keep in the cache, or None

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -269,19 +269,18 @@ class CacheResourceAPI:
         validate: ValidateFunc | None,
         experimental_allow_widgets: bool,
     ):
-        """Decorator to cache functions that return global resources (e.g.
-        database connections, ML models).
+        """Decorator to cache functions that return global resources (e.g. database connections, ML models).
 
         Cached objects are shared across all users, sessions, and reruns. They
         must be thread-safe because they can be accessed from multiple threads
-        concurrently. If thread safety is an issue, consider using `st.session_state`
+        concurrently. If thread safety is an issue, consider using ``st.session_state``
         to store resources per session instead.
 
-        You can clear a function's cache with `func.clear()` or clear the entire
-        cache with `st.cache_resource.clear()`.
+        You can clear a function's cache with ``func.clear()`` or clear the entire
+        cache with ``st.cache_resource.clear()``.
 
-        To cache data, use `st.cache_data` instead.
-        Learn more about caching at [https://docs.streamlit.io/library/advanced-features/caching](https://docs.streamlit.io/library/advanced-features/caching)
+        To cache data, use ``st.cache_data`` instead. Learn more about caching at
+        https://docs.streamlit.io/library/advanced-features/caching.
 
         Parameters
         ----------
@@ -304,9 +303,9 @@ class CacheResourceAPI:
             value of show_spinner param will be used for spinner text.
 
         validate : callable or None
-            An optional validation function for cached data. `validate` is called
+            An optional validation function for cached data. ``validate`` is called
             each time the cached value is accessed. It receives the cached value as
-            its only parameter and it must return a boolean. If `validate` returns
+            its only parameter and it must return a boolean. If ``validate`` returns
             False, the current cached value is discarded, and the decorated function
             is called to compute a new value. This is useful e.g. to check the
             health of database connections.


### PR DESCRIPTION
## 📚 Context

Our docstrings contain reStructuredText. Inline code in reStructuredText should be between two backticks. Single backticks are interpreted as italics. There are docstring formatting issues for both `st.cache_data` and `st.cache_resource` added in #5948.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Replaces single backticks with double backticks for inline code in `st.cache_data` and `st.cache_resource` docstrings.

Note: this PR does neither adds nor updates any tests as it is a mere refactor of docstrings.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/214024733-aedf5f4d-2dee-4022-b527-97328d2f3e50.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/214025061-4a80a5aa-5aac-4137-b671-4dd2aa315117.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
