### PR TITLE
Fix https tests by changing port

### DIFF
--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -79,7 +79,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertEqual(0, result.exit_code)
 
@@ -89,7 +88,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=False):
-
             result = self.runner.invoke(cli, ["run", "file_name.py"])
         self.assertNotEqual(0, result.exit_code)
         self.assertIn("File does not exist", result.output)
@@ -111,7 +109,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=True), patch(
             "streamlit.web.cli._main_run"
         ), requests_mock.mock() as m:
-
             file_content = b"content"
             m.get("http://url/app.py", content=file_content)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
@@ -131,7 +128,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=True), patch(
             "streamlit.web.cli._main_run"
         ), requests_mock.mock() as m:
-
             m.get("http://url/app.py", exc=requests.exceptions.RequestException)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
                 mock_tmp.return_value.__enter__.return_value = temp_dir.path
@@ -168,7 +164,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(
                 cli, ["run", "file_name.py", "--server.port=8502"]
             )
@@ -335,7 +330,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(cli, ["hello", "--server.port=8502"])
 
         streamlit.web.bootstrap.load_config_options.assert_called_once()
@@ -355,7 +349,6 @@ class CliTest(unittest.TestCase):
         with patch("validators.url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
-
             result = self.runner.invoke(cli, ["config", "show", "--server.port=8502"])
 
         streamlit.web.bootstrap.load_config_options.assert_called_once()
@@ -502,19 +495,20 @@ class HTTPServerIntegrationTest(unittest.TestCase):
                         str(key_file),
                         "--server.headless",
                         "true",
+                        "--server.port=8510",
                     ],
                     env={**os.environ, "HOME": tmp_home},
                 )
             )
             try:
                 response = https_session.get(
-                    "https://localhost:8501/healthz", verify=str(pem_file)
+                    "https://localhost:8510/healthz", verify=str(pem_file)
                 )
                 response.raise_for_status()
                 assert response.text == "ok"
                 # HTTP traffic is restricted
                 with pytest.raises(requests.exceptions.ConnectionError):
-                    response = https_session.get("http://localhost:8501/healthz")
+                    response = https_session.get("http://localhost:8510/healthz")
                     response.raise_for_status()
             finally:
                 proc.kill()


### PR DESCRIPTION
## 📚 Context

The https test currently uses the default port. If an app is already running on this port, the test is blocking indefinitely. This happened a couple of times during local development since the chance that I have a Streamlit app running on the default port is quite high. This PR changes the port to a different one, making it much more unlikely to run into this issue.

In addition, the file wasn't correctly formatted. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
