### PR TITLE
Fix #6440: Add uuid to types we natively hash

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -25,6 +25,7 @@ import sys
 import tempfile
 import threading
 import unittest.mock
+import uuid
 import weakref
 from enum import Enum
 from typing import Any, Dict, List, Optional, Pattern
@@ -130,6 +131,7 @@ def _key(obj: Optional[Any]) -> Any:
             or isinstance(obj, float)
             or isinstance(obj, int)
             or isinstance(obj, bool)
+            or isinstance(obj, uuid.UUID)
             or obj is None
         )
 
@@ -232,6 +234,9 @@ class _CacheFuncHasher:
 
         elif isinstance(obj, int):
             return _int_to_bytes(obj)
+
+        elif isinstance(obj, uuid.UUID):
+            return obj.bytes
 
         elif isinstance(obj, (list, tuple)):
             h = hashlib.new("md5")

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -80,9 +80,20 @@ class HashTest(unittest.TestCase):
         uuid1_copy = uuid.UUID(uuid1.hex)
         uuid2 = uuid.uuid4()
 
+        # Our hashing functionality should work with UUIDs
+        # regardless of UUID factory function.
+
+        uuid3 = uuid.uuid5(uuid.NAMESPACE_DNS, "streamlit.io")
+        uuid3_copy = uuid.UUID(uuid3.hex)
+        uuid4 = uuid.uuid5(uuid.NAMESPACE_DNS, "snowflake.com")
+
         self.assertEqual(get_hash(uuid1), get_hash(uuid1_copy))
         self.assertNotEqual(id(uuid1), id(uuid1_copy))
         self.assertNotEqual(get_hash(uuid1), get_hash(uuid2))
+
+        self.assertEqual(get_hash(uuid3), get_hash(uuid3_copy))
+        self.assertNotEqual(id(uuid3), id(uuid3_copy))
+        self.assertNotEqual(get_hash(uuid3), get_hash(uuid4))
 
     def test_mocks_do_not_result_in_infinite_recursion(self):
         try:

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -21,6 +21,7 @@ import re
 import tempfile
 import types
 import unittest
+import uuid
 from dataclasses import dataclass
 from enum import Enum, auto
 from io import BytesIO, StringIO
@@ -73,6 +74,15 @@ class HashTest(unittest.TestCase):
         self.assertNotEqual(get_hash(-1), get_hash(1))
         self.assertNotEqual(get_hash(2**7), get_hash(2**7 - 1))
         self.assertNotEqual(get_hash(2**7), get_hash(2**7 + 1))
+
+    def test_uuid(self):
+        uuid1 = uuid.uuid4()
+        uuid1_copy = uuid.UUID(uuid1.hex)
+        uuid2 = uuid.uuid4()
+
+        self.assertEqual(get_hash(uuid1), get_hash(uuid1_copy))
+        self.assertNotEqual(id(uuid1), id(uuid1_copy))
+        self.assertNotEqual(get_hash(uuid1), get_hash(uuid2))
 
     def test_mocks_do_not_result_in_infinite_recursion(self):
         try:


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context
UUID is a built-in Python type (lives in the standard library). This PR adds support for uuid hashing, so it would be possible to use uuid objects as parameters for functions decorated with `@st.cache_data` 

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6440

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
