### PR TITLE
Have util.calc_md5 also take bytes

### DIFF
--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -21,7 +21,7 @@ import functools
 import hashlib
 import os
 import subprocess
-from typing import Any, Dict, Iterable, List, Mapping, Set, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Mapping, Set, TypeVar, Union, cast
 
 from typing_extensions import Final
 
@@ -172,7 +172,12 @@ class Error(Exception):
 def calc_md5(s: Union[bytes, str]) -> str:
     """Return the md5 hash of the given string."""
     h = hashlib.new("md5")
-    h.update(s.encode("utf-8") if type(s) is str else s)
+
+    # mypy seems to have trouble inferring that the type of the if/else expression is
+    # always bytes.
+    b = cast(bytes, s.encode("utf-8") if type(s) is str else s)
+
+    h.update(b)
     return h.hexdigest()
 
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -21,7 +21,7 @@ import functools
 import hashlib
 import os
 import subprocess
-from typing import Any, Dict, Iterable, List, Mapping, Set, TypeVar
+from typing import Any, Dict, Iterable, List, Mapping, Set, TypeVar, Union
 
 from typing_extensions import Final
 
@@ -169,10 +169,10 @@ class Error(Exception):
     pass
 
 
-def calc_md5(s: str) -> str:
+def calc_md5(s: Union[bytes, str]) -> str:
     """Return the md5 hash of the given string."""
     h = hashlib.new("md5")
-    h.update(s.encode("utf-8"))
+    h.update(s.encode("utf-8") if type(s) is str else s)
     return h.hexdigest()
 
 

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -181,3 +181,9 @@ class UtilTest(unittest.TestCase):
         self.assertSetEqual(
             util.extract_key_query_params(query_params, param_key), result
         )
+
+    def test_calc_md5_can_handle_bytes_and_strings(self):
+        self.assertEqual(
+            util.calc_md5("eventually bytes"),
+            util.calc_md5("eventually bytes".encode("utf-8")),
+        )


### PR DESCRIPTION
## 📚 Context

This is another change needed in `feature/st.experimental_connection` that's being
merged straight into `develop` to keep the final diff size down.

- What kind of change does this PR introduce?
  - [x] Other, please describe: helper function tweaks

## 🧪 Testing Done

- [x] Added/Updated unit tests