### PR TITLE
Fix issue #6310

### DIFF
--- a/lib/streamlit/runtime/caching/storage/local_disk_cache_storage.py
+++ b/lib/streamlit/runtime/caching/storage/local_disk_cache_storage.py
@@ -193,9 +193,13 @@ class LocalDiskCacheStorage(CacheStorage):
         """Delete all keys for the current storage"""
         cache_dir = get_cache_folder_path()
 
-        for file_name in os.listdir(cache_dir):
-            if self._is_cache_file(file_name):
-                os.remove(os.path.join(cache_dir, file_name))
+        if os.path.isdir(cache_dir):
+            # We try to remove all files in the cache directory that start with
+            # the function key, whether `clear` called for `self.persist`
+            # storage or not, to avoid leaving orphaned files in the cache directory.
+            for file_name in os.listdir(cache_dir):
+                if self._is_cache_file(file_name):
+                    os.remove(os.path.join(cache_dir, file_name))
 
     def close(self) -> None:
         """Dummy implementation of close, we don't need to actually "close" anything"""

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -335,7 +335,9 @@ class CacheDataPersistTest(DeltaGeneratorTestCase):
 
         mock_os_remove.assert_not_called()
 
-        with patch("os.listdir", MagicMock(return_value=created_files_base_names)):
+        with patch(
+            "os.listdir", MagicMock(return_value=created_files_base_names)
+        ), patch("os.path.isdir", MagicMock(return_value=True)):
             # Clear foo's cache
             foo.clear()
 

--- a/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
+++ b/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
@@ -250,7 +250,7 @@ class LocalDiskPersistCacheStorageTest(unittest.TestCase):
         self.assertEqual(os.listdir(self.tempdir.path), [])
 
     def test_storage_clear_missing_directory(self):
-        """Test that storage.clear() not crush if cache directory does not exist."""
+        """Test that clear() is not crashing if the cache directory does not exist."""
         self.tempdir.cleanup()
         self.storage.clear()
 

--- a/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
+++ b/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
@@ -249,10 +249,25 @@ class LocalDiskPersistCacheStorageTest(unittest.TestCase):
         # test that cache folder is empty
         self.assertEqual(os.listdir(self.tempdir.path), [])
 
-    def test_storage_clear_missing_directory(self):
+    def test_storage_clear_not_existing_cache_directory(self):
         """Test that clear() is not crashing if the cache directory does not exist."""
         self.tempdir.cleanup()
         self.storage.clear()
+
+    def test_storage_clear_call_listdir_existing_cache_directory(self):
+        """Test that clear() call os.listdir if cache folder does not exist."""
+        with patch("os.listdir") as mock_listdir:
+            self.storage.clear()
+        mock_listdir.assert_called_once()
+
+    def test_storage_clear_not_call_listdir_not_existing_cache_directory(self):
+        """Test that clear() doesn't call os.listdir if cache folder does not exist."""
+        self.tempdir.cleanup()
+
+        with patch("os.listdir") as mock_listdir:
+            self.storage.clear()
+
+        mock_listdir.assert_not_called()
 
     def test_storage_close(self):
         """Test that storage.close() does not raise any exception."""

--- a/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
+++ b/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
@@ -250,7 +250,7 @@ class LocalDiskPersistCacheStorageTest(unittest.TestCase):
         self.assertEqual(os.listdir(self.tempdir.path), [])
 
     def test_storage_clear_missing_directory(self):
-        """Test that storage.clear() not crush if directory not exists."""
+        """Test that storage.clear() not crush if cache directory does not exist."""
         self.tempdir.cleanup()
         self.storage.clear()
 

--- a/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
+++ b/lib/tests/streamlit/runtime/caching/storage/local_disk_cache_storage_test.py
@@ -54,8 +54,7 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
         self.tempdir.cleanup()
 
     def test_create_persist_context(self):
-        """
-        Tests that LocalDiskCacheStorageManager.create()
+        """Tests that LocalDiskCacheStorageManager.create()
         returns a LocalDiskCacheStorage with correct parameters from context, if
         persist="disk"
         """
@@ -73,8 +72,7 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
         self.assertEqual(storage.max_entries, 100)
 
     def test_create_not_persist_context(self):
-        """
-        Tests that LocalDiskCacheStorageManager.create()
+        """Tests that LocalDiskCacheStorageManager.create()
         returns a LocalDiskCacheStorage with correct parameters from context, if
         persist is None
         """
