### PR TITLE
session_state: "common.py" module

### DIFF
--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -28,7 +28,7 @@ from streamlit.runtime.caching.cache_resource_api import (
     CacheResourceAPI,
     _resource_caches,
 )
-from streamlit.runtime.state.session_state import WidgetMetadata
+from streamlit.runtime.state.common import WidgetMetadata
 
 CACHE_DOCS_URL = "https://docs.streamlit.io/library/advanced-features/caching"
 

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -39,7 +39,7 @@ from streamlit.runtime.scriptrunner.script_run_context import (
     ScriptRunContext,
     get_script_run_ctx,
 )
-from streamlit.runtime.state.session_state import WidgetMetadata
+from streamlit.runtime.state.common import WidgetMetadata
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator

--- a/lib/streamlit/runtime/state/__init__.py
+++ b/lib/streamlit/runtime/state/__init__.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from streamlit.runtime.state.common import WidgetArgs as WidgetArgs
+from streamlit.runtime.state.common import WidgetCallback as WidgetCallback
+from streamlit.runtime.state.common import WidgetKwargs as WidgetKwargs
+
 # Explicitly re-export public symbols
 from streamlit.runtime.state.safe_session_state import (
     SafeSessionState as SafeSessionState,
@@ -23,9 +27,6 @@ from streamlit.runtime.state.session_state import SessionState as SessionState
 from streamlit.runtime.state.session_state import (
     SessionStateStatProvider as SessionStateStatProvider,
 )
-from streamlit.runtime.state.session_state import WidgetArgs as WidgetArgs
-from streamlit.runtime.state.session_state import WidgetCallback as WidgetCallback
-from streamlit.runtime.state.session_state import WidgetKwargs as WidgetKwargs
 from streamlit.runtime.state.session_state_proxy import (
     SessionStateProxy as SessionStateProxy,
 )

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Functions and data structures shared by session_state.py and widgets.py"""
+
 import hashlib
 from typing import Optional, Union
 

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Functions and data structures shared by session_state.py and widgets.py"""
+from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -17,12 +17,8 @@ from typing import Any, Dict, List, Optional, Set
 
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
-from streamlit.runtime.state.session_state import (
-    RegisterWidgetResult,
-    SessionState,
-    T,
-    WidgetMetadata,
-)
+from streamlit.runtime.state import SessionState
+from streamlit.runtime.state.common import RegisterWidgetResult, T, WidgetMetadata
 
 
 class SafeSessionState:

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -17,8 +17,8 @@ from typing import Any, Dict, List, Optional, Set
 
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
-from streamlit.runtime.state import SessionState
 from streamlit.runtime.state.common import RegisterWidgetResult, T, WidgetMetadata
+from streamlit.runtime.state.session_state import SessionState
 
 
 class SafeSessionState:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -39,7 +39,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
-from streamlit.runtime.state.util import is_keyed_widget_id, is_widget_id
+from streamlit.runtime.state.common import is_keyed_widget_id, is_widget_id
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 from streamlit.type_util import ValueFieldName, is_array_value_field_name
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -674,11 +674,12 @@ class SessionState:
 
 
 def _is_widget_id(key: str) -> bool:
+    """True if the given session_state key has the structure of a widget ID."""
     return key.startswith(GENERATED_WIDGET_KEY_PREFIX)
 
 
-# TODO: It would be better to make key vs not visible through more principled means
 def _is_keyed_widget_id(key: str) -> bool:
+    """True if the given session_state key has the structure of a widget ID with a user_key."""
     return _is_widget_id(key) and not key.endswith("-None")
 
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -35,6 +35,8 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
 from streamlit.runtime.state.common import (
+    RegisterWidgetResult,
+    T,
     WidgetMetadata,
     is_keyed_widget_id,
     is_widget_id,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -583,15 +583,13 @@ class SessionState:
         """Set all trigger values in our state dictionary to False."""
         for state_id in self._new_widget_state:
             metadata = self._new_widget_state.widget_metadata.get(state_id)
-            if metadata is not None:
-                if metadata.value_type == "trigger_value":
-                    self._new_widget_state[state_id] = Value(False)
+            if metadata is not None and metadata.value_type == "trigger_value":
+                self._new_widget_state[state_id] = Value(False)
 
         for state_id in self._old_state:
             metadata = self._new_widget_state.widget_metadata.get(state_id)
-            if metadata is not None:
-                if metadata.value_type == "trigger_value":
-                    self._old_state[state_id] = False
+            if metadata is not None and metadata.value_type == "trigger_value":
+                self._old_state[state_id] = False
 
     def _remove_stale_widgets(self, active_widget_ids: set[str]) -> None:
         """Remove widget state for widgets whose ids aren't in `active_widget_ids`."""

--- a/lib/streamlit/runtime/state/session_state_proxy.py
+++ b/lib/streamlit/runtime/state/session_state_proxy.py
@@ -19,9 +19,9 @@ from typing_extensions import Final
 from streamlit import logger as _logger
 from streamlit import runtime
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.state.common import require_valid_user_key
 from streamlit.runtime.state.safe_session_state import SafeSessionState
 from streamlit.runtime.state.session_state import SessionState
-from streamlit.runtime.state.util import require_valid_user_key
 from streamlit.type_util import Key
 
 LOGGER: Final = _logger.get_logger(__name__)

--- a/lib/streamlit/runtime/state/session_state_proxy.py
+++ b/lib/streamlit/runtime/state/session_state_proxy.py
@@ -20,7 +20,8 @@ from streamlit import logger as _logger
 from streamlit import runtime
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.state.safe_session_state import SafeSessionState
-from streamlit.runtime.state.session_state import SessionState, require_valid_user_key
+from streamlit.runtime.state.session_state import SessionState
+from streamlit.runtime.state.util import require_valid_user_key
 from streamlit.type_util import Key
 
 LOGGER: Final = _logger.get_logger(__name__)

--- a/lib/streamlit/runtime/state/util.py
+++ b/lib/streamlit/runtime/state/util.py
@@ -1,0 +1,51 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hashlib
+from typing import Optional
+
+from streamlit.runtime.state.session_state import GENERATED_WIDGET_KEY_PREFIX
+from streamlit.runtime.state.widgets import WidgetProto
+
+
+def compute_widget_id(
+    element_type: str, element_proto: WidgetProto, user_key: Optional[str] = None
+) -> str:
+    """Compute the widget id for the given widget. This id is stable: a given
+    set of inputs to this function will always produce the same widget id output.
+
+    The widget id includes the user_key so widgets with identical arguments can
+    use it to be distinct.
+
+    The widget id includes an easily identified prefix, and the user_key as a
+    suffix, to make it easy to identify it and know if a key maps to it.
+
+    Does not mutate the element_proto object.
+    """
+    h = hashlib.new("md5")
+    h.update(element_type.encode("utf-8"))
+    h.update(element_proto.SerializeToString())
+    return f"{GENERATED_WIDGET_KEY_PREFIX}-{h.hexdigest()}-{user_key}"
+
+
+def user_key_from_widget_id(widget_id: str) -> Optional[str]:
+    """Return the user key portion of a widget id, or None if the id does not
+    have a user key.
+
+    TODO This will incorrectly indicate no user key if the user actually provides
+    "None" as a key, but we can't avoid this kind of problem while storing the
+    string representation of the no-user-key sentinel as part of the widget id.
+    """
+    user_key = widget_id.split("-", maxsplit=2)[-1]
+    user_key = None if user_key == "None" else user_key
+    return user_key

--- a/lib/streamlit/runtime/state/util.py
+++ b/lib/streamlit/runtime/state/util.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import hashlib
 from typing import Optional, Union
 
@@ -56,7 +57,7 @@ WidgetProto: TypeAlias = Union[
     TimeInput,
 ]
 
-GENERATED_WIDGET_ID_PREFIX: Final = "$$GENERATED_WIDGET_KEY"
+GENERATED_WIDGET_ID_PREFIX: Final = "$$GENERATED_WIDGET_ID"
 
 
 def compute_widget_id(

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -20,6 +20,11 @@ from typing_extensions import Final, TypeAlias
 
 from streamlit.errors import DuplicateWidgetID
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
+from streamlit.runtime.state.common import (
+    WidgetProto,
+    compute_widget_id,
+    user_key_from_widget_id,
+)
 from streamlit.runtime.state.session_state import (
     RegisterWidgetResult,
     T,
@@ -29,11 +34,6 @@ from streamlit.runtime.state.session_state import (
     WidgetKwargs,
     WidgetMetadata,
     WidgetSerializer,
-)
-from streamlit.runtime.state.util import (
-    WidgetProto,
-    compute_widget_id,
-    user_key_from_widget_id,
 )
 from streamlit.type_util import ValueFieldName
 

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -201,10 +201,8 @@ def register_widget(
 
 
 def user_key_from_widget_id(wid: str) -> Optional[str]:
-    """Extract the user key used to generate a widget id, from that id.
-
-    Returns `None` instead of `"None"` if there was no user key,
-    for compatibility with the rest of the codebase, which represents it that way.
+    """Return the user key portion of a widget id, or None if the id does not
+    have a user key.
 
     TODO This will incorrectly indicate no user key if the user actually provides
     "None" as a key, but we can't avoid this kind of problem while storing the

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -184,7 +184,7 @@ def register_widget(
         For both paths a widget return value is provided, allowing the widgets
         to be used in a non-streamlit setting.
     """
-    widget_id = _get_widget_id(element_type, element_proto, user_key)
+    widget_id = _compute_widget_id(element_type, element_proto, user_key)
     element_proto.id = widget_id
 
     # Create the widget's updated metadata, and register it with session_state.
@@ -333,10 +333,11 @@ def _build_duplicate_widget_message(
     return message.strip("\n").format(widget_type=widget_func_name, user_key=user_key)
 
 
-def _get_widget_id(
+def _compute_widget_id(
     element_type: str, element_proto: WidgetProto, user_key: Optional[str] = None
 ) -> str:
-    """Generate a widget id for the given widget.
+    """Compute the widget id for the given widget. This id is stable: a given
+    set of inputs to this function will always produce the same widget id output.
 
     The widget id includes the user_key so widgets with identical arguments can
     use it to be distinct.

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -200,7 +200,7 @@ def register_widget(
     return register_widget_from_metadata(metadata, ctx, widget_func_name, element_type)
 
 
-def user_key_from_widget_id(wid: str) -> Optional[str]:
+def user_key_from_widget_id(widget_id: str) -> Optional[str]:
     """Return the user key portion of a widget id, or None if the id does not
     have a user key.
 
@@ -208,7 +208,7 @@ def user_key_from_widget_id(wid: str) -> Optional[str]:
     "None" as a key, but we can't avoid this kind of problem while storing the
     string representation of the no-user-key sentinel as part of the widget id.
     """
-    user_key = wid.split("-", maxsplit=2)[-1]
+    user_key = widget_id.split("-", maxsplit=2)[-1]
     user_key = None if user_key == "None" else user_key
     return user_key
 

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -21,11 +21,6 @@ from typing_extensions import Final, TypeAlias
 from streamlit.errors import DuplicateWidgetID
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime.state.common import (
-    WidgetProto,
-    compute_widget_id,
-    user_key_from_widget_id,
-)
-from streamlit.runtime.state.session_state import (
     RegisterWidgetResult,
     T,
     WidgetArgs,
@@ -33,7 +28,10 @@ from streamlit.runtime.state.session_state import (
     WidgetDeserializer,
     WidgetKwargs,
     WidgetMetadata,
+    WidgetProto,
     WidgetSerializer,
+    compute_widget_id,
+    user_key_from_widget_id,
 )
 from streamlit.type_util import ValueFieldName
 

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -14,28 +14,11 @@
 
 import textwrap
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Dict, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Dict, Mapping, Optional
 
 from typing_extensions import Final, TypeAlias
 
 from streamlit.errors import DuplicateWidgetID
-from streamlit.proto.Arrow_pb2 import Arrow
-from streamlit.proto.Button_pb2 import Button
-from streamlit.proto.CameraInput_pb2 import CameraInput
-from streamlit.proto.Checkbox_pb2 import Checkbox
-from streamlit.proto.ColorPicker_pb2 import ColorPicker
-from streamlit.proto.Components_pb2 import ComponentInstance
-from streamlit.proto.DateInput_pb2 import DateInput
-from streamlit.proto.DownloadButton_pb2 import DownloadButton
-from streamlit.proto.FileUploader_pb2 import FileUploader
-from streamlit.proto.MultiSelect_pb2 import MultiSelect
-from streamlit.proto.NumberInput_pb2 import NumberInput
-from streamlit.proto.Radio_pb2 import Radio
-from streamlit.proto.Selectbox_pb2 import Selectbox
-from streamlit.proto.Slider_pb2 import Slider
-from streamlit.proto.TextArea_pb2 import TextArea
-from streamlit.proto.TextInput_pb2 import TextInput
-from streamlit.proto.TimeInput_pb2 import TimeInput
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime.state.session_state import (
     RegisterWidgetResult,
@@ -47,32 +30,15 @@ from streamlit.runtime.state.session_state import (
     WidgetMetadata,
     WidgetSerializer,
 )
-from streamlit.runtime.state.util import compute_widget_id, user_key_from_widget_id
+from streamlit.runtime.state.util import (
+    WidgetProto,
+    compute_widget_id,
+    user_key_from_widget_id,
+)
 from streamlit.type_util import ValueFieldName
 
 if TYPE_CHECKING:
     from streamlit.runtime.scriptrunner import ScriptRunContext
-
-# Protobuf types for all widgets.
-WidgetProto: TypeAlias = Union[
-    Arrow,
-    Button,
-    CameraInput,
-    Checkbox,
-    ColorPicker,
-    ComponentInstance,
-    DateInput,
-    DownloadButton,
-    FileUploader,
-    MultiSelect,
-    NumberInput,
-    Radio,
-    Selectbox,
-    Slider,
-    TextArea,
-    TextInput,
-    TimeInput,
-]
 
 ElementType: TypeAlias = str
 

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -35,8 +35,8 @@ from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
+from streamlit.runtime.state.common import user_key_from_widget_id
 from streamlit.runtime.state.session_state import SessionState
-from streamlit.runtime.state.widgets import user_key_from_widget_id
 
 
 # TODO This class serves as a fallback option for elements that have not

--- a/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
@@ -22,7 +22,7 @@ import pytest
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import SafeSessionState, SessionState, SessionStateProxy
-from streamlit.runtime.state.util import (
+from streamlit.runtime.state.common import (
     GENERATED_WIDGET_ID_PREFIX,
     require_valid_user_key,
 )

--- a/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_proxy_test.py
@@ -22,8 +22,8 @@ import pytest
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import SafeSessionState, SessionState, SessionStateProxy
-from streamlit.runtime.state.session_state import (
-    GENERATED_WIDGET_KEY_PREFIX,
+from streamlit.runtime.state.util import (
+    GENERATED_WIDGET_ID_PREFIX,
     require_valid_user_key,
 )
 
@@ -45,7 +45,7 @@ def _create_mock_session_state(
     MagicMock(return_value=_create_mock_session_state({"foo": "bar"})),
 )
 class SessionStateProxyTests(unittest.TestCase):
-    reserved_key = f"{GENERATED_WIDGET_KEY_PREFIX}-some_key"
+    reserved_key = f"{GENERATED_WIDGET_ID_PREFIX}-some_key"
 
     def setUp(self):
         self.session_state_proxy = SessionStateProxy()

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -698,10 +698,10 @@ def test_map_set_del_3837_regression():
     to conveniently use the hypothesis `example` decorator."""
 
     meta1 = stst.mock_metadata(
-        "   $$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None", 0
+        "   $$GENERATED_WIDGET_ID-e3e70682-c209-4cac-629f-6fbed82c07cd-None", 0
     )
     meta2 = stst.mock_metadata(
-        "$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", 0
+        "$$GENERATED_WIDGET_ID-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", 0
     )
     m = SessionState()
     m["0"] = 0

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -132,7 +132,7 @@ class WStateTests(unittest.TestCase):
     def test_values(self):
         assert self.wstates.values() == {"5", 5}
 
-    def test_cull_nonexistent(self):
+    def test_remove_stale_widgets(self):
         self.wstates.remove_stale_widgets({"widget_id_1"})
         assert "widget_id_1" in self.wstates
         assert "widget_id_2" not in self.wstates
@@ -608,7 +608,7 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state._new_widget_state.set_from_value("foo", "bar")
         assert not self.session_state._widget_changed("foo")
 
-    def test_cull_nonexistent(self):
+    def test_remove_stale_widgets(self):
         generated_widget_key = f"{GENERATED_WIDGET_KEY_PREFIX}-removed_widget"
 
         self.session_state._old_state = {

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -30,13 +30,13 @@ from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import SessionState, get_session_state
+from streamlit.runtime.state.common import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.state.session_state import (
     Serialized,
     Value,
     WidgetMetadata,
     WStates,
 )
-from streamlit.runtime.state.util import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.testing.script_interactions import InteractiveScriptTests
 from tests.delta_generator_test_case import DeltaGeneratorTestCase

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -133,7 +133,7 @@ class WStateTests(unittest.TestCase):
         assert self.wstates.values() == {"5", 5}
 
     def test_cull_nonexistent(self):
-        self.wstates.cull_nonexistent({"widget_id_1"})
+        self.wstates.remove_stale_widgets({"widget_id_1"})
         assert "widget_id_1" in self.wstates
         assert "widget_id_2" not in self.wstates
 
@@ -620,7 +620,7 @@ class SessionStateMethodTests(unittest.TestCase):
         wstates = WStates()
         self.session_state._new_widget_state = wstates
 
-        self.session_state._cull_nonexistent({"existing_widget"})
+        self.session_state._remove_stale_widgets({"existing_widget"})
 
         assert self.session_state["existing_widget"] == True
         assert generated_widget_key not in self.session_state

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -31,12 +31,12 @@ from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import SessionState, get_session_state
 from streamlit.runtime.state.session_state import (
-    GENERATED_WIDGET_KEY_PREFIX,
     Serialized,
     Value,
     WidgetMetadata,
     WStates,
 )
+from streamlit.runtime.state.util import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from streamlit.testing.script_interactions import InteractiveScriptTests
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -500,7 +500,7 @@ class SessionStateMethodTests(unittest.TestCase):
         new_widget_state = WStates(
             {
                 "baz": Value("qux2"),
-                f"{GENERATED_WIDGET_KEY_PREFIX}-foo-None": Value("bar"),
+                f"{GENERATED_WIDGET_ID_PREFIX}-foo-None": Value("bar"),
             },
         )
         self.session_state = SessionState(
@@ -513,14 +513,14 @@ class SessionStateMethodTests(unittest.TestCase):
             "foo": "bar2",
             "baz": "qux2",
             "corge": "grault",
-            f"{GENERATED_WIDGET_KEY_PREFIX}-foo-None": "bar",
+            f"{GENERATED_WIDGET_ID_PREFIX}-foo-None": "bar",
         }
         assert self.session_state._new_session_state == {}
         assert self.session_state._new_widget_state == WStates()
 
     def test_clear_state(self):
         # Sanity test
-        keys = {"foo", "baz", "corge", f"{GENERATED_WIDGET_KEY_PREFIX}-foo-None"}
+        keys = {"foo", "baz", "corge", f"{GENERATED_WIDGET_ID_PREFIX}-foo-None"}
         self.assertEqual(keys, self.session_state._keys())
 
         # Clear state
@@ -540,7 +540,7 @@ class SessionStateMethodTests(unittest.TestCase):
         old_state = {"foo": "bar", "corge": "grault"}
         new_session_state = {}
         new_widget_state = WStates(
-            {f"{GENERATED_WIDGET_KEY_PREFIX}-baz": Serialized(WidgetStateProto())},
+            {f"{GENERATED_WIDGET_ID_PREFIX}-baz": Serialized(WidgetStateProto())},
         )
         self.session_state = SessionState(
             old_state, new_session_state, new_widget_state
@@ -609,7 +609,7 @@ class SessionStateMethodTests(unittest.TestCase):
         assert not self.session_state._widget_changed("foo")
 
     def test_remove_stale_widgets(self):
-        generated_widget_key = f"{GENERATED_WIDGET_KEY_PREFIX}-removed_widget"
+        generated_widget_key = f"{GENERATED_WIDGET_ID_PREFIX}-removed_widget"
 
         self.session_state._old_state = {
             "existing_widget": True,
@@ -635,7 +635,7 @@ class SessionStateMethodTests(unittest.TestCase):
         WIDGET_VALUE = 123
 
         metadata = WidgetMetadata(
-            id=f"{GENERATED_WIDGET_KEY_PREFIX}-0-widget_id_1",
+            id=f"{GENERATED_WIDGET_ID_PREFIX}-0-widget_id_1",
             deserializer=lambda _, __: WIDGET_VALUE,
             serializer=identity,
             value_type="int_value",
@@ -698,7 +698,7 @@ def test_map_set_del_3837_regression():
     to conveniently use the hypothesis `example` decorator."""
 
     meta1 = stst.mock_metadata(
-        "$$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None", 0
+        "   $$GENERATED_WIDGET_KEY-e3e70682-c209-4cac-629f-6fbed82c07cd-None", 0
     )
     meta2 = stst.mock_metadata(
         "$$GENERATED_WIDGET_KEY-f728b4fa-4248-5e3a-0a5d-2f346baa9455-0", 0

--- a/lib/tests/streamlit/runtime/state/strategies.py
+++ b/lib/tests/streamlit/runtime/state/strategies.py
@@ -14,8 +14,8 @@
 
 from hypothesis import strategies as hst
 
+from streamlit.runtime.state.common import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.state.session_state import SessionState, WidgetMetadata
-from streamlit.runtime.state.util import GENERATED_WIDGET_ID_PREFIX
 
 ASCII = list("abcdefghijklmnopqrstuvwxyz0123456789_-")
 

--- a/lib/tests/streamlit/runtime/state/strategies.py
+++ b/lib/tests/streamlit/runtime/state/strategies.py
@@ -14,11 +14,8 @@
 
 from hypothesis import strategies as hst
 
-from streamlit.runtime.state.session_state import (
-    GENERATED_WIDGET_KEY_PREFIX,
-    SessionState,
-    WidgetMetadata,
-)
+from streamlit.runtime.state.session_state import SessionState, WidgetMetadata
+from streamlit.runtime.state.util import GENERATED_WIDGET_ID_PREFIX
 
 ASCII = list("abcdefghijklmnopqrstuvwxyz0123456789_-")
 
@@ -26,13 +23,11 @@ USER_KEY = hst.one_of(hst.text(alphabet=ASCII, min_size=1), hst.integers().map(s
 
 NEW_SESSION_STATE = hst.dictionaries(keys=USER_KEY, values=hst.integers())
 
-UNKEYED_WIDGET_IDS = hst.uuids().map(
-    lambda s: f"{GENERATED_WIDGET_KEY_PREFIX}-{s}-None"
-)
+UNKEYED_WIDGET_IDS = hst.uuids().map(lambda s: f"{GENERATED_WIDGET_ID_PREFIX}-{s}-None")
 
 
 def as_keyed_widget_id(raw_wid, key):
-    return f"{GENERATED_WIDGET_KEY_PREFIX}-{raw_wid}-{key}"
+    return f"{GENERATED_WIDGET_ID_PREFIX}-{raw_wid}-{key}"
 
 
 def mock_metadata(widget_id: str, default_value: int) -> WidgetMetadata:

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -17,7 +17,6 @@
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-import pytest
 from parameterized import parameterized
 
 import streamlit as st
@@ -26,11 +25,8 @@ from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import coalesce_widget_states
-from streamlit.runtime.state.session_state import (
-    GENERATED_WIDGET_KEY_PREFIX,
-    SessionState,
-    WidgetMetadata,
-)
+from streamlit.runtime.state.session_state import SessionState, WidgetMetadata
+from streamlit.runtime.state.util import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.state.widgets import compute_widget_id, user_key_from_widget_id
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -244,7 +240,7 @@ class WidgetHelperTests(unittest.TestCase):
         button_proto.label = "the label"
         self.assertTrue(
             compute_widget_id("button", button_proto).startswith(
-                GENERATED_WIDGET_KEY_PREFIX
+                GENERATED_WIDGET_ID_PREFIX
             )
         )
 

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -25,8 +25,8 @@ from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import coalesce_widget_states
+from streamlit.runtime.state.common import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.state.session_state import SessionState, WidgetMetadata
-from streamlit.runtime.state.util import GENERATED_WIDGET_ID_PREFIX
 from streamlit.runtime.state.widgets import compute_widget_id, user_key_from_widget_id
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -31,7 +31,7 @@ from streamlit.runtime.state.session_state import (
     SessionState,
     WidgetMetadata,
 )
-from streamlit.runtime.state.widgets import _get_widget_id, user_key_from_widget_id
+from streamlit.runtime.state.widgets import _compute_widget_id, user_key_from_widget_id
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -243,7 +243,7 @@ class WidgetHelperTests(unittest.TestCase):
         button_proto = ButtonProto()
         button_proto.label = "the label"
         self.assertTrue(
-            _get_widget_id("button", button_proto).startswith(
+            _compute_widget_id("button", button_proto).startswith(
                 GENERATED_WIDGET_KEY_PREFIX
             )
         )

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -31,7 +31,7 @@ from streamlit.runtime.state.session_state import (
     SessionState,
     WidgetMetadata,
 )
-from streamlit.runtime.state.widgets import _compute_widget_id, user_key_from_widget_id
+from streamlit.runtime.state.widgets import compute_widget_id, user_key_from_widget_id
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -243,7 +243,7 @@ class WidgetHelperTests(unittest.TestCase):
         button_proto = ButtonProto()
         button_proto.label = "the label"
         self.assertTrue(
-            _compute_widget_id("button", button_proto).startswith(
+            compute_widget_id("button", button_proto).startswith(
                 GENERATED_WIDGET_KEY_PREFIX
             )
         )


### PR DESCRIPTION
Minor `streamlit.runtime.state` refactor:

- There are a number of functions and types declared in `session_state.py` and shared between `session_state.py` and `widgets.py`. These are now moved to a new `common.py` module, so that we can avoid sibling modules importing from each other.
- This also means that all functions that create, inspect, and validate widget_id values are now in the same source file. (This was the original motivation for the refactor.)
- Renamed our `cull_nonexistent` functions, for removing stale widgets, to `remove_stale_widgets`
- Renamed `get_widget_id` -> `compute_widget_id`
- Renamed `GENERATED_WIDGET_KEY_PREFIX` -> `GENERATED_WIDGET_ID_PREFIX`, for consistency