### PR TITLE
More misc st.experimental_connection renames

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -65,7 +65,6 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
         return connections_section.get(self._connection_name, AttrDict({}))
 
-    # TODO(vdonato): Finalize the name for this method. Should this be `invalidate`?
     def reset(self) -> None:
         self._raw_instance = None
 

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -82,17 +82,17 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
 
         return cast(Session, Session.builder.configs(conn_params).create())
 
-    def read_sql(
+    def query(
         self,
         sql: str,
         ttl: Optional[Union[float, int, timedelta]] = None,
     ) -> pd.DataFrame:
         @cache_data(ttl=ttl)
-        def _read_sql(sql: str) -> pd.DataFrame:
+        def _query(sql: str) -> pd.DataFrame:
             with self._lock:
                 return self._instance.sql(sql).to_pandas()
 
-        return _read_sql(sql)
+        return _query(sql)
 
     @contextmanager
     def session(self) -> Iterator["Session"]:

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -14,7 +14,7 @@
 
 from contextlib import contextmanager
 from datetime import timedelta
-from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Iterator, List, Optional, Union, cast
 
 import pandas as pd
 
@@ -66,17 +66,40 @@ class SQL(ExperimentalBaseConnection["Engine"]):
     def query(
         self,
         sql: str,
+        *,  # keyword-only arguments:
         ttl: Optional[Union[float, int, timedelta]] = None,
+        index_col: Optional[Union[str, List[str]]] = None,
+        chunksize: Optional[int] = None,
+        params=None,
         **kwargs,
     ) -> pd.DataFrame:
         from sqlalchemy import text
 
         @cache_data(ttl=ttl)
-        def _query(sql: str, **kwargs) -> pd.DataFrame:
+        def _query(
+            sql: str,
+            index_col=None,
+            chunksize=None,
+            params=None,
+            **kwargs,
+        ) -> pd.DataFrame:
             instance = self._instance.connect()
-            return pd.read_sql(text(sql), instance, **kwargs)
+            return pd.read_sql(
+                text(sql),
+                instance,
+                index_col=index_col,
+                chunksize=chunksize,
+                params=params,
+                **kwargs,
+            )
 
-        return _query(sql, **kwargs)
+        return _query(
+            sql,
+            index_col=index_col,
+            chunksize=chunksize,
+            params=params,
+            **kwargs,
+        )
 
     @contextmanager
     def session(self) -> Iterator["Session"]:

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -63,7 +63,7 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         else:
             return cast("Engine", eng)
 
-    def read_sql(
+    def query(
         self,
         sql: str,
         ttl: Optional[Union[float, int, timedelta]] = None,
@@ -72,11 +72,11 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         from sqlalchemy import text
 
         @cache_data(ttl=ttl)
-        def _read_sql(sql: str, **kwargs) -> pd.DataFrame:
+        def _query(sql: str, **kwargs) -> pd.DataFrame:
             instance = self._instance.connect()
             return pd.read_sql(text(sql), instance, **kwargs)
 
-        return _read_sql(sql, **kwargs)
+        return _query(sql, **kwargs)
 
     @contextmanager
     def session(self) -> Iterator["Session"]:

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -23,7 +23,7 @@ from tests.testutil import create_mock_script_run_ctx
 
 class SnowparkConnectionTest(unittest.TestCase):
     @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
-    def test_read_sql_caches_value(self):
+    def test_query_caches_value(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
 
@@ -33,6 +33,6 @@ class SnowparkConnectionTest(unittest.TestCase):
         conn = Snowpark("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
         conn._instance.sql.assert_called_once()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -80,13 +80,13 @@ class SQLConnectionTest(unittest.TestCase):
 
     @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
     @patch("streamlit.connections.sql_connection.pd.read_sql")
-    def test_read_sql_caches_value(self, patched_read_sql):
+    def test_query_caches_value(self, patched_read_sql):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQL("my_sql_connection")
 
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
         patched_read_sql.assert_called_once()

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -91,7 +91,7 @@ class ConnectionFactoryTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # No connection_class is specified, and there's no config file to find one
+            # No type is specified, and there's no config file to find one
             # in.
             (None, FileNotFoundError, "No secrets files found"),
             # Nonexistent module.
@@ -115,12 +115,10 @@ class ConnectionFactoryTest(unittest.TestCase):
         ]
     )
     def test_connection_factory_errors(
-        self, connection_class, expected_error_class, expected_error_msg
+        self, type, expected_error_class, expected_error_msg
     ):
         with pytest.raises(expected_error_class) as e:
-            connection_factory(
-                "nonexistsent_connection", connection_class=connection_class
-            )
+            connection_factory("nonexistsent_connection", type=type)
 
         assert expected_error_msg in str(e.value)
 
@@ -128,15 +126,13 @@ class ConnectionFactoryTest(unittest.TestCase):
     def test_can_specify_class_with_full_name_in_kwargs(
         self, patched_create_connection
     ):
-        connection_factory(
-            "my_connection", connection_class="streamlit.connections.SQL"
-        )
+        connection_factory("my_connection", type="streamlit.connections.SQL")
 
         patched_create_connection.assert_called_once_with("my_connection", SQL)
 
     @patch("streamlit.runtime.connection_factory._create_connection")
     def test_can_specify_first_party_class_in_kwargs(self, patched_create_connection):
-        connection_factory("my_connection", connection_class="sql")
+        connection_factory("my_connection", type="sql")
 
         patched_create_connection.assert_called_once_with("my_connection", SQL)
 
@@ -146,7 +142,7 @@ class ConnectionFactoryTest(unittest.TestCase):
     ):
         mock_toml = """
 [connections.my_connection]
-connection_class="streamlit.connections.SQL"
+type="streamlit.connections.SQL"
 """
         with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
             connection_factory("my_connection")
@@ -157,7 +153,7 @@ connection_class="streamlit.connections.SQL"
     def test_can_specify_first_party_class_in_config(self, patched_create_connection):
         mock_toml = """
 [connections.my_connection]
-connection_class="snowpark"
+type="snowpark"
 """
         with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
             connection_factory("my_connection")


### PR DESCRIPTION
Note: It's easier to review these changes commit-wise.

## 📚 Context

This PR batches some misc tweaks to `st.experimental_connection` that are all small enough to not
warrant their own PRs:
* Change the read helper method name for the `SQL` and `Snowpark` connections to `query`
* Plumb a few params through `SQL.query` to `pd.read_sql` (so that intellisense suggests them)
* Changed the name of the `connection_class` argument to `type`.
