### PR TITLE
Start work on the BaseConnection abstract class

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -12,15 +12,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC
-from typing import Generic, TypeVar
+from abc import ABC, abstractmethod
+from typing import Any, Generic, Mapping, Optional, TypeVar
+
+from streamlit.runtime.secrets import AttrDict, secrets_singleton
 
 T = TypeVar("T")
 
 
 class BaseConnection(ABC, Generic[T]):
-    """TODO(vdonato): Implement... this entire class.
+    """TODO(vdonato): docstrings for this class and all public methods."""
 
-    We intentionally leave this as just a stub implementation for now as it's needed
-    to define types in streamlit.runtime.connection_factory.
-    """
+    def __init__(self, connection_name: str = "default", **kwargs) -> None:
+        self._connection_name = connection_name
+        self._kwargs = kwargs
+
+        self._raw_instance: Optional[T] = self.connect(**kwargs)
+
+    def _repr_html_(self) -> str:
+        # TODO(vdonato): Change this to whatever we actually want the default to be.
+        return f"Hi, I am a {self.default_connection_name()} connection!"
+
+    # Methods with default implementations that we don't expect subclasses to want or
+    # need to overwrite.
+    def get_secrets(self) -> Mapping[str, Any]:
+        connection_name = self._connection_name
+        if connection_name == "default":
+            connection_name = self.default_connection_name()
+
+        connections_section = None
+        if secrets_singleton.load_if_toml_exists():
+            connections_section = secrets_singleton.get("connections")
+
+        if type(connections_section) is not AttrDict:
+            return AttrDict({})
+
+        return connections_section.get(connection_name, {})
+
+    @classmethod
+    def default_connection_name(cls) -> str:
+        name = cls._default_connection_name
+
+        if name is None:
+            raise NotImplementedError(
+                "Subclasses of BaseConnection must define a _default_connection_name attribute."
+            )
+        return name
+
+    # TODO(vdonato): Finalize the name for this method. Should this be `invalidate`?
+    def reset(self) -> None:
+        self._raw_instance = None
+
+    @property
+    def _instance(self) -> T:
+        if self._raw_instance is None:
+            self._raw_instance = self.connect(**self._kwargs)
+
+        return self._raw_instance
+
+    # Abstract fields/methods that subclasses of BaseConnection must implement
+    _default_connection_name: Optional[str] = None
+
+    @abstractmethod
+    def connect(self, **kwargs) -> T:
+        raise NotImplementedError

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -47,7 +47,7 @@ def _create_connection(
     connection_class must be a concrete type. The public-facing connection API allows
     the user to specify the connection class to use as a string literal for convenience.
     """
-    return connection_class(  # type: ignore
+    return connection_class(
         connection_name=name,
         **kwargs,
     )

--- a/lib/tests/streamlit/connections/__init__.py
+++ b/lib/tests/streamlit/connections/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Explicitly re-export public symbols.
+from streamlit.connections.base_connection import BaseConnection as BaseConnection

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -1,0 +1,96 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import mock_open, patch
+
+import pytest
+
+import streamlit as st
+from streamlit.connections import BaseConnection
+
+MOCK_TOML = """
+[connections.mock_connection]
+foo="bar"
+
+[connections.nondefault_connection_name]
+baz="qux"
+"""
+
+
+class MockConnection(BaseConnection[str]):
+    _default_connection_name = "mock_connection"
+
+    def connect(self, **kwargs) -> str:
+        return "hooray, I'm connected!"
+
+
+class BaseConnectionDefaultMethodTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # st.secrets modifies os.environ, so we save it here and
+        # restore in tearDown.
+        self._prev_environ = dict(os.environ)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._prev_environ)
+        st.secrets._reset()
+
+    def test_instance_set_to_connect_return_value(self):
+        assert MockConnection()._instance == "hooray, I'm connected!"
+
+    def test_default_connection_name(self):
+        assert MockConnection().default_connection_name() == "mock_connection"
+
+    def test_default_connection_name_with_unset_default(self):
+        class ExplodingConnection(BaseConnection[str]):
+            # Intentionally don't define _default_connection_name.
+
+            def connect(self, **kwargs):
+                pass
+
+        with pytest.raises(NotImplementedError):
+            ExplodingConnection().default_connection_name()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_get_secrets(self, _):
+        conn = MockConnection()
+        assert conn.get_secrets().foo == "bar"
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_get_secrets_nondefault_connection_name(self, _):
+        conn = MockConnection(connection_name="nondefault_connection_name")
+        assert conn.get_secrets().baz == "qux"
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_get_secrets_no_matching_section(self, _):
+        conn = MockConnection(connection_name="nonexistent")
+        assert conn.get_secrets() == {}
+
+    def test_get_secrets_no_secrets(self):
+        conn = MockConnection()
+        assert conn.get_secrets() == {}
+
+    def test_instance_prop_caches_raw_instance(self):
+        conn = MockConnection()
+        conn._raw_instance = "some other value"
+
+        assert conn._instance == "some other value"
+
+    def test_instance_prop_reinitializes_if_reset(self):
+        conn = MockConnection()
+        conn._raw_instance = None
+
+        assert conn._instance == "hooray, I'm connected!"

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -26,9 +26,10 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class MockConnection(BaseConnection[None]):
-    def __init__(self, connection_name: str, **kwargs):
-        self._connection_name = connection_name
-        self._kwargs = kwargs
+    _default_connection_name = "mock_connection"
+
+    def connect(self, **kwargs):
+        pass
 
 
 class ConnectionFactoryTest(unittest.TestCase):


### PR DESCRIPTION
Notes:
* This PR builds on top of #6332 and #6333, which should both be reviewed first. 
* The target branch of this PR is `feature/st.experimental_connection` and not `develop`

## 📚 Context

As part of the `st.experimental_connection` feature, we'll be providing a base class for connection class
authors to be able to use to help them write their own custom connection classes (we'll also be using
this same base class in the first party connections that we provide).

This PR starts work on this class by adding an implementation + tests for the parts of the base class
that we know we definitely want. Some of the details of the `BaseConnection` API are still being ironed
out, and these things will be built in subsequent PRs.

- What kind of change does this PR introduce?

  - [x] Feature

## 🧪 Testing Done

- [x] Added/Updated unit tests
