### PR TITLE
st.experimental_connection: The big merge

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -229,5 +229,7 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Run make develop
         run: make develop
+      - name: Run Type Checkers
+        run: scripts/mypy --report
       - name: Run Python Tests for Snowflake
         run: make pytest-snowflake

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -60,6 +60,9 @@ from streamlit.runtime.caching import (
     experimental_singleton as _experimental_singleton,
     experimental_memo as _experimental_memo,
 )
+from streamlit.runtime.connection_factory import (
+    connection_factory as _connection_factory,
+)
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
 from streamlit.runtime.state import SessionStateProxy as _SessionStateProxy
@@ -212,3 +215,4 @@ experimental_set_query_params = _set_query_params
 experimental_show = _show
 experimental_rerun = _rerun
 experimental_data_editor = _main.experimental_data_editor
+experimental_connection = _connection_factory

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -15,3 +15,4 @@
 
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -15,4 +15,5 @@
 
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.snowpark_connection import Snowpark as Snowpark
 from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -14,6 +14,8 @@
 
 
 # Explicitly re-export public symbols.
-from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.base_connection import (
+    ExperimentalBaseConnection as ExperimentalBaseConnection,
+)
 from streamlit.connections.snowpark_connection import Snowpark as Snowpark
 from streamlit.connections.sql_connection import SQL as SQL

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Explicitly re-export public symbols.
+from streamlit.connections.base_connection import BaseConnection as BaseConnection

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -17,5 +17,7 @@
 from streamlit.connections.base_connection import (
     ExperimentalBaseConnection as ExperimentalBaseConnection,
 )
-from streamlit.connections.snowpark_connection import Snowpark as Snowpark
-from streamlit.connections.sql_connection import SQL as SQL
+from streamlit.connections.snowpark_connection import (
+    SnowparkConnection as SnowparkConnection,
+)
+from streamlit.connections.sql_connection import SQLConnection as SQLConnection

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -19,20 +19,17 @@ from typing import Generic, Optional, TypeVar
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
 from streamlit.util import calc_md5
 
-T = TypeVar("T")
+RawConnectionT = TypeVar("RawConnectionT")
 
 
-class BaseConnection(ABC, Generic[T]):
+class BaseConnection(ABC, Generic[RawConnectionT]):
     """TODO(vdonato): docstrings for this class and all public methods."""
 
-    def __init__(self, connection_name: str = "default", **kwargs) -> None:
-        if connection_name == "default":
-            connection_name = self.default_connection_name()
-
+    def __init__(self, connection_name: str, **kwargs) -> None:
         self._connection_name = connection_name
         self._kwargs = kwargs
 
-        self._raw_instance: Optional[T] = self.connect(**kwargs)
+        self._raw_instance: Optional[RawConnectionT] = self.connect(**kwargs)
         secrets_dict = self.get_secrets().to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
@@ -42,7 +39,7 @@ class BaseConnection(ABC, Generic[T]):
 
     def _repr_html_(self) -> str:
         # TODO(vdonato): Change this to whatever we actually want the default to be.
-        return f"Hi, I am a {self.default_connection_name()} connection!"
+        return f"Hi, I am a {self._connection_name} connection!"
 
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
@@ -66,30 +63,18 @@ class BaseConnection(ABC, Generic[T]):
 
         return connections_section.get(self._connection_name, AttrDict({}))
 
-    @classmethod
-    def default_connection_name(cls) -> str:
-        name = cls._default_connection_name
-
-        if name is None:
-            raise NotImplementedError(
-                "Subclasses of BaseConnection must define a _default_connection_name attribute."
-            )
-        return name
-
     # TODO(vdonato): Finalize the name for this method. Should this be `invalidate`?
     def reset(self) -> None:
         self._raw_instance = None
 
     @property
-    def _instance(self) -> T:
+    def _instance(self) -> RawConnectionT:
         if self._raw_instance is None:
             self._raw_instance = self.connect(**self._kwargs)
 
         return self._raw_instance
 
     # Abstract fields/methods that subclasses of BaseConnection must implement
-    _default_connection_name: Optional[str] = None
-
     @abstractmethod
-    def connect(self, **kwargs) -> T:
+    def connect(self, **kwargs) -> RawConnectionT:
         raise NotImplementedError

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -26,25 +26,26 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     """The abstract base class that all Streamlit Connections must inherit from.
 
     This base class provides connection authors with a standardized way to hook into the
-    `st.experimental_connection()` factory function: connection authors are required to
-    provide an implementation for the abstract method `_connect` in their subclasses.
+    ``st.experimental_connection()`` factory function: connection authors are required to
+    provide an implementation for the abstract method ``_connect`` in their subclasses.
 
     Additionally, it also provides a few methods/properties designed to make
     implementation of connections more convenient. See the docstrings for each of the
     methods of this class for more information
 
-    NOTE: While providing an implementation of `_connect` is technically all that's
-    required to define a valid connection, connections should also provide the user with
-    context-specific ways of interacting with the underlying connection object. For
-    example, the first-party SQLConnection provides a `query()` method for reads and a
-    `session()` contextmanager for more complex operations.
+    .. note::
+        While providing an implementation of ``_connect`` is technically all that's
+        required to define a valid connection, connections should also provide the user
+        with context-specific ways of interacting with the underlying connection object.
+        For example, the first-party SQLConnection provides a ``query()`` method for
+        reads and a ``session`` property for more complex operations.
     """
 
     def __init__(self, connection_name: str, **kwargs) -> None:
         """Create an ExperimentalBaseConnection.
 
         This constructor is called by the connection factory machinery when a user
-        script calls `st.experimental_connection()` and when reconnecting after a
+        script calls ``st.experimental_connection()`` and when reconnecting after a
         connection is reset.
 
         Subclasses of ExperimentalBaseConnection that want to overwrite this method
@@ -54,9 +55,9 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         ----------
         connection_name : str
             The name of this connection. This corresponds to the
-            `[connections.<connection_name]` config section in `st.secrets`.
+            ``[connections.<connection_name>]`` config section in ``st.secrets``.
         kwargs : dict
-            Any other kwargs to pass to this connection class' `_connect` method.
+            Any other kwargs to pass to this connection class' ``_connect`` method.
 
         Returns
         -------
@@ -77,7 +78,7 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         """Return a human-friendly markdown string describing this connection.
 
         This is the string that will be written to the app if a user calls
-        `st.write(this_connection)`. Subclasses of ExperimentalBaseConnection can freely
+        ``st.write(this_connection)``. Subclasses of ExperimentalBaseConnection can freely
         overwrite this method if desired.
 
         Returns
@@ -122,7 +123,7 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         """Get the secrets for this connection from the corresponding st.secrets section.
 
         We expect this property to be used primarily by connection authors when they
-        are implementing their class' `_connect` method. User scripts should, for the
+        are implementing their class' ``_connect`` method. User scripts should, for the
         most part, have no reason to use this property.
         """
         connections_section = None
@@ -135,10 +136,24 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         return connections_section.get(self._connection_name, AttrDict({}))
 
     def reset(self) -> None:
-        """Reset this connection so that it gets reinstantiated the next time it's used.
+        """Reset this connection so that it gets reinitialized the next time it's used.
 
-        This method is one that we expect app developers to use when working with
-        concrete connection class instances, particularly in error handling code.
+        App developers can use this method when working with concrete connection class
+        instances, particularly in error handling code.
+
+        Example
+        -------
+        >>> import streamlit as st
+        >>>
+        >>> conn = st.experimental_connection("my_conn")
+        >>>
+        >>> # Reset the connection before using it if it isn't healthy
+        >>> # Note: is_healthy() is just shown for example here
+        >>> if not conn.is_healthy():
+        ...     conn.reset()
+        ...
+        >>> cursor = conn.query("...")
+        >>> # ...
         """
         self._raw_instance = None
 

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -12,15 +12,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC
-from typing import Generic, TypeVar
+from abc import ABC, abstractmethod
+from typing import Any, Generic, Mapping, Optional, TypeVar
+
+from streamlit.runtime.secrets import AttrDict, secrets_singleton
 
 T = TypeVar("T")
 
 
 class BaseConnection(ABC, Generic[T]):
-    """TODO(vdonato): Implement... this entire class.
+    """TODO(vdonato): docstrings for this class and all public methods."""
 
-    We intentionally leave this as just a stub implementation for now as it's needed
-    to define types in streamlit.runtime.connection_factory.
-    """
+    def __init__(self, connection_name: str = "default", **kwargs) -> None:
+        self._connection_name = connection_name
+        self._kwargs = kwargs
+
+        self._raw_instance: Optional[T] = self.connect(**kwargs)
+
+    def _repr_html_(self) -> str:
+        # TODO(vdonato): Change this to whatever we actually want the default to be.
+        return f"Hi, I am a {self.default_connection_name()} connection!"
+
+    # Methods with default implementations that we don't expect subclasses to want or
+    # need to overwrite.
+    def get_secrets(self) -> Mapping[str, Any]:
+        connection_name = self._connection_name
+        if connection_name == "default":
+            connection_name = self.default_connection_name()
+
+        connections_section = None
+        if secrets_singleton.load_if_toml_exists():
+            connections_section = secrets_singleton.get("connections")
+
+        if type(connections_section) is not AttrDict:
+            return AttrDict({})
+
+        return connections_section.get(connection_name, {})
+
+    @classmethod
+    def default_connection_name(cls) -> str:
+        name = cls._default_connection_name
+
+        if name is None:
+            raise NotImplementedError(
+                "Subclasses of BaseConnection must define a _default_connection_name attribute."
+            )
+        return name
+
+    # TODO(vdonato): Finalize the name for this method. Should this be `invalidate`?
+    def reset(self) -> None:
+        self._raw_instance = None
+
+    @property
+    def _instance(self) -> T:
+        if self._raw_instance is None:
+            self._raw_instance = self.connect(**self._kwargs)
+
+        return self._raw_instance
+
+    # Abstract fields/methods that subclasses of BaseConnection must implement
+    _default_connection_name: Optional[str] = None
+
+    @abstractmethod
+    def connect(self, **kwargs) -> T:
+        raise NotImplementedError

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -65,7 +65,6 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
         return connections_section.get(self._connection_name, AttrDict({}))
 
-    # TODO(vdonato): Finalize the name for this method. Should this be `invalidate`?
     def reset(self) -> None:
         self._raw_instance = None
 

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -1,0 +1,26 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class BaseConnection(ABC, Generic[T]):
+    """TODO(vdonato): Implement... this entire class.
+
+    We intentionally leave this as just a stub implementation for now as it's needed
+    to define types in streamlit.runtime.connection_factory.
+    """

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -33,7 +33,7 @@ class BaseConnection(ABC, Generic[T]):
         self._kwargs = kwargs
 
         self._raw_instance: Optional[T] = self.connect(**kwargs)
-        secrets_dict = self.get_secrets().__nested_secrets__
+        secrets_dict = self.get_secrets().to_dict()
         self._config_section_hash = calc_md5(json.dumps(secrets_dict))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
 
@@ -47,7 +47,7 @@ class BaseConnection(ABC, Generic[T]):
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
     def _on_secrets_changed(self, _) -> None:
-        secrets_dict = self.get_secrets().__nested_secrets__
+        secrets_dict = self.get_secrets().to_dict()
         new_hash = calc_md5(json.dumps(secrets_dict))
 
         # Only reset the connection if the secrets file section specific to this

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -39,8 +39,22 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         secrets_singleton.file_change_listener.disconnect(self._on_secrets_changed)
 
     def _repr_html_(self) -> str:
-        # TODO(vdonato): Change this to whatever we actually want the default to be.
-        return f"Hi, I am a {self._connection_name} connection!"
+        module_name = getattr(self, "__module__", None)
+        class_name = type(self).__name__
+
+        cfg = (
+            f"- Configured from `[connections.{self._connection_name}]`"
+            if len(self._secrets)
+            else ""
+        )
+
+        return f"""
+---
+**st.connection {self._connection_name} built from `{module_name}.{class_name}`**
+{cfg}
+- Learn more using `st.help()`
+---
+"""
 
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -36,7 +36,7 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     NOTE: While providing an implementation of `_connect` is technically all that's
     required to define a valid connection, connections should also provide the user with
     context-specific ways of interacting with the underlying connection object. For
-    example, the first-party SQL connection provides a `query()` method for reads and a
+    example, the first-party SQLConnection provides a `query()` method for reads and a
     `session()` contextmanager for more complex operations.
     """
 

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Mapping, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
+from streamlit.util import calc_md5
 
 T = TypeVar("T")
 
