### PR TITLE
Fix: File Uploader's File Selection Dialog limits available extensions

### DIFF
--- a/frontend/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -44,6 +44,9 @@ const FileDropzone = ({
     accept={acceptedExtensions.length ? acceptedExtensions : undefined}
     maxSize={maxSizeBytes}
     disabled={disabled}
+    // react-dropzone v12+ uses the File System Access API by default,
+    // causing the bug described in https://github.com/streamlit/streamlit/issues/6176.
+    useFsAccessApi={false}
   >
     {({ getRootProps, getInputProps }) => (
       <StyledFileDropzoneSection


### PR DESCRIPTION
## 📚 Context

Updating to `react-dropzone` v12 as part our FE dependency update process caused `st.file_uploader`'s File Selection Dialog to show all file types as available for selection, despite the extensions not being included in the `type` param. This should address the regression and bring behavior back in line with previous UI.

Additionally, [.showOpenFilePicker()](https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker#parameters) is still experimental and is not compatible with Firefox & Safari.

- What kind of change does this PR introduce?
  - [x] Bugfix

## 🧠 Description of Changes

- Override default use of [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) for `react-dropzone`

  - [x] This is a visible (user-facing) change

**Revised:**
<img width="829" alt="Screenshot 2023-03-14 at 3 51 31 PM" src="https://user-images.githubusercontent.com/63436329/225159728-5fbc09d5-766a-42e6-a3ab-524a98f1ed85.png">

**Current:**
<img width="823" alt="Screenshot 2023-03-14 at 3 52 32 PM" src="https://user-images.githubusercontent.com/63436329/225159677-f22694c0-911e-430a-b665-938841757c7f.png">

## 🌐 References

- **Issue**: Closes #6176 

