### PR TITLE
Improve typing annotations for file_uploader and text_input

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -216,7 +216,7 @@ class FileUploaderMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
-    ):
+    ) -> Union[NoneType, UploadedFile, List[UploadedFile]]:
         r"""Display a file uploader widget.
         By default, uploaded files are limited to 200MB. You can configure
         this using the `server.maxUploadSize` config option. For more info

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -345,7 +345,7 @@ class FileUploaderMixin:
 
         """
         ctx = get_script_run_ctx()
-        return cast(Union[UploadedFile, List[UploadedFile], None], self._file_uploader(
+        return self._file_uploader(
             label=label,
             type=type,
             accept_multiple_files=accept_multiple_files,
@@ -357,7 +357,7 @@ class FileUploaderMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             ctx=ctx,
-        ))
+        )
 
     def _file_uploader(
         self,
@@ -373,7 +373,7 @@ class FileUploaderMixin:
         label_visibility: LabelVisibility = "visible",
         disabled: bool = False,
         ctx: Optional[ScriptRunContext] = None,
-    ):
+    ) -> Union[UploadedFile, List[UploadedFile], None]:
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)
@@ -439,7 +439,7 @@ class FileUploaderMixin:
             )
 
         self.dg._enqueue("file_uploader", file_uploader_proto)
-        return widget_state.value
+        return cast(Union[UploadedFile, List[UploadedFile], None], widget_state.value)
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -216,7 +216,7 @@ class FileUploaderMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
-    ) -> Union[UploadedFile, List[UploadedFile], None]:
+    ) -> SomeUploadedFiles:
         r"""Display a file uploader widget.
         By default, uploaded files are limited to 200MB. You can configure
         this using the `server.maxUploadSize` config option. For more info
@@ -373,7 +373,7 @@ class FileUploaderMixin:
         label_visibility: LabelVisibility = "visible",
         disabled: bool = False,
         ctx: Optional[ScriptRunContext] = None,
-    ) -> Union[UploadedFile, List[UploadedFile], None]:
+    ) -> SomeUploadedFiles:
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)
@@ -439,7 +439,7 @@ class FileUploaderMixin:
             )
 
         self.dg._enqueue("file_uploader", file_uploader_proto)
-        return cast(Union[UploadedFile, List[UploadedFile], None], widget_state.value)
+        return widget_state.value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -14,7 +14,6 @@
 
 from dataclasses import dataclass
 from textwrap import dedent
-from types import NoneType
 from typing import List, Optional, Sequence, Union, cast, overload
 
 from typing_extensions import Literal
@@ -217,7 +216,7 @@ class FileUploaderMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
-    ) -> Union[NoneType, UploadedFile, List[UploadedFile]]:
+    ) -> Union[UploadedFile, List[UploadedFile], None]:
         r"""Display a file uploader widget.
         By default, uploaded files are limited to 200MB. You can configure
         this using the `server.maxUploadSize` config option. For more info

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -345,7 +345,7 @@ class FileUploaderMixin:
 
         """
         ctx = get_script_run_ctx()
-        return self._file_uploader(
+        return cast(Union[UploadedFile, List[UploadedFile], None], self._file_uploader(
             label=label,
             type=type,
             accept_multiple_files=accept_multiple_files,
@@ -357,7 +357,7 @@ class FileUploaderMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             ctx=ctx,
-        )
+        ))
 
     def _file_uploader(
         self,

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -15,7 +15,7 @@
 from dataclasses import dataclass
 from textwrap import dedent
 from types import NoneType
-from typing import List, Optional, Union, cast, overload
+from typing import List, Optional, Sequence, Union, cast, overload
 
 from typing_extensions import Literal
 
@@ -128,7 +128,7 @@ class FileUploaderMixin:
     def file_uploader(
         self,
         label: str,
-        type: Optional[Union[str, List[str]]],
+        type: Optional[Union[str, Sequence[str]]],
         accept_multiple_files: Literal[True],
         key: Optional[Key] = None,
         help: Optional[str] = None,
@@ -147,7 +147,7 @@ class FileUploaderMixin:
     def file_uploader(
         self,
         label: str,
-        type: Optional[Union[str, List[str]]],
+        type: Optional[Union[str, Sequence[str]]],
         accept_multiple_files: Literal[False] = False,
         key: Optional[Key] = None,
         help: Optional[str] = None,
@@ -173,7 +173,7 @@ class FileUploaderMixin:
         label: str,
         *,
         accept_multiple_files: Literal[True],
-        type: Optional[Union[str, List[str]]] = None,
+        type: Optional[Union[str, Sequence[str]]] = None,
         key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
@@ -192,7 +192,7 @@ class FileUploaderMixin:
         label: str,
         *,
         accept_multiple_files: Literal[False] = False,
-        type: Optional[Union[str, List[str]]] = None,
+        type: Optional[Union[str, Sequence[str]]] = None,
         key: Optional[Key] = None,
         help: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,
@@ -207,7 +207,7 @@ class FileUploaderMixin:
     def file_uploader(
         self,
         label: str,
-        type: Optional[Union[str, List[str]]] = None,
+        type: Optional[Union[str, Sequence[str]]] = None,
         accept_multiple_files: bool = False,
         key: Optional[Key] = None,
         help: Optional[str] = None,
@@ -363,7 +363,7 @@ class FileUploaderMixin:
     def _file_uploader(
         self,
         label: str,
-        type: Optional[Union[str, List[str]]] = None,
+        type: Optional[Union[str, Sequence[str]]] = None,
         accept_multiple_files: bool = False,
         key: Optional[Key] = None,
         help: Optional[str] = None,

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 from textwrap import dedent
+from types import NoneType
 from typing import List, Optional, Union, cast, overload
 
 from typing_extensions import Literal

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Optional, cast
+from typing import Literal, Optional, cast
 
 import streamlit
 from streamlit.elements.form import current_form_id
@@ -73,7 +73,7 @@ class TextWidgetsMixin:
         value: SupportsStr = "",
         max_chars: Optional[int] = None,
         key: Optional[Key] = None,
-        type: str = "default",
+        type: Literal["default", "password"] = "default",
         help: Optional[str] = None,
         autocomplete: Optional[str] = None,
         on_change: Optional[WidgetCallback] = None,

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -14,7 +14,9 @@
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Literal, Optional, cast
+from typing import Optional, cast
+
+from typing_extensions import Literal
 
 import streamlit
 from streamlit.elements.form import current_form_id

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -124,7 +124,7 @@ class TextWidgetsMixin:
             If this is omitted, a key will be generated for the widget
             based on its content. Multiple widgets of the same type may
             not share the same key.
-        type : str
+        type : "default" or "password"
             The type of the text input. This can be either "default" (for
             a regular text input), or "password" (for a text input that
             masks the user's typed value). Defaults to "default".


### PR DESCRIPTION
## 📚 Context

Complete some python typing annotation

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [X] Other, please describe: Typing completion

## 🧠 Description of Changes

- Add typing information for `file_uploader` not overloaded version
- Replace `text_input` function `type` argument annotation from `str` to `Literal`

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

.

**Current:**

.

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
