### PR TITLE
Disallow setting embed query param using set_query_param method

### DIFF
--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -135,5 +135,7 @@ def _ensure_no_embed_params(
     query_string = parse.urlencode(query_params, doseq=True)
 
     if query_string:
-        return f"{query_string}&{current_embed_params}"
+        return (
+            f"{query_string}{'&' if current_embed_params else ''}{current_embed_params}"
+        )
     return current_embed_params

--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -135,7 +135,6 @@ def _ensure_no_embed_params(
     query_string = parse.urlencode(query_params, doseq=True)
 
     if query_string:
-        return (
-            f"{query_string}{'&' if current_embed_params else ''}{current_embed_params}"
-        )
+        separator = "&" if current_embed_params else ""
+        return separator.join([query_string, current_embed_params])
     return current_embed_params

--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -115,25 +115,25 @@ def _ensure_no_embed_params(
         )
 
     all_current_params = parse.parse_qs(query_string)
-    current_embed_params = "".join(
-        [
-            f"&{EMBED_QUERY_PARAM}={param}"
-            for param in util.extract_key_query_params(
-                all_current_params, param_key=EMBED_QUERY_PARAM
-            )
-        ]
+    current_embed_params = parse.urlencode(
+        {
+            EMBED_QUERY_PARAM: [
+                param
+                for param in util.extract_key_query_params(
+                    all_current_params, param_key=EMBED_QUERY_PARAM
+                )
+            ],
+            EMBED_OPTIONS_QUERY_PARAM: [
+                param
+                for param in util.extract_key_query_params(
+                    all_current_params, param_key=EMBED_OPTIONS_QUERY_PARAM
+                )
+            ],
+        },
+        doseq=True,
     )
-    current_embed_options_params = "".join(
-        [
-            f"&{EMBED_OPTIONS_QUERY_PARAM}={param}"
-            for param in util.extract_key_query_params(
-                all_current_params, param_key=EMBED_OPTIONS_QUERY_PARAM
-            )
-        ]
-    )
-    current_embed_params += current_embed_options_params
     query_string = parse.urlencode(query_params, doseq=True)
 
     if query_string:
-        return query_string + current_embed_params
-    return current_embed_params[1:]
+        return f"{query_string}&{current_embed_params}"
+    return current_embed_params

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -14,6 +14,7 @@
 
 """A bunch of useful utilities."""
 
+import copy
 import functools
 import hashlib
 import os
@@ -154,3 +155,33 @@ def calc_md5(s: str) -> str:
     h = hashlib.new("md5")
     h.update(s.encode("utf-8"))
     return h.hexdigest()
+
+
+def drop_key_query_params(
+    query_params: Dict[str, List[str]], keys_to_drop: List[str]
+) -> bool:
+    """Drop query_params (passed by reference) containing keys_to_drop: List[str] (case-insensitive) query params
+    Returns True if at least one param was dropped. False when there were no keys_to_drop found.
+    """
+    found = False
+    for param_name in copy.deepcopy(query_params).keys():
+        if param_name.lower() in keys_to_drop:
+            found = True
+            query_params.pop(param_name)
+    return found
+
+
+def extract_key_query_params(query_params: Dict[str, List[str]], param_key: str) -> str:
+    """Extracts key (case-insensitive) query params from Dict,
+    and returns them as query params string."""
+    embed_values: List[str] = []
+    for param_name in query_params.keys():
+        if param_name.lower() == param_key:
+            values = query_params.get(param_name, [])
+            if values and len(values) > 0:
+                embed_values = embed_values + values
+    extracted_params = set([value.lower() for value in embed_values])
+    result = ""
+    for param in extracted_params:
+        result += f"&{param_key}={param}"
+    return result

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -683,6 +683,19 @@ class StreamlitAPITest(DeltaGeneratorTestCase):
         self.assertEqual(el.alert.icon, "⚠️")
         self.assertEqual(el.alert.format, Alert.WARNING)
 
+    def test_set_query_params_sends_protobuf_message(self):
+        """Test valid st.set_query_params sends protobuf message."""
+        st.experimental_set_query_params(x="a")
+        message = self.get_message_from_queue(0)
+        self.assertEqual(message.page_info_changed.query_string, "x=a")
+
+    def test_set_query_params_exceptions(self):
+        """Test invalid st.set_query_params raises exceptions."""
+        with self.assertRaises(StreamlitAPIException):
+            st.experimental_set_query_params(embed="True")
+        with self.assertRaises(StreamlitAPIException):
+            st.experimental_set_query_params(embed_options="show_colored_line")
+
     @parameterized.expand([(st.error,), (st.warning,), (st.info,), (st.success,)])
     def test_st_alert_exceptions(self, alert_func):
         """Test that alert functions throw an exception when a non-emoji is given as an icon."""

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -14,6 +14,7 @@
 
 import random
 import unittest
+from typing import Dict, List
 from unittest.mock import patch
 
 import numpy as np
@@ -123,3 +124,60 @@ class UtilTest(unittest.TestCase):
     def test_unsuccessful_index_(self, input, find_value):
         with self.assertRaises(ValueError):
             util.index_(input, find_value)
+
+    @parameterized.expand(
+        [
+            ({"x": ["a"]}, ["x"], {}, True),
+            ({"a": ["a1", "a2"], "b": ["b1", "b2"]}, ["a"], {"b": ["b1", "b2"]}, True),
+            ({"c": ["c1", "c2"]}, "no_existing_key", {"c": ["c1", "c2"]}, False),
+            (
+                {
+                    "embed": ["true"],
+                    "embed_options": ["show_padding", "show_colored_line"],
+                },
+                ["embed", "embed_options"],
+                {},
+                True,
+            ),
+            (
+                {"EMBED": ["TRUE"], "EMBED_OPTIONS": ["DISABLE_SCROLLING"]},
+                ["embed", "embed_options"],
+                {},
+                True,
+            ),
+        ]
+    )
+    def test_drop_key_query_params(
+        self,
+        query_params: Dict[str, List[str]],
+        keys_to_drop: List[str],
+        result: Dict[str, List[str]],
+        found: bool,
+    ):
+        self.assertEqual(util.drop_key_query_params(query_params, keys_to_drop), found)
+        self.assertDictEqual(query_params, result)
+
+    @parameterized.expand(
+        [
+            ({"x": ["a"]}, "x", "&x=a"),
+            ({"a": ["a1"], "b": ["b1", "b2"]}, "a", "&a=a1"),
+            ({"c": ["c1", "c2"]}, "no_existing_key", ""),
+            (
+                {
+                    "embed": ["true"],
+                    "embed_options": ["show_padding", "show_colored_line"],
+                },
+                "embed",
+                "&embed=true",
+            ),
+            (
+                {"EMBED": ["TRUE"], "EMBED_OPTIONS": ["DISABLE_SCROLLING"]},
+                "embed_options",
+                "&embed_options=disable_scrolling",
+            ),
+        ]
+    )
+    def test_extract_key_query_params(
+        self, query_params: Dict[str, List[str]], param_key: str, result: str
+    ):
+        self.assertEqual(util.extract_key_query_params(query_params, param_key), result)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

This is a proposal to disallow setting `embed` and `embed_options` query params using `set_query_param` method.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
Disable setting `embed` query param, when someone embeds the Streamlit app, one might not want the embedded stuff to have enabled scrollbar and remote Streamlit code should not be able to re-enable it overriding embed params.

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
