### PR TITLE
Prepare support for pandas styler in data editor

### DIFF
--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -538,6 +538,39 @@ describe("getCellFromArrow", () => {
   })
 })
 
+it("doesn't apply Pandas Styler CSS for editable columns", () => {
+  const element = {
+    data: STYLER,
+    styler: {
+      uuid: "FAKE_UUID",
+      styles:
+        "#T_FAKE_UUIDrow1_col1, #T_FAKE_UUIDrow0_col0 { color: white; background-color: pink }",
+      displayValues: DISPLAY_VALUES,
+      caption: "FAKE_CAPTION",
+    },
+  }
+  const data = new Quiver(element)
+
+  const cell = getCellFromArrow(
+    { ...MOCK_NUMBER_COLUMN, isEditable: true },
+    data.getCell(1, 1),
+    element.styler.styles
+  )
+
+  expect(cell).toEqual({
+    allowOverlay: true,
+    contentAlign: "right",
+    data: 1,
+    displayData: "1",
+    isMissingValue: false,
+    kind: "number",
+    readonly: true,
+    style: "normal",
+    allowNegative: true,
+    fixedDecimals: 0,
+  })
+})
+
 describe("getColumnTypeFromArrow", () => {
   it.each([
     [

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -358,30 +358,33 @@ export function getCellFromArrow(
     return cellTemplate
   }
 
-  if (notNullOrUndefined(arrowCell.displayContent)) {
-    const displayData = processDisplayData(arrowCell.displayContent)
-    // If the display content is set, use that instead of the content.
-    // This is only supported for text, object, date, datetime, time and number cells.
-    if (cellTemplate.kind === GridCellKind.Text) {
-      cellTemplate = {
-        ...cellTemplate,
-        displayData,
-      } as TextCell
-    } else if (cellTemplate.kind === GridCellKind.Number) {
-      cellTemplate = {
-        ...cellTemplate,
-        displayData,
-      } as NumberCell
+  if (!column.isEditable) {
+    // Only apply display content and css styles to non-editable cells.
+    if (notNullOrUndefined(arrowCell.displayContent)) {
+      const displayData = processDisplayData(arrowCell.displayContent)
+      // If the display content is set, use that instead of the content.
+      // This is only supported for text, object, date, datetime, time and number cells.
+      if (cellTemplate.kind === GridCellKind.Text) {
+        cellTemplate = {
+          ...cellTemplate,
+          displayData,
+        } as TextCell
+      } else if (cellTemplate.kind === GridCellKind.Number) {
+        cellTemplate = {
+          ...cellTemplate,
+          displayData,
+        } as NumberCell
+      }
+      // TODO (lukasmasuch): Also support datetime formatting here
     }
-    // TODO (lukasmasuch): Also support datetime formatting here
-  }
 
-  if (cssStyles && arrowCell.cssId) {
-    cellTemplate = applyPandasStylerCss(
-      cellTemplate,
-      arrowCell.cssId,
-      cssStyles
-    )
+    if (cssStyles && arrowCell.cssId) {
+      cellTemplate = applyPandasStylerCss(
+        cellTemplate,
+        arrowCell.cssId,
+        cssStyles
+      )
+    }
   }
   return cellTemplate
 }

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -188,7 +188,7 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: Optional[str] = None) 
         assert isinstance(
             default_uuid, str
         ), "Default UUID must be a string for Styler data."
-        _marshall_styler(proto, data, default_uuid)
+        marshall_styler(proto, data, default_uuid)
 
     if isinstance(data, pa.Table):
         proto.data = type_util.pyarrow_table_to_bytes(data)
@@ -197,7 +197,7 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: Optional[str] = None) 
         proto.data = type_util.data_frame_to_bytes(df)
 
 
-def _marshall_styler(proto: ArrowProto, styler: Styler, default_uuid: str) -> None:
+def marshall_styler(proto: ArrowProto, styler: Styler, default_uuid: str) -> None:
     """Marshall pandas.Styler into an Arrow proto.
 
     Parameters


### PR DESCRIPTION
## 📚 Context

This PR adds support for Pandas Styler styles & display values in data editor. However, this is only activated for non-editable columns. As of now, this feature isn't really usable but it will be soon once we support configuring column editability. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [x] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
