### PR TITLE
Move typecheck and eslint to manual stage of pre-commit

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Run linters
         run: |
           # Run eslint as a standalone command to generate the test report.
+          # We need to --hook-stage manual to trigger Typecheck too
           PRE_COMMIT_NO_CONCURRENCY=true SKIP=eslint pipenv run pre-commit run --hook-stage manual --show-diff-on-failure --color=always --all-files
+          # Run eslint using Makefile omitting the pre-commit
           make jslint
       - name: Validate NOTICES
         run: |

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run linters
         run: |
           # Run eslint as a standalone command to generate the test report.
-          PRE_COMMIT_NO_CONCURRENCY=true SKIP=eslint pipenv run pre-commit run --show-diff-on-failure --color=always --all-files
+          PRE_COMMIT_NO_CONCURRENCY=true SKIP=eslint pipenv run pre-commit run --hook-stage manual --show-diff-on-failure --color=always --all-files
           make jslint
       - name: Validate NOTICES
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,16 +60,22 @@ repos:
         pass_filenames: true
       - id: typecheck
         name: Typecheck
+        always_run: true
         entry: yarn --cwd frontend tsc --noEmit
         files: \.js$|\.jsx$|\.ts$|\.tsx$
         language: node
         pass_filenames: false
+        stages:
+          - manual
       - id: eslint
         name: Eslint
+        always_run: true
         entry: ./scripts/run_in_subdirectory.py frontend/ yarn lint -- --fix
         files: ^frontend/src/.*(.js|\.jsx|\.ts|\.tsx)$
         language: node
         pass_filenames: true
+        stages:
+          - manual
       - id: license-headers
         name: Checks that all files have the required license headers
         entry: ./scripts/check_license_headers.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         pass_filenames: false
         stages:
           - manual
-      # Eslint will be run on CI using --hook-stage manual flag,
+      # Eslint will be run on CI using Makefile,
       # check out .github/workflows/js-tests.yml "Run linters" step for details.
       - id: eslint
         name: Eslint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,8 @@ repos:
         exclude: /vendor/
         language: node
         pass_filenames: true
+      # Typecheck will be run on CI using --hook-stage manual flag,
+      # check out .github/workflows/js-tests.yml "Run linters" step for details.
       - id: typecheck
         name: Typecheck
         always_run: true
@@ -67,6 +69,8 @@ repos:
         pass_filenames: false
         stages:
           - manual
+      # Eslint will be run on CI using --hook-stage manual flag,
+      # check out .github/workflows/js-tests.yml "Run linters" step for details.
       - id: eslint
         name: Eslint
         always_run: true


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:

I often found myself in a situation when I changed a CSS property or text and then had to wait for typecheck and eslint run. Not a major thing, but I think we could move `eslint` and `typecheck` in pre-commit into manual stages, so one can trigger them on demand instead of automatically. 

Other checks are pretty fast so I've left them as they are, what do you think? If we agree on moving them to `manual` stage, then we need to double check if these checks will be still run on CI, if so, then I think we're good to go.

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
