### PR TITLE
sendMessageToHost: no longer a global function

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -544,7 +544,11 @@ export class App extends PureComponent<Props, State> {
     }
 
     if (favicon) {
-      handleFavicon(favicon, this.getBaseUriParts())
+      handleFavicon(
+        favicon,
+        this.props.hostCommunication.sendMessage,
+        this.getBaseUriParts()
+      )
     }
 
     // Only change layout/sidebar when the page config has changed.
@@ -818,6 +822,7 @@ export class App extends PureComponent<Props, State> {
     document.title = `${newPageName} · Streamlit`
     handleFavicon(
       `${process.env.PUBLIC_URL}/favicon.png`,
+      this.props.hostCommunication.sendMessage,
       this.getBaseUriParts()
     )
 
@@ -1560,6 +1565,7 @@ export class App extends PureComponent<Props, State> {
 
             <AppView
               sessionInfo={this.sessionInfo}
+              sendMessageToHost={this.props.hostCommunication.sendMessage}
               elements={elements}
               scriptRunId={scriptRunId}
               scriptRunState={scriptRunState}

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -64,6 +64,10 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
 }
 
 describe("AppView element", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it("renders without crashing", () => {
     const props = getProps()
     const wrapper = shallow(<AppView {...props} />)

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from "react"
-import { shallow } from "enzyme"
 import { Block as BlockProto, ForwardMsgMetadata } from "src/autogen/proto"
 import { ScriptRunState } from "src/lib/ScriptRunState"
 import { BlockNode, ElementNode, AppRoot } from "src/lib/AppNode"
@@ -28,6 +27,7 @@ import { makeElementWithInfoText } from "src/lib/utils"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent"
 import { getMetricsManagerForTest } from "src/lib/MetricsManagerTestUtils"
 import { mockEndpoints, mockSessionInfo } from "src/lib/mocks/mocks"
+import { shallow, mount } from "src/lib/test_util"
 import AppView, { AppViewProps } from "./AppView"
 
 function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
@@ -220,5 +220,23 @@ describe("AppView element", () => {
 
     expect(wrapper.find("StyledAppViewBlockSpacer").exists()).toBe(false)
     expect(wrapper.find("StyledAppViewFooter").exists()).toBe(false)
+  })
+
+  describe("when window.location.hash changes", () => {
+    let originalLocation: Location
+    beforeEach(() => (originalLocation = window.location))
+    afterEach(() => (window.location = originalLocation))
+
+    it("sends UPDATE_HASH message to host", () => {
+      const sendMessageToHost = jest.fn()
+      mount(<AppView {...getProps({ sendMessageToHost })} />)
+
+      window.location.hash = "mock_hash"
+      window.dispatchEvent(new HashChangeEvent("hashchange"))
+      expect(sendMessageToHost).toHaveBeenCalledWith({
+        hash: "#mock_hash",
+        type: "UPDATE_HASH",
+      })
+    })
   })
 })

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -27,7 +27,7 @@ import { makeElementWithInfoText } from "src/lib/utils"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent"
 import { getMetricsManagerForTest } from "src/lib/MetricsManagerTestUtils"
 import { mockEndpoints, mockSessionInfo } from "src/lib/mocks/mocks"
-import { shallow, mount } from "src/lib/test_util"
+import { render, shallow } from "src/lib/test_util"
 import AppView, { AppViewProps } from "./AppView"
 
 function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
@@ -229,7 +229,7 @@ describe("AppView element", () => {
 
     it("sends UPDATE_HASH message to host", () => {
       const sendMessageToHost = jest.fn()
-      mount(<AppView {...getProps({ sendMessageToHost })} />)
+      render(<AppView {...getProps({ sendMessageToHost })} />)
 
       window.location.hash = "mock_hash"
       window.dispatchEvent(new HashChangeEvent("hashchange"))

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -38,6 +38,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
 
   return {
     elements: AppRoot.empty(getMetricsManagerForTest(sessionInfo)),
+    sendMessageToHost: jest.fn(),
     sessionInfo: sessionInfo,
     scriptRunId: "script run 123",
     scriptRunState: ScriptRunState.NOT_RUNNING,

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -23,11 +23,11 @@ import { ScriptRunState } from "src/lib/ScriptRunState"
 import { FormsData, WidgetStateManager } from "src/lib/WidgetStateManager"
 import { FileUploadClient } from "src/lib/FileUploadClient"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent"
-import { sendMessageToHost } from "src/hocs/withHostCommunication"
 
 import AppContext from "src/components/core/AppContext"
 import { BlockNode, AppRoot } from "src/lib/AppNode"
 import { SessionInfo } from "src/lib/SessionInfo"
+import { IGuestToHostMessage } from "src/hocs/withHostCommunication/types"
 
 import {
   StyledAppViewBlockContainer,
@@ -43,6 +43,8 @@ export interface AppViewProps {
   elements: AppRoot
 
   sessionInfo: SessionInfo
+
+  sendMessageToHost: (message: IGuestToHostMessage) => void
 
   // The unique ID for the most recent script run.
   scriptRunId: string
@@ -90,6 +92,7 @@ function AppView(props: AppViewProps): ReactElement {
     currentPageScriptHash,
     hideSidebarNav,
     pageLinkBaseUrl,
+    sendMessageToHost,
   } = props
 
   React.useEffect(() => {
@@ -101,7 +104,7 @@ function AppView(props: AppViewProps): ReactElement {
     }
     window.addEventListener("hashchange", listener, false)
     return () => window.removeEventListener("hashchange", listener, false)
-  }, [])
+  }, [sendMessageToHost])
 
   const {
     wideMode,

--- a/frontend/src/components/elements/Favicon/Favicon.test.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.test.tsx
@@ -73,7 +73,7 @@ describe("Favicon element", () => {
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
-  it("calls `sendMessageToHost` with the proper args", () => {
+  it("sends SET_PAGE_FAVICON message to host", () => {
     const sendMessageToHost = jest.fn()
     handleFavicon(
       "https://streamlit.io/path/to/favicon.png",

--- a/frontend/src/components/elements/Favicon/Favicon.test.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.test.tsx
@@ -37,39 +37,51 @@ test("is set up with the default favicon", () => {
 })
 
 describe("Favicon element", () => {
-  it("should set the favicon in the DOM", () => {
-    handleFavicon("https://streamlit.io/path/to/favicon.png")
+  it("sets the favicon in the DOM", () => {
+    handleFavicon("https://streamlit.io/path/to/favicon.png", jest.fn())
     expect(getFaviconHref()).toBe("https://streamlit.io/path/to/favicon.png")
   })
 
-  it("should accept /media urls from backend", () => {
-    handleFavicon("/media/1234567890.png")
+  it("accepts /media urls from backend", () => {
+    handleFavicon("/media/1234567890.png", jest.fn())
     expect(getFaviconHref()).toBe("http://localhost/media/1234567890.png")
   })
 
-  it("should accept emojis directly", () => {
-    handleFavicon("🍕")
+  it("accepts emojis directly", () => {
+    handleFavicon("🍕", jest.fn())
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
-  it("should handle emoji variants correctly", () => {
-    handleFavicon("🛰")
+  it("handles emoji variants correctly", () => {
+    handleFavicon("🛰", jest.fn())
     expect(getFaviconHref()).toBe(SATELLITE_TWEMOJI_URL)
   })
 
-  it("should handle emoji shortcodes containing a dash correctly", () => {
-    handleFavicon(":crescent-moon:")
+  it("handles emoji shortcodes containing a dash correctly", () => {
+    handleFavicon(":crescent-moon:", jest.fn())
     expect(getFaviconHref()).toBe(CRESCENT_MOON_TWEMOJI_URL)
   })
 
-  it("should accept emoji shortcodes", () => {
-    handleFavicon(":pizza:")
+  it("accepts emoji shortcodes", () => {
+    handleFavicon(":pizza:", jest.fn())
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
-  it("should update the favicon when it changes", () => {
-    handleFavicon("/media/1234567890.png")
-    handleFavicon(":pizza:")
+  it("updates the favicon when it changes", () => {
+    handleFavicon("/media/1234567890.png", jest.fn())
+    handleFavicon(":pizza:", jest.fn())
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
+  })
+
+  it("calls `sendMessageToHost` with the proper args", () => {
+    const sendMessageToHost = jest.fn()
+    handleFavicon(
+      "https://streamlit.io/path/to/favicon.png",
+      sendMessageToHost
+    )
+    expect(sendMessageToHost).toHaveBeenCalledWith({
+      favicon: "https://streamlit.io/path/to/favicon.png",
+      type: "SET_PAGE_FAVICON",
+    })
   })
 })

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -17,16 +17,18 @@
 import nodeEmoji from "node-emoji"
 import { BaseUriParts, buildMediaUri } from "src/lib/UriUtil"
 import { grabTheRightIcon } from "src/vendor/twemoji"
-import { sendMessageToHost } from "src/hocs/withHostCommunication"
+import { IGuestToHostMessage } from "src/hocs/withHostCommunication/types"
 
 /**
  * Set the provided url/emoji as the page favicon.
  *
- * @param {string} favicon may be an image url, or an emoji like 🍕 or :pizza:
- * @param {function} callback
+ * @param {string} favicon an image url, or an emoji like 🍕 or :pizza:
+ * @param sendMessageToHost a function that posts messages to the app's parent iframe
+ * @param baseUriParts
  */
 export function handleFavicon(
   favicon: string,
+  sendMessageToHost: (message: IGuestToHostMessage) => void,
   baseUriParts?: BaseUriParts
 ): void {
   const emoji = extractEmoji(favicon)

--- a/frontend/src/hocs/withHostCommunication/index.tsx
+++ b/frontend/src/hocs/withHostCommunication/index.tsx
@@ -16,5 +16,5 @@
 
 import { HostCommunicationHOC as _HostCommunicationHOC } from "./withHostCommunication"
 
-export { default, sendMessageToHost } from "./withHostCommunication"
+export { default } from "./withHostCommunication"
 export type HostCommunicationHOC = _HostCommunicationHOC

--- a/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
+++ b/frontend/src/hocs/withHostCommunication/withHostCommunication.tsx
@@ -72,7 +72,7 @@ export interface HostCommunicationHOC {
 
 export const HOST_COMM_VERSION = 1
 
-export function sendMessageToHost(message: IGuestToHostMessage): void {
+function sendMessageToHost(message: IGuestToHostMessage): void {
   window.parent.postMessage(
     {
       stCommVersion: HOST_COMM_VERSION,


### PR DESCRIPTION
`sendMessageToHost` delivers "guest to host" messages to the Streamlit app's parent iframe (if one exists). It's currently implemented as a global function. This PR removes the global function; callers must now take the function as a property.

(`withHostCommunicationHOC` already passes the function to its wrapped component, so this isn't a huge change.)