### PR TITLE
Add sqlalchemy mypy types to test-requirements.txt

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -27,4 +27,4 @@ psycopg2-binary>=2.9.1
 pyodbc>=4.0.32
 # SQLAlchemy 2.0 causes hashing tests to fail (and we're deliberately
 # choosing not to support it.)
-sqlalchemy>=1.4.25, <2.0
+sqlalchemy[mypy]>=1.4.25, <2.0


### PR DESCRIPTION
## 📚 Context

Some upcoming work for `st.experimental_connection` will need SQLAlchemy types.

- What kind of change does this PR introduce?

  - [x] Other, please describe: adds typing dependency