@@ -24,10 +26,19 @@ class BaseConnection(ABC, Generic[T]):
     """TODO(vdonato): docstrings for this class and all public methods."""
 
     def __init__(self, connection_name: str = "default", **kwargs) -> None:
+        if connection_name == "default":
+            connection_name = self.default_connection_name()
+
         self._connection_name = connection_name
         self._kwargs = kwargs
 
         self._raw_instance: Optional[T] = self.connect(**kwargs)
+        secrets_dict = self.get_secrets().__nested_secrets__
+        self._config_section_hash = calc_md5(json.dumps(secrets_dict))
+        secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
+
+    def __del__(self) -> None:
+        secrets_singleton.file_change_listener.disconnect(self._on_secrets_changed)
 
     def _repr_html_(self) -> str:
         # TODO(vdonato): Change this to whatever we actually want the default to be.
@@ -35,11 +46,17 @@ class BaseConnection(ABC, Generic[T]):
 
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
-    def get_secrets(self) -> Mapping[str, Any]:
-        connection_name = self._connection_name
-        if connection_name == "default":
-            connection_name = self.default_connection_name()
+    def _on_secrets_changed(self, _) -> None:
+        secrets_dict = self.get_secrets().__nested_secrets__
+        new_hash = calc_md5(json.dumps(secrets_dict))
 
+        # Only reset the connection if the secrets file section specific to this
+        # connection has changed.
+        if new_hash != self._config_section_hash:
+            self._config_section_hash = new_hash
+            self.reset()
+
+    def get_secrets(self) -> AttrDict:
         connections_section = None
         if secrets_singleton.load_if_toml_exists():
             connections_section = secrets_singleton.get("connections")
@@ -47,7 +64,7 @@ class BaseConnection(ABC, Generic[T]):
         if type(connections_section) is not AttrDict:
             return AttrDict({})
 
-        return connections_section.get(connection_name, {})
+        return connections_section.get(self._connection_name, AttrDict({}))
 
     @classmethod
     def default_connection_name(cls) -> str:

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -23,14 +23,49 @@ RawConnectionT = TypeVar("RawConnectionT")
 
 
 class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
-    """TODO(vdonato): docstrings for this class and all public methods."""
+    """The abstract base class that all Streamlit Connections must inherit from.
+
+    This base class provides connection authors with a standardized way to hook into the
+    `st.experimental_connection()` factory function: connection authors are required to
+    provide an implementation for the abstract method `_connect` in their subclasses.
+
+    Additionally, it also provides a few methods/properties designed to make
+    implementation of connections more convenient. See the docstrings for each of the
+    methods of this class for more information
+
+    NOTE: While providing an implementation of `_connect` is technically all that's
+    required to define a valid connection, connections should also provide the user with
+    context-specific ways of interacting with the underlying connection object. For
+    example, the first-party SQL connection provides a `query()` method for reads and a
+    `session()` contextmanager for more complex operations.
+    """
 
     def __init__(self, connection_name: str, **kwargs) -> None:
+        """Create an ExperimentalBaseConnection.
+
+        This constructor is called by the connection factory machinery when a user
+        script calls `st.experimental_connection()` and when reconnecting after a
+        connection is reset.
+
+        Subclasses of ExperimentalBaseConnection that want to overwrite this method
+        should take care to also call the base class' implementation.
+
+        Parameters
+        ----------
+        connection_name : str
+            The name of this connection. This corresponds to the
+            `[connections.<connection_name]` config section in `st.secrets`.
+        kwargs : dict
+            Any other kwargs to pass to this connection class' `_connect` method.
+
+        Returns
+        -------
+        None
+        """
         self._connection_name = connection_name
         self._kwargs = kwargs
 
-        secrets_dict = self._secrets.to_dict()
-        self._config_section_hash = calc_md5(json.dumps(secrets_dict))
+        self._config_section_hash = calc_md5(json.dumps(self._secrets.to_dict()))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
 
         self._raw_instance: Optional[RawConnectionT] = self._connect(**kwargs)
@@ -39,6 +74,16 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         secrets_singleton.file_change_listener.disconnect(self._on_secrets_changed)
 
     def _repr_html_(self) -> str:
+        """Return a human-friendly markdown string describing this connection.
+
+        This is the string that will be written to the app if a user calls
+        `st.write(this_connection)`. Subclasses of ExperimentalBaseConnection can freely
+        overwrite this method if desired.
+
+        Returns
+        -------
+        str
+        """
         module_name = getattr(self, "__module__", None)
         class_name = type(self).__name__
 
@@ -59,8 +104,12 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     # Methods with default implementations that we don't expect subclasses to want or
     # need to overwrite.
     def _on_secrets_changed(self, _) -> None:
-        secrets_dict = self._secrets.to_dict()
-        new_hash = calc_md5(json.dumps(secrets_dict))
+        """Reset the raw connection object when this connection's secrets change.
+
+        We don't expect either user scripts of connection authors to have to use or
+        overwrite this method.
+        """
+        new_hash = calc_md5(json.dumps(self._secrets.to_dict()))
 
         # Only reset the connection if the secrets file section specific to this
         # connection has changed.
@@ -70,6 +119,12 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
     @property
     def _secrets(self) -> AttrDict:
+        """Get the secrets for this connection from the corresponding st.secrets section.
+
+        We expect this property to be used primarily by connection authors when they
+        are implementing their class' `_connect` method. User scripts should, for the
+        most part, have no reason to use this property.
+        """
         connections_section = None
         if secrets_singleton.load_if_toml_exists():
             connections_section = secrets_singleton.get("connections")
@@ -80,10 +135,16 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         return connections_section.get(self._connection_name, AttrDict({}))
 
     def reset(self) -> None:
+        """Reset this connection so that it gets reinstantiated the next time it's used.
+
+        This method is one that we expect app developers to use when working with
+        concrete connection class instances, particularly in error handling code.
+        """
         self._raw_instance = None
 
     @property
     def _instance(self) -> RawConnectionT:
+        """Get an instance of the underlying connection, creating a new one if needed."""
         if self._raw_instance is None:
             self._raw_instance = self._connect(**self._kwargs)
 
@@ -92,4 +153,18 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     # Abstract fields/methods that subclasses of ExperimentalBaseConnection must implement
     @abstractmethod
     def _connect(self, **kwargs) -> RawConnectionT:
+        """Create an instance of an underlying connection object.
+
+        This abstract method is the one method that we require subclasses of
+        ExperimentalBaseConnection to provide an implementation for.
+
+        Parameters
+        ----------
+        kwargs : dict
+
+        Returns
+        -------
+        RawConnectionT
+            The underlying connection object.
+        """
         raise NotImplementedError

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -82,17 +82,17 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
 
         return cast(Session, Session.builder.configs(conn_params).create())
 
-    def read_sql(
+    def query(
         self,
         sql: str,
         ttl: Optional[Union[float, int, timedelta]] = None,
     ) -> pd.DataFrame:
         @cache_data(ttl=ttl)
-        def _read_sql(sql: str) -> pd.DataFrame:
+        def _query(sql: str) -> pd.DataFrame:
             with self._lock:
                 return self._instance.sql(sql).to_pandas()
 
-        return _read_sql(sql)
+        return _query(sql)
 
     @contextmanager
     def session(self) -> Iterator["Session"]:

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -1,0 +1,101 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We won't always be able to import from snowflake.snowpark.session so need the
+# `type:ignore` comment below, but that comment will explode if `warn-unused-ignores` is
+# turned on when the package is available. Unfortunately, mypy doesn't provide a good
+# way to configure this at a per-line level :(
+# mypy: no-warn-unused-ignores
+
+import configparser
+import os
+import threading
+from contextlib import contextmanager
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
+
+import pandas as pd
+
+from streamlit.connections import BaseConnection
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_data
+
+if TYPE_CHECKING:
+    from snowflake.snowpark.session import Session  # type: ignore
+
+
+_REQUIRED_CONNECTION_PARAMS = {"account", "user"}
+_DEFAULT_CONNECTION_FILE = "~/.snowsql/config"
+
+
+def _load_from_snowsql_config_file() -> Dict[str, Any]:
+    """Loads the dictionary from snowsql config file."""
+    snowsql_config_file = os.path.expanduser(_DEFAULT_CONNECTION_FILE)
+    if not os.path.exists(snowsql_config_file):
+        return {}
+
+    config = configparser.ConfigParser(inline_comment_prefixes="#")
+    config.read(snowsql_config_file)
+
+    conn_params = config["connections"]
+    conn_params = {k.replace("name", ""): v.strip('"') for k, v in conn_params.items()}
+    if "db" in conn_params:
+        conn_params["database"] = conn_params["db"]
+        del conn_params["db"]
+    return conn_params
+
+
+class Snowpark(BaseConnection["Session"]):
+    _default_connection_name = "snowpark"
+
+    def __init__(self, connection_name: str = "default", **kwargs) -> None:
+        self._lock = threading.RLock()
+
+        # Grab the lock before calling BaseConnection.__init__() so that we can guarantee
+        # thread safety when the parent class' constructor initializes our connection.
+        with self._lock:
+            super().__init__(connection_name, **kwargs)
+
+    # TODO(vdonato): Teach the .connect() method how to automagically connect in a SiS
+    # runtime environment.
+    def connect(self, **kwargs) -> "Session":
+        from snowflake.snowpark.session import Session
+
+        conn_params = self.get_secrets().to_dict()
+
+        if not conn_params:
+            conn_params = _load_from_snowsql_config_file()
+
+        for p in _REQUIRED_CONNECTION_PARAMS:
+            if p not in conn_params:
+                raise StreamlitAPIException(f"Missing Snowpark connection param: {p}")
+
+        return cast(Session, Session.builder.configs(conn_params).create())
+
+    def read_sql(
+        self,
+        sql: str,
+        ttl: Optional[Union[float, int, timedelta]] = None,
+    ) -> pd.DataFrame:
+        @cache_data(ttl=ttl)
+        def _read_sql(sql: str) -> pd.DataFrame:
+            with self._lock:
+                return self._instance.sql(sql).to_pandas()
+
+        return _read_sql(sql)
+
+    @contextmanager
+    def session(self) -> Iterator["Session"]:
+        with self._lock:
+            yield self._instance

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -40,7 +40,7 @@ _REQUIRED_CONNECTION_PARAMS = {"account", "user"}
 _DEFAULT_CONNECTION_FILE = "~/.snowsql/config"
 
 
-def _load_from_snowsql_config_file() -> Dict[str, Any]:
+def _load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
     """Loads the dictionary from snowsql config file."""
     snowsql_config_file = os.path.expanduser(_DEFAULT_CONNECTION_FILE)
     if not os.path.exists(snowsql_config_file):
@@ -49,11 +49,21 @@ def _load_from_snowsql_config_file() -> Dict[str, Any]:
     config = configparser.ConfigParser(inline_comment_prefixes="#")
     config.read(snowsql_config_file)
 
-    conn_params = config["connections"]
-    conn_params = {k.replace("name", ""): v.strip('"') for k, v in conn_params.items()}
+    if f"connections.{connection_name}" in config:
+        raw_conn_params = config[f"connections.{connection_name}"]
+    elif "connections" in config:
+        raw_conn_params = config["connections"]
+    else:
+        return {}
+
+    conn_params = {
+        k.replace("name", ""): v.strip('"') for k, v in raw_conn_params.items()
+    }
+
     if "db" in conn_params:
         conn_params["database"] = conn_params["db"]
         del conn_params["db"]
+
     return conn_params
 
 
@@ -80,6 +90,7 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
             super().__init__(connection_name, **kwargs)
 
     def _connect(self, **kwargs) -> "Session":
+        import tenacity  # Import tenacity so we get a ModuleNotFoundError if it's not installed
         from snowflake.snowpark.context import get_active_session  # type: ignore
         from snowflake.snowpark.exceptions import (  # type: ignore
             SnowparkSessionException,
@@ -97,8 +108,15 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
         conn_params = ChainMap(
             kwargs,
             self._secrets.to_dict(),
-            _load_from_snowsql_config_file(),
+            _load_from_snowsql_config_file(self._connection_name),
         )
+
+        if not len(conn_params):
+            raise StreamlitAPIException(
+                "Missing Snowpark connection configuration. "
+                f"Did you forget to set this in `secrets.toml`, `{_DEFAULT_CONNECTION_FILE}`, "
+                "or as kwargs to `st.experimental_connection`?"
+            )
 
         for p in _REQUIRED_CONNECTION_PARAMS:
             if p not in conn_params:
@@ -134,7 +152,10 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
             retry=retry_if_exception_type(SnowparkServerException),
             wait=wait_fixed(1),
         )
-        @cache_data(ttl=ttl)
+        @cache_data(
+            show_spinner="Running `snowpark.query(...)`.",
+            ttl=ttl,
+        )
         def _query(sql: str) -> pd.DataFrame:
             with self._lock:
                 return self._instance.sql(sql).to_pandas()

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -87,6 +87,14 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
         sql: str,
         ttl: Optional[Union[float, int, timedelta]] = None,
     ) -> pd.DataFrame:
