### PR TITLE
Remove UriUtil.buildMediaUri

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -549,7 +549,7 @@ export class App extends PureComponent<Props, State> {
       handleFavicon(
         favicon,
         this.props.hostCommunication.sendMessage,
-        this.getBaseUriParts()
+        this.endpoints
       )
     }
 
@@ -825,7 +825,7 @@ export class App extends PureComponent<Props, State> {
     handleFavicon(
       `${process.env.PUBLIC_URL}/favicon.png`,
       this.props.hostCommunication.sendMessage,
-      this.getBaseUriParts()
+      this.endpoints
     )
 
     this.metricsMgr.setMetadata(

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -438,6 +438,7 @@ const RawElementNodeRenderer = (
         widgetProps.disabled || downloadButtonProto.disabled
       return (
         <DownloadButton
+          endpoints={props.endpoints}
           key={downloadButtonProto.id}
           element={downloadButtonProto}
           width={width}

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -380,7 +380,13 @@ const RawElementNodeRenderer = (
       )
 
     case "video":
-      return <Video width={width} element={node.element.video as VideoProto} />
+      return (
+        <Video
+          width={width}
+          element={node.element.video as VideoProto}
+          endpoints={props.endpoints}
+        />
+      )
 
     // Widgets
     case "arrowDataFrame": {

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -313,6 +313,7 @@ const RawElementNodeRenderer = (
         <ImageList
           width={width}
           element={node.element.imgs as ImageListProto}
+          endpoints={props.endpoints}
         />
       )
 

--- a/frontend/src/components/elements/Favicon/Favicon.test.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { mockEndpoints } from "src/lib/mocks/mocks"
 import { handleFavicon } from "./Favicon"
 
 function getFaviconHref(): string {
@@ -37,39 +38,40 @@ test("is set up with the default favicon", () => {
 })
 
 describe("Favicon element", () => {
-  it("sets the favicon in the DOM", () => {
-    handleFavicon("https://streamlit.io/path/to/favicon.png", jest.fn())
-    expect(getFaviconHref()).toBe("https://streamlit.io/path/to/favicon.png")
-  })
+  const buildMediaURL = jest.fn().mockReturnValue("https://mock.media.url")
+  const endpoints = mockEndpoints({ buildMediaURL: buildMediaURL })
 
-  it("accepts /media urls from backend", () => {
-    handleFavicon("/media/1234567890.png", jest.fn())
-    expect(getFaviconHref()).toBe("http://localhost/media/1234567890.png")
+  it("sets the favicon in the DOM", () => {
+    handleFavicon("https://some/random/favicon.png", jest.fn(), endpoints)
+    expect(buildMediaURL).toHaveBeenCalledWith(
+      "https://some/random/favicon.png"
+    )
+    expect(getFaviconHref()).toBe("https://mock.media.url/")
   })
 
   it("accepts emojis directly", () => {
-    handleFavicon("🍕", jest.fn())
+    handleFavicon("🍕", jest.fn(), endpoints)
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
   it("handles emoji variants correctly", () => {
-    handleFavicon("🛰", jest.fn())
+    handleFavicon("🛰", jest.fn(), endpoints)
     expect(getFaviconHref()).toBe(SATELLITE_TWEMOJI_URL)
   })
 
   it("handles emoji shortcodes containing a dash correctly", () => {
-    handleFavicon(":crescent-moon:", jest.fn())
+    handleFavicon(":crescent-moon:", jest.fn(), endpoints)
     expect(getFaviconHref()).toBe(CRESCENT_MOON_TWEMOJI_URL)
   })
 
   it("accepts emoji shortcodes", () => {
-    handleFavicon(":pizza:", jest.fn())
+    handleFavicon(":pizza:", jest.fn(), endpoints)
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
   it("updates the favicon when it changes", () => {
-    handleFavicon("/media/1234567890.png", jest.fn())
-    handleFavicon(":pizza:", jest.fn())
+    handleFavicon("/media/1234567890.png", jest.fn(), endpoints)
+    handleFavicon(":pizza:", jest.fn(), endpoints)
     expect(getFaviconHref()).toBe(PIZZA_TWEMOJI_URL)
   })
 
@@ -77,10 +79,11 @@ describe("Favicon element", () => {
     const sendMessageToHost = jest.fn()
     handleFavicon(
       "https://streamlit.io/path/to/favicon.png",
-      sendMessageToHost
+      sendMessageToHost,
+      endpoints
     )
     expect(sendMessageToHost).toHaveBeenCalledWith({
-      favicon: "https://streamlit.io/path/to/favicon.png",
+      favicon: "https://mock.media.url",
       type: "SET_PAGE_FAVICON",
     })
   })

--- a/frontend/src/components/elements/Favicon/Favicon.tsx
+++ b/frontend/src/components/elements/Favicon/Favicon.tsx
@@ -15,21 +15,21 @@
  */
 
 import nodeEmoji from "node-emoji"
-import { BaseUriParts, buildMediaUri } from "src/lib/UriUtil"
 import { grabTheRightIcon } from "src/vendor/twemoji"
 import { IGuestToHostMessage } from "src/hocs/withHostCommunication/types"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 /**
  * Set the provided url/emoji as the page favicon.
  *
  * @param {string} favicon an image url, or an emoji like 🍕 or :pizza:
  * @param sendMessageToHost a function that posts messages to the app's parent iframe
- * @param baseUriParts
+ * @param endpoints
  */
 export function handleFavicon(
   favicon: string,
   sendMessageToHost: (message: IGuestToHostMessage) => void,
-  baseUriParts?: BaseUriParts
+  endpoints: StreamlitEndpoints
 ): void {
   const emoji = extractEmoji(favicon)
   let imageUrl
@@ -41,7 +41,7 @@ export function handleFavicon(
 
     imageUrl = emojiUrl
   } else {
-    imageUrl = buildMediaUri(favicon, baseUriParts)
+    imageUrl = endpoints.buildMediaURL(favicon)
   }
 
   overwriteFavicon(imageUrl)

--- a/frontend/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.test.tsx
@@ -29,14 +29,8 @@ describe("ImageList Element", () => {
   ): ImageListProps => ({
     element: ImageListProto.create({
       imgs: [
-        {
-          caption: "a",
-          url: "/media/mockImage1.jpeg",
-        },
-        {
-          caption: "b",
-          url: "/media/mockImage2.jpeg",
-        },
+        { caption: "a", url: "/media/mockImage1.jpeg" },
+        { caption: "b", url: "/media/mockImage2.jpeg" },
       ],
       width: -1,
       ...elementProps,

--- a/frontend/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.test.tsx
@@ -18,30 +18,34 @@ import React from "react"
 import { shallow } from "src/lib/test_util"
 
 import { ImageList as ImageListProto } from "src/autogen/proto"
+import { mockEndpoints } from "src/lib/mocks/mocks"
 import { ImageList, ImageListProps } from "./ImageList"
 
-const getProps = (
-  elementProps: Partial<ImageListProto> = {}
-): ImageListProps => ({
-  element: ImageListProto.create({
-    imgs: [
-      {
-        caption: "a",
-        url: "/media/e275965f8926e17fa8c92c6530be58be11cf5a55474619c16f5442f9.jpeg",
-      },
-      {
-        caption: "b",
-        url: "/media/e275965f8926e17fa8c92c6530be58be11cf5a55474619c16f5442f9.jpeg",
-      },
-    ],
-    width: -1,
-    ...elementProps,
-  }),
-  width: 0,
-  isFullScreen: false,
-})
-
 describe("ImageList Element", () => {
+  const buildMediaURL = jest.fn().mockReturnValue("https://mock.media.url")
+
+  const getProps = (
+    elementProps: Partial<ImageListProto> = {}
+  ): ImageListProps => ({
+    element: ImageListProto.create({
+      imgs: [
+        {
+          caption: "a",
+          url: "/media/mockImage1.jpeg",
+        },
+        {
+          caption: "b",
+          url: "/media/mockImage2.jpeg",
+        },
+      ],
+      width: -1,
+      ...elementProps,
+    }),
+    endpoints: mockEndpoints({ buildMediaURL: buildMediaURL }),
+    width: 0,
+    isFullScreen: false,
+  })
+
   it("renders without crashing", () => {
     const props = getProps()
     const wrapper = shallow(<ImageList {...props} />)
@@ -49,30 +53,29 @@ describe("ImageList Element", () => {
     expect(wrapper.find("StyledImageContainer").length).toBe(2)
   })
 
-  it("should render explicit width for each image", () => {
+  it("renders explicit width for each image", () => {
     const props = getProps({ width: 300 })
     const wrapper = shallow(<ImageList {...props} />)
 
     expect(wrapper.find("StyledImageContainer").length).toEqual(2)
   })
 
-  it("should have a src", () => {
+  it("creates its `src` attribute using buildMediaURL", () => {
     const props = getProps()
     const wrapper = shallow(<ImageList {...props} />)
 
-    const { imgs } = props.element
     expect(wrapper.find("StyledImageContainer").length).toEqual(2)
+    expect(buildMediaURL).toHaveBeenNthCalledWith(1, "/media/mockImage1.jpeg")
+    expect(buildMediaURL).toHaveBeenNthCalledWith(2, "/media/mockImage2.jpeg")
     wrapper
       .find("StyledImageContainer")
       .find("img")
-      .forEach((imgWrapper, id) => {
-        expect(imgWrapper.prop("src")).toBe(
-          `http://localhost:80${imgs[id].url}`
-        )
+      .forEach(imgWrapper => {
+        expect(imgWrapper.prop("src")).toBe("https://mock.media.url")
       })
   })
 
-  it("should have a caption", () => {
+  it("has a caption", () => {
     const props = getProps()
     const wrapper = shallow(<ImageList {...props} />)
 
@@ -83,7 +86,7 @@ describe("ImageList Element", () => {
     })
   })
 
-  it("should render explicit width for each caption", () => {
+  it("renders explicit width for each caption", () => {
     const props = getProps({ width: 300 })
     const captionWidth = { width: 300 }
     const wrapper = shallow(<ImageList {...props} />)
@@ -93,36 +96,15 @@ describe("ImageList Element", () => {
     })
   })
 
-  it("should render absolute src", () => {
-    const props = getProps({
-      imgs: [
-        {
-          caption: "a",
-          url: "https://streamlit.io/path/test.jpg",
-        },
-      ],
-    })
-    const wrapper = shallow(<ImageList {...props} />)
-
-    const { imgs } = props.element
-    expect(wrapper.find("StyledImageContainer").length).toEqual(1)
-    wrapper
-      .find("StyledImageContainer")
-      .find("img")
-      .forEach((imgWrapper, id) => {
-        expect(imgWrapper.prop("src")).toBe(imgs[id].url)
-      })
-  })
-
   describe("fullScreen", () => {
     const props = { ...getProps(), isFullScreen: true, height: 100 }
     const wrapper = shallow(<ImageList {...props} />)
 
-    it("should have a caption", () => {
+    it("has a caption", () => {
       expect(wrapper.find("StyledCaption").length).toBe(2)
     })
 
-    it("should have the proper style", () => {
+    it("has the proper style", () => {
       const fullScreenAppearance = { maxHeight: 100, "object-fit": "contain" }
 
       expect(wrapper.find("StyledImageContainer").length).toEqual(2)

--- a/frontend/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/src/components/elements/ImageList/ImageList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useContext, ReactElement } from "react"
+import React, { ReactElement } from "react"
 import ReactHtmlParser from "react-html-parser"
 
 import {
@@ -22,9 +22,9 @@ import {
   Image as ImageProto,
   ImageList as ImageListProto,
 } from "src/autogen/proto"
-import { AppContext } from "src/components/core/AppContext"
 import withFullScreenWrapper from "src/hocs/withFullScreenWrapper"
-import { buildMediaUri, xssSanitizeSvg } from "src/lib/UriUtil"
+import { xssSanitizeSvg } from "src/lib/UriUtil"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 import {
   StyledCaption,
@@ -33,6 +33,7 @@ import {
 } from "./styled-components"
 
 export interface ImageListProps {
+  endpoints: StreamlitEndpoints
   width: number
   isFullScreen: boolean
   element: ImageListProto
@@ -53,9 +54,8 @@ export function ImageList({
   isFullScreen,
   element,
   height,
+  endpoints,
 }: ImageListProps): ReactElement {
-  const { getBaseUriParts } = useContext(AppContext)
-
   // The width field in the proto sets the image width, but has special
   // cases for -1, -2, and -3.
   let containerWidth: number | undefined
@@ -103,7 +103,7 @@ export function ImageList({
             ) : (
               <img
                 style={imgStyle}
-                src={buildMediaUri(image.url, getBaseUriParts())}
+                src={endpoints.buildMediaURL(image.url)}
                 alt={idx.toString()}
               />
             )}

--- a/frontend/src/components/elements/Video/Video.tsx
+++ b/frontend/src/components/elements/Video/Video.tsx
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext, useEffect, useRef } from "react"
-import { AppContext } from "src/components/core/AppContext"
+import React, { ReactElement, useEffect, useRef } from "react"
 import { Video as VideoProto } from "src/autogen/proto"
-import { buildMediaUri } from "src/lib/UriUtil"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 const DEFAULT_HEIGHT = 528
 
 export interface VideoProps {
+  endpoints: StreamlitEndpoints
   width: number
   element: VideoProto
 }
 
-export default function Video({ element, width }: VideoProps): ReactElement {
+export default function Video({
+  element,
+  width,
+  endpoints,
+}: VideoProps): ReactElement {
   const videoRef = useRef<HTMLVideoElement>(null)
-  const { getBaseUriParts } = useContext(AppContext)
 
   /* Element may contain "url" or "data" property. */
 
@@ -92,7 +95,7 @@ export default function Video({ element, width }: VideoProps): ReactElement {
     <video
       ref={videoRef}
       controls
-      src={buildMediaUri(url, getBaseUriParts())}
+      src={endpoints.buildMediaURL(url)}
       className="stVideo"
       style={{ width, height: width === 0 ? DEFAULT_HEIGHT : undefined }}
     />

--- a/frontend/src/components/elements/Video/__snapshots__/Video.test.tsx.snap
+++ b/frontend/src/components/elements/Video/__snapshots__/Video.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video Element YouTube should render a youtube iframe 1`] = `
+exports[`Video Element YouTube renders a youtube iframe 1`] = `
 Object {
   "allow": "autoplay; encrypted-media",
   "allowFullScreen": true,
@@ -12,7 +12,7 @@ Object {
 }
 `;
 
-exports[`Video Element YouTube should render a youtube iframe with an starting time 1`] = `
+exports[`Video Element YouTube renders a youtube iframe with an starting time 1`] = `
 Object {
   "allow": "autoplay; encrypted-media",
   "allowFullScreen": true,

--- a/frontend/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -22,22 +22,26 @@ import UIButton from "src/components/shared/Button"
 import StreamlitMarkdown from "src/components/shared/StreamlitMarkdown"
 
 import { DownloadButton as DownloadButtonProto } from "src/autogen/proto"
+import { mockEndpoints } from "src/lib/mocks/mocks"
 import DownloadButton, { Props } from "./DownloadButton"
 
 jest.mock("src/lib/WidgetStateManager")
-
-const sendBackMsg = jest.fn()
+jest.mock("src/lib/StreamlitEndpoints")
 
 const getProps = (elementProps: Partial<DownloadButtonProto> = {}): Props => ({
   element: DownloadButtonProto.create({
     id: "1",
     label: "Label",
+    url: "/media/mockDownloadURL",
     ...elementProps,
   }),
   width: 0,
   disabled: false,
-  // @ts-expect-error
-  widgetMgr: new WidgetStateManager(sendBackMsg),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
+  endpoints: mockEndpoints(),
 })
 
 describe("DownloadButton widget", () => {
@@ -48,7 +52,7 @@ describe("DownloadButton widget", () => {
     expect(wrapper).toBeDefined()
   })
 
-  it("should have correct className and style", () => {
+  it("has correct className and style", () => {
     const wrapper = shallow(<DownloadButton {...getProps()} />)
 
     const wrappedDiv = wrapper.find("div").first()
@@ -63,7 +67,7 @@ describe("DownloadButton widget", () => {
     expect(style.width).toBe(getProps().width)
   })
 
-  it("should render a label within the button", () => {
+  it("renders a label within the button", () => {
     const wrapper = shallow(<DownloadButton {...getProps()} />)
 
     const wrappedUIButton = wrapper.find(UIButton)
@@ -74,8 +78,8 @@ describe("DownloadButton widget", () => {
     expect(wrappedButtonLabel.props().isButton).toBe(true)
   })
 
-  describe("UIButton props should work", () => {
-    it("onClick prop", () => {
+  describe("wrapped UIButton", () => {
+    it("sets widget triggerValue and creates a download URL on click", () => {
       const props = getProps()
       const wrapper = shallow(<DownloadButton {...props} />)
 
@@ -87,9 +91,13 @@ describe("DownloadButton widget", () => {
         props.element,
         { fromUi: true }
       )
+
+      expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(
+        "/media/mockDownloadURL"
+      )
     })
 
-    it("disable prop", () => {
+    it("handles the disabled prop", () => {
       const props = getProps()
       const wrapper = shallow(<DownloadButton {...props} />)
 

--- a/frontend/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useContext } from "react"
+import React, { ReactElement } from "react"
 import { DownloadButton as DownloadButtonProto } from "src/autogen/proto"
-import { AppContext } from "src/components/core/AppContext"
 import UIButton, {
   ButtonTooltip,
   Kind,
@@ -24,9 +23,10 @@ import UIButton, {
 } from "src/components/shared/Button"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import StreamlitMarkdown from "src/components/shared/StreamlitMarkdown"
-import { buildMediaUri } from "src/lib/UriUtil"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 export interface Props {
+  endpoints: StreamlitEndpoints
   disabled: boolean
   element: DownloadButtonProto
   widgetMgr: WidgetStateManager
@@ -34,18 +34,16 @@ export interface Props {
 }
 
 function DownloadButton(props: Props): ReactElement {
-  const { disabled, element, widgetMgr, width } = props
+  const { disabled, element, widgetMgr, width, endpoints } = props
   const style = { width }
-  const { getBaseUriParts } = useContext(AppContext)
 
   const handleDownloadClick: () => void = () => {
     // Downloads are only done on links, so create a hidden one and click it
     // for the user.
     widgetMgr.setTriggerValue(element, { fromUi: true })
     const link = document.createElement("a")
-    const uri = `${buildMediaUri(
-      element.url,
-      getBaseUriParts()
+    const uri = `${endpoints.buildMediaURL(
+      element.url
     )}?title=${encodeURIComponent(document.title)}`
     link.setAttribute("href", uri)
     link.setAttribute("target", "_blank")

--- a/frontend/src/lib/UriUtil.test.ts
+++ b/frontend/src/lib/UriUtil.test.ts
@@ -16,7 +16,6 @@
 
 import {
   buildHttpUri,
-  buildMediaUri,
   buildWsUri,
   getPossibleBaseUris,
   getWindowBaseUriParts,
@@ -157,18 +156,6 @@ test("builds WS URI with no base path", () => {
     "baz"
   )
   expect(uri).toBe("ws://the_host:9988/baz")
-})
-
-test("builds uri correctly for streamlit-served media", () => {
-  const uri = buildMediaUri("/media/1234567890.png")
-
-  expect(uri).toBe("http://the_host:9988/foo/bar/media/1234567890.png")
-})
-
-test("passes through other media uris", () => {
-  const uri = buildMediaUri("http://example/blah.png")
-
-  expect(uri).toBe("http://example/blah.png")
 })
 
 test("sanitizes SVG uris", () => {

--- a/frontend/src/lib/UriUtil.ts
+++ b/frontend/src/lib/UriUtil.ts
@@ -148,23 +148,6 @@ export function xssSanitizeSvg(uri: string): string {
 }
 
 /**
- * If this is a relative URI, assume it's being served from streamlit and
- * construct it appropriately.  Otherwise leave it alone.
- */
-export function buildMediaUri(
-  uri: string,
-  baseUriParts?: BaseUriParts
-): string {
-  if (uri.startsWith(SVG_PREFIX)) {
-    return `${SVG_PREFIX}${xssSanitizeSvg(uri)}`
-  }
-  if (!baseUriParts) {
-    baseUriParts = getWindowBaseUriParts()
-  }
-  return uri.startsWith("/media") ? buildHttpUri(baseUriParts, uri) : uri
-}
-
-/**
  * Check if the given origin follows the allowed origin pattern, which could
  * include wildcards.
  *


### PR DESCRIPTION
- `Video`, `ImageList`, `Favicon`, and `DownloadButton` elements now all use the interface-ized `StreamlitEndpoints.buildMediaURL` function.
- `UriUtil.buildMediaUri` is gone

(The PR also has some drive-by test naming changes.)