### PR TITLE
Wait for hamburger menu to be closed before printing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1315,6 +1315,7 @@ export class App extends PureComponent<Props, State> {
     } catch (err) {
       windowToPrint = window
     } finally {
+      // wait 1 second before printing, to be 100% sure hamburger close animation ends
       setTimeout(() => {
         if (!windowToPrint) windowToPrint = window
         windowToPrint.print()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1304,7 +1304,7 @@ export class App extends PureComponent<Props, State> {
       setTimeout(this.printCallback, 500)
       return
     }
-    let windowToPrint
+    let windowToPrint: Window
     try {
       const htmlIFrameElement = getIFrameEnclosingApp(this.embeddingId)
       if (htmlIFrameElement && htmlIFrameElement.contentWindow) {
@@ -1315,8 +1315,10 @@ export class App extends PureComponent<Props, State> {
     } catch (err) {
       windowToPrint = window
     } finally {
-      if (!windowToPrint) windowToPrint = window
-      windowToPrint.print()
+      setTimeout(() => {
+        if (!windowToPrint) windowToPrint = window
+        windowToPrint.print()
+      }, 1000)
     }
   }
 


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?
Sometimes when using "Print" from hamburger Menu, the App is being printed without closing Hamburger menu, this PR adds 1 second of waiting before calling `.print` method, at this point hamburger menu should be closed.

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