+        from tenacity import retry, stop_after_attempt, wait_fixed
+
+        @retry(
+            after=lambda _: self.reset(),
+            stop=stop_after_attempt(3),
+            reraise=True,
+            wait=wait_fixed(1),
+        )
         @cache_data(ttl=ttl)
         def _query(sql: str) -> pd.DataFrame:
             with self._lock:

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -21,6 +21,7 @@
 import configparser
 import os
 import threading
+from collections import ChainMap
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
@@ -83,10 +84,11 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
     def _connect(self, **kwargs) -> "Session":
         from snowflake.snowpark.session import Session
 
-        conn_params = self._secrets.to_dict()
-
-        if not conn_params:
-            conn_params = _load_from_snowsql_config_file()
+        conn_params = ChainMap(
+            kwargs,
+            self._secrets.to_dict(),
+            _load_from_snowsql_config_file(),
+        )
 
         for p in _REQUIRED_CONNECTION_PARAMS:
             if p not in conn_params:

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -57,9 +57,7 @@ def _load_from_snowsql_config_file() -> Dict[str, Any]:
 
 
 class Snowpark(BaseConnection["Session"]):
-    _default_connection_name = "snowpark"
-
-    def __init__(self, connection_name: str = "default", **kwargs) -> None:
+    def __init__(self, connection_name: str, **kwargs) -> None:
         self._lock = threading.RLock()
 
         # Grab the lock before calling BaseConnection.__init__() so that we can guarantee

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -118,12 +118,21 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         """
 
         from sqlalchemy import text
-        from tenacity import retry, stop_after_attempt, wait_fixed
+        from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
+        from tenacity import (
+            retry,
+            retry_if_exception_type,
+            stop_after_attempt,
+            wait_fixed,
+        )
 
         @retry(
             after=lambda _: self.reset(),
             stop=stop_after_attempt(3),
             reraise=True,
+            retry=retry_if_exception_type(
+                (DatabaseError, InternalError, OperationalError)
+            ),
             wait=wait_fixed(1),
         )
         @cache_data(ttl=ttl)

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -14,7 +14,7 @@
 
 from contextlib import contextmanager
 from datetime import timedelta
-from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Iterator, List, Optional, Union, cast
 
 import pandas as pd
 
@@ -63,20 +63,43 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         else:
             return cast("Engine", eng)
 
-    def read_sql(
+    def query(
         self,
         sql: str,
+        *,  # keyword-only arguments:
         ttl: Optional[Union[float, int, timedelta]] = None,
+        index_col: Optional[Union[str, List[str]]] = None,
+        chunksize: Optional[int] = None,
+        params=None,
         **kwargs,
     ) -> pd.DataFrame:
         from sqlalchemy import text
 
         @cache_data(ttl=ttl)
-        def _read_sql(sql: str, **kwargs) -> pd.DataFrame:
+        def _query(
+            sql: str,
+            index_col=None,
+            chunksize=None,
+            params=None,
+            **kwargs,
+        ) -> pd.DataFrame:
             instance = self._instance.connect()
-            return pd.read_sql(text(sql), instance, **kwargs)
+            return pd.read_sql(
+                text(sql),
+                instance,
+                index_col=index_col,
+                chunksize=chunksize,
+                params=params,
+                **kwargs,
+            )
 
-        return _read_sql(sql, **kwargs)
+        return _query(
+            sql,
+            index_col=index_col,
+            chunksize=chunksize,
+            params=params,
+            **kwargs,
+        )
 
     @contextmanager
     def session(self) -> Iterator["Session"]:

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -81,7 +81,10 @@ class SQL(ExperimentalBaseConnection["Engine"]):
                 database=conn_params.get("database"),
             )
 
-        eng = sqlalchemy.create_engine(url, **kwargs)
+        create_engine_kwargs = ChainMap(
+            kwargs, self._secrets.get("create_engine_kwargs", {})
+        )
+        eng = sqlalchemy.create_engine(url, **create_engine_kwargs)
 
         if autocommit:
             return cast("Engine", eng.execution_options(isolation_level="AUTOCOMMIT"))

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -125,3 +125,28 @@ class SQL(ExperimentalBaseConnection["Engine"]):
 
         with Session(self._instance) as s:
             yield s
+
+    # NOTE: This more or less duplicates the default implementation in
+    # ExperimentalBaseConnection so that we can add another bullet point between the
+    # "Configured from" and "Learn more" items :/
+    def _repr_html_(self) -> str:
+        module_name = getattr(self, "__module__", None)
+        class_name = type(self).__name__
+
+        cfg = (
+            f"- Configured from `[connections.{self._connection_name}]`"
+            if len(self._secrets)
+            else ""
+        )
+
+        with self.session() as s:
+            dialect = s.bind.dialect.name if s.bind is not None else "unknown"
+
+        return f"""
+---
+**st.connection {self._connection_name} built from `{module_name}.{class_name}`**
+{cfg}
+- Dialect: `{dialect}`
+- Learn more using `st.help()`
+---
+"""

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -1,0 +1,106 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from datetime import timedelta
+from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
+
+import pandas as pd
+
+from streamlit.connections import BaseConnection
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_data
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine.base import Engine
+    from sqlalchemy.orm import Session
+
+
+_REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
+
+
+class SQL(BaseConnection["Engine"]):
+    _default_connection_name = "sql"
+
+    def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
+        import sqlalchemy
+
+        secrets = self.get_secrets()
+
+        if "url" in secrets:
+            url = sqlalchemy.engine.make_url(secrets["url"])
+        else:
+            for p in _REQUIRED_CONNECTION_PARAMS:
+                if p not in secrets:
+                    raise StreamlitAPIException(f"Missing SQL DB connection param: {p}")
+
+            drivername = secrets["dialect"] + (
+                f"+{secrets['driver']}" if "driver" in secrets else ""
+            )
+
+            url = sqlalchemy.engine.URL.create(
+                drivername=drivername,
+                username=secrets["username"],
+                password=secrets.get("password"),
+                host=secrets["host"],
+                port=int(secrets["port"]) if "port" in secrets else None,
+                database=secrets.get("database"),
+            )
+
+        eng = sqlalchemy.create_engine(url, **kwargs)
+
+        if autocommit:
+            return cast("Engine", eng.execution_options(isolation_level="AUTOCOMMIT"))
+        else:
+            return cast("Engine", eng)
+
+    def read_sql(
+        self,
+        sql: str,
+        ttl: Optional[Union[float, int, timedelta]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        from sqlalchemy import text
+
+        @cache_data(ttl=ttl)
+        def _read_sql(sql: str, **kwargs) -> pd.DataFrame:
+            instance = self._instance.connect()
+            return pd.read_sql(text(sql), instance, **kwargs)
+
+        return _read_sql(sql, **kwargs)
+
+    @contextmanager
+    def session(self) -> Iterator["Session"]:
+        """A simple wrapper around SQLAlchemy Session context management.
+
+        This allows us to write
+            `with conn.session() as session:`
+        instead of importing the sqlalchemy.orm.Session object and writing
+            `with Session(conn._instance) as session:`
+
+        See the usage example below, which assumes we have a table `numbers` with a
+        single integer column `val`.
+
+        Example
+        -------
+        >>> n = st.slider("Pick a number")
+        >>> if st.button("Add the number!"):
+        ...     with conn.session() as session:
+        ...         session.execute("INSERT INTO numbers (val) VALUES (:n);", {"n": n})
+        ...         session.commit()
+        """
+        from sqlalchemy.orm import Session
+
+        with Session(self._instance) as s:
+            yield s

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -31,8 +31,6 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
 class SQL(BaseConnection["Engine"]):
-    _default_connection_name = "sql"
-
     def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import BaseConnection
+from streamlit.connections import ExperimentalBaseConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -30,11 +30,11 @@ if TYPE_CHECKING:
 _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
-class SQL(BaseConnection["Engine"]):
-    def connect(self, autocommit: bool = False, **kwargs) -> "Engine":
+class SQL(ExperimentalBaseConnection["Engine"]):
+    def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
-        secrets = self.get_secrets()
+        secrets = self._secrets
 
         if "url" in secrets:
             url = sqlalchemy.engine.make_url(secrets["url"])

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -74,7 +74,14 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         **kwargs,
     ) -> pd.DataFrame:
         from sqlalchemy import text
+        from tenacity import retry, stop_after_attempt, wait_fixed
 
+        @retry(
+            after=lambda _: self.reset(),
+            stop=stop_after_attempt(3),
+            reraise=True,
+            wait=wait_fixed(1),
+        )
         @cache_data(ttl=ttl)
         def _query(
             sql: str,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import ChainMap
 from contextlib import contextmanager
+from copy import deepcopy
 from datetime import timedelta
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union, cast
 
 import pandas as pd
 
 from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections.util import extract_from_dict
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -27,6 +30,16 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
+_ALL_CONNECTION_PARAMS = {
+    "url",
+    "driver",
+    "dialect",
+    "username",
+    "password",
+    "host",
+    "port",
+    "database",
+}
 _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
@@ -44,26 +57,28 @@ class SQL(ExperimentalBaseConnection["Engine"]):
     def _connect(self, autocommit: bool = False, **kwargs) -> "Engine":
         import sqlalchemy
 
-        secrets = self._secrets
+        kwargs = deepcopy(kwargs)
+        conn_param_kwargs = extract_from_dict(_ALL_CONNECTION_PARAMS, kwargs)
+        conn_params = ChainMap(conn_param_kwargs, self._secrets.to_dict())
 
-        if "url" in secrets:
-            url = sqlalchemy.engine.make_url(secrets["url"])
+        if "url" in conn_params:
+            url = sqlalchemy.engine.make_url(conn_params["url"])
         else:
             for p in _REQUIRED_CONNECTION_PARAMS:
-                if p not in secrets:
+                if p not in conn_params:
                     raise StreamlitAPIException(f"Missing SQL DB connection param: {p}")
 
-            drivername = secrets["dialect"] + (
-                f"+{secrets['driver']}" if "driver" in secrets else ""
+            drivername = conn_params["dialect"] + (
+                f"+{conn_params['driver']}" if "driver" in conn_params else ""
             )
 
             url = sqlalchemy.engine.URL.create(
                 drivername=drivername,
-                username=secrets["username"],
-                password=secrets.get("password"),
-                host=secrets["host"],
-                port=int(secrets["port"]) if "port" in secrets else None,
-                database=secrets.get("database"),
+                username=conn_params["username"],
+                password=conn_params.get("password"),
+                host=conn_params["host"],
+                port=int(conn_params["port"]) if "port" in conn_params else None,
+                database=conn_params.get("database"),
             )
 
         eng = sqlalchemy.create_engine(url, **kwargs)

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -1,0 +1,42 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, Collection, Dict
+
+
+def extract_from_dict(
+    keys: Collection[str], source_dict: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Extract the specified keys from source_dict and return them in a new dict.
+
+    Parameters
+    ----------
+    keys : Collection[str]
+        The keys to extract from source_dict.
+    source_dict : Dict[str, Any]
+        The dict to extract keys from. Note that this function mutates source_dict.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A new dict containing the keys/values extracted from source_dict.
+    """
+    d = {}
+
+    for k in keys:
+        if k in source_dict:
+            d[k] = source_dict.pop(k)
+
+    return d

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import SQL, BaseConnection, Snowpark
+from streamlit.connections import SQL, ExperimentalBaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
@@ -39,10 +39,11 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 
-# The BaseConnection bound is parameterized to `Any` below as subclasses of
-# BaseConnection are responsible for binding the type parameter of BaseConnection to a
-# concrete type, but the type it gets bound to isn't important to us here.
-ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
+# The ExperimentalBaseConnection bound is parameterized to `Any` below as subclasses of
+# ExperimentalBaseConnection are responsible for binding the type parameter of
+# ExperimentalBaseConnection to a concrete type, but the type it gets bound to isn't
+# important to us here.
+ConnectionClass = TypeVar("ConnectionClass", bound=ExperimentalBaseConnection[Any])
 
 
 # NOTE: The order of the decorators below is important: @gather_metrics must be above
