### PR TITLE
Pin altair version to <5

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -29,7 +29,7 @@ NAME = "streamlit"
 # And if you do add one, make the required version as general as possible.
 # But include relevant lower bounds for any features we use from our dependencies.
 INSTALL_REQUIRES = [
-    "altair>=3.2.0",
+    "altair<5,>=3.2.0",
     "blinker>=1.0.0",
     "cachetools>=4.0",
     "click>=7.0",


### PR DESCRIPTION
## 📚 Context

A new major release of altair (5.x) is currently prepared which will break Streamlit (as reported [here](https://github.com/streamlit/streamlit/issues/6215)). As a quick fix, we are pinning the max version of altair to <5. In the long term, we need to work on supporting Altair 5.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
