### PR TITLE
Avoid storing GitHub token in .git directory

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,8 +140,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.create-nightly-tag.outputs.tag }}
-          # To limit the ways a secret can be leaked, it should not be kept
-          # in the repository, but in this case we need git commands to work.
+          # Save the access token to the local git config, so
+          # later git commands can work.
           persist-credentials: true
           submodules: 'recursive'
       - name: Set Python version vars
@@ -222,8 +222,8 @@ jobs:
           # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
           # Accessing streamlit/core-previews repo requires a separate auth token.
           token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
-          # To limit the ways a secret can be leaked, it should not be kept
-          # in the repository, but in this case we need git commands to work.
+          # Save the access token to the local git config, so
+          # later git commands can work.
           persist-credentials: true
       - name: Setup preview repo
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,7 +140,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.create-nightly-tag.outputs.tag }}
-          persist-credentials: false
+          # To limit the ways a secret can be leaked, it should not be kept
+          # in the repository, but in this case we need git commands to work.
+          persist-credentials: true
           submodules: 'recursive'
       - name: Set Python version vars
         uses: ./.github/actions/build_info
@@ -220,6 +222,9 @@ jobs:
           # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
           # Accessing streamlit/core-previews repo requires a separate auth token.
           token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
+          # To limit the ways a secret can be leaked, it should not be kept
+          # in the repository, but in this case we need git commands to work.
+          persist-credentials: true
       - name: Setup preview repo
         env:
           NIGHTLY_TAG: ${{ needs.create-nightly-tag.outputs.tag }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -131,6 +131,9 @@ jobs:
           # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
           # Accessing streamlit/core-previews repo requires a separate auth token.
           token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
+          # To limit the ways a secret can be leaked, it should not be kept
+          # in the repository, but in this case we need git commands to work.
+          persist-credentials: true
       - name: Setup preview repo
         env:
           PREVIEW_BRANCH: ${{ needs.upload-whl.outputs.preview-branch }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -131,8 +131,8 @@ jobs:
           # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
           # Accessing streamlit/core-previews repo requires a separate auth token.
           token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
-          # To limit the ways a secret can be leaked, it should not be kept
-          # in the repository, but in this case we need git commands to work.
+          # Save the access token to the local git config, so
+          # later git commands can work.
           persist-credentials: true
       - name: Setup preview repo
         env:

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -144,6 +144,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_BRANCH }}
+          # To limit the ways a secret can be leaked, it should not be kept
+          # in the repository, but in this case we need git commands to work.
+          persist-credentials: true
 
       - uses: actions/download-artifact@v3
         with:
@@ -193,7 +196,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-          persist-credentials: false
+          # To limit the ways a secret can be leaked, it should not be kept
+          # in the repository, but in this case we need git commands to work.
+          persist-credentials: true
           submodules: 'recursive'
       - name: Set up Python 3.8
         uses: actions/setup-python@v4

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -144,8 +144,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_BRANCH }}
-          # To limit the ways a secret can be leaked, it should not be kept
-          # in the repository, but in this case we need git commands to work.
+          # Save the access token to the local git config, so
+          # later git commands can work.
           persist-credentials: true
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -196,9 +196,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-          # To limit the ways a secret can be leaked, it should not be kept
-          # in the repository, but in this case we need git commands to work.
-          persist-credentials: true
+          persist-credentials: false
           submodules: 'recursive'
       - name: Set up Python 3.8
         uses: actions/setup-python@v4


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

This change introduces two changes:
* By default, all `action/checkout` uses now have the `persiste-credentials` flag set to False, so the GitHub token is not written to disk to limit the ways a secret can be leaked. Whenever it is necessary to use action/checkout with `persisten-credentials` set to True, it is commented out to show that this is a conscious decision and not a mistake.
* The nightly build works now as it has a GitHub token stored in the repository.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
