### PR TITLE
Embed `st.experimental_data_editor` apps in docstring

### DIFF
--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -531,6 +531,10 @@ class DataEditorMixin:
         >>> favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
         >>> st.markdown(f"Your favorite command is **{favorite_command}** 🎈")
 
+        .. output::
+           https://doc-data-editor.streamlit.app/
+           height: 350px
+
         You can also allow the user to add and delete rows by setting `num_rows` to "dynamic":
 
         >>> import streamlit as st
@@ -547,6 +551,10 @@ class DataEditorMixin:
         >>>
         >>> favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
         >>> st.markdown(f"Your favorite command is **{favorite_command}** 🎈")
+
+        .. output::
+           https://doc-data-editor1.streamlit.app/
+           height: 450px
 
         """
 

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -535,7 +535,7 @@ class DataEditorMixin:
            https://doc-data-editor.streamlit.app/
            height: 350px
 
-        You can also allow the user to add and delete rows by setting `num_rows` to "dynamic":
+        You can also allow the user to add and delete rows by setting ``num_rows`` to "dynamic":
 
         >>> import streamlit as st
         >>> import pandas as pd


### PR DESCRIPTION
## 📚 Context

Version 1.19.0 will include the release of a new `st.experimental_data_editor` command. We need to embed two apps to accompany the two examples in the docstring.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Embeds two apps to accompany the two examples in the `st.experimental_data_editor` docstring. These apps were added to the docs repo by https://github.com/streamlit/docs/pull/594 and will render in the docs as shown in the below screenshots.
- Note to reviewers: this PR neither adds nor updates any tests as the changes are merely refactoring the docstring.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

<details><summary><h3>View revised screenshots<h3></summary>

![image](https://user-images.githubusercontent.com/20672874/219397166-b89b59d4-54c1-4199-968d-9a4e6e305846.png)
![image](https://user-images.githubusercontent.com/20672874/219397296-2a3218dd-3d44-4c28-a963-e9f7e536d31d.png)

</details>

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
