### PR TITLE
Allow pytest unit test to be discoverable via IDE

### DIFF
--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -94,7 +94,7 @@ def pytest_configure(config: pytest.Config):
         "when --require-snowflake option is passed to pytest",
     )
 
-    is_require_snowflake = config.getoption("--require-snowflake")
+    is_require_snowflake = config.getoption("--require-snowflake", default=False)
     if is_require_snowflake:
         if sys.version_info[0:2] != (3, 8):
             raise pytest.UsageError("Python 3.8 is required to run Snowflake tests")


### PR DESCRIPTION
## 📚 Context

At the moment, it is required to provide the `--require-snowflake` flag when running the python unit tests. This makes it complicated to run it via the IDE (e.g. VS Code). This PR adds a default value that is used when the flag is not provided. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
