### PR TITLE
Rework connection factory function API

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -19,17 +19,17 @@ from typing import Generic, Optional, TypeVar
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
 from streamlit.util import calc_md5
 
-T = TypeVar("T")
+RawConnectionT = TypeVar("RawConnectionT")
 
 
-class BaseConnection(ABC, Generic[T]):
+class BaseConnection(ABC, Generic[RawConnectionT]):
     """TODO(vdonato): docstrings for this class and all public methods."""
 
     def __init__(self, connection_name: str, **kwargs) -> None:
         self._connection_name = connection_name
         self._kwargs = kwargs
 
-        self._raw_instance: Optional[T] = self.connect(**kwargs)
+        self._raw_instance: Optional[RawConnectionT] = self.connect(**kwargs)
         secrets_dict = self.get_secrets().to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
@@ -68,7 +68,7 @@ class BaseConnection(ABC, Generic[T]):
         self._raw_instance = None
 
     @property
-    def _instance(self) -> T:
+    def _instance(self) -> RawConnectionT:
         if self._raw_instance is None:
             self._raw_instance = self.connect(**self._kwargs)
 
@@ -76,5 +76,5 @@ class BaseConnection(ABC, Generic[T]):
 
     # Abstract fields/methods that subclasses of BaseConnection must implement
     @abstractmethod
-    def connect(self, **kwargs) -> T:
+    def connect(self, **kwargs) -> RawConnectionT:
         raise NotImplementedError

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -25,10 +25,7 @@ T = TypeVar("T")
 class BaseConnection(ABC, Generic[T]):
     """TODO(vdonato): docstrings for this class and all public methods."""
 
-    def __init__(self, connection_name: str = "default", **kwargs) -> None:
-        if connection_name == "default":
-            connection_name = self.default_connection_name()
-
+    def __init__(self, connection_name: str, **kwargs) -> None:
         self._connection_name = connection_name
         self._kwargs = kwargs
 
@@ -42,7 +39,7 @@ class BaseConnection(ABC, Generic[T]):
 
     def _repr_html_(self) -> str:
         # TODO(vdonato): Change this to whatever we actually want the default to be.
-        return f"Hi, I am a {self.default_connection_name()} connection!"
+        return f"Hi, I am a {self._connection_name} connection!"
 
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
@@ -66,16 +63,6 @@ class BaseConnection(ABC, Generic[T]):
 
         return connections_section.get(self._connection_name, AttrDict({}))
 
-    @classmethod
-    def default_connection_name(cls) -> str:
-        name = cls._default_connection_name
-
-        if name is None:
-            raise NotImplementedError(
-                "Subclasses of BaseConnection must define a _default_connection_name attribute."
-            )
-        return name
-
     # TODO(vdonato): Finalize the name for this method. Should this be `invalidate`?
     def reset(self) -> None:
         self._raw_instance = None
@@ -88,8 +75,6 @@ class BaseConnection(ABC, Generic[T]):
         return self._raw_instance
 
     # Abstract fields/methods that subclasses of BaseConnection must implement
-    _default_connection_name: Optional[str] = None
-
     @abstractmethod
     def connect(self, **kwargs) -> T:
         raise NotImplementedError

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -57,9 +57,7 @@ def _load_from_snowsql_config_file() -> Dict[str, Any]:
 
 
 class Snowpark(BaseConnection["Session"]):
-    _default_connection_name = "snowpark"
-
-    def __init__(self, connection_name: str = "default", **kwargs) -> None:
+    def __init__(self, connection_name: str, **kwargs) -> None:
         self._lock = threading.RLock()
 
         # Grab the lock before calling BaseConnection.__init__() so that we can guarantee

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -31,8 +31,6 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
 class SQL(BaseConnection["Engine"]):
-    _default_connection_name = "sql"
-
     def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import re
-from typing import Any, Dict, Type, TypeVar, overload
+from typing import Any, Dict, Type, TypeVar, Union, overload
 
 from typing_extensions import Final, Literal
 
@@ -21,7 +22,16 @@ from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.secrets import secrets_singleton
 
+# NOTE: Adding support for a new first party connection requires:
+#   1. Adding the new connection name and class to this dict.
+#   2. Writing a new @overload for connection_factory.
+#   3. Updating test_get_first_party_connection_helper in connection_factory_test.py.
+FIRST_PARTY_CONNECTIONS = {
+    "snowpark": Snowpark,
+    "sql": SQL,
+}
 MODULE_EXTRACTION_REGEX = re.compile(r"No module named \'(.+)\'")
 MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "sqlalchemy": "sqlalchemy",
