### PR TITLE
#3978 Change root logger to be in streamlit namespace.

### DIFF
--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -117,7 +117,7 @@ def get_logger(name: str) -> logging.Logger:
         return _loggers[name]
 
     if name == "root":
-        logger = logging.getLogger()
+        logger = logging.getLogger("streamlit")
     else:
         logger = logging.getLogger(name)
 


### PR DESCRIPTION
## 📚 Context

Importing streamlit (`import streamlit as st`) replaces the Python root logger which can be detrimental to a project or other libraries in the same process. I think it was an accident. Looking into how the root python logger is used within streamlit (ie type_util.py logging), I think it was more intended to log to the `streamlit` namespace.

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- When streamlit asks for the "root" logger, it returns one in the `streamlit` namespace instead. The root logger in python is unaffected.
  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #3978 
- **Issue**: Might close #4742 since doing things in a "non-standard" way matters less when it's just within streamlit's namespace. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
