### PR TITLE
supress warning when call `get_script_run_ctx` from `gather_metrics` …

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -277,7 +277,7 @@ def gather_metrics(name: str, func: Optional[F] = None) -> Union[Callable[[F], F
         # get_script_run_ctx gets imported here to prevent circular dependencies
         from streamlit.runtime.scriptrunner import get_script_run_ctx
 
-        ctx = get_script_run_ctx()
+        ctx = get_script_run_ctx(suppress_warning=True)
 
         tracking_activated = (
             ctx is not None

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -29,7 +29,6 @@ from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
 LOGGER: Final = get_logger(__name__)
 
-
 UserInfo: TypeAlias = Dict[str, Optional[str]]
 
 
@@ -141,8 +140,12 @@ def add_script_run_ctx(
     return thread
 
 
-def get_script_run_ctx() -> Optional[ScriptRunContext]:
+def get_script_run_ctx(suppress_warning: bool = False) -> Optional[ScriptRunContext]:
     """
+    Parameters
+    ----------
+    suppress_warning : bool
+        If True, don't log a warning if there's no ScriptRunContext.
     Returns
     -------
     ScriptRunContext | None
@@ -153,9 +156,9 @@ def get_script_run_ctx() -> Optional[ScriptRunContext]:
     ctx: Optional[ScriptRunContext] = getattr(
         thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None
     )
-    if ctx is None and runtime.exists():
-        # Only warn about a missing ScriptRunContext if we were started
-        # via `streamlit run`. Otherwise, the user is likely running a
+    if ctx is None and runtime.exists() and not suppress_warning:
+        # Only warn about a missing ScriptRunContext if suppress_warning is False, and
+        # we were started via `streamlit run`. Otherwise, the user is likely running a
         # script "bare", and doesn't need to be warned about streamlit
         # bits that are irrelevant when not connected to a session.
         LOGGER.warning("Thread '%s': missing ScriptRunContext", thread.name)


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

Since we did not rerun the script on `clear cache` and our `@gather_metric` try to get context via `get_script_run_ctx`, it raises a warning in the console. In order to fix that, we suppress that warning in `get_script_run_ctx` when trying to get it from `gather_metric`. 


- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6372 , #6206

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