@@ -41,7 +51,7 @@ ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
 @gather_metrics("experimental_connection")
 @cache_resource
 def _create_connection(
-    connection_class: Type[ConnectionClass], name: str = "default", **kwargs
+    name: str, connection_class: Type[ConnectionClass], **kwargs
 ) -> ConnectionClass:
     """Create an instance of connection_class with the given name and kwargs.
 
@@ -49,44 +59,59 @@ def _create_connection(
     connection_class must be a concrete type. The public-facing connection API allows
     the user to specify the connection class to use as a string literal for convenience.
     """
+
+    if not issubclass(connection_class, BaseConnection):
+        raise StreamlitAPIException(
+            f"{connection_class} is not a subclass of BaseConnection!"
+        )
+
     return connection_class(connection_name=name, **kwargs)
 
 
-# NOTE: Adding support for a new first party connection requires:
-#   1. Adding the new connection name and class to this function.
-#   2. Writing a new @overload signature mapping the connection's name to its class.
-def _get_first_party_connection(connection_name: str):
-    FIRST_PARTY_CONNECTIONS = {"snowpark", "sql"}
-
-    if connection_name == "snowpark":
-        return Snowpark
-    elif connection_name == "sql":
-        return SQL
+def _get_first_party_connection(connection_class: str):
+    if connection_class in FIRST_PARTY_CONNECTIONS:
+        return FIRST_PARTY_CONNECTIONS[connection_class]
 
     raise StreamlitAPIException(
-        f"Invalid connection {connection_name}. "
+        f"Invalid connection '{connection_class}'. "
         f"Supported connection classes: {FIRST_PARTY_CONNECTIONS}"
     )
 
 
 @overload
 def connection_factory(
-    connection_class: Literal["sql"],
-    name: str = "default",
-    autocommit: bool = False,
-    **kwargs,
+    name: str, connection_class: Literal["sql"], autocommit: bool = False, **kwargs
 ) -> SQL:
     pass
 
 
 @overload
 def connection_factory(
-    connection_class: Type[ConnectionClass], name: str = "default", **kwargs
+    name: str, connection_class: Literal["snowpark"], **kwargs
+) -> Snowpark:
+    pass
+
+
+@overload
+def connection_factory(
+    name: str, connection_class: Type[ConnectionClass], **kwargs
 ) -> ConnectionClass:
     pass
 
 
-def connection_factory(connection_class, name="default", **kwargs):
+@overload
+def connection_factory(
+    name: str, connection_class: Union[str, None], **kwargs
+) -> BaseConnection[Any]:
+    pass
+
+
+# TODO(vdonato): Decide between the following names for the second parameter of this
+# function:
+#   * type (not great because it conflicts with a builtin function)
+#   * type_ (the Python convention for avoiding `type` the name conflict, but feels funny)
+#   * connection_class (a bit more verbose than `type_`)
+def connection_factory(name, connection_class=None, **kwargs):
     """TODO(vdonato): Write a docstring (maybe with the help of the documentation team).
 
     The docstring should describe:
@@ -94,11 +119,33 @@ def connection_factory(connection_class, name="default", **kwargs):
         literal as the connection_class.
       * Plugging your own ConnectionClass into st.experimental_connection.
     """
-    if type(connection_class) == str:
-        connection_class = _get_first_party_connection(connection_class)
 
+    if connection_class is None:
+        secrets_singleton.load_if_toml_exists()
+
+        # The user didn't specify a connection_class, so we try to pull it out from
+        # their secrets.toml file. NOTE: we're okay with any of the dict lookups
+        # below exploding with a KeyError since, if connection_class isn't explicitly
+        # specified here, it must be the case that it's defined in secrets.toml and
+        # should raise an Exception otherwise.
+        connection_class = secrets_singleton["connections"][name]["connection_class"]
+
+    if type(connection_class) == str:
+        # We assume that a connection_class specified via string is either the fully
+        # qualified name of a class (its module and exported classname) or the string
+        # literal shorthand for one of our first party connections. In the former case,
+        # connection_class will always contain a "." in its name.
+        if "." in connection_class:
+            parts = connection_class.split(".")
+            classname = parts.pop()
+            connection_module = importlib.import_module(".".join(parts))
+            connection_class = getattr(connection_module, classname)
+        else:
+            connection_class = _get_first_party_connection(connection_class)
+
+    # At this point, connection_class should be of type Type[ConnectionClass].
     try:
