### PR TITLE
Add ability to turn off anchors

### DIFF
--- a/e2e/scripts/st_heading.py
+++ b/e2e/scripts/st_heading.py
@@ -16,15 +16,17 @@ import streamlit as st
 
 st.header("This header is awesome!")
 st.header("This header is awesome too!", anchor="awesome-header")
+st.header("This header with hidden anchor is awesome tooooo!", anchor=False)
 
 st.title("`Code` - Title without Anchor")
 st.title("`Code` - Title with Anchor", anchor="title")
-
+st.title("`Code` - Title with hidden Anchor", anchor=False)
 
 st.subheader("`Code` - Subheader without Anchor")
 st.subheader(
     """`Code` - Subheader with Anchor [test_link](href)""",
     anchor="subheader",
 )
+st.subheader("`Code` - Subheader with hidden Anchor", anchor=False)
 
 st.title("a [link]()")

--- a/e2e/specs/st_heading.spec.js
+++ b/e2e/specs/st_heading.spec.js
@@ -20,28 +20,35 @@ describe("st.header", () => {
   });
 
   it("displays correct number of header elements", () => {
-    cy.get(".element-container .stMarkdown h2").should("have.length", 2);
+    cy.get(".element-container .stMarkdown h2").should("have.length", 3);
   });
 
   it("displays correct number of title elements", () => {
-    cy.get(".element-container .stMarkdown h1").should("have.length", 3);
+    cy.get(".element-container .stMarkdown h1").should("have.length", 4);
   });
 
   it("displays correct number of subheader elements", () => {
-    cy.get(".element-container .stMarkdown h3").should("have.length", 2);
+    cy.get(".element-container .stMarkdown h3").should("have.length", 3);
   });
 
   it("displays a header", () => {
     cy.get(".element-container .stMarkdown h2").then(els => {
       expect(els[0].textContent).to.eq("This header is awesome!");
       expect(els[1].textContent).to.eq("This header is awesome too!");
+      expect(els[2].textContent).to.eq("This header with hidden anchor is awesome tooooo!");
     });
   });
 
