### PR TITLE
Fix retrieving messages from the server's ForwardMsgCache

### DIFF
--- a/e2e/scripts/forward_msg_cache.py
+++ b/e2e/scripts/forward_msg_cache.py
@@ -1,0 +1,25 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+# Send a ForwardMsg to the client that's long enough that we cache it.
+st.markdown(
+    "\n\n".join(
+        50
+        * [
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus quis neque eu orci faucibus pellentesque. Vivamus dapibus pellentesque sem, vitae ultricies sem pharetra at. Curabitur eu congue magna, eu tempor libero. Donec vitae condimentum odio. Sed neque elit, porttitor eget laoreet volutpat, imperdiet et leo. Phasellus vel velit sit amet nulla hendrerit pharetra et non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In malesuada sem sit amet felis vestibulum, maximus imperdiet nibh mollis. Cras in ipsum at neque mollis facilisis nec et tortor. Duis fringilla tortor id urna laoreet lobortis."
+        ]
+    )
+)

--- a/e2e/specs/forward_msg_cache.spec.js
+++ b/e2e/specs/forward_msg_cache.spec.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("ForwardMsgCache test", () => {
+  beforeEach(() => {
+    cy.loadApp("http://localhost:3000/");
+  });
+
+  it("can fetch missing cached messages from the server", () => {
+    cy.window().then((win) => {
+      win.streamlitDebug.clearForwardMsgCache();
+    });
+
+    cy.rerunScript();
+    cy.waitForRerun();
+
+    cy.get('[role="dialog"]').should("not.exist");
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -261,6 +261,7 @@ export class App extends PureComponent<Props, State> {
     this.pendingElementsBuffer = this.state.elements
 
     window.streamlitDebug = {
+      clearForwardMsgCache: this.debugClearForwardMsgCache,
       disconnectWebsocket: this.debugDisconnectWebsocket,
       shutdownRuntime: this.debugShutdownRuntime,
     }
@@ -1038,7 +1039,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Used by e2e tests to test disabling widgets.
+   * Test-only method used by e2e tests to test disabling widgets.
    */
   debugShutdownRuntime = (): void => {
     if (this.isServerConnected()) {
@@ -1049,7 +1050,7 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Used by e2e tests to test reconnect behavior.
+   * Test-only method used by e2e tests to test reconnect behavior.
    */
   debugDisconnectWebsocket = (): void => {
     if (this.isServerConnected()) {
@@ -1057,6 +1058,21 @@ export class App extends PureComponent<Props, State> {
       backMsg.type = "debugDisconnectWebsocket"
       this.sendBackMsg(backMsg)
     }
+  }
+
+  /**
+   * Test-only method used by e2e tests to test fetching cached ForwardMsgs
+   * from the server.
+   */
+  debugClearForwardMsgCache = (): void => {
+    if (!isLocalhost()) {
+      return
+    }
+
+    // It's not a problem that we're mucking around with private fields since
+    // this is a test-only method anyway.
+    // @ts-ignore
+    this.connectionManager?.connection?.cache.messages.clear()
   }
 
   /**

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -16,7 +16,10 @@
 
 import { ForwardMsg } from "src/autogen/proto"
 import fetchMock from "fetch-mock"
-import { ForwardMsgCache } from "src/lib/ForwardMessageCache"
+import {
+  FETCH_MESSAGE_PATH,
+  ForwardMsgCache,
+} from "src/lib/ForwardMessageCache"
 import { buildHttpUri } from "src/lib/UriUtil"
 
 const MOCK_SERVER_URI = {
@@ -77,7 +80,11 @@ function mockGetMessageResponse(msg: ForwardMsg): void {
     method: "get",
   }
 
-  fetchMock.mock(buildHttpUri(MOCK_SERVER_URI, "message"), response, options)
+  fetchMock.mock(
+    buildHttpUri(MOCK_SERVER_URI, FETCH_MESSAGE_PATH),
+    response,
+    options
+  )
 }
 
 /**
@@ -91,7 +98,11 @@ function mockMissingMessageResponse(msg: ForwardMsg): void {
     method: "get",
   }
 
-  fetchMock.mock(buildHttpUri(MOCK_SERVER_URI, "message"), response, options)
+  fetchMock.mock(
+    buildHttpUri(MOCK_SERVER_URI, FETCH_MESSAGE_PATH),
+    response,
+    options
+  )
 }
 
 beforeEach(() => {

--- a/frontend/src/lib/ForwardMessageCache.ts
+++ b/frontend/src/lib/ForwardMessageCache.ts
@@ -19,6 +19,8 @@ import { logMessage } from "src/lib/log"
 import { BaseUriParts, buildHttpUri } from "src/lib/UriUtil"
 import { ensureError } from "./ErrorHandling"
 
+export const FETCH_MESSAGE_PATH = "_stcore/message"
+
 class CacheEntry {
   public readonly encodedMsg: Uint8Array
 
@@ -145,7 +147,7 @@ export class ForwardMsgCache {
       )
     }
 
-    const url = buildHttpUri(serverURI, `message?hash=${hash}`)
+    const url = buildHttpUri(serverURI, `${FETCH_MESSAGE_PATH}?hash=${hash}`)
     const rsp = await fetch(url)
     if (!rsp.ok) {
       // `fetch` doesn't reject for bad HTTP statuses, so


### PR DESCRIPTION
## 📚 Context

#5534 caused a regression where we forgot to update the `/message` endpoint (used to fetch
cached forward msgs from the server when the client's cache is out of sync) to use the new
`/_stcore/message` endpoint.

Thankfully, this issue only comes up occasionally since
* A `ForwardMsg` has to be reasonably large before we decide that it's worth caching to begin with
* The client and server normally have `ForwardMsgCache`s that are in sync
   
This PR makes the trivial fix to correct the endpoint name and also adds e2e tests for fetching
messages from the server's `FowardMsgCache`.

## 🧪 Testing Done

- [x] Added/Updated e2e tests
