### PR TITLE
Fix detecting arrow df as widget when not editable

### DIFF
--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -281,9 +281,8 @@ class CachedMessageReplayContext(threading.local):
         if not runtime.exists():
             return
         if len(self._cached_message_stack) >= 1:
-
             id_to_save = self.select_dg_to_save(invoked_dg_id, used_dg_id)
-            if isinstance(element_proto, Widget):
+            if isinstance(element_proto, Widget) and element_proto.id:
                 wid = element_proto.id
                 # TODO replace `Message` with a more precise type
                 if not self._registered_metadata:

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -282,6 +282,9 @@ class CachedMessageReplayContext(threading.local):
             return
         if len(self._cached_message_stack) >= 1:
             id_to_save = self.select_dg_to_save(invoked_dg_id, used_dg_id)
+            # Arrow dataframes have an ID but only set it when used as data editor
+            # widgets, so we have to check that the ID has been actually set to
+            # know if an element is a widget.
             if isinstance(element_proto, Widget) and element_proto.id:
                 wid = element_proto.id
                 # TODO replace `Message` with a more precise type

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -971,7 +971,7 @@ class WidgetReplayInteractionTest(InteractiveScriptTests):
 
 class WidgetReplayTest(InteractiveScriptTests):
     def test_arrow_replay(self):
-        """Regression test for GH#6103"""
+        """Regression test for https://github.com/streamlit/streamlit/issues/6103"""
         script = self.script_from_filename(__file__, "arrow_replay.py")
 
         sr = script.run()

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -967,3 +967,12 @@ class WidgetReplayInteractionTest(InteractiveScriptTests):
         sr4 = sr3.get("checkbox")[0].uncheck().run()
         sr5 = sr4.get("button")[0].click().run()
         assert sr5.get("text")[0].value == "['foo']"
+
+
+class WidgetReplayTest(InteractiveScriptTests):
+    def test_arrow_replay(self):
+        """Regression test for GH#6103"""
+        script = self.script_from_filename(__file__, "arrow_replay.py")
+
+        sr = script.run()
+        assert len(sr.get("exception")) == 0

--- a/lib/tests/streamlit/runtime/caching/test_data/arrow_replay.py
+++ b/lib/tests/streamlit/runtime/caching/test_data/arrow_replay.py
@@ -1,0 +1,32 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A small script that reproduces the bug from #6103"""
+
+import pandas as pd
+
+import streamlit as st
+
+df = pd.DataFrame(
+    {"col1": [1, 2, 3, 4], "col2": ["pino", "gino", "lucullo", "augusto"]}
+)
+
+st.write(df)
+
+
+@st.cache_resource
+def stampa_df(df_param: pd.DataFrame) -> None:
+    st.write(df_param)
+
+
+stampa_df(df)


### PR DESCRIPTION
The data editor introduced a new kind of state for an element, being a widget only conditionally. Element replay code relied on the presence of an id field in the protobuf for determining what is a widget, but arrow dfs don't act like a widget, and don't call `register_widget`, unless used with the data editor. In this situation, the id isn't actually set on the protobuf, so we can use it being set for our widget detection.

Fixes #6103


## 📚 Context

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: #6103 
