### PR TITLE
Don't install SQLAlchemy 2.0

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -25,4 +25,6 @@ cx-Oracle<8.0.0
 mysqlclient>=2.0.3
 psycopg2-binary>=2.9.1
 pyodbc>=4.0.32
-sqlalchemy>=1.4.25
+# SQLAlchemy 2.0 causes hashing tests to fail (and we're deliberately
+# choosing not to support it.)
+sqlalchemy>=1.4.25, <2.0


### PR DESCRIPTION
SQLAlchemy is a test dependency for our legacy, deprecated `@st.cache` testing. SQLAlchemy 2 was just released, and it's incompatible with our legacy hashing code - but we're not going to update that code to support it, because we've moved to `@st.cache_data` and `@st.cache_resource` instead.

This PR pins SQLAlchemy < 2.0.