### PR TITLE
Fix https tests by changing port

### DIFF
--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -538,6 +538,39 @@ describe("getCellFromArrow", () => {
   })
 })
 
+it("doesn't apply Pandas Styler CSS for editable columns", () => {
+  const element = {
+    data: STYLER,
+    styler: {
+      uuid: "FAKE_UUID",
+      styles:
+        "#T_FAKE_UUIDrow1_col1, #T_FAKE_UUIDrow0_col0 { color: white; background-color: pink }",
+      displayValues: DISPLAY_VALUES,
+      caption: "FAKE_CAPTION",
+    },
+  }
+  const data = new Quiver(element)
+
+  const cell = getCellFromArrow(
+    { ...MOCK_NUMBER_COLUMN, isEditable: true },
+    data.getCell(1, 1),
+    element.styler.styles
+  )
+
+  expect(cell).toEqual({
+    allowOverlay: true,
+    contentAlign: "right",
+    data: 1,
+    displayData: "1",
+    isMissingValue: false,
+    kind: "number",
+    readonly: true,
+    style: "normal",
+    allowNegative: true,
+    fixedDecimals: 0,
+  })
+})
+
 describe("getColumnTypeFromArrow", () => {
   it.each([
     [

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -358,30 +358,33 @@ export function getCellFromArrow(
     return cellTemplate
   }
 
-  if (notNullOrUndefined(arrowCell.displayContent)) {
-    const displayData = processDisplayData(arrowCell.displayContent)
-    // If the display content is set, use that instead of the content.
-    // This is only supported for text, object, date, datetime, time and number cells.
-    if (cellTemplate.kind === GridCellKind.Text) {
-      cellTemplate = {
-        ...cellTemplate,
-        displayData,
-      } as TextCell
-    } else if (cellTemplate.kind === GridCellKind.Number) {
-      cellTemplate = {
-        ...cellTemplate,
-        displayData,
-      } as NumberCell
+  if (!column.isEditable) {
+    // Only apply display content and css styles to non-editable cells.
+    if (notNullOrUndefined(arrowCell.displayContent)) {
+      const displayData = processDisplayData(arrowCell.displayContent)
+      // If the display content is set, use that instead of the content.
+      // This is only supported for text, object, date, datetime, time and number cells.
+      if (cellTemplate.kind === GridCellKind.Text) {
+        cellTemplate = {
+          ...cellTemplate,
+          displayData,
+        } as TextCell
+      } else if (cellTemplate.kind === GridCellKind.Number) {
+        cellTemplate = {
+          ...cellTemplate,
+          displayData,
+        } as NumberCell
+      }
+      // TODO (lukasmasuch): Also support datetime formatting here
     }
-    // TODO (lukasmasuch): Also support datetime formatting here
-  }
 
-  if (cssStyles && arrowCell.cssId) {
-    cellTemplate = applyPandasStylerCss(
-      cellTemplate,
-      arrowCell.cssId,
-      cssStyles
-    )
+    if (cssStyles && arrowCell.cssId) {
+      cellTemplate = applyPandasStylerCss(
+        cellTemplate,
+        arrowCell.cssId,
+        cssStyles
+      )
+    }
   }
   return cellTemplate
 }

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -188,7 +188,7 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: Optional[str] = None) 
         assert isinstance(
             default_uuid, str
         ), "Default UUID must be a string for Styler data."
-        _marshall_styler(proto, data, default_uuid)
+        marshall_styler(proto, data, default_uuid)
 
     if isinstance(data, pa.Table):
         proto.data = type_util.pyarrow_table_to_bytes(data)
@@ -197,7 +197,7 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: Optional[str] = None) 
         proto.data = type_util.data_frame_to_bytes(df)
 
 
-def _marshall_styler(proto: ArrowProto, styler: Styler, default_uuid: str) -> None:
+def marshall_styler(proto: ArrowProto, styler: Styler, default_uuid: str) -> None:
     """Marshall pandas.Styler into an Arrow proto.
 
     Parameters

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -79,7 +79,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertEqual(0, result.exit_code)
 
@@ -89,7 +88,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=False):
-
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertNotEqual(0, result.exit_code)
         self.assertIn("File does not exist", result.output)
@@ -111,7 +109,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=True), patch(
             "streamlit.web.cli._main_run"
         ), requests_mock.mock() as m:
-
             file_content = b"content"
             m.get("http://url/app.py", content=file_content)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
@@ -131,7 +128,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=True), patch(
             "streamlit.web.cli._main_run"
         ), requests_mock.mock() as m:
-
             m.get("http://url/app.py", exc=requests.exceptions.RequestException)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
                 mock_tmp.return_value.__enter__.return_value = temp_dir.path
@@ -168,7 +164,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(
                 cli, ["run", "file_name.py", "--server.port=8502"]
             )
@@ -335,7 +330,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(cli, ["hello", "--server.port=8502"])
 
         streamlit.web.bootstrap.load_config_options.assert_called_once()
@@ -355,7 +349,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(cli, ["config", "show", "--server.port=8502"])
 
         streamlit.web.bootstrap.load_config_options.assert_called_once()
@@ -502,19 +495,20 @@ class HTTPServerIntegrationTest(unittest.TestCase):
                         str(key_file),
                         "--server.headless",
                         "true",
+                        "--server.port=8510",
                     ],
                     env={**os.environ, "HOME": tmp_home},
                 )
             )
             try:
                 response = https_session.get(
-                    "https://localhost:8501/healthz", verify=str(pem_file)
+                    "https://localhost:8510/healthz", verify=str(pem_file)
                 )
                 response.raise_for_status()
                 assert response.text == "ok"
                 # HTTP traffic is restricted
                 with pytest.raises(requests.exceptions.ConnectionError):
-                    response = https_session.get("http://localhost:8501/healthz")
+                    response = https_session.get("http://localhost:8510/healthz")
                     response.raise_for_status()
             finally:
                 proc.kill()


### PR DESCRIPTION
## 📚 Context

The https test currently uses the default port. If there is already an app running on this port, the test is blocking indefinitely. This happened a couple of times during local development since the chance that I have a Streamlit app running on the default port is quite high. This PR just changes the port to a different one. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
