### PR TITLE
Don't forget to stop script execution on websocket close

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -232,9 +232,8 @@ class AppSession:
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until
-            # after this is called.
-            if self._scriptrunner is not None:
-                self._scriptrunner.request_stop()
+            # *after* this is called.
+            self.request_script_stop()
 
             self._state = AppSessionState.SHUTDOWN_REQUESTED
 
@@ -364,6 +363,14 @@ class AppSession:
         # current ScriptRunner is shutting down and cannot handle a rerun
         # request - so we'll create and start a new ScriptRunner.
         self._create_scriptrunner(rerun_data)
+
+    def request_script_stop(self) -> None:
+        """Request that the scriptrunner stop execution.
+
+        Does nothing if no scriptrunner exists.
+        """
+        if self._scriptrunner is not None:
+            self._scriptrunner.request_stop()
 
     def _create_scriptrunner(self, initial_rerun_data: RerunData) -> None:
         """Create and run a new ScriptRunner with the given RerunData."""
@@ -519,7 +526,6 @@ class AppSession:
             event == ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
             or event == ScriptRunnerEvent.SCRIPT_STOPPED_WITH_COMPILE_ERROR
         ):
-
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_NOT_RUNNING
 
@@ -698,8 +704,7 @@ class AppSession:
 
     def _handle_stop_script_request(self) -> None:
         """Tell the ScriptRunner to stop running its script."""
-        if self._scriptrunner is not None:
-            self._scriptrunner.request_stop()
+        self.request_script_stop()
 
     def _handle_clear_cache_request(self) -> None:
         """Clear this app's cache.

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -104,12 +104,15 @@ class WebsocketSessionManager(SessionManager):
     def disconnect_session(self, session_id: str) -> None:
         if session_id in self._active_session_info_by_id:
             active_session_info = self._active_session_info_by_id[session_id]
-            active_session_info.session.disconnect_file_watchers()
+            session = active_session_info.session
+
+            session.request_script_stop()
+            session.disconnect_file_watchers()
 
             self._session_storage.save(
                 SessionInfo(
                     client=None,
-                    session=active_session_info.session,
+                    session=session,
                     script_run_count=active_session_info.script_run_count,
                 )
             )

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -123,9 +123,28 @@ class AppSessionTest(unittest.TestCase):
 
         mock_scriptrunner.reset_mock()
 
-        # A 2nd shutdown call should have no affect.
+        # A 2nd shutdown call should have no effect.
         session.shutdown()
         mock_scriptrunner.request_stop.assert_not_called()
+
+    def test_request_script_stop(self):
+        """Verify that request_script_stop forwards the request to the scriptrunner."""
+        session = _create_test_session()
+        mock_scriptrunner = MagicMock(spec=ScriptRunner)
+        session._scriptrunner = mock_scriptrunner
+
+        session.request_script_stop()
+        mock_scriptrunner.request_stop.assert_called()
+
+    def test_request_script_stop_no_scriptrunner(self):
+        """Test that calling request_script_stop when there is no scriptrunner doesn't
+        result in an error.
+        """
+        session = _create_test_session()
+        session._scriptrunner = None
+
+        # Nothing else to do here aside from ensuring that no exception is thrown.
+        session.request_script_stop()
 
     def test_unique_id(self):
         """Each AppSession should have a unique ID"""
@@ -685,7 +704,6 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         ) as handle_backmsg_exception, patch.object(
             session, "_handle_clear_cache_request"
         ) as handle_clear_cache_request:
-
             error = Exception("explode!")
             handle_clear_cache_request.side_effect = error
 

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -97,11 +97,15 @@ class WebsocketSessionManagerTests(unittest.TestCase):
                 self.connect_session()
 
     @patch(
-        "streamlit.runtime.app_session.AppSession.register_file_watchers",
+        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
         new=MagicMock(),
     )
     @patch(
-        "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
+        "streamlit.runtime.app_session.AppSession.request_script_stop",
+        new=MagicMock(),
+    )
+    @patch(
+        "streamlit.runtime.app_session.AppSession.register_file_watchers",
         new=MagicMock(),
     )
     def test_disconnect_and_reconnect_session(self):
@@ -117,6 +121,7 @@ class WebsocketSessionManagerTests(unittest.TestCase):
         assert session_id not in self.session_mgr._active_session_info_by_id
         assert session_id in self.session_mgr._session_storage._cache
         original_session_info.session.disconnect_file_watchers.assert_called_once()
+        original_session_info.session.request_script_stop.assert_called_once()
 
         # Call disconnect_session again to verify that disconnect_session is idempotent.
         self.session_mgr.disconnect_session(session_id)
@@ -124,6 +129,7 @@ class WebsocketSessionManagerTests(unittest.TestCase):
         assert session_id not in self.session_mgr._active_session_info_by_id
         assert session_id in self.session_mgr._session_storage._cache
         original_session_info.session.disconnect_file_watchers.assert_called_once()
+        original_session_info.session.request_script_stop.assert_called_once()
 
         # Reconnect to the existing session.
         reconnected_session_id = self.connect_session(existing_session_id=session_id)


### PR DESCRIPTION
## 📚 Context

There's a bug in the websocket reconnect logic that was implemented in #5856 where I forgot
to stop script execution in the websocket disconnect handler. This is fine with the vast majority
of scripts since most of them execute relatively quickly, but it does result in some weird behavior
with the (admittedly, rare and not-very-well-supported) use-case where a script is written to be
long-lived (via a `while True` loop or something similar). See #6166 for more information on the
bug.

This PR fixes this bug by simply requesting that the scriptrunner stop execution when on websocket
disconnect.

## 🧪 Testing Done

- [x] Added/Updated unit tests

## 🌐 References

Closes #6166
