### PR TITLE
Add editing support for numeric index types

### DIFF
--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -51,7 +51,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
-from streamlit.type_util import DataFormat, DataFrameGenericAlias, Key, to_key
+from streamlit.type_util import DataFormat, DataFrameGenericAlias, Key, is_type, to_key
 
 if TYPE_CHECKING:
     import numpy as np
@@ -564,12 +564,18 @@ class DataEditorMixin:
         data_df = type_util.convert_anything_to_df(data, ensure_copy=True)
 
         # Check if the index is supported.
-        # Theoretically, we could also support Int64Index and Float64Index here,
-        # but those indices are deprecated and will be removed in the future.
-        if type(data_df.index) not in [
-            pd.RangeIndex,
-            pd.Index,
-        ]:
+        if not (
+            type(data_df.index)
+            in [
+                pd.RangeIndex,
+                pd.Index,
+            ]
+            # We need to check these index types without importing, since they are deprecated
+            # and planned to be removed soon.
+            or is_type(data_df.index, "pandas.core.indexes.numeric.Int64Index")
+            or is_type(data_df.index, "pandas.core.indexes.numeric.Float64Index")
+            or is_type(data_df.index, "pandas.core.indexes.numeric.UInt64Index")
+        ):
             raise StreamlitAPIException(
                 f"The type of the dataframe index - {type(data_df.index).__name__} - is not "
                 "yet supported by the data editor."

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -371,8 +371,6 @@ class DataEditorTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (pd.CategoricalIndex(["a", "b", "c"]),),
-            (pd.Int64Index([1, 2, 3]),),
-            (pd.Float64Index([1.0, 2.0, 3.0]),),
             (pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"]),),
             (pd.PeriodIndex(["2020-01-01", "2020-01-02", "2020-01-03"], freq="D"),),
             (pd.TimedeltaIndex(["1 day", "2 days", "3 days"]),),
@@ -392,3 +390,26 @@ class DataEditorTest(DeltaGeneratorTestCase):
 
         with self.assertRaises(StreamlitAPIException):
             st.experimental_data_editor(df)
+
+    @parameterized.expand(
+        [
+            (pd.RangeIndex(0, 3, 1),),
+            (pd.Int64Index([1, 2, -3]),),
+            (pd.UInt64Index([1, 2, 3]),),
+            (pd.Float64Index([1.0, 2.0, 3.0]),),
+            (pd.Index(["a", "b", "c"]),),
+        ]
+    )
+    def test_with_supported_index(self, index: pd.Index):
+        """Test that supported indices raise no exceptions."""
+        df = pd.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [True, False, True],
+            }
+        )
+        df.set_index(index, inplace=True)
+        # This should run without an issue and return a valid dataframe
+        return_df = st.experimental_data_editor(df)
+        self.assertIsInstance(return_df, pd.DataFrame)


### PR DESCRIPTION
## 📚 Context

The current implementation does not allow the deprecated numeric index types in Pandas: `Int64Index`, `Float64Index` and  `UInt64Index`. Even so, they are deprecated, there isn't any specific reason why we should not support them when used with older Pandas versions.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Allow numeric indices as well. We need to check based on the string type name, since they are planned to be removed from pandas in future versions. This would potentially break if we do an instance check.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
