### PR TITLE
Introduce make frontendFast command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,8 +278,8 @@ react-build:
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/build/ lib/streamlit/static/
 
-.PHONY: frontendFast
-frontendFast:
+.PHONY: frontend-fast
+frontend-fast:
 	cd frontend/ ; yarn run buildFast
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/build/ lib/streamlit/static/

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,6 @@ mini-init: setup pipenv-dev-install react-init protobuf
 # Build frontend into static files.
 frontend: react-build
 
-.PHONY: frontendFast
-# Build frontend into static files without TypeChecking and EsLint.
-frontendFast: react-build-fast
-
 .PHONY: setup
 setup:
 	pip install pipenv
@@ -282,8 +278,8 @@ react-build:
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/build/ lib/streamlit/static/
 
-.PHONY: react-build-fast
-react-build-fast:
+.PHONY: frontendFast
+frontendFast:
 	cd frontend/ ; yarn run buildFast
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/build/ lib/streamlit/static/

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ mini-init: setup pipenv-dev-install react-init protobuf
 # Build frontend into static files.
 frontend: react-build
 
+.PHONY: frontendFast
+# Build frontend into static files without TypeChecking and EsLint.
+frontendFast: react-build-fast
+
 .PHONY: setup
 setup:
 	pip install pipenv
@@ -275,6 +279,12 @@ react-init:
 .PHONY: react-build
 react-build:
 	cd frontend/ ; yarn run build
+	rsync -av --delete --delete-excluded --exclude=reports \
+		frontend/build/ lib/streamlit/static/
+
+.PHONY: react-build-fast
+react-build-fast:
+	cd frontend/ ; yarn run buildFast
 	rsync -av --delete --delete-excluded --exclude=reports \
 		frontend/build/ lib/streamlit/static/
 

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,7 @@ react-build:
 		frontend/build/ lib/streamlit/static/
 
 .PHONY: frontend-fast
+# Build frontend into static files faster by setting BUILD_AS_FAST_AS_POSSIBLE=true flag, which disables eslint and typechecking.
 frontend-fast:
 	cd frontend/ ; yarn run buildFast
 	rsync -av --delete --delete-excluded --exclude=reports \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true craco start",
     "build": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 GENERATE_SOURCEMAP=false craco build",
+    "buildFast": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 GENERATE_SOURCEMAP=false BUILD_AS_FAST_AS_POSSIBLE=true craco build",
     "test": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=./jsdom-polyfill-env.js",
     "test:coverage": "./scripts/preload-bokeh.sh && env NODE_OPTIONS=--max_old_space_size=8192 craco test --env=./jsdom-polyfill-env.js --coverage --watchAll false --watch false ./",
     "cy:open": "unset NODE_OPTIONS && cypress open --env devicePixelRatio=1",


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
This is dev convenience PR, it introduces alias to Makefile which allows using existing fast build mechanism.
On my machine is much faster `make frontend` takes 300seconds to complete, while `make frontendFast` around 60 seconds.

This command will be useful for fast demoing and prototyping, can we please introduce it?

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
