### PR TITLE
Update docstring style

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -307,8 +307,8 @@ def get_data_cache_stats_provider() -> CacheStatsProvider:
 
 
 class CacheDataAPI:
-    """Implements the public st.cache_data API: the @st.cache_data decorator, and
-    st.cache_data.clear().
+    """Implements the public st.cache_data API
+    Specifically, the @st.cache_data decorator, and st.cache_data.clear().
     """
 
     def __init__(

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -188,8 +188,8 @@ class CachedResourceFuncInfo(CachedFuncInfo):
 
 
 class CacheResourceAPI:
-    """Implements the public st.cache_resource API: the @st.cache_resource decorator,
-    and st.cache_resource.clear().
+    """Implements the public st.cache_resource API
+    Specifically, the @st.cache_resource decorator, and st.cache_resource.clear().
     """
 
     def __init__(


### PR DESCRIPTION
## 📚 Context

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

This only affects docstring style for new caching methods to follow the python convention that the first line of a docstring should concisely explain what the method does.

This has no effect on any functionality

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
