### PR TITLE
Allow users to set a secrets.toml file in their home directory

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -180,7 +180,7 @@ class AppSession:
         self._stop_pages_listener = source_util.register_pages_changed_callback(
             self._on_pages_changed
         )
-        secrets_singleton._file_change_listener.connect(self._on_secrets_file_changed)
+        secrets_singleton.file_change_listener.connect(self._on_secrets_file_changed)
 
     def disconnect_file_watchers(self) -> None:
         """Disconnect the file watcher handlers registered by register_file_watchers."""
@@ -191,9 +191,7 @@ class AppSession:
         if self._stop_pages_listener is not None:
             self._stop_pages_listener()
 
-        secrets_singleton._file_change_listener.disconnect(
-            self._on_secrets_file_changed
-        )
+        secrets_singleton.file_change_listener.disconnect(self._on_secrets_file_changed)
 
         self._local_sources_watcher = None
         self._stop_config_listener = None
@@ -416,7 +414,7 @@ class AppSession:
             self._enqueue_forward_msg(self._create_file_change_message())
 
     def _on_secrets_file_changed(self, _) -> None:
-        """Called when `secrets._file_change_listener` emits a Signal."""
+        """Called when `secrets.file_change_listener` emits a Signal."""
 
         # NOTE: At the time of writing, this function only calls `_on_source_file_changed`.
         # The reason behind creating this function instead of just passing `_on_source_file_changed`

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -19,6 +19,7 @@ from typing import (
     ItemsView,
     Iterator,
     KeysView,
+    List,
     Mapping,
     NoReturn,
     Optional,
@@ -31,11 +32,16 @@ from typing_extensions import Final
 
 import streamlit as st
 import streamlit.watcher.path_watcher
-from streamlit import runtime
+from streamlit import file_util, runtime
 from streamlit.logger import get_logger
 
 _LOGGER = get_logger(__name__)
-SECRETS_FILE_LOC = os.path.abspath(os.path.join(".", ".streamlit", "secrets.toml"))
+SECRETS_FILE_LOCS: Final[List[str]] = [
+    file_util.get_streamlit_file_path("secrets.toml"),
+    # NOTE: The order here is important! Project-level secrets should overwrite global
+    # secrets.
+    file_util.get_project_streamlit_file_path("secrets.toml"),
+]
 
 
 def _missing_attr_error_message(attr_name: str) -> str:
@@ -107,19 +113,20 @@ class Secrets(Mapping[str, Any]):
     Safe to use from multiple threads.
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_paths: List[str]):
         # Our secrets dict.
         self._secrets: Optional[Mapping[str, Any]] = None
         self._lock = threading.RLock()
