### PR TITLE
[DRAFT] Hamburger menu cleanup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "homepage": "./",
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "start": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true craco start",
+    "start": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true GENERATE_SOURCEMAP=false craco start",
     "build": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 GENERATE_SOURCEMAP=false craco build",
     "test": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=./jsdom-polyfill-env.js",
     "test:coverage": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=./jsdom-polyfill-env.js --coverage --watchAll false --watch false ./",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "homepage": "./",
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "start": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true GENERATE_SOURCEMAP=false craco start",
+    "start": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true craco start",
     "build": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 GENERATE_SOURCEMAP=false craco build",
     "test": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=./jsdom-polyfill-env.js",
     "test:coverage": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=./jsdom-polyfill-env.js --coverage --watchAll false --watch false ./",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1288,6 +1288,8 @@ export class App extends PureComponent<Props, State> {
       type: DialogType.ABOUT,
       onClose: this.closeDialog,
       aboutSectionMd: menuItems?.aboutSectionMd,
+      getHelpUrl: menuItems?.getHelpUrl,
+      reportABugUrl: menuItems?.reportABugUrl,
     }
     this.openDialog(newDialog)
   }

--- a/frontend/src/components/core/MainMenu/MainMenu.test.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.test.tsx
@@ -116,10 +116,7 @@ describe("App", () => {
       .prop("items")
       // @ts-ignore
       .map(item => item.label)
-    expect(devMenuLabels).toEqual([
-      "Developer options",
-      "Clear cache",
-    ])
+    expect(devMenuLabels).toEqual(["Developer options", "Clear cache"])
   })
 
   it("should render core set of menu elements", () => {

--- a/frontend/src/components/core/MainMenu/MainMenu.test.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.test.tsx
@@ -104,11 +104,9 @@ describe("App", () => {
       "Settings",
       "Print",
       "Record a screencast",
-      "Report a bug",
-      "Get help",
       "View app source",
       "Report bug with app",
-      "About",
+      "About & help",
     ])
 
     // @ts-ignore
@@ -121,10 +119,6 @@ describe("App", () => {
     expect(devMenuLabels).toEqual([
       "Developer options",
       "Clear cache",
-      "Streamlit Cloud",
-      "Report a Streamlit bug",
-      "Visit Streamlit docs",
-      "Visit Streamlit forums",
     ])
   })
 
@@ -147,9 +141,7 @@ describe("App", () => {
       "Settings",
       "Print",
       "Record a screencast",
-      "Report a bug",
-      "Get help",
-      "About",
+      "About & help",
     ])
 
     // @ts-ignore
@@ -163,10 +155,6 @@ describe("App", () => {
       "Developer options",
       "Clear cache",
       "Deploy this app",
-      "Streamlit Cloud",
-      "Report a Streamlit bug",
-      "Visit Streamlit docs",
-      "Visit Streamlit forums",
     ])
   })
 
@@ -189,9 +177,7 @@ describe("App", () => {
       "Settings",
       "Print",
       "Record a screencast",
-      "Report a bug",
-      "Get help",
-      "About",
+      "About & help",
     ])
 
     // @ts-ignore
@@ -205,10 +191,6 @@ describe("App", () => {
       "Developer options",
       "Clear cache",
       "Deploy this app",
-      "Streamlit Cloud",
-      "Report a Streamlit bug",
-      "Visit Streamlit docs",
-      "Visit Streamlit forums",
     ])
   })
 
@@ -354,7 +336,7 @@ describe("App", () => {
       "Settings",
       "Print",
       "Record a screencast",
-      "About",
+      "About & help",
     ])
   })
 
@@ -383,8 +365,7 @@ describe("App", () => {
       "Settings",
       "Print",
       "Record a screencast",
-      "Get help",
-      "About",
+      "About & help",
     ])
   })
 