@@ -60,9 +61,9 @@ def _create_connection(
     the user to specify the connection class to use as a string literal for convenience.
     """
 
-    if not issubclass(connection_class, BaseConnection):
+    if not issubclass(connection_class, ExperimentalBaseConnection):
         raise StreamlitAPIException(
-            f"{connection_class} is not a subclass of BaseConnection!"
+            f"{connection_class} is not a subclass of ExperimentalBaseConnection!"
         )
 
     return connection_class(connection_name=name, **kwargs)
@@ -102,7 +103,7 @@ def connection_factory(
 @overload
 def connection_factory(
     name: str, connection_class: Optional[str], **kwargs
-) -> BaseConnection[Any]:
+) -> ExperimentalBaseConnection[Any]:
     pass
 
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -30,7 +30,8 @@ from streamlit.runtime.secrets import secrets_singleton
 
 # NOTE: Adding support for a new first party connection requires:
 #   1. Adding the new connection name and class to this dict.
-#   2. Writing a new @overload for connection_factory.
+#   2. Writing two new @overloads for connection_factory (one for the case where the
+#      only the connection name is specified and another when both name and type are).
 #   3. Updating test_get_first_party_connection_helper in connection_factory_test.py.
 FIRST_PARTY_CONNECTIONS = {
     "snowpark": Snowpark,
@@ -93,6 +94,17 @@ def _get_first_party_connection(connection_class: str):
 
 @overload
 def connection_factory(
+    name: Literal["sql"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
+) -> SQL:
+    pass
+
+
+@overload
+def connection_factory(
     name: str,
     type: Literal["sql"],
     max_entries: int | None = None,
@@ -100,6 +112,16 @@ def connection_factory(
     autocommit: bool = False,
     **kwargs,
 ) -> SQL:
+    pass
+
+
+@overload
+def connection_factory(
+    name: Literal["snowpark"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    **kwargs,
+) -> Snowpark:
     pass
 
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -174,13 +174,40 @@ def connection_factory(
     ttl=None,
     **kwargs,
 ):
-    """Create a new connection or return an existing one.
+    """Create a new connection to a data store or API, or return an existing one.
 
     Config options, credentials, secrets, etc. for connections are sourced from various
     sources:
-      * Any connection-specific configuration files.
-      * An app's `secrets.toml` files.
-      * The kwargs passed to this function.
+
+    - Any connection-specific configuration files.
+    - An app's ``secrets.toml`` files.
+    - The kwargs passed to this function.
+
+    Parameters
+    ----------
+    name : str
+        The connection name used for secrets lookup in ``[connections.<name>]``.
+        Type will be inferred from passing ``"sql"`` or ``"snowpark"``.
+    type : str or connection class
+        The type of connection to create. It can be a keyword (``"sql"`` or ``"snowpark"``),
+        a path to an importable class, or an imported class reference. All classes
+        must extend ``st.connections.ExperimentalBaseConnection`` and implement the
+        ``_connect()`` method.
+    max_entries : int or None
+        The maximum number of connections to keep in the cache, or None
+        for an unbounded cache. (When a new entry is added to a full cache,
+        the oldest cached entry will be removed.) The default is None.
+    ttl : float or timedelta or None
+        The maximum number of seconds to keep results in the cache, or
+        None if cached results should not expire. The default is None.
+    **kwargs : any
+        Additional connection specific kwargs that are passed to the Connection's
+        ``_connect()`` method. Learn more from the specific Connection's documentation.
+
+    Returns
+    -------
+    Connection object
+        An initialized Connection object of the specified type.
 
     Examples
     --------
@@ -188,15 +215,15 @@ def connection_factory(
     default names and define corresponding sections in your config.toml file.
 
     >>> import streamlit as st
-    >>> conn = st.connection("sql")  # Config section defined in [connections.sql] in secrets.toml.
+    >>> conn = st.connection("sql") # Config section defined in [connections.sql] in secrets.toml.
 
     Creating a SQLConnection with a custom name requires you to explicitly specify the
     type. If type is not passed in as a kwarg, we try to infer it from the contents of
     your secrets.toml.
 
     >>> import streamlit as st
-    >>> conn1 = st.connection("my_sql_connection", type="sql")  # Config section defined in [connections.my_sql_connection].
-    >>> conn2 = st.connection("my_other_sql_connection")  # Type is inferred from [connections.my_other_sql_connection].
+    >>> conn1 = st.connection("my_sql_connection", type="sql") # Config section defined in [connections.my_sql_connection].
+    >>> conn2 = st.connection("my_other_sql_connection") # Type is inferred from [connections.my_other_sql_connection].
 
     Passing the full module path to the connection class that you want to use can be
     useful, especially when working with a custom connection:

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -41,6 +41,7 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "sqlalchemy": "sqlalchemy",
     "snowflake": "snowflake-snowpark-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
+    "tenacity": "tenacity",
 }
 
 # The ExperimentalBaseConnection bound is parameterized to `Any` below as subclasses of

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import os
 import re
 from typing import Any, Dict, Optional, Type, TypeVar, overload
 
@@ -120,6 +121,13 @@ def connection_factory(name, connection_class=None, **kwargs):
         literal as the connection_class.
       * Plugging your own ConnectionClass into st.experimental_connection.
     """
+    USE_ENV_PREFIX = "env:"
+
+    if name.startswith(USE_ENV_PREFIX):
+        # It'd be nice to use str.removeprefix() here, but we won't be able to do that
+        # until the minimium Python version we support is 3.9.
+        envvar_name = name[len(USE_ENV_PREFIX) :]
+        name = os.environ[envvar_name]
 
     if connection_class is None:
         secrets_singleton.load_if_toml_exists()

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -39,6 +39,8 @@ FIRST_PARTY_CONNECTIONS = {
 }
 MODULE_EXTRACTION_REGEX = re.compile(r"No module named \'(.+)\'")
 MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
+    "MySQLdb": "mysqlclient",
+    "psycopg2": "psycopg2-binary",
     "sqlalchemy": "sqlalchemy",
     "snowflake": "snowflake-snowpark-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
@@ -150,7 +152,7 @@ def connection_factory(
 @overload
 def connection_factory(
     name: str,
-    type: str | None,
+    type: str | None = None,
     max_entries: int | None = None,
     ttl: float | timedelta | None = None,
     **kwargs,

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -1,0 +1,84 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import Any, Dict, Type, TypeVar, overload
+
+from typing_extensions import Final
+
+from streamlit.connections.base_connection import BaseConnection
+from streamlit.runtime.caching import cache_resource
+from streamlit.runtime.metrics_util import gather_metrics
+
+MODULE_EXTRACTION_REGEX = re.compile(r"No module named \'(.+)\'")
+MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
+    "sqlalchemy": "sqlalchemy",
+    "snowflake.snowpark": "snowflake-snowpark-python",
+}
+
+# The BaseConnection bound is parameterized to `Any` below as subclasses of
+# BaseConnection are responsible for binding the type parameter of BaseConnection to a
+# concrete type, but the type it gets bound to isn't important to us here.
+ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
+
+
+# NOTE: The order of the decorators below is important: @gather_metrics must be above
+# @cache_resource so that it is called even if the return value of _create_connection
+# is cached.
+@gather_metrics("experimental_connection")
+@cache_resource
+def _create_connection(
+    connection_class: Type[ConnectionClass], name: str = "default", **kwargs
+) -> ConnectionClass:
+    """Create an instance of connection_class with the given name and kwargs.
+
+    This function is useful because it allows us to @gather_metrics at a point where
+    connection_class must be a concrete type. The public-facing connection API allows
+    the user to specify the connection class to use as a string literal for convenience.
+    """
+    return connection_class(  # type: ignore
+        connection_name=name,
+        **kwargs,
+    )
+
+
+@overload  # type: ignore
+def connection_factory(
+    connection_class: Type[ConnectionClass], name: str = "default", **kwargs
+) -> ConnectionClass:
+    pass
+
+
+def connection_factory(connection_class, name="default", **kwargs):
+    """TODO(vdonato): Write a docstring (maybe with the help of the documentation team).
+
+    The docstring should describe:
+      * Using st.connection with one of our first party connections by passing a string
+        literal as the connection_class.
+      * Plugging your own ConnectionClass into st.experimental_connection.
+    """
+    try:
+        return _create_connection(connection_class, name=name, **kwargs)
+    except ModuleNotFoundError as e:
+        err_string = str(e)
+        missing_module = re.search(MODULE_EXTRACTION_REGEX, err_string)
+
+        # TODO(vdonato): Finalize these error messages.
+        extra_info = "You may be missing a dependency required to use this connection."
+        if missing_module:
+            pypi_package = MODULES_TO_PYPI_PACKAGES.get(missing_module.group(1))
+            if pypi_package:
+                extra_info = f"You need to install the '{pypi_package}' package to use this connection."
+
+        raise ModuleNotFoundError(f"{str(e)}. {extra_info}")

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -24,6 +24,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 MODULE_EXTRACTION_REGEX = re.compile(r"No module named \'(.+)\'")
 MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "sqlalchemy": "sqlalchemy",
+    "snowflake": "snowflake-snowpark-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -47,7 +47,7 @@ def _create_connection(
     connection_class must be a concrete type. The public-facing connection API allows
     the user to specify the connection class to use as a string literal for convenience.
     """
-    return connection_class(  # type: ignore
+    return connection_class(
         connection_name=name,
         **kwargs,
     )

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -15,9 +15,10 @@
 import re
 from typing import Any, Dict, Type, TypeVar, overload
 
-from typing_extensions import Final
+from typing_extensions import Final, Literal
 
-from streamlit.connections.base_connection import BaseConnection
+from streamlit.connections import SQL, BaseConnection
+from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
 
@@ -48,13 +49,35 @@ def _create_connection(
     connection_class must be a concrete type. The public-facing connection API allows
     the user to specify the connection class to use as a string literal for convenience.
     """
-    return connection_class(
-        connection_name=name,
-        **kwargs,
+    return connection_class(connection_name=name, **kwargs)
+
+
+# NOTE: Adding support for a new first party connection requires:
+#   1. Adding the new connection name and class to this function.
+#   2. Writing a new @overload signature mapping the connection's name to its class.
+def _get_first_party_connection(connection_name: str):
+    FIRST_PARTY_CONNECTIONS = {"sql"}
+
+    if connection_name == "sql":
+        return SQL
+
+    raise StreamlitAPIException(
+        f"Invalid connection {connection_name}. "
+        f"Supported connection classes: {FIRST_PARTY_CONNECTIONS}"
     )
 
 
-@overload  # type: ignore
+@overload
+def connection_factory(
+    connection_class: Literal["sql"],
+    name: str = "default",
+    autocommit: bool = False,
+    **kwargs,
+) -> SQL:
+    pass
+
+
+@overload
 def connection_factory(
     connection_class: Type[ConnectionClass], name: str = "default", **kwargs
 ) -> ConnectionClass:
@@ -69,6 +92,9 @@ def connection_factory(connection_class, name="default", **kwargs):
         literal as the connection_class.
       * Plugging your own ConnectionClass into st.experimental_connection.
     """
+    if type(connection_class) == str:
+        connection_class = _get_first_party_connection(connection_class)
+
     try:
         return _create_connection(connection_class, name=name, **kwargs)
     except ModuleNotFoundError as e:

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import importlib
 import os
 import re
-from typing import Any, Dict, Optional, Type, TypeVar, overload
+from datetime import timedelta
+from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
@@ -47,27 +50,34 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
 ConnectionClass = TypeVar("ConnectionClass", bound=ExperimentalBaseConnection[Any])
 
 
-# NOTE: The order of the decorators below is important: @gather_metrics must be above
-# @cache_resource so that it is called even if the return value of _create_connection
-# is cached.
 @gather_metrics("experimental_connection")
-@cache_resource
 def _create_connection(
-    name: str, connection_class: Type[ConnectionClass], **kwargs
+    name: str,
+    connection_class: Type[ConnectionClass],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    **kwargs,
 ) -> ConnectionClass:
     """Create an instance of connection_class with the given name and kwargs.
 
-    This function is useful because it allows us to @gather_metrics at a point where
-    connection_class must be a concrete type. The public-facing connection API allows
-    the user to specify the connection class to use as a string literal for convenience.
+    The weird implementation of this function with the @cache_resource annotated
+    function defined internally is done to:
+      * Always @gather_metrics on the call even if the return value is a cached one.
+      * Allow the user to specify ttl and max_entries when calling st.experimental_connection.
     """
+
+    @cache_resource(ttl=ttl, max_entries=max_entries)
+    def __create_connection(
+        name: str, connection_class: Type[ConnectionClass], **kwargs
+    ) -> ConnectionClass:
+        return connection_class(connection_name=name, **kwargs)
 
     if not issubclass(connection_class, ExperimentalBaseConnection):
         raise StreamlitAPIException(
             f"{connection_class} is not a subclass of ExperimentalBaseConnection!"
         )
 
-    return connection_class(connection_name=name, **kwargs)
+    return __create_connection(name, connection_class, **kwargs)
 
 
 def _get_first_party_connection(connection_class: str):
@@ -82,31 +92,56 @@ def _get_first_party_connection(connection_class: str):
 
 @overload
 def connection_factory(
-    name: str, type: Literal["sql"], autocommit: bool = False, **kwargs
+    name: str,
+    type: Literal["sql"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
 ) -> SQL:
     pass
 
 
 @overload
-def connection_factory(name: str, type: Literal["snowpark"], **kwargs) -> Snowpark:
+def connection_factory(
+    name: str,
+    type: Literal["snowpark"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    **kwargs,
+) -> Snowpark:
     pass
 
 
 @overload
 def connection_factory(
-    name: str, type: Type[ConnectionClass], **kwargs
+    name: str,
+    type: Type[ConnectionClass],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    **kwargs,
 ) -> ConnectionClass:
     pass
 
 
 @overload
 def connection_factory(
-    name: str, type: Optional[str], **kwargs
+    name: str,
+    type: str | None,
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    **kwargs,
 ) -> ExperimentalBaseConnection[Any]:
     pass
 
 
-def connection_factory(name, type=None, **kwargs):
+def connection_factory(
+    name,
+    type=None,
+    max_entries=None,
+    ttl=None,
+    **kwargs,
+):
     """TODO(vdonato): Write a docstring (maybe with the help of the documentation team).
 
     The docstring should describe:
@@ -152,7 +187,9 @@ def connection_factory(name, type=None, **kwargs):
 
     # At this point, connection_class should be of type Type[ConnectionClass].
     try:
-        return _create_connection(name, connection_class, **kwargs)
+        return _create_connection(
+            name, connection_class, max_entries=max_entries, ttl=ttl, **kwargs
+        )
     except ModuleNotFoundError as e:
         err_string = str(e)
         missing_module = re.search(MODULE_EXTRACTION_REGEX, err_string)

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -143,12 +143,41 @@ def connection_factory(
     ttl=None,
     **kwargs,
 ):
-    """TODO(vdonato): Write a docstring (maybe with the help of the documentation team).
+    """Create a new connection or return an existing one.
 
-    The docstring should describe:
-      * Using st.connection with one of our first party connections by passing a string
-        literal as the type.
-      * Plugging your own ConnectionClass into st.experimental_connection.
+    Config options, credentials, secrets, etc. for connections are sourced from various
+    sources:
+      * Any connection-specific configuration files.
+      * An app's `secrets.toml` files.
+      * The kwargs passed to this function.
+
+    Examples
+    --------
+    The easiest way to create a first-party (SQL or Snowpark) connection is to use their
+    default names and define corresponding sections in your config.toml file.
+
+    >>> import streamlit as st
+    >>> conn = st.connection("sql")  # Config section defined in [connections.sql] in secrets.toml.
+
+    Creating a SQL connection with a custom name requires you to explicitly specify the
+    type. If type is not passed in as a kwarg, we try to infer it from the contents of
+    your secrets.toml.
+
+    >>> import streamlit as st
+    >>> conn1 = st.connection("my_sql_connection", type="sql")  # Config section defined in [connections.my_sql_connection].
+    >>> conn2 = st.connection("my_other_sql_connection")  # Type is inferred from [connections.my_other_sql_connection].
+
+    Passing the full module path to the connection class that you want to use can be
+    useful, especially when working with a custom connection:
+
+    >>> import streamlit as st
+    >>> conn = st.connection("my_sql_connection", type="streamlit.connections.SQL")
+
+    Finally, you can even pass the connection class to use directly to this function.
+
+    >>> import streamlit as st
+    >>> from streamlit.connections import SQL
+    >>> conn = st.connection("my_sql_connection", type=SQL)
     """
     USE_ENV_PREFIX = "env:"
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import SQL, BaseConnection
+from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
@@ -56,9 +56,11 @@ def _create_connection(
 #   1. Adding the new connection name and class to this function.
 #   2. Writing a new @overload signature mapping the connection's name to its class.
 def _get_first_party_connection(connection_name: str):
-    FIRST_PARTY_CONNECTIONS = {"sql"}
+    FIRST_PARTY_CONNECTIONS = {"snowpark", "sql"}
 
-    if connection_name == "sql":
+    if connection_name == "snowpark":
+        return Snowpark
+    elif connection_name == "sql":
         return SQL
 
     raise StreamlitAPIException(

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -14,7 +14,6 @@ rich>=11.2.0
 scipy>=1.7.3
 seaborn>=0.11.2
 setuptools>=65.5.1
-tenacity>=8.2.2
 watchdog>=2.1.5
 
 # These requirements exist only for `@st.cache` tests. st.cache is deprecated, and

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -8,13 +8,14 @@ graphviz>=0.17
 matplotlib>=3.3.4
 opencv-python>=4.5.3
 plotly>=5.3.1
+pyspark>=3.1.1
 pydot>=1.4.2
+rich>=11.2.0
 scipy>=1.7.3
 seaborn>=0.11.2
 setuptools>=65.5.1
+tenacity>=8.2.2
 watchdog>=2.1.5
-rich>=11.2.0
-pyspark>=3.1.1
 
 # These requirements exist only for `@st.cache` tests. st.cache is deprecated, and
 # we're not going to update its associated tests anymore. Please don't modify

--- a/lib/tests/streamlit/connections/__init__.py
+++ b/lib/tests/streamlit/connections/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Explicitly re-export public symbols.
+from streamlit.connections.base_connection import BaseConnection as BaseConnection

--- a/lib/tests/streamlit/connections/__init__.py
+++ b/lib/tests/streamlit/connections/__init__.py
@@ -11,6 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Explicitly re-export public symbols.
-from streamlit.connections.base_connection import BaseConnection as BaseConnection

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -1,0 +1,96 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import mock_open, patch
+
+import pytest
+
+import streamlit as st
+from streamlit.connections import BaseConnection
+
+MOCK_TOML = """
+[connections.mock_connection]
+foo="bar"
+
+[connections.nondefault_connection_name]
+baz="qux"
+"""
+
+
+class MockConnection(BaseConnection[str]):
+    _default_connection_name = "mock_connection"
+
+    def connect(self, **kwargs) -> str:
+        return "hooray, I'm connected!"
+
+
+class BaseConnectionDefaultMethodTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # st.secrets modifies os.environ, so we save it here and
+        # restore in tearDown.
+        self._prev_environ = dict(os.environ)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._prev_environ)
+        st.secrets._reset()
+
+    def test_instance_set_to_connect_return_value(self):
+        assert MockConnection()._instance == "hooray, I'm connected!"
+
+    def test_default_connection_name(self):
+        assert MockConnection().default_connection_name() == "mock_connection"
+
+    def test_default_connection_name_with_unset_default(self):
+        class ExplodingConnection(BaseConnection[str]):
+            # Intentionally don't define _default_connection_name.
+
+            def connect(self, **kwargs):
+                pass
+
+        with pytest.raises(NotImplementedError):
+            ExplodingConnection().default_connection_name()
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_get_secrets(self, _):
+        conn = MockConnection()
+        assert conn.get_secrets().foo == "bar"
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_get_secrets_nondefault_connection_name(self, _):
+        conn = MockConnection(connection_name="nondefault_connection_name")
+        assert conn.get_secrets().baz == "qux"
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_get_secrets_no_matching_section(self, _):
+        conn = MockConnection(connection_name="nonexistent")
+        assert conn.get_secrets() == {}
+
+    def test_get_secrets_no_secrets(self):
+        conn = MockConnection()
+        assert conn.get_secrets() == {}
+
+    def test_instance_prop_caches_raw_instance(self):
+        conn = MockConnection()
+        conn._raw_instance = "some other value"
+
+        assert conn._instance == "some other value"
+
+    def test_instance_prop_reinitializes_if_reset(self):
+        conn = MockConnection()
+        conn._raw_instance = None
+
+        assert conn._instance == "hooray, I'm connected!"

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -14,10 +14,10 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import PropertyMock, mock_open, patch
 
 import streamlit as st
-from streamlit.connections import BaseConnection
+from streamlit.connections import ExperimentalBaseConnection
 from streamlit.runtime.secrets import AttrDict
 
 MOCK_TOML = """
@@ -26,12 +26,12 @@ foo="bar"
 """
 
 
-class MockConnection(BaseConnection[str]):
-    def connect(self, **kwargs) -> str:
+class MockConnection(ExperimentalBaseConnection[str]):
+    def _connect(self, **kwargs) -> str:
         return "hooray, I'm connected!"
 
 
-class BaseConnectionDefaultMethodTests(unittest.TestCase):
+class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
     def setUp(self) -> None:
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
@@ -48,18 +48,18 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         )
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
-    def test_get_secrets(self, _):
+    def test_secrets_property(self, _):
         conn = MockConnection("my_mock_connection")
-        assert conn.get_secrets().foo == "bar"
+        assert conn._secrets.foo == "bar"
 
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
-    def test_get_secrets_no_matching_section(self, _):
+    def test_secrets_property_no_matching_section(self, _):
         conn = MockConnection("nonexistent")
-        assert conn.get_secrets() == {}
+        assert conn._secrets == {}
 
-    def test_get_secrets_no_secrets(self):
+    def test_secrets_property_no_secrets(self):
         conn = MockConnection("my_mock_connection")
-        assert conn.get_secrets() == {}
+        assert conn._secrets == {}
 
     def test_instance_prop_caches_raw_instance(self):
         conn = MockConnection("my_mock_connection")
@@ -79,7 +79,7 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         # conn.reset() shouldn't be called because secrets haven't changed since conn
         # was constructed.
         with patch(
-            "streamlit.connections.base_connection.BaseConnection.reset"
+            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
         ) as patched_reset:
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_not_called()
@@ -88,10 +88,10 @@ class BaseConnectionDefaultMethodTests(unittest.TestCase):
         conn = MockConnection("my_mock_connection")
 
         with patch(
-            "streamlit.connections.base_connection.BaseConnection.reset"
+            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.BaseConnection.get_secrets",
-            MagicMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
+            "streamlit.connections.base_connection.ExperimentalBaseConnection._secrets",
+            PropertyMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_called_once()

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -95,3 +95,21 @@ class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
         ):
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_called_once()
+
+    def test_repr_html_(self):
+        repr_ = MockConnection("my_mock_connection")._repr_html_()
+
+        assert (
+            "st.connection my_mock_connection built from `tests.streamlit.connections.base_connection_test.MockConnection`"
+            in repr_
+        )
+
+    @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
+    def test_repr_html_with_secrets(self, _):
+        repr_ = MockConnection("my_mock_connection")._repr_html_()
+
+        assert (
+            "st.connection my_mock_connection built from `tests.streamlit.connections.base_connection_test.MockConnection`"
+            in repr_
+        )
+        assert "Configured from `[connections.my_mock_connection]`" in repr_

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -30,7 +30,7 @@ class SnowparkConnectionTest(unittest.TestCase):
         mock_sql_return = MagicMock()
         mock_sql_return.to_pandas = MagicMock(return_value="i am a dataframe")
 
-        conn = Snowpark()
+        conn = Snowpark("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
         assert conn.read_sql("SELECT 1;") == "i am a dataframe"

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -16,12 +16,18 @@ import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+import streamlit as st
 from streamlit.connections import Snowpark
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from tests.testutil import create_mock_script_run_ctx
 
 
 class SnowparkConnectionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        st.cache_data.clear()
+
     @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_query_caches_value(self):
         # Caching functions rely on an active script run ctx
@@ -36,3 +42,24 @@ class SnowparkConnectionTest(unittest.TestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
         assert conn.query("SELECT 1;") == "i am a dataframe"
         conn._instance.sql.assert_called_once()
+
+    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
+    def test_retry_behavior(self):
+        mock_sql_return = MagicMock()
+        mock_sql_return.to_pandas = MagicMock(side_effect=Exception("oh noes :("))
+
+        conn = Snowpark("my_snowpark_connection")
+        conn._instance.sql.return_value = mock_sql_return
+
+        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+            with pytest.raises(Exception):
+                conn.query("SELECT 1;")
+
+            # Our connection should have been reset after each failed attempt to call
+            # query.
+            assert wrapped_reset.call_count == 3
+
+        # conn._connect should have been called three times: once in the initial
+        # connection, then once each after the second and third attempts to call
+        # query.
+        assert conn._connect.call_count == 3

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -14,12 +14,14 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 import pytest
 
 import streamlit as st
 from streamlit.connections import Snowpark
+from streamlit.connections.snowpark_connection import _load_from_snowsql_config_file
+from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
@@ -29,6 +31,53 @@ from tests.testutil import create_mock_script_run_ctx
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
+
+    def test_load_from_snowsql_config_file_no_file(self):
+        assert _load_from_snowsql_config_file("my_snowpark_connection") == {}
+
+    @patch(
+        "streamlit.connections.snowpark_connection.os.path.exists",
+        MagicMock(return_value=True),
+    )
+    def test_load_from_snowsql_config_file_no_section(self):
+        with patch("builtins.open", new_callable=mock_open, read_data=""):
+            assert _load_from_snowsql_config_file("my_snowpark_connection") == {}
+
+    @patch(
+        "streamlit.connections.snowpark_connection.os.path.exists",
+        MagicMock(return_value=True),
+    )
+    def test_load_from_snowsql_config_file_named_section(self):
+        config_data = """
+[connections.my_snowpark_connection]
+accountname = "hello"
+dbname = notPostgres
+
+[connections]
+accountname = "i get overwritten"
+schemaname = public
+"""
+        with patch("builtins.open", new_callable=mock_open, read_data=config_data):
+            assert _load_from_snowsql_config_file("my_snowpark_connection") == {
+                "account": "hello",
+                "database": "notPostgres",
+            }
+
+    @patch(
+        "streamlit.connections.snowpark_connection.os.path.exists",
+        MagicMock(return_value=True),
+    )
+    def test_load_from_snowsql_config_file_default_section(self):
+        config_data = """
+[connections]
+accountname = "not overwritten"
+schemaname = public
+"""
+        with patch("builtins.open", new_callable=mock_open, read_data=config_data):
+            assert _load_from_snowsql_config_file("my_snowpark_connection") == {
+                "account": "not overwritten",
+                "schema": "public",
+            }
 
     @patch(
         "snowflake.snowpark.context.get_active_session",
@@ -41,9 +90,7 @@ class SnowparkConnectionTest(unittest.TestCase):
     @patch(
         "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
         MagicMock(
-            return_value=AttrDict(
-                {"account": "some_val_1", "password": "i get overwritten"}
-            )
+            return_value={"account": "some_val_1", "password": "i get overwritten"}
         ),
     )
     @patch(
@@ -66,6 +113,16 @@ class SnowparkConnectionTest(unittest.TestCase):
                 "password": "hunter2",
             }
         )
+
+    def test_error_if_no_conn_params(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            Snowpark("my_snowpark_connection")
+        assert "Missing Snowpark connection configuration." in str(e.value)
+
+    def test_error_if_missing_required_conn_params(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            Snowpark("my_snowpark_connection", account="my_account")
+        assert "Missing Snowpark connection param: user" == str(e.value)
 
     @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_query_caches_value(self):

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -23,7 +23,7 @@ from tests.testutil import create_mock_script_run_ctx
 
 class SnowparkConnectionTest(unittest.TestCase):
     @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
-    def test_read_sql_caches_value(self):
+    def test_query_caches_value(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
 
@@ -33,6 +33,6 @@ class SnowparkConnectionTest(unittest.TestCase):
         conn = Snowpark("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
         conn._instance.sql.assert_called_once()

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -14,19 +14,50 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
 import streamlit as st
 from streamlit.connections import Snowpark
 from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
+
+    @pytest.mark.require_snowflake
+    @patch(
+        "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
+        MagicMock(
+            return_value=AttrDict(
+                {"account": "some_val_1", "password": "i get overwritten"}
+            )
+        ),
+    )
+    @patch(
+        "streamlit.connections.snowpark_connection.Snowpark._secrets",
+        PropertyMock(
+            return_value=AttrDict(
+                {"user": "some_val_2", "some_key": "i get overwritten"}
+            )
+        ),
+    )
+    @patch("snowflake.snowpark.session.Session")
+    def test_merges_params_from_all_config_sources(self, patched_session):
+        Snowpark("my_snowpark_connection", some_key="some_val_3", password="hunter2")
+
+        patched_session.builder.configs.assert_called_with(
+            {
+                "account": "some_val_1",
+                "user": "some_val_2",
+                "some_key": "some_val_3",
+                "password": "hunter2",
+            }
+        )
 
     @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_query_caches_value(self):

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -25,11 +25,19 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
+@pytest.mark.require_snowflake
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
 
-    @pytest.mark.require_snowflake
+    @patch(
+        "snowflake.snowpark.context.get_active_session",
+        MagicMock(return_value="some active session"),
+    )
+    def test_just_uses_current_active_session_if_available(self):
+        conn = Snowpark("my_snowpark_connection")
+        assert conn._instance == "some active session"
+
     @patch(
         "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
         MagicMock(

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -22,7 +22,7 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class SnowparkConnectionTest(unittest.TestCase):
-    @patch("streamlit.connections.snowpark_connection.Snowpark.connect", MagicMock())
+    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
     def test_read_sql_caches_value(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -1,0 +1,38 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from streamlit.connections import Snowpark
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx
+
+
+class SnowparkConnectionTest(unittest.TestCase):
+    @patch("streamlit.connections.snowpark_connection.Snowpark.connect", MagicMock())
+    def test_read_sql_caches_value(self):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+        mock_sql_return = MagicMock()
+        mock_sql_return.to_pandas = MagicMock(return_value="i am a dataframe")
+
+        conn = Snowpark()
+        conn._instance.sql.return_value = mock_sql_return
+
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        conn._instance.sql.assert_called_once()

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 import pytest
 
 import streamlit as st
-from streamlit.connections import Snowpark
+from streamlit.connections import SnowparkConnection
 from streamlit.connections.snowpark_connection import _load_from_snowsql_config_file
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.scriptrunner import add_script_run_ctx
@@ -84,7 +84,7 @@ schemaname = public
         MagicMock(return_value="some active session"),
     )
     def test_just_uses_current_active_session_if_available(self):
-        conn = Snowpark("my_snowpark_connection")
+        conn = SnowparkConnection("my_snowpark_connection")
         assert conn._instance == "some active session"
 
     @patch(
@@ -94,7 +94,7 @@ schemaname = public
         ),
     )
     @patch(
-        "streamlit.connections.snowpark_connection.Snowpark._secrets",
+        "streamlit.connections.snowpark_connection.SnowparkConnection._secrets",
         PropertyMock(
             return_value=AttrDict(
                 {"user": "some_val_2", "some_key": "i get overwritten"}
@@ -103,7 +103,9 @@ schemaname = public
     )
     @patch("snowflake.snowpark.session.Session")
     def test_merges_params_from_all_config_sources(self, patched_session):
-        Snowpark("my_snowpark_connection", some_key="some_val_3", password="hunter2")
+        SnowparkConnection(
+            "my_snowpark_connection", some_key="some_val_3", password="hunter2"
+        )
 
         patched_session.builder.configs.assert_called_with(
             {
@@ -116,15 +118,18 @@ schemaname = public
 
     def test_error_if_no_conn_params(self):
         with pytest.raises(StreamlitAPIException) as e:
-            Snowpark("my_snowpark_connection")
+            SnowparkConnection("my_snowpark_connection")
         assert "Missing Snowpark connection configuration." in str(e.value)
 
     def test_error_if_missing_required_conn_params(self):
         with pytest.raises(StreamlitAPIException) as e:
-            Snowpark("my_snowpark_connection", account="my_account")
-        assert "Missing Snowpark connection param: user" == str(e.value)
+            SnowparkConnection("my_snowpark_connection", user="my_user")
+        assert "Missing Snowpark connection param: account" == str(e.value)
 
-    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
+    @patch(
+        "streamlit.connections.snowpark_connection.SnowparkConnection._connect",
+        MagicMock(),
+    )
     def test_query_caches_value(self):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
@@ -132,14 +137,17 @@ schemaname = public
         mock_sql_return = MagicMock()
         mock_sql_return.to_pandas = MagicMock(return_value="i am a dataframe")
 
-        conn = Snowpark("my_snowpark_connection")
+        conn = SnowparkConnection("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
         assert conn.query("SELECT 1;") == "i am a dataframe"
         assert conn.query("SELECT 1;") == "i am a dataframe"
         conn._instance.sql.assert_called_once()
 
-    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
+    @patch(
+        "streamlit.connections.snowpark_connection.SnowparkConnection._connect",
+        MagicMock(),
+    )
     def test_retry_behavior(self):
         from snowflake.snowpark.exceptions import SnowparkServerException
 
@@ -148,7 +156,7 @@ schemaname = public
             side_effect=SnowparkServerException("oh noes :(")
         )
 
-        conn = Snowpark("my_snowpark_connection")
+        conn = SnowparkConnection("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
         with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
@@ -164,14 +172,17 @@ schemaname = public
         # query.
         assert conn._connect.call_count == 3
 
-    @patch("streamlit.connections.snowpark_connection.Snowpark._connect", MagicMock())
+    @patch(
+        "streamlit.connections.snowpark_connection.SnowparkConnection._connect",
+        MagicMock(),
+    )
     def test_retry_fails_fast_for_most_errors(self):
         from snowflake.snowpark.exceptions import SnowparkServerException
 
         mock_sql_return = MagicMock()
         mock_sql_return.to_pandas = MagicMock(side_effect=Exception("oh noes :("))
 
-        conn = Snowpark("my_snowpark_connection")
+        conn = SnowparkConnection("my_snowpark_connection")
         conn._instance.sql.return_value = mock_sql_return
 
         with pytest.raises(Exception):

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -1,0 +1,92 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import unittest
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
+from parameterized import parameterized
+
+from streamlit.connections import SQL
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import AttrDict
+from tests.testutil import create_mock_script_run_ctx
+
+DB_SECRETS = {
+    "dialect": "postgres",
+    "driver": "psycopg2",
+    "username": "AzureDiamond",
+    "password": "hunter2",
+    "host": "localhost",
+    "port": "5432",
+    "database": "postgres",
+}
+
+
+class SQLConnectionTest(unittest.TestCase):
+    @patch("sqlalchemy.engine.make_url", MagicMock(return_value="some_sql_conn_string"))
+    @patch(
+        "streamlit.connections.sql_connection.SQL.get_secrets",
+        MagicMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_url_set_explicitly_in_secrets(self, patched_create_engine):
+        SQL()
+
+        patched_create_engine.assert_called_once_with("some_sql_conn_string")
+
+    @patch(
+        "streamlit.connections.sql_connection.SQL.get_secrets",
+        MagicMock(return_value=AttrDict(DB_SECRETS)),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_url_constructed_from_secrets_params(self, patched_create_engine):
+        SQL()
+
+        patched_create_engine.assert_called_once()
+        args, _ = patched_create_engine.call_args_list[0]
+        assert (
+            str(args[0])
+            == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
+        )
+
+    @parameterized.expand([("dialect",), ("username",), ("host",)])
+    def test_error_if_missing_required_param(self, missing_param):
+        secrets = deepcopy(DB_SECRETS)
+        del secrets[missing_param]
+
+        with patch(
+            "streamlit.connections.sql_connection.SQL.get_secrets",
+            MagicMock(return_value=AttrDict(secrets)),
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                SQL()
+
+            assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
+
+    @patch("streamlit.connections.sql_connection.SQL.connect", MagicMock())
+    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    def test_read_sql_caches_value(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
+
+        conn = SQL()
+
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        patched_read_sql.assert_called_once()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -68,6 +68,21 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://AzureDiamond:hunter2@localhost:5432/postgres"
         )
 
+    @patch(
+        "streamlit.connections.sql_connection.SQL._secrets",
+        PropertyMock(return_value=AttrDict(DB_SECRETS)),
+    )
+    @patch("sqlalchemy.create_engine")
+    def test_kwargs_overwrite_secrets_values(self, patched_create_engine):
+        SQL("my_sql_connection", port=2345, username="DnomaidEruza")
+
+        patched_create_engine.assert_called_once()
+        args, _ = patched_create_engine.call_args_list[0]
+        assert (
+            str(args[0])
+            == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres"
+        )
+
     @parameterized.expand([("dialect",), ("username",), ("host",)])
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -90,3 +90,34 @@ class SQLConnectionTest(unittest.TestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
         assert conn.query("SELECT 1;") == "i am a dataframe"
         patched_read_sql.assert_called_once()
+
+    @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
+    def test_repr_html_(self):
+        conn = SQL("my_sql_connection")
+        with conn.session() as s:
+            s.bind.dialect.name = "postgres"
+        repr_ = conn._repr_html_()
+
+        assert (
+            "st.connection my_sql_connection built from `streamlit.connections.sql_connection.SQL`"
+            in repr_
+        )
+        assert "Dialect: `postgres`" in repr_
+
+    @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
+    @patch(
+        "streamlit.connections.sql_connection.SQL._secrets",
+        PropertyMock(return_value=AttrDict({"url": "some_sql_conn_string"})),
+    )
+    def test_repr_html_with_secrets(self):
+        conn = SQL("my_sql_connection")
+        with conn.session() as s:
+            s.bind.dialect.name = "postgres"
+        repr_ = conn._repr_html_()
+
+        assert (
+            "st.connection my_sql_connection built from `streamlit.connections.sql_connection.SQL`"
+            in repr_
+        )
+        assert "Dialect: `postgres`" in repr_
+        assert "Configured from `[connections.my_sql_connection]`" in repr_

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -80,13 +80,13 @@ class SQLConnectionTest(unittest.TestCase):
 
     @patch("streamlit.connections.sql_connection.SQL._connect", MagicMock())
     @patch("streamlit.connections.sql_connection.pd.read_sql")
-    def test_read_sql_caches_value(self, patched_read_sql):
+    def test_query_caches_value(self, patched_read_sql):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
         conn = SQL("my_sql_connection")
 
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
-        assert conn.read_sql("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
         patched_read_sql.assert_called_once()

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -45,7 +45,7 @@ class SQLConnectionTest(unittest.TestCase):
     )
     @patch("sqlalchemy.create_engine")
     def test_url_set_explicitly_in_secrets(self, patched_create_engine):
-        SQL()
+        SQL("my_sql_connection")
 
         patched_create_engine.assert_called_once_with("some_sql_conn_string")
 
@@ -55,7 +55,7 @@ class SQLConnectionTest(unittest.TestCase):
     )
     @patch("sqlalchemy.create_engine")
     def test_url_constructed_from_secrets_params(self, patched_create_engine):
-        SQL()
+        SQL("my_sql_connection")
 
         patched_create_engine.assert_called_once()
         args, _ = patched_create_engine.call_args_list[0]
@@ -74,7 +74,7 @@ class SQLConnectionTest(unittest.TestCase):
             MagicMock(return_value=AttrDict(secrets)),
         ):
             with pytest.raises(StreamlitAPIException) as e:
-                SQL()
+                SQL("my_sql_connection")
 
             assert str(e.value) == f"Missing SQL DB connection param: {missing_param}"
 
@@ -85,7 +85,7 @@ class SQLConnectionTest(unittest.TestCase):
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
-        conn = SQL()
+        conn = SQL("my_sql_connection")
 
         assert conn.read_sql("SELECT 1;") == "i am a dataframe"
         assert conn.read_sql("SELECT 1;") == "i am a dataframe"

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -84,6 +84,16 @@ class SQLConnectionTest(unittest.TestCase):
             == "postgres+psycopg2://DnomaidEruza:hunter2@localhost:2345/postgres"
         )
 
+    def test_error_if_no_config(self):
+        with patch(
+            "streamlit.connections.sql_connection.SQL._secrets",
+            PropertyMock(return_value=AttrDict({})),
+        ):
+            with pytest.raises(StreamlitAPIException) as e:
+                SQL("my_sql_connection")
+
+            assert "Missing SQL DB connection configuration." in str(e.value)
+
     @parameterized.expand([("dialect",), ("username",), ("host",)])
     def test_error_if_missing_required_param(self, missing_param):
         secrets = deepcopy(DB_SECRETS)

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -1,0 +1,30 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from streamlit.connections.util import extract_from_dict
+
+
+class ConnectionUtilTest(unittest.TestCase):
+    def test_extract_from_dict(self):
+        d = {"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"}
+
+        extracted = extract_from_dict(
+            ["k1", "k2", "nonexistent_key"],
+            d,
+        )
+
+        assert extracted == {"k1": "v1", "k2": "v2"}
+        assert d == {"k3": "v3", "k4": "v4"}

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -241,3 +241,13 @@ type="snowpark"
         patched_create_connection.assert_called_once_with(
             "staging", MockConnection, max_entries=None, ttl=None
         )
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_only_set_name_if_equal_to_desired_type(
+        self, patched_create_connection
+    ):
+        connection_factory("sql")
+
+        patched_create_connection.assert_called_once_with(
+            "sql", SQL, max_entries=None, ttl=None
+        )

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import SQL, BaseConnection
+from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.connection_factory import _create_connection, connection_factory
 from streamlit.runtime.scriptrunner import add_script_run_ctx
@@ -117,10 +117,9 @@ class ConnectionFactoryTest(unittest.TestCase):
         assert "Invalid connection nonexistent" in str(e.value)
 
     @patch("streamlit.runtime.connection_factory._create_connection")
-    def test_sql_connection_string_shorthand(self, patched_create_connection):
+    def test_connection_string_shorthand(self, patched_create_connection):
         connection_factory("sql")
+        patched_create_connection.assert_called_with(SQL, name="default")
 
-        patched_create_connection.assert_called_once_with(
-            SQL,
-            name="default",
-        )
+        connection_factory("snowpark")
+        patched_create_connection.assert_called_with(Snowpark, name="default")

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -34,8 +34,6 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class MockConnection(ExperimentalBaseConnection[None]):
-    _default_connection_name = "mock_connection"
-
     def _connect(self, **kwargs):
         pass
 
@@ -230,3 +228,10 @@ connection_class="snowpark"
         for m in modules:
             for disallowed_import in DISALLOWED_IMPORTS:
                 assert disallowed_import not in m
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_set_connection_name_via_env_var(self, patched_create_connection):
+        os.environ["MY_CONN_NAME"] = "staging"
+        connection_factory("env:MY_CONN_NAME", MockConnection)
+
+        patched_create_connection.assert_called_once_with("staging", MockConnection)

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import SQL, BaseConnection, Snowpark
+from streamlit.connections import SQL, ExperimentalBaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.connection_factory import (
     _create_connection,
@@ -33,10 +33,10 @@ from streamlit.runtime.secrets import secrets_singleton
 from tests.testutil import create_mock_script_run_ctx
 
 
-class MockConnection(BaseConnection[None]):
+class MockConnection(ExperimentalBaseConnection[None]):
     _default_connection_name = "mock_connection"
 
-    def connect(self, **kwargs):
+    def _connect(self, **kwargs):
         pass
 
 
@@ -60,14 +60,16 @@ class ConnectionFactoryTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self._prev_environ)
 
-    def test_create_connection_helper_explodes_if_not_BaseConnection_subclass(self):
+    def test_create_connection_helper_explodes_if_not_ExperimentalBaseConnection_subclass(
+        self,
+    ):
         class NotABaseConnection:
             pass
 
         with pytest.raises(StreamlitAPIException) as e:
             _create_connection("my_connection", NotABaseConnection)
 
-        assert "is not a subclass of BaseConnection" in str(e.value)
+        assert "is not a subclass of ExperimentalBaseConnection" in str(e.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -26,9 +26,10 @@ from tests.testutil import create_mock_script_run_ctx
 
 
 class MockConnection(BaseConnection[None]):
-    def __init__(self, connection_name: str, **kwargs):
-        self._connection_name = connection_name
-        self._kwargs = kwargs
+    _default_connection_name = "mock_connection"
+
+    def connect(self, **kwargs):
+        pass
 
 
 class ConnectionFactoryTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -1,0 +1,96 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit.connections import BaseConnection
+from streamlit.runtime.connection_factory import _create_connection, connection_factory
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx
+
+
+class MockConnection(BaseConnection[None]):
+    def __init__(self, connection_name: str, **kwargs):
+        self._connection_name = connection_name
+        self._kwargs = kwargs
+
+
+class ConnectionFactoryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        _create_connection.clear()
+
+    def test_passes_name_and_args_to_class(self):
+        conn = connection_factory(MockConnection, name="nondefault", foo="bar")
+        assert conn._connection_name == "nondefault"
+        assert conn._kwargs == {"foo": "bar"}
+
+    def test_caches_connection_instance(self):
+        conn = connection_factory(MockConnection)
+        assert connection_factory(MockConnection) is conn
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_friendly_error_with_certain_missing_dependencies(
+        self, patched_create_connection
+    ):
+        """Test that our error messages are extra-friendly when a ModuleNotFoundError
+        error is thrown for certain missing packages.
+        """
+
+        patched_create_connection.side_effect = ModuleNotFoundError(
+            "No module named 'sqlalchemy'"
+        )
+
+        with pytest.raises(ModuleNotFoundError) as e:
+            connection_factory(MockConnection)
+        assert str(e.value) == (
+            "No module named 'sqlalchemy'. "
+            "You need to install the 'sqlalchemy' package to use this connection."
+        )
+
+        _create_connection.clear()
+        patched_create_connection.side_effect = ModuleNotFoundError(
+            "No module named 'snowflake.snowpark'"
+        )
+
+        with pytest.raises(ModuleNotFoundError) as e:
+            connection_factory(MockConnection)
+        assert str(e.value) == (
+            "No module named 'snowflake.snowpark'. "
+            "You need to install the 'snowflake-snowpark-python' package to use this connection."
+        )
+
+    @patch(
+        "streamlit.runtime.connection_factory._create_connection",
+        MagicMock(side_effect=ModuleNotFoundError("No module named 'foo'")),
+    )
+    def test_generic_missing_dependency_error(self):
+        """Test our generic error message when a ModuleNotFoundError is thrown."""
+        with pytest.raises(ModuleNotFoundError) as e:
+            connection_factory(MockConnection)
+        assert str(e.value) == (
+            "No module named 'foo'. "
+            "You may be missing a dependency required to use this connection."
+        )

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -91,7 +91,7 @@ class ConnectionFactoryTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            # No connection_class is specified, and there's no config file to find one
+            # No type is specified, and there's no config file to find one
             # in.
             (None, FileNotFoundError, "No secrets files found"),
             # Nonexistent module.
@@ -115,12 +115,10 @@ class ConnectionFactoryTest(unittest.TestCase):
         ]
     )
     def test_connection_factory_errors(
-        self, connection_class, expected_error_class, expected_error_msg
+        self, type, expected_error_class, expected_error_msg
     ):
         with pytest.raises(expected_error_class) as e:
-            connection_factory(
-                "nonexistsent_connection", connection_class=connection_class
-            )
+            connection_factory("nonexistsent_connection", type=type)
 
         assert expected_error_msg in str(e.value)
 
@@ -128,15 +126,13 @@ class ConnectionFactoryTest(unittest.TestCase):
     def test_can_specify_class_with_full_name_in_kwargs(
         self, patched_create_connection
     ):
-        connection_factory(
-            "my_connection", connection_class="streamlit.connections.SQL"
-        )
+        connection_factory("my_connection", type="streamlit.connections.SQL")
 
         patched_create_connection.assert_called_once_with("my_connection", SQL)
 
     @patch("streamlit.runtime.connection_factory._create_connection")
     def test_can_specify_first_party_class_in_kwargs(self, patched_create_connection):
-        connection_factory("my_connection", connection_class="sql")
+        connection_factory("my_connection", type="sql")
 
         patched_create_connection.assert_called_once_with("my_connection", SQL)
 
@@ -146,7 +142,7 @@ class ConnectionFactoryTest(unittest.TestCase):
     ):
         mock_toml = """
 [connections.my_connection]
-connection_class="streamlit.connections.SQL"
+type="streamlit.connections.SQL"
 """
         with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
             connection_factory("my_connection")
@@ -157,7 +153,7 @@ connection_class="streamlit.connections.SQL"
     def test_can_specify_first_party_class_in_config(self, patched_create_connection):
         mock_toml = """
 [connections.my_connection]
-connection_class="snowpark"
+type="snowpark"
 """
         with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
             connection_factory("my_connection")

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -12,18 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from parameterized import parameterized
 
 from streamlit.connections import SQL, BaseConnection, Snowpark
 from streamlit.errors import StreamlitAPIException
-from streamlit.runtime.connection_factory import _create_connection, connection_factory
+from streamlit.runtime.connection_factory import (
+    _create_connection,
+    _get_first_party_connection,
+    connection_factory,
+)
 from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import secrets_singleton
 from tests.testutil import create_mock_script_run_ctx
 
 
@@ -38,6 +44,10 @@ class ConnectionFactoryTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
+        # st.secrets modifies os.environ, so we save it here and
+        # restore in tearDown.
+        self._prev_environ = dict(os.environ)
+
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
 
@@ -45,14 +55,123 @@ class ConnectionFactoryTest(unittest.TestCase):
         super().tearDown()
         _create_connection.clear()
 
-    def test_passes_name_and_args_to_class(self):
-        conn = connection_factory(MockConnection, name="nondefault", foo="bar")
-        assert conn._connection_name == "nondefault"
+        secrets_singleton._reset()
+
+        os.environ.clear()
+        os.environ.update(self._prev_environ)
+
+    def test_create_connection_helper_explodes_if_not_BaseConnection_subclass(self):
+        class NotABaseConnection:
+            pass
+
+        with pytest.raises(StreamlitAPIException) as e:
+            _create_connection("my_connection", NotABaseConnection)
+
+        assert "is not a subclass of BaseConnection" in str(e.value)
+
+    @parameterized.expand(
+        [
+            ("snowpark", Snowpark),
+            ("sql", SQL),
+        ]
+    )
+    def test_get_first_party_connection_helper(
+        self, connection_class_name, expected_connection_class
+    ):
+        assert (
+            _get_first_party_connection(connection_class_name)
+            == expected_connection_class
+        )
+
+    def test_get_first_party_connection_helper_errors_when_invalid(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            _get_first_party_connection("not_a_first_party_connection")
+
+        assert "Invalid connection" in str(e.value)
+
+    @parameterized.expand(
+        [
+            # No connection_class is specified, and there's no config file to find one
+            # in.
+            (None, FileNotFoundError, "No secrets files found"),
+            # Nonexistent module.
+            (
+                "nonexistent.module.SomeConnection",
+                ModuleNotFoundError,
+                "No module named 'nonexistent'",
+            ),
+            # The module exists, but the connection_class doesn't.
+            (
+                "streamlit.connections.Nonexistent",
+                AttributeError,
+                "module 'streamlit.connections' has no attribute 'Nonexistent'",
+            ),
+            # Invalid first party connection name.
+            (
+                "not_a_first_party_connection",
+                StreamlitAPIException,
+                "Invalid connection 'not_a_first_party_connection'",
+            ),
+        ]
+    )
+    def test_connection_factory_errors(
+        self, connection_class, expected_error_class, expected_error_msg
+    ):
+        with pytest.raises(expected_error_class) as e:
+            connection_factory(
+                "nonexistsent_connection", connection_class=connection_class
+            )
+
+        assert expected_error_msg in str(e.value)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_class_with_full_name_in_kwargs(
+        self, patched_create_connection
+    ):
+        connection_factory(
+            "my_connection", connection_class="streamlit.connections.SQL"
+        )
+
+        patched_create_connection.assert_called_once_with("my_connection", SQL)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_first_party_class_in_kwargs(self, patched_create_connection):
+        connection_factory("my_connection", connection_class="sql")
+
+        patched_create_connection.assert_called_once_with("my_connection", SQL)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_class_with_full_name_in_config(
+        self, patched_create_connection
+    ):
+        mock_toml = """
+[connections.my_connection]
+connection_class="streamlit.connections.SQL"
+"""
+        with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
+            connection_factory("my_connection")
+
+        patched_create_connection.assert_called_once_with("my_connection", SQL)
+
+    @patch("streamlit.runtime.connection_factory._create_connection")
+    def test_can_specify_first_party_class_in_config(self, patched_create_connection):
+        mock_toml = """
+[connections.my_connection]
+connection_class="snowpark"
+"""
+        with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
+            connection_factory("my_connection")
+
+        patched_create_connection.assert_called_once_with("my_connection", Snowpark)
+
+    def test_can_pass_class_directly_to_factory_func(self):
+        conn = connection_factory("my_connection", MockConnection, foo="bar")
+        assert conn._connection_name == "my_connection"
         assert conn._kwargs == {"foo": "bar"}
 
     def test_caches_connection_instance(self):
-        conn = connection_factory(MockConnection)
-        assert connection_factory(MockConnection) is conn
+        conn = connection_factory("my_connection", MockConnection)
+        assert connection_factory("my_connection", MockConnection) is conn
 
     @parameterized.expand(
         [
@@ -75,7 +194,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         )
 
         with pytest.raises(ModuleNotFoundError) as e:
-            connection_factory(MockConnection)
+            connection_factory("my_connection", MockConnection)
         assert str(e.value) == (
             f"No module named '{missing_module}'. "
             f"You need to install the '{pypi_package}' package to use this connection."
@@ -88,7 +207,7 @@ class ConnectionFactoryTest(unittest.TestCase):
     def test_generic_missing_dependency_error(self):
         """Test our generic error message when a ModuleNotFoundError is thrown."""
         with pytest.raises(ModuleNotFoundError) as e:
-            connection_factory(MockConnection)
+            connection_factory("my_connection", MockConnection)
         assert str(e.value) == (
             "No module named 'foo'. "
             "You may be missing a dependency required to use this connection."
@@ -109,17 +228,3 @@ class ConnectionFactoryTest(unittest.TestCase):
         for m in modules:
             for disallowed_import in DISALLOWED_IMPORTS:
                 assert disallowed_import not in m
-
-    def test_raises_exception_when_passed_invalid_class_string(self):
-        with pytest.raises(StreamlitAPIException) as e:
-            connection_factory("nonexistent")
-
-        assert "Invalid connection nonexistent" in str(e.value)
-
-    @patch("streamlit.runtime.connection_factory._create_connection")
-    def test_connection_string_shorthand(self, patched_create_connection):
-        connection_factory("sql")
-        patched_create_connection.assert_called_with(SQL, name="default")
-
-        connection_factory("snowpark")
-        patched_create_connection.assert_called_with(Snowpark, name="default")

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -183,6 +183,7 @@ type="snowpark"
             ("sqlalchemy", "sqlalchemy"),
             ("snowflake", "snowflake-snowpark-python"),
             ("snowflake.snowpark", "snowflake-snowpark-python"),
+            ("tenacity", "tenacity"),
         ]
     )
     @patch("streamlit.runtime.connection_factory._create_connection")

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -180,6 +180,8 @@ type="snowpark"
 
     @parameterized.expand(
         [
+            ("MySQLdb", "mysqlclient"),
+            ("psycopg2", "psycopg2-binary"),
             ("sqlalchemy", "sqlalchemy"),
             ("snowflake", "snowflake-snowpark-python"),
             ("snowflake.snowpark", "snowflake-snowpark-python"),

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,7 +21,11 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import SQL, ExperimentalBaseConnection, Snowpark
+from streamlit.connections import (
+    ExperimentalBaseConnection,
+    SnowparkConnection,
+    SQLConnection,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
@@ -72,8 +76,8 @@ class ConnectionFactoryTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("snowpark", Snowpark),
-            ("sql", SQL),
+            ("snowpark", SnowparkConnection),
+            ("sql", SQLConnection),
         ]
     )
     def test_get_first_party_connection_helper(
@@ -127,10 +131,10 @@ class ConnectionFactoryTest(unittest.TestCase):
     def test_can_specify_class_with_full_name_in_kwargs(
         self, patched_create_connection
     ):
-        connection_factory("my_connection", type="streamlit.connections.SQL")
+        connection_factory("my_connection", type="streamlit.connections.SQLConnection")
 
         patched_create_connection.assert_called_once_with(
-            "my_connection", SQL, max_entries=None, ttl=None
+            "my_connection", SQLConnection, max_entries=None, ttl=None
         )
 
     @patch("streamlit.runtime.connection_factory._create_connection")
@@ -138,7 +142,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         connection_factory("my_connection", type="sql")
 
         patched_create_connection.assert_called_once_with(
-            "my_connection", SQL, max_entries=None, ttl=None
+            "my_connection", SQLConnection, max_entries=None, ttl=None
         )
 
     @patch("streamlit.runtime.connection_factory._create_connection")
@@ -147,13 +151,13 @@ class ConnectionFactoryTest(unittest.TestCase):
     ):
         mock_toml = """
 [connections.my_connection]
-type="streamlit.connections.SQL"
+type="streamlit.connections.SQLConnection"
 """
         with patch("builtins.open", new_callable=mock_open, read_data=mock_toml):
             connection_factory("my_connection")
 
         patched_create_connection.assert_called_once_with(
-            "my_connection", SQL, max_entries=None, ttl=None
+            "my_connection", SQLConnection, max_entries=None, ttl=None
         )
 
     @patch("streamlit.runtime.connection_factory._create_connection")
@@ -166,7 +170,7 @@ type="snowpark"
             connection_factory("my_connection")
 
         patched_create_connection.assert_called_once_with(
-            "my_connection", Snowpark, max_entries=None, ttl=None
+            "my_connection", SnowparkConnection, max_entries=None, ttl=None
         )
 
     def test_can_pass_class_directly_to_factory_func(self):
@@ -185,7 +189,6 @@ type="snowpark"
             ("sqlalchemy", "sqlalchemy"),
             ("snowflake", "snowflake-snowpark-python"),
             ("snowflake.snowpark", "snowflake-snowpark-python"),
-            ("tenacity", "tenacity"),
         ]
     )
     @patch("streamlit.runtime.connection_factory._create_connection")
@@ -252,5 +255,5 @@ type="snowpark"
         connection_factory("sql")
 
         patched_create_connection.assert_called_once_with(
-            "sql", SQL, max_entries=None, ttl=None
+            "sql", SQLConnection, max_entries=None, ttl=None
         )

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -85,7 +85,6 @@ class MetricsUtilTest(unittest.TestCase):
         with patch(
             "streamlit.runtime.metrics_util.uuid.getnode", return_value=MAC
         ), patch("streamlit.runtime.metrics_util.os.path.isfile", return_value=False):
-
             machine_id = metrics_util._get_machine_id_v3()
         self.assertEqual(machine_id, MAC)
 
@@ -246,6 +245,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         """All commands of the public API should be tracked with the correct name."""
         # Some commands are currently not tracked for various reasons:
         ignored_commands = {
+            "experimental_connection",
             "experimental_rerun",
             "stop",
             "spinner",

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -245,6 +245,10 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         """All commands of the public API should be tracked with the correct name."""
         # Some commands are currently not tracked for various reasons:
         ignored_commands = {
+            # We need to ignore `experimental_connection` because the `@gather_metrics`
+            # decorator is attached to a helper function rather than the
+            # publicly-exported function, which causes it not to be executed before an
+            # Exception is raised due to a lack of required arguments.
             "experimental_connection",
             "experimental_rerun",
             "stop",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -145,6 +145,7 @@ class StreamlitTest(unittest.TestCase):
                 "experimental_rerun",
                 "experimental_show",
                 "experimental_data_editor",
+                "experimental_connection",
                 "get_option",
                 "set_option",
             },


### PR DESCRIPTION
## 📚 Context

This is the big merge of the `feature/st.experimental_connection` branch into `develop`!

Note that this feature was built incrementally with small PRs being merged into the feature branch, and
each of the PRs was reviewed. Thus, it's not necessary to do an extremely thorough code review on this PR
before approving it, but it would still be good to do some sanity checks on the code before rubber-stamping
the PR. 

`st.experimental_connection` is a new feature designed to help with the currently tedious process of configuring
and using connections to data sources inside of a Streamlit app. It provides a few things as part of its
public-facing API:
* The `st.experimental_connection` factory function, which helps developers with initializing a connection
   while following best practices that are often easy to overlook. Most notably, it ensures that connections
   created with it are cached so that they don't get reinitialized with every script run.
* Two first-party connections: `SQLConnection` and `SnowparkConnection`. These connections can easily
   be created from the `st.experimental_connection` factory function. They provide ways to work with the
   SQLAlchemy and Snowpark for Python libraries, respectively, with built-in support for Streamlit's secrets
   management mechanisms.
   * We'll be releasing additional connections that aren't shipped as part of the core library but are maintained
      by the Streamlit team. These connections may eventually be integrated into the core library after we're
      more confident in their quality and assuming there aren't dependency-related reasons we're unable to
      include them.
* For developers who want to create their own connections, we provide an `ExperimentalBaseConnection`
   abstract class to simplify the process of writing an `st.experimental_connection`-compatible connection
   implementation.