### PR TITLE
Add implementation of SQL connection

### DIFF
--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -15,3 +15,4 @@
 
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -71,10 +71,12 @@ class SQL(BaseConnection["Engine"]):
         ttl: Optional[Union[float, int, timedelta]] = None,
         **kwargs,
     ) -> pd.DataFrame:
+        from sqlalchemy import text
+
         @cache_data(ttl=ttl)
         def _read_sql(sql: str, **kwargs) -> pd.DataFrame:
             instance = self._instance.connect()
-            return pd.read_sql(sql, instance, **kwargs)
+            return pd.read_sql(text(sql), instance, **kwargs)
 
         return _read_sql(sql, **kwargs)
 

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -1,0 +1,104 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from datetime import timedelta
+from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
+
+import pandas as pd
+
+from streamlit.connections import BaseConnection
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_data
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine.base import Engine
+    from sqlalchemy.orm import Session
+
+
+_REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
+
+
+class SQL(BaseConnection["Engine"]):
+    _default_connection_name = "sql"
+
+    def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
+        import sqlalchemy
+
+        secrets = self.get_secrets()
+
+        if "url" in secrets:
+            url = sqlalchemy.engine.make_url(secrets["url"])
+        else:
+            for p in _REQUIRED_CONNECTION_PARAMS:
+                if p not in secrets:
+                    raise StreamlitAPIException(f"Missing SQL DB connection param: {p}")
+
+            drivername = secrets["dialect"] + (
+                f"+{secrets['driver']}" if "driver" in secrets else ""
+            )
+
+            url = sqlalchemy.engine.URL.create(
+                drivername=drivername,
+                username=secrets["username"],
+                password=secrets.get("password"),
+                host=secrets["host"],
+                port=int(secrets["port"]) if "port" in secrets else None,
+                database=secrets.get("database"),
+            )
+
+        eng = sqlalchemy.create_engine(url, **kwargs)
+
+        if autocommit:
+            return cast("Engine", eng.execution_options(isolation_level="AUTOCOMMIT"))
+        else:
+            return cast("Engine", eng)
+
+    def read_sql(
+        self,
+        sql: str,
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        @cache_data(ttl=ttl)
+        def _read_sql(sql: str, **kwargs) -> pd.DataFrame:
+            instance = self._instance.connect()
+            return pd.read_sql(sql, instance, **kwargs)
+
+        return _read_sql(sql, **kwargs)
+
+    @contextmanager
+    def session(self) -> Iterator["Session"]:
+        """A simple wrapper around SQLAlchemy Session context management.
+
+        This allows us to write
+            `with conn.session() as session:`
+        instead of importing the sqlalchemy.orm.Session object and writing
+            `with Session(conn._instance) as session:`
+
+        See the usage example below, which assumes we have a table `numbers` with a
+        single integer column `val`.
+
+        Example
+        -------
+        >>> n = st.slider("Pick a number")
+        >>> if st.button("Add the number!"):
+        ...     with conn.session() as session:
+        ...         session.execute("INSERT INTO numbers (val) VALUES (:n);", {"n": n})
+        ...         session.commit()
+        """
+        from sqlalchemy.orm import Session
+
+        with Session(self._instance) as s:
+            yield s

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -68,7 +68,10 @@ def _get_first_party_connection(connection_name: str):
 
 @overload
 def connection_factory(
-    connection_class: Literal["sql"], name: str = "default", **kwargs
+    connection_class: Literal["sql"],
+    name: str = "default",
+    autocommit: bool = False,
+    **kwargs,
 ) -> SQL:
     pass
 

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -1,0 +1,92 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import unittest
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
+from parameterized import parameterized
+
+from streamlit.connections import SQL
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import AttrDict
+from tests.testutil import create_mock_script_run_ctx
+
+DB_SECRETS = {
+    "dialect": "postgres",
+    "driver": "psycopg2",
+    "username": "AzureDiamond",
+    "password": "hunter2",
+    "host": "localhost",
+    "port": "5432",
+    "database": "postgres",
+}
+
+
+class SQLConnectionTest(unittest.TestCase):
+    @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
+    @patch(
+        "streamlit.connections.sql_connection.SQL.get_secrets",
+        MagicMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_url_set_explicitly_in_secrets(self, patched_create_engine):
+        SQL()
+
+        patched_create_engine.assert_called_once_with("some_sql_conn_string")
+
+    @patch(
+        "streamlit.connections.sql_connection.SQL.get_secrets",
+        MagicMock(return_value=AttrDict(DB_SECRETS)),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_url_constructed_from_secrets_params(self, patched_create_engine):
+        SQL()
+
+        patched_create_engine.assert_called_once()
+        args, _ = patched_create_engine.call_args_list[0]
+        assert (
+            str(args[0])
+            == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
+        )
+
+    @parameterized.expand([("dialect",), ("username",), ("host",)])
+    def test_error_if_missing_required_param(self, missing_param):
+        secrets = deepcopy(DB_SECRETS)
+        del secrets[missing_param]
+
+        with patch(
+            "streamlit.connections.sql_connection.SQL.get_secrets",
+            MagicMock(return_value=AttrDict(secrets)),
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                SQL()
+
+            assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
+
+    @patch("streamlit.connections.sql_connection.SQL.connect", MagicMock())
+    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    def test_read_sql_caches_value(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
+
+        conn = SQL()
+
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        patched_read_sql.assert_called_once()

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import sys
 import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from streamlit.connections import BaseConnection
+from streamlit.connections import SQL, BaseConnection
+from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.connection_factory import _create_connection, connection_factory
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from tests.testutil import create_mock_script_run_ctx
@@ -94,4 +95,35 @@ class ConnectionFactoryTest(unittest.TestCase):
         assert str(e.value) == (
             "No module named 'foo'. "
             "You may be missing a dependency required to use this connection."
+        )
+
+    @pytest.mark.skip(
+        reason="Existing tests import some of these modules, so we need to figure out some other way to test this."
+    )
+    def test_optional_dependencies_not_imported(self):
+        """Test that the dependencies of first party connections aren't transitively
+        imported just by importing the connection_factory function.
+        """
+
+        DISALLOWED_IMPORTS = ["sqlalchemy"]
+
+        modules = list(sys.modules.keys())
+
+        for m in modules:
+            for disallowed_import in DISALLOWED_IMPORTS:
+                assert disallowed_import not in m
+
+    def test_raises_exception_when_passed_invalid_class_string(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            connection_factory("nonexistent")
+
+        assert "Invalid connection nonexistent" in str(e.value)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_sql_connection_string_shorthand(self, patched_create_connection):
+        connection_factory("sql")
+
+        patched_create_connection.assert_called_once_with(
+            SQL,
+            name="default",
         )


### PR DESCRIPTION
Note: This PR is being merged into `feature/st.experimental_connection`.

## 📚 Context

This PR adds an implementation for one of our first party connection classes: the `SQL` connection.
The SQL connection is a simple wrapper around SQLAchemy that plays nicely with a developer's
`secrets.toml` file and the `st.experimental_connection` factory function.

There are a few notable things missing from the `SQL` connection class for now. Notably,
* Retries for the `read_sql` method still need to be implemented.
* ~~We need to add some unit tests for the class itself. This will be done in a later PR.~~