### PR TITLE
List `str` as supported type for `show_spinner` in cache data docs

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -413,9 +413,10 @@ class CacheDataAPI:
             for an unbounded cache. (When a new entry is added to a full cache,
             the oldest cached entry will be removed.) The default is None.
 
-        show_spinner : boolean
+        show_spinner : boolean or string
             Enable the spinner. Default is True to show a spinner when there is
-            a cache miss.
+            a "cache miss" and the cached data is being created. If string,
+            value of show_spinner param will be used for spinner text.
 
         persist : str or boolean or None
             Optional location to persist cached data to. Passing "disk" (or True)
@@ -574,7 +575,6 @@ class DataCache(Cache):
         self.allow_widgets = allow_widgets
 
     def get_stats(self) -> list[CacheStat]:
-
         if isinstance(self.storage, CacheStatsProvider):
             return self.storage.get_stats()
         return []


### PR DESCRIPTION
## 📚 Context

Fixes #6207.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Adds `str` as a supported type for `st.cache_data`'s `show_spinner` param in the docstring.
- Note: this PR neither adds nor updates any tests as it is merely refactoring docstring text.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

<details><summary><h4>View revised:</h4></summary>

![image](https://user-images.githubusercontent.com/20672874/222631326-6968f7ba-dbd9-40e3-afb5-c85d45dfc8c7.png)
</details>

<details><summary><h4>View current:</h4></summary>

![image](https://user-images.githubusercontent.com/20672874/222631509-87cb72f5-16e1-40a8-ace9-f79bd988de61.png)
</details>

## 🧪 Testing Done

- [x] Screenshots included

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6207 
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
