### PR TITLE
`CachedStFunctionWarning` should include `experimental_allow_widgets`, not `suppress_st_warning`

### DIFF
--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -115,8 +115,8 @@ a cache "miss", which can lead to unexpected results.
 
 How to fix this:
 * Move the %(st_func_name)s call outside %(func_name)s.
-* Or, if you know what you're doing, use `@st.%(decorator_name)s(suppress_st_warning=True)`
-to suppress the warning.
+* Or, if you know what you're doing, use `@st.%(decorator_name)s(experimental_allow_widgets=True)`
+to enable widget replay and suppress this warning.
             """
             % args
         ).strip("\n")


### PR DESCRIPTION
## 📚 Context

Fixes #6216.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Instead of asking users to pass a non-existent param (`suppress_st_warning`) to the new caching decorators when widget replay is disabled and the cache-decorated function contains a Streamlit widget, we now ask them to pass `experimental_allow_widgets=True` to the caching decorator to enable widget replay and suppress the`CachedStFunctionWarning`.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6216 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
