### PR TITLE
Add implementation of Snowpark connection

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -3,8 +3,8 @@ name: Python Versions
 on:
   push:
     branches:
-      - 'develop'
-      - 'feature/**'
+      - "develop"
+      - "feature/**"
   pull_request:
     types: [opened, synchronize, reopened]
   # Allows workflow to be called from other workflows
@@ -15,7 +15,7 @@ on:
         type: string
     secrets:
       PARAMETER_PASSWORD:
-        description: 'Token passed from caller workflows for snowflake integration tests'
+        description: "Token passed from caller workflows for snowflake integration tests"
         required: true
 
 # Avoid duplicate workflows on same branch
@@ -42,7 +42,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-          submodules: 'recursive'
+          submodules: "recursive"
 
       # Set $PYTHON_VERSION from either $PYTHON_MIN_VERSION or $PYTHON_MAX_VERSION,
       # depending on our 'min-or-max' strategy matrix value.
@@ -80,12 +80,12 @@ jobs:
     # See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
     # Runs triggered by Release/RC are workflow_dispatch events ; Nightly is a schedule event
     if: |
-        github.repository == 'streamlit/streamlit' && (
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') ||
-        (github.event_name == 'push') ||
-        (github.event_name == 'workflow_dispatch') ||
-        (github.event_name == 'schedule')
-        )
+      github.repository == 'streamlit/streamlit' && (
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'push') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'schedule')
+      )
 
     steps:
       - name: Checkout Streamlit code
@@ -93,7 +93,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
@@ -106,5 +106,7 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Run make develop
         run: make develop
+      - name: Run Type Checkers
+        run: scripts/mypy --report
       - name: Run Python Tests for Snowflake
         run: make pytest-snowflake

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -15,4 +15,5 @@
 
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.snowpark_connection import Snowpark as Snowpark
 from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -33,7 +33,7 @@ class BaseConnection(ABC, Generic[T]):
         self._kwargs = kwargs
 
         self._raw_instance: Optional[T] = self.connect(**kwargs)
-        secrets_dict = self.get_secrets().__nested_secrets__
+        secrets_dict = self.get_secrets().to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
 
@@ -47,7 +47,7 @@ class BaseConnection(ABC, Generic[T]):
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
     def _on_secrets_changed(self, _) -> None:
-        secrets_dict = self.get_secrets().__nested_secrets__
+        secrets_dict = self.get_secrets().to_dict()
         new_hash = calc_md5(json.dumps(secrets_dict))
 
         # Only reset the connection if the secrets file section specific to this

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -72,7 +72,7 @@ class Snowpark(BaseConnection["Session"]):
     def connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
