### PR TITLE
Fix: Handle ResizeObserver loop limit exceeded error

### DIFF
--- a/e2e/specs/label_markdown.spec.js
+++ b/e2e/specs/label_markdown.spec.js
@@ -19,6 +19,15 @@ describe("label markdown", () => {
         // Increasing timeout since we are loading a bunch of widgets
         Cypress.config("defaultCommandTimeout", 10000);
 
+        cy.on('uncaught:exception', (err) => {
+            // This error can be safely ignored
+            // https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+            expect(err.message).to.include('ResizeObserver loop limit exceeded')
+
+            // return false to prevent the error from failing this test
+            return false
+          })
+
         cy.loadApp("http://localhost:3000/");
 
         cy.prepForElementSnapshots();


### PR DESCRIPTION
## 📚 Context
The label-markdown e2e test script will occasionally throw a benign `ResizeObserver loop limit exceeded` exception which causes the entire test suite to fail. [This error](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded) can be safely ignored.

- What kind of change does this PR introduce?
  - [x] Other, please describe: Test fix

**Error Log:**
<img width="500" alt="Screenshot 2023-03-14 at 5 36 25 PM" src="https://user-images.githubusercontent.com/63436329/225173340-517636b1-96e6-4e76-b80c-8213b382a8ff.png">

**Video:**
https://user-images.githubusercontent.com/63436329/225173170-8c2497ac-0b13-4bac-8095-55d932f52705.mp4

## 🧠 Description of Changes

- Add a catch for single uncaught exception ([Cypress docs](https://docs.cypress.io/api/events/catalog-of-events#To-catch-a-single-uncaught-exception))
