### PR TITLE
Tweak some st.experimental_connection-related names

### DIFF
--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -14,6 +14,8 @@
 
 
 # Explicitly re-export public symbols.
-from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.base_connection import (
+    ExperimentalBaseConnection as ExperimentalBaseConnection,
+)
 from streamlit.connections.snowpark_connection import Snowpark as Snowpark
 from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -45,7 +45,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
     def _on_secrets_changed(self, _) -> None:
-        secrets_dict = self.get_secrets().to_dict()
+        secrets_dict = self._get_secrets().to_dict()
         new_hash = calc_md5(json.dumps(secrets_dict))
 
         # Only reset the connection if the secrets file section specific to this
@@ -54,7 +54,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
             self._config_section_hash = new_hash
             self.reset()
 
-    def get_secrets(self) -> AttrDict:
+    def _get_secrets(self) -> AttrDict:
         connections_section = None
         if secrets_singleton.load_if_toml_exists():
             connections_section = secrets_singleton.get("connections")

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -22,7 +22,7 @@ from streamlit.util import calc_md5
 RawConnectionT = TypeVar("RawConnectionT")
 
 
-class BaseConnection(ABC, Generic[RawConnectionT]):
+class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     """TODO(vdonato): docstrings for this class and all public methods."""
 
     def __init__(self, connection_name: str, **kwargs) -> None:
@@ -76,7 +76,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
 
         return self._raw_instance
 
-    # Abstract fields/methods that subclasses of BaseConnection must implement
+    # Abstract fields/methods that subclasses of ExperimentalBaseConnection must implement
     @abstractmethod
     def _connect(self, **kwargs) -> RawConnectionT:
         raise NotImplementedError

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -29,7 +29,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         self._connection_name = connection_name
         self._kwargs = kwargs
 
-        secrets_dict = self._get_secrets().to_dict()
+        secrets_dict = self._secrets.to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
 
@@ -45,7 +45,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
     def _on_secrets_changed(self, _) -> None:
-        secrets_dict = self._get_secrets().to_dict()
+        secrets_dict = self._secrets.to_dict()
         new_hash = calc_md5(json.dumps(secrets_dict))
 
         # Only reset the connection if the secrets file section specific to this
@@ -54,7 +54,8 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
             self._config_section_hash = new_hash
             self.reset()
 
-    def _get_secrets(self) -> AttrDict:
+    @property
+    def _secrets(self) -> AttrDict:
         connections_section = None
         if secrets_singleton.load_if_toml_exists():
             connections_section = secrets_singleton.get("connections")

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -70,7 +70,7 @@ class Snowpark(BaseConnection["Session"]):
     def _connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
-        conn_params = self._get_secrets().to_dict()
+        conn_params = self._secrets.to_dict()
 
         if not conn_params:
             conn_params = _load_from_snowsql_config_file()

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import BaseConnection
+from streamlit.connections import ExperimentalBaseConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -56,12 +56,13 @@ def _load_from_snowsql_config_file() -> Dict[str, Any]:
     return conn_params
 
 
-class Snowpark(BaseConnection["Session"]):
+class Snowpark(ExperimentalBaseConnection["Session"]):
     def __init__(self, connection_name: str, **kwargs) -> None:
         self._lock = threading.RLock()
 
-        # Grab the lock before calling BaseConnection.__init__() so that we can guarantee
-        # thread safety when the parent class' constructor initializes our connection.
+        # Grab the lock before calling ExperimentalBaseConnection.__init__() so that we
+        # can guarantee thread safety when the parent class' constructor initializes our
+        # connection.
         with self._lock:
             super().__init__(connection_name, **kwargs)
 

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -70,7 +70,7 @@ class Snowpark(BaseConnection["Session"]):
     def _connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
-        conn_params = self.get_secrets().to_dict()
+        conn_params = self._get_secrets().to_dict()
 
         if not conn_params:
             conn_params = _load_from_snowsql_config_file()

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -67,7 +67,7 @@ class Snowpark(BaseConnection["Session"]):
 
     # TODO(vdonato): Teach the .connect() method how to automagically connect in a SiS
     # runtime environment.
