### PR TITLE
Unpin pillow

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -38,8 +38,7 @@ INSTALL_REQUIRES = [
     "numpy",
     "packaging>=14.1",
     "pandas<2,>=0.25",
-    # Temp pin pillow to below 9.5 until we investigate the breaking changes that cause our tests to fail
-    "pillow>=6.2.0, <9.5.0",
+    "pillow>=6.2.0",
     "protobuf<4,>=3.12",
     "pyarrow>=4.0",
     "pympler>=0.9",

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -7,7 +7,6 @@ chart-studio>=1.1.0
 graphviz>=0.17
 matplotlib>=3.3.4
 opencv-python>=4.5.3
-pillow<9.5.0
 plotly>=5.3.1
 pydot>=1.4.2
 scipy>=1.7.3

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -534,7 +534,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
 
         @cache_decorator
         def img_fn_multi():
-            st.image([create_image(5), create_image(15), create_image(1)])
+            st.image([create_image(5), create_image(15), create_image(100)])
 
         img_fn_multi()
         img_fn_multi()


### PR DESCRIPTION
Fixing rectangle generation in tests allows us to remove the upper bound on pillow, as I have determined that the failure does not reflect a potential problem in our code, just incidental to the test.




## 🧠 Description of Changes

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change



## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

