### PR TITLE
Check availability of local storage to prevent exceptions

### DIFF
--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -23,6 +23,7 @@ import Icon from "src/components/shared/Icon"
 import Button, { Kind } from "src/components/shared/Button"
 import { IAppPage, PageConfig } from "src/autogen/proto"
 import { Theme } from "src/theme"
+import { localStorageAvailable } from "src/lib/storageUtils"
 
 import {
   StyledSidebar,
@@ -74,10 +75,14 @@ class Sidebar extends PureComponent<SidebarProps, State> {
     this.mediumBreakpointPx = Sidebar.calculateMaxBreakpoint(
       props.theme.breakpoints.md
     )
+
+    const cachedSidebarWidth = localStorageAvailable()
+      ? localStorage.getItem("sidebarWidth")
+      : undefined
+
     this.state = {
       collapsedSidebar: Sidebar.shouldCollapse(props, this.mediumBreakpointPx),
-      sidebarWidth:
-        window.localStorage.getItem("sidebarWidth") || Sidebar.minWidth,
+      sidebarWidth: cachedSidebarWidth || Sidebar.minWidth,
       lastInnerWidth: window ? window.innerWidth : Infinity,
       hideScrollbar: false,
     }
@@ -145,14 +150,19 @@ class Sidebar extends PureComponent<SidebarProps, State> {
     const newWidth = width.toString()
 
     this.setState({ sidebarWidth: newWidth })
-    window.localStorage.setItem("sidebarWidth", newWidth)
+
+    if (localStorageAvailable()) {
+      window.localStorage.setItem("sidebarWidth", newWidth)
+    }
   }
 
   resetSidebarWidth = (event: any): void => {
     // Double clicking on the resize handle resets sidebar to default width
     if (event.detail === 2) {
       this.setState({ sidebarWidth: Sidebar.minWidth })
-      window.localStorage.setItem("sidebarWidth", Sidebar.minWidth)
+      if (localStorageAvailable()) {
+        window.localStorage.setItem("sidebarWidth", Sidebar.minWidth)
+      }
     }
   }
 

--- a/frontend/src/lib/storageUtils.test.ts
+++ b/frontend/src/lib/storageUtils.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { localStorageAvailable } from "./storageUtils"
+
+describe("localStorageAvailable", () => {
+  // NOTE: localStorage is weird, and calling .spyOn(window.localStorage, "setItem")
+  // doesn't work. Accessing .__proto__ here isn't too bad of a crime since
+  // it's test code.
+  const breakLocalStorage = (): void => {
+    jest
+      // eslint-disable-next-line no-proto
+      .spyOn(window.localStorage.__proto__, "setItem")
+      .mockImplementation(() => {
+        throw new Error("boom")
+      })
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("returns false if a localStorage function explodes", () => {
+    breakLocalStorage()
+    expect(localStorageAvailable()).toBe(false)
+  })
+
+  it("returns true if all localStorage functions work", () => {
+    expect(localStorageAvailable()).toBe(true)
+  })
+})

--- a/frontend/src/lib/storageUtils.ts
+++ b/frontend/src/lib/storageUtils.ts
@@ -25,3 +25,19 @@ export const LocalStore = {
 
   ACTIVE_THEME: `${CACHED_THEME_BASE_KEY}-v${CACHED_THEME_VERSION}`,
 }
+
+// Method taken from
+// https://stackoverflow.com/questions/16427636/check-if-localstorage-is-available
+export const localStorageAvailable = (): boolean => {
+  const testData = "testData"
+
+  try {
+    const { localStorage } = window
+    localStorage.setItem(testData, testData)
+    localStorage.getItem(testData)
+    localStorage.removeItem(testData)
+  } catch (e) {
+    return false
+  }
+  return true
+}

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -34,7 +34,6 @@ import {
   isColor,
   isPresetTheme,
   toThemeInput,
-  localStorageAvailable,
   getCachedTheme,
   removeCachedTheme,
   setCachedTheme,
@@ -102,17 +101,6 @@ describe("Cached theme helpers", () => {
   afterEach(() => {
     jest.restoreAllMocks()
     window.localStorage.clear()
-  })
-
-  describe("localStorageAvailable", () => {
-    it("returns false if a localStorage function explodes", () => {
-      breakLocalStorage()
-      expect(localStorageAvailable()).toBe(false)
-    })
-
-    it("returns true if all localStorage functions work", () => {
-      expect(localStorageAvailable()).toBe(true)
-    })
   })
 
   describe("getCachedTheme", () => {

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -27,7 +27,7 @@ import merge from "lodash/merge"
 
 import { CustomThemeConfig, ICustomThemeConfig } from "src/autogen/proto"
 import { logError } from "src/lib/log"
-import { LocalStore } from "src/lib/storageUtils"
+import { LocalStore, localStorageAvailable } from "src/lib/storageUtils"
 import {
   baseTheme,
   CachedTheme,
@@ -39,6 +39,7 @@ import {
   ThemeConfig,
   ThemeSpacing,
 } from "src/theme"
+
 import { fonts } from "./primitives/typography"
 
 export const AUTO_THEME_NAME = "Use system setting"
@@ -511,22 +512,6 @@ export const getSystemTheme = (): ThemeConfig => {
     window.matchMedia("(prefers-color-scheme: dark)").matches
     ? darkTheme
     : lightTheme
-}
-
-// Method taken from
-// https://stackoverflow.com/questions/16427636/check-if-localstorage-is-available
-export const localStorageAvailable = (): boolean => {
-  const testData = "testData"
-
-  try {
-    const { localStorage } = window
-    localStorage.setItem(testData, testData)
-    localStorage.getItem(testData)
-    localStorage.removeItem(testData)
-  } catch (e) {
-    return false
-  }
-  return true
 }
 
 export const getCachedTheme = (): ThemeConfig | null => {


### PR DESCRIPTION
## 📚 Context

As stated in https://github.com/streamlit/streamlit/issues/6087, iframe embedded Streamlit apps might break in Chrome with third party cookie blocking setting.

The main problem is that we are accessing the localStorage for `sidebarWidth` without properly checking the availability of localStorage.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Move `localStorageAvailable` method to `storageUtils`  
- Check availability for localStorage before caching the current sidebar width (the caching here is more of an optional feature anyways).

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6087

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
