### PR TITLE
[Fix CI tests] Failure on virtual env setup for pre-commit: Disable/Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
           - --target-version=py37
         files: \.py$|\.pyi$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,15 @@ repos:
           # Configure Black to support only syntax supported by the minimum supported Python version in setup.py.
           - --target-version=py37
         files: \.py$|\.pyi$
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args:
-          - --filter-files
-        exclude: ^lib/streamlit/__init__\.py$
+# Turning off isort temporary due to https://github.com/PyCQA/isort/issues/2077
+# As of 1.28.23, bumping isort to 5.12.0 would resolve the error but requires python3.8+
+  # - repo: https://github.com/PyCQA/isort
+  #   rev: 5.12.0
+  #   hooks:
+  #     - id: isort
+  #       args:
+  #         - --filter-files
+  #       exclude: ^lib/streamlit/__init__\.py$
   - repo: https://github.com/PyCQA/autoflake
     rev: v1.7.7
     hooks:


### PR DESCRIPTION
Virtual Env setup for GHA CI broken due to https://github.com/PyCQA/isort/issues/2077 
Fixed by https://github.com/PyCQA/isort/pull/2078 in [isort 5.12.0](https://github.com/PyCQA/isort/releases/tag/5.12.0), which also **dropped support for Python 3.7**

Temporarily disabling isort will unblock CI tests/PRs/Nightly until either a fix is available (track below) or we transition `PYTHON_MIN_VERSION` to 3.8...

Issue asking for fix applicable for Python 3.7 [here](https://github.com/PyCQA/isort/issues/2083)