### PR TITLE
Allow users to set SQL create_engine kwargs from secrets

### DIFF
--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -81,7 +81,10 @@ class SQL(ExperimentalBaseConnection["Engine"]):
                 database=conn_params.get("database"),
             )
 
-        eng = sqlalchemy.create_engine(url, **kwargs)
+        create_engine_kwargs = ChainMap(
+            kwargs, self._secrets.get("create_engine_kwargs", {})
+        )
+        eng = sqlalchemy.create_engine(url, **create_engine_kwargs)
 
         if autocommit:
             return cast("Engine", eng.execution_options(isolation_level="AUTOCOMMIT"))


### PR DESCRIPTION
## 📚 Context

As mentioned in https://github.com/streamlit/streamlit/pull/6487/files#r1167331299, it'd be nice to support
a way to pass kwargs to SQLAlchemy's `create_engine` function from a user's `secrets.toml` file. This PR
allows this by letting a user specify a `[connections.<conn_name>.create_engine_kwargs]` section in their
config file.
