### PR TITLE
Fix: Broken Nightly Build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,9 @@ jobs:
 
   run-python-tests:
     needs: create-nightly-tag
+    permissions:
+      # Pass additional permission needed to upload constraints
+      contents: write
     uses: ./.github/workflows/python-versions.yml
     with:
       ref: ${{needs.create-nightly-tag.outputs.tag}}


### PR DESCRIPTION
## 📚 Context

Changes made as part of [this PR](https://github.com/streamlit/streamlit/pull/6234) to `python-versions.yml`, specifically the `py_constraint` job expanded the workflow's necessary permissions. This then broke the Nightly Build workflow (see [failure log](https://github.com/streamlit/streamlit/actions/runs/4626145170)) - this is intended to fix nightly, with follow-ons likely necessary to the Release Candidate and Release workflows. 

- What kind of change does this PR introduce?
  - [x] Other, please describe: Fix nightly build workflow