### PR TITLE
Add config option to control the hamburger menu

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -15,15 +15,18 @@
  */
 
 import React from "react"
-import { ShallowWrapper, ReactWrapper } from "enzyme"
+import { ReactWrapper, ShallowWrapper } from "enzyme"
 import { waitFor } from "@testing-library/dom"
 import cloneDeep from "lodash/cloneDeep"
 import { LocalStore } from "src/lib/storageUtils"
 import { hashString } from "src/lib/utils"
-import { shallow, mount } from "src/lib/test_util"
+import { mockWindowLocation, mount, shallow } from "src/lib/test_util"
 import {
+  Config,
   CustomThemeConfig,
   ForwardMsg,
+  ICustomThemeConfig,
+  INewSession,
   NewSession,
   PageConfig,
   PageInfo,
@@ -32,28 +35,34 @@ import {
 } from "src/autogen/proto"
 import { HostCommunicationHOC } from "src/hocs/withHostCommunication"
 import {
+  HostCommunicationState,
   IMenuItem,
   IToolbarItem,
-  HostCommunicationState,
 } from "src/hocs/withHostCommunication/types"
 import { ConnectionState } from "src/lib/ConnectionState"
 import { ScriptRunState } from "src/lib/ScriptRunState"
+import { SessionInfo } from "src/lib/SessionInfo"
 import {
-  CUSTOM_THEME_NAME,
   createAutoTheme,
+  CUSTOM_THEME_NAME,
   darkTheme,
   lightTheme,
   toExportedTheme,
 } from "src/theme"
 import Modal from "./components/shared/Modal"
 import { DialogType, StreamlitDialog } from "./components/core/StreamlitDialog"
-import { App, Props } from "./App"
+import { App, Props, showDevelopmentOptions } from "./App"
 import MainMenu from "./components/core/MainMenu"
 import ToolbarActions from "./components/core/ToolbarActions"
 import { mockSessionInfo, mockSessionInfoProps } from "./lib/mocks/mocks"
-import { SessionInfo } from "./lib/SessionInfo"
 
 jest.mock("src/lib/ConnectionManager")
+jest.mock("src/lib/baseconsts", () => {
+  return {
+    ...jest.requireActual("src/lib/baseconsts"),
+    SHOW_DEPLOY_BUTTON: true,
+  }
+})
 
 const getHostCommunicationState = (
   extend?: Partial<HostCommunicationState>
@@ -529,7 +538,7 @@ const mockGetBaseUriParts = (basePath?: string) => () => ({
 })
 
 describe("App.handleNewSession", () => {
-  const NEW_SESSION_JSON = {
+  const NEW_SESSION_JSON: INewSession = {
     config: {
       gatherUsageStats: false,
       maxCachedMessageAge: 0,
@@ -629,9 +638,8 @@ describe("App.handleNewSession", () => {
     const wrapper = shallow(<App {...props} />)
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-expect-error
-    newSessionJson.customTheme = null
 
+    newSessionJson.customTheme = null
     // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
     expect(props.theme.addThemes).toHaveBeenCalled()
@@ -646,7 +654,6 @@ describe("App.handleNewSession", () => {
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
-    // @ts-expect-error
     newSessionJson.customTheme = null
 
     // @ts-expect-error
@@ -669,7 +676,6 @@ describe("App.handleNewSession", () => {
     const wrapper = shallow(<App {...props} />)
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-expect-error
     newSessionJson.customTheme = null
 
     // @ts-expect-error
@@ -705,7 +711,7 @@ describe("App.handleNewSession", () => {
     const wrapper = shallow(<App {...props} />)
 
     const customThemeConfig = new CustomThemeConfig(
-      NEW_SESSION_JSON.customTheme
+      NEW_SESSION_JSON.customTheme as ICustomThemeConfig
     )
     // @ts-expect-error
     const themeHash = wrapper.instance().createThemeHash(customThemeConfig)
@@ -724,7 +730,6 @@ describe("App.handleNewSession", () => {
     wrapper.setState({ themeHash: "hash_for_undefined_custom_theme" })
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-expect-error
     newSessionJson.customTheme = null
 
     // @ts-expect-error
@@ -1095,6 +1100,99 @@ describe("App.handleNewSession", () => {
       window.history.pushState.mockClear()
     })
   })
+
+  describe("DeployButton", () => {
+    it("initially button should be hidden", () => {
+      const props = getProps()
+      const wrapper = shallow(<App {...props} />)
+
+      expect(wrapper.find("DeployButton")).toHaveLength(0)
+    })
+
+    it("button should be visible in development mode", () => {
+      const props = getProps()
+      const wrapper = shallow(<App {...props} />)
+      const instance = wrapper.instance() as App
+
+      const newSession = new NewSession({
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.DEVELOPER,
+        },
+      })
+      instance.handleNewSession(newSession)
+
+      expect(wrapper.find("DeployButton")).toHaveLength(1)
+    })
+
+    it("button should be hidden in viewer mode", () => {
+      const props = getProps()
+      const wrapper = shallow(<App {...props} />)
+      const instance = wrapper.instance() as App
+
+      instance.handleNewSession(
+        new NewSession({
+          ...NEW_SESSION_JSON,
+          config: {
+            ...NEW_SESSION_JSON.config,
+            toolbarMode: Config.ToolbarMode.VIEWER,
+          },
+        })
+      )
+
+      expect(wrapper.find("DeployButton")).toHaveLength(0)
+    })
+
+    it("button should be hidden for hello app", () => {
+      const props = getProps()
+      const wrapper = shallow(<App {...props} />)
+      const instance = wrapper.instance() as App
+
+      instance.handleNewSession(
+        new NewSession({
+          ...NEW_SESSION_JSON,
+          config: {
+            ...NEW_SESSION_JSON.config,
+            toolbarMode: Config.ToolbarMode.DEVELOPER,
+          },
+          initialize: {
+            ...NEW_SESSION_JSON.initialize,
+            commandLine: "streamlit hello",
+          },
+        })
+      )
+
+      expect(wrapper.find("DeployButton")).toHaveLength(0)
+    })
+
+    it("button should be hidden for cloud environment", () => {
+      const props = getProps({
+        hostCommunication: getHostCommunicationProp({
+          currentState: getHostCommunicationState({
+            isOwner: false,
+            menuItems: [
+              { label: "Host menu item", key: "host-item", type: "text" },
+            ],
+          }),
+        }),
+      })
+      const wrapper = shallow(<App {...props} />)
+      const instance = wrapper.instance() as App
+
+      instance.handleNewSession(
+        new NewSession({
+          ...NEW_SESSION_JSON,
+          config: {
+            ...NEW_SESSION_JSON.config,
+            toolbarMode: Config.ToolbarMode.DEVELOPER,
+          },
+        })
+      )
+
+      expect(wrapper.find("DeployButton")).toHaveLength(0)
+    })
+  })
 })
 
 describe("App.onHistoryChange", () => {
@@ -1459,6 +1557,9 @@ describe("Test Main Menu shortcut functionality", () => {
     const wrapper = shallow<App>(<App {...props} />)
 
     wrapper.instance().openClearCacheDialog = jest.fn()
+
+    wrapper.instance().setState({ toolbarMode: Config.ToolbarMode.DEVELOPER })
+
     wrapper.instance().keyHandlers.CLEAR_CACHE()
 
     expect(wrapper.instance().openClearCacheDialog).toBeCalled()
@@ -1476,4 +1577,43 @@ describe("test app has printCallback method", () => {
     const appComponentInstance = wrapper.find(App).instance() as App
     expect(appComponentInstance.printCallback).toBeDefined()
   })
+})
+
+describe("showDevelopmentMenu", () => {
+  it.each([
+    // # Test cases for toolbarMode = Config.ToolbarMode.AUTO
+    // Show developer menu only for localhost.
+    ["localhost", false, Config.ToolbarMode.AUTO, true],
+    ["127.0.0.1", false, Config.ToolbarMode.AUTO, true],
+    ["remoteHost", false, Config.ToolbarMode.AUTO, false],
+    // Show developer menu only for all host when hostIsOwner == true.
+    ["localhost", true, Config.ToolbarMode.AUTO, true],
+    ["127.0.0.1", true, Config.ToolbarMode.AUTO, true],
+    ["remoteHost", true, Config.ToolbarMode.AUTO, true],
+    // # Test cases for toolbarMode = Config.ToolbarMode.DEVELOPER
+    // Show developer menu always regardless of other parameters
+    ["localhost", false, Config.ToolbarMode.DEVELOPER, true],
+    ["127.0.0.1", false, Config.ToolbarMode.DEVELOPER, true],
+    ["remoteHost", false, Config.ToolbarMode.DEVELOPER, true],
+    ["localhost", true, Config.ToolbarMode.DEVELOPER, true],
+    ["127.0.0.1", true, Config.ToolbarMode.DEVELOPER, true],
+    ["remoteHost", true, Config.ToolbarMode.DEVELOPER, true],
+    // # Test cases for toolbarMode = Config.ToolbarMode.VIEWER
+    // Hide developer menu always regardless of other parameters
+    ["localhost", false, Config.ToolbarMode.VIEWER, false],
+    ["127.0.0.1", false, Config.ToolbarMode.VIEWER, false],
+    ["remoteHost", false, Config.ToolbarMode.VIEWER, false],
+    ["localhost", true, Config.ToolbarMode.VIEWER, false],
+    ["127.0.0.1", true, Config.ToolbarMode.VIEWER, false],
+    ["remoteHost", true, Config.ToolbarMode.VIEWER, false],
+  ])(
+    "should render or not render dev menu depending on hostname, host ownership, toolbarMode[%s, %s, %s]",
+    async (hostname, hostIsOwnr, toolbarMode, expectedResult) => {
+      mockWindowLocation(hostname)
+
+      const result = showDevelopmentOptions(hostIsOwnr, toolbarMode)
+
+      expect(result).toEqual(expectedResult)
+    }
+  )
 })

--- a/frontend/src/components/core/MainMenu/MainMenu.test.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.test.tsx
@@ -15,13 +15,11 @@
  */
 
 import React from "react"
-import { screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 
 import { mount, render } from "src/lib/test_util"
 import { IMenuItem } from "src/hocs/withHostCommunication/types"
 
-import { GitInfo, IGitInfo } from "src/autogen/proto"
+import { Config, GitInfo, IGitInfo } from "src/autogen/proto"
 import { IDeployErrorDialog } from "src/components/core/StreamlitDialog/DeployErrorDialogs/types"
 import {
   DetachedHead,
@@ -31,6 +29,7 @@ import {
 
 import MainMenu, { Props } from "./MainMenu"
 import { waitFor } from "@testing-library/dom"
+import { fireEvent, RenderResult } from "@testing-library/react"
 import { MockMetricsManager } from "src/lib/mocks/mocks"
 
 const { GitStates } = GitInfo
@@ -52,13 +51,37 @@ const getProps = (extend?: Partial<Props>): Props => ({
   closeDialog: jest.fn(),
   canDeploy: true,
   menuItems: {},
-  hostIsOwner: false,
+  developmentMode: true,
   gitInfo: null,
   metricsMgr: new MockMetricsManager(),
+  toolbarMode: Config.ToolbarMode.AUTO,
   ...extend,
 })
 
-describe("App", () => {
+async function openMenu(wrapper: RenderResult): Promise<void> {
+  fireEvent.click(wrapper.getByRole("button"))
+  await waitFor(() => expect(wrapper.findByRole("listbox")).toBeDefined())
+}
+
+function getMenuStructure(
+  renderResult: RenderResult
+): ({ type: "separator" } | { type: "option"; label: string })[][] {
+  return Array.from(
+    renderResult.baseElement.querySelectorAll('[role="listbox"]')
+  ).map(listBoxElement => {
+    return Array.from(
+      listBoxElement.querySelectorAll(
+        '[role=option] span:first-of-type, [data-testid="main-menu-divider"]'
+      )
+    ).map(d =>
+      d.getAttribute("data-testid") == "main-menu-divider"
+        ? { type: "separator" }
+        : { type: "option", label: d.textContent as string }
+    )
+  })
+}
+
+describe("MainMenu", () => {
   it("renders without crashing", () => {
     const props = getProps()
     const wrapper = mount(<MainMenu {...props} />)
@@ -67,7 +90,6 @@ describe("App", () => {
   })
 
   it("should render host menu items", async () => {
-    const user = userEvent.setup()
     const items: IMenuItem[] = [
       {
         type: "separator",
@@ -90,7 +112,7 @@ describe("App", () => {
       hostMenuItems: items,
     })
     const wrapper = render(<MainMenu {...props} />)
-    await user.click(screen.getByRole("button"))
+    await openMenu(wrapper)
 
     await waitFor(() =>
       expect(
@@ -112,10 +134,9 @@ describe("App", () => {
   })
 
   it("should render core set of menu elements", async () => {
-    const user = userEvent.setup()
     const props = getProps()
     const wrapper = render(<MainMenu {...props} />)
-    await user.click(screen.getByRole("button"))
+    await openMenu(wrapper)
 
     await waitFor(() =>
       expect(
@@ -136,10 +157,9 @@ describe("App", () => {
   })
 
   it("should render deploy app menu item", async () => {
-    const user = userEvent.setup()
     const props = getProps({ gitInfo: {} })
     const wrapper = render(<MainMenu {...props} />)
-    await user.click(screen.getByRole("button"))
+    await openMenu(wrapper)
 
     await waitFor(() =>
       expect(
@@ -256,7 +276,6 @@ describe("App", () => {
   })
 
   it("should not render report a bug in core menu", async () => {
-    const user = userEvent.setup()
     const menuItems = {
       getHelpUrl: "testing",
       hideGetHelp: false,
@@ -265,7 +284,7 @@ describe("App", () => {
     }
     const props = getProps({ menuItems })
     const wrapper = render(<MainMenu {...props} />)
-    await user.click(screen.getByRole("button"))
+    await openMenu(wrapper)
 
     await waitFor(() =>
       expect(
@@ -275,7 +294,6 @@ describe("App", () => {
   })
 
   it("should render report a bug in core menu", async () => {
-    const user = userEvent.setup()
     const menuItems = {
       reportABugUrl: "testing",
       hideGetHelp: false,
@@ -284,7 +302,7 @@ describe("App", () => {
     }
     const props = getProps({ menuItems })
     const wrapper = render(<MainMenu {...props} />)
-    await user.click(screen.getByRole("button"))
+    await openMenu(wrapper)
 
     await waitFor(() =>
       expect(
@@ -293,17 +311,8 @@ describe("App", () => {
     )
   })
 
-  it("should not render dev menu when hostIsOwner is false and not on localhost", () => {
-    // set isLocalhost to false by deleting window.location.
-    // Source: https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
-    // @ts-expect-error
-    delete window.location
-
-    // @ts-expect-error
-    window.location = {
-      assign: jest.fn(),
-    }
-    const props = getProps()
+  it("should not render dev menu when developmentMode is false", () => {
+    const props = getProps({ developmentMode: false })
     const wrapper = mount(<MainMenu {...props} />)
     const popoverContent = wrapper.find("StatefulPopover").prop("content")
     // @ts-expect-error
@@ -322,6 +331,182 @@ describe("App", () => {
       "Print",
       "Record a screencast",
       "About",
+    ])
+  })
+
+  it.each([
+    [Config.ToolbarMode.AUTO],
+    [Config.ToolbarMode.DEVELOPER],
+    [Config.ToolbarMode.VIEWER],
+    [Config.ToolbarMode.MINIMAL],
+  ])("should render host menu items if available[%s]", async toolbarMode => {
+    const props = getProps({
+      toolbarMode,
+      hostMenuItems: [
+        { label: "Host menu item", key: "host-item", type: "text" },
+      ],
+    })
+    const wrapper = render(<MainMenu {...props} />)
+    await openMenu(wrapper)
+
+    const menuStructure = getMenuStructure(wrapper)
+    expect(menuStructure[0]).toContainEqual({
+      type: "option",
+      label: "Host menu item",
+    })
+  })
+
+  it("should hide hamburger when toolbarMode is Minimal and no host items", async () => {
+    const props = getProps({
+      developmentMode: false,
+      toolbarMode: Config.ToolbarMode.MINIMAL,
+      hostMenuItems: [],
+    })
+
+    const wrapper = render(<MainMenu {...props} />)
+
+    expect(wrapper.queryByRole("button")).toBeNull()
+  })
+
+  it("should skip divider from host menu items if it is at the beginning and end", async () => {
+    const props = getProps({
+      developmentMode: false,
+      toolbarMode: Config.ToolbarMode.MINIMAL,
+      hostMenuItems: [
+        { type: "separator" },
+        { type: "text", label: "View all apps", key: "viewAllApps" },
+        { type: "separator" },
+        { type: "text", label: "About Streamlit Cloud", key: "about" },
+        { type: "separator" },
+      ],
+    })
+    const wrapper = render(<MainMenu {...props} />)
+    await openMenu(wrapper)
+
+    const menuStructure = getMenuStructure(wrapper)
+    expect(menuStructure).toEqual([
+      [{ type: "option", label: "View all apps" }],
+    ])
+  })
+
+  it.each([
+    [
+      ["getHelpUrl", "reportABugUrl", "aboutSectionMd"],
+      [
+        {
+          label: "Report a bug",
+          type: "option",
+        },
+        {
+          label: "Get help",
+          type: "option",
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "About",
+          type: "option",
+        },
+      ],
+    ],
+    [
+      ["getHelpUrl"],
+      [
+        {
+          label: "Get help",
+          type: "option",
+        },
+      ],
+    ],
+    [
+      ["reportABugUrl"],
+      [
+        {
+          label: "Report a bug",
+          type: "option",
+        },
+      ],
+    ],
+    [
+      ["aboutSectionMd"],
+      [
+        {
+          label: "About",
+          type: "option",
+        },
+      ],
+    ],
+  ])(
+    "should render custom items in minimal mode[%s]",
+    async (menuItems, expectedMenuItems) => {
+      const allMenuItems = {
+        getHelpUrl: "https://www.extremelycoolapp.com/help",
+        reportABugUrl: "https://www.extremelycoolapp.com/bug",
+        aboutSectionMd: "# This is a header. This is an *extremely* cool app!",
+      }
+      const props = getProps({
+        developmentMode: false,
+        toolbarMode: Config.ToolbarMode.MINIMAL,
+        menuItems: Object.fromEntries(
+          Object.entries(allMenuItems).filter(d => menuItems.includes(d[0]))
+        ),
+      })
+
+      const wrapper = render(<MainMenu {...props} />)
+      await openMenu(wrapper)
+
+      const menuStructure = getMenuStructure(wrapper)
+      expect(menuStructure).toEqual([expectedMenuItems])
+    }
+  )
+
+  it("should render host menu items and custom items in minimal mode", async () => {
+    const props = getProps({
+      developmentMode: false,
+      toolbarMode: Config.ToolbarMode.MINIMAL,
+      hostMenuItems: [
+        { type: "separator" },
+        { type: "text", label: "View all apps", key: "viewAllApps" },
+        { type: "separator" },
+        { type: "text", label: "About Streamlit Cloud", key: "about" },
+        { type: "separator" },
+      ],
+      menuItems: {
+        getHelpUrl: "https://www.extremelycoolapp.com/help",
+        reportABugUrl: "https://www.extremelycoolapp.com/bug",
+        aboutSectionMd: "# This is a header. This is an *extremely* cool app!",
+      },
+    })
+    const wrapper = render(<MainMenu {...props} />)
+    await openMenu(wrapper)
+
+    const menuStructure = getMenuStructure(wrapper)
+    expect(menuStructure).toEqual([
+      [
+        {
+          label: "Report a bug",
+          type: "option",
+        },
+        {
+          label: "Get help",
+          type: "option",
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "View all apps",
+          type: "option",
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "About",
+          type: "option",
+        },
+      ],
     ])
   })
 })

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -40,17 +40,17 @@ import {
   IGuestToHostMessage,
   IMenuItem,
 } from "src/hocs/withHostCommunication/types"
-import { GitInfo, IGitInfo, PageConfig } from "src/autogen/proto"
+import { Config, GitInfo, IGitInfo, PageConfig } from "src/autogen/proto"
 import { MetricsManager } from "src/lib/MetricsManager"
 import { DEPLOY_URL, STREAMLIT_CLOUD_URL } from "src/urls"
 import {
+  StyledCoreItem,
+  StyledDevItem,
   StyledMenuDivider,
   StyledMenuItem,
   StyledMenuItemLabel,
   StyledMenuItemShortcut,
   StyledRecordingIndicator,
-  StyledCoreItem,
-  StyledDevItem,
   StyledUl,
 } from "./styled-components"
 
@@ -108,7 +108,9 @@ export interface Props {
 
   menuItems?: PageConfig.IMenuItems | null
 
-  hostIsOwner?: boolean
+  developmentMode: boolean
+
+  toolbarMode: Config.ToolbarMode
 
   metricsMgr: MetricsManager
 }
@@ -217,7 +219,9 @@ function buildMenuItemComponent(
 
       return (
         <>
-          {hasDividerAbove && <StyledMenuDivider />}
+          {hasDividerAbove && (
+            <StyledMenuDivider data-testid="main-menu-divider" />
+          )}
           <StyledMenuItem
             ref={ref}
             role="option"
@@ -271,6 +275,93 @@ const SubMenu = (props: SubMenuProps): ReactElement => {
       }}
     />
   )
+}
+
+function getDevMenuItems(
+  coreDevMenuItems: Record<string, any>,
+  showDeploy: boolean
+): any[] {
+  const devMenuItems = []
+  const preferredDevMenuOrder: any[] = [
+    coreDevMenuItems.developerOptions,
+    coreDevMenuItems.clearCache,
+    showDeploy && coreDevMenuItems.deployApp,
+  ]
+
+  let devLastMenuItem = null
+
+  for (const devMenuItem of preferredDevMenuOrder) {
+    if (devMenuItem) {
+      if (devMenuItem !== coreDevMenuItems.DIVIDER) {
+        if (devLastMenuItem === coreDevMenuItems.DIVIDER) {
+          devMenuItems.push({ ...devMenuItem, hasDividerAbove: true })
+        } else {
+          devMenuItems.push(devMenuItem)
+        }
+      }
+
+      devLastMenuItem = devMenuItem
+    }
+  }
+
+  if (devLastMenuItem != null) {
+    devLastMenuItem.styleProps = {
+      margin: "0 0 -.5rem 0",
+      padding: ".25rem 0 .25rem 1.5rem",
+    }
+  }
+  return devMenuItems
+}
+
+function getPreferredMenuOrder(
+  props: Props,
+  hostMenuItems: any[],
+  coreMenuItems: Record<string, any>
+): any[] {
+  let preferredMenuOrder: any[]
+  if (props.toolbarMode == Config.ToolbarMode.MINIMAL) {
+    // If toolbar mode == minimal then show only host menu items if any.
+    preferredMenuOrder = [
+      coreMenuItems.report,
+      coreMenuItems.community,
+      coreMenuItems.DIVIDER,
+      ...(hostMenuItems.length > 0 ? hostMenuItems : [coreMenuItems.DIVIDER]),
+      coreMenuItems.about,
+    ]
+
+    preferredMenuOrder = preferredMenuOrder.filter(d => d)
+    // If the first or last item is a divider, delete it, because
+    // we don't want to start/end the menu with it.
+    // TODO(sfc-gh-kbregula): We should use Array#at when supported by
+    //  browsers/cypress or transpilers.
+    //  See: https://github.com/tc39/proposal-relative-indexing-method
+    while (
+      preferredMenuOrder.length > 0 &&
+      preferredMenuOrder[0] == coreMenuItems.DIVIDER
+    ) {
+      preferredMenuOrder.shift()
+    }
+    while (
+      preferredMenuOrder.length > 0 &&
+      preferredMenuOrder.at(preferredMenuOrder.length - 1) ==
+        coreMenuItems.DIVIDER
+    ) {
+      preferredMenuOrder.pop()
+    }
+    return preferredMenuOrder
+  }
+  return [
+    coreMenuItems.rerun,
+    coreMenuItems.settings,
+    coreMenuItems.DIVIDER,
+    coreMenuItems.print,
+    coreMenuItems.recordScreencast,
+    coreMenuItems.DIVIDER,
+    coreMenuItems.report,
+    coreMenuItems.community,
+    ...(hostMenuItems.length > 0 ? hostMenuItems : [coreMenuItems.DIVIDER]),
+    coreMenuItems.about,
+  ]
 }
 
 function MainMenu(props: Props): ReactElement {
@@ -336,6 +427,12 @@ function MainMenu(props: Props): ReactElement {
 
     onClickDeployApp()
   }, [props.gitInfo, props.isDeployErrorModalOpen, onClickDeployApp])
+
+  const showAboutMenu =
+    props.toolbarMode != Config.ToolbarMode.MINIMAL ||
+    (props.toolbarMode == Config.ToolbarMode.MINIMAL &&
+      props.menuItems?.aboutSectionMd)
+
   const coreMenuItems = {
     DIVIDER: { isDivider: true },
     rerun: {
@@ -370,7 +467,9 @@ function MainMenu(props: Props): ReactElement {
         },
       }),
     settings: { onClick: props.settingsCallback, label: "Settings" },
-    about: { onClick: props.aboutCallback, label: "About" },
+    ...(showAboutMenu && {
+      about: { onClick: props.aboutCallback, label: "About" },
+    }),
   }
 
   const coreDevMenuItems = {
@@ -396,11 +495,6 @@ function MainMenu(props: Props): ReactElement {
       label: "Clear cache",
       shortcut: "c",
     },
-  }
-
-  const lastDevMenuItemStyleProps = {
-    margin: "0 0 -.5rem 0",
-    padding: ".25rem 0 .25rem 1.5rem",
   }
 
   const hostMenuItems = props.hostMenuItems.map(item => {
@@ -432,24 +526,11 @@ function MainMenu(props: Props): ReactElement {
 
   const shouldShowHostMenu = !!hostMenuItems.length
   const showDeploy = isLocalhost() && !shouldShowHostMenu && props.canDeploy
-  const preferredMenuOrder: any[] = [
-    coreMenuItems.rerun,
-    coreMenuItems.settings,
-    coreMenuItems.DIVIDER,
-    coreMenuItems.print,
-    coreMenuItems.recordScreencast,
-    coreMenuItems.DIVIDER,
-    coreMenuItems.report,
-    coreMenuItems.community,
-    ...(shouldShowHostMenu ? hostMenuItems : [coreMenuItems.DIVIDER]),
-    coreMenuItems.about,
-  ]
-
-  const preferredDevMenuOrder: any[] = [
-    coreDevMenuItems.developerOptions,
-    coreDevMenuItems.clearCache,
-    showDeploy && coreDevMenuItems.deployApp,
-  ]
+  const preferredMenuOrder = getPreferredMenuOrder(
+    props,
+    hostMenuItems,
+    coreMenuItems
+  )
 
   // Remove empty entries, and add dividers into menu options as needed.
   const menuItems: any[] = []
@@ -468,27 +549,14 @@ function MainMenu(props: Props): ReactElement {
     }
   }
 
-  const devMenuItems: any[] = []
-  let devLastMenuItem = null
-  for (const devMenuItem of preferredDevMenuOrder) {
-    if (devMenuItem) {
-      if (devMenuItem !== coreDevMenuItems.DIVIDER) {
-        if (devLastMenuItem === coreDevMenuItems.DIVIDER) {
-          devMenuItems.push({ ...devMenuItem, hasDividerAbove: true })
-        } else {
-          devMenuItems.push(devMenuItem)
-        }
-      }
+  const devMenuItems: any[] = props.developmentMode
+    ? getDevMenuItems(coreDevMenuItems, showDeploy)
+    : []
 
-      devLastMenuItem = devMenuItem
-    }
+  if (menuItems.length == 0 && devMenuItems.length == 0) {
+    // Don't show an empty menu.
+    return <></>
   }
-
-  if (devLastMenuItem != null) {
-    devLastMenuItem.styleProps = lastDevMenuItemStyleProps
-  }
-
-  const { hostIsOwner } = props
 
   return (
     <StatefulPopover
@@ -501,13 +569,15 @@ function MainMenu(props: Props): ReactElement {
       placement={PLACEMENT.bottomRight}
       content={({ close }) => (
         <>
-          <SubMenu
-            menuItems={menuItems}
-            closeMenu={close}
-            isDevMenu={false}
-            metricsMgr={props.metricsMgr}
-          />
-          {(hostIsOwner || isLocalhost()) && (
+          {menuItems.length != 0 && (
+            <SubMenu
+              menuItems={menuItems}
+              closeMenu={close}
+              isDevMenu={false}
+              metricsMgr={props.metricsMgr}
+            />
+          )}
+          {devMenuItems.length != 0 && (
             <StyledUl>
               <SubMenu
                 menuItems={devMenuItems}

--- a/frontend/src/lib/baseconsts.ts
+++ b/frontend/src/lib/baseconsts.ts
@@ -48,3 +48,9 @@ export const FETCH_PARAMS: RequestInit = {
  * StatusWidget.
  */
 export const RERUN_PROMPT_MODAL_DIALOG = false
+
+/**
+ * Feature flag for https://github.com/streamlit/streamlit/pull/6223/files
+ * If this is true, we show a deploy button in the toolbar.
+ */
+export const SHOW_DEPLOY_BUTTON = false

--- a/frontend/src/lib/test_util.tsx
+++ b/frontend/src/lib/test_util.tsx
@@ -83,3 +83,16 @@ export function render(
     ...options,
   })
 }
+
+export function mockWindowLocation(hostname: string): void {
+  // Mock window.location by creating a new object
+  // Source: https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
+  // @ts-expect-error
+  delete window.location
+
+  // @ts-expect-error
+  window.location = {
+    assign: jest.fn(),
+    hostname: hostname,
+  }
+}

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -454,6 +454,26 @@ _create_option(
     scriptable=True,
 )
 
+_create_option(
+    "client.toolbarMode",
+    description="""
+        Change the visibility of items in the toolbar, options menu,
+        and settings dialog (top right of the app).
+
+        Allowed values:
+        * “auto”      : Show the developer options if the app is accessed through
+                        localhost and hide them otherwise.
+        * “developer” : Show the developer options.
+        * “viewer”    : Hide the developer options.
+        * “minimal”   : Show only options set externally (e.g. through
+                        Streamlit Community Cloud) or through st.set_page_config.
+                        If there are no options left, hide the menu.
+""",
+    default_val="auto",
+    type_=str,
+    scriptable=True,
+)
+
 # Config Section: Runner #
 
 _create_section("runner", "Settings for how Streamlit executes your script")

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -461,11 +461,11 @@ _create_option(
         and settings dialog (top right of the app).
 
         Allowed values:
-        * “auto”      : Show the developer options if the app is accessed through
+        * "auto"      : Show the developer options if the app is accessed through
                         localhost and hide them otherwise.
-        * “developer” : Show the developer options.
-        * “viewer”    : Hide the developer options.
-        * “minimal”   : Show only options set externally (e.g. through
+        * "developer" : Show the developer options.
+        * "viewer"    : Hide the developer options.
+        * "minimal"   : Show only options set externally (e.g. through
                         Streamlit Community Cloud) or through st.set_page_config.
                         If there are no options left, hide the menu.
 """,

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -730,10 +730,15 @@ class AppSession:
         self._enqueue_forward_msg(self._create_session_status_changed_message())
 
 
-def _get_toolbar_mode() -> Config.ToolbarMode.ValueType:
+# Config.ToolbarMode.ValueType does not exist at runtime (only in the pyi stubs), so
+# we need to use quotes.
+# This field will be available at runtime as of protobuf 3.20.1, but
+# we are using an older version.
+# For details, see: https://github.com/protocolbuffers/protobuf/issues/8175
+def _get_toolbar_mode() -> "Config.ToolbarMode.ValueType":
     config_key = "client.toolbarMode"
     config_value = config.get_option(config_key)
-    enum_value: Optional[Config.ToolbarMode.ValueType] = getattr(
+    enum_value: Optional["Config.ToolbarMode.ValueType"] = getattr(
         Config.ToolbarMode, config_value.upper()
     )
     if enum_value is None:

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -730,6 +730,22 @@ class AppSession:
         self._enqueue_forward_msg(self._create_session_status_changed_message())
 
 
+def _get_toolbar_mode() -> Config.ToolbarMode.ValueType:
+    config_key = "client.toolbarMode"
+    config_value = config.get_option(config_key)
+    enum_value: Optional[Config.ToolbarMode.ValueType] = getattr(
+        Config.ToolbarMode, config_value.upper()
+    )
+    if enum_value is None:
+        allowed_values = ", ".join(k.lower() for k in Config.ToolbarMode.keys())
+        raise ValueError(
+            f"Config {config_key!r} expects to have one of "
+            f"the following values: {allowed_values}. "
+            f"Current value: {config_value}"
+        )
+    return enum_value
+
+
 def _populate_config_msg(msg: Config) -> None:
     msg.gather_usage_stats = config.get_option("browser.gatherUsageStats")
     msg.max_cached_message_age = config.get_option("global.maxCachedMessageAge")
@@ -737,6 +753,7 @@ def _populate_config_msg(msg: Config) -> None:
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
     msg.hide_top_bar = config.get_option("ui.hideTopBar")
     msg.hide_sidebar_nav = config.get_option("ui.hideSidebarNav")
+    msg.toolbar_mode = _get_toolbar_mode()
 
 
 def _populate_theme_msg(msg: CustomThemeConfig) -> None:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -314,6 +314,7 @@ class ConfigTest(unittest.TestCase):
                 "client.caching",
                 "client.displayEnabled",
                 "client.showErrorDetails",
+                "client.toolbarMode",
                 "theme.base",
                 "theme.primaryColor",
                 "theme.backgroundColor",

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -98,6 +98,15 @@ message Config {
   // See config option "ui.hideSidebarNav".
   bool hide_sidebar_nav = 7;
 
+  // See config option "client.toolbarMode".
+  enum ToolbarMode {
+    AUTO = 0;
+    DEVELOPER = 1;
+    VIEWER = 2;
+    MINIMAL = 3;
+  }
+  ToolbarMode toolbar_mode = 8;
+
   reserved 1;
 }
 


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Now we have a new option `client.toolbarMode` that change the visibility of items in the toolbar, options menu, and settings dialog (top right of the app).
Allowed values:
* `auto`      : Show the developer options if the app is accessed through localhost and hide them otherwise.
* `developer` : Show the developer options.
* `viewer`    : Hide the developer options.
* `minimal`   : Show only options set externally (e.g. through Streamlit Community Cloud) or through st.set_page_config. If there are no options left, hide the menu.


_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [X] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

Minimal mode with custom items
![Screenshot 2023-04-14 at 08 19 45](https://user-images.githubusercontent.com/78743291/231959215-366b6678-7c64-490d-81c9-001b995881cc.png)


## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