-    def connect(self, **kwargs) -> "Session":
+    def _connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
         conn_params = self.get_secrets().to_dict()

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -34,7 +34,7 @@ class SQL(BaseConnection["Engine"]):
     def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
-        secrets = self._get_secrets()
+        secrets = self._secrets
 
         if "url" in secrets:
             url = sqlalchemy.engine.make_url(secrets["url"])

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -31,7 +31,7 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
 class SQL(BaseConnection["Engine"]):
-    def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
+    def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
         secrets = self.get_secrets()

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -34,7 +34,7 @@ class SQL(BaseConnection["Engine"]):
     def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
-        secrets = self.get_secrets()
+        secrets = self._get_secrets()
 
         if "url" in secrets:
             url = sqlalchemy.engine.make_url(secrets["url"])

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import BaseConnection
+from streamlit.connections import ExperimentalBaseConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
-class SQL(BaseConnection["Engine"]):
+class SQL(ExperimentalBaseConnection["Engine"]):
     def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import SQL, BaseConnection, Snowpark
+from streamlit.connections import SQL, ExperimentalBaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
@@ -39,10 +39,11 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 
-# The BaseConnection bound is parameterized to `Any` below as subclasses of
-# BaseConnection are responsible for binding the type parameter of BaseConnection to a
-# concrete type, but the type it gets bound to isn't important to us here.
-ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
+# The ExperimentalBaseConnection bound is parameterized to `Any` below as subclasses of
+# ExperimentalBaseConnection are responsible for binding the type parameter of
+# ExperimentalBaseConnection to a concrete type, but the type it gets bound to isn't
+# important to us here.
+ConnectionClass = TypeVar("ConnectionClass", bound=ExperimentalBaseConnection[Any])
 
 
 # NOTE: The order of the decorators below is important: @gather_metrics must be above
