### PR TITLE
Return whether a secrets.toml file is successfully parsed

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -124,18 +124,21 @@ class Secrets(Mapping[str, Any]):
             doc="Emitted when a `secrets.toml` file has been changed."
         )
 
-    def load_if_toml_exists(self) -> None:
+    def load_if_toml_exists(self) -> bool:
         """Load secrets.toml files from disk if they exists. If none exist,
         no exception will be raised. (If a file exists but is malformed,
         an exception *will* be raised.)
+
+        Returns True if a secrets.toml file was successfully parsed, False otherwise.
 
         Thread-safe.
         """
         try:
             self._parse(print_exceptions=False)
+            return True
         except FileNotFoundError:
             # No secrets.toml files exist. That's fine.
-            pass
+            return False
 
     def _reset(self) -> None:
         """Clear the secrets dictionary and remove any secrets that were

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -115,6 +115,13 @@ class SecretsTest(unittest.TestCase):
         # Subsections do not get loaded into os.environ
         self.assertEqual(os.environ.get("subsection"), None)
 
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_load_if_toml_exists_returns_true_if_parse_succeeds(self, _):
+        self.assertTrue(self.secrets.load_if_toml_exists())
+
+    def test_load_if_toml_exists_returns_false_if_parse_fails(self):
+        self.assertFalse(self.secrets.load_if_toml_exists())
+
     @patch("streamlit.error")
     def test_missing_toml_error(self, mock_st_error):
         """Secrets access raises an error, and calls st.error, if


### PR DESCRIPTION
## 📚 Context

This is another tiny change that'll be useful for what's being built in the
`feature/st.experimental_connection` feature branch but can go straight into `develop`
so that the final diff is smaller.

We simply have the `load_if_toml_exists` method report back to the caller whether
parsing the `secrets.toml` file succeeded.

## 🧪 Testing Done

- [x] Added/Updated unit tests