### PR TITLE
Remove frontend dependencies codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, that is.
-frontend/package.json @vdonato @anoctopus @tconkling @kmcgrady
 lib/Pipfile @vdonato @anoctopus @tconkling @kmcgrady
 lib/setup.py @vdonato @anoctopus @tconkling @kmcgrady
 proto/ @vdonato @tconkling @LukasMasuch @sfc-gh-mnowotka


### PR DESCRIPTION
We added the frontend dependencies file to ensure licenses for new dependencies would be properly checked, but now we have a check for it in CI.