-        self._file_watcher_installed = False
-        self._file_path = file_path
-        self._file_change_listener = Signal(
-            doc="Emitted when the `secrets.toml` file has been changed."
+        self._file_watchers_installed = False
+        self._file_paths = file_paths
+
+        self.file_change_listener = Signal(
+            doc="Emitted when a `secrets.toml` file has been changed."
         )
 
     def load_if_toml_exists(self) -> None:
-        """Load secrets.toml from disk if it exists. If it doesn't exist,
-        no exception will be raised. (If the file exists but is malformed,
+        """Load secrets.toml files from disk if they exists. If none exist,
+        no exception will be raised. (If a file exists but is malformed,
         an exception *will* be raised.)
 
         Thread-safe.
@@ -127,7 +134,7 @@ class Secrets(Mapping[str, Any]):
         try:
             self._parse(print_exceptions=False)
         except FileNotFoundError:
-            # No secrets.toml file exists. That's fine.
+            # No secrets.toml files exist. That's fine.
             pass
 
     def _reset(self) -> None:
@@ -145,7 +152,7 @@ class Secrets(Mapping[str, Any]):
             self._secrets = None
 
     def _parse(self, print_exceptions: bool) -> Mapping[str, Any]:
-        """Parse our secrets.toml file if it's not already parsed.
+        """Parse our secrets.toml files if they're not already parsed.
         This function is safe to call from multiple threads.
 
         Parameters
@@ -170,26 +177,45 @@ class Secrets(Mapping[str, Any]):
             if self._secrets is not None:
                 return self._secrets
 
-            try:
-                with open(self._file_path, encoding="utf-8") as f:
-                    secrets_file_str = f.read()
-            except FileNotFoundError:
-                if print_exceptions:
-                    st.error(f"Secrets file not found. Expected at: {self._file_path}")
-                raise
+            # It's fine for a user to only have one secrets.toml file defined, so
+            # we ignore individual FileNotFoundErrors when attempting to read files
+            # below and only raise an exception if we weren't able read *any* secrets
+            # file.
+            found_secrets_file = False
+            secrets = {}
 
-            try:
-                secrets = toml.loads(secrets_file_str)
-            except:
+            for path in self._file_paths:
+                try:
+                    with open(path, encoding="utf-8") as f:
+                        secrets_file_str = f.read()
+                    found_secrets_file = True
+                except FileNotFoundError:
+                    continue
+
+                try:
+                    secrets.update(toml.loads(secrets_file_str))
+                except:
+                    if print_exceptions:
+                        st.error(f"Error parsing secrets file at {path}")
+                    raise
+
+            if not found_secrets_file:
+                err_msg = f"No secrets files found. Valid paths for a secrets.toml file are: {', '.join(self._file_paths)}"
                 if print_exceptions:
-                    st.error("Error parsing Secrets file.")
-                raise
+                    st.error(err_msg)
+                raise FileNotFoundError(err_msg)
+
+            if len([p for p in self._file_paths if os.path.exists(p)]) > 1:
+                _LOGGER.info(
+                    f"Secrets found in multiple locations: {', '.join(self._file_paths)}. "
+                    "When multiple secret.toml files exist, local secrets will take precedence over global secrets."
+                )
 
             for k, v in secrets.items():
                 self._maybe_set_environment_variable(k, v)
 
             self._secrets = secrets
-            self._maybe_install_file_watcher()
+            self._maybe_install_file_watchers()
 
             return self._secrets
 
@@ -211,33 +237,37 @@ class Secrets(Mapping[str, Any]):
         if value_type in (str, int, float) and os.environ.get(k) == v:
             del os.environ[k]
 
-    def _maybe_install_file_watcher(self) -> None:
+    def _maybe_install_file_watchers(self) -> None:
         with self._lock:
-            if self._file_watcher_installed:
+            if self._file_watchers_installed:
                 return
 
-            # We force our watcher_type to 'poll' because Streamlit Cloud
-            # stores `secrets.toml` in a virtual filesystem that is
-            # incompatible with watchdog.
-            streamlit.watcher.path_watcher.watch_file(
-                self._file_path,
-                self._on_secrets_file_changed,
-                watcher_type="poll",
-            )
+            for path in self._file_paths:
+                try:
+                    streamlit.watcher.path_watcher.watch_file(
+                        path,
+                        self._on_secrets_file_changed,
+                        watcher_type="poll",
+                    )
+                except FileNotFoundError:
+                    # A user may only have one secrets.toml file defined, so we'd expect
+                    # FileNotFoundErrors to be raised when attempting to install a
+                    # watcher on the nonexistent ones.
+                    pass
 
-            # We set file_watcher_installed to True even if watch_file
-            # returns False to avoid repeatedly trying to install it.
-            self._file_watcher_installed = True
+            # We set file_watchers_installed to True even if the installation attempt
+            # failed to avoid repeatedly trying to install it.
+            self._file_watchers_installed = True
 
-    def _on_secrets_file_changed(self, _) -> None:
+    def _on_secrets_file_changed(self, changed_file_path) -> None:
         with self._lock:
-            _LOGGER.debug("Secrets file %s changed, reloading", self._file_path)
+            _LOGGER.debug("Secrets file %s changed, reloading", changed_file_path)
             self._reset()
             self._parse(print_exceptions=True)
 
         # Emit a signal to notify receivers that the `secrets.toml` file
         # has been changed.
-        self._file_change_listener.send()
+        self.file_change_listener.send()
 
     def __getattr__(self, key: str) -> Any:
         """Return the value with the given key. If no such key
@@ -279,7 +309,7 @@ class Secrets(Mapping[str, Any]):
         # the file must already exist.
         """A string representation of the contents of the dict. Thread-safe."""
         if not runtime.exists():
-            return f"{self.__class__.__name__}(file_path={self._file_path!r})"
+            return f"{self.__class__.__name__}(file_paths={self._file_paths!r})"
         return repr(self._parse(True))
 
     def __len__(self) -> int:
@@ -311,4 +341,4 @@ class Secrets(Mapping[str, Any]):
         return iter(self._parse(True))
 
 
-secrets_singleton: Final = Secrets(SECRETS_FILE_LOC)
+secrets_singleton: Final = Secrets(SECRETS_FILE_LOCS)

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -93,7 +93,7 @@ class AppSessionTest(unittest.TestCase):
         Runtime._instance = None
 
     @patch(
-        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.disconnect"
+        "streamlit.runtime.app_session.secrets_singleton.file_change_listener.disconnect"
     )
     def test_shutdown(self, patched_disconnect):
         """Test that AppSession.shutdown behaves sanely."""
@@ -175,7 +175,7 @@ class AppSessionTest(unittest.TestCase):
         clear_legacy_cache.assert_called_once()
 
     @patch(
-        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.connect"
+        "streamlit.runtime.app_session.secrets_singleton.file_change_listener.connect"
     )
     def test_request_rerun_on_secrets_file_change(self, patched_connect):
         """AppSession should add a secrets listener on creation."""
@@ -399,7 +399,7 @@ class AppSessionTest(unittest.TestCase):
     @patch("streamlit.runtime.app_session.config.on_config_parsed")
     @patch("streamlit.runtime.app_session.source_util.register_pages_changed_callback")
     @patch(
-        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.connect"
+        "streamlit.runtime.app_session.secrets_singleton.file_change_listener.connect"
     )
     def test_registers_file_watchers(
         self,
@@ -430,7 +430,7 @@ class AppSessionTest(unittest.TestCase):
         self.assertIsNotNone(session._local_sources_watcher)
 
     @patch(
-        "streamlit.runtime.app_session.secrets_singleton._file_change_listener.disconnect"
+        "streamlit.runtime.app_session.secrets_singleton.file_change_listener.disconnect"
     )
     def test_disconnect_file_watchers(self, patched_secrets_disconnect):
         session = _create_test_session()

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -15,6 +15,7 @@
 """st.secrets unit tests."""
 
 import os
+import tempfile
 import unittest
 from collections.abc import Mapping as MappingABC
 from collections.abc import MutableMapping as MutableMappingABC
@@ -24,7 +25,7 @@ from unittest.mock import MagicMock, mock_open, patch
 from parameterized import parameterized
 from toml import TomlDecodeError
 
-from streamlit.runtime.secrets import SECRETS_FILE_LOC, Secrets
+from streamlit.runtime.secrets import SECRETS_FILE_LOCS, Secrets
 from tests.exception_capturing_thread import call_on_threads
 
 MOCK_TOML = """
@@ -41,13 +42,15 @@ MOCK_SECRETS_FILE_LOC = "/mock/secrets.toml"
 
 
 class SecretsTest(unittest.TestCase):
+    """Tests for st.secrets with a single secrets.toml file"""
+
     def setUp(self) -> None:
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
         self._prev_environ = dict(os.environ)
         # Run tests on our own Secrets instance to reduce global state
         # mutations.
-        self.secrets = Secrets(MOCK_SECRETS_FILE_LOC)
+        self.secrets = Secrets([MOCK_SECRETS_FILE_LOC])
 
     def tearDown(self) -> None:
         os.environ.clear()
@@ -64,7 +67,7 @@ class SecretsTest(unittest.TestCase):
         [
             [
                 False,
-                "Secrets(file_path='/mock/secrets.toml')",
+                "Secrets(file_paths=['/mock/secrets.toml'])",
             ],
             [
                 True,
@@ -90,7 +93,14 @@ class SecretsTest(unittest.TestCase):
 
     def test_secrets_file_location(self):
         """Verify that we're looking for secrets.toml in the right place."""
-        self.assertEqual(os.path.abspath("./.streamlit/secrets.toml"), SECRETS_FILE_LOC)
+        self.assertEqual(
+            [
+                # conftest.py sets the HOME envvar to "/mock/home/folder".
+                "/mock/home/folder/.streamlit/secrets.toml",
+                os.path.abspath("./.streamlit/secrets.toml"),
+            ],
+            SECRETS_FILE_LOCS,
+        )
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_os_environ(self, _):
@@ -113,11 +123,11 @@ class SecretsTest(unittest.TestCase):
         with patch("builtins.open", mock_open()) as mock_file:
             mock_file.side_effect = FileNotFoundError()
 
-            with self.assertRaises(OSError):
+            with self.assertRaises(FileNotFoundError):
                 self.secrets.get("no_such_secret", None)
 
         mock_st_error.assert_called_once_with(
-            f"Secrets file not found. Expected at: {MOCK_SECRETS_FILE_LOC}"
+            f"No secrets files found. Valid paths for a secrets.toml file are: {MOCK_SECRETS_FILE_LOC}"
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data="invalid_toml")
@@ -129,7 +139,9 @@ class SecretsTest(unittest.TestCase):
         with self.assertRaises(TomlDecodeError):
             self.secrets.get("no_such_secret", None)
 
-        mock_st_error.assert_called_once_with("Error parsing Secrets file.")
+        mock_st_error.assert_called_once_with(
+            f"Error parsing secrets file at /mock/secrets.toml"
+        )
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
@@ -191,7 +203,7 @@ class SecretsTest(unittest.TestCase):
         )
 
         # Mock the `send` method to later verify that it has been called.
-        self.secrets._file_change_listener.send = MagicMock()
+        self.secrets.file_change_listener.send = MagicMock()
 
         # Change the text that will be loaded on the next call to `open`
         new_mock_toml = "db_username='Joan'"
@@ -202,12 +214,107 @@ class SecretsTest(unittest.TestCase):
             self.secrets._on_secrets_file_changed(MOCK_SECRETS_FILE_LOC)
 
             # A change in `secrets.toml` should emit a signal.
-            self.secrets._file_change_listener.send.assert_called_once()
+            self.secrets.file_change_listener.send.assert_called_once()
 
             self.assertEqual("Joan", self.secrets["db_username"])
             self.assertIsNone(self.secrets.get("db_password"))
             self.assertEqual("Joan", os.environ["db_username"])
             self.assertIsNone(os.environ.get("db_password"))
+
+
+class MultipleSecretsFilesTest(unittest.TestCase):
+    """Tests for st.secrets with multiple secrets.toml files."""
+
+    def setUp(self) -> None:
+        self._fd1, self._path1 = tempfile.mkstemp()
+        self._fd2, self._path2 = tempfile.mkstemp()
+
+        # st.secrets modifies os.environ, so we save it here and
+        # restore in tearDown.
+        self._prev_environ = dict(os.environ)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._prev_environ)
+
+        os.remove(self._path1)
+        os.remove(self._path2)
+
+    @patch("streamlit.error")
+    def test_no_secrets_files_explodes(self, mock_st_error):
+        """Validate that an error is thrown if none of the given secrets.toml files exist."""
+
+        secrets_file_locations = [
+            "/mock1/secrets.toml",
+            "/mock2/secrets.toml",
+        ]
+        secrets = Secrets(secrets_file_locations)
+
+        with self.assertRaises(FileNotFoundError):
+            secrets.get("no_such_secret", None)
+
+        mock_st_error.assert_called_once_with(
+            f"No secrets files found. Valid paths for a secrets.toml file are: /mock1/secrets.toml, /mock2/secrets.toml"
+        )
+
+    @patch("streamlit.runtime.secrets._LOGGER")
+    def test_only_one_secrets_file_fine(self, patched_logger):
+        with os.fdopen(self._fd1, "w") as tmp:
+            tmp.write(MOCK_TOML)
+
+        secrets_file_locations = [
+            self._path1,
+            "/mock2/secrets.toml",
+        ]
+        secrets = Secrets(secrets_file_locations)
+
+        self.assertEqual(secrets.db_username, "Jane")
+        patched_logger.info.assert_not_called()
+
+    @patch("streamlit.runtime.secrets._LOGGER")
+    def test_secret_overwriting(self, patched_logger):
+        """Test that if both global and project-level secrets.toml files exist, secrets
+        from both are present in st.secrets, and secrets from the project-level file
+        "win" when secrets have conflicting names.
+        """
+        with os.fdopen(self._fd1, "w") as tmp:
+            tmp.write(MOCK_TOML)
+
+        with os.fdopen(self._fd2, "w") as tmp:
+            tmp.write(
+                """
+db_password="54321dvorak"
+hi="I'm new"
+
+[subsection]
+email2="eng2@streamlit.io"
+"""
+            )
+
+        secrets_file_locations = [
+            self._path1,
+            self._path2,
+        ]
+        secrets = Secrets(secrets_file_locations)
+
+        # secrets.db_username is only defined in the first secrets.toml file, so it
+        # remains unchanged.
+        self.assertEqual(secrets.db_username, "Jane")
+
+        # secrets.db_password should be overwritten because it's set to a different
+        # value in our second secrets.toml file.
+        self.assertEqual(secrets.db_password, "54321dvorak")
+
+        # secrets.hi only appears in our second secrets.toml file.
+        self.assertEqual(secrets.hi, "I'm new")
+
+        # Secrets subsections are overwritten entirely rather than being merged.
+        self.assertEqual(secrets.subsection, {"email2": "eng2@streamlit.io"})
+
+        patched_logger.info.assert_called_once_with(
+            f"Secrets found in multiple locations: {self._path1}, {self._path2}. "
+            "When multiple secret.toml files exist, local secrets will take precedence over global secrets."
+        )
 
 
 class SecretsThreadingTests(unittest.TestCase):


### PR DESCRIPTION
## 📚 Context

As part of the upcoming `st.connection` feature, we thought that it'd be useful to allow
users to set secrets via a global `~/.streamlit/secrets.toml` file along with the per-project
`secrets.toml` files that are supported today.

This works similarly to how `config.toml` files currently do: values set in the global
`secrets.toml` file are overwritten by those set in per-project files.


- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

  - [x] This is a visible (user-facing) change


## 🧪 Testing Done

- [x] Added/Updated unit tests
