### PR TITLE
Merge config parameters from various sources in SQL/Snowpark connections

### DIFF
--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -21,6 +21,7 @@
 import configparser
 import os
 import threading
+from collections import ChainMap
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
@@ -28,7 +29,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
 import pandas as pd
 
 from streamlit.connections import ExperimentalBaseConnection
-from streamlit.connections.util import merge_dicts
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -72,12 +72,10 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
     def _connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
-        conn_params = merge_dicts(
-            [
-                _load_from_snowsql_config_file(),
-                self._secrets.to_dict(),
-                kwargs,
-            ]
+        conn_params = ChainMap(
+            kwargs,
+            self._secrets.to_dict(),
+            _load_from_snowsql_config_file(),
         )
 
         for p in _REQUIRED_CONNECTION_PARAMS:

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from snowflake.snowpark.session import Session  # type: ignore
 
 
-_REQUIRED_CONNECTION_PARAMS = {"account", "user", "password"}
+_REQUIRED_CONNECTION_PARAMS = {"account", "user"}
 _DEFAULT_CONNECTION_FILE = "~/.snowsql/config"
 
 

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import ChainMap
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import timedelta
@@ -20,7 +21,7 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Union, cast
 import pandas as pd
 
 from streamlit.connections import ExperimentalBaseConnection
-from streamlit.connections.util import extract_from_dict, merge_dicts
+from streamlit.connections.util import extract_from_dict
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -46,8 +47,9 @@ class SQL(ExperimentalBaseConnection["Engine"]):
     def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
-        kwargs = extract_from_dict(_ALL_CONNECTION_PARAMS, deepcopy(kwargs))
-        conn_params = merge_dicts([self._secrets.to_dict(), kwargs])
+        kwargs = deepcopy(kwargs)
+        conn_param_kwargs = extract_from_dict(_ALL_CONNECTION_PARAMS, kwargs)
+        conn_params = ChainMap(conn_param_kwargs, self._secrets.to_dict())
 
         if "url" in conn_params:
             url = sqlalchemy.engine.make_url(conn_params["url"])

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -1,0 +1,63 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, Collection, Dict
+
+
+def extract_from_dict(
+    keys: Collection[str], source_dict: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Extract the specified keys from source_dict and return them in a new dict.
+
+    Parameters
+    ----------
+    keys : Collection[str]
+        The keys to extract from source_dict.
+    source_dict : Dict[str, Any]
+        The dict to extract keys from. Note that this function mutates source_dict.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A new dict containing the keys/values extracted from source_dict.
+    """
+    d = {}
+
+    for k in keys:
+        if k in source_dict:
+            d[k] = source_dict.pop(k)
+
+    return d
+
+
+def merge_dicts(dicts: Collection[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge the given dicts, having keys in later dicts overwrite those of earlier dicts.
+
+    Parameters
+    ----------
+    dicts : Collection[Dict[str, Any]]
+        A collection of dicts to merge.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The merged dict.
+    """
+    d = {}
+
+    for source_dict in dicts:
+        d.update(source_dict)
+
+    return d

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -40,24 +40,3 @@ def extract_from_dict(
             d[k] = source_dict.pop(k)
 
     return d
-
-
-def merge_dicts(dicts: Collection[Dict[str, Any]]) -> Dict[str, Any]:
-    """Merge the given dicts, having keys in later dicts overwrite those of earlier dicts.
-
-    Parameters
-    ----------
-    dicts : Collection[Dict[str, Any]]
-        A collection of dicts to merge.
-
-    Returns
-    -------
-    Dict[str, Any]
-        The merged dict.
-    """
-    d = {}
-
-    for source_dict in dicts:
-        d.update(source_dict)
-
-    return d

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -29,6 +29,7 @@ class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
 
+    @pytest.mark.require_snowflake
     @patch(
         "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
         MagicMock(return_value=AttrDict({"account": "some_val_1"})),

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -32,11 +32,19 @@ class SnowparkConnectionTest(unittest.TestCase):
     @pytest.mark.require_snowflake
     @patch(
         "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
-        MagicMock(return_value=AttrDict({"account": "some_val_1"})),
+        MagicMock(
+            return_value=AttrDict(
+                {"account": "some_val_1", "password": "i get overwritten"}
+            )
+        ),
     )
     @patch(
         "streamlit.connections.snowpark_connection.Snowpark._secrets",
-        PropertyMock(return_value=AttrDict({"user": "some_val_2"})),
+        PropertyMock(
+            return_value=AttrDict(
+                {"user": "some_val_2", "some_key": "i get overwritten"}
+            )
+        ),
     )
     @patch("snowflake.snowpark.session.Session")
     def test_merges_params_from_all_config_sources(self, patched_session):

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -68,6 +68,21 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
         )
 
+    @patch(
+        "streamlit.connections.sql_connection.SQL._secrets",
+        PropertyMock(return_value=AttrDict(DB_SECRETS)),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_kwargs_overwrite_secrets_values(self, patched_create_engine):
+        SQL("my_sql_connection", port=2345, username="DnomaidEruza")
+
+        patched_create_engine.assert_called_once()
+        args, _ = patched_create_engine.call_args_list[0]
+        assert (
+            str(args[0])
+            == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres"
+        )
+
     @parameterized.expand([("dialect",), ("username",), ("host",)])
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -1,0 +1,46 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from streamlit.connections.util import extract_from_dict, merge_dicts
+
+
+class ConnectionUtilTest(unittest.TestCase):
+    def test_extract_from_dict(self):
+        d = {"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"}
+
+        extracted = extract_from_dict(
+            ["k1", "k2", "nonexistent_key"],
+            d,
+        )
+
+        assert extracted == {"k1": "v1", "k2": "v2"}
+        assert d == {"k3": "v3", "k4": "v4"}
+
+    def test_merge_dicts(self):
+        assert merge_dicts(
+            [
+                {"k1": "v1_1"},
+                {"k1": "v1_2", "k2": "v2_1", "k3": "v3"},
+                {"k4": "v4", "k2": "v2_2"},
+                {"k1": "v1_3", "k5": "v5"},
+            ]
+        ) == {
+            "k1": "v1_3",
+            "k2": "v2_2",
+            "k3": "v3",
+            "k4": "v4",
+            "k5": "v5",
+        }

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from streamlit.connections.util import extract_from_dict, merge_dicts
+from streamlit.connections.util import extract_from_dict
 
 
 class ConnectionUtilTest(unittest.TestCase):
@@ -28,19 +28,3 @@ class ConnectionUtilTest(unittest.TestCase):
 
         assert extracted == {"k1": "v1", "k2": "v2"}
         assert d == {"k3": "v3", "k4": "v4"}
-
-    def test_merge_dicts(self):
-        assert merge_dicts(
-            [
-                {"k1": "v1_1"},
-                {"k1": "v1_2", "k2": "v2_1", "k3": "v3"},
-                {"k4": "v4", "k2": "v2_2"},
-                {"k1": "v1_3", "k5": "v5"},
-            ]
-        ) == {
-            "k1": "v1_3",
-            "k2": "v2_2",
-            "k3": "v3",
-            "k4": "v4",
-            "k5": "v5",
-        }


### PR DESCRIPTION
## 📚 Context

Another small-ish thing on our TODO list was to merge the connection config params we receive
from various sources. This PR does this for both our SQL and Snowpark first party connections, and
we additionally write a few small helper functions to help with this that are likely to be useful for many
other connections.