### PR TITLE
Fix dtype check

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -650,13 +650,11 @@ def pyarrow_table_to_bytes(table: pa.Table) -> bytes:
 
 def is_colum_type_arrow_incompatible(column: Union[Series, Index]) -> bool:
     """Return True if the column type is known to cause issues during Arrow conversion."""
-    if column.dtype in [
-        # timedelta64[ns] is supported by pyarrow but not in the Arrow JS:
+    if column.dtype.kind in [
+        # timedelta is supported by pyarrow but not in the Arrow JS:
         # https://github.com/streamlit/streamlit/issues/4489
-        "timedelta64[ns]",
-        "complex64",
-        "complex128",
-        "complex256",
+        "m",  # timedelta64[ns]
+        "c",  # complex64, complex128, complex256
     ]:
         return True
 

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -180,7 +180,8 @@ class TypeUtilTest(unittest.TestCase):
     @parameterized.expand(
         [
             # Complex numbers:
-            (pd.Series([1 + 2j, 3 + 4j, 5 + 6 * 1j]), True),
+            (pd.Series([1 + 2j, 3 + 4j, 5 + 6 * 1j], dtype=np.complex64), True),
+            (pd.Series([1 + 2j, 3 + 4j, 5 + 6 * 1j], dtype=np.complex128), True),
             # Timedelta:
             (pd.Series([pd.Timedelta("1 days"), pd.Timedelta("2 days")]), True),
             # Mixed-integer types:


### PR DESCRIPTION
## 📚 Context

Checking `dtypes` against strings might lead to issues on platforms that don't support the given dtypes. Therefore, we use [`kind`](https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html) instead to check the kind of data.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6185
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
