### PR TITLE
Allow st.experimental_connection callers to set a name via envvar

### DIFF
--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import os
 import re
 from typing import Any, Dict, Optional, Type, TypeVar, overload
 
@@ -120,6 +121,13 @@ def connection_factory(name, connection_class=None, **kwargs):
         literal as the connection_class.
       * Plugging your own ConnectionClass into st.experimental_connection.
     """
+    USE_ENV_PREFIX = "env:"
+
+    if name.startswith(USE_ENV_PREFIX):
+        # It'd be nice to use str.removeprefix() here, but we won't be able to do that
+        # until the minimium Python version we support is 3.9.
+        envvar_name = name[len(USE_ENV_PREFIX) :]
+        name = os.environ[envvar_name]
 
     if connection_class is None:
         secrets_singleton.load_if_toml_exists()

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -34,8 +34,6 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class MockConnection(ExperimentalBaseConnection[None]):
-    _default_connection_name = "mock_connection"
-
     def _connect(self, **kwargs):
         pass
 
@@ -230,3 +228,10 @@ connection_class="snowpark"
         for m in modules:
             for disallowed_import in DISALLOWED_IMPORTS:
                 assert disallowed_import not in m
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_set_connection_name_via_env_var(self, patched_create_connection):
+        os.environ["MY_CONN_NAME"] = "staging"
+        connection_factory("env:MY_CONN_NAME", MockConnection)
+
+        patched_create_connection.assert_called_once_with("staging", MockConnection)


### PR DESCRIPTION
## 📚 Context

This small feature allows users to be able to set the name of their connection in their
environment variables, then denote which environment variable to get the name from
by passing `env:<NAME_OF_ENVVAR>` to `st.experimental_connection`.

A similar pattern already exists within our config options set via command line flag or
`config.toml`.