### PR TITLE
Introduce st.dialog api (Spec v2 - @st.dialog (PrPr))

### DIFF
--- a/frontend/src/components/core/Block/Block.tsx
+++ b/frontend/src/components/core/Block/Block.tsx
@@ -22,6 +22,8 @@ import { BlockNode, AppNode, ElementNode } from "src/lib/AppNode"
 import { getElementWidgetID } from "src/lib/utils"
 import withExpandable from "src/hocs/withExpandable"
 import { Form } from "src/components/widgets/Form"
+import { Dialog } from "src/components/widgets/Dialog"
+
 import Tabs from "src/components/elements/Tabs"
 
 import {
@@ -83,10 +85,35 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   )
 
   if (node.deltaBlock.type === "form") {
-    const { formId, clearOnSubmit } = node.deltaBlock.form as BlockProto.Form
+    const {
+      formId,
+      clearOnSubmit,
+      isDialog,
+      title,
+      closeOnSubmit,
+      clearOnClose,
+      dismissible,
+    } = node.deltaBlock.form as BlockProto.Form
     const submitButtonCount = props.formsData.submitButtonCount.get(formId)
     const hasSubmitButton =
       submitButtonCount !== undefined && submitButtonCount > 0
+    if (isDialog) {
+      return (
+        <Dialog
+          formId={formId}
+          clearOnSubmit={clearOnSubmit}
+          hasSubmitButton={hasSubmitButton}
+          scriptRunState={props.scriptRunState}
+          widgetMgr={props.widgetMgr}
+          title={title}
+          closeOnSubmit={closeOnSubmit}
+          clearOnClose={clearOnClose}
+          dismissible={dismissible}
+        >
+          {child}
+        </Dialog>
+      )
+    }
     return (
       <Form
         formId={formId}

--- a/frontend/src/components/shared/Modal/Modal.tsx
+++ b/frontend/src/components/shared/Modal/Modal.tsx
@@ -85,6 +85,7 @@ function ModalBody({ children }: ModalBodyProps): ReactElement {
         color: colors.bodyText,
         fontSize: fontSizes.md,
         overflowY: "auto",
+        overflowX: "hidden",
       }}
     >
       {children}

--- a/frontend/src/components/widgets/Dialog/Dialog.tsx
+++ b/frontend/src/components/widgets/Dialog/Dialog.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, ReactNode, useEffect, useState } from "react"
+import Modal, { ModalHeader, ModalBody } from "src/components/shared/Modal"
+import { ScriptRunState } from "src/lib/ScriptRunState"
+import { WidgetStateManager } from "src/lib/WidgetStateManager"
+import {
+  shouldDialogBeOpened,
+  clearShouldDialogBeOpened,
+  shouldDialogBeClosed,
+  closeDialog,
+} from "src/lib/utils"
+
+export interface State {
+  isOpen: boolean
+}
+
+export interface Props {
+  formId: string
+  clearOnSubmit: boolean
+  hasSubmitButton: boolean
+  scriptRunState: ScriptRunState
+  children?: ReactNode
+  widgetMgr: WidgetStateManager
+  title: string
+  closeOnSubmit: boolean
+  clearOnClose: boolean
+  dismissible: boolean
+}
+
+export function Dialog(props: Props): ReactElement {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const {
+    clearOnSubmit,
+    widgetMgr,
+    formId,
+    children,
+    title,
+    closeOnSubmit,
+    clearOnClose,
+    dismissible,
+  } = props
+
+  // Tell WidgetStateManager if this dialog form state so that it can
+  // do the right thing when the dialog form is submitted.
+  useEffect(() => {
+    widgetMgr.setFormState(
+      formId,
+      clearOnSubmit,
+      closeOnSubmit,
+      clearOnClose,
+      setIsOpen
+    )
+  }, [
+    widgetMgr,
+    formId,
+    clearOnSubmit,
+    clearOnClose,
+    closeOnSubmit,
+    setIsOpen,
+  ])
+
+  if (shouldDialogBeOpened(formId)) {
+    clearShouldDialogBeOpened(formId)
+    setIsOpen(true)
+  } else if (shouldDialogBeClosed(formId)) {
+    if (clearOnClose) {
+      widgetMgr.clearForm(formId)
+    }
+    closeDialog(formId)
+    setIsOpen(false)
+  }
+  return (
+    <Modal
+      isOpen={isOpen}
+      closeable={dismissible}
+      onClose={() => {
+        if (clearOnClose) {
+          widgetMgr.clearForm(formId)
+        }
+        closeDialog(formId)
+        setIsOpen(false)
+      }}
+    >
+      <ModalHeader>{title}</ModalHeader>
+      <ModalBody>{children}</ModalBody>
+    </Modal>
+  )
+}

--- a/frontend/src/components/widgets/Dialog/index.tsx
+++ b/frontend/src/components/widgets/Dialog/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Dialog } from "./Dialog"

--- a/frontend/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/src/components/widgets/Form/FormSubmitButton.tsx
@@ -58,7 +58,9 @@ export function FormSubmitButton(props: Props): ReactElement {
           size={Size.SMALL}
           fluidWidth={element.useContainerWidth || false}
           disabled={disabled || hasInProgressUpload}
-          onClick={() => widgetMgr.submitForm(element)}
+          onClick={() => {
+            widgetMgr.submitForm(element)
+          }}
         >
           <StreamlitMarkdown
             source={element.label}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -448,20 +448,85 @@ export function extractPageNameFromPathName(
   )
 }
 
-export const TESTING_QUERY_PARAM_KEY = "_stcore_testing"
-export function isTesting(): boolean {
+export function isQueryParam(key: string): boolean {
   const urlParams = new URLSearchParams(window.location.search)
-  let isTesting = false
+  let isQueryParam = false
   urlParams.forEach((paramValue, paramKey) => {
     paramKey = paramKey.toString().toLowerCase()
     paramValue = paramValue.toString().toLowerCase()
-    if (
-      paramKey === TESTING_QUERY_PARAM_KEY.toLowerCase() &&
-      paramValue === "true"
-    ) {
-      isTesting = true
-      return isTesting
+    if (paramKey === key.toLowerCase() && paramValue.length > 0) {
+      isQueryParam = true
+      return isQueryParam
     }
   })
-  return isTesting
+  return isQueryParam
+}
+
+export function getQueryParam(key: string): string {
+  const urlParams = new URLSearchParams(window.location.search)
+  let result = ""
+  urlParams.forEach((paramValue, paramKey) => {
+    paramKey = paramKey.toString().toLowerCase()
+    paramValue = paramValue.toString().toLowerCase()
+    if (paramKey === key.toLowerCase() && paramValue === "true") {
+      result = paramValue
+    }
+  })
+  return result
+}
+
+export const TESTING_QUERY_PARAM_KEY = "_stcore_testing"
+export function isTesting(): boolean {
+  return isQueryParam(TESTING_QUERY_PARAM_KEY)
+}
+
+export const OPEN_DIALOG_QUERY_PARAM_KEY = "_stcore_open_dialog"
+export const CLOSE_DIALOG_QUERY_PARAM_KEY = "_stcore_close_dialog"
+export function shouldDialogBeOpened(formId: string): string {
+  return getQueryParam(
+    `${OPEN_DIALOG_QUERY_PARAM_KEY}_${formId}`.trim().toLowerCase()
+  )
+}
+export function shouldDialogBeClosed(formId: string): string {
+  return getQueryParam(
+    `${CLOSE_DIALOG_QUERY_PARAM_KEY}_${formId}`.trim().toLowerCase()
+  )
+}
+export function clearDialogParams(formId: string): void {
+  const openKey = `${OPEN_DIALOG_QUERY_PARAM_KEY}_${formId}`
+    .trim()
+    .toLowerCase()
+  const closeKey = `${CLOSE_DIALOG_QUERY_PARAM_KEY}_${formId}`
+    .trim()
+    .toLowerCase()
+  const urlParams = new URLSearchParams(window.location.search)
+  urlParams.delete(openKey)
+  urlParams.delete(closeKey)
+  let params = urlParams.toString()
+  if (params.length > 0) {
+    params = `?${params}`
+  }
+  const newUrl = window.location.origin + window.location.pathname + params
+  window.history.replaceState({ path: newUrl }, "", newUrl)
+  try {
+    if (window.parent && window.parent.history && window.parent.location) {
+      const parentURLParams = new URLSearchParams(
+        window.parent.location.search
+      )
+      parentURLParams.delete(openKey)
+      parentURLParams.delete(closeKey)
+      let params = urlParams.toString()
+      if (params.length > 0) {
+        params = `?${params}`
+      }
+      const newUrl = window.location.origin + window.location.pathname + params
+      window.parent.history.replaceState({ path: newUrl }, "", newUrl)
+    }
+  } catch (err) {}
+}
+export function clearShouldDialogBeOpened(formId: string): void {
+  clearDialogParams(formId)
+}
+export function closeDialog(formId: string): void {
+  clearDialogParams(formId)
 }

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -134,6 +134,7 @@ error = _main.error
 exception = _main.exception
 file_uploader = _main.file_uploader
 form = _main.form
+dialog = _main.dialog
 form_submit_button = _main.form_submit_button
 graphviz_chart = _main.graphviz_chart
 header = _main.header

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -52,6 +52,7 @@ from streamlit.elements.color_picker import ColorPickerMixin
 from streamlit.elements.data_editor import DataEditorMixin
 from streamlit.elements.dataframe_selector import DataFrameSelectorMixin
 from streamlit.elements.deck_gl_json_chart import PydeckMixin
+from streamlit.elements.dialog import DialogMixin
 from streamlit.elements.doc_string import HelpMixin
 from streamlit.elements.empty import EmptyMixin
 from streamlit.elements.exception import ExceptionMixin
@@ -163,6 +164,7 @@ class DeltaGenerator(
     ExceptionMixin,
     FileUploaderMixin,
     FormMixin,
+    DialogMixin,
     GraphvizMixin,
     HeadingMixin,
     HelpMixin,

--- a/lib/streamlit/elements/button.py
+++ b/lib/streamlit/elements/button.py
@@ -344,7 +344,7 @@ class ButtonMixin:
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)
         if is_in_form(self.dg):
             raise StreamlitAPIException(
-                f"`st.download_button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
+                f"`st.download_button()` can't be used in an `st.form()` or `st.dialog()`.{FORM_DOCS_INFO}"
             )
 
         download_button_proto = DownloadButtonProto()
@@ -407,11 +407,11 @@ class ButtonMixin:
         if runtime.exists():
             if is_in_form(self.dg) and not is_form_submitter:
                 raise StreamlitAPIException(
-                    f"`st.button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
+                    f"`st.button()` can't be used in an `st.form() or `st.dialog()`.{FORM_DOCS_INFO}"
                 )
             elif not is_in_form(self.dg) and is_form_submitter:
                 raise StreamlitAPIException(
-                    f"`st.form_submit_button()` must be used inside an `st.form()`.{FORM_DOCS_INFO}"
+                    f"`st.form_submit_button()` must be used inside an `st.form() or `st.dialog()`.{FORM_DOCS_INFO}"
                 )
 
         button_proto = ButtonProto()

--- a/lib/streamlit/elements/dialog.py
+++ b/lib/streamlit/elements/dialog.py
@@ -1,0 +1,221 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import urllib.parse
+from typing import TYPE_CHECKING, Optional, cast
+
+from streamlit.elements.form import FormData, build_duplicate_key_message, is_in_form
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto import Block_pb2
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.proto.PageInfo_pb2 import PageInfo
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+class DialogMixin:
+    @gather_metrics("dialog")
+    def dialog(
+        self,
+        title: str,
+        *,
+        close_on_submit: bool = True,
+        clear_on_close: bool = True,
+        clear_on_submit: bool = False,
+        dismissible: bool = True,
+        key: Optional[str] = None,
+    ) -> DeltaGenerator:
+        """Create a modal dialog that shows up as an overlay on top of the app.
+
+        A dialog is a container that contains elements and widgets.
+        To add elements to a dialog, you can use `with` notation or just call methods directly on the dialog. See examples below.
+
+        Dialogs work similarly to [forms](https://docs.streamlit.io/library/api-reference/control-flow/st.form):
+            * It can contain one or multiple submit buttons via st.form_submit_button.
+            * When the viewer interacts with a widget inside of a dialog, the app does not rerun.
+                Only when a submit button is pressed, are all widget values inside the dialog sent to Streamlit in a batch.
+            * `st.button` and `st.download_button` cannot be added to dialogs.
+            * Dialogs cannot contain other dialogs or forms.
+        But there are also some differences:
+            * Dialogs do not have to contain a submit button (only if `dismissible` is set to False).
+            * Dialogs need to be opened by calling their `.open()` method in order to show them. See examples below.
+            * Dialogs are closed automatically when pressing a submit button, as long as close_on_submit is set to `True` (the default).
+                If it is set to `False`, you need to manually close the dialog by calling `.close()` on it. See examples below.
+
+        Parameters
+        ----------
+        title : str
+            The title of the dialog, displayed at the top.
+        close_on_submit : bool
+             If `True`, the dialog with be closed when a submit button is pressed.
+             If `False`, the dialog needs to be manually closed by calling `.close()` on the return object.
+             This is useful e.g. to validate widget input and only close the dialog if it’s valid.
+             Defaults to `True`.
+        clear_on_close : bool
+            If `True`, all widgets inside the dialog will be reset to their default values when the form closes.
+            Defaults to `True`. Note that custom components are unaffected by this parameter and will not be reset.
+        clear_on_submit : bool
+            If `True`, all widgets inside the dialog will be reset to their default values when a submit button is pressed.
+            Defaults to `False`. Note that custom components are unaffected by this parameter and will not be reset.
+        dismissible : bool
+             If `True`, the dialog shows a close button in the top right and can be dismissed by clicking
+             on this button or on the background of the app, or by pressing `Esc`. Note: if `dismissible` is set to `False`,
+             the dialog has to contain a submit button. Defaults to `True`.
+        key : str
+            A string that identifies the dialog. If this is omitted, a key will be generated for the dialog based on its title.
+
+        Examples
+        --------
+        Create a simple dialog that just shows text to the user:
+
+        >>> import streamlit as st
+        >>>
+        >>> dial = st.dialog("Warning")
+        >>> dial.write("Here's a warning!")
+        >>>
+        >>> if st.button("Show warning"):
+        >>>     dial.open()
+        >>>
+
+        Of course, you could also show charts, dataframes, or any other static element instead.
+        Note that this dialog doesn’t contain a submit button.
+        That’s valid as long as you don’t set `dismissible` to `False`.
+
+        Create a dialog with interactive widgets and retrieve their values:
+
+        >>> import streamlit as st
+        >>>
+        >>> dial = st.dialog("Data entry")
+        >>> with dial:
+        >>>     name = st.text_input("What's your name?")
+        >>>     age = st.number_input("What's your age?", min_value=0)
+        >>>     submitted = st.form_submit_button("Submit")
+        >>>
+        >>> if st.button("Enter data"):
+        >>>     dial.open()
+        >>>
+        >>> if submitted:
+        >>>     st.write(f"Your name is {name} and you are {age} years old.")
+        >>>
+
+        Note that you should **always** create the dialog outside of where you are actually opening it!
+        Here, we are creating the dialog on the top level of the code. Inside the `if st.button(”Enter data”)` block,
+        we are just calling `dial.open()`. If you would also create the dialog inside of that block,
+        it would be impossible to retrieve name and age, the return values of the widgets:
+        the dialog code would only be run directly after the viewer pressed the “Enter data” button.
+        Once they click the submit button inside the dialog, the “Enter data” button would return False again,
+        and the dialog code wouldn’t be called at all – therefore not setting name and age.
+
+        Create a dialog that is closed programmatically, e.g. after validating the user input:
+
+        >>> import streamlit as st
+        >>>
+        >>> forbidden_animals = ["Lion", "Snake", "Shark"]
+        >>>
+        >>> dial = st.dialog("Animal check", close_on_submit=False)
+        >>> with dial:
+        >>>     animal = st.text_input("Enter the animal")
+        >>>     if st.form_submit_button("Submit"):
+        >>>         if animal in forbidden_animals:
+        >>>             st.error("This animal is forbidden! Try another one.")
+        >>>         else:
+        >>>             dial.close()
+        >>>
+        >>> if st.button("Check an animal"):
+        >>>     dial.open()
+        >>>
+
+        """
+
+        # Import this here to avoid circular imports.
+        from streamlit.elements.utils import check_session_state_rules
+
+        if is_in_form(self.dg):
+            raise StreamlitAPIException("Forms cannot be nested in other forms.")
+
+        if not key:
+            key = title
+
+        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+
+        # A form is uniquely identified by its key.
+        form_id = key
+
+        ctx = get_script_run_ctx()
+        if ctx is not None:
+            new_form_id = form_id not in ctx.form_ids_this_run
+            if new_form_id:
+                ctx.form_ids_this_run.add(form_id)
+            else:
+                raise StreamlitAPIException(build_duplicate_key_message(key))
+
+        block_proto = Block_pb2.Block()
+        block_proto.form.is_dialog = True
+        block_proto.form.title = title
+        block_proto.form.form_id = form_id
+        block_proto.form.clear_on_submit = clear_on_submit
+        block_proto.form.close_on_submit = close_on_submit
+        block_proto.form.clear_on_close = clear_on_close
+        block_proto.form.dismissible = dismissible
+        block_dg = self.dg._block(block_proto)
+
+        # Attach the form's button info to the newly-created block's
+        # DeltaGenerator.
+        block_dg._form_data = FormData(form_id)
+        return block_dg
+
+    def open(self):
+        if not self.dg._form_data:
+            return
+        form_id = urllib.parse.quote_plus(self.dg._form_data.form_id.strip().lower())
+        ctx = get_script_run_ctx()
+        if not ctx:
+            return
+        if f"_stcore_open_dialog_{form_id}" in ctx.query_string:
+            return
+        txt = f"_stcore_open_dialog_{form_id}=true"
+        if not ctx.query_string:
+            ctx.query_string = f"{txt}"
+        else:
+            ctx.query_string = f"{ctx.query_string}&{txt}"
+        ctx.enqueue(
+            ForwardMsg(page_info_changed=PageInfo(query_string=ctx.query_string))
+        )
+
+    def close(self):
+        if not self.dg._form_data:
+            return
+        form_id = urllib.parse.quote_plus(self.dg._form_data.form_id.strip().lower())
+        ctx = get_script_run_ctx()
+        if not ctx:
+            return
+        if f"_stcore_close_dialog_{form_id}" in ctx.query_string:
+            return
+        txt = f"_stcore_close_dialog_{form_id}=true"
+        if not ctx.query_string:
+            ctx.query_string = f"{txt}"
+        else:
+            ctx.query_string = f"{ctx.query_string}&{txt}"
+        ctx.enqueue(
+            ForwardMsg(page_info_changed=PageInfo(query_string=ctx.query_string))
+        )
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -87,27 +87,27 @@ def is_in_form(dg: DeltaGenerator) -> bool:
     return current_form_id(dg) != ""
 
 
-def _build_duplicate_form_message(user_key: str | None = None) -> str:
+def build_duplicate_key_message(user_key: str | None = None) -> str:
     if user_key is not None:
         message = textwrap.dedent(
             f"""
-            There are multiple identical forms with `key='{user_key}'`.
+            There are multiple identical dialogs/forms with `key='{user_key}'`.
 
             To fix this, please make sure that the `key` argument is unique for
-            each `st.form` you create.
+            each `st.dialog` and `st.form` you create.
             """
         )
     else:
         message = textwrap.dedent(
             """
-            There are multiple identical forms with the same generated key.
+            There are multiple identical dialogs/forms with the same generated key.
 
             When a form is created, it's assigned an internal key based on
             its structure. Multiple forms with an identical structure will
             result in the same internal key, which causes this error.
 
             To fix this error, please pass a unique `key` argument to
-            `st.form`.
+            `st.dialog` and `st.form`.
             """
         )
 
@@ -196,7 +196,7 @@ class FormMixin:
             if new_form_id:
                 ctx.form_ids_this_run.add(form_id)
             else:
-                raise StreamlitAPIException(_build_duplicate_form_message(key))
+                raise StreamlitAPIException(build_duplicate_key_message(key))
 
         block_proto = Block_pb2.Block()
         block_proto.form.form_id = form_id

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -253,6 +253,19 @@ class Runtime:
             return None
         return session_info.client
 
+    def get_app_session(self, session_id: str) -> Optional[AppSession]:
+        """Get the AppSession for the given session_id, or None
+        if no such session exists.
+
+        Notes
+        -----
+        Threading: SAFE. May be called on any thread.
+        """
+        session_info = self._session_mgr.get_active_session_info(session_id)
+        if session_info is None:
+            return None
+        return session_info.session
+
     def _on_files_updated(self, session_id: str) -> None:
         """Event handler for UploadedFileManager.on_file_added.
         Ensures that uploaded files from stale sessions get deleted.

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -153,6 +153,9 @@ class RunWarningTest(unittest.TestCase):
                 "video",
                 "warning",
                 "write",
+                "dialog",
+                "open",
+                "close",
             },
         )
 

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -199,7 +199,8 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
             st.form(key="foo")
 
         self.assertIn(
-            "There are multiple identical forms with `key='foo'`", str(ctx.exception)
+            "There are multiple identical dialogs/forms with `key='foo'`",
+            str(ctx.exception),
         )
 
     def test_multiple_forms_same_labels_different_keys(self):
@@ -230,7 +231,8 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
                 st.button("foo")
 
         self.assertIn(
-            "`st.button()` can't be used in an `st.form()`", str(ctx.exception)
+            "`st.button()` can't be used in an `st.form() or `st.dialog()`",
+            str(ctx.exception),
         )
 
     def test_form_block_data(self):
@@ -260,7 +262,7 @@ class FormSubmitButtonTest(DeltaGeneratorTestCase):
             st.form_submit_button()
 
         self.assertIn(
-            "`st.form_submit_button()` must be used inside an `st.form()`",
+            "`st.form_submit_button()` must be used inside an `st.form() or `st.dialog()",
             str(ctx.exception),
         )
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -148,6 +148,7 @@ class StreamlitTest(unittest.TestCase):
                 "experimental_connection",
                 "get_option",
                 "set_option",
+                "dialog",
             },
         )
 

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -49,6 +49,11 @@ message Block {
   message Form {
     string form_id = 1;
     bool clear_on_submit = 2;
+    bool is_dialog = 3;
+    string title = 4;
+    bool close_on_submit = 5;
+    bool clear_on_close = 6;
+    bool dismissible = 7;
   }
 
   message TabContainer {


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This PR adds Dialog api to Streamlit

- What kind of change does this PR introduce?
  - [x] Feature

## 🧠 Description of Changes

This PR Adds the ability to overlay (a subset of) content on top of the Streamlit applications.

A modal window creates a mode that disables the main window but keeps it visible, with the modal window as a child window in front of it. Users must interact with the modal window before they can return to the parent application. 

This PR adds a new command called `st.dialog`. The main purpose of this widget is getting a user input, without disrupting the application flow. It is similiar to `st.form` in its behaviour.

- act as a context manager
- allow selected types of input
- defer rerun until the submit button is clicked

It has a header/title.

  - [x] This is a visible (user-facing) change


## 🧪 Revised

- [x] Screenshots included

![image](https://user-images.githubusercontent.com/78742618/231718359-148dc738-63fd-4ae2-84fc-47eb4679fe88.png)
![image](https://user-images.githubusercontent.com/78742618/231718535-4bf02489-5278-4962-992a-d7a5d47fa47b.png)
![image](https://user-images.githubusercontent.com/78742618/231718674-dd2c7756-ec3b-49ff-a871-005acf79a6cf.png)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