@@ -416,9 +397,7 @@ describe("App", () => {
       "Settings",
       "Print",
       "Record a screencast",
-      "Report a bug",
-      "Get help",
-      "About",
+      "About & help",
     ])
   })
 })

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -45,10 +45,7 @@ import {
 } from "src/hocs/withHostCommunication/types"
 import { GitInfo, IGitInfo, PageConfig } from "src/autogen/proto"
 import { MetricsManager } from "src/lib/MetricsManager"
-import {
-  DEPLOY_URL,
-  STREAMLIT_CLOUD_URL,
-} from "src/urls"
+import { DEPLOY_URL, STREAMLIT_CLOUD_URL } from "src/urls"
 import {
   StyledMenuDivider,
   StyledMenuItem,

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -49,9 +49,7 @@ import {
   BUG_URL,
   COMMUNITY_URL,
   DEPLOY_URL,
-  ONLINE_DOCS_URL,
   STREAMLIT_CLOUD_URL,
-  TEAMS_URL,
 } from "src/urls"
 import {
   StyledMenuDivider,
@@ -432,26 +430,6 @@ function MainMenu(props: Props): ReactElement {
       label: "Clear cache",
       shortcut: "c",
     },
-    s4t: {
-      onClick: getOpenInWindowCallback(TEAMS_URL),
-      label: "Streamlit Cloud",
-    },
-    reportSt: {
-      onClick: getOpenInWindowCallback(BUG_URL),
-      label: "Report a Streamlit bug",
-    },
-    documentation: {
-      onClick: getOpenInWindowCallback(ONLINE_DOCS_URL),
-      label: "Visit Streamlit docs",
-    },
-    visitStForum: {
-      onClick: getOpenInWindowCallback(COMMUNITY_URL),
-      label: "Visit Streamlit forums",
-      styleProps: {
-        margin: "0 0 -.5rem 0",
-        padding: ".25rem 0 .25rem 1.5rem",
-      },
-    },
   }
 
   const hostMenuItems = props.hostMenuItems.map(item => {
@@ -500,10 +478,6 @@ function MainMenu(props: Props): ReactElement {
     coreDevMenuItems.developerOptions,
     coreDevMenuItems.clearCache,
     showDeploy && coreDevMenuItems.deployApp,
-    isLocalhost() && coreDevMenuItems.s4t,
-    coreDevMenuItems.reportSt,
-    coreDevMenuItems.documentation,
-    coreDevMenuItems.visitStForum,
   ]
 
   // Remove empty entries, and add dividers into menu options as needed.

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -46,8 +46,6 @@ import {
 import { GitInfo, IGitInfo, PageConfig } from "src/autogen/proto"
 import { MetricsManager } from "src/lib/MetricsManager"
 import {
-  BUG_URL,
-  COMMUNITY_URL,
   DEPLOY_URL,
   STREAMLIT_CLOUD_URL,
 } from "src/urls"

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -387,24 +387,8 @@ function MainMenu(props: Props): ReactElement {
       disabled: isServerDisconnected,
       label: "Save a snapshot",
     },
-    ...(!props.menuItems?.hideGetHelp && {
-      community: {
-        onClick: getOpenInWindowCallback(
-          props.menuItems?.getHelpUrl || COMMUNITY_URL
-        ),
-        label: "Get help",
-      },
-    }),
-    ...(!props.menuItems?.hideReportABug && {
-      report: {
-        onClick: getOpenInWindowCallback(
-          props.menuItems?.reportABugUrl || BUG_URL
-        ),
-        label: "Report a bug",
-      },
-    }),
     settings: { onClick: props.settingsCallback, label: "Settings" },
-    about: { onClick: props.aboutCallback, label: "About" },
+    about: { onClick: props.aboutCallback, label: "About & help" },
   }
 
   const coreDevMenuItems = {
@@ -468,8 +452,6 @@ function MainMenu(props: Props): ReactElement {
     coreMenuItems.print,
     coreMenuItems.recordScreencast,
     coreMenuItems.DIVIDER,
-    coreMenuItems.report,
-    coreMenuItems.community,
     ...(shouldShowHostMenu ? hostMenuItems : [coreMenuItems.DIVIDER]),
     coreMenuItems.about,
   ]

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -47,6 +47,7 @@ import {
   StyledCommandLine,
   StyledDeployErrorContent,
   StyledAboutInfo,
+  StyledAnchorsContent,
 } from "./styled-components"
 
 type PlainEventHandler = () => void
@@ -165,7 +166,7 @@ function aboutDialog(props: AboutProps): ReactElement {
     <Modal isOpen onClose={props.onClose}>
       <ModalHeader>About</ModalHeader>
       <ModalBody>
-        <div>
+        <StyledAnchorsContent>
           <p>
             {/* Show our version string only if SessionInfo has been created. If Streamlit
             hasn't yet connected to the server, the SessionInfo singleton will be null. */}
@@ -187,7 +188,7 @@ function aboutDialog(props: AboutProps): ReactElement {
             {" - "}
             <a href={BUG_URL}>Report a bug</a>
           </p>
-        </div>
+        </StyledAnchorsContent>
       </ModalBody>
       <ModalFooter>
         <ModalButton kind={Kind.SECONDARY} onClick={props.onClose}>

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -50,6 +50,8 @@ import {
   StyledAnchorsContent,
 } from "./styled-components"
 
+const ANCHOR_SEPARATOR = " - "
+
 type PlainEventHandler = () => void
 
 interface SettingsProps extends SettingsDialogProps {
@@ -123,6 +125,34 @@ interface AboutProps {
   aboutSectionMd?: string | null
 }
 
+function StreamlitInfoBox(): ReactElement {
+  return (
+    <StyledAnchorsContent>
+      <p>
+        {/* Show our version string only if SessionInfo has been created. If Streamlit
+            hasn't yet connected to the server, the SessionInfo singleton will be null. */}
+        {SessionInfo.isSet() && (
+          <>
+            Streamlit v{SessionInfo.current.streamlitVersion}
+            <br />
+          </>
+        )}
+        <a href={STREAMLIT_HOME_URL}>{STREAMLIT_HOME_URL}</a>
+        <br />
+        Copyright {new Date().getFullYear()} Snowflake Inc. All rights
+        reserved.
+      </p>
+      <p>
+        <a href={ONLINE_DOCS_URL}>Documentation</a>
+        {ANCHOR_SEPARATOR}
+        <a href={COMMUNITY_URL}>Forum</a>
+        {ANCHOR_SEPARATOR}
+        <a href={BUG_URL}>Report a bug</a>
+      </p>
+    </StyledAnchorsContent>
+  )
+}
+
 /** About Dialog */
 function aboutDialog(props: AboutProps): ReactElement {
   if (props.aboutSectionMd) {
@@ -132,27 +162,24 @@ function aboutDialog(props: AboutProps): ReactElement {
       maxHeight: "35vh",
     }
 
-    // Markdown New line is 2 spaces + \n
-    const newLineMarkdown = "  \n"
-    const StreamlitInfo = [
-      `Made with Streamlit v${SessionInfo.current.streamlitVersion}`,
-      STREAMLIT_HOME_URL,
-      `Copyright ${new Date().getFullYear()} Snowflake Inc. All rights reserved.`,
-    ].join(newLineMarkdown)
-
-    const source = `${props.aboutSectionMd} ${newLineMarkdown} ${newLineMarkdown} ${StreamlitInfo}`
-
     return (
       <Modal isOpen onClose={props.onClose}>
         <ModalHeader>About</ModalHeader>
         <ModalBody>
           <StyledAboutInfo>
             <StreamlitMarkdown
-              source={source}
+              source={props.aboutSectionMd}
               allowHTML={false}
               style={markdownStyle}
             />
+            <StyledAnchorsContent>
+              <a href={ONLINE_DOCS_URL}>Get help</a>
+              {ANCHOR_SEPARATOR}
+              <a href={COMMUNITY_URL}>Report a bug with this app</a>
+            </StyledAnchorsContent>
           </StyledAboutInfo>
+          <hr />
+          <StreamlitInfoBox />
         </ModalBody>
         <ModalFooter>
           <ModalButton kind={Kind.SECONDARY} onClick={props.onClose}>
@@ -162,34 +189,11 @@ function aboutDialog(props: AboutProps): ReactElement {
       </Modal>
     )
   }
-  const anchorSeparator = " - "
   return (
     <Modal isOpen onClose={props.onClose}>
       <ModalHeader>About</ModalHeader>
       <ModalBody>
-        <StyledAnchorsContent>
-          <p>
-            {/* Show our version string only if SessionInfo has been created. If Streamlit
-            hasn't yet connected to the server, the SessionInfo singleton will be null. */}
-            {SessionInfo.isSet() && (
-              <>
-                Streamlit v{SessionInfo.current.streamlitVersion}
-                <br />
-              </>
-            )}
-            <a href={STREAMLIT_HOME_URL}>{STREAMLIT_HOME_URL}</a>
-            <br />
-            Copyright {new Date().getFullYear()} Snowflake Inc. All rights
-            reserved.
-          </p>
-          <p>
-            <a href={ONLINE_DOCS_URL}>Documentation</a>
-            {anchorSeparator}
-            <a href={COMMUNITY_URL}>Forum</a>
-            {anchorSeparator}
-            <a href={BUG_URL}>Report a bug</a>
-          </p>
-        </StyledAnchorsContent>
+        <StreamlitInfoBox />
       </ModalBody>
       <ModalFooter>
         <ModalButton kind={Kind.SECONDARY} onClick={props.onClose}>

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -50,7 +50,7 @@ import {
   StyledAnchorsContent,
 } from "./styled-components"
 
-const ANCHOR_SEPARATOR = " | "
+const ANCHOR_SEPARATOR = " - "
 
 type PlainEventHandler = () => void
 

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -162,6 +162,7 @@ function aboutDialog(props: AboutProps): ReactElement {
       </Modal>
     )
   }
+  const anchorSeparator = " - "
   return (
     <Modal isOpen onClose={props.onClose}>
       <ModalHeader>About</ModalHeader>
@@ -183,9 +184,9 @@ function aboutDialog(props: AboutProps): ReactElement {
           </p>
           <p>
             <a href={ONLINE_DOCS_URL}>Documentation</a>
-            {" - "}
+            {anchorSeparator}
             <a href={COMMUNITY_URL}>Forum</a>
-            {" - "}
+            {anchorSeparator}
             <a href={BUG_URL}>Report a bug</a>
           </p>
         </StyledAnchorsContent>

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -123,9 +123,14 @@ interface AboutProps {
   onClose: PlainEventHandler
 
   aboutSectionMd?: string | null
+  getHelpUrl?: string | null
+  reportABugUrl?: string | null
 }
 
-function StreamlitInfoBox(): ReactElement {
+interface StreamlitInfo {
+  reportABugUrl?: string | null
+}
+function StreamlitInfoBox(props: StreamlitInfo): ReactElement {
   return (
     <StyledAnchorsContent>
       <p>
@@ -147,7 +152,7 @@ function StreamlitInfoBox(): ReactElement {
         {ANCHOR_SEPARATOR}
         <a href={COMMUNITY_URL}>Forum</a>
         {ANCHOR_SEPARATOR}
-        <a href={BUG_URL}>Report a bug</a>
+        <a href={props?.reportABugUrl || BUG_URL}>Report a bug</a>
       </p>
     </StyledAnchorsContent>
   )
@@ -173,13 +178,13 @@ function aboutDialog(props: AboutProps): ReactElement {
               style={markdownStyle}
             />
             <StyledAnchorsContent>
-              <a href={ONLINE_DOCS_URL}>Get help</a>
+              <a href={props?.getHelpUrl || COMMUNITY_URL}>Get help</a>
               {ANCHOR_SEPARATOR}
               <a href={COMMUNITY_URL}>Report a bug with this app</a>
             </StyledAnchorsContent>
           </StyledAboutInfo>
           <hr />
-          <StreamlitInfoBox />
+          <StreamlitInfoBox reportABugUrl={props.reportABugUrl} />
         </ModalBody>
         <ModalFooter>
           <ModalButton kind={Kind.SECONDARY} onClick={props.onClose}>
@@ -193,7 +198,7 @@ function aboutDialog(props: AboutProps): ReactElement {
     <Modal isOpen onClose={props.onClose}>
       <ModalHeader>About</ModalHeader>
       <ModalBody>
-        <StreamlitInfoBox />
+        <StreamlitInfoBox reportABugUrl={props.reportABugUrl} />
       </ModalBody>
       <ModalFooter>
         <ModalButton kind={Kind.SECONDARY} onClick={props.onClose}>

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -50,7 +50,7 @@ import {
   StyledAnchorsContent,
 } from "./styled-components"
 
-const ANCHOR_SEPARATOR = " - "
+const ANCHOR_SEPARATOR = " | "
 
 type PlainEventHandler = () => void
 

--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -30,7 +30,12 @@ import {
 } from "src/components/core/StreamlitDialog/ScriptChangedDialog"
 import { IException } from "src/autogen/proto"
 import { SessionInfo } from "src/lib/SessionInfo"
-import { STREAMLIT_HOME_URL } from "src/urls"
+import {
+  BUG_URL,
+  COMMUNITY_URL,
+  ONLINE_DOCS_URL,
+  STREAMLIT_HOME_URL,
+} from "src/urls"
 import StreamlitMarkdown from "src/components/shared/StreamlitMarkdown"
 import { Props as SettingsDialogProps, SettingsDialog } from "./SettingsDialog"
 import ThemeCreatorDialog, {
@@ -158,21 +163,30 @@ function aboutDialog(props: AboutProps): ReactElement {
   }
   return (
     <Modal isOpen onClose={props.onClose}>
-      <ModalHeader>Powered by</ModalHeader>
+      <ModalHeader>About</ModalHeader>
       <ModalBody>
         <div>
-          {/* Show our version string only if SessionInfo has been created. If Streamlit
-          hasn't yet connected to the server, the SessionInfo singleton will be null. */}
-          {SessionInfo.isSet() && (
-            <>
-              Streamlit v{SessionInfo.current.streamlitVersion}
-              <br />
-            </>
-          )}
-          <a href={STREAMLIT_HOME_URL}>{STREAMLIT_HOME_URL}</a>
-          <br />
-          Copyright {new Date().getFullYear()} Snowflake Inc. All rights
-          reserved.
+          <p>
+            {/* Show our version string only if SessionInfo has been created. If Streamlit
+            hasn't yet connected to the server, the SessionInfo singleton will be null. */}
+            {SessionInfo.isSet() && (
+              <>
+                Streamlit v{SessionInfo.current.streamlitVersion}
+                <br />
+              </>
+            )}
+            <a href={STREAMLIT_HOME_URL}>{STREAMLIT_HOME_URL}</a>
+            <br />
+            Copyright {new Date().getFullYear()} Snowflake Inc. All rights
+            reserved.
+          </p>
+          <p>
+            <a href={ONLINE_DOCS_URL}>Documentation</a>
+            {" - "}
+            <a href={COMMUNITY_URL}>Forum</a>
+            {" - "}
+            <a href={BUG_URL}>Report a bug</a>
+          </p>
         </div>
       </ModalBody>
       <ModalFooter>

--- a/frontend/src/components/core/StreamlitDialog/styled-components.ts
+++ b/frontend/src/components/core/StreamlitDialog/styled-components.ts
@@ -145,3 +145,9 @@ export const StyledAboutInfo = styled.div(() => ({
   padding: "0 0 1rem 0",
   overflowY: "scroll",
 }))
+
+export const StyledAnchorsContent = styled.div(({ theme }) => ({
+  a: {
+    color: theme.colors.linkText,
+  },
+}))

--- a/frontend/src/components/core/StreamlitDialog/styled-components.ts
+++ b/frontend/src/components/core/StreamlitDialog/styled-components.ts
@@ -142,7 +142,7 @@ export const StyledDeployErrorContent = styled.div(({ theme }) => ({
 }))
 
 export const StyledAboutInfo = styled.div(() => ({
-  padding: "0 0 1rem 0",
+  padding: "0",
   overflowY: "scroll",
 }))
 

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -19,7 +19,6 @@ export const DEPLOY_URL = "https://share.streamlit.io/deploy"
 export const STREAMLIT_CLOUD_URL = "https://streamlit.io/cloud"
 export const ONLINE_DOCS_URL = "https://docs.streamlit.io"
 export const COMMUNITY_URL = "https://discuss.streamlit.io"
-export const TEAMS_URL = "https://streamlit.io/for-teams"
 export const BUG_URL =
   "https://github.com/streamlit/streamlit/issues/new/choose"
 


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

This PR implements the hamburger menu items cleanup, according to the according to the "Clean up the hamburger menu" [Product spec](https://www.notion.so/streamlit/Product-spec-fa80e423ee5e4863963f5d0f4c873c7c).

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

* Renamed "About" to "About & help" menu item.
* Moved "Report a bug" item from menu to the "About" modal
* Moved "Get help" item from menu to the "About" modal
* Removed the following menu items from "Developer options" section:
  * Streamlit could
  * Report a Streamlit bug
  * Visit Streamlit docs (link to documentation is now in the "About" modal)
  * Visit Streamlit forums (link to documentation is now in the "About" modal)
* The "Promote this app" and "Report a bug with this app" menu items are added by the s4t project and removed in a [dedicated PR](https://github.com/streamlit/s4t/pull/5087)
* Visual changes to the "About modal":
  * Information about Streamlit version and Streamlit-related urls are separated into a dedicated component
  * URLs are blue not red
  * Horizontal line separates user-added markdown from the core streamlit into 

Changes:

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

*Simplified hamburger menu in the local environment:
<img width="206" alt="Screenshot 2023-02-07 at 10 24 50" src="https://user-images.githubusercontent.com/119880369/217205261-d04ea783-f4bb-459e-8489-fae184a7487b.png">

* "About" modal with custom markdown message specified by the user:
<img width="513" alt="Screenshot 2023-02-07 at 14 18 46" src="https://user-images.githubusercontent.com/119880369/217255777-188a2224-ca43-4912-a9c7-af21a130c162.png">


* "About" modal default view:
<img width="520" alt="Screenshot 2023-02-07 at 10 26 02" src="https://user-images.githubusercontent.com/119880369/217205583-2434827a-4236-4f48-8814-6a814e72eb41.png">


**Current:**

_Insert screenshot of existing UI/code here_

* Original hamburger menu in the local environment:
<img width="222" alt="Screenshot 2023-02-07 at 10 31 20" src="https://user-images.githubusercontent.com/119880369/217206679-f12498cd-7d48-47c0-9c07-19f260e53ee2.png">


* Original "About" modal with custom markdown message specified by the user:
<img width="513" alt="Screenshot 2023-02-07 at 10 32 10" src="https://user-images.githubusercontent.com/119880369/217206759-c5796dd9-c3e1-4092-9ced-5678b0d9ee73.png">


* Original "About" modal default view:
<img width="510" alt="Screenshot 2023-02-07 at 10 31 35" src="https://user-images.githubusercontent.com/119880369/217206799-6e155917-b1a8-4c39-8757-e449199657e6.png">



## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: [STREAMLIT-2113](https://snowflakecomputing.atlassian.net/browse/STREAMLIT-2113)
- **PR in s4t repo**: https://github.com/streamlit/s4t/pull/5087

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
