### PR TITLE
Fix expander overflow during animation

### DIFF
--- a/frontend/src/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.tsx
@@ -92,11 +92,11 @@ function withExpandable(
               }),
               props: { className: "streamlit-expanderContent" },
             },
-            // allow fullscreen button to show
+            // Allow fullscreen button to overflow the expander
             ContentAnimationContainer: {
-              style: {
-                overflow: "visible",
-              },
+              style: ({ $expanded }: SharedStylePropsArg) => ({
+                overflow: $expanded ? "visible" : "hidden",
+              }),
             },
             PanelContainer: {
               style: () => ({


### PR DESCRIPTION
## 📚 Context

https://github.com/streamlit/streamlit/pull/6083 introduced small change to the animation of the expander. This PR adds a fix, so the expander behaves as in previous versions.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Only show overflow if the state is `expanded` 

**Revised:**

https://user-images.githubusercontent.com/2852129/219681158-82c2b83d-717c-4dc7-831f-c76b614548a5.mov

**Current:**

https://user-images.githubusercontent.com/2852129/219681106-6496839d-1be1-4cac-8080-95e59853668b.mov

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