@@ -60,9 +61,9 @@ def _create_connection(
     the user to specify the connection class to use as a string literal for convenience.
     """
 
-    if not issubclass(connection_class, BaseConnection):
+    if not issubclass(connection_class, ExperimentalBaseConnection):
         raise StreamlitAPIException(
-            f"{connection_class} is not a subclass of BaseConnection!"
+            f"{connection_class} is not a subclass of ExperimentalBaseConnection!"
         )
 
     return connection_class(connection_name=name, **kwargs)
@@ -102,7 +103,7 @@ def connection_factory(
 @overload
 def connection_factory(
     name: str, connection_class: Optional[str], **kwargs
-) -> BaseConnection[Any]:
+) -> ExperimentalBaseConnection[Any]:
     pass
 
 

--- a/lib/tests/streamlit/connections/__init__.py
+++ b/lib/tests/streamlit/connections/__init__.py
@@ -11,6 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Explicitly re-export public symbols.
-from streamlit.connections.base_connection import BaseConnection as BaseConnection

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -27,7 +27,7 @@ foo="bar"
 
 
 class MockConnection(BaseConnection[str]):
-    def connect(self, **kwargs) -> str:
+    def _connect(self, **kwargs) -> str:
         return "hooray, I'm connected!"
 
 

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -50,16 +50,16 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_get_secrets(self, _):
         conn = MockConnection("my_mock_connection")
-        assert conn.get_secrets().foo == "bar"
+        assert conn._get_secrets().foo == "bar"
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_get_secrets_no_matching_section(self, _):
         conn = MockConnection("nonexistent")
-        assert conn.get_secrets() == {}
+        assert conn._get_secrets() == {}
 
     def test_get_secrets_no_secrets(self):
         conn = MockConnection("my_mock_connection")
-        assert conn.get_secrets() == {}
+        assert conn._get_secrets() == {}
 
     def test_instance_prop_caches_raw_instance(self):
         conn = MockConnection("my_mock_connection")
@@ -90,7 +90,7 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         with patch(
             "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.BaseConnection.get_secrets",
+            "streamlit.connections.base_connection.BaseConnection._get_secrets",
             MagicMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -14,7 +14,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import PropertyMock, mock_open, patch
 
 import streamlit as st
 from streamlit.connections import BaseConnection
@@ -48,18 +48,18 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
-    def test_get_secrets(self, _):
+    def test_secrets_property(self, _):
         conn = MockConnection("my_mock_connection")
-        assert conn._get_secrets().foo == "bar"
+        assert conn._secrets.foo == "bar"
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
-    def test_get_secrets_no_matching_section(self, _):
+    def test_secrets_property_no_matching_section(self, _):
         conn = MockConnection("nonexistent")
-        assert conn._get_secrets() == {}
+        assert conn._secrets == {}
 
-    def test_get_secrets_no_secrets(self):
+    def test_secrets_property_no_secrets(self):
         conn = MockConnection("my_mock_connection")
-        assert conn._get_secrets() == {}
+        assert conn._secrets == {}
 
     def test_instance_prop_caches_raw_instance(self):
         conn = MockConnection("my_mock_connection")
@@ -90,8 +90,8 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         with patch(
             "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.BaseConnection._get_secrets",
-            MagicMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
+            "streamlit.connections.base_connection.BaseConnection._secrets",
+            PropertyMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_called_once()

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -17,7 +17,7 @@ import unittest
 from unittest.mock import PropertyMock, mock_open, patch
 
 import streamlit as st
-from streamlit.connections import BaseConnection
+from streamlit.connections import ExperimentalBaseConnection
 from streamlit.runtime.secrets import AttrDict
 
 MOCK_TOML = """
@@ -26,12 +26,12 @@ foo="bar"
 """
 
 
-class MockConnection(BaseConnection[str]):
+class MockConnection(ExperimentalBaseConnection[str]):
     def _connect(self, **kwargs) -> str:
         return "hooray, I'm connected!"
 
 
-class BaseConnectionDefaultMethodTests(unittest.TestCase):
+class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
     def setUp(self) -> None:
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
@@ -79,7 +79,7 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         # conn.reset() shouldn't be called because secrets haven't changed since conn
         # was constructed.
         with patch(
-            "streamlit.connections.base_connection.BaseConnection.reset"
+            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
         ) as patched_reset:
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_not_called()
@@ -88,9 +88,9 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         conn = MockConnection("my_mock_connection")
 
         with patch(
-            "streamlit.connections.base_connection.BaseConnection.reset"
+            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.BaseConnection._secrets",
+            "streamlit.connections.base_connection.ExperimentalBaseConnection._secrets",
             PropertyMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -22,7 +22,7 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class SnowparkConnectionTest(unittest.TestCase):
-    @patch("streamlit.connections.snowpark_connection.Snowpark.connect", MagicMock())
+    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_read_sql_caches_value(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -78,7 +78,7 @@ class SQLConnectionTest(unittest.TestCase):
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
-    @patch("streamlit.connections.sql_connection.SQL.connect", MagicMock())
+    @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
     @patch("streamlit.connections.sql_connection.pd.read_sql")
     def test_read_sql_caches_value(self, patched_read_sql):
         # Caching functions rely on an active script run ctx

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -15,7 +15,7 @@
 import threading
 import unittest
 from copy import deepcopy
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -40,8 +40,8 @@ DB_SECRETS = {
 class SQLConnectionTest(unittest.TestCase):
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
-        "streamlit.connections.sql_connection.SQL._get_secrets",
-        MagicMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
+        "streamlit.connections.sql_connection.SQL._secrets",
+        PropertyMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
     )
     @patch("sqlalchemy.create_engine")
     def test_url_set_explicitly_in_secrets(self, patched_create_engine):
@@ -50,8 +50,8 @@ class SQLConnectionTest(unittest.TestCase):
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
     @patch(
-        "streamlit.connections.sql_connection.SQL._get_secrets",
-        MagicMock(return_value=AttrDict(DB_SECRETS)),
+        "streamlit.connections.sql_connection.SQL._secrets",
+        PropertyMock(return_value=AttrDict(DB_SECRETS)),
     )
     @patch("sqlalchemy.create_engine")
     def test_url_constructed_from_secrets_params(self, patched_create_engine):
@@ -70,8 +70,8 @@ class SQLConnectionTest(unittest.TestCase):
         del secrets[missing_param]
 
         with patch(
-            "streamlit.connections.sql_connection.SQL._get_secrets",
-            MagicMock(return_value=AttrDict(secrets)),
+            "streamlit.connections.sql_connection.SQL._secrets",
+            PropertyMock(return_value=AttrDict(secrets)),
         ):
             with pytest.raises(StreamlitAPIException) as e:
                 SQL("my_sql_connection")

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -40,7 +40,7 @@ DB_SECRETS = {
 class SQLConnectionTest(unittest.TestCase):
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
-        "streamlit.connections.sql_connection.SQL.get_secrets",
+        "streamlit.connections.sql_connection.SQL._get_secrets",
         MagicMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
     )
     @patch("sqlalchemy.create_engine")
@@ -50,7 +50,7 @@ class SQLConnectionTest(unittest.TestCase):
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
     @patch(
-        "streamlit.connections.sql_connection.SQL.get_secrets",
+        "streamlit.connections.sql_connection.SQL._get_secrets",
         MagicMock(return_value=AttrDict(DB_SECRETS)),
     )
     @patch("sqlalchemy.create_engine")
@@ -70,7 +70,7 @@ class SQLConnectionTest(unittest.TestCase):
         del secrets[missing_param]
 
         with patch(
-            "streamlit.connections.sql_connection.SQL.get_secrets",
+            "streamlit.connections.sql_connection.SQL._get_secrets",
             MagicMock(return_value=AttrDict(secrets)),
         ):
             with pytest.raises(StreamlitAPIException) as e:

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -36,7 +36,7 @@ from tests.testutil import create_mock_script_run_ctx
 class MockConnection(BaseConnection[None]):
     _default_connection_name = "mock_connection"
 
-    def connect(self, **kwargs):
+    def _connect(self, **kwargs):
         pass
 
 

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import SQL, BaseConnection, Snowpark
+from streamlit.connections import SQL, ExperimentalBaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.connection_factory import (
     _create_connection,
@@ -33,7 +33,7 @@ from streamlit.runtime.secrets import secrets_singleton
 from tests.testutil import create_mock_script_run_ctx
 
 
-class MockConnection(BaseConnection[None]):
+class MockConnection(ExperimentalBaseConnection[None]):
     _default_connection_name = "mock_connection"
 
     def _connect(self, **kwargs):
@@ -60,14 +60,16 @@ class ConnectionFactoryTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self._prev_environ)
 
-    def test_create_connection_helper_explodes_if_not_BaseConnection_subclass(self):
+    def test_create_connection_helper_explodes_if_not_ExperimentalBaseConnection_subclass(
+        self,
+    ):
         class NotABaseConnection:
             pass
 
         with pytest.raises(StreamlitAPIException) as e:
             _create_connection("my_connection", NotABaseConnection)
 
-        assert "is not a subclass of BaseConnection" in str(e.value)
+        assert "is not a subclass of ExperimentalBaseConnection" in str(e.value)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
NOTE: This is being targeted to the `vdonato/rework-api` branch for now to make the diff show up nicely.
We'll be merging #6436 first, at which point we'll retarget this PR to `feature/st.experimental_connection`.

## 📚 Context

This is a small PR to tweak some names related to the upcoming `st.experimental_connection` feature.
We make the following changes:

* Prefixed all methods meant to be used by the connection author with an underscore.
* Renamed `get_secrets()` -> `_secrets` and made it a property
* Renamed `BaseConnection` -> `ExperimentalBaseConnection`

