### PR TITLE
Printed / logged strings papercut fixes

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, cast
 
+from streamlit import util
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.state import coalesce_widget_states
 
@@ -44,6 +45,9 @@ class RerunData:
     page_script_hash: str = ""
     page_name: str = ""
 
+    def __repr__(self) -> str:
+        return util.repr_(self)
+
 
 @dataclass(frozen=True)
 class ScriptRequest:
@@ -57,6 +61,9 @@ class ScriptRequest:
         if self.type is not ScriptRequestType.RERUN:
             raise RuntimeError("RerunData is only set for RERUN requests.")
         return cast(RerunData, self._rerun_data)
+
+    def __repr__(self) -> str:
+        return util.repr_(self)
 
 
 class ScriptRequests:

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -62,7 +62,7 @@ WidgetProto: TypeAlias = Union[
     TimeInput,
 ]
 
-GENERATED_WIDGET_ID_PREFIX: Final = "$$GENERATED_WIDGET_ID"
+GENERATED_WIDGET_ID_PREFIX: Final = "$$WIDGET_ID"
 
 
 T = TypeVar("T")

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import Final, TypeAlias
 
+from streamlit import util
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow
 from streamlit.proto.Button_pb2 import Button
@@ -96,6 +97,9 @@ class WidgetMetadata(Generic[T]):
     callback: WidgetCallback | None = None
     callback_args: WidgetArgs | None = None
     callback_kwargs: WidgetKwargs | None = None
+
+    def __repr__(self) -> str:
+        return util.repr_(self)
 
 
 @dataclass(frozen=True)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -32,7 +32,7 @@ from pympler.asizeof import asizeof
 from typing_extensions import Final, TypeAlias
 
 import streamlit as st
-from streamlit import config
+from streamlit import config, util
 from streamlit.errors import StreamlitAPIException, UnserializableSessionStateError
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
@@ -82,6 +82,9 @@ class WStates(MutableMapping[str, Any]):
 
     states: dict[str, WState] = field(default_factory=dict)
     widget_metadata: dict[str, WidgetMetadata[Any]] = field(default_factory=dict)
+
+    def __repr__(self):
+        return util.repr_(self)
 
     def __getitem__(self, k: str) -> Any:
         """Return the value of the widget with the given key.
@@ -281,6 +284,9 @@ class SessionState:
 
     # Keys used for widgets will be eagerly converted to the matching widget id
     _key_id_mapping: dict[str, str] = field(default_factory=dict)
+
+    def __repr__(self):
+        return util.repr_(self)
 
     # is it possible for a value to get through this without being deserialized?
     def _compact_state(self) -> None:


### PR DESCRIPTION
Shrinks the widget id prefix to reduce noise in logs, and uses the clean repr in some commonly printed dataclasses to further reduce noise.

## 📚 Context

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe:
  debugging QoL improvements

## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

