### PR TITLE
Handle page_cache in script test setup to remove patch

### DIFF
--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -921,7 +921,6 @@ class CommonCacheThreadingTest(unittest.TestCase):
         self.assertEqual(1, get_counter())
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class WidgetReplayInteractionTest(InteractiveScriptTests):
     def test_dynamic_widget_replay(self):
         script = self.script_from_filename(__file__, "cached_widget_replay_dynamic.py")

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -286,7 +286,6 @@ class SessionStateTest(DeltaGeneratorTestCase):
         patched_warning.assert_called_once()
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class SessionStateInteractionTest(InteractiveScriptTests):
     def test_updates(self):
         script = self.script_from_filename(__file__, "linked_sliders.py")

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import patch
-
 import pytest
 
 from streamlit.testing.script_interactions import InteractiveScriptTests
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class InteractiveScriptTest(InteractiveScriptTests):
     def test_widgets_script(self):
         script = self.script_from_filename(__file__, "widgets_script.py")

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 from datetime import datetime, time
-from unittest.mock import patch
 
 import pytest
 
 from streamlit.testing.script_interactions import InteractiveScriptTests
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class CheckboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
@@ -47,7 +45,6 @@ class CheckboxTest(InteractiveScriptTests):
 
 
 @pytest.mark.xfail(reason="button does not work correctly with session state")
-@patch("streamlit.source_util._cached_pages", new=None)
 class ButtonTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
@@ -72,7 +69,6 @@ class ButtonTest(InteractiveScriptTests):
         assert sr3.get("button")[1].value == False
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class MultiselectTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
@@ -101,7 +97,6 @@ class MultiselectTest(InteractiveScriptTests):
         assert set(sr3.get("multiselect")[1].value) == set(["zero", "one", "two"])
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class MarkdownTest(InteractiveScriptTests):
     def test_markdown(self):
         script = self.script_from_string(
@@ -189,7 +184,6 @@ class MarkdownTest(InteractiveScriptTests):
         assert len(sr.get("latex")) == 2
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class HeadingTest(InteractiveScriptTests):
     def test_title(self):
         script = self.script_from_string(
@@ -267,7 +261,6 @@ class HeadingTest(InteractiveScriptTests):
         assert len(sr.get("subheader")) == 2
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class SliderTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
@@ -303,7 +296,6 @@ class SliderTest(InteractiveScriptTests):
         assert s[4].value == 0.1
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class SelectSliderTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
@@ -326,7 +318,6 @@ class SelectSliderTest(InteractiveScriptTests):
         assert sr3.get("select_slider")[1].value == ("orange", "yellow")
 
 
-@patch("streamlit.source_util._cached_pages", new=None)
 class SelectboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(


### PR DESCRIPTION

## 📚 Context

`InteractiveScriptTests` required patching of the page cache, which was annoying. It now handles it during setup.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

