### PR TITLE
Allow overriding timeout arg for running a script

### DIFF
--- a/lib/streamlit/testing/local_script_runner.py
+++ b/lib/streamlit/testing/local_script_runner.py
@@ -92,14 +92,18 @@ class LocalScriptRunner(ScriptRunner):
         """Return all messages in our ForwardMsgQueue."""
         return self.forward_msg_queue._queue
 
-    def run(self, widget_state: WidgetStates | None = None) -> ElementTree:
+    def run(
+        self,
+        widget_state: WidgetStates | None = None,
+        timeout: float = 3,
+    ) -> ElementTree:
         """Run the script, and parse the output messages for querying
         and interaction."""
         rerun_data = RerunData(widget_states=widget_state)
         self.request_rerun(rerun_data)
         if not self._script_thread:
             self.start()
-        require_widgets_deltas(self)
+        require_widgets_deltas(self, timeout)
         tree = parse_tree_from_messages(self.forward_msgs())
         tree.script_path = self.script_path
         tree._session_state = self.session_state


### PR DESCRIPTION
3s is plenty for small scripts that test Streamlit feature implementations, but not for testing apps, so let app devs override it. Possibly the default should be changed when this goes public/stable.

I wrote a test but haven't included it here, because the change is trivial and I don't want to add a test that takes a significant amount of time by itself.


## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

