### PR TITLE
Make ping and websocket timeouts far more forgiving

### DIFF
--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -49,17 +49,21 @@ const ALLOWED_ORIGINS_PATH = "_stcore/allowed-message-origins"
 const WEBSOCKET_STREAM_PATH = "_stcore/stream"
 
 /**
- * Wait this long between pings, in millis.
+ * Min and max wait time between pings in millis.
  */
 const PING_MINIMUM_RETRY_PERIOD_MS = 500
-
 const PING_MAXIMUM_RETRY_PERIOD_MS = 1000 * 60
+
+/**
+ * Ping timeout in millis.
+ */
+const PING_TIMEOUT_MS = 15 * 1000
 
 /**
  * Timeout when attempting to connect to a websocket, in millis.
  * This should be <= bootstrap.py#BROWSER_WAIT_TIMEOUT_SEC.
  */
-const WEBSOCKET_TIMEOUT_MS = 1000
+const WEBSOCKET_TIMEOUT_MS = 15 * 1000
 
 /**
  * If the ping retrieves a 403 status code a message will be displayed.
@@ -681,8 +685,8 @@ export function doInitPings(
     // not to do so as it's semantically cleaner to not give the healthcheck
     // endpoint additional responsibilities.
     Promise.all([
-      axios.get(healthzUri, { timeout: minimumTimeoutMs }),
-      axios.get(allowedOriginsUri, { timeout: minimumTimeoutMs }),
+      axios.get(healthzUri, { timeout: PING_TIMEOUT_MS }),
+      axios.get(allowedOriginsUri, { timeout: PING_TIMEOUT_MS }),
     ])
       .then(([_, originsResp]) => {
         setAllowedOriginsResp(originsResp.data)


### PR DESCRIPTION
## 📚 Context

Our timeouts for websocket connects / healthcheck pings are currently far too unforgiving. Ideally, we'd
want to make these parameters configurable, but this is a surprisingly difficult thing to do because
of a chicken and egg problem: config params set in `config.toml` or via flag to `streamlit run` are first
passed to the web client via the websocket connection 😕 

The most reasonable way of dynamically setting these timeouts using config options would likely
be to bake them into the react app shipped to the browser, but this would require a decent amount
of work as we currently assume that the app assets are static and can just be shipped to the browser.

For now, the most reasonable thing to do that wouldn't take a ton of effort would be to make these
timeouts far more generous.