### PR TITLE
Fix timeout on label-markdown e2e test

### DIFF
--- a/e2e/specs/label_markdown.spec.js
+++ b/e2e/specs/label_markdown.spec.js
@@ -16,6 +16,9 @@
 
 describe("label markdown", () => {
     before(() => {
+        // Increasing timeout since we are loading a bunch of widgets
+        Cypress.config("defaultCommandTimeout", 10000);
+
         cy.loadApp("http://localhost:3000/");
 
         cy.prepForElementSnapshots();


### PR DESCRIPTION
## 📚 Context

The label-markdown e2e test is flaky because it isn't always able to load all the widgets within Cypress' default command timeout. This change increases the default timeout in the beforeAll hook to (hopefully) resolve. 

See example failure vid:

https://user-images.githubusercontent.com/63436329/225108582-eb90996e-0d85-42e8-b0bc-65c38d263562.mp4