### PR TITLE
Make "Build Release" workflow run in private forks

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -4,6 +4,10 @@ inputs:
   use_cached_venv:
     description: "Use Cached Virtual Env"
     default: "true"
+  github_token:
+    description: "GitHub token or PAT token"
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -79,6 +83,8 @@ runs:
         make python-init
         deactivate
       shell: bash --login -eo pipefail {0}
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
     - name: Activate virtualenv
       run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
       shell: bash --login -eo pipefail {0}

--- a/.github/workflows/cli-regression.yml
+++ b/.github/workflows/cli-regression.yml
@@ -38,6 +38,8 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Build Package - Fast
         timeout-minutes: 120
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           sudo apt install rsync
           BUILD_AS_FAST_AS_POSSIBLE=1 make package

--- a/.github/workflows/cypress-update-snapshots.yml
+++ b/.github/workflows/cypress-update-snapshots.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           sudo apt install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 curl
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Register Streamlit User & Mapbox Token
         run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,8 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-8-cores
+    # Forks may not have 8 cores runners available, so use the default runners.
+    runs-on: $(( github.repository == 'streamlit/streamlit' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
 
     defaults:
       run:
@@ -56,6 +57,8 @@ jobs:
         run: |
           sudo apt install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 curl
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Register Streamlit User & Mapbox Token
         run: |

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Audit frontend licenses
         run: ./scripts/audit_frontend_licenses.py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Create tag
         id: create_tag
@@ -165,6 +167,8 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Verify git tag vs. version
         env:
@@ -174,6 +178,8 @@ jobs:
           python setup.py verify
       - name: Build Package
         timeout-minutes: 120
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           sudo apt install rsync
           make package

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -47,6 +47,8 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Create Wheel File
         timeout-minutes: 120
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sudo apt install rsync
           BUILD_AS_FAST_AS_POSSIBLE=1 make package

--- a/.github/workflows/py-prod-deps-smoke-test.yml
+++ b/.github/workflows/py-prod-deps-smoke-test.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           use_cached_venv: "false"
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Run CLI smoke tests
         run: make cli-smoke-tests

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -107,6 +107,8 @@ jobs:
         uses: ./.github/actions/make_init
       - name: Run make develop
         run: make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Run Linters
         run: |
           PRE_COMMIT_NO_CONCURRENCY=true pre-commit run --show-diff-on-failure --color=always --all-files
@@ -131,7 +133,12 @@ jobs:
         if: ${{ always() }}
         run: |
           CONSTRAINT_URL="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${CONSTRAINTS_BRANCH}/constraints-${PYTHON_VERSION}.txt"
-          diff -y <(echo "Old"; curl -s "${CONSTRAINT_URL}") <(echo "New"; cat "${CONSTRAINTS_FILE}") || true
+          echo "CONSTRAINT_URL=${CONSTRAINT_URL}"
+          diff -y \
+            <(echo "Old"; curl -s "${CONSTRAINT_URL}" --header "Authorization: Bearer $GH_TOKEN") \
+            <(echo "New"; cat "${CONSTRAINTS_FILE}") || true
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Upload constraints file
         uses: actions/upload-artifact@v3
         with:
@@ -228,6 +235,8 @@ jobs:
       - name: Setup virtual env
         uses: ./.github/actions/make_init
       - name: Run make develop
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: make develop
       - name: Run Type Checkers
         run: scripts/mypy --report

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -16,16 +16,19 @@ jobs:
     uses: ./.github/workflows/js-tests.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets: inherit
 
   run-py-prod-deps-smoke-test:
     uses: ./.github/workflows/py-prod-deps-smoke-test.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets: inherit
 
   run-cypress-tests:
     uses: ./.github/workflows/cypress.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets: inherit
 
   build-release-candidate:
     runs-on: ubuntu-latest
@@ -82,6 +85,8 @@ jobs:
           python scripts/update_version.py "$STREAMLIT_RELEASE_SEMVER"
       - name: Create Package
         timeout-minutes: 120
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           sudo apt install rsync
           make package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     uses: ./.github/workflows/python-versions.yml
     with:
       ref: ${{ github.ref_name }}
+      force-canary: true
     secrets:
       PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
 
@@ -16,16 +17,19 @@ jobs:
     uses: ./.github/workflows/js-tests.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets: inherit
 
   run-py-prod-deps-smoke-test:
     uses: ./.github/workflows/py-prod-deps-smoke-test.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets: inherit
 
   run-cypress-tests:
     uses: ./.github/workflows/cypress.yml
     with:
       ref: ${{ github.ref_name }}
+    secrets: inherit
 
   build-release:
     runs-on: ubuntu-latest
@@ -43,6 +47,8 @@ jobs:
     permissions:
       # Additional permission needed to generate release
       contents: write
+      # Required by "scripts/get_release_branch.py" script
+      pull-requests: read
 
     env:
       # Name of the tag
@@ -110,6 +116,8 @@ jobs:
           python scripts/update_version.py "$STREAMLIT_RELEASE_VERSION"
       - name: Create Package
         timeout-minutes: 120
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           sudo apt install rsync
           make package
@@ -119,6 +127,8 @@ jobs:
           name: Release
           path: lib/dist
       - name: Upload to PyPI
+        # For private forks, we don't want to publish releases in PyPi.
+        if: github.repository == 'streamlit/streamlit'
         env:
           TWINE_USERNAME: ${{ secrets.STREAMLIT_PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.STREAMLIT_PYPI_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,14 @@ python-init-test-only: lib/test-requirements.txt
 python-init:
 	pip_args=("install" "--editable" "lib[snowflake]");\
 	if [ "${USE_CONSTRAINT_FILE}" = "true" ] ; then\
-		pip_args+=(--constraint "${CONSTRAINTS_URL}"); \
+		if [ -n "$${GH_TOKEN}" ] ; then \
+			constraint_file="$$(mktemp)";\
+			echo "Downloading file ${CONSTRAINTS_URL} to $${constraint_file}";\
+			curl -s "${CONSTRAINTS_URL}" --header "Authorization: Bearer $${GH_TOKEN}" > "$${constraint_file}";\
+			pip_args+=(--constraint "$${constraint_file}"); \
+		else\
+			pip_args+=(--constraint "${CONSTRAINTS_URL}"); \
+		fi;\
 	fi;\
 	if [ "${INSTALL_DEV_REQS}" = "true" ] ; then\
 		pip_args+=("--requirement" "lib/dev-requirements.txt"); \

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -24,11 +24,12 @@ def create_release():
 
     tag = os.getenv("GIT_TAG")
     access_token = os.getenv("GH_TOKEN")
+    repo = os.getenv("GH_REPO")
 
     if not tag:
         raise Exception("Unable to retrieve GIT_TAG environment variable")
 
-    url = "https://api.github.com/repos/streamlit/streamlit/releases"
+    url = f"https://api.github.com/repos/{repo}/releases"
     header = {"Authorization": f"token {access_token}"}
     payload = {"tag_name": tag, "name": tag}
 


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Continuation of work: https://github.com/streamlit/streamlit/pull/6495

To make it easier to test the "Release build" workflow, I made a few changes to make this workflow work on private forks. Especially, if the GitHub token is available, it is passed to HTTP requests and the correct permissions are set for the Github Action token.

In private forks, only the step "Upload to PyPI" is not running, because PyPi is a public package repository, so we don't want to put private artifacts in there.


_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
