### PR TITLE
Fix deprecation warning for new health endpoint

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -142,7 +142,7 @@ class HealthHandler(_SpecialRequestHandler):
         self._callback = callback
 
     async def get(self):
-        if self.request.uri and not self.request.uri.startswith("_stcore/"):
+        if self.request.uri and "_stcore/" not in self.request.uri:
             new_path = (
                 "/_stcore/script-health-check"
                 if "script-health-check" in self.request.uri

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -39,7 +39,7 @@ class StatsRequestHandler(tornado.web.RequestHandler):
         self.finish()
 
     def get(self) -> None:
-        if self.request.uri and not self.request.uri.startswith("_stcore/"):
+        if self.request.uri and "_stcore/" not in self.request.uri:
             emit_endpoint_deprecation_notice(self, new_path="/_stcore/metrics")
 
         stats = self._manager.get_stats()

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -91,6 +91,17 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         )
         self.assertEqual(response.headers["deprecation"], "True")
 
+    def test_new_health_endpoint_should_not_display_deprecation_warning(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            "no logs of level INFO or higher triggered on "
+            r"streamlit\.web\.server\.server\_util",
+        ), self.assertLogs("streamlit.web.server.server_util") as logs:
+            response = self.fetch("/_stcore/health")
+        self.assertEqual(len(logs.records), 0)
+        self.assertNotIn("link", response.headers)
+        self.assertNotIn("deprecation", response.headers)
+
 
 class MessageCacheHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):

--- a/lib/tests/streamlit/web/server/stats_handler_test.py
+++ b/lib/tests/streamlit/web/server/stats_handler_test.py
@@ -100,6 +100,17 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(expected_body, response.body)
 
+    def test_new_metrics_endpoint_should_not_display_deprecation_warning(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            "no logs of level INFO or higher triggered on "
+            r"streamlit\.web\.server\.server\_util",
+        ), self.assertLogs("streamlit.web.server.server_util") as logs:
+            response = self.fetch("/_stcore/metrics")
+        self.assertEqual(len(logs.records), 0)
+        self.assertNotIn("link", response.headers)
+        self.assertNotIn("deprecation", response.headers)
+
     def test_protobuf_stats(self):
         """Stats requests are returned in OpenMetrics protobuf format
         if the request's Content-Type header is protobuf.


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Previously, the warning was displayed to all users. Now only for users who use the old endpoint.

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
