### PR TITLE
Restrict the setting of sensitive options by the CLI flag

### DIFF
--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -24,7 +24,6 @@ import streamlit.runtime.caching as caching
 import streamlit.runtime.legacy_caching as legacy_caching
 import streamlit.web.bootstrap as bootstrap
 from streamlit import config as _config
-from streamlit.case_converters import to_snake_case
 from streamlit.config_option import ConfigOption
 from streamlit.runtime.credentials import Credentials, check_credentials
 from streamlit.web.cache_storage_manager_config import (
@@ -49,28 +48,53 @@ def _convert_config_option_to_click_option(
         description += (
             f"\n {config_option.deprecation_text} - {config_option.expiration_date}"
         )
-    envvar = f"STREAMLIT_{to_snake_case(param).upper()}"
 
     return {
         "param": param,
         "description": description,
         "type": config_option.type,
         "option": option,
-        "envvar": envvar,
+        "envvar": config_option.env_var,
     }
+
+
+def _make_sensitive_option_callback(config_option: ConfigOption):
+    def callback(_ctx: click.Context, _param: click.Parameter, cli_value) -> None:
+        if cli_value is None:
+            return None
+        raise SystemExit(
+            f"Setting {config_option.key!r} option using the CLI flag is not allowed. "
+            f"Set this option in the configuration file or environment "
+            f"variable: {config_option.env_var!r}"
+        )
+
+    return callback
 
 
 def configurator_options(func):
     """Decorator that adds config param keys to click dynamically."""
     for _, value in reversed(_config._config_options_template.items()):
         parsed_parameter = _convert_config_option_to_click_option(value)
+        if value.sensitive:
+            # Display a warning if the user tries to set sensitive
+            # options using the CLI and exit with non-zero code.
+            click_option_kwargs = {
+                "expose_value": False,
+                "hidden": True,
+                "is_eager": True,
+                "callback": _make_sensitive_option_callback(value),
+            }
+        else:
+            click_option_kwargs = {
+                "show_envvar": True,
+                "envvar": parsed_parameter["envvar"],
+            }
         config_option = click.option(
             parsed_parameter["option"],
             parsed_parameter["param"],
             help=parsed_parameter["description"],
             type=parsed_parameter["type"],
-            show_envvar=True,
-            envvar=parsed_parameter["envvar"],
+            **click_option_kwargs,
         )
         func = config_option(func)
     return func

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -39,6 +39,7 @@ class ConfigTest(unittest.TestCase):
                 config, "_section_descriptions", new=copy.deepcopy(SECTION_DESCRIPTIONS)
             ),
             patch.object(config, "_config_options", new=copy.deepcopy(CONFIG_OPTIONS)),
+            patch.dict(os.environ),
         ]
 
         for p in self.patches:
@@ -48,10 +49,6 @@ class ConfigTest(unittest.TestCase):
         for p in self.patches:
             p.stop()
 
-        try:
-            del os.environ["TEST_ENV_VAR"]
-        except Exception:
-            pass
         config._delete_option("_test.tomlTest")
 
     def test_set_user_option_scriptable(self):
@@ -89,6 +86,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config_option.description, "Simple config option.")
         self.assertEqual(config_option.where_defined, ConfigOption.DEFAULT_DEFINITION)
         self.assertEqual(config_option.value, 12345)
+        self.assertEqual(config_option.env_var, "STREAMLIT__TEST_SIMPLE_PARAM")
 
     def test_complex_config_option(self):
         """Test setting a complex (functional) config option."""
@@ -106,6 +104,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config_option.description, "Complex config option.")
         self.assertEqual(config_option.where_defined, ConfigOption.DEFAULT_DEFINITION)
         self.assertEqual(config_option.value, 12345)
+        self.assertEqual(config_option.env_var, "STREAMLIT__TEST_COMPLEX_PARAM")
 
     def test_complex_config_option_must_have_doc_strings(self):
         """Test that complex config options use funcs with doc stringsself.
@@ -265,6 +264,32 @@ class ConfigTest(unittest.TestCase):
         config._update_config_with_toml(NEW_TOML, DUMMY_DEFINITION)
         self.assertEqual(config.get_option("_test.tomlTest"), DESIRED_VAL)
         self.assertEqual(config.get_where_defined("_test.tomlTest"), DUMMY_DEFINITION)
+
+    def test_parsing_sensitive_options(self):
+        """Test config._update_config_with_sensitive_env_var()."""
+        # Some useful variables.
+        DUMMY_VAL_1, DUMMY_VAL_2 = "Adam", "Malysz"
+
+        # Create a dummy default option.
+        config._create_option(
+            "_test.sensitiveTest",
+            description="This sensitive option tests the config parser.",
+            default_val=DUMMY_VAL_1,
+            sensitive=True,
+        )
+        config.get_config_options(force_reparse=True)
+        self.assertEqual(config.get_option("_test.sensitiveTest"), DUMMY_VAL_1)
+        self.assertEqual(
+            config.get_where_defined("_test.sensitiveTest"),
+            ConfigOption.DEFAULT_DEFINITION,
+        )
+        with patch.dict(os.environ, STREAMLIT__TEST_SENSITIVE_TEST=DUMMY_VAL_2):
+            config.get_config_options(force_reparse=True)
+            self.assertEqual(config.get_option("_test.sensitiveTest"), DUMMY_VAL_2)
+            self.assertEqual(
+                config.get_where_defined("_test.sensitiveTest"),
+                config._DEFINED_BY_ENV_VAR,
+            )
 
     def test_delete_option(self):
         # Create a dummy default option.

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -173,6 +173,18 @@ class CliTest(unittest.TestCase):
         self.assertEqual(kwargs["flag_options"]["server_port"], 8502)
         self.assertEqual(0, result.exit_code)
 
+    @parameterized.expand(["mapbox.token", "server.cookieSecret"])
+    def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
+        with patch("validators.url", return_value=False), patch(
+            "streamlit.web.cli._main_run"
+        ), patch("os.path.exists", return_value=True):
+            result = self.runner.invoke(
+                cli, ["run", "file_name.py", f"--{sensitive_option}=TESTSECRET"]
+            )
+
+        self.assertIn("option using the CLI flag is not allowed", result.output)
+        self.assertEqual(1, result.exit_code)
+
     def test_get_command_line(self):
         """Test that _get_command_line_as_string correctly concatenates values
         from click.


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Setting passwords or other secrets via CLI options is not considered secure. To promote setting sensitive configuration values using environment variables or files, we disable setting particular sensitive configuration values using CLI parameters.

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [x] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
