### PR TITLE
Make slight improvement to missing requirement handling

### DIFF
--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -24,6 +24,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 MODULE_EXTRACTION_REGEX = re.compile(r"No module named \'(.+)\'")
 MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "sqlalchemy": "sqlalchemy",
+    "snowflake": "snowflake-snowpark-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 


### PR DESCRIPTION
## 📚 Context

While manually testing the Snowpark first party connection, I realized that the import
can fail at multiple points when importing from a nested module.

## 🧪 Testing Done

- [x] Added/Updated unit tests