### PR TITLE
ForwardMessageCache: interface-ize endpoint

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,6 +107,7 @@ import {
 } from "src/theme"
 import { DefaultStreamlitEndpoints } from "./lib/DefaultStreamlitEndpoints"
 import { SegmentMetricsManager } from "./lib/SegmentMetricsManager"
+import { StreamlitEndpoints } from "./lib/StreamlitEndpoints"
 
 import { StyledApp } from "./styled-components"
 
@@ -170,6 +171,8 @@ declare global {
 }
 
 export class App extends PureComponent<Props, State> {
+  private readonly endpoints: StreamlitEndpoints
+
   private readonly sessionInfo = new SessionInfo()
 
   private readonly metricsMgr = new SegmentMetricsManager(this.sessionInfo)
@@ -248,14 +251,14 @@ export class App extends PureComponent<Props, State> {
       formsDataChanged: formsData => this.setState({ formsData }),
     })
 
-    const endpoints = new DefaultStreamlitEndpoints({
+    this.endpoints = new DefaultStreamlitEndpoints({
       getServerUri: this.getBaseUriParts,
       csrfEnabled: true,
     })
 
     this.uploadClient = new FileUploadClient({
       sessionInfo: this.sessionInfo,
-      endpoints,
+      endpoints: this.endpoints,
       // A form cannot be submitted if it contains a FileUploader widget
       // that's currently uploading. We write that state here, in response
       // to a FileUploadClient callback. The FormSubmitButton element
@@ -264,7 +267,7 @@ export class App extends PureComponent<Props, State> {
         this.widgetMgr.setFormsWithUploads(formIds),
     })
 
-    this.componentRegistry = new ComponentRegistry(endpoints)
+    this.componentRegistry = new ComponentRegistry(this.endpoints)
 
     this.pendingElementsTimerRunning = false
     this.pendingElementsBuffer = this.state.elements
@@ -304,6 +307,7 @@ export class App extends PureComponent<Props, State> {
     // "Can't call setState on a component that is not yet mounted." error.
     this.connectionManager = new ConnectionManager({
       sessionInfo: this.sessionInfo,
+      endpoints: this.endpoints,
       onMessage: this.handleMessage,
       onConnectionError: this.handleConnectionError,
       connectionStateChanged: this.handleConnectionStateChanged,

--- a/frontend/src/lib/ConnectionManager.ts
+++ b/frontend/src/lib/ConnectionManager.ts
@@ -22,6 +22,7 @@ import { BaseUriParts, getPossibleBaseUris } from "src/lib/UriUtil"
 import { ConnectionState } from "./ConnectionState"
 import { logError } from "./log"
 import { SessionInfo } from "./SessionInfo"
+import { StreamlitEndpoints } from "./StreamlitEndpoints"
 import { WebsocketConnection } from "./WebsocketConnection"
 import { ensureError } from "./ErrorHandling"
 
@@ -37,6 +38,9 @@ const RETRY_COUNT_FOR_WARNING = 6
 interface Props {
   /** The app's SessionInfo instance */
   sessionInfo: SessionInfo
+
+  /** The app's StreamlitEndpoints instance */
+  endpoints: StreamlitEndpoints
 
   /**
    * Function to be called when we receive a message from the server.
@@ -177,6 +181,7 @@ export class ConnectionManager {
 
     return new WebsocketConnection({
       sessionInfo: this.props.sessionInfo,
+      endpoints: this.props.endpoints,
       baseUriPartsList,
       onMessage: this.props.onMessage,
       onConnectionStateChange: this.setConnectionState,

--- a/frontend/src/lib/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/lib/DefaultStreamlitEndpoints.ts
@@ -74,6 +74,22 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     })
   }
 
+  public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
+    const serverURI = this.requireServerUri()
+    const url = buildHttpUri(serverURI, `_stcore/message?hash=${hash}`)
+    const rsp = await fetch(url)
+    if (!rsp.ok) {
+      // `fetch` doesn't reject for bad HTTP statuses, so
+      // we explicitly check for that.
+      throw new Error(
+        `Failed to retrieve ForwardMsg (hash=${hash}): ${rsp.statusText}`
+      )
+    }
+
+    const data = await rsp.arrayBuffer()
+    return new Uint8Array(data)
+  }
+
   /**
    * Fetch the server URI. If our server is disconnected, default to the most
    * recent cached value of the URI. If we're disconnected and have no cached

--- a/frontend/src/lib/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/lib/DefaultStreamlitEndpoints.ts
@@ -76,18 +76,13 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
 
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
     const serverURI = this.requireServerUri()
-    const url = buildHttpUri(serverURI, `_stcore/message?hash=${hash}`)
-    const rsp = await fetch(url)
-    if (!rsp.ok) {
-      // `fetch` doesn't reject for bad HTTP statuses, so
-      // we explicitly check for that.
-      throw new Error(
-        `Failed to retrieve ForwardMsg (hash=${hash}): ${rsp.statusText}`
-      )
-    }
+    const rsp = await axios.request({
+      url: buildHttpUri(serverURI, `_stcore/message?hash=${hash}`),
+      method: "GET",
+      responseType: "arraybuffer",
+    })
 
-    const data = await rsp.arrayBuffer()
-    return new Uint8Array(data)
+    return new Uint8Array(rsp.data)
   }
 
   /**

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -33,6 +33,7 @@ describe("FileUploadClient Upload", () => {
       endpoints: {
         buildComponentURL: jest.fn(),
         uploadFileUploaderFile: uploadFileUploaderFile,
+        fetchCachedForwardMsg: jest.fn(),
       },
       formsWithPendingRequestsChanged,
     })

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -16,10 +16,7 @@
 
 import { ForwardMsg } from "src/autogen/proto"
 import fetchMock from "fetch-mock"
-import {
-  FETCH_MESSAGE_PATH,
-  ForwardMsgCache,
-} from "src/lib/ForwardMessageCache"
+import { ForwardMsgCache } from "src/lib/ForwardMessageCache"
 import { buildHttpUri } from "src/lib/UriUtil"
 
 const MOCK_SERVER_URI = {

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -15,29 +15,28 @@
  */
 
 import { ForwardMsg } from "src/autogen/proto"
-import fetchMock from "fetch-mock"
 import { ForwardMsgCache } from "src/lib/ForwardMessageCache"
-import { buildHttpUri } from "src/lib/UriUtil"
-
-const MOCK_SERVER_URI = {
-  host: "streamlit.mock",
-  port: 80,
-  basePath: "",
-}
 
 interface MockCache {
   cache: ForwardMsgCache
   getCachedMessage: (hash: string) => ForwardMsg | undefined
+  mockFetchCachedForwardMsg: jest.Mock
 }
 
 function createCache(): MockCache {
-  const cache = new ForwardMsgCache(() => MOCK_SERVER_URI)
+  const mockFetchCachedForwardMsg = jest.fn()
+
+  const cache = new ForwardMsgCache({
+    buildComponentURL: jest.fn(),
+    uploadFileUploaderFile: jest.fn(),
+    fetchCachedForwardMsg: mockFetchCachedForwardMsg,
+  })
 
   const getCachedMessage = (hash: string): ForwardMsg | undefined =>
-    // @ts-expect-error accessing into internals for testing
+    // @ts-expect-error (accessing internals for testing)
     cache.getCachedMessage(hash, false)
 
-  return { cache, getCachedMessage }
+  return { cache, getCachedMessage, mockFetchCachedForwardMsg }
 }
 
 /**
@@ -60,52 +59,6 @@ function createRefMsg(msg: ForwardMsg): ForwardMsg {
     refHash: msg.hash,
   })
 }
-
-/**
- * Configure fetch-mock to respond to /message requests for the given
- * ForwardMsg with a valid payload.
- */
-function mockGetMessageResponse(msg: ForwardMsg): void {
-  const response = {
-    status: 200,
-    headers: { "Content-Type": "application/octet-stream" },
-    body: ForwardMsg.encode(msg).finish(),
-  }
-
-  const options = {
-    query: { hash: msg.hash },
-    method: "get",
-  }
-
-  fetchMock.mock(
-    buildHttpUri(MOCK_SERVER_URI, FETCH_MESSAGE_PATH),
-    response,
-    options
-  )
-}
-
-/**
- * Configure fetch-mock to respond to /message requests for the given
- * ForwardMsg with a 404.
- */
-function mockMissingMessageResponse(msg: ForwardMsg): void {
-  const response = { status: 404 }
-  const options = {
-    query: { hash: msg.hash },
-    method: "get",
-  }
-
-  fetchMock.mock(
-    buildHttpUri(MOCK_SERVER_URI, FETCH_MESSAGE_PATH),
-    response,
-    options
-  )
-}
-
-beforeEach(() => {
-  fetchMock.config.sendAsJson = false
-})
-afterEach(() => fetchMock.restore())
 
 test("caches messages correctly", async () => {
   const { cache, getCachedMessage } = createCache()
@@ -173,10 +126,10 @@ test("fetches uncached messages from server", async () => {
   const refMsg = createRefMsg(msg)
   const encodedRefMsg = ForwardMsg.encode(refMsg).finish()
 
-  // Mock response: /message?hash=Cacheable -> msg
-  mockGetMessageResponse(msg)
-
-  const { cache, getCachedMessage } = createCache()
+  const { cache, getCachedMessage, mockFetchCachedForwardMsg } = createCache()
+  mockFetchCachedForwardMsg.mockResolvedValue(
+    new Uint8Array(ForwardMsg.encode(msg).finish())
+  )
 
   // processMessagePayload on a reference message whose
   // original version does *not* exist in our local cache. We
@@ -194,10 +147,9 @@ test("errors when uncached message is not on server", async () => {
   const refMsg = createRefMsg(msg)
   const encodedRefMsg = ForwardMsg.encode(refMsg).finish()
 
-  // Mock response: /message?hash=Cacheable -> 404
-  mockMissingMessageResponse(msg)
+  const { cache, mockFetchCachedForwardMsg } = createCache()
+  mockFetchCachedForwardMsg.mockRejectedValue(new Error("404"))
 
-  const { cache } = createCache()
   await expect(
     cache.processMessagePayload(refMsg, encodedRefMsg)
   ).rejects.toThrow()

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -43,4 +43,13 @@ export interface StreamlitEndpoints {
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<number>
+
+  /**
+   * Fetch a cached ForwardMsg from the server.
+   * This is called when the ForwardMessageCache has a cache miss - that is, when
+   * the server sends a ForwardMsg reference and we don't have the original message
+   * in our local cache.
+   * @param hash the message's hash
+   */
+  fetchCachedForwardMsg(hash: string): Promise<Uint8Array>
 }

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -46,9 +46,11 @@ export interface StreamlitEndpoints {
 
   /**
    * Fetch a cached ForwardMsg from the server.
+   *
    * This is called when the ForwardMessageCache has a cache miss - that is, when
    * the server sends a ForwardMsg reference and we don't have the original message
    * in our local cache.
+   *
    * @param hash the message's hash
    */
   fetchCachedForwardMsg(hash: string): Promise<Uint8Array>

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -52,6 +52,9 @@ export interface StreamlitEndpoints {
    * in our local cache.
    *
    * @param hash the message's hash
+   *
+   * @return a Promise<Uint8Array> that resolves with the serialized ForwardMsg data returned
+   * from the server. Callers can use `ForwardMsg.decode` to deserialize the data.
    */
   fetchCachedForwardMsg(hash: string): Promise<Uint8Array>
 }

--- a/frontend/src/lib/WebsocketConnection.test.tsx
+++ b/frontend/src/lib/WebsocketConnection.test.tsx
@@ -29,7 +29,7 @@ import {
   doInitPings,
   Args,
 } from "src/lib/WebsocketConnection"
-import { mockSessionInfoProps } from "./mocks/mocks"
+import { mockEndpoints, mockSessionInfoProps } from "./mocks/mocks"
 
 const MOCK_ALLOWED_ORIGINS_RESPONSE = {
   data: {
@@ -44,6 +44,7 @@ const MOCK_HEALTH_RESPONSE = { status: "ok" }
 function createMockArgs(overrides?: Partial<Args>): Args {
   return {
     sessionInfo: new SessionInfo(),
+    endpoints: mockEndpoints(),
     baseUriPartsList: [
       {
         host: "localhost",

--- a/frontend/src/lib/WebsocketConnection.tsx
+++ b/frontend/src/lib/WebsocketConnection.tsx
@@ -27,6 +27,7 @@ import Resolver from "src/lib/Resolver"
 import { SessionInfo } from "src/lib/SessionInfo"
 import { BaseUriParts, buildHttpUri, buildWsUri } from "src/lib/UriUtil"
 import React, { Fragment } from "react"
+import { StreamlitEndpoints } from "./StreamlitEndpoints"
 
 /**
  * Name of the logger.
@@ -85,6 +86,8 @@ type OnRetry = (
 export interface Args {
   /** The application's SessionInfo instance */
   sessionInfo: SessionInfo
+
+  endpoints: StreamlitEndpoints
 
   /**
    * List of URLs to connect to. We'll try the first, then the second, etc. If
@@ -218,7 +221,7 @@ export class WebsocketConnection {
 
   constructor(props: Args) {
     this.args = props
-    this.cache = new ForwardMsgCache(() => this.getBaseUriParts())
+    this.cache = new ForwardMsgCache(props.endpoints)
     this.stepFsm("INITIALIZED")
   }
 

--- a/frontend/src/lib/mocks/mocks.ts
+++ b/frontend/src/lib/mocks/mocks.ts
@@ -51,6 +51,9 @@ const MOCK_ENDPOINTS: StreamlitEndpoints = {
   },
 
   uploadFileUploaderFile: jest.fn().mockResolvedValue(1),
+  fetchCachedForwardMsg: jest
+    .fn()
+    .mockRejectedValue(new Error("unimplemented mock endpoint")),
 }
 
 /** Return a mock Endpoints implementation. */


### PR DESCRIPTION
Moves `ForwardMessageCache`'s "message cache endpoint" functionality into our `StreamlitEndpoints` interface (similar to ComponentRegistry and FileUploadClient).

- `StreamlitEndpoints.fetchCachedForwardMsg` is the new interface method
- `DefaultStreamlitEndpoints` talks to the Streamlit server `/_stcore/message` endpoint