@@ -92,8 +90,7 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
         self.assertEqual(storage.max_entries, math.inf)
 
     def test_check_context_with_persist_and_ttl(self):
-        """
-        Tests that LocalDiskCacheStorageManager.check_context() writes a warning
+        """Tests that LocalDiskCacheStorageManager.check_context() writes a warning
         in logs when persist="disk" and ttl_seconds is not None
         """
         context = CacheStorageContext(
@@ -119,9 +116,8 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
             )
 
     def test_check_context_without_persist(self):
-        """
-        Tests that LocalDiskCacheStorageManager.check_context() does not write a warning
-        in logs when persist is None and ttl_seconds is NOT None
+        """Tests that LocalDiskCacheStorageManager.check_context() does not
+        write a warning in logs when persist is None and ttl_seconds is NOT None.
         """
         context = CacheStorageContext(
             function_key="func-key",
@@ -153,8 +149,7 @@ class LocalDiskCacheStorageManagerTest(unittest.TestCase):
 
     @patch("shutil.rmtree", wraps=shutil.rmtree)
     def test_clear_all(self, mock_rmtree):
-        """
-        Tests that LocalDiskCacheStorageManager.clear_all() calls shutil.rmtree
+        """Tests that LocalDiskCacheStorageManager.clear_all() calls shutil.rmtree
         to remove the cache folder
         """
         manager = LocalDiskCacheStorageManager()
@@ -208,25 +203,19 @@ class LocalDiskPersistCacheStorageTest(unittest.TestCase):
         MagicMock(side_effect=util.Error("mock exception")),
     )
     def test_storage_set_error(self):
-        """
-        Test that storage.set() raises an exception when it fails to write to disk.
-        """
+        """Test that storage.set() raises an exception when it fails to write to disk."""
         with self.assertRaises(CacheStorageError) as e:
             self.storage.set("uniqueKey", b"new-value")
         self.assertEqual(str(e.exception), "Unable to write to cache")
 
     def test_storage_set_override(self):
-        """
-        Test that storage.set() overrides the value of an existing key.
-        """
+        """Test that storage.set() overrides the value of an existing key."""
         self.storage.set("another_key", b"another_value")
         self.storage.set("another_key", b"new_value")
         self.assertEqual(self.storage.get("another_key"), b"new_value")
 
     def test_storage_delete(self):
-        """
-        Test that storage.delete() removes the correct file from disk.
-        """
+        """Test that storage.delete() removes the correct file from disk."""
         self.storage.set("new-key", b"new-value")
         self.assertTrue(os.path.exists(self.tempdir.path + "/func-key-new-key.memo"))
         self.storage.delete("new-key")
@@ -236,9 +225,7 @@ class LocalDiskPersistCacheStorageTest(unittest.TestCase):
             self.storage.get("new-key")
 
     def test_storage_clear(self):
-        """
-        Test that storage.clear() removes all storage files from disk.
-        """
+        """Test that storage.clear() removes all storage files from disk."""
         self.storage.set("some-key", b"some-value")
         self.storage.set("another-key", b"another-value")
         self.assertTrue(os.path.exists(self.tempdir.path + "/func-key-some-key.memo"))
@@ -261,6 +248,11 @@ class LocalDiskPersistCacheStorageTest(unittest.TestCase):
 
         # test that cache folder is empty
         self.assertEqual(os.listdir(self.tempdir.path), [])
+
+    def test_storage_clear_missing_directory(self):
+        """Test that storage.clear() not crush if directory not exists."""
+        self.tempdir.cleanup()
+        self.storage.clear()
 
     def test_storage_close(self):
         """Test that storage.close() does not raise any exception."""


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
We try to remove all files in the cache directory that start with the function key, whether `clear` is called for `self.persist`
storage or not, to avoid leaving orphaned files in the cache directory. This leads to a bug, when cache directory is not exists, but we try to list all files there (to filter only those that belong to the corresponding function). 

The solution is to check that directory exists before, trying to filter corresponding files there.


- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6310

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
