### PR TITLE
Add a skeleton implementation of st.experimental_connection

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -60,6 +60,9 @@ from streamlit.runtime.caching import (
     experimental_singleton as _experimental_singleton,
     experimental_memo as _experimental_memo,
 )
+from streamlit.runtime.connection_factory import (
+    connection_factory as _connection_factory,
+)
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
 from streamlit.runtime.state import SessionStateProxy as _SessionStateProxy
@@ -212,3 +215,4 @@ experimental_set_query_params = _set_query_params
 experimental_show = _show
 experimental_rerun = _rerun
 experimental_data_editor = _main.experimental_data_editor
+experimental_connection = _connection_factory

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Explicitly re-export public symbols.
+from streamlit.connections.base_connection import BaseConnection as BaseConnection

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -1,0 +1,26 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class BaseConnection(ABC, Generic[T]):
+    """TODO(vdonato): Implement... this entire class.
+
+    We intentionally leave this as just a stub implementation for now as it's needed
+    to define types in streamlit.runtime.connection_factory.
+    """

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -1,0 +1,84 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import Any, Dict, Type, TypeVar, overload
+
+from typing_extensions import Final
+
+from streamlit.connections.base_connection import BaseConnection
+from streamlit.runtime.caching import cache_resource
+from streamlit.runtime.metrics_util import gather_metrics
+
+MODULE_EXTRACTION_REGEX = re.compile(r"No module named \'(.+)\'")
+MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
+    "sqlalchemy": "sqlalchemy",
+    "snowflake.snowpark": "snowflake-snowpark-python",
+}
+
+# The BaseConnection bound is parameterized to `Any` below as subclasses of
+# BaseConnection are responsible for binding the type parameter of BaseConnection to a
+# concrete type, but the type it gets bound to isn't important to us here.
+ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
+
+
+# NOTE: The order of the decorators below is important: @gather_metrics must be above
+# @cache_resource so that it is called even if the return value of _create_connection
+# is cached.
+@gather_metrics("experimental_connection")
+@cache_resource
+def _create_connection(
+    connection_class: Type[ConnectionClass], name: str = "default", **kwargs
+) -> ConnectionClass:
+    """Create an instance of connection_class with the given name and kwargs.
+
+    This function is useful because it allows us to @gather_metrics at a point where
+    connection_class must be a concrete type. The public-facing connection API allows
+    the user to specify the connection class to use as a string literal for convenience.
+    """
+    return connection_class(  # type: ignore
+        connection_name=name,
+        **kwargs,
+    )
+
+
+@overload  # type: ignore
+def connection_factory(
+    connection_class: Type[ConnectionClass], name: str = "default", **kwargs
+) -> ConnectionClass:
+    pass
+
+
+def connection_factory(connection_class, name="default", **kwargs):
+    """TODO(vdonato): Write a docstring (maybe with the help of the documentation team).
+
+    The docstring should describe:
+      * Using st.connection with one of our first party connections by passing a string
+        literal as the connection_class.
+      * Plugging your own ConnectionClass into st.experimental_connection.
+    """
+    try:
+        return _create_connection(connection_class, name=name, **kwargs)
+    except ModuleNotFoundError as e:
+        err_string = str(e)
+        missing_module = re.search(MODULE_EXTRACTION_REGEX, err_string)
+
+        # TODO(vdonato): Finalize these error messages.
+        extra_info = "You may be missing a dependency required to use this connection."
+        if missing_module:
+            pypi_package = MODULES_TO_PYPI_PACKAGES.get(missing_module.group(1))
+            if pypi_package:
+                extra_info = f"You need to install the '{pypi_package}' package to use this connection."
+
+        raise ModuleNotFoundError(f"{str(e)}. {extra_info}")

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -1,0 +1,96 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.connections import BaseConnection
+from streamlit.runtime.connection_factory import _create_connection, connection_factory
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx
+
+
+class MockConnection(BaseConnection[None]):
+    def __init__(self, connection_name: str, **kwargs):
+        self._connection_name = connection_name
+        self._kwargs = kwargs
+
+
+class ConnectionFactoryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        _create_connection.clear()
+
+    def test_passes_name_and_args_to_class(self):
+        conn = connection_factory(MockConnection, name="nondefault", foo="bar")
+        assert conn._connection_name == "nondefault"
+        assert conn._kwargs == {"foo": "bar"}
+
+    def test_caches_connection_instance(self):
+        conn = connection_factory(MockConnection)
+        assert connection_factory(MockConnection) is conn
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_friendly_error_with_certain_missing_dependencies(
+        self, patched_create_connection
+    ):
+        """Test that our error messages are extra-friendly when a ModuleNotFoundError
+        error is thrown for certain missing packages.
+        """
+
+        patched_create_connection.side_effect = ModuleNotFoundError(
+            "No module named 'sqlalchemy'"
+        )
+
+        with pytest.raises(ModuleNotFoundError) as e:
+            connection_factory(MockConnection)
+        assert str(e.value) == (
+            "No module named 'sqlalchemy'. "
+            "You need to install the 'sqlalchemy' package to use this connection."
+        )
+
+        _create_connection.clear()
+        patched_create_connection.side_effect = ModuleNotFoundError(
+            "No module named 'snowflake.snowpark'"
+        )
+
+        with pytest.raises(ModuleNotFoundError) as e:
+            connection_factory(MockConnection)
+        assert str(e.value) == (
+            "No module named 'snowflake.snowpark'. "
+            "You need to install the 'snowflake-snowpark-python' package to use this connection."
+        )
+
+    @patch(
+        "streamlit.runtime.connection_factory._create_connection",
+        MagicMock(side_effect=ModuleNotFoundError("No module named 'foo'")),
+    )
+    def test_generic_missing_dependency_error(self):
+        """Test our generic error message when a ModuleNotFoundError is thrown."""
+        with pytest.raises(ModuleNotFoundError) as e:
+            connection_factory(MockConnection)
+        assert str(e.value) == (
+            "No module named 'foo'. "
+            "You may be missing a dependency required to use this connection."
+        )

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -85,7 +85,6 @@ class MetricsUtilTest(unittest.TestCase):
         with patch(
             "streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC
         ), patch("streamlit.runtime.metrics_util.os.path.isfile", return_value=False):
-
             machine_id = metrics_util._get_machine_id_v3()
         self.assertEqual(machine_id, MAC)
 
@@ -246,6 +245,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         """All commands of the public API should be tracked with the correct name."""
         # Some commands are currently not tracked for various reasons:
         ignored_commands = {
+            "experimental_connection",
             "experimental_rerun",
             "stop",
             "spinner",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -158,6 +158,7 @@ class StreamlitTest(unittest.TestCase):
                 "experimental_rerun",
                 "experimental_show",
                 "experimental_data_editor",
+                "experimental_connection",
                 "get_option",
                 "set_option",
             },


### PR DESCRIPTION
Note: This PR is going into `feature/st.experimental_connection` and not `develop`.

## 📚 Context

This PR kicks off the work to implement the real version of `st.experimental_connection` that was
prototyped in #6035. We start off by doing mostly uninteresting stuff:

* Expose `st.experimental_connection` as part of the public API
* Add a stub implementation of `BaseConnection` and use it to define types in `connection_factory.py`
* Implement friendly error messages for when users are missing packages that a connection requires.
   * These are being added mostly for the benefit of the first-party connections we'll be providing.

What's currently implemented doesn't really do anything at the moment, but it does define the general
structure of the code we'll be adding for this feature.

The next PR will implement the `BaseConnection` class, and after that we'll add a few first-party connectors.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests
