### PR TITLE
Prefix most of our BaseConnection methods with underscores

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -27,7 +27,7 @@ class BaseConnection(ABC, Generic[T]):
 
     def __init__(self, connection_name: str = "default", **kwargs) -> None:
         if connection_name == "default":
-            connection_name = self.default_connection_name()
+            connection_name = self._default_name()
 
         self._connection_name = connection_name
         self._kwargs = kwargs
@@ -42,7 +42,7 @@ class BaseConnection(ABC, Generic[T]):
 
     def _repr_html_(self) -> str:
         # TODO(vdonato): Change this to whatever we actually want the default to be.
-        return f"Hi, I am a {self.default_connection_name()} connection!"
+        return f"Hi, I am a {self._default_name()} connection!"
 
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
@@ -67,7 +67,7 @@ class BaseConnection(ABC, Generic[T]):
         return connections_section.get(self._connection_name, AttrDict({}))
 
     @classmethod
-    def default_connection_name(cls) -> str:
+    def _default_name(cls) -> str:
         name = cls._default_connection_name
 
         if name is None:

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -33,7 +33,7 @@ class BaseConnection(ABC, Generic[T]):
         self._kwargs = kwargs
 
         self._raw_instance: Optional[T] = self.connect(**kwargs)
-        secrets_dict = self.get_secrets().to_dict()
+        secrets_dict = self._get_secrets().to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
 
@@ -47,7 +47,7 @@ class BaseConnection(ABC, Generic[T]):
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
     def _on_secrets_changed(self, _) -> None:
-        secrets_dict = self.get_secrets().to_dict()
+        secrets_dict = self._get_secrets().to_dict()
         new_hash = calc_md5(json.dumps(secrets_dict))
 
         # Only reset the connection if the secrets file section specific to this
@@ -56,7 +56,7 @@ class BaseConnection(ABC, Generic[T]):
             self._config_section_hash = new_hash
             self.reset()
 
-    def get_secrets(self) -> AttrDict:
+    def _get_secrets(self) -> AttrDict:
         connections_section = None
         if secrets_singleton.load_if_toml_exists():
             connections_section = secrets_singleton.get("connections")

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -32,10 +32,11 @@ class BaseConnection(ABC, Generic[T]):
         self._connection_name = connection_name
         self._kwargs = kwargs
 
-        self._raw_instance: Optional[T] = self.connect(**kwargs)
         secrets_dict = self._get_secrets().to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
+
+        self._raw_instance: Optional[T] = self._connect(**kwargs)
 
     def __del__(self) -> None:
         secrets_singleton.file_change_listener.disconnect(self._on_secrets_changed)
@@ -83,7 +84,7 @@ class BaseConnection(ABC, Generic[T]):
     @property
     def _instance(self) -> T:
         if self._raw_instance is None:
-            self._raw_instance = self.connect(**self._kwargs)
+            self._raw_instance = self._connect(**self._kwargs)
 
         return self._raw_instance
 
@@ -91,5 +92,5 @@ class BaseConnection(ABC, Generic[T]):
     _default_connection_name: Optional[str] = None
 
     @abstractmethod
-    def connect(self, **kwargs) -> T:
+    def _connect(self, **kwargs) -> T:
         raise NotImplementedError

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -69,7 +69,7 @@ class Snowpark(BaseConnection["Session"]):
 
     # TODO(vdonato): Teach the .connect() method how to automagically connect in a SiS
     # runtime environment.
-    def connect(self, **kwargs) -> "Session":
+    def _connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
         conn_params = self._get_secrets().to_dict()

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -72,7 +72,7 @@ class Snowpark(BaseConnection["Session"]):
     def connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
-        conn_params = self.get_secrets().to_dict()
+        conn_params = self._get_secrets().to_dict()
 
         if not conn_params:
             conn_params = _load_from_snowsql_config_file()

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -33,7 +33,7 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 class SQL(BaseConnection["Engine"]):
     _default_connection_name = "sql"
 
-    def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
+    def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
         secrets = self._get_secrets()

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -36,7 +36,7 @@ class SQL(BaseConnection["Engine"]):
     def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
-        secrets = self.get_secrets()
+        secrets = self._get_secrets()
 
         if "url" in secrets:
             url = sqlalchemy.engine.make_url(secrets["url"])

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -52,10 +52,10 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
     def test_instance_set_to_connect_return_value(self):
         assert MockConnection()._instance == "hooray, I'm connected!"
 
-    def test_default_connection_name(self):
-        assert MockConnection().default_connection_name() == "mock_connection"
+    def test_default_name(self):
+        assert MockConnection()._default_name() == "mock_connection"
 