-  it("displays headers with anchors", () => {
+  it("displays headers with anchors and style icons", () => {
     cy.get(".element-container .stMarkdown h2").then(els => {
       cy.wrap(els[0]).should("have.attr", "id", "this-header-is-awesome");
+      cy.wrap(els[0]).find("svg").should('exist');
+
       cy.wrap(els[1]).should("have.attr", "id", "awesome-header");
+      cy.wrap(els[1]).find("svg").should('exist');
+
+      cy.wrap(els[2]).should("have.attr", "id", "this-header-with-hidden-anchor-is-awesome-tooooo");
+      cy.wrap(els[2]).find("svg").should('not.exist');
     });
   });
 
@@ -54,7 +61,7 @@ describe("st.header", () => {
 
   it("should display links correctly", () => {
     cy
-      .getIndexed(".element-container .stMarkdown h1", 2)
+      .getIndexed(".element-container .stMarkdown h1", 3)
       .matchThemedSnapshots("heading_link");
   })
 });

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -320,6 +320,18 @@ describe("Heading", () => {
     expect(wrapper.find("StyledStreamlitMarkdown")).toHaveLength(1)
   })
 
+  it("renders anchor link", () => {
+    const props = getHeadingProps({ body: "hello" })
+    const wrapper = mount(<Heading {...props} />)
+    expect(wrapper.find("StyledLinkIcon")).toHaveLength(1)
+  })
+
+  it("does not renders anchor link when it is hidden", () => {
+    const props = getHeadingProps({ body: "hello", hideAnchor: true })
+    const wrapper = mount(<Heading {...props} />)
+    expect(wrapper.find("StyledLinkIcon")).toHaveLength(0)
+  })
+
   it("renders properly with help text", () => {
     const props = getHeadingProps({ body: "hello", help: "help text" })
     const wrapper = mount(<Heading {...props} />)

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -134,6 +134,7 @@ const scrollNodeIntoView = once((node: HTMLElement): void => {
 interface HeadingWithAnchorProps {
   tag: string
   anchor?: string
+  hideAnchor?: boolean
   children: ReactNode[] | ReactNode
   tagProps?: HTMLProps<HTMLHeadingElement>
 }
@@ -146,6 +147,7 @@ export interface HeadingProtoProps {
 export const HeadingWithAnchor: FunctionComponent<HeadingWithAnchorProps> = ({
   tag,
   anchor: propsAnchor,
+  hideAnchor,
   children,
   tagProps,
 }) => {
@@ -194,7 +196,7 @@ export const HeadingWithAnchor: FunctionComponent<HeadingWithAnchorProps> = ({
     tag,
     { ...tagProps, ref, id: elementId },
     <StyledLinkIconContainer>
-      {elementId && (
+      {elementId && !hideAnchor && (
         <StyledLinkIcon href={`#${elementId}`}>
           <LinkIcon size="18" />
         </StyledLinkIcon>
@@ -489,7 +491,7 @@ function makeMarkdownHeading(tag: string, markdown: string): string {
 
 export function Heading(props: HeadingProtoProps): ReactElement {
   const { width, element } = props
-  const { tag, anchor, body, help } = element
+  const { tag, anchor, body, help, hideAnchor } = element
   const isSidebar = React.useContext(IsSidebarContext)
   // st.header can contain new lines which are just interpreted as new
   // markdown to be rendered as such.
@@ -504,7 +506,7 @@ export function Heading(props: HeadingProtoProps): ReactElement {
         data-testid="stMarkdownContainer"
       >
         <StyledHeaderContainer>
-          <HeadingWithAnchor tag={tag} anchor={anchor}>
+          <HeadingWithAnchor tag={tag} anchor={anchor} hideAnchor={hideAnchor}>
             {help ? (
               <StyledLabelHelpWrapper>
                 <RenderedMarkdown

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -208,7 +208,7 @@ class HeadingMixin:
     def _create_heading_proto(
         tag: HeadingProtoTag,
         body: SupportsStr,
-        anchor: Optional[str] = None,
+        anchor: Anchor = None,
         help: Optional[str] = None,
     ) -> HeadingProto:
         proto = HeadingProto()

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
+from typing_extensions import Literal
+
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text
@@ -29,13 +32,15 @@ class HeadingProtoTag(Enum):
     HEADER_TAG = "h2"
     SUBHEADER_TAG = "h3"
 
+Anchor = Optional[Union[str, Literal[False]]]
+
 
 class HeadingMixin:
     @gather_metrics("header")
     def header(
         self,
         body: SupportsStr,
-        anchor: Optional[str] = None,
+        anchor: Anchor = None,
         *,  # keyword-only arguments:
         help: Optional[str] = None,
     ) -> "DeltaGenerator":
@@ -61,9 +66,10 @@ class HeadingMixin:
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet.
 
-        anchor : str
+        anchor : str or False
             The anchor name of the header that can be accessed with #anchor
             in the URL. If omitted, it generates an anchor using the body.
+            If False, the anchor is not shown in the UI.
 
         help : str
             An optional tooltip that gets displayed next to the header.
@@ -87,7 +93,7 @@ class HeadingMixin:
     def subheader(
         self,
         body: SupportsStr,
-        anchor: Optional[str] = None,
+        anchor: Anchor = None,
         *,  # keyword-only arguments:
         help: Optional[str] = None,
     ) -> "DeltaGenerator":
@@ -113,9 +119,10 @@ class HeadingMixin:
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet.
 
-        anchor : str
+        anchor : str or False
             The anchor name of the header that can be accessed with #anchor
             in the URL. If omitted, it generates an anchor using the body.
+            If False, the anchor is not shown in the UI.
 
         help : str
             An optional tooltip that gets displayed next to the subheader.
@@ -139,7 +146,7 @@ class HeadingMixin:
     def title(
         self,
         body: SupportsStr,
-        anchor: Optional[str] = None,
+        anchor: Anchor = None,
         *,  # keyword-only arguments:
         help: Optional[str] = None,
     ) -> "DeltaGenerator":
@@ -168,9 +175,10 @@ class HeadingMixin:
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet.
 
-        anchor : str
+        anchor : str or False
             The anchor name of the header that can be accessed with #anchor
             in the URL. If omitted, it generates an anchor using the body.
+            If False, the anchor is not shown in the UI.
 
         help : str
             An optional tooltip that gets displayed next to the title.
@@ -205,8 +213,22 @@ class HeadingMixin:
         proto = HeadingProto()
         proto.tag = tag.value
         proto.body = clean_text(body)
-        if anchor:
-            proto.anchor = anchor
+        if anchor is not None:
+            if anchor is False:
+                proto.hide_anchor = True
+            elif isinstance(anchor, str):
+                proto.anchor = anchor
+            elif anchor is True:  # type: ignore
+                raise StreamlitAPIException(
+                    "Anchor parameter has invalid value: %s. "
+                    "Supported values: None, any string or False" % anchor
+                )
+            else:
+                raise StreamlitAPIException(
+                    "Anchor parameter has invalid type: %s. "
+                    "Supported values: None, any string or False" % type(anchor).__name__
+                )
+
         if help:
             proto.help = help
         return proto

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -32,6 +32,7 @@ class HeadingProtoTag(Enum):
     HEADER_TAG = "h2"
     SUBHEADER_TAG = "h3"
 
+
 Anchor = Optional[Union[str, Literal[False]]]
 
 
@@ -226,7 +227,8 @@ class HeadingMixin:
             else:
                 raise StreamlitAPIException(
                     "Anchor parameter has invalid type: %s. "
-                    "Supported values: None, any string or False" % type(anchor).__name__
+                    "Supported values: None, any string or False"
+                    % type(anchor).__name__
                 )
 
         if help:

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -111,6 +111,7 @@ class HeadingBase(Element, ABC):
     type: str
     tag: str
     anchor: str | None
+    hide_anchor: bool
     root: ElementTree = field(repr=False)
     key: None
 
@@ -119,6 +120,7 @@ class HeadingBase(Element, ABC):
         self.key = None
         self.tag = proto.tag
         self.anchor = proto.anchor
+        self.hide_anchor = proto.hide_anchor
         self.root = root
         self.type = type_
 

--- a/lib/tests/streamlit/elements/heading_test.py
+++ b/lib/tests/streamlit/elements/heading_test.py
@@ -1,0 +1,164 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+class StHeaderTest(DeltaGeneratorTestCase):
+    """Test ability to marshall header protos."""
+
+    def test_st_header(self):
+        """Test st.header."""
+        st.header("some header")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some header")
+        self.assertEqual(el.heading.tag, "h2")
+        self.assertFalse(el.heading.hide_anchor, False)
+
+    def test_st_header_with_anchor(self):
+        """Test st.header with anchor."""
+        st.header("some header", anchor="some-anchor")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some header")
+        self.assertEqual(el.heading.tag, "h2")
+        self.assertEqual(el.heading.anchor, "some-anchor")
+        self.assertFalse(el.heading.hide_anchor, False)
+
+    def test_st_header_with_hidden_anchor(self):
+        """Test st.header with hidden anchor."""
+        st.header("some header", anchor=False)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some header")
+        self.assertEqual(el.heading.tag, "h2")
+        self.assertEqual(el.heading.anchor, "")
+        self.assertTrue(el.heading.hide_anchor, True)
+
+    def test_st_header_with_invalid_anchor(self):
+        """Test st.header with invalid anchor."""
+        with pytest.raises(StreamlitAPIException):
+            st.header("some header", anchor=True)
+
+    def test_st_header_with_help(self):
+        """Test st.header with help."""
+        st.header("some header", help="help text")
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some header")
+        self.assertEqual(el.heading.tag, "h2")
+        self.assertEqual(el.heading.help, "help text")
+
+
+class StSubheaderTest(DeltaGeneratorTestCase):
+    """Test ability to marshall subheader protos."""
+
+    def test_st_subheader(self):
+        """Test st.subheader."""
+        st.subheader("some subheader")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some subheader")
+        self.assertEqual(el.heading.tag, "h3")
+        self.assertFalse(el.heading.hide_anchor)
+
+    def test_st_subheader_with_anchor(self):
+        """Test st.subheader with anchor."""
+        st.subheader("some subheader", anchor="some-anchor")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some subheader")
+        self.assertEqual(el.heading.tag, "h3")
+        self.assertEqual(el.heading.anchor, "some-anchor")
+        self.assertFalse(el.heading.hide_anchor)
+
+    def test_st_subheader_with_hidden_anchor(self):
+        """Test st.subheader with hidden anchor."""
+        st.subheader("some subheader", anchor=False)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some subheader")
+        self.assertEqual(el.heading.tag, "h3")
+        self.assertEqual(el.heading.anchor, "")
+        self.assertTrue(el.heading.hide_anchor, True)
+
+    def test_st_subheader_with_invalid_anchor(self):
+        """Test st.subheader with invalid anchor."""
+        with pytest.raises(StreamlitAPIException):
+            st.subheader("some header", anchor=True)
+
+    def test_st_subheader_with_help(self):
+        """Test st.subheader with help."""
+        st.subheader("some subheader", help="help text")
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some subheader")
+        self.assertEqual(el.heading.tag, "h3")
+        self.assertEqual(el.heading.help, "help text")
+
+
+class StTitleTest(DeltaGeneratorTestCase):
+    """Test ability to marshall subheader protos."""
+
+    def test_st_title(self):
+        """Test st.title."""
+        st.title("some title")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some title")
+        self.assertEqual(el.heading.tag, "h1")
+        self.assertFalse(el.heading.hide_anchor)
+
+    def test_st_title_with_anchor(self):
+        """Test st.title with anchor."""
+        st.title("some title", anchor="some-anchor")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some title")
+        self.assertEqual(el.heading.tag, "h1")
+        self.assertEqual(el.heading.anchor, "some-anchor")
+        self.assertFalse(el.heading.hide_anchor)
+
+    def test_st_title_with_hidden_anchor(self):
+        """Test st.title with hidden anchor."""
+        st.title("some title", anchor=False)
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some title")
+        self.assertEqual(el.heading.tag, "h1")
+        self.assertEqual(el.heading.anchor, "")
+        self.assertTrue(el.heading.hide_anchor)
+
+    def test_st_title_with_invalid_anchor(self):
+        """Test st.title with invalid anchor."""
+        with pytest.raises(
+            StreamlitAPIException, match="Anchor parameter has invalid value:"
+        ):
+            st.title("some header", anchor=True)
+        with pytest.raises(
+            StreamlitAPIException, match="Anchor parameter has invalid type:"
+        ):
+            st.title("some header", anchor=6)
+
+    def test_st_title_with_help(self):
+        """Test st.title with help."""
+        st.title("some title", help="help text")
+
+        el = self.get_delta_from_queue().new_element
+        self.assertEqual(el.heading.body, "some title")
+        self.assertEqual(el.heading.tag, "h1")
+        self.assertEqual(el.heading.help, "help text")

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -383,53 +383,23 @@ class StreamlitAPITest(DeltaGeneratorTestCase):
             # streamlit.elements.exception_element
             self.assertEqual(el.exception.stack_trace, [])
 
-    def test_st_header(self):
-        """Test st.header."""
-        st.header("some header")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some header")
-        self.assertEqual(el.heading.tag, "h2")
-
-    def test_st_header_with_anchor(self):
-        """Test st.header with anchor."""
-        st.header("some header", anchor="some-anchor")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some header")
-        self.assertEqual(el.heading.tag, "h2")
-        self.assertEqual(el.heading.anchor, "some-anchor")
-
-    def test_st_header_with_help(self):
-        """Test st.header with help."""
-        st.header("some header", help="help text")
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some header")
-        self.assertEqual(el.heading.tag, "h2")
-        self.assertEqual(el.heading.help, "help text")
-
     def test_st_help(self):
         """Test st.help."""
-        st.help(st.header)
+        st.help(st.help)
 
         el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.doc_string.name, "header")
+        self.assertEqual(el.doc_string.name, "help")
         self.assertEqual(el.doc_string.module, "streamlit")
         self.assertTrue(
-            el.doc_string.doc_string.startswith("Display text in header formatting.")
+            el.doc_string.doc_string.startswith(
+                "Display object's doc string, nicely formatted."
+            )
         )
         self.assertEqual(el.doc_string.type, "<class 'method'>")
-        if sys.version_info < (3, 9):
-            # Python < 3.9 represents the signature slightly differently
-            self.assertEqual(
-                el.doc_string.signature,
-                "(body: object, anchor: Union[str, NoneType] = None, *, help: Union[str, NoneType] = None) -> 'DeltaGenerator'",
-            )
-        else:
-            self.assertEqual(
-                el.doc_string.signature,
-                "(body: object, anchor: Optional[str] = None, *, help: Optional[str] = None) -> 'DeltaGenerator'",
-            )
+        self.assertEqual(
+            el.doc_string.signature,
+            "(obj: Any) -> 'DeltaGenerator'",
+        )
 
     def test_st_info(self):
         """Test st.info."""
@@ -580,31 +550,6 @@ class StreamlitAPITest(DeltaGeneratorTestCase):
         self.assertNotEqual(el.plotly_chart.url, "the_url")
         self.assertEqual(el.plotly_chart.use_container_width, False)
 
-    def test_st_subheader(self):
-        """Test st.subheader."""
-        st.subheader("some subheader")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some subheader")
-        self.assertEqual(el.heading.tag, "h3")
-
-    def test_st_subheader_with_anchor(self):
-        """Test st.subheader with anchor."""
-        st.subheader("some subheader", anchor="some-anchor")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some subheader")
-        self.assertEqual(el.heading.tag, "h3")
-        self.assertEqual(el.heading.anchor, "some-anchor")
-
-    def test_st_subheader_with_help(self):
-        """Test st.subheader with help."""
-        st.subheader("some subheader", help="help text")
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some subheader")
-        self.assertEqual(el.heading.tag, "h3")
-        self.assertEqual(el.heading.help, "help text")
-
     def test_st_success(self):
         """Test st.success."""
         st.success("some success")
@@ -678,32 +623,6 @@ class StreamlitAPITest(DeltaGeneratorTestCase):
         )
         el = self.get_delta_from_queue().new_element
         self.assertEqual(el.markdown.help, "help text")
-
-    def test_st_title(self):
-        """Test st.title."""
-        st.title("some title")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some title")
-        self.assertEqual(el.heading.tag, "h1")
-
-    def test_st_title_with_anchor(self):
-        """Test st.title with anchor."""
-        st.title("some title", anchor="some-anchor")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some title")
-        self.assertEqual(el.heading.tag, "h1")
-        self.assertEqual(el.heading.anchor, "some-anchor")
-
-    def test_st_title_with_help(self):
-        """Test st.title with help."""
-        st.title("some title", help="help text")
-
-        el = self.get_delta_from_queue().new_element
-        self.assertEqual(el.heading.body, "some title")
-        self.assertEqual(el.heading.tag, "h1")
-        self.assertEqual(el.heading.help, "help text")
 
     def test_st_time_input(self):
         """Test st.time_input."""

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -193,14 +193,16 @@ class HeadingTest(InteractiveScriptTests):
 
             st.title("This is a title")
             st.title("This is a title with anchor", anchor="anchor text")
+            st.title("This is a title with hidden anchor", anchor=False)
             """,
         )
         sr = script.run()
 
-        assert len(sr.get("title")) == 2
+        assert len(sr.get("title")) == 3
         assert sr.get("title")[1].tag == "h1"
         assert sr.get("title")[1].anchor == "anchor text"
         assert sr.get("title")[1].value == "This is a title with anchor"
+        assert sr.get("title")[2].hide_anchor
 
     def test_header(self):
         script = self.script_from_string(
@@ -210,14 +212,16 @@ class HeadingTest(InteractiveScriptTests):
 
             st.header("This is a header")
             st.header("This is a header with anchor", anchor="header anchor text")
+            st.header("This is a header with hidden anchor", anchor=False)
             """,
         )
         sr = script.run()
 
-        assert len(sr.get("header")) == 2
+        assert len(sr.get("header")) == 3
         assert sr.get("header")[1].tag == "h2"
         assert sr.get("header")[1].anchor == "header anchor text"
         assert sr.get("header")[1].value == "This is a header with anchor"
+        assert sr.get("header")[2].hide_anchor
 
     def test_subheader(self):
         script = self.script_from_string(
@@ -230,14 +234,16 @@ class HeadingTest(InteractiveScriptTests):
                 "This is a subheader with anchor",
                 anchor="subheader anchor text"
             )
+            st.subheader("This is a subheader with hidden anchor", anchor=False)
             """,
         )
         sr = script.run()
 
-        assert len(sr.get("subheader")) == 2
+        assert len(sr.get("subheader")) == 3
         assert sr.get("subheader")[1].tag == "h3"
         assert sr.get("subheader")[1].anchor == "subheader anchor text"
         assert sr.get("subheader")[1].value == "This is a subheader with anchor"
+        assert sr.get("subheader")[2].hide_anchor
 
     def test_heading_elements_by_type(self):
         script = self.script_from_string(

--- a/proto/streamlit/proto/Heading.proto
+++ b/proto/streamlit/proto/Heading.proto
@@ -24,4 +24,5 @@ message Heading {
     string body = 3;
 
     string help = 4;
+    bool hide_anchor = 5;
 }


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

Header elements have anchors that show up when hovering. Sometimes they are visually annoying (e.g. on component.streamlit.app). We already have a parameter anchor – let’s just allow anchor=False to turn them off. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [X] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
