### PR TITLE
Make using @ts-ignore illegal

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -77,10 +77,17 @@
       "warn",
       { "allowExpressions": true }
     ],
-    // It's OK to use ts-ignore when we're missing type definitions
-    // for a JS library.
-    "@typescript-eslint/ban-ts-ignore": "off",
-    "@typescript-eslint/ban-ts-comment": "off",
+    // Disallow the @ts-ignore directive in favor of the more
+    // strict @ts-expect-error.
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+      {
+        "ts-expect-error": false,
+        "ts-nocheck": false,
+        "ts-check": false,
+        "ts-ignore": true
+      }
+    ],
     // Permit for-of loops (https://stackoverflow.com/a/42237667)
     "no-restricted-syntax": [
       "error",
@@ -120,7 +127,7 @@
       "error",
       { "allowSameFolder": true, "rootDir": "src", "prefix": "src" }
     ],
-    "no-else-return": ["error", {"allowElseIf": false}]
+    "no-else-return": ["error", { "allowElseIf": false }]
   },
   "settings": {
     "react": {


### PR DESCRIPTION
## 📚 Context

In #6308, we replaced usage of the `@ts-ignore` with the more strict but otherwise equivalent
`@ts-expect-error`. It seems unlikely we'll ever want to use the `@ts-ignore` directive in place of
`@ts-expect-error` since they're mostly equivalent except `@ts-expect-error` requires that the
line actually contain an error.

Ths PR enforces that this will be true going forward by adding a linter rule to make usage of `@ts-ignore`
illegal.

- What kind of change does this PR introduce?

  - [x] Other, please describe: angrier linting