-    def test_default_connection_name_with_unset_default(self):
+    def test_default_name_with_unset_default(self):
         class ExplodingConnection(BaseConnection[str]):
             # Intentionally don't define _default_connection_name.
 

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -68,21 +68,21 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_get_secrets(self, _):
         conn = MockConnection()
-        assert conn.get_secrets().foo == "bar"
+        assert conn._get_secrets().foo == "bar"
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_get_secrets_nondefault_connection_name(self, _):
         conn = MockConnection(connection_name="nondefault_connection_name")
-        assert conn.get_secrets().baz == "qux"
+        assert conn._get_secrets().baz == "qux"
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_get_secrets_no_matching_section(self, _):
         conn = MockConnection(connection_name="nonexistent")
-        assert conn.get_secrets() == {}
+        assert conn._get_secrets() == {}
 
     def test_get_secrets_no_secrets(self):
         conn = MockConnection()
-        assert conn.get_secrets() == {}
+        assert conn._get_secrets() == {}
 
     def test_instance_prop_caches_raw_instance(self):
         conn = MockConnection()
@@ -113,7 +113,7 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         with patch(
             "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.BaseConnection.get_secrets",
+            "streamlit.connections.base_connection.BaseConnection._get_secrets",
             MagicMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -34,7 +34,7 @@ baz="qux"
 class MockConnection(BaseConnection[str]):
     _default_connection_name = "mock_connection"
 
-    def connect(self, **kwargs) -> str:
+    def _connect(self, **kwargs) -> str:
         return "hooray, I'm connected!"
 
 
@@ -59,7 +59,7 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         class ExplodingConnection(BaseConnection[str]):
             # Intentionally don't define _default_connection_name.
 
-            def connect(self, **kwargs):
+            def _connect(self, **kwargs):
                 pass
 
         with pytest.raises(NotImplementedError):

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -22,7 +22,7 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class SnowparkConnectionTest(unittest.TestCase):
-    @patch("streamlit.connections.snowpark_connection.Snowpark.connect", MagicMock())
+    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_read_sql_caches_value(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -78,7 +78,7 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
-    @patch("streamlit.connections.sql_connection.SQL.connect", MagicMock())
+    @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
     @patch("streamlit.connections.sql_connection.pd.read_sql")
     def test_read_sql_caches_value(self, patched_read_sql):
         # Caching functions rely on an active script run ctx

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -40,7 +40,7 @@ DB_SECRETS = {
 class SQLConnectionTest(unittest.TestCase):
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
-        "streamlit.connections.sql_connection.SQL.get_secrets",
+        "streamlit.connections.sql_connection.SQL._get_secrets",
         MagicMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
     )
     @patch("sqlalchemy.create_engine")
@@ -50,7 +50,7 @@ class SQLConnectionTest(unittest.TestCase):
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
     @patch(
-        "streamlit.connections.sql_connection.SQL.get_secrets",
+        "streamlit.connections.sql_connection.SQL._get_secrets",
         MagicMock(return_value=AttrDict(DB_SECRETS)),
     )
     @patch("sqlalchemy.create_engine")
@@ -70,7 +70,7 @@ class SQLConnectionTest(unittest.TestCase):
         del secrets[missing_param]
 
         with patch(
-            "streamlit.connections.sql_connection.SQL.get_secrets",
+            "streamlit.connections.sql_connection.SQL._get_secrets",
             MagicMock(return_value=AttrDict(secrets)),
         ):
             with pytest.raises(StreamlitAPIException) as e:

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -30,7 +30,7 @@ from tests.testutil import create_mock_script_run_ctx
 class MockConnection(BaseConnection[None]):
     _default_connection_name = "mock_connection"
 
-    def connect(self, **kwargs):
+    def _connect(self, **kwargs):
         pass
 
 


### PR DESCRIPTION
## 📚 Context

Note: Added the `do-not-merge` tag for now since we're not fully set on doing this on the
product side.

When testing that connection instances work with the new and improved `st.help`,
I noticed that we were displaying docstrings for a ton of `BaseConnection` methods meant
to be used by connection authors but not final app developers.

This PR prefixes most of the `BaseConnection` methods with an underscore so that this
no longer happens. This is a tiny bit weird because `BaseConnection` methods are in this
weird place where they're both "exported" (for a connection author) and "internal" (for an
application developer), but I think it makes more sense to optimize for the convenience of
the app developer since the connection authors will tend to be more advanced users anyway.


## 🧪 Testing Done

- [x] Added/Updated unit tests