### PR TITLE
`withMapboxToken`: add types

### DIFF
--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
@@ -23,6 +23,7 @@ import withMapboxToken from "./withMapboxToken"
 
 interface TestProps {
   label: string
+  width: number
   mapboxToken: string
 }
 
@@ -37,10 +38,6 @@ function waitOneTick(): Promise<void> {
 describe("withMapboxToken", () => {
   const token = "mockToken"
   const commandLine = "streamlit run test.py"
-
-  function getProps(): Record<string, unknown> {
-    return { label: "label" }
-  }
 
   beforeAll(() => {
     SessionInfo.current = new SessionInfo({
@@ -70,22 +67,24 @@ describe("withMapboxToken", () => {
   })
 
   it("renders without crashing", async () => {
-    const props = getProps()
     const WrappedComponent = withMapboxToken("st.test")(TestComponent)
-    const wrapper = shallow(<WrappedComponent {...props} />)
+    const wrapper = shallow(
+      <WrappedComponent label={"mockLabel"} width={100} />
+    )
 
     expect(wrapper.find("Alert").exists()).toBe(true)
   })
 
   it("passes mapboxToken to wrapped component", async () => {
-    const props = getProps()
     const WrappedComponent = withMapboxToken("st.test")(TestComponent)
-    const wrapper = shallow(<WrappedComponent {...props} />)
+    const wrapper = shallow(
+      <WrappedComponent label={"mockLabel"} width={100} />
+    )
 
     // Wait one tick for our MapboxToken promise to resolve
     await waitOneTick()
 
-    expect(wrapper.props().label).toBe("label")
+    expect(wrapper.props().label).toBe("mockLabel")
     expect(wrapper.props().mapboxToken).toBe("mockToken")
   })
 })

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.test.tsx
@@ -87,4 +87,11 @@ describe("withMapboxToken", () => {
     expect(wrapper.props().label).toBe("mockLabel")
     expect(wrapper.props().mapboxToken).toBe("mockToken")
   })
+
+  it("defines `displayName`", () => {
+    const WrappedComponent = withMapboxToken("st.test")(TestComponent)
+    expect(WrappedComponent.displayName).toEqual(
+      "withMapboxToken(TestComponent)"
+    )
+  })
 })

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.tsx
@@ -22,8 +22,9 @@ import hoistNonReactStatics from "hoist-non-react-statics"
 import React, { ComponentType, PureComponent, ReactNode } from "react"
 import MapboxTokenError from "./MapboxTokenError"
 
-interface Props {
+interface InjectedProps {
   width: number
+  mapboxToken: string
 }
 
 interface State {
@@ -42,13 +43,16 @@ interface State {
 
 const withMapboxToken =
   (deltaType: string) =>
-  (WrappedComponent: ComponentType<any>): ComponentType<any> => {
-    class WithMapboxToken extends PureComponent<Props, State> {
+  <P extends InjectedProps>(WrappedComponent: ComponentType<P>) => {
+    class WithMapboxToken extends PureComponent<
+      Omit<P, "mapboxToken">,
+      State
+    > {
       public static readonly displayName = `withMapboxToken(${
         WrappedComponent.displayName || WrappedComponent.name
       })`
 
-      public constructor(props: Props) {
+      public constructor(props: P) {
         super(props)
 
         this.state = {
@@ -102,7 +106,9 @@ const withMapboxToken =
         }
 
         // We have the mapbox token. Pass it through to our component.
-        return <WrappedComponent mapboxToken={mapboxToken} {...this.props} />
+        return (
+          <WrappedComponent {...(this.props as P)} mapboxToken={mapboxToken} />
+        )
       }
     }
 

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.tsx
@@ -88,7 +88,7 @@ const withMapboxToken =
         }
       }
 
-      public render(): ReactNode {
+      public render = (): ReactNode => {
         const { mapboxToken, mapboxTokenError, isFetching } = this.state
         const { width } = this.props
 

--- a/frontend/src/hocs/withMapboxToken/withMapboxToken.tsx
+++ b/frontend/src/hocs/withMapboxToken/withMapboxToken.tsx
@@ -44,6 +44,9 @@ interface State {
 const withMapboxToken =
   (deltaType: string) =>
   <P extends InjectedProps>(WrappedComponent: ComponentType<P>) => {
+    // Return a wrapper that accepts the wrapped component's props, minus
+    // "mapboxToken". The wrapper will fetch the mapboxToken and inject it into
+    // the wrapped component automatically.
     class WithMapboxToken extends PureComponent<
       Omit<P, "mapboxToken">,
       State
@@ -52,7 +55,7 @@ const withMapboxToken =
         WrappedComponent.displayName || WrappedComponent.name
       })`
 
-      public constructor(props: P) {
+      public constructor(props: Omit<P, "mapboxToken">) {
         super(props)
 
         this.state = {


### PR DESCRIPTION
`withMapboxToken` removes typing from its wrapped component. This PR adds proper typing - which is a readability nightmare, because HOCs are ugly.

With this change, TypeScript will raise a compile error if the wrapped component is instantiated with the wrong properties.