### PR TITLE
Fix StreamlitDialog "Clear Cache" description

### DIFF
--- a/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/StreamlitDialog.tsx
@@ -220,8 +220,8 @@ function clearCacheDialog(props: ClearCacheProps): ReactElement {
             </div>
             <div>
               This will remove all cached entries from functions using{" "}
-              <code>@st.cache</code>, <code>@st.experimental_memo</code>, and{" "}
-              <code>@st.experimental_singleton</code>.
+              <code>@st.cache</code>, <code>@st.cache_data</code>, and{" "}
+              <code>@st.cache_resource</code>.
             </div>
           </ModalBody>
           <ModalFooter>


### PR DESCRIPTION
The "Clear Cache" confirm dialog now refers to "cache_data/resource" instead of "experimental_memo/singleton"