### PR TITLE
Add support for number and boolean types in categorical columns

### DIFF
--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -335,7 +335,7 @@ describe("getColumnFromArrow", () => {
       isIndex: false,
       isHidden: false,
       columnTypeMetadata: {
-        options: ["", "bar", "foo"],
+        options: ["bar", "foo"],
       },
     })
   })

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -247,7 +247,7 @@ export function getColumnFromArrow(
     const options = data.getCategoricalOptions(columnPosition)
     if (notNullOrUndefined(options)) {
       columnTypeMetadata = {
-        options: ["", ...options.filter(opt => opt !== "")],
+        options,
       }
     }
   }

--- a/frontend/src/components/widgets/DataFrame/columns/BooleanColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/BooleanColumn.ts
@@ -20,19 +20,14 @@ import {
   GridCellKind,
 } from "@glideapps/glide-data-grid"
 
-import { notNullOrUndefined } from "src/lib/utils"
-
 import {
   BaseColumn,
   BaseColumnProps,
   getErrorCell,
   ColumnCreator,
   toSafeString,
+  toSafeBoolean,
 } from "./utils"
-
-// See pydantic for inspiration: https://pydantic-docs.helpmanual.io/usage/types/#booleans
-const BOOLEAN_TRUE_VALUES = ["true", "t", "yes", "y", "on", "1"]
-const BOOLEAN_FALSE_VALUES = ["false", "f", "no", "n", "off", "0"]
 
 /**
  * A column type that supports optimized rendering and editing for boolean values
@@ -55,24 +50,12 @@ function BooleanColumn(props: BaseColumnProps): BaseColumn {
     getCell(data?: any): GridCell {
       let cellData = null
 
-      if (notNullOrUndefined(data)) {
-        if (typeof data === "boolean") {
-          cellData = data
-        } else {
-          const cleanedValue = String(data).toLowerCase().trim()
-          if (cleanedValue === "") {
-            cellData = null
-          } else if (BOOLEAN_TRUE_VALUES.includes(cleanedValue)) {
-            cellData = true
-          } else if (BOOLEAN_FALSE_VALUES.includes(cleanedValue)) {
-            cellData = false
-          } else {
-            return getErrorCell(
-              toSafeString(data),
-              `The value cannot be interpreted as boolean.`
-            )
-          }
-        }
+      cellData = toSafeBoolean(data)
+      if (cellData === undefined) {
+        return getErrorCell(
+          toSafeString(data),
+          `The value cannot be interpreted as boolean.`
+        )
       }
 
       // We are not setting isMissingValue here because the checkbox column

--- a/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
@@ -55,7 +55,7 @@ function getCategoricalColumn(
 }
 
 describe("CategoricalColumn", () => {
-  it("creates a valid column instance", () => {
+  it("creates a valid column instance with string values", () => {
     const mockColumn = getCategoricalColumn(MOCK_CATEGORICAL_TYPE, {
       options: ["foo", "bar"],
     })
@@ -69,6 +69,20 @@ describe("CategoricalColumn", () => {
     expect(mockColumn.getCellValue(mockCell)).toEqual("foo")
   })
 
+  it("creates a valid column instance number values", () => {
+    const mockColumn = getCategoricalColumn(MOCK_CATEGORICAL_TYPE, {
+      options: [1, 2, 3],
+    })
+    expect(mockColumn.kind).toEqual("categorical")
+    expect(mockColumn.title).toEqual(CATEGORICAL_COLUMN_TEMPLATE.title)
+    expect(mockColumn.id).toEqual(CATEGORICAL_COLUMN_TEMPLATE.id)
+    expect(mockColumn.sortMode).toEqual("default")
+
+    const mockCell = mockColumn.getCell(1)
+    expect(mockCell.kind).toEqual(GridCellKind.Custom)
+    expect(mockColumn.getCellValue(mockCell)).toEqual(1)
+  })
+
   it("creates a valid column instance from boolean type", () => {
     const mockColumn = getCategoricalColumn(MOCK_BOOLEAN_ARROW_TYPE)
     expect(mockColumn.kind).toEqual("categorical")
@@ -76,7 +90,7 @@ describe("CategoricalColumn", () => {
 
     const mockCell = mockColumn.getCell(true)
     expect(mockCell.kind).toEqual(GridCellKind.Custom)
-    expect(mockColumn.getCellValue(mockCell)).toEqual("true")
+    expect(mockColumn.getCellValue(mockCell)).toEqual(true)
   })
 
   it("creates error cell if value is not in options", () => {

--- a/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -27,6 +27,7 @@ import {
   mergeColumnParameters,
   isMissingValueCell,
   BaseColumnProps,
+  toSafeBoolean,
   toGlideColumn,
 } from "./utils"
 import { TextColumn } from "."
@@ -144,6 +145,37 @@ describe("toSafeString", () => {
     ],
   ])("converts %p to a valid string: %p", (input, expected) => {
     expect(toSafeString(input)).toEqual(expected)
+  })
+})
+
+describe("toSafeBoolean", () => {
+  it.each([
+    [true, true],
+    [false, false],
+    ["true", true],
+    ["false", false],
+    ["yes", true],
+    ["no", false],
+    ["t", true],
+    ["f", false],
+    ["y", true],
+    ["n", false],
+    ["on", true],
+    ["off", false],
+    ["1", true],
+    ["0", false],
+    [1, true],
+    [0, false],
+    [[], null],
+    [null, null],
+    [undefined, null],
+    ["", null],
+    ["foo", undefined],
+    [12345, undefined],
+    [[1, 2], undefined],
+    [0.1, undefined],
+  ])("converts %p to a boolean: %p", (input, expected) => {
+    expect(toSafeBoolean(input)).toEqual(expected)
   })
 })
 

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -86,6 +86,10 @@ export type ColumnCreator = {
   readonly isEditableType: boolean
 }
 
+// See pydantic for inspiration: https://pydantic-docs.helpmanual.io/usage/types/#booleans
+const BOOLEAN_TRUE_VALUES = ["true", "t", "yes", "y", "on", "1"]
+const BOOLEAN_FALSE_VALUES = ["false", "f", "no", "n", "off", "0"]
+
 /**
  * Interface used for indicating if a cell contains an error.
  */
