### PR TITLE
StreamlitEndpoints.buildAppPageURL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1541,7 +1541,6 @@ export class App extends PureComponent<Props, State> {
           addThemes: this.props.theme.addThemes,
           sidebarChevronDownshift:
             this.props.hostCommunication.currentState.sidebarChevronDownshift,
-          getBaseUriParts: this.getBaseUriParts,
           embedded: isEmbed(),
           showPadding: !isEmbed() || isPaddingDisplayed(),
           disableScrolling: isScrollingHidden(),

--- a/frontend/src/components/core/AppContext.tsx
+++ b/frontend/src/components/core/AppContext.tsx
@@ -18,7 +18,6 @@ import React from "react"
 
 import { PageConfig } from "src/autogen/proto"
 import { baseTheme, ThemeConfig } from "src/theme"
-import { BaseUriParts, getWindowBaseUriParts } from "src/lib/UriUtil"
 
 export interface Props {
   /**
@@ -110,13 +109,6 @@ export interface Props {
    * @see StyledSidebarCollapsedControl
    */
   sidebarChevronDownshift: number
-
-  /**
-   * Function that returns the BaseUriParts object for the server we're
-   * connected to, if we're connected.
-   * @see WebsocketConnection.getBaseUriParts
-   */
-  getBaseUriParts: () => BaseUriParts | undefined
 }
 
 export const AppContext = React.createContext<Props>({
@@ -137,5 +129,4 @@ export const AppContext = React.createContext<Props>({
   availableThemes: [],
   addThemes: () => {},
   sidebarChevronDownshift: 0,
-  getBaseUriParts: getWindowBaseUriParts,
 })

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -156,6 +156,7 @@ function AppView(props: AppViewProps): ReactElement {
     >
       {showSidebar && (
         <ThemedSidebar
+          endpoints={endpoints}
           initialSidebarState={initialSidebarState}
           appPages={appPages}
           hasElements={hasSidebarElements}

--- a/frontend/src/components/core/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.test.tsx
@@ -22,6 +22,7 @@ import { PageConfig } from "src/autogen/proto"
 import { mount } from "src/lib/test_util"
 import { spacing } from "src/theme/primitives/spacing"
 import lightTheme from "src/theme/lightTheme"
+import { mockEndpoints } from "src/lib/mocks/mocks"
 import Sidebar, { SidebarProps } from "./Sidebar"
 import SidebarNav from "./SidebarNav"
 
@@ -30,6 +31,7 @@ expect.extend(matchers)
 function renderSideBar(props: Partial<SidebarProps> = {}): ReactWrapper {
   return mount(
     <Sidebar
+      endpoints={mockEndpoints()}
       chevronDownshift={0}
       theme={lightTheme}
       appPages={[]}

--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -24,6 +24,7 @@ import Button, { Kind } from "src/components/shared/Button"
 import { IAppPage, PageConfig } from "src/autogen/proto"
 import { Theme } from "src/theme"
 import { localStorageAvailable } from "src/lib/storageUtils"
+import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
 
 import {
   StyledSidebar,
@@ -37,6 +38,7 @@ import IsSidebarContext from "./IsSidebarContext"
 import SidebarNav from "./SidebarNav"
 
 export interface SidebarProps {
+  endpoints: StreamlitEndpoints
   chevronDownshift: number
   children?: ReactElement
   initialSidebarState?: PageConfig.SidebarState
@@ -259,6 +261,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
             </StyledSidebarCloseButton>
             {!hideSidebarNav && (
               <SidebarNav
+                endpoints={this.props.endpoints}
                 appPages={appPages}
                 collapseSidebar={this.toggleCollapse}
                 currentPageScriptHash={currentPageScriptHash}

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -26,6 +26,7 @@ import Icon from "src/components/shared/Icon"
 import { useIsOverflowing } from "src/lib/Hooks"
 import { mount, shallow } from "src/lib/test_util"
 import { BaseUriParts } from "src/lib/UriUtil"
+import { mockEndpoints } from "src/lib/mocks/mocks"
 
 import SidebarNav, { Props } from "./SidebarNav"
 import {
@@ -58,6 +59,7 @@ const getProps = (props: Partial<Props> = {}): Props => ({
   hideParentScrollbar: jest.fn(),
   onPageChange: jest.fn(),
   pageLinkBaseUrl: "",
+  endpoints: mockEndpoints(),
   ...props,
 })
 

--- a/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
+++ b/frontend/src/components/core/Sidebar/SidebarNav.test.tsx
@@ -25,8 +25,8 @@ import { act } from "react-dom/test-utils"
 import Icon from "src/components/shared/Icon"
 import { useIsOverflowing } from "src/lib/Hooks"
 import { mount, shallow } from "src/lib/test_util"
-import { BaseUriParts } from "src/lib/UriUtil"
 import { mockEndpoints } from "src/lib/mocks/mocks"
+import { IAppPage } from "src/autogen/proto"
 
 import SidebarNav, { Props } from "./SidebarNav"
 import {
@@ -114,86 +114,22 @@ describe("SidebarNav", () => {
     })
 
     it("are added to each link", () => {
-      const wrapper = shallow(<SidebarNav {...getProps()} />)
+      const buildAppPageURL = jest
+        .fn()
+        .mockImplementation(
+          (pageLinkBaseURL: string, page: IAppPage, pageIndex: number) => {
+            return `http://mock/app/page/${page.pageName}.${pageIndex}`
+          }
+        )
+      const props = getProps({ endpoints: mockEndpoints({ buildAppPageURL }) })
 
-      expect(
-        wrapper.find("StyledSidebarNavLink").map(node => node.props().href)
-      ).toEqual(["http://localhost/", "http://localhost/my_other_page"])
-    })
-
-    it("work with non-default port", () => {
-      window.location.port = "3000"
-      const wrapper = shallow(<SidebarNav {...getProps()} />)
-
-      expect(
-        wrapper.find("StyledSidebarNavLink").map(node => node.props().href)
-      ).toEqual([
-        "http://localhost:3000/",
-        "http://localhost:3000/my_other_page",
-      ])
-    })
-
-    it("work with non-default baseUrlPaths", () => {
-      const getBaseUriParts = (): Partial<BaseUriParts> => ({
-        basePath: "foo/bar",
-        host: "example.com",
-      })
-
-      const mockUseContext = jest
-        .spyOn(React, "useContext")
-        .mockImplementation(() => ({ getBaseUriParts }))
-
-      const wrapper = shallow(<SidebarNav {...getProps()} />)
+      const wrapper = shallow(<SidebarNav {...props} />)
 
       expect(
         wrapper.find("StyledSidebarNavLink").map(node => node.props().href)
       ).toEqual([
-        "http://example.com/foo/bar/",
-        "http://example.com/foo/bar/my_other_page",
-      ])
-
-      mockUseContext.mockRestore()
-    })
-
-    it("work with non-default port and non-default baseUrlPaths", () => {
-      window.location.port = "3000"
-      const getBaseUriParts = (): Partial<BaseUriParts> => ({
-        basePath: "foo/bar",
-        host: "localhost",
-      })
-
-      const mockUseContext = jest
-        .spyOn(React, "useContext")
-        .mockImplementation(() => ({ getBaseUriParts }))
-
-      const wrapper = shallow(<SidebarNav {...getProps()} />)
-
-      expect(
-        wrapper.find("StyledSidebarNavLink").map(node => node.props().href)
-      ).toEqual([
-        "http://localhost:3000/foo/bar/",
-        "http://localhost:3000/foo/bar/my_other_page",
-      ])
-
-      mockUseContext.mockRestore()
-    })
-
-    it("is built using the pageLinkBaseUrl if one is set", () => {
-      window.location.port = "3000"
-
-      const wrapper = shallow(
-        <SidebarNav
-          {...getProps({
-            pageLinkBaseUrl: "https://share.streamlit.io/vdonato/foo/bar",
-          })}
-        />
-      )
-
-      expect(
-        wrapper.find("StyledSidebarNavLink").map(node => node.props().href)
-      ).toEqual([
-        "https://share.streamlit.io/vdonato/foo/bar/",
-        "https://share.streamlit.io/vdonato/foo/bar/my_other_page",
+        "http://mock/app/page/streamlit_app.0",
+        "http://mock/app/page/my_other_page.1",
       ])
     })
   })

--- a/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/src/components/core/Sidebar/ThemedSidebar.test.tsx
@@ -17,6 +17,7 @@
 import React from "react"
 import { mount } from "src/lib/test_util"
 import lightTheme from "src/theme/lightTheme"
+import { mockEndpoints } from "src/lib/mocks/mocks"
 import { SidebarProps } from "./Sidebar"
 import ThemedSidebar from "./ThemedSidebar"
 
@@ -24,6 +25,7 @@ function getProps(
   props: Partial<SidebarProps> = {}
 ): Omit<SidebarProps, "chevronDownshift" | "theme"> {
   return {
+    endpoints: mockEndpoints(),
     appPages: [],
     onPageChange: jest.fn(),
     currentPageScriptHash: "page_hash",

--- a/frontend/src/lib/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/lib/DefaultStreamlitEndpoints.ts
@@ -22,6 +22,7 @@ import {
   xssSanitizeSvg,
 } from "src/lib/UriUtil"
 import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
+import { IAppPage } from "src/autogen/proto"
 import { getCookie } from "./utils"
 
 interface Props {
@@ -66,6 +67,31 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     return url.startsWith(MEDIA_ENDPOINT)
       ? buildHttpUri(this.requireServerUri(), url)
       : url
+  }
+
+  /** Construct a URL for an app page in a multi-page app. */
+  public buildAppPageURL(
+    pageLinkBaseURL: string | undefined,
+    page: IAppPage,
+    pageIndex: number
+  ): string {
+    const pageName = page.pageName as string
+    const navigateTo = pageIndex === 0 ? "" : pageName
+
+    if (pageLinkBaseURL != null && pageLinkBaseURL.length > 0) {
+      return `${pageLinkBaseURL}/${navigateTo}`
+    }
+
+    // NOTE: We use window.location to get the port instead of
+    // getBaseUriParts() because the port may differ in dev mode (since
+    // the frontend is served by the react dev server and not the
+    // streamlit server).
+    const { port, protocol } = window.location
+    const { basePath, host } = this.requireServerUri()
+    const portSection = port ? `:${port}` : ""
+    const basePathSection = basePath ? `${basePath}/` : ""
+
+    return `${protocol}//${host}${portSection}/${basePathSection}${navigateTo}`
   }
 
   public async uploadFileUploaderFile(

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -33,6 +33,7 @@ describe("FileUploadClient Upload", () => {
       endpoints: {
         buildComponentURL: jest.fn(),
         buildMediaURL: jest.fn(),
+        buildAppPageURL: jest.fn(),
         uploadFileUploaderFile: uploadFileUploaderFile,
         fetchCachedForwardMsg: jest.fn(),
       },

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -29,6 +29,7 @@ function createCache(): MockCache {
   const cache = new ForwardMsgCache({
     buildComponentURL: jest.fn(),
     buildMediaURL: jest.fn(),
+    buildAppPageURL: jest.fn(),
     uploadFileUploaderFile: jest.fn(),
     fetchCachedForwardMsg: mockFetchCachedForwardMsg,
   })

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -15,6 +15,7 @@
  */
 
 import { CancelToken } from "axios"
+import { IAppPage } from "src/autogen/proto"
 
 /** Exposes non-websocket endpoints used by the frontend. */
 export interface StreamlitEndpoints {
@@ -32,6 +33,18 @@ export interface StreamlitEndpoints {
    * the media file from the connected Streamlit instance.
    */
   buildMediaURL(url: string): string
+
+  /**
+   * Construct a URL for an app page in a multi-page app.
+   * @param pageLinkBaseURL the optional pageLinkBaseURL set by the host communication layer.
+   * @param page the page's AppPage protobuf properties
+   * @param pageIndex the page's zero-based index
+   */
+  buildAppPageURL(
+    pageLinkBaseURL: string | undefined,
+    page: IAppPage,
+    pageIndex: number
+  ): string
 
   /**
    * Upload a file to the FileUploader endpoint.

--- a/frontend/src/lib/mocks/mocks.ts
+++ b/frontend/src/lib/mocks/mocks.ts
@@ -52,6 +52,7 @@ export function mockEndpoints(
   return {
     buildComponentURL: jest.fn(),
     buildMediaURL: jest.fn(),
+    buildAppPageURL: jest.fn(),
     uploadFileUploaderFile: jest
       .fn()
       .mockRejectedValue(new Error("unimplemented mock endpoint")),


### PR DESCRIPTION
- Adds `StreamlitEndpoints.buildAppPageURL` to the StreamlitEndpoints interface.
- This function is used by `SidebarNav` to create URLs for app pages into multi-page apps
- `DefaultStreamlitEndpoints.buildAppPageURL` implements the app page URL logic that was previously in `SidebarNav`
- `AppContext.getBaseUriParts` is no longer used, and is now gone