### PR TITLE
Use the current active Snowpark session if one is available

### DIFF
--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -79,10 +79,18 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
         with self._lock:
             super().__init__(connection_name, **kwargs)
 
-    # TODO(vdonato): Teach the .connect() method how to automagically connect in a SiS
-    # runtime environment.
     def _connect(self, **kwargs) -> "Session":
+        from snowflake.snowpark.context import get_active_session
+        from snowflake.snowpark.exceptions import SnowparkSessionException
         from snowflake.snowpark.session import Session
+
+        # If we're in a runtime environment where there's already an active session
+        # available, we just use that one. Otherwise, we fall back to attempting to
+        # create a new one from whatever credentials we have available.
+        try:
+            return get_active_session()
+        except SnowparkSessionException:
+            pass
 
         conn_params = ChainMap(
             kwargs,

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -80,8 +80,10 @@ class Snowpark(ExperimentalBaseConnection["Session"]):
             super().__init__(connection_name, **kwargs)
 
     def _connect(self, **kwargs) -> "Session":
-        from snowflake.snowpark.context import get_active_session
-        from snowflake.snowpark.exceptions import SnowparkSessionException
+        from snowflake.snowpark.context import get_active_session  # type: ignore
+        from snowflake.snowpark.exceptions import (  # type: ignore
+            SnowparkSessionException,
+        )
         from snowflake.snowpark.session import Session
 
         # If we're in a runtime environment where there's already an active session

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -25,11 +25,11 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
+@pytest.mark.require_snowflake
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:
         st.cache_data.clear()
 
-    @pytest.mark.require_snowflake
     @patch(
         "snowflake.snowpark.context.get_active_session",
         MagicMock(return_value="some active session"),
@@ -38,7 +38,6 @@ class SnowparkConnectionTest(unittest.TestCase):
         conn = Snowpark("my_snowpark_connection")
         assert conn._instance == "some active session"
 
-    @pytest.mark.require_snowflake
     @patch(
         "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
         MagicMock(

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -31,6 +31,15 @@ class SnowparkConnectionTest(unittest.TestCase):
 
     @pytest.mark.require_snowflake
     @patch(
+        "snowflake.snowpark.context.get_active_session",
+        MagicMock(return_value="some active session"),
+    )
+    def test_just_uses_current_active_session_if_available(self):
+        conn = Snowpark("my_snowpark_connection")
+        assert conn._instance == "some active session"
+
+    @pytest.mark.require_snowflake
+    @patch(
         "streamlit.connections.snowpark_connection._load_from_snowsql_config_file",
         MagicMock(
             return_value=AttrDict(


### PR DESCRIPTION
## 📚 Context

This one's pretty self-explanatory. In some runtime environments, we'll already have an active
Snowpark session available (grabbing it is easy thanks to the Snowpark library's `get_active_session`
function). We just want to use this active session when possible.