### PR TITLE
Add retry behavior to the SQL/Snowpark read helper methods

### DIFF
--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -87,6 +87,14 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
         sql: str,
         ttl: Optional[Union[float, int, timedelta]] = None,
     ) -> pd.DataFrame:
+        from tenacity import retry, stop_after_attempt, wait_fixed
+
+        @retry(
+            after=lambda _: self.reset(),
+            stop=stop_after_attempt(3),
+            reraise=True,
+            wait=wait_fixed(1),
+        )
         @cache_data(ttl=ttl)
         def _query(sql: str) -> pd.DataFrame:
             with self._lock:

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -74,7 +74,14 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         **kwargs,
     ) -> pd.DataFrame:
         from sqlalchemy import text
+        from tenacity import retry, stop_after_attempt, wait_fixed
 
+        @retry(
+            after=lambda _: self.reset(),
+            stop=stop_after_attempt(3),
+            reraise=True,
+            wait=wait_fixed(1),
+        )
         @cache_data(ttl=ttl)
         def _query(
             sql: str,

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -41,6 +41,7 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "sqlalchemy": "sqlalchemy",
     "snowflake": "snowflake-snowpark-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
+    "tenacity": "tenacity",
 }
 
 # The ExperimentalBaseConnection bound is parameterized to `Any` below as subclasses of

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -8,13 +8,14 @@ graphviz>=0.17
 matplotlib>=3.3.4
 opencv-python>=4.5.3
 plotly>=5.3.1
+pyspark>=3.1.1
 pydot>=1.4.2
+rich>=11.2.0
 scipy>=1.7.3
 seaborn>=0.11.2
 setuptools>=65.5.1
+tenacity>=8.2.2
 watchdog>=2.1.5
-rich>=11.2.0
-pyspark>=3.1.1
 
 # These requirements exist only for `@st.cache` tests. st.cache is deprecated, and
 # we're not going to update its associated tests anymore. Please don't modify

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -53,13 +53,13 @@ class SnowparkConnectionTest(unittest.TestCase):
 
         with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
             with pytest.raises(Exception):
-                conn.read_sql("SELECT 1;")
+                conn.query("SELECT 1;")
 
             # Our connection should have been reset after each failed attempt to call
-            # read_sql.
+            # query.
             assert wrapped_reset.call_count == 3
 
         # conn._connect should have been called three times: once in the initial
         # connection, then once each after the second and third attempts to call
-        # read_sql.
+        # query.
         assert conn._connect.call_count == 3

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -16,12 +16,18 @@ import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+import streamlit as st
 from streamlit.connections import Snowpark
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from tests.testutil import create_mock_script_run_ctx
 
 
 class SnowparkConnectionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        st.cache_data.clear()
+
     @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_query_caches_value(self):
         # Caching functions rely on an active script run ctx
@@ -36,3 +42,24 @@ class SnowparkConnectionTest(unittest.TestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
         assert conn.query("SELECT 1;") == "i am a dataframe"
         conn._instance.sql.assert_called_once()
+
+    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
+    def test_retry_behavior(self):
+        mock_sql_return = MagicMock()
+        mock_sql_return.to_pandas = MagicMock(side_effect=Exception("oh noes :("))
+
+        conn = Snowpark("my_snowpark_connection")
+        conn._instance.sql.return_value = mock_sql_return
+
+        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+            with pytest.raises(Exception):
+                conn.read_sql("SELECT 1;")
+
+            # Our connection should have been reset after each failed attempt to call
+            # read_sql.
+            assert wrapped_reset.call_count == 3
+
+        # conn._connect should have been called three times: once in the initial
+        # connection, then once each after the second and third attempts to call
+        # read_sql.
+        assert conn._connect.call_count == 3

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from parameterized import parameterized
 
+import streamlit as st
 from streamlit.connections import SQL
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.scriptrunner import add_script_run_ctx
@@ -38,6 +39,9 @@ DB_SECRETS = {
 
 
 class SQLConnectionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        st.cache_data.clear()
+
     @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
     @patch(
         "streamlit.connections.sql_connection.SQL._secrets",
@@ -121,3 +125,22 @@ class SQLConnectionTest(unittest.TestCase):
         )
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
+
+    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    def test_retry_behavior(self, patched_read_sql):
+        patched_read_sql.side_effect = Exception("kaboom")
+
+        conn = SQL("my_sql_connection")
+
+        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+            with pytest.raises(Exception):
+                conn.read_sql("SELECT 1;")
+
+            # Our connection should have been reset after each failed attempt to call
+            # read_sql.
+            assert wrapped_reset.call_count == 3
+
+        # conn._connect should have been called three times: once in the initial
+        # connection, then once each after the second and third attempts to call
+        # read_sql.
+        assert conn._connect.call_count == 3

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -126,6 +126,7 @@ class SQLConnectionTest(unittest.TestCase):
         assert "Dialect: `postgres`" in repr_
         assert "Configured from `[connections.my_sql_connection]`" in repr_
 
+    @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
     @patch("streamlit.connections.sql_connection.pd.read_sql")
     def test_retry_behavior(self, patched_read_sql):
         patched_read_sql.side_effect = Exception("kaboom")
@@ -134,13 +135,13 @@ class SQLConnectionTest(unittest.TestCase):
 
         with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
             with pytest.raises(Exception):
-                conn.read_sql("SELECT 1;")
+                conn.query("SELECT 1;")
 
             # Our connection should have been reset after each failed attempt to call
-            # read_sql.
+            # query.
             assert wrapped_reset.call_count == 3
 
         # conn._connect should have been called three times: once in the initial
         # connection, then once each after the second and third attempts to call
-        # read_sql.
+        # query.
         assert conn._connect.call_count == 3

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -183,6 +183,7 @@ type="snowpark"
             ("sqlalchemy", "sqlalchemy"),
             ("snowflake", "snowflake-snowpark-python"),
             ("snowflake.snowpark", "snowflake-snowpark-python"),
+            ("tenacity", "tenacity"),
         ]
     )
     @patch("streamlit.runtime.connection_factory._create_connection")


### PR DESCRIPTION
## 📚 Context

This PR adds simple retry behavior to the `read_sql` helper methods of the `SQL` and `Snowpark`
connectors. We rely on the `tenacity` library to implement this, which we add as a "dependency" only
when actually using a connection.

For now, the behavior is quite simplistic:
* We currently retry regardless of the type of the exception thrown
   * This will be improved before this feature branch is merged into `develop`
* We attempt to retry 3 times, waiting 1 second between attempts
   * This is potentially something we may improve before moving this out of the `experimental_`
      namespace. 
* After a failed call, we reset the connection entirely so that the next
   attempt to use recreates the underlying connection object.