### PR TITLE
Stop waiting for a browser to connect before opening a new tab

### DIFF
--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -61,7 +61,6 @@ const PING_TIMEOUT_MS = 15 * 1000
 
 /**
  * Timeout when attempting to connect to a websocket, in millis.
- * This should be <= bootstrap.py#BROWSER_WAIT_TIMEOUT_SEC.
  */
 const WEBSOCKET_TIMEOUT_MS = 15 * 1000
 


### PR DESCRIPTION
## 📚 Context

Awhile back, we taught the client how to exponentially back off its retry attempts when 
attempting to reconnect to a streamlit server to reduce thundering herd issues that streamlit
clients were causing with hosting platforms.

In doing so, one side effect was that some logic that we have to not open a new browser tab
on server init when an existing tab manages to connect became a whole lot less useful. Since
existing tabs now back off how frequently they try to reconnect (vs trying every 500ms to 1s like
they did before), it's now much more unlikely that an old tab will reconnect in time if the server has
been stopped for more than a second or two. Because of this, we should probably just drop this
behavior so that the code is less complex.