### PR TITLE
Printing adjustments

### DIFF
--- a/frontend/src/components/core/AppView/styled-components.ts
+++ b/frontend/src/components/core/AppView/styled-components.ts
@@ -48,14 +48,9 @@ export const StyledAppViewMain = styled.section<StyledAppViewMainProps>(
     width: theme.sizes.full,
     overflow: isEmbedded ? "hidden" : "auto",
     alignItems: "center",
+
     "&:focus": {
       outline: "none",
-    },
-    "@media print": {
-      "@-moz-document url-prefix()": {
-        display: "block",
-      },
-      overflow: "visible",
     },
 
     // Added so sidebar overlays main app content on
@@ -66,6 +61,11 @@ export const StyledAppViewMain = styled.section<StyledAppViewMainProps>(
       left: 0,
       right: 0,
       bottom: 0,
+    },
+
+    "@media print": {
+      position: "relative",
+      display: "block",
     },
   })
 )
@@ -99,6 +99,7 @@ export const StyledAppViewBlockContainer =
 
         [`@media print`]: {
           minWidth: "100%",
+          paddingTop: 0,
         },
       }
     }

--- a/frontend/src/components/core/AppView/styled-components.ts
+++ b/frontend/src/components/core/AppView/styled-components.ts
@@ -96,6 +96,10 @@ export const StyledAppViewBlockContainer =
           : bottomEmbedPadding,
         minWidth: isWideMode ? "auto" : undefined,
         maxWidth: isWideMode ? "initial" : theme.sizes.contentMaxWidth,
+
+        [`@media print`]: {
+          minWidth: "100%",
+        },
       }
     }
   )

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -49,6 +49,14 @@ export const StyledSidebar = styled.section<StyledSidebarProps>(
           isCollapsed ? "transparent" : "#00000029"
         }`,
       },
+
+      [`@media print`]: {
+        backgroundColor: "transparent",
+        margin: "auto",
+        boxShadow: "none",
+        maxWidth: "none",
+        minWidth: "100%",
+      },
     }
   }
 )
@@ -228,6 +236,10 @@ export const StyledSidebarUserContent =
     paddingLeft: theme.spacing.lg,
     paddingRight: theme.spacing.lg,
 
+    "@media print": {
+      paddingTop: `1rem`,
+    },
+
     "& h1": {
       fontSize: theme.fontSizes.xl,
       fontWeight: 600,
@@ -281,6 +293,10 @@ export const StyledSidebarCloseButton = styled.div(({ theme }) => ({
   "&:hover button": {
     backgroundColor: transparentize(theme.colors.fadedText60, 0.5),
   },
+
+  [`@media print`]: {
+    display: "none",
+  },
 }))
 
 export interface StyledSidebarCollapsedControlProps {
@@ -303,6 +319,10 @@ export const StyledSidebarCollapsedControl =
 
       [`@media (max-width: ${theme.breakpoints.md})`]: {
         color: theme.colors.bodyText,
+      },
+
+      [`@media print`]: {
+        display: "none",
       },
     })
   )

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -56,6 +56,8 @@ export const StyledSidebar = styled.section<StyledSidebarProps>(
         boxShadow: "none",
         maxWidth: "none",
         minWidth: "100%",
+        width: "100% !important",
+        paddingTop: "1rem",
       },
     }
   }
@@ -83,6 +85,10 @@ export const StyledSidebarNavItems = styled.ul<StyledSidebarNavItemsProps>(
       margin: 0,
       paddingTop: theme.sizes.sidebarTopSpace,
       paddingBottom: theme.spacing.lg,
+
+      "@media print": {
+        paddingTop: theme.spacing.sm,
+      },
 
       "&::before": isOverflowing
         ? {
@@ -208,6 +214,10 @@ export const StyledSidebarNavLink = styled.a<StyledSidebarNavLinkProps>(
 
       "&:focus-visible": {
         backgroundColor: theme.colors.darkenedBgMix15,
+      },
+
+      [`@media print`]: {
+        paddingLeft: theme.spacing.none,
       },
     }
   }


### PR DESCRIPTION
## 📚 Context

This PR makes a series of adjustments to our `@media print` media queries, to ensure apps that are being printed or saved as a PDF look good, especially the sidebar.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

* Several style changes in our `print` media queries, mostly in our `Sidebar` and `AppView` components, to improve the layout when printing/saving as a PDF.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![Screenshot 2023-02-23 at 3 46 17 PM](https://user-images.githubusercontent.com/103376966/221004465-fc7933e6-7c8c-49f5-a279-281f9cbdf38d.png)

**Current:**

![Screenshot 2023-02-23 at 3 52 35 PM](https://user-images.githubusercontent.com/103376966/221004614-2cd1474e-79b1-4f75-95d4-60992305ade3.png)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- https://www.notion.so/streamlit/CSS-follow-ups-for-f96a2e61b28f41adbf12a30d089fb673?pvs=4

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
