### PR TITLE
Add File connection and more convenience methods in Snowpark connection

### DIFF
--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -16,5 +16,6 @@
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
 from streamlit.connections.connection_factory import connection as connection
+from streamlit.connections.file_connection import File as File
 from streamlit.connections.snowpark_connection import Snowpark as Snowpark
 from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -16,6 +16,6 @@
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
 from streamlit.connections.connection_factory import connection as connection
-from streamlit.connections.file_connection import File as File
+from streamlit.connections.file_connection import FileSystem as FileSystem
 from streamlit.connections.snowpark_connection import Snowpark as Snowpark
 from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/connection_factory.py
+++ b/lib/streamlit/connections/connection_factory.py
@@ -17,6 +17,7 @@ from typing import Any, Type, TypeVar, overload
 from typing_extensions import Literal
 
 from streamlit.connections.base_connection import BaseConnection
+from streamlit.connections.file_connection import File
 from streamlit.connections.snowpark_connection import Snowpark
 from streamlit.connections.sql_connection import SQL
 from streamlit.errors import StreamlitAPIException
@@ -35,12 +36,14 @@ ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
 # TODO(vdonato): Some way to test that optional dependencies required by a connection
 # don't cause `ModuleNotFoundError`s until the connection is actually instantiated.
 def _get_first_party_connection(connection_name: str):
-    FIRST_PARTY_CONNECTIONS = {"snowpark", "sql"}
+    FIRST_PARTY_CONNECTIONS = {"snowpark", "sql", "file"}
 
     if connection_name == "sql":
         return SQL
     elif connection_name == "snowpark":
         return Snowpark
+    elif connection_name == "file":
+        return File
 
     raise StreamlitAPIException(
         f"Invalid connection {connection_name}. Supported connection classes: {FIRST_PARTY_CONNECTIONS}"
@@ -62,6 +65,13 @@ def connection(
 def connection(
     connection_class: Literal["snowpark"], name: str = "default", **kwargs
 ) -> "Snowpark":
+    ...
+
+
+@overload
+def connection(
+    connection_class: Literal["file"], name: str = "default", **kwargs
+) -> "File":
     ...
 
 

--- a/lib/streamlit/connections/file_connection.py
+++ b/lib/streamlit/connections/file_connection.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
     from fsspec.spec import AbstractBufferedFile
 
 
-class File(BaseConnection["AbstractFileSystem"]):
-    _default_connection_name = "file"
+class FileSystem(BaseConnection["AbstractFileSystem"]):
+    _default_connection_name = "files"
 
     def __init__(
         self, connection_name: str = "default", protocol: str | None = None, **kwargs

--- a/lib/streamlit/connections/file_connection.py
+++ b/lib/streamlit/connections/file_connection.py
@@ -1,0 +1,134 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import timedelta
+from io import TextIOWrapper
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator
+
+import pandas as pd
+
+from streamlit import cache_data
+from streamlit.connections import BaseConnection
+
+if TYPE_CHECKING:
+    from fsspec import AbstractFileSystem, filesystem
+    from fsspec.spec import AbstractBufferedFile
+
+
+TTLType = int | float | timedelta
+
+
+class File(BaseConnection[AbstractFileSystem]):
+    _default_connection_name = "file"
+
+    def __init__(
+        self, connection_name: str = "default", protocol: str | None = None, **kwargs
+    ) -> None:
+        self.protocol = protocol
+        super().__init__(connection_name, **kwargs)
+
+    def connect(self, **kwargs) -> AbstractFileSystem:
+        """
+        Pass a protocol such as "s3", "gcs", or "file"
+        """
+        from fsspec import AbstractFileSystem, filesystem
+        from fsspec.spec import AbstractBufferedFile
+
+        self._closed = False
+
+        _secrets = self.get_secrets()
+        secrets = dict(_secrets)
+
+        protocol = secrets.pop("protocol", self.protocol)
+
+        if protocol is None:
+            protocol = "file"
+
+        if protocol == "gcs" and secrets:
+            secrets = {"token": secrets}
+
+        secrets.update(kwargs)
+
+        fs = filesystem(protocol, **secrets)
+
+        return fs
+
+    def disconnect(self) -> None:
+        self._closed = True
+
+    def is_connected(self) -> bool:
+        return not self._closed
+
+    @contextmanager
+    def open(
+        self, path: str | Path, mode: str = "rb", *args, **kwargs
+    ) -> Iterator[TextIOWrapper | AbstractBufferedFile]:
+        # Connection name is only passed to make sure that the cache is
+        # connection-specific
+        if "connection_name" in kwargs:
+            kwargs.pop("connection_name")
+
+        with self.instance.open(path, mode, *args, **kwargs) as f:
+            yield f
+
+    def _read_data(
+        self, path: str | Path, binary: bool = True, *args, **kwargs
+    ) -> str | bytes:
+        mode = "rb" if binary else "rt"
+        with self.instance.open(path, mode, *args, **kwargs) as f:
+            return f.read()
+
+    def read_text(self, path: str | Path, ttl: TTLType = 3600, **kwargs) -> str:
+        return cache_data(self._read_data, ttl=ttl)(  # type: ignore
+            path, binary=False, connection_name=self._connection_name, **kwargs
+        )
+
+    def read_bytes(self, path: str | Path, ttl: TTLType = 3600, **kwargs) -> bytes:
+        return cache_data(self._read_data, ttl=ttl)(  # type: ignore
+            path, binary=True, connection_name=self._connection_name, **kwargs
+        )
+
+    def _read_csv(self, path: str | Path, **kwargs) -> pd.DataFrame:
+        # Connection name is only passed to make sure that the cache is
+        # connection-specific
+        if "connection_name" in kwargs:
+            kwargs.pop("connection_name")
+
+        with self.open(path, "rt") as f:
+            return pd.read_csv(f, **kwargs)
+
+    def read_csv(self, path: str | Path, ttl: TTLType = 3600, **kwargs) -> pd.DataFrame:
+        return cache_data(self._read_csv, ttl=ttl)(  # type: ignore
+            path, connection_name=self._connection_name, **kwargs
+        )
+
+    def _read_parquet(self, path: str | Path, **kwargs) -> pd.DataFrame:
+        # Connection name is only passed to make sure that the cache is
+        # connection-specific
+        if "connection_name" in kwargs:
+            kwargs.pop("connection_name")
+
+        with self.open(path, "rb") as f:
+            return pd.read_parquet(f, **kwargs)  # type: ignore
+
+    def read_parquet(
+        self, path: str | Path, ttl: TTLType = 3600, **kwargs
+    ) -> pd.DataFrame:
+        return cache_data(self._read_parquet, ttl=ttl)(  # type: ignore
+            path, connection_name=self._connection_name, **kwargs
+        )


### PR DESCRIPTION
Put the following into the st.connect prototype branch
* Merge File connection from Zachary's standalone version
* Add convenience support in the factory function for gcs and s3
* Add snowsql config file lookup option for Snowpark init
* Add read_sql() convenience method for Snowpark

Working in a local app:

![image](https://user-images.githubusercontent.com/116604821/216196911-ffcfe30f-7f1d-4493-b2a2-d239427e876d.png)
