### PR TITLE
Use constraint files to install dependencies on PRs

### DIFF
--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -14,6 +14,10 @@ outputs:
   PYTHON_MAX_VERSION:
     description: Latest version of Python supported by Streamlit
     value: ${{ steps.build_info.outputs.PYTHON_MAX_VERSION }}
+  USE_CONSTRAINT_FILE:
+    description: Whether to use a constraint file to install Python dependencies
+    value: ${{ steps.build_info.outputs.USE_CONSTRAINT_FILE }}
+
 
 runs:
   using: composite

--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -157,7 +157,7 @@ def check_if_pr_has_label(action: str, label: str):
     """
     Checks if the PR has the given label.
 
-    The function works all GitHub events, but then returns false.
+    The function works for all GitHub events, but then returns false.
     """
     if GITHUB_EVENT_NAME == GithubEvent.PULL_REQUEST.value:
         pr_labels = get_current_pr_labels()
@@ -227,8 +227,11 @@ def get_output_variables() -> Dict[str, str]:
         )
         else [ALL_PYTHON_VERSIONS[0], ALL_PYTHON_VERSIONS[-1]]
     )
-    use_constraint_file = canary_build or check_if_pr_has_label(
-        "Latest dependencies will be used", LABEL_UPGRADE_DEPENDENCIES
+    use_constraint_file = not (
+        canary_build
+        or check_if_pr_has_label(
+            "Latest dependencies will be used", LABEL_UPGRADE_DEPENDENCIES
+        )
     )
     return {
         "PYTHON_MIN_VERSION": PYTHON_MIN_VERSION,

--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -153,11 +153,12 @@ def get_changed_python_dependencies_files() -> List[str]:
     return changed_dependencies_files
 
 
-def check_if_pr_has_label(action: str, label: str):
+def check_if_pr_has_label(label: str, action: str):
     """
     Checks if the PR has the given label.
 
-    The function works for all GitHub events, but then returns false.
+    The function works for all GitHub events, but returns false
+    for any event that is not a PR.
     """
     if GITHUB_EVENT_NAME == GithubEvent.PULL_REQUEST.value:
         pr_labels = get_current_pr_labels()
@@ -223,14 +224,14 @@ def get_output_variables() -> Dict[str, str]:
         ALL_PYTHON_VERSIONS
         if canary_build
         or check_if_pr_has_label(
-            "All Python versions will be tested", LABEL_FULL_MATRIX
+            LABEL_FULL_MATRIX, "All Python versions will be tested"
         )
         else [ALL_PYTHON_VERSIONS[0], ALL_PYTHON_VERSIONS[-1]]
     )
     use_constraint_file = not (
         canary_build
         or check_if_pr_has_label(
-            "Latest dependencies will be used", LABEL_UPGRADE_DEPENDENCIES
+            LABEL_UPGRADE_DEPENDENCIES, "Latest dependencies will be used"
         )
     )
     return {

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -52,6 +52,7 @@ jobs:
       PYTHON_VERSIONS: ${{ steps.build_info.outputs.PYTHON_VERSIONS }}
       PYTHON_MIN_VERSION: ${{ steps.build_info.outputs.PYTHON_MIN_VERSION }}
       PYTHON_MAX_VERSION: ${{ steps.build_info.outputs.PYTHON_MAX_VERSION }}
+      USE_CONSTRAINT_FILE: ${{ steps.build_info.outputs.USE_CONSTRAINT_FILE }}
 
   py_version:
     needs:
@@ -75,6 +76,7 @@ jobs:
             (matrix.python_version == 'max' && needs.build_info.outputs.PYTHON_MAX_VERSION || matrix.python_version)
           )
         }}
+      USE_CONSTRAINT_FILE: "${{ fromJson(needs.build_info.outputs.USE_CONSTRAINT_FILE )}}"
 
     steps:
       - name: Checkout Streamlit code

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ INSTALL_DEV_REQS ?= true
 INSTALL_TEST_REQS ?= true
 TENSORFLOW_SUPPORTED ?= $(shell python scripts/should_install_tensorflow.py)
 INSTALL_TENSORFLOW ?= $(shell python scripts/should_install_tensorflow.py)
+USE_CONSTRAINT_FILE ?= true
+PYTHON_VERSION := $(shell python --version | cut -d " " -f 2 | cut -d "." -f 1-2)
+CONSTRAINTS_URL ?= https://raw.githubusercontent.com/streamlit/streamlit/constraints-develop/constraints-${PYTHON_VERSION}.txt
 
 # Black magic to get module directories
 PYTHON_MODULES := $(foreach initpy, $(foreach dir, $(wildcard lib/*), $(wildcard $(dir)/__init__.py)), $(realpath $(dir $(initpy))))
@@ -95,6 +98,9 @@ python-init-test-only: lib/test-requirements.txt
 .PHONY: python-init
 python-init:
 	pip_args=("install" "--editable" "lib[snowflake]");\
+	if [ "${USE_CONSTRAINT_FILE}" = "true" ] ; then\
+		pip_args+=(--constraint "${CONSTRAINTS_URL}"); \
+	fi;\
 	if [ "${INSTALL_DEV_REQS}" = "true" ] ; then\
 		pip_args+=("--requirement" "lib/dev-requirements.txt"); \
 	fi;\


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This change introduces two changes:
- introduces the concept of the canary build.
- uses constraints files when installing dependencies for non-canary builds

**Canary build**

Canary build is a new concept, but these are PR builds that aim to quickly spot dependency issues or incompatibilities between different versions of Python. 

A build is canary if one of the following conditions is met.
* The Github event is a pull request and dependencies have been modified
* The Github event is a push, the default branch(`develop`) is checked. 

All other build is non-canary build.

**Constraints files**
For pull requests or for local installation, constraint files will now be used by default. This will improve stability as we will be using dependencies that have already been proven to work. Canary build will always install the latest dependencies.

To force install the latest dependencies:
* For PR, we can use the PR `dev:upgrade-dependencies` label.
* For a local installation, we can use the environment variable `USE_CONSTRAINT_FILE=false`.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
