### PR TITLE
Improve logging when arrow serialization fails

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -759,8 +759,9 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
         table = pa.Table.from_pandas(df)
     except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
         _LOGGER.info(
+            "Serialization of dataframe to Arrow table was unsuccessful due to: %s. "
             "Applying automatic fixes for column types to make the dataframe Arrow-compatible.",
-            exc_info=ex,
+            ex,
         )
         df = fix_arrow_incompatible_column_types(df)
         table = pa.Table.from_pandas(df)


### PR DESCRIPTION
## 📚 Context

We currently print out the full stack trace as an info log when the Arrow serialization fails. This was added  #6022 as debugging help during development but isn't that useful for the users. This PR removes the stack trace and only shows the Arrow exception message.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