-        return _create_connection(connection_class, name=name, **kwargs)
+        return _create_connection(name, connection_class, **kwargs)
     except ModuleNotFoundError as e:
         err_string = str(e)
         missing_module = re.search(MODULE_EXTRACTION_REGEX, err_string)

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -14,7 +14,7 @@
 
 import importlib
 import re
-from typing import Any, Dict, Type, TypeVar, Union, overload
+from typing import Any, Dict, Optional, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
@@ -101,7 +101,7 @@ def connection_factory(
 
 @overload
 def connection_factory(
-    name: str, connection_class: Union[str, None], **kwargs
+    name: str, connection_class: Optional[str], **kwargs
 ) -> BaseConnection[Any]:
     pass
 

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -30,7 +30,7 @@ class SnowparkConnectionTest(unittest.TestCase):
         mock_sql_return = MagicMock()
         mock_sql_return.to_pandas = MagicMock(return_value="i am a dataframe")
 
-        conn = Snowpark()
+        conn = Snowpark("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
         assert conn.read_sql("SELECT 1;") == "i am a dataframe"

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -45,7 +45,7 @@ class SQLConnectionTest(unittest.TestCase):
     )
     @patch("sqlalchemy.create_engine")
     def test_url_set_explicitly_in_secrets(self, patched_create_engine):
-        SQL()
+        SQL("my_sql_connection")
 
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
@@ -55,7 +55,7 @@ class SQLConnectionTest(unittest.TestCase):
     )
     @patch("sqlalchemy.create_engine")
     def test_url_constructed_from_secrets_params(self, patched_create_engine):
-        SQL()
+        SQL("my_sql_connection")
 
         patched_create_engine.assert_called_once()
         args, _ = patched_create_engine.call_args_list[0]
@@ -74,7 +74,7 @@ class SQLConnectionTest(unittest.TestCase):
             MagicMock(return_value=AttrDict(secrets)),
         ):
             with pytest.raises(StreamlitAPIException) as e:
-                SQL()
+                SQL("my_sql_connection")
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
@@ -85,7 +85,7 @@ class SQLConnectionTest(unittest.TestCase):
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
-        conn = SQL()
+        conn = SQL("my_sql_connection")
 
         assert conn.read_sql("SELECT 1;") == "i am a dataframe"
         assert conn.read_sql("SELECT 1;") == "i am a dataframe"

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -12,18 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from parameterized import parameterized
 
 from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
-from streamlit.runtime.connection_factory import _create_connection, connection_factory
+from streamlit.runtime.connection_factory import (
+    _create_connection,
+    _get_first_party_connection,
+    connection_factory,
+)
 from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import secrets_singleton
 from tests.testutil import create_mock_script_run_ctx
 
 
@@ -38,6 +44,10 @@ class ConnectionFactoryTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
+        # st.secrets modifies os.environ, so we save it here and
+        # restore in tearDown.
+        self._prev_environ = dict(os.environ)
+
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
 
@@ -45,14 +55,123 @@ class ConnectionFactoryTest(unittest.TestCase):
         super().tearDown()
         _create_connection.clear()
 
