### PR TITLE
Embed example apps in `st.help` docstring

### DIFF
--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -109,8 +109,8 @@ class HelpMixin:
         >>> import streamlit as st
         >>> import pandas
         >>>
-        >>> # Get help for Pandas DataFrame:
-        >>> pandas.DataFrame
+        >>> # Get help for Pandas read_csv:
+        >>> pandas.read_csv
         >>>
         >>> # Get help for Streamlit itself:
         >>> st

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -70,6 +70,10 @@ class HelpMixin:
         >>>
         >>> st.help(pandas.DataFrame)
 
+        .. output::
+            https://doc-string.streamlit.app/
+            height: 700px
+
         Want to quickly check what data type is output by a certain function?
         Try:
 
@@ -95,6 +99,10 @@ class HelpMixin:
         >>>
         >>> st.help(fido)
 
+        .. output::
+            https://doc-string1.streamlit.app/
+            height: 300px
+
         And if you're using Magic, you can get help for functions, classes,
         and modules without even typing ``st.help``:
 
@@ -106,6 +114,10 @@ class HelpMixin:
         >>>
         >>> # Get help for Streamlit itself:
         >>> st
+
+        .. output::
+            https://doc-string2.streamlit.app/
+            height: 700px
         """
         doc_string_proto = DocStringProto()
         _marshall(doc_string_proto, obj)


### PR DESCRIPTION
## 📚 Context

#5857 improved `st.help` to make it even greater for quickly inspecting objects, classes, etc. @sfc-gh-tteixeira intended to embed apps in the `st.help` docstring's `Example` section, but the apps could only be embedded after the feature branch was merged into develop. This PR adds those embedded apps.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [x] Other, please describe: Doc improvement request

## 🧠 Description of Changes

- Embeds three apps in the `st.help` docstring's `Example` section that were added to `streamlit/docs` on [0a80a44](https://github.com/streamlit/docs/commit/0a80a442e98e54a6f4b0e4a6a5bbe59beb25fc68).
- Note to reviewers: this PR neither adds nor updates any tests as it the changes are merely refactoring the docstring and do not change any functionality.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

<details open><summary><h3>View revised</h3></summary>

![image](https://user-images.githubusercontent.com/20672874/228154705-04a1e071-5552-4777-9743-8436d31b92fc.png)
![image](https://user-images.githubusercontent.com/20672874/228154779-ec55145d-f13b-4795-859f-0b013a9bb479.png)
![image](https://user-images.githubusercontent.com/20672874/229032761-927e5e36-6c3f-4855-bea1-467253aa2d84.png)
</details>

<details><summary><h3>View current</h3></summary>

![image](https://user-images.githubusercontent.com/20672874/228155513-4dcfc596-c03d-45d6-8638-f5ecb16a5fc8.png)
![image](https://user-images.githubusercontent.com/20672874/228155596-02a39f99-518a-4e39-8cbf-d5667c89c362.png)
</details>

## 🧪 Testing Done

- [x] Screenshots included

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
