### PR TITLE
Fix `make tstypecheck`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ pylint:
 .PHONY: pyformat
 # Fix Python files that are not properly formatted.
 pyformat:
-	pre-commit run black --all-files
-	pre-commit run isort --all-files
+	pre-commit run black --all-files --hook-stage manual
+	pre-commit run isort --all-files --hook-stage manual
 
 .PHONY: pytest
 # Run Python unit tests.
@@ -303,12 +303,12 @@ endif #CIRCLECI
 .PHONY: tstypecheck
 # Type check the JS/TS code
 tstypecheck:
-	pre-commit run typecheck --all-files
+	pre-commit run typecheck --all-files --hook-stage manual
 
 .PHONY: jsformat
 # Fix formatting issues in our JavaScript & TypeScript files.
 jsformat:
-	pre-commit run prettier --all-files
+	pre-commit run prettier --all-files --hook-stage manual
 
 .PHONY: jstest
 # Run JS unit tests.
@@ -367,8 +367,8 @@ notices:
 .PHONY: headers
 # Update the license header on all source files.
 headers:
-	pre-commit run insert-license --all-files
-	pre-commit run license-headers --all-files
+	pre-commit run insert-license --all-files --hook-stage manual
+	pre-commit run license-headers --all-files --hook-stage manual
 
 .PHONY: build-test-env
 # Build docker image that mirrors circleci


### PR DESCRIPTION
`make tstypecheck` currently errors out with "No hook with id `typecheck` in stage `commit`". 

The fix is to pass `--hook-stage manual` to the precommit command. (The commit adds the hook-stake param to all make rules that use `pre-commit`, to prevent regressions in the future.)