-    def test_passes_name_and_args_to_class(self):
-        conn = connection_factory(MockConnection, name="nondefault", foo="bar")
-        assert conn._connection_name == "nondefault"
+        secrets_singleton._reset()
+
+        os.environ.clear()
+        os.environ.update(self._prev_environ)
+
+    def test_create_connection_helper_explodes_if_not_BaseConnection_subclass(self):
+        class NotABaseConnection:
+            pass
+
+        with pytest.raises(StreamlitAPIException) as e:
+            _create_connection("my_connection", NotABaseConnection)
+
+        assert "is not a subclass of BaseConnection" in str(e.value)
+
+    @parameterized.expand(
+        [
+            ("snowpark", Snowpark),
+            ("sql", SQL),
+        ]
+    )
+    def test_get_first_party_connection_helper(
+        self, connection_class_name, expected_connection_class
+    ):
+        assert (
+            _get_first_party_connection(connection_class_name)
+            == expected_connection_class
+        )
+
+    def test_get_first_party_connection_helper_errors_when_invalid(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            _get_first_party_connection("not_a_first_party_connection")
+
+        assert "Invalid connection" in str(e.value)
+
+    @parameterized.expand(
+        [
+            # No connection_class is specified, and there's no config file to find one
+            # in.
+            (None, FileNotFoundError, "No secrets files found"),
+            # Nonexistent module.
+            (
+                "nonexistent.module.SomeConnection",
+                ModuleNotFoundError,
+                "No module named 'nonexistent'",
+            ),
+            # The module exists, but the connection_class doesn't.
+            (
+                "streamlit.connections.Nonexistent",
+                AttributeError,
+                "module 'streamlit.connections' has no attribute 'Nonexistent'",
+            ),
+            # Invalid first party connection name.
+            (
+                "not_a_first_party_connection",
+                StreamlitAPIException,
+                "Invalid connection 'not_a_first_party_connection'",
+            ),
+        ]
+    )
+    def test_connection_factory_errors(
+        self, connection_class, expected_error_class, expected_error_msg
+    ):
+        with pytest.raises(expected_error_class) as e:
+            connection_factory(
+                "nonexistsent_connection", connection_class=connection_class
+            )
+
+        assert expected_error_msg in str(e.value)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_class_with_full_name_in_kwargs(
+        self, patched_create_connection
+    ):
+        connection_factory(
+            "my_connection", connection_class="streamlit.connections.SQL"
+        )
+
+        patched_create_connection.assert_called_once_with("my_connection", SQL)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_first_party_class_in_kwargs(self, patched_create_connection):
+        connection_factory("my_connection", connection_class="sql")
+
+        patched_create_connection.assert_called_once_with("my_connection", SQL)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_class_with_full_name_in_config(
+        self, patched_create_connection
+    ):
+        mock_toml = """
+[connections.my_connection]
+connection_class="streamlit.connections.SQL"
+"""
+        with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
+            connection_factory("my_connection")
+
+        patched_create_connection.assert_called_once_with("my_connection", SQL)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_first_party_class_in_config(self, patched_create_connection):
+        mock_toml = """
+[connections.my_connection]
+connection_class="snowpark"
+"""
+        with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
+            connection_factory("my_connection")
+
+        patched_create_connection.assert_called_once_with("my_connection", Snowpark)
+
+    def test_can_pass_class_directly_to_factory_func(self):
+        conn = connection_factory("my_connection", MockConnection, foo="bar")
+        assert conn._connection_name == "my_connection"
         assert conn._kwargs == {"foo": "bar"}
 
     def test_caches_connection_instance(self):
-        conn = connection_factory(MockConnection)
-        assert connection_factory(MockConnection) is conn
+        conn = connection_factory("my_connection", MockConnection)
+        assert connection_factory("my_connection", MockConnection) is conn
 
     @parameterized.expand(
         [
@@ -75,7 +194,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         )
 
         with pytest.raises(ModuleNotFoundError) as e:
-            connection_factory(MockConnection)
+            connection_factory("my_connection", MockConnection)
         assert str(e.value) == (
             f"No module named '{missing_module}'. "
             f"You need to install the '{pypi_package}' package to use this connection."
@@ -88,7 +207,7 @@ class ConnectionFactoryTest(unittest.TestCase):
     def test_generic_missing_dependency_error(self):
         """Test our generic error message when a ModuleNotFoundError is thrown."""
         with pytest.raises(ModuleNotFoundError) as e:
-            connection_factory(MockConnection)
+            connection_factory("my_connection", MockConnection)
         assert str(e.value) == (
             "No module named 'foo'. "
             "You may be missing a dependency required to use this connection."
@@ -109,17 +228,3 @@ class ConnectionFactoryTest(unittest.TestCase):
         for m in modules:
             for disallowed_import in DISALLOWED_IMPORTS:
                 assert disallowed_import not in m
-
-    def test_raises_exception_when_passed_invalid_class_string(self):
-        with pytest.raises(StreamlitAPIException) as e:
-            connection_factory("nonexistent")
-
-        assert "Invalid connection nonexistent" in str(e.value)
-
-    @patch("streamlit.runtime.connection_factory._create_connection")
-    def test_connection_string_shorthand(self, patched_create_connection):
-        connection_factory("sql")
-        patched_create_connection.assert_called_with(SQL, name="default")
-
-        connection_factory("snowpark")
-        patched_create_connection.assert_called_with(Snowpark, name="default")


### PR DESCRIPTION
## 📚 Context

This PR reworks the API of the `st.experimental_connection` factory function. After some discussion, we
decided that it'd be better to flip the arguments so that the name of a connection comes before its type.
We also (although this is still being finalized) decided to allow users to specify the types of their connections
either via the corresponding section in the `secrets.toml` file or via `kwarg` to the factory function. 

Note:
* static typechecking tools will only be able to infer the exact type of a connection if specified via `kwarg`.
* there are still some details about the exact behavior that we're ironing out, but tweaks from here
   should be quite straightforward, so it's worth reviewing this PR now and potentially making changes
   down the line.

