### PR TITLE
Bump min tornado version to 6.0.3

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -62,8 +62,9 @@ INSTALL_REQUIRES = [
 SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
     "gitpython!=3.1.19",
     "pydeck>=0.1.dev5",
-    # 5.0 has a fix for etag header: https://github.com/tornadoweb/tornado/issues/2262
-    "tornado>=5.0",
+    # Tornado 6.0.3 was the current Tornado version when Python 3.8, our earliest supported Python version,
+    # was released (Oct 14, 2019).
+    "tornado>=6.0.3",
 ]
 
 if not os.getenv("SNOWPARK_CONDA_BUILD"):


### PR DESCRIPTION
We claim to support Tornado 5.0, but it's an ancient version (March 2018) and we don't actually test against it.

This PR bumps our Tornado dependency to `>=6.0.3`. 6.0.3 was the current version of Tornado when Python 3.8 was released.