### PR TITLE
Relax session reconnect asserts

### DIFF
--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -62,13 +62,18 @@ class WebsocketSessionManager(SessionManager):
         user_info: Dict[str, Optional[str]],
         existing_session_id: Optional[str] = None,
     ) -> str:
-        assert (
-            existing_session_id not in self._active_session_info_by_id
-        ), f"session with id '{existing_session_id}' is already connected!"
+        if existing_session_id in self._active_session_info_by_id:
+            LOGGER.warning(
+                "Session with id %s is already connected! Connecting to a new session.",
+                existing_session_id,
+            )
 
-        session_info = existing_session_id and self._session_storage.get(
+        session_info = (
             existing_session_id
+            and existing_session_id not in self._active_session_info_by_id
+            and self._session_storage.get(existing_session_id)
         )
+
         if session_info:
             existing_session = session_info.session
             existing_session.register_file_watchers()

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -82,11 +82,18 @@ class WebsocketSessionManagerTests(unittest.TestCase):
         assert session_info.session.id == session_id
         assert session_info.session.id != "not a valid session"
 
-    def test_connect_session_explodes_if_already_connected(self):
+    @patch("streamlit.runtime.websocket_session_manager.LOGGER.warning")
+    def test_connect_session_connects_new_session_if_already_connected(
+        self, patched_warning
+    ):
         session_id = self.connect_session()
+        new_session_id = self.connect_session(existing_session_id=session_id)
+        assert session_id != new_session_id
 
-        with pytest.raises(AssertionError):
-            self.connect_session(existing_session_id=session_id)
+        patched_warning.assert_called_with(
+            "Session with id %s is already connected! Connecting to a new session.",
+            session_id,
+        )
 
     def test_connect_session_explodes_if_ID_collission(self):
         session_id = self.connect_session()


### PR DESCRIPTION
## 📚 Context

From error reporting we have set up in Community Cloud, we've seen some instances of
an error in the wild that should theoretically never happen (it's possible that it's due to some
webcrawler-related weirdness because despite the error apparently happening nontrivially
often, no user has ever mentioned it in the issues/forums/etc, which makes me think that
it's likely that only robots are hitting this).

The issue is that occasionally, a client will attempt to reconnect to a session ID that it's
already connected to, which hits an assert in the websocket connect handler on the server
because this should never happen.

Even if it turns out that it's just robots that are running into this error, it makes sense to
be a bit less strict about this case since it doesn't hurt to just have this connection
attempt connect to a new session (which is what would have happened in the pre-reconnect
improvements world anyway) and downgrade this assert to a warning log.

- What kind of change does this PR introduce?

  - [x] Bugfix?

## 🧪 Testing Done

- [x] Added/Updated unit tests
