### PR TITLE
cache_errors: don't refer to experimental_memo|singleton

### DIFF
--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -23,14 +23,13 @@ from streamlit.runtime.caching.cache_data_api import (
     CacheDataAPI,
     _data_caches,
 )
+from streamlit.runtime.caching.cache_errors import CACHE_DOCS_URL as CACHE_DOCS_URL
 from streamlit.runtime.caching.cache_resource_api import (
     CACHE_RESOURCE_MESSAGE_REPLAY_CTX,
     CacheResourceAPI,
     _resource_caches,
 )
 from streamlit.runtime.state.common import WidgetMetadata
-
-CACHE_DOCS_URL = "https://docs.streamlit.io/library/advanced-features/caching"
 
 
 def save_element_message(

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -23,6 +23,8 @@ from streamlit.errors import (
 )
 from streamlit.runtime.caching.cache_type import CacheType, get_decorator_api_name
 
+CACHE_DOCS_URL = "https://docs.streamlit.io/library/advanced-features/caching"
+
 
 def get_cached_func_name_md(func: Any) -> str:
     """Get markdown representation of the function name."""
@@ -161,10 +163,10 @@ class UnserializableReturnValueError(MarkdownFormattedException):
             self,
             f"""
             Cannot serialize the return value (of type {get_return_value_type(return_value)}) in {get_cached_func_name_md(func)}.
-            `st.experimental_memo` uses [pickle](https://docs.python.org/3/library/pickle.html) to
+            `st.cache_data` uses [pickle](https://docs.python.org/3/library/pickle.html) to
             serialize the function’s return value and safely store it in the cache without mutating the original object. Please convert the return value to a pickle-serializable type.
             If you want to cache unserializable objects such as database connections or Tensorflow
-            sessions, use `st.experimental_singleton` instead (see [our docs](https://docs.streamlit.io/library/advanced-features/experimental-cache-primitives) for differences).""",
+            sessions, use `st.cache_resource` instead (see [our docs]({CACHE_DOCS_URL}) for differences).""",
         )
 
 

--- a/lib/tests/streamlit/runtime/caching/cache_errors_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_errors_test.py
@@ -94,10 +94,10 @@ def unhashable_type_func(_lock, ...):
 
         expected_message = f"""
             Cannot serialize the return value (of type {get_return_value_type(return_value=threading.Lock())}) in `unserializable_return_value_func()`.
-            `st.experimental_memo` uses [pickle](https://docs.python.org/3/library/pickle.html) to
+            `st.cache_data` uses [pickle](https://docs.python.org/3/library/pickle.html) to
             serialize the function’s return value and safely store it in the cache without mutating the original object. Please convert the return value to a pickle-serializable type.
             If you want to cache unserializable objects such as database connections or Tensorflow
-            sessions, use `st.experimental_singleton` instead (see [our docs](https://docs.streamlit.io/library/advanced-features/experimental-cache-primitives) for differences)."""
+            sessions, use `st.cache_resource` instead (see [our docs](https://docs.streamlit.io/library/advanced-features/caching) for differences)."""
 
         self.assertEqual(
             testutil.normalize_md(expected_message), testutil.normalize_md(ep.message)


### PR DESCRIPTION
Our `UnserializableReturnValueError` cache error currently refers to our old cache decorator names (`@st.experimental_memo|singleton`), and our old experimental cache decorator docs. This PR updates the error text to refer to the new decorators and the new cache docs.