### PR TITLE
Allow users to specify name only for first party connections

### DIFF
--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -241,3 +241,13 @@ type="snowpark"
         patched_create_connection.assert_called_once_with(
             "staging", MockConnection, max_entries=None, ttl=None
         )
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_only_set_name_if_equal_to_desired_type(
+        self, patched_create_connection
+    ):
+        connection_factory("sql")
+
+        patched_create_connection.assert_called_once_with(
+            "sql", SQL, max_entries=None, ttl=None
+        )


### PR DESCRIPTION
## 📚 Context

We decided that we want a super short way to use `st.connection` in the case that the user
wants to use a first party connection class and wants to set its name equal to its type.

This PR allows users to write
```python3
conn = st.connection("sql")
```

which ends up being equivalent to
```python3
conn = st.connection("sql", type="sql")
```