### PR TITLE
Allow full screen button to show for dataframes, charts, etc in expander

### DIFF
--- a/frontend/src/hocs/withExpandable/styled-components.ts
+++ b/frontend/src/hocs/withExpandable/styled-components.ts
@@ -28,6 +28,7 @@ export const StyledExpandableContainer = styled.div(({ theme }) => ({
       textAlign: "center",
       paddingBottom: theme.spacing.lg,
       paddingTop: theme.spacing.lg,
+      overflow: "visible",
 
       "&:before": {
         content: '"empty"',

--- a/frontend/src/hocs/withExpandable/styled-components.ts
+++ b/frontend/src/hocs/withExpandable/styled-components.ts
@@ -28,7 +28,6 @@ export const StyledExpandableContainer = styled.div(({ theme }) => ({
       textAlign: "center",
       paddingBottom: theme.spacing.lg,
       paddingTop: theme.spacing.lg,
-      overflow: "visible",
 
       "&:before": {
         content: '"empty"',

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -80,6 +80,7 @@ function withExpandable(
                 marginRight: spacing.none,
                 marginTop: spacing.none,
                 marginBottom: spacing.none,
+                overflow: "visible",
                 paddingLeft: spacing.lg,
                 paddingRight: spacing.lg,
                 paddingTop: 0,
@@ -88,7 +89,6 @@ function withExpandable(
                 borderBottomStyle: "none",
                 borderRightStyle: "none",
                 borderLeftStyle: "none",
-                overflow: "visible",
               }),
               props: { className: "streamlit-expanderContent" },
             },
@@ -182,7 +182,6 @@ function withExpandable(
                 allowHTML={false}
                 isLabel
                 isExpander
-                style={{ overflow: "visible" }}
               />
             }
             key="panel"

--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -80,7 +80,6 @@ function withExpandable(
                 marginRight: spacing.none,
                 marginTop: spacing.none,
                 marginBottom: spacing.none,
-                overflow: "visible",
                 paddingLeft: spacing.lg,
                 paddingRight: spacing.lg,
                 paddingTop: 0,
@@ -89,8 +88,15 @@ function withExpandable(
                 borderBottomStyle: "none",
                 borderRightStyle: "none",
                 borderLeftStyle: "none",
+                overflow: "visible",
               }),
               props: { className: "streamlit-expanderContent" },
+            },
+            // allow fullscreen button to show
+            ContentAnimationContainer: {
+              style: {
+                overflow: "visible",
+              },
             },
             PanelContainer: {
               style: () => ({
@@ -176,6 +182,7 @@ function withExpandable(
                 allowHTML={false}
                 isLabel
                 isExpander
+                style={{ overflow: "visible" }}
               />
             }
             key="panel"


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
https://github.com/streamlit/streamlit/issues/5694
_Please describe the project or issue background here_
Fullscreen button can't be found because the overflow is hidden so just setting the parent div to overflow: visible will solve this.
Solution was found by: @LukasMasuch 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes
- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**
_Insert screenshot of your updated UI/code here_
![Screenshot 2023-02-08 at 11 07 47 AM](https://user-images.githubusercontent.com/16749069/217629584-a6ce8b9e-ec64-4dab-b338-97b513c9af69.png)


**Current:**
![Screenshot 2023-02-08 at 11 16 51 AM](https://user-images.githubusercontent.com/16749069/217629763-439d27a2-2548-4d30-8540-6ee4ffea632f.png)

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #5694 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
