### PR TITLE
Mock theme data in tests

### DIFF
--- a/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/src/components/core/StatusWidget/StatusWidget.test.tsx
@@ -20,7 +20,7 @@ import { ConnectionState } from "src/lib/ConnectionState"
 import { ScriptRunState } from "src/lib/ScriptRunState"
 import { SessionEventDispatcher } from "src/lib/SessionEventDispatcher"
 import { SessionEvent } from "src/autogen/proto"
-import { lightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
 import StatusWidget, { StatusWidgetProps } from "./StatusWidget"
 
@@ -33,7 +33,7 @@ const getProps = (
   rerunScript: () => {},
   stopScript: () => {},
   allowRunOnSave: true,
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
   ...propOverrides,
 })
 

--- a/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -27,7 +27,7 @@ import {
   VEGA_LITE,
 } from "src/lib/mocks/arrow"
 import { Quiver } from "src/lib/Quiver"
-import { darkTheme, lightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import {
   PropsWithHeight,
   ArrowVegaLiteChart,
@@ -56,7 +56,7 @@ const getProps = (props: Partial<PropsWithHeight> = {}): PropsWithHeight => ({
   element: MOCK,
   width: 0,
   height: 0,
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
   ...props,
 })
 
@@ -69,17 +69,17 @@ describe("VegaLiteChart Element", () => {
   })
 
   it("pulls default config values from theme", () => {
-    const props = getProps({ theme: darkTheme.emotion })
+    const props = getProps({ theme: mockTheme.emotion })
 
     const wrapper = mount(<ArrowVegaLiteChart {...props} />)
     // @ts-expect-error
     const generatedSpec = wrapper.instance().generateSpec()
 
     expect(generatedSpec.config.background).toBe(
-      darkTheme.emotion.colors.bgColor
+      mockTheme.emotion.colors.bgColor
     )
     expect(generatedSpec.config.axis.labelColor).toBe(
-      darkTheme.emotion.colors.bodyText
+      mockTheme.emotion.colors.bodyText
     )
   })
 
@@ -108,7 +108,7 @@ describe("VegaLiteChart Element", () => {
   })
 
   it("has user specified config take priority", () => {
-    const props = getProps({ theme: darkTheme.emotion })
+    const props = getProps({ theme: mockTheme.emotion })
 
     const spec = JSON.parse(props.element.spec)
     spec.config = { background: "purple", axis: { labelColor: "blue" } }
@@ -127,7 +127,7 @@ describe("VegaLiteChart Element", () => {
     // Verify that things not overwritten by the user still fall back to the
     // theme default.
     expect(generatedSpec.config.axis.titleColor).toBe(
-      darkTheme.emotion.colors.bodyText
+      mockTheme.emotion.colors.bodyText
     )
   })
 

--- a/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
+++ b/frontend/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.test.tsx
@@ -17,10 +17,10 @@
 import React from "react"
 import { DeckGL } from "deck.gl"
 import { shallow } from "src/lib/test_util"
-import { lightTheme } from "src/theme"
 
 import { DeckGlJsonChart as DeckGlJsonChartProto } from "src/autogen/proto"
 import { NavigationControl } from "react-map-gl"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import { DeckGlJsonChart, PropsWithHeight } from "./DeckGlJsonChart"
 
 const getProps = (
@@ -68,7 +68,7 @@ const getProps = (
     width: 0,
     mapboxToken: "mapboxToken",
     height: undefined,
-    theme: lightTheme.emotion,
+    theme: mockTheme.emotion,
   }
 }
 

--- a/frontend/src/components/elements/Json/Json.test.tsx
+++ b/frontend/src/components/elements/Json/Json.test.tsx
@@ -17,8 +17,7 @@
 import React from "react"
 import { mount } from "src/lib/test_util"
 import { Json as JsonProto } from "src/autogen/proto"
-import ThemeProvider from "src/components/core/ThemeProvider"
-import { darkTheme, baseuiDarkTheme } from "src/theme"
+import * as themeUtils from "src/theme/utils"
 import Json, { JsonProps } from "./Json"
 
 const getProps = (elementProps: Partial<JsonProto> = {}): JsonProps => ({
@@ -33,6 +32,10 @@ const getProps = (elementProps: Partial<JsonProto> = {}): JsonProps => ({
 })
 
 describe("JSON element", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it("renders json as expected", () => {
     const props = getProps()
     const wrapper = mount(<Json {...props} />)
@@ -56,6 +59,8 @@ describe("JSON element", () => {
   })
 
   it("picks a reasonable theme when the background is light", () => {
+    jest.spyOn(themeUtils, "hasLightBackgroundColor").mockReturnValue(true)
+
     const props = getProps()
     const wrapper = mount(<Json {...props} />)
 
@@ -64,12 +69,10 @@ describe("JSON element", () => {
   })
 
   it("picks a reasonable theme when the background is dark", () => {
+    jest.spyOn(themeUtils, "hasLightBackgroundColor").mockReturnValue(false)
+
     const props = getProps()
-    const wrapper = mount(
-      <ThemeProvider theme={darkTheme.emotion} baseuiTheme={baseuiDarkTheme}>
-        <Json {...props} />
-      </ThemeProvider>
-    )
+    const wrapper = mount(<Json {...props} />)
 
     expect(wrapper.find('[theme="rjv-default"]').exists()).toBeFalsy()
     expect(wrapper.find('[theme="monokai"]').exists()).toBeTruthy()

--- a/frontend/src/components/elements/Json/Json.test.tsx
+++ b/frontend/src/components/elements/Json/Json.test.tsx
@@ -59,6 +59,8 @@ describe("JSON element", () => {
   })
 
   it("picks a reasonable theme when the background is light", () => {
+    // <Json> uses `hasLightBackgroundColor` to test whether our theme
+    // is "light" or "dark". Mock the return value for the test.
     jest.spyOn(themeUtils, "hasLightBackgroundColor").mockReturnValue(true)
 
     const props = getProps()
@@ -69,6 +71,8 @@ describe("JSON element", () => {
   })
 
   it("picks a reasonable theme when the background is dark", () => {
+    // <Json> uses `hasLightBackgroundColor` to test whether our theme
+    // is "light" or "dark". Mock the return value for the test.
     jest.spyOn(themeUtils, "hasLightBackgroundColor").mockReturnValue(false)
 
     const props = getProps()

--- a/frontend/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -19,8 +19,8 @@ import { mount } from "src/lib/test_util"
 import Plot from "react-plotly.js"
 
 import ThemeProvider from "src/components/core/ThemeProvider"
-import { darkTheme } from "src/theme"
 import { PlotlyChart as PlotlyChartProto } from "src/autogen/proto"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import mock from "./mock"
 import { DEFAULT_HEIGHT, PlotlyChartProps } from "./PlotlyChart"
 
@@ -164,16 +164,16 @@ describe("PlotlyChart Element", () => {
       const props = getProps()
       const wrapper = mount(
         <ThemeProvider
-          theme={darkTheme.emotion}
-          baseuiTheme={darkTheme.basewebTheme}
+          theme={mockTheme.emotion}
+          baseuiTheme={mockTheme.basewebTheme}
         >
           <PlotlyChart {...props} />
         </ThemeProvider>
       )
 
       const { layout } = wrapper.find(Plot).first().props()
-      expect(layout.paper_bgcolor).toBe(darkTheme.emotion.colors.bgColor)
-      expect(layout.font?.color).toBe(darkTheme.emotion.colors.bodyText)
+      expect(layout.paper_bgcolor).toBe(mockTheme.emotion.colors.bgColor)
+      expect(layout.font?.color).toBe(mockTheme.emotion.colors.bodyText)
     })
 
     it("has user specified config take priority", () => {
@@ -190,8 +190,8 @@ describe("PlotlyChart Element", () => {
 
       const wrapper = mount(
         <ThemeProvider
-          theme={darkTheme.emotion}
-          baseuiTheme={darkTheme.basewebTheme}
+          theme={mockTheme.emotion}
+          baseuiTheme={mockTheme.basewebTheme}
         >
           <PlotlyChart {...props} />
         </ThemeProvider>
@@ -201,7 +201,7 @@ describe("PlotlyChart Element", () => {
       expect(layout.paper_bgcolor).toBe("orange")
       // Verify that things not overwritten by the user still fall back to the
       // theme default.
-      expect(layout.font?.color).toBe(darkTheme.emotion.colors.bodyText)
+      expect(layout.font?.color).toBe(mockTheme.emotion.colors.bodyText)
     })
   })
 })

--- a/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.test.tsx
+++ b/frontend/src/components/elements/VegaLiteChart/VegaLiteChart.test.tsx
@@ -18,8 +18,8 @@ import React from "react"
 import { mount } from "src/lib/test_util"
 import { fromJS, Map as ImmutableMap } from "immutable"
 import { VegaLiteChart as VegaLiteChartProto } from "src/autogen/proto"
-import { darkTheme, lightTheme } from "src/theme"
 import { tableGetRowsAndCols } from "src/lib/dataFrameProto"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
 import mock from "./mock"
 import {
@@ -38,7 +38,7 @@ const getProps = (
   }) as ImmutableMap<string, any>,
   width: 0,
   height: 0,
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
   ...props,
 })
 
@@ -166,21 +166,21 @@ describe("VegaLiteChart Element", () => {
   })
 
   it("pulls default config values from theme", () => {
-    const props = getProps(undefined, { theme: darkTheme.emotion })
+    const props = getProps(undefined, { theme: mockTheme.emotion })
 
     const wrapper = mount<VegaLiteChart>(<VegaLiteChart {...props} />)
     const generatedSpec = wrapper.instance().generateSpec()
 
     expect(generatedSpec.config.background).toBe(
-      darkTheme.emotion.colors.bgColor
+      mockTheme.emotion.colors.bgColor
     )
     expect(generatedSpec.config.axis.labelColor).toBe(
-      darkTheme.emotion.colors.bodyText
+      mockTheme.emotion.colors.bodyText
     )
   })
 
   it("has user specified config take priority", () => {
-    const props = getProps(undefined, { theme: darkTheme.emotion })
+    const props = getProps(undefined, { theme: mockTheme.emotion })
 
     const spec = JSON.parse(props.element.get("spec"))
     spec.config = { background: "purple", axis: { labelColor: "blue" } }
@@ -198,7 +198,7 @@ describe("VegaLiteChart Element", () => {
     // Verify that things not overwritten by the user still fall back to the
     // theme default.
     expect(generatedSpec.config.axis.titleColor).toBe(
-      darkTheme.emotion.colors.bodyText
+      mockTheme.emotion.colors.bodyText
     )
   })
 })

--- a/frontend/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/src/components/shared/Radio/Radio.test.tsx
@@ -19,7 +19,7 @@ import { mount } from "src/lib/test_util"
 
 import { Radio as UIRadio, RadioGroup, ALIGN } from "baseui/radio"
 import { LabelVisibilityOptions } from "src/lib/utils"
-import { lightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import Radio, { Props } from "./Radio"
 
 const getProps = (props: Partial<Props> = {}): Props => ({
@@ -30,7 +30,7 @@ const getProps = (props: Partial<Props> = {}): Props => ({
   onChange: () => {},
   options: ["a", "b", "c"],
   label: "Label",
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
   ...props,
 })
 

--- a/frontend/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
+++ b/frontend/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
@@ -17,13 +17,16 @@
 import React from "react"
 import { mount } from "enzyme"
 import ThemeProvider from "src/components/core/ThemeProvider"
-import { lightTheme, baseuiLightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import TooltipIcon from "./TooltipIcon"
 
 describe("TooltipIcon element", () => {
   it("renders a TooltipIcon", () => {
     const wrapper = mount(
-      <ThemeProvider theme={lightTheme.emotion} baseuiTheme={baseuiLightTheme}>
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
         <TooltipIcon content="" />
       </ThemeProvider>
     )

--- a/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -30,9 +30,10 @@ import { mount } from "src/lib/test_util"
 import { buildHttpUri } from "src/lib/UriUtil"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import React from "react"
-import { darkTheme, lightTheme, toExportedTheme } from "src/theme"
+import { bgColorToBaseString, toExportedTheme } from "src/theme"
 import { fonts } from "src/theme/primitives/typography"
 import { mockEndpoints } from "src/lib/mocks/mocks"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import {
   COMPONENT_READY_WARNING_TIME_MS,
   ComponentInstance,
@@ -101,7 +102,7 @@ class MockComponent {
         registry={this.registry}
         width={100}
         disabled={false}
-        theme={lightTheme.emotion}
+        theme={mockTheme.emotion}
         widgetMgr={
           new WidgetStateManager({
             sendRerunBackMsg: jest.fn(),
@@ -325,15 +326,15 @@ describe("ComponentInstance", () => {
 
     const jsonArgs = {}
     const element = createElementProp(jsonArgs, [])
-    mc.wrapper.setProps({ element, theme: darkTheme.emotion })
+    mc.wrapper.setProps({ element, theme: mockTheme.emotion })
 
     expect(mc.instance.state.componentError).toBeUndefined()
 
     // We should get the theme object in our receiveForwardMsg callback.
     expect(mc.receiveForwardMsg).toHaveBeenLastCalledWith(
       renderMsg(jsonArgs, [], false, {
-        ...toExportedTheme(darkTheme.emotion),
-        base: "dark",
+        ...toExportedTheme(mockTheme.emotion),
+        base: bgColorToBaseString(mockTheme.emotion.colors.bgColor),
         font: fonts.sansSerif,
       }),
       "*"
@@ -429,7 +430,7 @@ describe("ComponentInstance", () => {
       const element = createElementProp(jsonArgs, [
         new SpecialArg({ key: "foo" }),
       ])
-      mc.wrapper.setProps({ element, theme: darkTheme.emotion })
+      mc.wrapper.setProps({ element, theme: mockTheme.emotion })
       const child = mc.wrapper.childAt(0)
       expect(child.type()).toEqual(ErrorElement)
       expect(child.prop("message")).toEqual(
@@ -593,8 +594,8 @@ function renderMsg(
   dataframes: any[],
   disabled = false,
   theme = {
-    ...toExportedTheme(lightTheme.emotion),
-    base: "light",
+    ...toExportedTheme(mockTheme.emotion),
+    base: bgColorToBaseString(mockTheme.emotion.colors.bgColor),
     font: fonts.sansSerif,
   }
 ): any {

--- a/frontend/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/src/components/widgets/DateInput/DateInput.test.tsx
@@ -23,7 +23,7 @@ import {
 } from "src/autogen/proto"
 
 import { Datepicker as UIDatePicker } from "baseui/datepicker"
-import { lightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import DateInput, { Props } from "./DateInput"
 
 const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
@@ -36,7 +36,7 @@ const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),

--- a/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -23,7 +23,7 @@ import {
   LabelVisibilityMessage as LabelVisibilityMessageProto,
   MultiSelect as MultiSelectProto,
 } from "src/autogen/proto"
-import { lightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import Multiselect, { Props } from "./Multiselect"
 
 const getProps = (elementProps: Partial<MultiSelectProto> = {}): Props => ({
@@ -36,7 +36,7 @@ const getProps = (elementProps: Partial<MultiSelectProto> = {}): Props => ({
   }),
   width: 0,
   disabled: false,
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),

--- a/frontend/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/src/components/widgets/Slider/Slider.test.tsx
@@ -24,7 +24,7 @@ import {
 } from "src/autogen/proto"
 import { mount } from "src/lib/test_util"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
-import { lightTheme } from "src/theme"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 import Slider, { Props } from "./Slider"
 
 const getProps = (elementProps: Partial<SliderProto> = {}): Props => ({
@@ -45,7 +45,7 @@ const getProps = (elementProps: Partial<SliderProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
-  theme: lightTheme.emotion,
+  theme: mockTheme.emotion,
 })
 
 describe("Slider widget", () => {

--- a/frontend/src/lib/mocks/mockTheme.ts
+++ b/frontend/src/lib/mocks/mockTheme.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** A mock theme definition for use in unit tests. */
+
+import { transparentize } from "color2k"
+import { createEmotionColors } from "src/theme"
+import {
+  breakpoints,
+  fonts,
+  fontSizes,
+  fontWeights,
+  genericFonts,
+  iconSizes,
+  lineHeights,
+  letterSpacings,
+  radii,
+  sizes,
+  spacing,
+  zIndices,
+  colors,
+} from "src/theme/primitives"
+
+const requiredThemeColors = {
+  bgColor: colors.white,
+  secondaryBg: colors.gray20,
+  bodyText: colors.gray85,
+  warning: colors.yellow110,
+  warningBg: transparentize(colors.yellow80, 0.8),
+  success: colors.green100,
+  successBg: transparentize(colors.green80, 0.8),
+  infoBg: transparentize(colors.blue70, 0.9),
+  info: colors.blue100,
+  danger: colors.red100,
+  dangerBg: transparentize(colors.red70, 0.8),
+
+  primary: colors.red70,
+  disabled: colors.gray40,
+  lightestGray: colors.gray20,
+  lightGray: colors.gray30,
+  gray: colors.gray60,
+  darkGray: colors.gray70,
+  red: colors.red80,
+  blue: colors.blue80,
+  green: colors.green80,
+  yellow: colors.yellow80,
+}
+
+interface OptionalThemeColors {
+  widgetBackgroundColor?: string
+  widgetBorderColor?: string
+}
+
+const optionalThemeColors: OptionalThemeColors = {}
+
+const genericColors = {
+  ...colors,
+  ...requiredThemeColors,
+  ...optionalThemeColors,
+}
+
+export default {
+  inSidebar: false,
+  breakpoints,
+  colors: createEmotionColors(genericColors),
+  genericColors,
+  fonts,
+  fontSizes,
+  fontWeights,
+  genericFonts,
+  iconSizes,
+  lineHeights,
+  letterSpacings,
+  radii,
+  sizes,
+  spacing,
+  zIndices,
+}

--- a/frontend/src/lib/mocks/mockTheme.ts
+++ b/frontend/src/lib/mocks/mockTheme.ts
@@ -16,8 +16,9 @@
 
 /** A mock theme definition for use in unit tests. */
 
+import { LightTheme, lightThemePrimitives } from "baseui"
 import { transparentize } from "color2k"
-import { createEmotionColors } from "src/theme"
+import { createBaseUiTheme, createEmotionColors, ThemeConfig } from "src/theme"
 import {
   breakpoints,
   fonts,
@@ -72,7 +73,7 @@ const genericColors = {
   ...optionalThemeColors,
 }
 
-export default {
+const emotionMockTheme = {
   inSidebar: false,
   breakpoints,
   colors: createEmotionColors(genericColors),
@@ -88,4 +89,17 @@ export default {
   sizes,
   spacing,
   zIndices,
+}
+
+const baseuiMockTheme = createBaseUiTheme(
+  emotionMockTheme,
+  lightThemePrimitives
+)
+
+export const mockTheme: ThemeConfig = {
+  name: "MockTheme",
+  emotion: emotionMockTheme,
+  baseweb: LightTheme,
+  basewebTheme: baseuiMockTheme,
+  primitives: lightThemePrimitives,
 }

--- a/frontend/src/lib/test_util.tsx
+++ b/frontend/src/lib/test_util.tsx
@@ -31,7 +31,8 @@ import {
 /* eslint-enable */
 import React, { Component, FC, ReactElement } from "react"
 import ThemeProvider from "src/components/core/ThemeProvider"
-import { lightTheme, EmotionTheme } from "src/theme"
+import { EmotionTheme } from "src/theme"
+import { mockTheme } from "./mocks/mockTheme"
 
 export function mount<C extends Component, P = C["props"], S = C["state"]>(
   node: ReactElement<P>,
@@ -42,7 +43,7 @@ export function mount<C extends Component, P = C["props"], S = C["state"]>(
     ...(options || {}),
     wrappingComponent: ThemeProvider,
     wrappingComponentProps: {
-      theme: theme || lightTheme.emotion,
+      theme: theme || mockTheme.emotion,
     },
   }
 
@@ -58,7 +59,7 @@ export function shallow<C extends Component, P = C["props"], S = C["state"]>(
     ...(options || {}),
     wrappingComponent: ThemeProvider,
     wrappingComponentProps: {
-      theme: theme || lightTheme.emotion,
+      theme: theme || mockTheme.emotion,
     },
   }
 
@@ -66,7 +67,7 @@ export function shallow<C extends Component, P = C["props"], S = C["state"]>(
 }
 
 const RenderWrapper: FC = ({ children }) => {
-  return <ThemeProvider theme={lightTheme.emotion}>{children}</ThemeProvider>
+  return <ThemeProvider theme={mockTheme.emotion}>{children}</ThemeProvider>
 }
 
 /**


### PR DESCRIPTION
Some of our tests use concrete `lightTheme`/`darkTheme` theme implementations. When the upcoming lib/app frontend split happens, our component test files will no longer have access to these themes. 

This PR adds a new `mockTheme` theme, and changes our tests to use it instead.