### PR TITLE
Pin unixodbc version to fix CI pipeline

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -35,7 +35,7 @@ runs:
         sudo apt update
         # protobuf, pyodbc, dot, & graphviz dependencies
         sudo apt install -y gnupg \
-            unixodbc-dev \
+            unixodbc-dev=2.3.9-5 \
             graphviz \
             libgvc6 \
             protobuf-compiler


### PR DESCRIPTION
## 📚 Context

The CI pipeline is broken because it tries to install a newer version of `unixodbc-dev` (2.3.11). It fails to update the old version that already exists in the container (`2.3.9-5`).

![image](https://user-images.githubusercontent.com/2852129/218763629-37b837ea-9a71-4221-91c4-bea451ac2a07.png)

![image](https://user-images.githubusercontent.com/2852129/218763689-a831e43b-5124-4253-8c9c-538cc50d5111.png)

![image](https://user-images.githubusercontent.com/2852129/218763766-e1a7f351-1d03-4a28-a868-f9bb2f5c0853.png)

![image](https://user-images.githubusercontent.com/2852129/218763736-35f730f2-c322-406d-b411-aa3151c47192.png)

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- As a quick fix, we pin the `unixodbc-dev` dependency to the old version. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