@@ -295,12 +299,44 @@ export function toSafeString(data: any): string {
 }
 
 /**
+ * Converts the given value of unknown type to a boolean without
+ * the risks of any exceptions.
+ *
+ * @param value - The value to convert to a boolean.
+ *
+ * @return The converted boolean, null if the value is empty or undefined if the
+ *         value cannot be interpreted as a boolean.
+ */
+export function toSafeBoolean(value: any): boolean | null | undefined {
+  if (isNullOrUndefined(value)) {
+    return null
+  }
+
+  if (typeof value === "boolean") {
+    return value
+  }
+
+  const cleanedValue = toSafeString(value).toLowerCase().trim()
+  if (cleanedValue === "") {
+    return null
+  } else if (BOOLEAN_TRUE_VALUES.includes(cleanedValue)) {
+    return true
+  } else if (BOOLEAN_FALSE_VALUES.includes(cleanedValue)) {
+    return false
+  } else {
+    // The value cannot be interpreted as boolean
+    return undefined
+  }
+}
+
+/**
  * Converts the given value of unknown type to a number without
  * the risks of any exceptions.
  *
  * @param value - The value to convert to a number.
  *
- * @returns The converted number or null if the value cannot be interpreted as a number.
+ * @returns The converted number or null if the value is empty or undefined or NaN if the
+ *          value cannot be interpreted as a number.
  */
 export function toSafeNumber(value: any): number | null {
   // TODO(lukasmasuch): Should this return null as replacement for NaN?


### PR DESCRIPTION
## 📚 Context

Categorical columns in Pandas can also use other underlying types than string. This PR adds support for numerical and boolean types to be used correctly with the categorical column.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Check the common type of options to determine which type to use.
- Return the actual type in `getCellValues` 
- Move the boolean parse logic to utils for reusability.

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
