### PR TITLE
SVG image from e2e tests render in Firefox

### DIFF
--- a/e2e/scripts/st_image.py
+++ b/e2e/scripts/st_image.py
@@ -82,7 +82,7 @@ st.image(
     <clipPath id="clipCircle">
         <circle r="25" cx="25" cy="25"/>
     </clipPath>
-    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
+    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clipPath="url(#clipCircle)"/>
 </svg>
 """
 )


### PR DESCRIPTION
Checklist

- [x]  I have searched the [existing issues](https://github.com/streamlit/streamlit/issues) for similar issues.

- [x]  I added a very descriptive title to this issue.
 

- [x] I have provided sufficient information below to help reproduce this issue.

Summary
The st.image cypress test renders an svg with a github avatar. The avatar appears as expected in chromium, but does not appear in firefox 100.

Reproducible Code Example
import streamlit as st

`st.image(
    """<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
    <clipPath id="clipCircle">
        <circle r="25" cx="25" cy="25"/>
    </clipPath>
    <image href="https://avatars.githubusercontent.com/karriebear" width="50" height="50" clip-path="url(#clipCircle)"/>
</svg>
"""
)`

Expected Behavior
Avatar renders in all supported browsers

