### PR TITLE
Replace @ts-ignore with @ts-expect-error and remove unused directives

### DIFF
--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -39,7 +39,7 @@ describe("st.date_input", () => {
     cy.get(".stDateInput").should("have.length", 9);
 
     cy.get(".stDateInput").each((el, idx) => {
-      // @ts-ignore
+      // @ts-expect-error
       return cy.wrap(el).matchThemedSnapshots("date_input" + idx);
     });
   });

--- a/e2e/specs/st_number_input.spec.js
+++ b/e2e/specs/st_number_input.spec.js
@@ -25,7 +25,7 @@ describe("st.number_input", () => {
     cy.get(".stNumberInput").should("have.length", 9);
 
     cy.get(".stNumberInput").each((el, idx) => {
-      // @ts-ignore
+      // @ts-expect-error
       return cy.wrap(el).matchThemedSnapshots("number_input" + idx);
     });
   });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -135,7 +135,7 @@ describe("App", () => {
 
     wrapper.unmount()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(instance.connectionManager.disconnect).toHaveBeenCalled()
   })
 
@@ -202,7 +202,7 @@ describe("App", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().keyHandlers.STOP_RECORDING()
 
     expect(props.screenCast.stopRecording).toBeCalled()
@@ -340,13 +340,10 @@ describe("App", () => {
     const wrapper = shallow(<App {...props} />)
     const mockThemeConfig = { emotion: darkTheme.emotion }
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().setAndSendTheme(mockThemeConfig)
 
-    // @ts-ignore
     expect(props.theme.setTheme).toHaveBeenCalledWith(mockThemeConfig)
-
-    // @ts-ignore
     expect(props.hostCommunication.sendMessage).toHaveBeenCalledWith({
       type: "SET_THEME_CONFIG",
       themeInfo: toExportedTheme(darkTheme.emotion),
@@ -468,13 +465,10 @@ describe("App.handleNewSession", () => {
     )
     const wrapper = shallow(<App {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(NEW_SESSION)
 
-    // @ts-ignore
     expect(props.theme.addThemes).toHaveBeenCalled()
-
-    // @ts-ignore
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
@@ -484,16 +478,13 @@ describe("App.handleNewSession", () => {
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
-    // @ts-ignore
     expect(props.theme.addThemes).toHaveBeenCalled()
-
-    // @ts-ignore
     expect(props.theme.setTheme).toHaveBeenCalled()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe(CUSTOM_THEME_NAME)
   })
 
@@ -511,16 +502,13 @@ describe("App.handleNewSession", () => {
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
-    // @ts-ignore
     expect(props.theme.addThemes).toHaveBeenCalled()
-
-    // @ts-ignore
     expect(props.theme.setTheme).toHaveBeenCalled()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.theme.setTheme.mock.calls[0][0].name).toBe(CUSTOM_THEME_NAME)
   })
 
@@ -529,16 +517,14 @@ describe("App.handleNewSession", () => {
     const wrapper = shallow(<App {...props} />)
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-ignore
+    // @ts-expect-error
     newSessionJson.customTheme = null
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
-
-    // @ts-ignore
     expect(props.theme.addThemes).toHaveBeenCalled()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.theme.addThemes.mock.calls[0][0]).toEqual([])
   })
 
@@ -548,19 +534,17 @@ describe("App.handleNewSession", () => {
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
-    // @ts-ignore
+    // @ts-expect-error
     newSessionJson.customTheme = null
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
-    // @ts-ignore
     expect(props.theme.addThemes).toHaveBeenCalled()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.theme.addThemes.mock.calls[0][0]).toEqual([])
 
-    // @ts-ignore
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
@@ -573,18 +557,18 @@ describe("App.handleNewSession", () => {
     const wrapper = shallow(<App {...props} />)
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-ignore
+    // @ts-expect-error
     newSessionJson.customTheme = null
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
     expect(props.theme.addThemes).toHaveBeenCalled()
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.theme.addThemes.mock.calls[0][0]).toEqual([])
 
     expect(props.theme.setTheme).toHaveBeenCalled()
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.theme.setTheme.mock.calls[0][0]).toEqual(createAutoTheme())
   })
 
@@ -593,11 +577,11 @@ describe("App.handleNewSession", () => {
     const wrapper = shallow(<App {...props} />)
 
     const customThemeConfig = new CustomThemeConfig({ primaryColor: "blue" })
-    // @ts-ignore
+    // @ts-expect-error
     const themeHash = wrapper.instance().createThemeHash(customThemeConfig)
     wrapper.setState({ themeHash })
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(NEW_SESSION)
 
     expect(props.theme.addThemes).toHaveBeenCalled()
@@ -611,11 +595,11 @@ describe("App.handleNewSession", () => {
     const customThemeConfig = new CustomThemeConfig(
       NEW_SESSION_JSON.customTheme
     )
-    // @ts-ignore
+    // @ts-expect-error
     const themeHash = wrapper.instance().createThemeHash(customThemeConfig)
     wrapper.setState({ themeHash })
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(NEW_SESSION)
 
     expect(props.theme.addThemes).not.toHaveBeenCalled()
@@ -628,10 +612,10 @@ describe("App.handleNewSession", () => {
     wrapper.setState({ themeHash: "hash_for_undefined_custom_theme" })
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-ignore
+    // @ts-expect-error
     newSessionJson.customTheme = null
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
     expect(props.theme.addThemes).not.toHaveBeenCalled()
@@ -647,13 +631,13 @@ describe("App.handleNewSession", () => {
 
     const oneTimeInitialization = jest.spyOn(
       app,
-      // @ts-ignore
+      // @ts-expect-error
       "handleOneTimeInitialization"
     )
 
     expect(sessionInfo.isSet).toBe(false)
 
-    // @ts-ignore
+    // @ts-expect-error
     app.handleNewSession(NEW_SESSION)
 
     expect(oneTimeInitialization).toHaveBeenCalledTimes(1)
@@ -669,17 +653,17 @@ describe("App.handleNewSession", () => {
 
     const oneTimeInitialization = jest.spyOn(
       app,
-      // @ts-ignore
+      // @ts-expect-error
       "handleOneTimeInitialization"
     )
 
     expect(sessionInfo.isSet).toBe(false)
 
-    // @ts-ignore
+    // @ts-expect-error
     app.handleNewSession(NEW_SESSION)
-    // @ts-ignore
+    // @ts-expect-error
     app.handleNewSession(NEW_SESSION)
-    // @ts-ignore
+    // @ts-expect-error
     app.handleNewSession(NEW_SESSION)
 
     // Multiple NEW_SESSION messages should not result in one-time
@@ -697,23 +681,23 @@ describe("App.handleNewSession", () => {
 
     const oneTimeInitialization = jest.spyOn(
       app,
-      // @ts-ignore
+      // @ts-expect-error
       "handleOneTimeInitialization"
     )
 
     expect(sessionInfo.isSet).toBe(false)
 
-    // @ts-ignore
+    // @ts-expect-error
     app.handleNewSession(NEW_SESSION)
     expect(oneTimeInitialization).toHaveBeenCalledTimes(1)
 
-    // @ts-ignore
+    // @ts-expect-error
     app.handleConnectionStateChanged(ConnectionState.PINGING_SERVER)
     expect(sessionInfo.isSet).toBe(false)
 
-    // @ts-ignore
+    // @ts-expect-error
     app.handleConnectionStateChanged(ConnectionState.CONNECTED)
-    // @ts-ignore
+    // @ts-expect-error
     app.handleNewSession(NEW_SESSION)
 
     expect(oneTimeInitialization).toHaveBeenCalledTimes(2)
@@ -729,7 +713,7 @@ describe("App.handleNewSession", () => {
       connectionState: ConnectionState.CONNECTING,
     })
     wrapper.update()
-    // @ts-ignore
+    // @ts-expect-error
     expect(window.prerenderReady).toBe(false)
 
     wrapper.setState({
@@ -737,7 +721,7 @@ describe("App.handleNewSession", () => {
       connectionState: ConnectionState.CONNECTED,
     })
     wrapper.update()
-    // @ts-ignore
+    // @ts-expect-error
     expect(window.prerenderReady).toBe(false)
 
     wrapper.setState({
@@ -745,7 +729,7 @@ describe("App.handleNewSession", () => {
       connectionState: ConnectionState.CONNECTED,
     })
     wrapper.update()
-    // @ts-ignore
+    // @ts-expect-error
     expect(window.prerenderReady).toBe(true)
 
     // window.prerenderReady is set to true after first
@@ -754,7 +738,7 @@ describe("App.handleNewSession", () => {
       connectionState: ConnectionState.CONNECTED,
     })
     wrapper.update()
-    // @ts-ignore
+    // @ts-expect-error
     expect(window.prerenderReady).toBe(true)
   })
 
@@ -770,13 +754,10 @@ describe("App.handleNewSession", () => {
     ]
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-ignore
     newSessionJson.appPages = appPages
-
-    // @ts-ignore
     newSessionJson.pageScriptHash = "hash1"
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
     expect(wrapper.find("AppView").prop("appPages")).toEqual(appPages)
     expect(wrapper.find("AppView").prop("currentPageScriptHash")).toEqual(
@@ -800,10 +781,9 @@ describe("App.handleNewSession", () => {
     instance.clearAppState = jest.fn()
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
-    // @ts-ignore
     newSessionJson.pageScriptHash = "different_hash"
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
     expect(instance.clearAppState).toHaveBeenCalled()
@@ -820,7 +800,7 @@ describe("App.handleNewSession", () => {
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.instance().handleNewSession(new NewSession(newSessionJson))
 
     expect(instance.clearAppState).not.toHaveBeenCalled()
@@ -859,19 +839,14 @@ describe("App.handleNewSession", () => {
     beforeEach(() => {
       wrapper = shallow(<App {...getProps()} />)
       instance = wrapper.instance() as App
-      // @ts-ignore
+      // @ts-expect-error
       instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
 
       window.history.pushState({}, "", "/")
-      pushStateSpy = jest.spyOn(
-        window.history,
-        // @ts-ignore
-        "pushState"
-      )
+      pushStateSpy = jest.spyOn(window.history, "pushState")
     })
 
     afterEach(() => {
-      // @ts-ignore
       pushStateSpy.mockRestore()
       window.history.pushState({}, "", "/")
     })
@@ -916,7 +891,7 @@ describe("App.handleNewSession", () => {
 
     it("works with baseUrlPaths", () => {
       const instance = wrapper.instance() as App
-      // @ts-ignore
+      // @ts-expect-error
       instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo")
 
       const newSessionJson = cloneDeep(NEW_SESSION_JSON)
@@ -948,7 +923,7 @@ describe("App.handleNewSession", () => {
         new NewSession({ ...newSessionJson, pageScriptHash: "toppage_hash" })
       )
       expect(window.history.pushState).toHaveBeenLastCalledWith({}, "", "/")
-      // @ts-ignore
+      // @ts-expect-error
       window.history.pushState.mockClear()
 
       // When running the same, e.g. clicking the "rerun" button,
@@ -957,7 +932,7 @@ describe("App.handleNewSession", () => {
         new NewSession({ ...newSessionJson, pageScriptHash: "toppage_hash" })
       )
       expect(window.history.pushState).not.toHaveBeenCalled()
-      // @ts-ignore
+      // @ts-expect-error
       window.history.pushState.mockClear()
 
       // When accessing a different page, a new history for that page is pushed.
@@ -969,7 +944,7 @@ describe("App.handleNewSession", () => {
         "",
         "/page2"
       )
-      // @ts-ignore
+      // @ts-expect-error
       window.history.pushState.mockClear()
     })
   })
@@ -1010,11 +985,7 @@ describe("App.handlePageInfoChanged", () => {
     // Setup wrapper and app and spy on window.history.pushState.
     wrapper = shallow<App>(<App {...getProps()} />)
     app = wrapper.instance()
-    pushStateSpy = jest.spyOn(
-      window.history,
-      // @ts-ignore
-      "pushState"
-    )
+    pushStateSpy = jest.spyOn(window.history, "pushState")
   })
 
   afterEach(() => {
@@ -1033,7 +1004,6 @@ describe("App.handlePageInfoChanged", () => {
     })
     const expectedUrl = `${pathname}?${pageInfo.queryString}`
 
-    // @ts-ignore
     app.handlePageInfoChanged(pageInfo)
 
     expect(pushStateSpy).toHaveBeenLastCalledWith({}, "", expectedUrl)
@@ -1048,7 +1018,6 @@ describe("App.handlePageInfoChanged", () => {
       queryString: "",
     })
 
-    // @ts-ignore
     app.handlePageInfoChanged(pageInfo)
 
     expect(pushStateSpy).toHaveBeenLastCalledWith({}, "", pathname)
@@ -1061,8 +1030,6 @@ describe("App.handlePageInfoChanged", () => {
     const pageInfo = new PageInfo({
       queryString: "",
     })
-
-    // @ts-ignore
     app.handlePageInfoChanged(pageInfo)
 
     expect(pushStateSpy).toHaveBeenLastCalledWith({}, "", "/")
@@ -1076,7 +1043,6 @@ describe("App.handlePageInfoChanged", () => {
       queryString: "flying=spaghetti&monster=omg",
     })
 
-    // @ts-ignore
     app.handlePageInfoChanged(pageInfo)
 
     const expectedUrl = `/?${pageInfo.queryString}`
@@ -1091,9 +1057,9 @@ describe("App.sendRerunBackMsg", () => {
   beforeEach(() => {
     wrapper = shallow(<App {...getProps()} />)
     instance = wrapper.instance() as App
-    // @ts-ignore
+    // @ts-expect-error
     instance.sendBackMsg = jest.fn()
-    // @ts-ignore
+    // @ts-expect-error
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
   })
 
@@ -1104,7 +1070,7 @@ describe("App.sendRerunBackMsg", () => {
   it("sends the pageScriptHash if one is given", () => {
     instance.sendRerunBackMsg(undefined, "some_page_hash")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: {
         pageScriptHash: "some_page_hash",
@@ -1118,7 +1084,7 @@ describe("App.sendRerunBackMsg", () => {
     wrapper.setState({ currentPageScriptHash: "some_other_page_hash" })
     instance.sendRerunBackMsg()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: {
         pageScriptHash: "some_other_page_hash",
@@ -1131,7 +1097,7 @@ describe("App.sendRerunBackMsg", () => {
   it("extracts the pageName as an empty string if we can't get a pageScriptHash (main page)", () => {
     instance.sendRerunBackMsg()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: {
         pageScriptHash: "",
@@ -1145,7 +1111,7 @@ describe("App.sendRerunBackMsg", () => {
     window.history.pushState({}, "", "/foo/")
     instance.sendRerunBackMsg()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: {
         pageScriptHash: "",
@@ -1156,13 +1122,13 @@ describe("App.sendRerunBackMsg", () => {
   })
 
   it("extracts the pageName as the last part of the URL if we can't get a pageScriptHash and we have a nonempty basePath", () => {
-    // @ts-ignore
+    // @ts-expect-error
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts("foo/bar")
 
     window.history.pushState({}, "", "/foo/bar/baz")
     instance.sendRerunBackMsg()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(instance.sendBackMsg).toHaveBeenCalledWith({
       rerunScript: {
         pageScriptHash: "",
@@ -1183,7 +1149,7 @@ describe("App.handlePageNotFound", () => {
     })
     const instance = wrapper.instance() as App
 
-    // @ts-ignore
+    // @ts-expect-error
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
     instance.showError = jest.fn()
 
@@ -1210,7 +1176,7 @@ describe("App.handlePageNotFound", () => {
     })
     const instance = wrapper.instance() as App
 
-    // @ts-ignore
+    // @ts-expect-error
     instance.connectionManager.getBaseUriParts = mockGetBaseUriParts()
     instance.showError = jest.fn()
 
@@ -1258,9 +1224,8 @@ describe("Test Main Menu shortcut functionality", () => {
       }),
     })
     const wrapper = shallow<App>(<App {...props} />)
-    wrapper.instance().openClearCacheDialog = jest.fn()
 
-    // @ts-ignore
+    wrapper.instance().openClearCacheDialog = jest.fn()
     wrapper.instance().keyHandlers.CLEAR_CACHE()
 
     expect(wrapper.instance().openClearCacheDialog).not.toBeCalled()
@@ -1269,9 +1234,8 @@ describe("Test Main Menu shortcut functionality", () => {
   it("Tests dev menu shortcuts can be accessed as a developer", () => {
     const props = getProps()
     const wrapper = shallow<App>(<App {...props} />)
-    wrapper.instance().openClearCacheDialog = jest.fn()
 
-    // @ts-ignore
+    wrapper.instance().openClearCacheDialog = jest.fn()
     wrapper.instance().keyHandlers.CLEAR_CACHE()
 
     expect(wrapper.instance().openClearCacheDialog).toBeCalled()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -334,7 +334,7 @@ export class App extends PureComponent<Props, State> {
         },
       }
 
-      // @ts-ignore
+      // @ts-expect-error
       import("iframe-resizer/js/iframeResizer.contentWindow")
     }
 
@@ -366,9 +366,9 @@ export class App extends PureComponent<Props, State> {
       this.onPageChange(requestedPageScriptHash)
       this.props.hostCommunication.onPageChanged()
     }
-    // @ts-ignore
+    // @ts-expect-error
     if (window.prerenderReady === false && this.isAppInReadyState(prevState)) {
-      // @ts-ignore
+      // @ts-expect-error
       window.prerenderReady = true
     }
   }
@@ -1083,7 +1083,7 @@ export class App extends PureComponent<Props, State> {
 
     // It's not a problem that we're mucking around with private fields since
     // this is a test-only method anyway.
-    // @ts-ignore
+    // @ts-expect-error
     this.connectionManager?.connection?.cache.messages.clear()
   }
 

--- a/frontend/src/ThemedApp.test.tsx
+++ b/frontend/src/ThemedApp.test.tsx
@@ -63,7 +63,6 @@ describe("ThemedApp", () => {
 
   it("updates theme", () => {
     const wrapper = shallow(<ThemedApp />)
-    // @ts-ignore
     wrapper.find(AppWithScreencast).props().theme.setTheme(darkTheme)
     const updatedTheme: ThemeConfig = wrapper.find(AppWithScreencast).props()
       .theme.activeTheme
@@ -76,7 +75,6 @@ describe("ThemedApp", () => {
 
   it("does not save Auto theme", () => {
     const wrapper = shallow(<ThemedApp />)
-    // @ts-ignore
     wrapper.find(AppWithScreencast).props().theme.setTheme(darkTheme)
 
     wrapper

--- a/frontend/src/components/core/Block/Block.test.tsx
+++ b/frontend/src/components/core/Block/Block.test.tsx
@@ -51,13 +51,13 @@ describe("Vertical Block Component", () => {
         scriptRunId={""}
         scriptRunState={ScriptRunState.NOT_RUNNING}
         widgetsDisabled={false}
-        // @ts-ignore
+        // @ts-expect-error
         widgetMgr={undefined}
-        // @ts-ignore
+        // @ts-expect-error
         uploadClient={undefined}
-        // @ts-ignore
+        // @ts-expect-error
         componentRegistry={undefined}
-        // @ts-ignore
+        // @ts-expect-error
         formsData={undefined}
       />
     )

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -54,7 +54,6 @@ import {
 } from "src/autogen/proto"
 
 import React, { ReactElement, Suspense } from "react"
-// @ts-ignore
 import debounceRender from "react-debounce-render"
 import { ElementNode } from "src/lib/AppNode"
 import { Quiver } from "src/lib/Quiver"

--- a/frontend/src/components/core/Block/styled-components.ts
+++ b/frontend/src/components/core/Block/styled-components.ts
@@ -126,7 +126,6 @@ export interface StyledVerticalBlockProps {
 }
 
 export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
-  // @ts-ignore
   ({ width, theme }) => ({
     width,
     position: "relative", // Required for the automatic width computation.

--- a/frontend/src/components/core/MainMenu/MainMenu.test.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.test.tsx
@@ -162,24 +162,24 @@ describe("App", () => {
       const wrapper = mount(<MainMenu {...props} />)
       const popoverContent = wrapper.find("StatefulPopover").prop("content")
 
-      // @ts-ignore
+      // @ts-expect-error
       const menuWrapper = mount(popoverContent(() => {}))
       const items: any = menuWrapper.find("StatefulMenu").at(1).prop("items")
 
       const deployOption = items.find(
-        // @ts-ignore
+        // @ts-expect-error
         ({ label }) => label === "Deploy this app"
       )
 
       deployOption.onClick()
 
-      // @ts-ignore
+      // @ts-expect-error
       const dialog = dialogComponent(props.gitInfo.module)
-      // @ts-ignore
+      // @ts-expect-error
       expect(props.showDeployError.mock.calls[0][0]).toStrictEqual(
         dialog.title
       )
-      // @ts-ignore
+      // @ts-expect-error
       expect(props.showDeployError.mock.calls[0][1]).toStrictEqual(dialog.body)
     }
 
@@ -278,15 +278,15 @@ describe("App", () => {
     const props = getProps({ menuItems })
     const wrapper = mount(<MainMenu {...props} />)
     const popoverContent = wrapper.find("StatefulPopover").prop("content")
-    // @ts-ignore
+    // @ts-expect-error
     const menuWrapper = mount(popoverContent(() => {}))
 
-    // @ts-ignore
+    // @ts-expect-error
     const menuLabels = menuWrapper
       .find("MenuStatefulContainer")
       .at(0)
       .prop("items")
-      // @ts-ignore
+      // @ts-expect-error
       .map(item => item.label)
     expect(menuLabels).toEqual([
       "Rerun",
@@ -338,25 +338,25 @@ describe("App", () => {
   it("should not render dev menu when hostIsOwner is false and not on localhost", () => {
     // set isLocalhost to false by deleting window.location.
     // Source: https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
-    // @ts-ignore
+    // @ts-expect-error
     delete window.location
 
-    // @ts-ignore
+    // @ts-expect-error
     window.location = {
       assign: jest.fn(),
     }
     const props = getProps()
     const wrapper = mount(<MainMenu {...props} />)
     const popoverContent = wrapper.find("StatefulPopover").prop("content")
-    // @ts-ignore
+    // @ts-expect-error
     const menuWrapper = mount(popoverContent(() => {}))
 
-    // @ts-ignore
+    // @ts-expect-error
     const menuLabels = menuWrapper
       .find("MenuStatefulContainer")
       // make sure that we only have one menu otherwise prop will fail
       .prop("items")
-      // @ts-ignore
+      // @ts-expect-error
       .map(item => item.label)
     expect(menuLabels).toEqual([
       "Rerun",

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -244,7 +244,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
             this.setSidebarWidth(newWidth)
           }}
           // Props part of StyledSidebar, but not Resizable component
-          // @ts-ignore
+          // @ts-expect-error
           isCollapsed={collapsedSidebar}
           sidebarWidth={sidebarWidth}
         >

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -39,7 +39,6 @@ expect.extend(matchers)
 
 jest.mock("src/lib/Hooks", () => ({
   __esModule: true,
-  // @ts-ignore
   ...jest.requireActual("src/lib/Hooks"),
   useIsOverflowing: jest.fn(),
 }))
@@ -68,7 +67,7 @@ describe("SidebarNav", () => {
   afterEach(() => {
     mockUseIsOverflowing.mockReset()
 
-    // @ts-ignore
+    // @ts-expect-error
     reactDeviceDetect.isMobile = false
   })
 
@@ -103,7 +102,7 @@ describe("SidebarNav", () => {
     beforeEach(() => {
       // Replace window.location with a mutable object that otherwise has
       // the same contents so that we can change port below.
-      // @ts-ignore
+      // @ts-expect-error
       delete window.location
       window.location = { ...originalLocation }
     })
@@ -354,7 +353,7 @@ describe("SidebarNav", () => {
   })
 
   it("collapses sidebar on page change when on mobile", () => {
-    // @ts-ignore
+    // @ts-expect-error
     reactDeviceDetect.isMobile = true
 
     const props = getProps()

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -46,9 +46,9 @@ describe("ThemedSidebar Component", () => {
 
     const updatedTheme = wrapper.find("Sidebar").prop("theme")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(updatedTheme.colors.bgColor).toBe(lightTheme.colors.secondaryBg)
-    // @ts-ignore
+    // @ts-expect-error
     expect(updatedTheme.inSidebar).toBe(true)
   })
 

--- a/frontend/src/components/core/StreamlitDialog/SettingsDialog.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/SettingsDialog.test.tsx
@@ -39,7 +39,7 @@ const getContext = (
 
 // This is a workaround since enzyme does not support context yet
 // https://github.com/enzymejs/enzyme/issues/2189
-// @ts-ignore
+// @ts-expect-error
 SettingsDialog.contextTypes = {
   availableThemes: PropTypes.array,
   activeTheme: PropTypes.shape,
@@ -89,7 +89,7 @@ describe("SettingsDialog", () => {
 
     expect(wrapper.state("runOnSave")).toBe(true)
     expect(props.onSave).toHaveBeenCalled()
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.onSave.mock.calls[0][0].runOnSave).toBe(true)
   })
 
@@ -109,7 +109,7 @@ describe("SettingsDialog", () => {
 
     expect(wrapper.state("wideMode")).toBe(true)
     expect(props.onSave).toHaveBeenCalled()
-    // @ts-ignore
+    // @ts-expect-error
     expect(props.onSave.mock.calls[0][0].wideMode).toBe(true)
   })
 
@@ -127,7 +127,6 @@ describe("SettingsDialog", () => {
     selectbox.prop("onChange")(1)
     wrapper.update()
     expect(mockSetTheme).toHaveBeenCalled()
-    // @ts-ignore
     expect(mockSetTheme.mock.calls[0][0]).toBe(darkTheme)
   })
 

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.test.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.test.tsx
@@ -241,7 +241,7 @@ describe("Opened ThemeCreatorDialog", () => {
     // thrown off by us mocking `useContext` above :(
     const updateCopied = jest.fn()
     const useStateSpy = jest.spyOn(React, "useState")
-    // @ts-ignore
+    // @ts-expect-error
     useStateSpy.mockImplementation(init => [init, updateCopied])
 
     const props = getProps()

--- a/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.tsx
+++ b/frontend/src/components/core/StreamlitDialog/ThemeCreatorDialog.tsx
@@ -59,7 +59,7 @@ const valueToColor = (value: string, _config: ThemeOptionBuilder): string =>
 const displayFontOption = (
   font: CustomThemeConfig.FontFamily | string
 ): string =>
-  // @ts-ignore
+  // @ts-expect-error
   humanizeString(CustomThemeConfig.FontFamily[font])
 
 const themeBuilder: Record<string, ThemeOptionBuilder> = {

--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -72,7 +72,7 @@ describe("VegaLiteChart Element", () => {
     const props = getProps({ theme: darkTheme.emotion })
 
     const wrapper = mount(<ArrowVegaLiteChart {...props} />)
-    // @ts-ignore
+    // @ts-expect-error
     const generatedSpec = wrapper.instance().generateSpec()
 
     expect(generatedSpec.config.background).toBe(
@@ -101,7 +101,7 @@ describe("VegaLiteChart Element", () => {
     })
 
     const wrapper = mount(<ArrowVegaLiteChart {...props} />)
-    // @ts-ignore
+    // @ts-expect-error
     const generatedSpec = wrapper.instance().generateSpec()
     // Should have 10 colors defined in range.diverging
     expect(generatedSpec.config.range?.diverging?.length).toBe(10)
@@ -119,7 +119,7 @@ describe("VegaLiteChart Element", () => {
     }
 
     const wrapper = mount(<ArrowVegaLiteChart {...props} />)
-    // @ts-ignore
+    // @ts-expect-error
     const generatedSpec = wrapper.instance().generateSpec()
 
     expect(generatedSpec.config.background).toBe("purple")

--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -405,7 +405,6 @@ function getDataArrays(
   const datasetArrays: { [dataset: string]: any[] } = {}
 
   for (const [name, dataset] of Object.entries(datasets)) {
-    // @ts-ignore
     datasetArrays[name] = getDataArray(dataset)
   }
 

--- a/frontend/src/components/elements/BokehChart/BokehChart.test.tsx
+++ b/frontend/src/components/elements/BokehChart/BokehChart.test.tsx
@@ -103,7 +103,7 @@ describe("BokehChart element", () => {
       })
 
       expect(mockBokehEmbed.embed.embed_item).toHaveBeenCalledWith(
-        // @ts-ignore
+        // @ts-expect-error
         expect.toMatchBokehDimensions(400, 400),
         "bokeh-chart-1"
       )
@@ -122,7 +122,7 @@ describe("BokehChart element", () => {
       })
 
       expect(mockBokehEmbed.embed.embed_item).toHaveBeenCalledWith(
-        // @ts-ignore
+        // @ts-expect-error
         expect.toMatchBokehDimensions(400),
         "bokeh-chart-1"
       )

--- a/frontend/src/components/elements/CodeBlock/CopyButton.test.tsx
+++ b/frontend/src/components/elements/CodeBlock/CopyButton.test.tsx
@@ -65,7 +65,7 @@ describe("CopyButton Element", () => {
 
       wrapper.unmount()
 
-      // @ts-ignore
+      // @ts-expect-error
       const mockClipboard = Clipboard.mock.instances[0]
       const mockDestroy = mockClipboard.destroy
 

--- a/frontend/src/components/elements/DataFrame/DataFrameCell.test.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrameCell.test.tsx
@@ -92,7 +92,7 @@ describe("DataFrameCell Element", () => {
     })
     const wrapper = shallow(<DataFrameCell {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     const result = wrapper.find(StyledDataFrameCornerCell).prop("onClick")()
 
     expect(props.headerClickedCallback).toHaveBeenCalledWith(0)

--- a/frontend/src/components/elements/DataFrame/DataFrameCell.tsx
+++ b/frontend/src/components/elements/DataFrame/DataFrameCell.tsx
@@ -101,7 +101,7 @@ export default function DataFrameCell({
     // eslint-disable-next-line
 
     <CellType
-      // @ts-ignore
+      // @ts-expect-error
       style={style}
       onClick={onClick}
       role={role}

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -97,7 +97,6 @@ describe("DeckGlJsonChart element", () => {
     // @ts-expect-error
     wrapper.setProps(getProps({}, { pitch: 40.5, zoom: 10 }))
 
-    // @ts-ignore
     expect(wrapper.state("viewState")).toStrictEqual({
       pitch: 5,
       zoom: 10,
@@ -114,7 +113,7 @@ describe("DeckGlJsonChart element", () => {
     expect(deckGL.length).toBe(1)
     expect(deckGL.prop("getTooltip")).toBeDefined()
 
-    // @ts-ignore
+    // @ts-expect-error
     const createdTooltip = deckGL.prop("getTooltip")({
       object: {
         elevationValue: 10,
@@ -134,7 +133,7 @@ describe("DeckGlJsonChart element", () => {
     expect(deckGL.length).toBe(1)
     expect(deckGL.prop("getTooltip")).toBeDefined()
 
-    // @ts-ignore
+    // @ts-expect-error
     const createdTooltip = deckGL.prop("getTooltip")({
       object: {
         elevationValue: 10,

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -118,14 +118,14 @@ export class DeckGlJsonChart extends PureComponent<PropsWithHeight, State> {
     if (!isEqual(deck.initialViewState, state.initialViewState)) {
       const diff = Object.keys(deck.initialViewState).reduce(
         (diff, key): any => {
-          // @ts-ignore
+          // @ts-expect-error
           if (deck.initialViewState[key] === state.initialViewState[key]) {
             return diff
           }
 
           return {
             ...diff,
-            // @ts-ignore
+            // @ts-expect-error
             [key]: deck.initialViewState[key],
           }
         },

--- a/frontend/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
+++ b/frontend/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
@@ -53,7 +53,7 @@ const getProps = (
 
 describe("GraphVizChart Element", () => {
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error
     logError.mockClear()
   })
 
@@ -72,7 +72,7 @@ describe("GraphVizChart Element", () => {
     })
     const wrapper = mount(<GraphVizChart {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     logError.mockClear()
 
     wrapper.setProps({

--- a/frontend/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.test.tsx
@@ -66,7 +66,6 @@ describe("ImageList Element", () => {
       .find("StyledImageContainer")
       .find("img")
       .forEach((imgWrapper, id) => {
-        // @ts-ignore
         expect(imgWrapper.prop("src")).toBe(
           `http://localhost:80${imgs[id].url}`
         )
@@ -80,7 +79,6 @@ describe("ImageList Element", () => {
     const { imgs } = props.element
     expect(wrapper.find("StyledCaption").length).toEqual(2)
     wrapper.find("StyledCaption").forEach((captionWrapper, id) => {
-      // @ts-ignore
       expect(captionWrapper.text()).toBe(` ${imgs[id].caption} `)
     })
   })
@@ -112,7 +110,6 @@ describe("ImageList Element", () => {
       .find("StyledImageContainer")
       .find("img")
       .forEach((imgWrapper, id) => {
-        // @ts-ignore
         expect(imgWrapper.prop("src")).toBe(imgs[id].url)
       })
   })

--- a/frontend/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -142,7 +142,7 @@ describe("PlotlyChart Element", () => {
 
       expect(wrapper.find("iframe").length).toBe(1)
       expect(wrapper.find("iframe").props()).toMatchSnapshot()
-      // @ts-ignore
+      // @ts-expect-error
       expect(wrapper.find("iframe").prop("style").height).toBe(DEFAULT_HEIGHT)
     })
 
@@ -154,7 +154,7 @@ describe("PlotlyChart Element", () => {
       }
       const wrapper = mount(<PlotlyChart {...propsWithHeight} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(wrapper.find("iframe").prop("style").height).toBe(400)
     })
   })

--- a/frontend/src/components/shared/AlertContainer/AlertContainer.test.tsx
+++ b/frontend/src/components/shared/AlertContainer/AlertContainer.test.tsx
@@ -50,7 +50,7 @@ describe("AlertContainer element", () => {
 
     const overrides = wrapper.find("Notification").prop("overrides")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(overrides.Body.style.width).toEqual("100")
   })
 })

--- a/frontend/src/components/shared/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/src/components/shared/ColorPicker/ColorPicker.test.tsx
@@ -74,7 +74,7 @@ describe("ColorPicker widget", () => {
     const wrappedDiv = wrapper.find("StyledColorPicker")
     const { style } = wrappedDiv.props()
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -96,7 +96,7 @@ describe("ColorPicker widget", () => {
   it("supports hex shorthand", () => {
     wrapper.find(UIPopover).simulate("click")
 
-    // @ts-ignore do not need change event added
+    // @ts-expect-error do not need change event added
     colorPickerWrapper.prop("onChange")({
       hex: "#333",
     })
@@ -114,7 +114,7 @@ describe("ColorPicker widget", () => {
     const newColor = "#E91E63"
     wrapper.find(UIPopover).simulate("click")
 
-    // @ts-ignore do not need change event added
+    // @ts-expect-error do not need change event added
     colorPickerWrapper.prop("onChange")({
       hex: newColor,
     })

--- a/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -51,13 +51,13 @@ describe("Selectbox widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("row-widget")
     expect(splittedClassName).toContain("stSelectbox")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -103,7 +103,7 @@ describe("Selectbox widget", () => {
   it("renders options", () => {
     const options = wrapper.find(UISelect).prop("options") || []
 
-    // @ts-ignore
+    // @ts-expect-error
     options.forEach(option => {
       expect(option).toHaveProperty("label")
       expect(option).toHaveProperty("value")
@@ -119,7 +119,7 @@ describe("Selectbox widget", () => {
   })
 
   it("is able to select an option", () => {
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       value: [{ label: "b", value: "1" }],
       option: { label: "b", value: "1" },
@@ -152,7 +152,7 @@ describe("Selectbox widget", () => {
     if (filterOptionsFn === undefined || options === undefined) {
       fail("Unexpected undefined value")
     }
-    // @ts-ignore
+    // @ts-expect-error
     const filteredOptions = filterOptionsFn(options, "1")
     expect(filteredOptions).toEqual([])
   })
@@ -163,14 +163,14 @@ describe("Selectbox widget", () => {
     if (filterOptionsFn === undefined || options === undefined) {
       fail("Unexpected undefined value")
     }
-    // @ts-ignore
+    // @ts-expect-error
     expect(filterOptionsFn(options, "b")).toEqual([
       {
         label: "b",
         value: "1",
       },
     ])
-    // @ts-ignore
+    // @ts-expect-error
     expect(filterOptionsFn(options, "B")).toEqual([
       {
         label: "b",
@@ -214,7 +214,7 @@ describe("Selectbox widget", () => {
   })
 
   it("updates value if new value provided from parent", () => {
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       value: [{ label: "b", value: "1" }],
       option: { label: "b", value: "1" },

--- a/frontend/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/src/components/shared/Radio/Radio.test.tsx
@@ -76,13 +76,13 @@ describe("Radio widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("row-widget")
     expect(splittedClassName).toContain("stRadio")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -135,7 +135,7 @@ describe("Radio widget", () => {
     const props = getProps()
     const wrapper = mount(<Radio {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(RadioGroup).prop("onChange")({
       target: {
         value: "1",

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -311,7 +311,6 @@ export function RenderedMarkdown({
   )
   function remarkColoring() {
     return (tree: any) => {
-      // @ts-ignore
       visit(tree, node => {
         if (node.type === "textDirective") {
           const nodeName = String(node.name)
@@ -370,7 +369,7 @@ export function RenderedMarkdown({
 
   return (
     <ErrorBoundary>
-      <ReactMarkdown // @ts-ignore
+      <ReactMarkdown
         remarkPlugins={plugins}
         rehypePlugins={rehypePlugins}
         components={renderers}

--- a/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -61,7 +61,7 @@ describe("Tooltip element", () => {
     const wrapper = mount(<Tooltip {...getProps({ content })} />)
 
     expect(
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find("StatefulTooltip").props().content.props.children
     ).toEqual(content)
   })

--- a/frontend/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/src/components/widgets/Button/Button.test.tsx
@@ -36,7 +36,7 @@ const getProps = (elementProps: Partial<ButtonProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  // @ts-ignore
+  // @ts-expect-error
   widgetMgr: new WidgetStateManager(sendBackMsg),
 })
 
@@ -54,12 +54,12 @@ describe("Button widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("stButton")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 

--- a/frontend/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -57,7 +57,7 @@ const getProps = (elementProps: Partial<CameraInputProto> = {}): Props => {
       formsDataChanged: jest.fn(),
     }),
     mockServerFileIdCounter: 1,
-    // @ts-ignore
+    // @ts-expect-error
     uploadClient: {
       uploadFile: jest.fn().mockImplementation(() => {
         // Mock UploadClient to return an incremented ID for each upload.
@@ -136,7 +136,7 @@ describe("CameraInput widget", () => {
       wrapper
         .find("Webcam")
         .props()
-        // @ts-ignore
+        // @ts-expect-error
         .onUserMedia(null)
     })
 
@@ -155,7 +155,7 @@ describe("CameraInput widget", () => {
       wrapper
         .find("Webcam")
         .props()
-        // @ts-ignore
+        // @ts-expect-error
         .onUserMedia(null)
     })
 
@@ -174,7 +174,7 @@ describe("CameraInput widget", () => {
     const wrapper = shallow<CameraInput, Props, State>(
       <CameraInput {...props} />
     )
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.instance().handleCapture("test img")
 
     expect(wrapper.instance().state.files).toHaveLength(1)
@@ -191,10 +191,10 @@ describe("CameraInput widget", () => {
     const wrapper = shallow<CameraInput, Props, State>(
       <CameraInput {...props} />
     )
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.instance().handleCapture("test img")
 
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.instance().removeCapture()
     expect(wrapper.state()).toEqual({
       files: [],

--- a/frontend/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -65,7 +65,7 @@ describe("Test Webcam Component", () => {
       wrapper
         .find("Webcam")
         .props()
-        // @ts-ignore
+        // @ts-expect-error
         .onUserMediaError(null)
     })
     wrapper.update()
@@ -87,7 +87,7 @@ describe("Test Webcam Component", () => {
       wrapper
         .find("Webcam")
         .props()
-        // @ts-ignore
+        // @ts-expect-error
         .onUserMedia(null)
     })
     wrapper.update()

--- a/frontend/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -70,13 +70,13 @@ describe("Checkbox widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("row-widget")
     expect(splittedClassName).toContain("stCheckbox")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -135,7 +135,7 @@ describe("Checkbox widget", () => {
 
     const wrapper = mount(<Checkbox {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UICheckbox).prop("onChange")({
       target: { checked: true },
     } as EventTarget)
@@ -159,7 +159,7 @@ describe("Checkbox widget", () => {
     const wrapper = mount(<Checkbox {...props} />)
 
     // Change the widget value
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UICheckbox).prop("onChange")({
       target: { checked: true },
     } as EventTarget)

--- a/frontend/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -42,11 +42,10 @@ const getProps = (elementProps: Partial<ColorPickerProto> = {}): Props => ({
 
 /** Return the ColorPicker's popover (where the color picking happens). */
 function getPopoverWrapper(wrapper: ReactWrapper<ColorPicker>): any {
-  // @ts-ignore
   return (
     wrapper
       .find(UIPopover)
-      // @ts-ignore
+      // @ts-expect-error
       .renderProp("content")(null)
       .find(StyledChromePicker)
   )

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -95,7 +95,6 @@ class MockComponent {
 
     // Create and mount our ComponentInstance. We need to mount it to an
     // existing DOM element - otherwise, iframe contentWindow is not available.
-    // @ts-ignore
     this.wrapper = mount(
       <ComponentInstance
         element={createElementProp(initialJSONArgs, initialSpecialArgs)}

--- a/frontend/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -51,7 +51,7 @@ describe("DataFrame widget", () => {
   beforeEach(() => {
     // Mocking ResizeObserver to prevent:
     // TypeError: window.ResizeObserver is not a constructor
-    // @ts-ignore
+    // @ts-expect-error
     delete window.ResizeObserver
     window.ResizeObserver = jest.fn().mockImplementation(() => ({
       observe: jest.fn(),

--- a/frontend/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrame.tsx
@@ -96,7 +96,7 @@ const drawMissingCells: DrawCustomCellCallback = args => {
           textMedium: theme.textLight,
         },
         // The following props are just added for technical reasons:
-        // @ts-ignore
+        // @ts-expect-error
         spriteManager: {},
         hyperWrapping: false,
       },

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -101,12 +101,12 @@ describe("DateInput widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("stDateInput")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -138,7 +138,7 @@ describe("DateInput widget", () => {
     const wrapper = mount(<DateInput {...props} />)
     const newDate = new Date("2020/02/06")
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIDatePicker).prop("onChange")({
       date: newDate,
     })
@@ -161,19 +161,18 @@ describe("DateInput widget", () => {
     const wrapper = mount(<DateInput {...props} />)
     const newDate = new Date("2020/02/06")
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIDatePicker).prop("onChange")({
       date: newDate,
     })
     wrapper.update()
 
     expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([newDate])
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIDatePicker).prop("onChange")({
-      // @ts-ignore
       date: null,
     })
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIDatePicker).prop("onClose")()
     wrapper.update()
     expect(wrapper.find(UIDatePicker).prop("value")).toStrictEqual([
@@ -229,7 +228,7 @@ describe("DateInput widget", () => {
     // Change the widget value
     const newDate = new Date("2020/02/06")
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIDatePicker).prop("onChange")({
       date: newDate,
     })

--- a/frontend/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -36,7 +36,7 @@ const getProps = (elementProps: Partial<DownloadButtonProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  // @ts-ignore
+  // @ts-expect-error
   widgetMgr: new WidgetStateManager(sendBackMsg),
 })
 
@@ -54,12 +54,12 @@ describe("DownloadButton widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("stDownloadButton")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 

--- a/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -87,7 +87,7 @@ const getProps = (elementProps: Partial<FileUploaderProto> = {}): Props => {
       formsDataChanged: jest.fn(),
     }),
     mockServerFileIdCounter: 1,
-    // @ts-ignore
+    // @ts-expect-error
     uploadClient: {
       uploadFile: jest.fn().mockImplementation(() => {
         // Mock UploadClient to return an incremented ID for each upload.
@@ -391,7 +391,6 @@ describe("FileUploader widget", () => {
     )
 
     // Delete the first file
-    // @ts-ignore
     instance.deleteFile(initialFiles[0].id)
 
     await process.nextTick
@@ -556,7 +555,7 @@ describe("FileUploader widget", () => {
   it("resets on disconnect", () => {
     const props = getProps()
     const wrapper = shallow(<FileUploader {...props} />)
-    // @ts-ignore
+    // @ts-expect-error
     const resetSpy = jest.spyOn(wrapper.instance(), "reset")
     wrapper.setProps({ disabled: true })
     expect(resetSpy).toBeCalled()

--- a/frontend/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -78,12 +78,12 @@ describe("FormSubmitButton", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const classNameParts = className.split(" ")
 
     expect(classNameParts).toContain("stButton")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 

--- a/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -70,13 +70,13 @@ describe("Multiselect widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("row-widget")
     expect(splittedClassName).toContain("stMultiSelect")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -132,7 +132,7 @@ describe("Multiselect widget", () => {
   it("renders options", () => {
     const props = getProps()
     const wrapper = mount(<Multiselect {...props} />)
-    // @ts-ignore
+    // @ts-expect-error
     const options = (wrapper.find(UISelect).prop("options") as string[]) || []
 
     options.forEach(option => {
@@ -153,9 +153,9 @@ describe("Multiselect widget", () => {
     const filterOptionsFn =
       wrapper.find(UISelect).prop("filterOptions") || (() => [])
 
-    // @ts-ignore filterOptionsFn expects readonly options
+    // @ts-expect-error filterOptionsFn expects readonly options
     expect(filterOptionsFn(options, "1").length).toEqual(0)
-    // @ts-ignore filterOptionsFn expects readonly options
+    // @ts-expect-error filterOptionsFn expects readonly options
     expect(filterOptionsFn(options, "b").length).toEqual(1)
   })
 
@@ -181,7 +181,7 @@ describe("Multiselect widget", () => {
     const props = getProps()
     const wrapper = mount(<Multiselect {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       type: "select",
       option: {
@@ -200,7 +200,7 @@ describe("Multiselect widget", () => {
     const props = getProps()
     const wrapper = mount(<Multiselect {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       type: "remove",
       option: {
@@ -218,7 +218,7 @@ describe("Multiselect widget", () => {
     const props = getProps()
     const wrapper = mount(<Multiselect {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({ type: "clear" })
     wrapper.update()
 
@@ -231,7 +231,7 @@ describe("Multiselect widget", () => {
     const UNKNOWN_TRANSITION = "UNKNOWN_TRANSITION"
     const onChange = wrapper.find(UISelect).prop("onChange")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(() => onChange({ type: UNKNOWN_TRANSITION })).toThrow(
       `State transition is unknown: ${UNKNOWN_TRANSITION}`
     )
@@ -247,7 +247,7 @@ describe("Multiselect widget", () => {
     const wrapper = mount(<Multiselect {...props} />)
 
     // Change the widget value
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       type: "select",
       option: {
@@ -352,7 +352,7 @@ describe("Multiselect widget", () => {
       )
       const wrapper = mount(<Multiselect {...props} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UISelect).prop("onChange")({
         type: "select",
         option: {
@@ -378,7 +378,7 @@ describe("Multiselect widget", () => {
       )
       const wrapper = mount(<Multiselect {...props} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UISelect).prop("onChange")({
         type: "remove",
         option: {

--- a/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -78,7 +78,7 @@ describe("NumberInput widget", () => {
 
     expect(wrapper).toBeDefined()
 
-    // @ts-ignore
+    // @ts-expect-error
     input.props().onFocus()
 
     expect(wrapper.state("isFocused")).toBe(true)
@@ -92,7 +92,7 @@ describe("NumberInput widget", () => {
 
     expect(wrapper).toBeDefined()
 
-    // @ts-ignore
+    // @ts-expect-error
     input.props().onBlur()
 
     expect(wrapper.state("isFocused")).toBe(false)
@@ -148,9 +148,9 @@ describe("NumberInput widget", () => {
     const props = getIntProps()
     const wrapper = shallow(<NumberInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.instance().getMin()).toBe(-Infinity)
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.instance().getMax()).toBe(+Infinity)
   })
 
@@ -164,9 +164,9 @@ describe("NumberInput widget", () => {
     })
     const wrapper = shallow(<NumberInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.instance().getMin()).toBe(0)
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.instance().getMax()).toBe(10)
   })
 
@@ -182,7 +182,7 @@ describe("NumberInput widget", () => {
     // Change the widget value
     wrapper.setState({ dirty: true, value: 15 })
     const inputWrapper = wrapper.find(UIInput)
-    // @ts-ignore
+    // @ts-expect-error
     inputWrapper.props().onKeyPress({ key: "Enter" })
 
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
@@ -218,7 +218,7 @@ describe("NumberInput widget", () => {
 
       const preventDefault = jest.fn()
 
-      // @ts-ignore
+      // @ts-expect-error
       InputWrapper.props().onKeyDown({
         key: "ArrowDown",
         preventDefault,
@@ -254,7 +254,7 @@ describe("NumberInput widget", () => {
 
       const InputWrapper = wrapper.find(UIInput)
 
-      // @ts-ignore
+      // @ts-expect-error
       InputWrapper.props().onKeyPress({
         key: "Enter",
       })
@@ -303,10 +303,10 @@ describe("NumberInput widget", () => {
 
       const InputWrapper = wrapper.find(UIInput)
 
-      // @ts-ignore
+      // @ts-expect-error
       InputWrapper.props().onChange({
         target: {
-          // @ts-ignore
+          // @ts-expect-error
           value: 1,
         },
       })
@@ -325,7 +325,7 @@ describe("NumberInput widget", () => {
 
       const InputWrapper = wrapper.find(UIInput)
 
-      // @ts-ignore
+      // @ts-expect-error
       InputWrapper.props().onKeyPress({
         key: "Enter",
       })
@@ -362,7 +362,7 @@ describe("NumberInput widget", () => {
       const props = getIntProps({ default: 10, step: 1 })
       const wrapper = shallow(<NumberInput {...props} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(wrapper.find(UIInput).props().overrides.Input.props.step).toBe(1)
     })
 
@@ -377,7 +377,7 @@ describe("NumberInput widget", () => {
 
       const preventDefault = jest.fn()
 
-      // @ts-ignore
+      // @ts-expect-error
       InputWrapper.props().onKeyDown({
         key: "ArrowUp",
         preventDefault,
@@ -399,7 +399,7 @@ describe("NumberInput widget", () => {
 
       const preventDefault = jest.fn()
 
-      // @ts-ignore
+      // @ts-expect-error
       InputWrapper.props().onKeyDown({
         key: "ArrowDown",
         preventDefault,

--- a/frontend/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/src/components/widgets/Radio/Radio.test.tsx
@@ -65,13 +65,13 @@ describe("Radio widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("row-widget")
     expect(splittedClassName).toContain("stRadio")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -121,7 +121,7 @@ describe("Radio widget", () => {
     jest.spyOn(props.widgetMgr, "setIntValue")
     const wrapper = mount(<Radio {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(RadioGroup).prop("onChange")({
       target: { value: "1" },
     } as React.ChangeEvent<HTMLInputElement>)
@@ -145,7 +145,7 @@ describe("Radio widget", () => {
     const wrapper = mount(<Radio {...props} />)
 
     // Change the widget value
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(RadioGroup).prop("onChange")({
       target: { value: "1" },
     } as React.ChangeEvent<HTMLInputElement>)

--- a/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -63,7 +63,7 @@ describe("Selectbox widget", () => {
 
     const wrapper = mount(<Selectbox {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       value: [{ label: "b", value: "1" }],
       option: { label: "b", value: "1" },
@@ -88,7 +88,7 @@ describe("Selectbox widget", () => {
     const wrapper = mount(<Selectbox {...props} />)
 
     // Change the widget value
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UISelect).prop("onChange")({
       value: [{ label: "b", value: "1" }],
       option: { label: "b", value: "1" },

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -151,7 +151,7 @@ describe("Slider widget", () => {
       jest.spyOn(props.widgetMgr, "setDoubleArrayValue")
 
       const wrapper = mount(<Slider {...props} />)
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UISlider).prop("onChange")({ value: [10] })
 
       // We need to do this as we are using a debounce when the widget value is set
@@ -177,7 +177,7 @@ describe("Slider widget", () => {
       const wrapper = mount(<Slider {...props} />)
 
       // Change the widget value
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UISlider).prop("onChange")({ value: [10] })
 
       jest.runAllTimers()
@@ -244,7 +244,7 @@ describe("Slider widget", () => {
       const wrapper = mount(<Slider {...props} />)
 
       it("start > end", () => {
-        // @ts-ignore
+        // @ts-expect-error
         wrapper.find(UISlider).prop("onChange")({
           value: [11, 10],
         })
@@ -254,7 +254,7 @@ describe("Slider widget", () => {
       })
 
       it("start < min", () => {
-        // @ts-ignore
+        // @ts-expect-error
         wrapper.find(UISlider).prop("onChange")({
           value: [-1, 10],
         })
@@ -264,7 +264,7 @@ describe("Slider widget", () => {
       })
 
       it("start > max", () => {
-        // @ts-ignore
+        // @ts-expect-error
         wrapper.find(UISlider).prop("onChange")({
           value: [11],
         })
@@ -274,7 +274,7 @@ describe("Slider widget", () => {
       })
 
       it("end < min", () => {
-        // @ts-ignore
+        // @ts-expect-error
         wrapper.find(UISlider).prop("onChange")({
           value: [1, -1],
         })
@@ -284,7 +284,7 @@ describe("Slider widget", () => {
       })
 
       it("end > max", () => {
-        // @ts-ignore
+        // @ts-expect-error
         wrapper.find(UISlider).prop("onChange")({
           value: [1, 11],
         })
@@ -300,7 +300,7 @@ describe("Slider widget", () => {
 
       const wrapper = mount(<Slider {...props} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UISlider).prop("onChange")({
         value: [1, 10],
       })
@@ -420,7 +420,7 @@ describe("Slider widget", () => {
       const props = getProps(originalProps)
       const wrapper = mount(<Slider {...props} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UISlider).prop("onChange")({
         value: [4],
       })

--- a/frontend/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/src/components/widgets/TextArea/TextArea.test.tsx
@@ -69,12 +69,12 @@ describe("TextArea widget", () => {
     const wrappedDiv = wrapper.find("div").first()
 
     const { className, style } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("stTextArea")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(style.width).toBe(getProps().width)
   })
 
@@ -137,12 +137,12 @@ describe("TextArea widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "testing" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onBlur")()
 
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
@@ -159,12 +159,12 @@ describe("TextArea widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "testing" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onKeyDown")({
       preventDefault: jest.fn(),
       ctrlKey: true,
@@ -187,7 +187,7 @@ describe("TextArea widget", () => {
     const wrapper = shallow(<TextArea {...props} />)
     const overrides = wrapper.find(UITextArea).prop("overrides")
 
-    // @ts-ignore
+    // @ts-expect-error
     const { height, resize } = overrides.Input.style
 
     expect(height).toBe("500px")
@@ -201,14 +201,14 @@ describe("TextArea widget", () => {
     })
     const wrapper = shallow(<TextArea {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "0123456789" },
     } as EventTarget)
 
     expect(wrapper.find(UITextArea).prop("value")).toBe("0123456789")
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "0123456789a" },
     } as EventTarget)
@@ -221,7 +221,7 @@ describe("TextArea widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "TEST" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
@@ -243,7 +243,7 @@ describe("TextArea widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextArea {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "TEST" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
@@ -270,7 +270,7 @@ describe("TextArea widget", () => {
     const wrapper = shallow(<TextArea {...props} />)
 
     // Change the widget value
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UITextArea).prop("onChange")({
       target: { value: "TEST" },
     } as React.ChangeEvent<HTMLTextAreaElement>)
@@ -310,12 +310,12 @@ describe("TextArea widget", () => {
       jest.spyOn(props.widgetMgr, "setStringValue")
       const wrapper = shallow(<TextArea {...props} />)
 
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UITextArea).prop("onChange")({
         target: { value: "testing" },
       } as React.ChangeEvent<HTMLTextAreaElement>)
 
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(UITextArea).prop("onKeyDown")({
         preventDefault: jest.fn(),
         metaKey: true,

--- a/frontend/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/src/components/widgets/TextInput/TextInput.test.tsx
@@ -128,12 +128,11 @@ describe("TextInput widget", () => {
     const wrappedDiv = wrapper.find("StyledTextInput").first()
 
     const { className, width } = wrappedDiv.props()
-    // @ts-ignore
+    // @ts-expect-error
     const splittedClassName = className.split(" ")
 
     expect(splittedClassName).toContain("stTextInput")
 
-    // @ts-ignore
     expect(width).toBe(getProps().width)
   })
 
@@ -148,12 +147,12 @@ describe("TextInput widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "testing" },
     } as React.ChangeEvent<HTMLInputElement>)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onBlur")()
 
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
@@ -170,12 +169,12 @@ describe("TextInput widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "testing" },
     } as React.ChangeEvent<HTMLInputElement>)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onKeyPress")({
       preventDefault: jest.fn(),
       key: "Enter",
@@ -195,7 +194,7 @@ describe("TextInput widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onKeyPress")({
       preventDefault: jest.fn(),
       key: "Enter",
@@ -203,7 +202,7 @@ describe("TextInput widget", () => {
 
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledTimes(1)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onBlur")()
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledTimes(1)
   })
@@ -212,14 +211,14 @@ describe("TextInput widget", () => {
     const props = getProps({ maxChars: 10 })
     const wrapper = shallow(<TextInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "0123456789" },
     } as EventTarget)
 
     expect(wrapper.find(UIInput).prop("value")).toBe("0123456789")
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "0123456789a" },
     } as EventTarget)
@@ -232,7 +231,7 @@ describe("TextInput widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "TEST" },
     } as React.ChangeEvent<HTMLInputElement>)
@@ -254,7 +253,7 @@ describe("TextInput widget", () => {
     jest.spyOn(props.widgetMgr, "setStringValue")
     const wrapper = shallow(<TextInput {...props} />)
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "TEST" },
     } as React.ChangeEvent<HTMLInputElement>)
@@ -281,7 +280,7 @@ describe("TextInput widget", () => {
     const wrapper = shallow(<TextInput {...props} />)
 
     // Change the widget value
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(UIInput).prop("onChange")({
       target: { value: "TEST" },
     } as React.ChangeEvent<HTMLInputElement>)

--- a/frontend/src/hocs/withExpandable/withExpandable.test.tsx
+++ b/frontend/src/hocs/withExpandable/withExpandable.test.tsx
@@ -34,7 +34,6 @@ describe("withExpandable HOC", () => {
   it("renders without crashing", () => {
     const props = getProps()
     const WithHoc = withExpandable(testComponent)
-    // @ts-ignore
     const wrapper = mount(<WithHoc {...props} />)
     expect(wrapper.find(StatelessAccordion).exists()).toBe(true)
   })
@@ -42,7 +41,6 @@ describe("withExpandable HOC", () => {
   it("renders expander label as expected", () => {
     const props = getProps()
     const WithHoc = withExpandable(testComponent)
-    // @ts-ignore
     const wrapper = mount(<WithHoc {...props} />)
     const wrappedExpandLabel = wrapper.find(StreamlitMarkdown)
 
@@ -53,7 +51,6 @@ describe("withExpandable HOC", () => {
   it("should render a expanded component", () => {
     const props = getProps()
     const WithHoc = withExpandable(testComponent)
-    // @ts-ignore
     const wrapper = mount(<WithHoc {...props} />)
     const accordion = wrapper.find(StatelessAccordion)
 
@@ -65,7 +62,6 @@ describe("withExpandable HOC", () => {
       expanded: false,
     })
     const WithHoc = withExpandable(testComponent)
-    // @ts-ignore
     const wrapper = mount(<WithHoc {...props} />)
     const accordion = wrapper.find(StatelessAccordion)
 
@@ -77,12 +73,11 @@ describe("withExpandable HOC", () => {
       isStale: true,
     })
     const WithHoc = withExpandable(testComponent)
-    // @ts-ignore
     const wrapper = mount(<WithHoc {...props} />)
     const accordion = wrapper.find(StatelessAccordion)
     const overrides = accordion.prop("overrides")
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(overrides.Header.props.isStale).toBeTruthy()
   })
 })

--- a/frontend/src/hocs/withPagination/withPagination.test.tsx
+++ b/frontend/src/hocs/withPagination/withPagination.test.tsx
@@ -32,13 +32,12 @@ const getProps = (props: Partial<HocProps> = {}): HocProps => ({
 describe("withPagination HOC", () => {
   const setState = jest.fn()
   const useStateSpy = jest.spyOn(React, "useState")
-  // @ts-ignore
+  // @ts-expect-error
   useStateSpy.mockImplementation(init => [init, setState])
 
   it("renders without crashing", () => {
     const props = getProps()
     const WithHoc = withPagination(TestComponent)
-    // @ts-ignore
     const wrapper = shallow(<WithHoc {...props} />)
 
     expect(wrapper).toBeDefined()
@@ -54,7 +53,7 @@ describe("withPagination HOC", () => {
     const pagination = wrapper.find(Pagination)
     const paginatedComponent = wrapper.find(TestComponent)
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(paginatedComponent.props().items.length).toBe(props.pageSize)
     expect(pagination.length).toBe(1)
     expect(pagination.props().totalPages).toBe(2)
@@ -71,7 +70,7 @@ describe("withPagination HOC", () => {
     const paginatedComponent = wrapper.find(TestComponent)
 
     expect(pagination.length).toBe(0)
-    // @ts-ignore
+    // @ts-expect-error
     expect(paginatedComponent.props().items.length).toBe(props.items.length)
   })
 

--- a/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
+++ b/frontend/src/hocs/withScreencast/components/VideoRecordedDialog/VideoRecordedDialog.test.tsx
@@ -74,7 +74,7 @@ describe("VideoRecordedDialog", () => {
 
   it("should render a Modal with overridden width", () => {
     const overrides = wrapper.find(Modal).prop("overrides")
-    // @ts-ignore
+    // @ts-expect-error
     expect(overrides.Dialog.style.width).toEqual("80vw")
   })
 })

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -50,7 +50,7 @@ describe("FileUploadClient Upload", () => {
 
   afterEach(() => {
     axiosMock.restore()
-    // @ts-ignore
+    // @ts-expect-error
     SessionInfo.singleton = undefined
   })
 
@@ -73,7 +73,7 @@ describe("FileUploadClient Upload", () => {
         }
 
         if (getCookie("_xsrf")) {
-          // @ts-ignore - TS errors that config.headers is possibly 'undefined`
+          // @ts-expect-error - TS errors that config.headers is possibly 'undefined`
           if (!("X-Xsrftoken" in config.headers)) {
             return [403]
           }

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -37,7 +37,7 @@ function createCache(): MockCache {
   const cache = new ForwardMsgCache(() => MOCK_SERVER_URI)
 
   const getCachedMessage = (hash: string): ForwardMsg | undefined =>
-    // @ts-ignore accessing into internals for testing
+    // @ts-expect-error accessing into internals for testing
     cache.getCachedMessage(hash, false)
 
   return { cache, getCachedMessage }
@@ -212,7 +212,7 @@ test("removes expired messages", () => {
   const encodedMsg = ForwardMsg.encode(msg).finish()
 
   // Add the message to the cache
-  // @ts-ignore accessing into internals for testing
+  // @ts-expect-error accessing into internals for testing
   cache.maybeCacheMessage(msg, encodedMsg)
   expect(getCachedMessage(msg.hash)).toEqual(msg)
 

--- a/frontend/src/lib/Hooks.test.ts
+++ b/frontend/src/lib/Hooks.test.ts
@@ -20,7 +20,6 @@ const stateSetters: Array<any> = []
 
 jest.mock("react", () => ({
   __esModule: true,
-  // @ts-ignore
   ...jest.requireActual("react"),
   useEffect: jest.fn().mockImplementation(cb => cb()),
   useState: jest.fn().mockImplementation(() => {
@@ -37,7 +36,7 @@ jest.mock("react", () => ({
 describe("useIsOverflowing", () => {
   it("sets state to true if the element is overflowing", () => {
     const ref = { current: { scrollHeight: 1, clientHeight: 0 } }
-    // @ts-ignore
+    // @ts-expect-error
     useIsOverflowing(ref)
 
     const setIsOverflowing = stateSetters.pop()
@@ -46,7 +45,7 @@ describe("useIsOverflowing", () => {
 
   it("sets state to false if the element is not overflowing", () => {
     const ref = { current: { scrollHeight: 1, clientHeight: 1 } }
-    // @ts-ignore
+    // @ts-expect-error
     useIsOverflowing(ref)
 
     const setIsOverflowing = stateSetters.pop()

--- a/frontend/src/lib/Quiver.ts
+++ b/frontend/src/lib/Quiver.ts
@@ -605,7 +605,7 @@ but was expecting \`${JSON.stringify(expectedIndexTypes)}\`.
 
     // Concatenate each index with its counterpart in the other table
     const zipped = zip(this._index, otherIndex)
-    // @ts-ignore We know the two indexes are of the same size
+    // @ts-expect-error We know the two indexes are of the same size
     return zipped.map(a => a[0].concat(a[1]))
   }
 

--- a/frontend/src/lib/ScreenCastRecorder.ts
+++ b/frontend/src/lib/ScreenCastRecorder.ts
@@ -39,7 +39,6 @@ class ScreenCastRecorder {
     return (
       navigator.mediaDevices != null &&
       navigator.mediaDevices.getUserMedia != null &&
-      // @ts-ignore reason: https://github.com/microsoft/TypeScript/issues/33232
       navigator.mediaDevices.getDisplayMedia != null &&
       MediaRecorder.isTypeSupported(BLOB_TYPE)
     )
@@ -60,7 +59,6 @@ class ScreenCastRecorder {
    * for permissions to the user which are needed to start recording.
    */
   public async initialize(): Promise<void> {
-    // @ts-ignore reason: https://github.com/microsoft/TypeScript/issues/33232
     const desktopStream = await navigator.mediaDevices.getDisplayMedia({
       video: true,
     })

--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -147,7 +147,7 @@ describe("Widget State Manager", () => {
   it("sets trigger value correctly", () => {
     const widget = getWidget({ insideForm: false })
     widgetMgr.setTriggerValue(widget, { fromUi: true })
-    // @ts-ignore
+    // @ts-expect-error
     expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
     assertCallbacks({ insideForm: false })
   })

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -58,7 +58,7 @@ export const fontToEnum = (font: string): CustomThemeConfig.FontFamily => {
   if (fontStyle) {
     const parsedFontStyle = decamelize(fontStyle).toUpperCase()
     return parsedFontStyle in CustomThemeConfig.FontFamily
-      ? // @ts-ignore
+      ? // @ts-expect-error
         CustomThemeConfig.FontFamily[parsedFontStyle]
       : defaultFont
   }
@@ -375,9 +375,9 @@ export const createEmotionTheme = (
 
   const parsedColors = Object.entries(customColors).reduce(
     (colors: Record<string, string>, [key, color]) => {
-      // @ts-ignore
+      // @ts-expect-error
       if (isColor(color)) {
-        // @ts-ignore
+        // @ts-expect-error
         colors[key] = color
       } else if (isColor(`#${color}`)) {
         colors[key] = `#${color}`


### PR DESCRIPTION
## 📚 Context

We recently decided that using `@ts-expect-error` instead of `@ts-ignore` would be a good change
to make. This PR swaps out all of our current usage of `@ts-ignore` with `@ts-expect-error`.

This was done in a mostly automated way by running
`rg -l ts-ignore | xargs sed -i '' -e 's/ts-ignore/ts-expect-error/g'` (note that `sed` on MacOS differs from
`sed` on Linux, thus the weird syntax), then getting rid of the directives that started erroring out when
changed to `@ts-expect-error`.

- What kind of change does this PR introduce?

  - [x] Refactoring