### PR TITLE
Tweak no-else-return config options

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -127,7 +127,7 @@
       "error",
       { "allowSameFolder": true, "rootDir": "src", "prefix": "src" }
     ],
-    "no-else-return": ["error", { "allowElseIf": false }]
+    "no-else-return": ["error", { "allowElseIf": true }]
   },
   "settings": {
     "react": {

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -323,10 +323,9 @@ export function toSafeBoolean(value: any): boolean | null | undefined {
     return true
   } else if (BOOLEAN_FALSE_VALUES.includes(cleanedValue)) {
     return false
-  } else {
-    // The value cannot be interpreted as boolean
-    return undefined
   }
+  // The value cannot be interpreted as boolean
+  return undefined
 }
 
 /**


### PR DESCRIPTION
## 📚 Context

#6205 turned on the `no-else-return` eslint rule, which was violated in 2 places by #6248, so
the merge order of the two resulted in the linter failing on `develop`.

I was apparently a bit careless when reviewing #6205 because I didn't realize what the implications of
setting `{ "allowElseIf": false }` were at the time. I think writing

```typescript
if (predicateA) {
  return valA
} else if (predicateB) {
  return valB
}
return valC
```

is preferable to 

```typescript
if (predicateA) {
  return valA
}
if (predicateB) {
  return valB
}
return valC
```

in many cases (the only thing I feel strongly about disallowing is the final `else`). This PR switches the
option to `true` so that the first code snippet above is allowed again.

- What kind of change does this PR introduce?
  - [x] Bugfix
