### PR TITLE
StreamlitEndpoints.buildMediaURL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1610,6 +1610,7 @@ export class App extends PureComponent<Props, State> {
             </Header>
 
             <AppView
+              endpoints={this.endpoints}
               sessionInfo={this.sessionInfo}
               sendMessageToHost={this.props.hostCommunication.sendMessage}
               elements={elements}

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -37,6 +37,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
   const endpoints = mockEndpoints()
 
   return {
+    endpoints: endpoints,
     elements: AppRoot.empty(getMetricsManagerForTest(sessionInfo)),
     sendMessageToHost: jest.fn(),
     sessionInfo: sessionInfo,

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -28,6 +28,7 @@ import { AppContext } from "src/components/core/AppContext"
 import { BlockNode, AppRoot } from "src/lib/AppNode"
 import { SessionInfo } from "src/lib/SessionInfo"
 import { IGuestToHostMessage } from "src/hocs/withHostCommunication/types"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 import {
   StyledAppViewBlockContainer,
@@ -41,6 +42,8 @@ import {
 
 export interface AppViewProps {
   elements: AppRoot
+
+  endpoints: StreamlitEndpoints
 
   sessionInfo: SessionInfo
 
@@ -93,6 +96,7 @@ function AppView(props: AppViewProps): ReactElement {
     hideSidebarNav,
     pageLinkBaseUrl,
     sendMessageToHost,
+    endpoints,
   } = props
 
   React.useEffect(() => {
@@ -125,6 +129,7 @@ function AppView(props: AppViewProps): ReactElement {
     >
       <VerticalBlock
         node={node}
+        endpoints={endpoints}
         sessionInfo={sessionInfo}
         scriptRunId={scriptRunId}
         scriptRunState={scriptRunState}

--- a/frontend/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -66,6 +66,7 @@ function getProps(
   const sessionInfo = mockSessionInfo()
   const endpoints = mockEndpoints()
   return {
+    endpoints: endpoints,
     scriptRunState: ScriptRunState.RUNNING,
     sessionInfo: sessionInfo,
     widgetMgr: new WidgetStateManager({

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -223,7 +223,13 @@ const RawElementNodeRenderer = (
     }
 
     case "audio":
-      return <Audio width={width} element={node.element.audio as AudioProto} />
+      return (
+        <Audio
+          width={width}
+          element={node.element.audio as AudioProto}
+          endpoints={props.endpoints}
+        />
+      )
 
     case "balloons":
       return hideIfStale(

--- a/frontend/src/components/core/Block/utils.ts
+++ b/frontend/src/components/core/Block/utils.ts
@@ -20,6 +20,7 @@ import { FormsData, WidgetStateManager } from "src/lib/WidgetStateManager"
 import { FileUploadClient } from "src/lib/FileUploadClient"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent/"
 import { SessionInfo } from "src/lib/SessionInfo"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 export function shouldComponentBeEnabled(
   elementType: string,
@@ -54,6 +55,7 @@ export function isComponentStale(
 }
 
 export interface BaseBlockProps {
+  endpoints: StreamlitEndpoints
   sessionInfo: SessionInfo
   scriptRunId: string
   scriptRunState: ScriptRunState

--- a/frontend/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/src/components/elements/Audio/Audio.test.tsx
@@ -21,48 +21,41 @@ import { Audio as AudioProto } from "src/autogen/proto"
 import { mockEndpoints } from "src/lib/mocks/mocks"
 import Audio, { AudioProps } from "./Audio"
 
-const getProps = (elementProps: Partial<AudioProto> = {}): AudioProps => ({
-  element: AudioProto.create({
-    startTime: 0,
-    url: "/media/08a569df5f3bd617f11b7d137861a3bef91379309ce95bdb9ff04a38.wav",
-    ...elementProps,
-  }),
-  endpoints: mockEndpoints(),
-  width: 0,
-})
-
 describe("Audio Element", () => {
-  const props = getProps()
-  const wrapper = shallow(<Audio {...props} />)
-  const audioElement = wrapper.find("audio")
+  const buildMediaURL = jest.fn().mockReturnValue("https://mock.media.url")
+
+  const getProps = (elementProps: Partial<AudioProto> = {}): AudioProps => ({
+    element: AudioProto.create({
+      startTime: 0,
+      url: "/media/mockAudioFile.wav",
+      ...elementProps,
+    }),
+    endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
+    width: 0,
+  })
 
   it("renders without crashing", () => {
+    const wrapper = shallow(<Audio {...getProps()} />)
+    const audioElement = wrapper.find("audio")
+
     expect(audioElement.length).toBe(1)
   })
 
-  it("should have controls", () => {
+  it("has controls", () => {
+    const wrapper = shallow(<Audio {...getProps()} />)
+    const audioElement = wrapper.find("audio")
+
     expect(audioElement.prop("controls")).toBeDefined()
   })
 
-  describe("should have a src", () => {
-    it("when the url starts with media", () => {
-      expect(audioElement.prop("src")).toBe(
-        "http://localhost:80/media/08a569df5f3bd617f11b7d137861a3bef91379309ce95bdb9ff04a38.wav"
-      )
-    })
-
-    it("when it's a complete url", () => {
-      const props = getProps({
-        url: "http://localhost:80/media/sound.wav",
-      })
-      const wrapper = shallow(<Audio {...props} />)
-      const audioElement = wrapper.find("audio")
-
-      expect(audioElement.prop("src")).toBe(props.element.url)
-    })
+  it("creates its `src` attribute using buildMediaURL", () => {
+    const wrapper = shallow(<Audio {...getProps()} />)
+    const audioElement = wrapper.find("audio")
+    expect(buildMediaURL).toHaveBeenCalledWith("/media/mockAudioFile.wav")
+    expect(audioElement.prop("src")).toBe("https://mock.media.url")
   })
 
-  it("should update time when the prop is changed", () => {
+  it("updates time when the prop is changed", () => {
     const props = getProps({
       url: "http://localhost:80/media/sound.wav",
     })

--- a/frontend/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/src/components/elements/Audio/Audio.test.tsx
@@ -18,6 +18,7 @@ import React from "react"
 import { mount, shallow } from "src/lib/test_util"
 
 import { Audio as AudioProto } from "src/autogen/proto"
+import { mockEndpoints } from "src/lib/mocks/mocks"
 import Audio, { AudioProps } from "./Audio"
 
 const getProps = (elementProps: Partial<AudioProto> = {}): AudioProps => ({
@@ -26,6 +27,7 @@ const getProps = (elementProps: Partial<AudioProto> = {}): AudioProps => ({
     url: "/media/08a569df5f3bd617f11b7d137861a3bef91379309ce95bdb9ff04a38.wav",
     ...elementProps,
   }),
+  endpoints: mockEndpoints(),
   width: 0,
 })
 

--- a/frontend/src/components/elements/Audio/Audio.tsx
+++ b/frontend/src/components/elements/Audio/Audio.tsx
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext, useEffect, useRef } from "react"
+import React, { ReactElement, useEffect, useRef } from "react"
 import { Audio as AudioProto } from "src/autogen/proto"
-import { AppContext } from "src/components/core/AppContext"
-import { buildMediaUri } from "src/lib/UriUtil"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 export interface AudioProps {
+  endpoints: StreamlitEndpoints
   width: number
   element: AudioProto
 }
 
-export default function Audio({ element, width }: AudioProps): ReactElement {
+export default function Audio({
+  element,
+  width,
+  endpoints,
+}: AudioProps): ReactElement {
   const audioRef = useRef<HTMLAudioElement>(null)
-  const { getBaseUriParts } = useContext(AppContext)
 
   useEffect(() => {
     if (audioRef.current) {
@@ -34,7 +37,7 @@ export default function Audio({ element, width }: AudioProps): ReactElement {
     }
   }, [element.startTime])
 
-  const uri = buildMediaUri(element.url, getBaseUriParts())
+  const uri = endpoints.buildMediaURL(element.url)
   return (
     <audio
       id="audio"

--- a/frontend/src/lib/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/lib/DefaultStreamlitEndpoints.ts
@@ -54,6 +54,11 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     )
   }
 
+  /**
+   * Construct a URL for a media file. If the url is relative and starts with
+   * "/media", assume it's being served from Streamlit and construct it
+   * appropriately. Otherwise leave it alone.
+   */
   public buildMediaURL(url: string): string {
     if (url.startsWith(SVG_PREFIX)) {
       return `${SVG_PREFIX}${xssSanitizeSvg(url)}`

--- a/frontend/src/lib/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/lib/DefaultStreamlitEndpoints.ts
@@ -29,6 +29,11 @@ interface Props {
   csrfEnabled: boolean
 }
 
+const MEDIA_ENDPOINT = "/media"
+const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file"
+const COMPONENT_ENDPOINT_BASE = "/component"
+const FORWARD_MSG_CACHE_ENDPOINT = "/_stcore/message"
+
 /** Default Streamlit server implementation of the StreamlitEndpoints interface. */
 export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   private readonly getServerUri: () => BaseUriParts | undefined
@@ -45,7 +50,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   public buildComponentURL(componentName: string, path: string): string {
     return buildHttpUri(
       this.requireServerUri(),
-      `component/${componentName}/${path}`
+      `${COMPONENT_ENDPOINT_BASE}/${componentName}/${path}`
     )
   }
 
@@ -53,7 +58,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     if (url.startsWith(SVG_PREFIX)) {
       return `${SVG_PREFIX}${xssSanitizeSvg(url)}`
     }
-    return url.startsWith("/media")
+    return url.startsWith(MEDIA_ENDPOINT)
       ? buildHttpUri(this.requireServerUri(), url)
       : url
   }
@@ -70,7 +75,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     form.append("widgetId", widgetId)
     form.append(file.name, file)
 
-    return this.csrfRequest<number>("_stcore/upload_file", {
+    return this.csrfRequest<number>(UPLOAD_FILE_ENDPOINT, {
       cancelToken,
       method: "POST",
       data: form,
@@ -91,7 +96,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
     const serverURI = this.requireServerUri()
     const rsp = await axios.request({
-      url: buildHttpUri(serverURI, `_stcore/message?hash=${hash}`),
+      url: buildHttpUri(
+        serverURI,
+        `${FORWARD_MSG_CACHE_ENDPOINT}?hash=${hash}`
+      ),
       method: "GET",
       responseType: "arraybuffer",
     })

--- a/frontend/src/lib/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/lib/DefaultStreamlitEndpoints.ts
@@ -15,7 +15,12 @@
  */
 
 import axios, { AxiosRequestConfig, AxiosResponse, CancelToken } from "axios"
-import { BaseUriParts, buildHttpUri } from "src/lib/UriUtil"
+import {
+  BaseUriParts,
+  buildHttpUri,
+  SVG_PREFIX,
+  xssSanitizeSvg,
+} from "src/lib/UriUtil"
 import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 import { getCookie } from "./utils"
 
@@ -42,6 +47,15 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       this.requireServerUri(),
       `component/${componentName}/${path}`
     )
+  }
+
+  public buildMediaURL(url: string): string {
+    if (url.startsWith(SVG_PREFIX)) {
+      return `${SVG_PREFIX}${xssSanitizeSvg(url)}`
+    }
+    return url.startsWith("/media")
+      ? buildHttpUri(this.requireServerUri(), url)
+      : url
   }
 
   public async uploadFileUploaderFile(

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -32,6 +32,7 @@ describe("FileUploadClient Upload", () => {
       sessionInfo: mockSessionInfo(),
       endpoints: {
         buildComponentURL: jest.fn(),
+        buildMediaURL: jest.fn(),
         uploadFileUploaderFile: uploadFileUploaderFile,
         fetchCachedForwardMsg: jest.fn(),
       },

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -28,6 +28,7 @@ function createCache(): MockCache {
 
   const cache = new ForwardMsgCache({
     buildComponentURL: jest.fn(),
+    buildMediaURL: jest.fn(),
     uploadFileUploaderFile: jest.fn(),
     fetchCachedForwardMsg: mockFetchCachedForwardMsg,
   })

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -26,6 +26,14 @@ export interface StreamlitEndpoints {
   buildComponentURL(componentName: string, path: string): string
 
   /**
+   * Construct a URL for a media file.
+   * @param url a relative or absolute URL. If `url` is absolute, it will be
+   * returned unchanged. Otherwise, the return value will be a URL for fetching
+   * the media file from the connected Streamlit instance.
+   */
+  buildMediaURL(url: string): string
+
+  /**
    * Upload a file to the FileUploader endpoint.
    *
    * @param file The file to upload

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -30,7 +30,7 @@ export interface BaseUriParts {
 
 const FINAL_SLASH_RE = /\/+$/
 const INITIAL_SLASH_RE = /^\/+/
-const SVG_PREFIX = "data:image/svg+xml,"
+export const SVG_PREFIX = "data:image/svg+xml,"
 
 /**
  * Return the BaseUriParts for the global window

--- a/frontend/src/lib/mocks/mocks.ts
+++ b/frontend/src/lib/mocks/mocks.ts
@@ -45,19 +45,19 @@ export function mockSessionInfo(
   return sessionInfo
 }
 
-const MOCK_ENDPOINTS: StreamlitEndpoints = {
-  buildComponentURL: jest.fn(),
-  buildMediaURL: jest.fn(),
-
-  uploadFileUploaderFile: jest
-    .fn()
-    .mockRejectedValue(new Error("unimplemented")),
-  fetchCachedForwardMsg: jest
-    .fn()
-    .mockRejectedValue(new Error("unimplemented mock endpoint")),
-}
-
-/** Return a mock Endpoints implementation. */
-export function mockEndpoints(): StreamlitEndpoints {
-  return MOCK_ENDPOINTS
+/** Return a mock StreamlitEndpoints implementation. */
+export function mockEndpoints(
+  overrides: Partial<StreamlitEndpoints> = {}
+): StreamlitEndpoints {
+  return {
+    buildComponentURL: jest.fn(),
+    buildMediaURL: jest.fn(),
+    uploadFileUploaderFile: jest
+      .fn()
+      .mockRejectedValue(new Error("unimplemented mock endpoint")),
+    fetchCachedForwardMsg: jest
+      .fn()
+      .mockRejectedValue(new Error("unimplemented mock endpoint")),
+    ...overrides,
+  }
 }

--- a/frontend/src/lib/mocks/mocks.ts
+++ b/frontend/src/lib/mocks/mocks.ts
@@ -46,11 +46,12 @@ export function mockSessionInfo(
 }
 
 const MOCK_ENDPOINTS: StreamlitEndpoints = {
-  buildComponentURL: (componentName: string, path: string): string => {
-    return `http://streamlit.mock:80/component/${componentName}/${path}`
-  },
+  buildComponentURL: jest.fn(),
+  buildMediaURL: jest.fn(),
 
-  uploadFileUploaderFile: jest.fn().mockResolvedValue(1),
+  uploadFileUploaderFile: jest
+    .fn()
+    .mockRejectedValue(new Error("unimplemented")),
   fetchCachedForwardMsg: jest
     .fn()
     .mockRejectedValue(new Error("unimplemented mock endpoint")),


### PR DESCRIPTION
Adds `StreamlitEndpoints.buildMediaURL` and updates `Audio.tsx` to use it. (This is the first of several PRs that will update existing components to use this new API.)

- We currently have a top-level function, `buildMediaUri`, that takes a `BaseUriParts` instance and handles constructing Streamlit-relative URLs for media files. It has some assumptions about how Streamlit endpoints are named that we want to move away from for the StreamlitView project.
- This PR adds `StreamlitEndpoints.buildMediaURL` to the StreamlitEndpoints interface, and replicates the current implementation in `DefaultStreamlitEndpoints`.
- `Audio.tsx` is updated to use the interface-ized version of the function. 