### PR TITLE
Refactoring App.test.tsx

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -878,7 +878,7 @@ describe("App.handleNewSession", () => {
       const instance = wrapper.instance() as App
       instance.handleNewSession(new NewSession(NEW_SESSION_JSON))
 
-      expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
+      expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
     })
 
     it("can switch to a non-main page", () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1135,22 +1135,6 @@ describe("App.sendRerunBackMsg", () => {
 
 //   * handlePageNotFound has branching error messages depending on pageName
 describe("App.handlePageNotFound", () => {
-  let pushStateSpy: any
-
-  beforeEach(() => {
-    pushStateSpy = jest.spyOn(
-      window.history,
-      // @ts-ignore
-      "pushState"
-    )
-  })
-
-  afterEach(() => {
-    // @ts-ignore
-    pushStateSpy.mockRestore()
-    window.history.pushState({}, "", "/")
-  })
-
   it("includes the missing page name in error modal message if available", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -852,6 +852,7 @@ describe("App.handleNewSession", () => {
   describe("page change URL handling", () => {
     let wrapper: ShallowWrapper
     let instance: App
+    let pushStateSpy: any
 
     beforeEach(() => {
       wrapper = shallow(<App {...getProps()} />)
@@ -860,7 +861,7 @@ describe("App.handleNewSession", () => {
       instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
 
       window.history.pushState({}, "", "/")
-      jest.spyOn(
+      pushStateSpy = jest.spyOn(
         window.history,
         // @ts-ignore
         "pushState"
@@ -868,6 +869,8 @@ describe("App.handleNewSession", () => {
     })
 
     afterEach(() => {
+      // @ts-ignore
+      pushStateSpy.mockRestore()
       window.history.pushState({}, "", "/")
     })
 
@@ -975,6 +978,7 @@ describe("App.handlePageInfoChanged", () => {
   })
 
   afterEach(() => {
+    pushStateSpy.mockRestore()
     // Reset the value of document.location.pathname.
     window.history.pushState({}, "", "/")
   })
@@ -1131,6 +1135,22 @@ describe("App.sendRerunBackMsg", () => {
 
 //   * handlePageNotFound has branching error messages depending on pageName
 describe("App.handlePageNotFound", () => {
+  let pushStateSpy: any
+
+  beforeEach(() => {
+    pushStateSpy = jest.spyOn(
+      window.history,
+      // @ts-ignore
+      "pushState"
+    )
+  })
+
+  afterEach(() => {
+    // @ts-ignore
+    pushStateSpy.mockRestore()
+    window.history.pushState({}, "", "/")
+  })
+
   it("includes the missing page name in error modal message if available", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
@@ -1147,7 +1167,6 @@ describe("App.handlePageNotFound", () => {
       new PageNotFound({ pageName: "nonexistentPage" })
     )
 
-    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
     expect(instance.showError).toHaveBeenCalledWith(
       "Page not found",
       expect.stringMatching("You have requested page /nonexistentPage")
@@ -1173,7 +1192,6 @@ describe("App.handlePageNotFound", () => {
 
     instance.handlePageNotFound(new PageNotFound({ pageName: "" }))
 
-    expect(window.history.pushState).toHaveBeenCalledWith({}, "", "/")
     expect(instance.showError).toHaveBeenCalledWith(
       "Page not found",
       expect.stringMatching(


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

Some refactoring suggestions on what I found when developing #6266

Points are:
* The clean-up functions must reset the mocks. If we skip it, tests depending on mocks set in other tests can pass.
  * Actually there are 2 cases, where calls of `window.history.pushState` are asserted even though this method is never called in the actual implementation (`handlePageNotFound`).
* Ideally, `jest.resetAllMocks()` (or setting `jest.resetMocks=true` in `package.json`) is the best solution, but introducing it directly caused too many errors, so I started un-mocking `window.history` separately first.

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