-        conn_params = self.get_secrets().__nested_secrets__
+        conn_params = self.get_secrets().to_dict()
 
         if not conn_params:
             conn_params = _load_from_snowsql_config_file()

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -1,0 +1,101 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We won't always be able to import from snowflake.snowpark.session so need the
+# `type:ignore` comment below, but that comment will explode if `warn-unused-ignores` is
+# turned on when the package is available. Unfortunately, mypy doesn't provide a good
+# way to configure this at a per-line level :(
+# mypy: no-warn-unused-ignores
+
+import configparser
+import os
+import threading
+from contextlib import contextmanager
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
+
+import pandas as pd
+
+from streamlit.connections import BaseConnection
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_data
+
+if TYPE_CHECKING:
+    from snowflake.snowpark.session import Session  # type: ignore
+
+
+_REQUIRED_CONNECTION_PARAMS = {"account", "user"}
+_DEFAULT_CONNECTION_FILE = "~/.snowsql/config"
+
+
+def _load_from_snowsql_config_file() -> Dict[str, Any]:
+    """Loads the dictionary from snowsql config file."""
+    snowsql_config_file = os.path.expanduser(_DEFAULT_CONNECTION_FILE)
+    if not os.path.exists(snowsql_config_file):
+        return {}
+
+    config = configparser.ConfigParser(inline_comment_prefixes="#")
+    config.read(snowsql_config_file)
+
+    conn_params = config["connections"]
+    conn_params = {k.replace("name", ""): v.strip('"') for k, v in conn_params.items()}
+    if "db" in conn_params:
+        conn_params["database"] = conn_params["db"]
+        del conn_params["db"]
+    return conn_params
+
+
+class Snowpark(BaseConnection["Session"]):
+    _default_connection_name = "snowpark"
+
+    def __init__(self, connection_name: str = "default", **kwargs) -> None:
+        self._lock = threading.RLock()
+
+        # Grab the lock before calling BaseConnection.__init__() so that we can guarantee
+        # thread safety when the parent class' constructor initializes our connection.
+        with self._lock:
+            super().__init__(connection_name, **kwargs)
+
+    # TODO(vdonato): Teach the .connect() method how to automagically connect in a SiS
+    # runtime environment.
+    def connect(self, **kwargs) -> "Session":
+        from snowflake.snowpark.session import Session
+
+        conn_params = self.get_secrets().__nested_secrets__
+
+        if not conn_params:
+            conn_params = _load_from_snowsql_config_file()
+
+        for p in _REQUIRED_CONNECTION_PARAMS:
+            if p not in conn_params:
+                raise StreamlitAPIException(f"Missing Snowpark connection param: {p}")
+
+        return cast(Session, Session.builder.configs(conn_params).create())
+
+    def read_sql(
+        self,
+        sql: str,
+        ttl: Optional[Union[float, int, timedelta]] = None,
+    ) -> pd.DataFrame:
+        @cache_data(ttl=ttl)
+        def _read_sql(sql: str) -> pd.DataFrame:
+            with self._lock:
+                return self._instance.sql(sql).to_pandas()
+
+        return _read_sql(sql)
+
+    @contextmanager
+    def session(self) -> Iterator["Session"]:
+        with self._lock:
+            yield self._instance

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import SQL, BaseConnection
+from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
@@ -56,9 +56,11 @@ def _create_connection(
 #   1. Adding the new connection name and class to this function.
 #   2. Writing a new @overload signature mapping the connection's name to its class.
 def _get_first_party_connection(connection_name: str):
-    FIRST_PARTY_CONNECTIONS = {"sql"}
+    FIRST_PARTY_CONNECTIONS = {"snowpark", "sql"}
 
-    if connection_name == "sql":
+    if connection_name == "snowpark":
+        return Snowpark
+    elif connection_name == "sql":
         return SQL
 
     raise StreamlitAPIException(

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -1,0 +1,38 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from streamlit.connections import Snowpark
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx
+
+
+class SnowparkConnectionTest(unittest.TestCase):
+    @patch("streamlit.connections.snowpark_connection.Snowpark.connect", MagicMock())
+    def test_read_sql_caches_value(self):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+        mock_sql_return = MagicMock()
+        mock_sql_return.to_pandas = MagicMock(return_value="i am a dataframe")
+
+        conn = Snowpark()
+        conn._instance.sql.return_value = mock_sql_return
+
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        conn._instance.sql.assert_called_once()

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import SQL, BaseConnection
+from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.connection_factory import _create_connection, connection_factory
 from streamlit.runtime.scriptrunner import add_script_run_ctx
@@ -117,10 +117,9 @@ class ConnectionFactoryTest(unittest.TestCase):
         assert "Invalid connection nonexistent" in str(e.value)
 
     @patch("streamlit.runtime.connection_factory._create_connection")
-    def test_sql_connection_string_shorthand(self, patched_create_connection):
+    def test_connection_string_shorthand(self, patched_create_connection):
         connection_factory("sql")
+        patched_create_connection.assert_called_with(SQL, name="default")
 
-        patched_create_connection.assert_called_once_with(
-            SQL,
-            name="default",
-        )
+        connection_factory("snowpark")
+        patched_create_connection.assert_called_with(Snowpark, name="default")


### PR DESCRIPTION
Note: This PR is targeting the `vdonato/sql-connection` branch for now so that the diff looks nicer.
We'll retarget it to `feature/st.experimental_connection` once the other branch is merged.

## 📚 Context

This PR adds an implementation of another first party connection class: the `Snowpark` connection.
This connection is a thin wrapper around the `snowflake-snowpark-python` library to make it play nicely
with the `st.experimental_connection` factory function. It also implements locking around operations with
the underlying library so that the app author doesn't have to think of thread safety.

Similarly to with our `SQL` connector, there's still a bit of work to do for this one:
* Retries for the `read_sql` method still need to be implemented.
* We need to add some unit tests for the class itself. This will be done in a later PR.