### PR TITLE
Add AttrDict.to_dict()

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -14,8 +14,10 @@
 
 import os
 import threading
+from copy import deepcopy
 from typing import (
     Any,
+    Dict,
     ItemsView,
     Iterator,
     KeysView,
@@ -104,6 +106,9 @@ class AttrDict(Mapping[str, Any]):
 
     def __setattr__(self, key, value) -> NoReturn:
         raise TypeError("Secrets does not support attribute assignment.")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return deepcopy(self.__nested_secrets__)
 
 
 class Secrets(Mapping[str, Any]):


### PR DESCRIPTION
## 📚 Context

This is a PR that'll be useful for work being done in `feature/st.experimental_connection`
but is being made to `develop` to reduce the size of the final diff.

There are some cases coming up where it'll be useful for us to be able to get the original
dict object used to create an `AttrDict`. This change allows us to do so by adding a
`to_dict()` method to the `AttrDict` class.

## 🧪 Testing Done

- [x] Added/Updated unit tests
