### PR TITLE
Add support for pandas 2.0

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES = [
     "importlib-metadata>=1.4",
     "numpy",
     "packaging>=14.1",
-    "pandas<2,>=0.25",
+    "pandas>=0.25",
     "pillow>=6.2.0",
     "protobuf<4,>=3.12",
     "pyarrow>=4.0",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -37,7 +37,7 @@ INSTALL_REQUIRES = [
     "importlib-metadata>=1.4",
     "numpy",
     "packaging>=14.1",
-    "pandas>=0.25",
+    "pandas<3,>=0.25",
     "pillow>=6.2.0",
     "protobuf<4,>=3.12",
     "pyarrow>=4.0",

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -420,7 +420,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         self.assertIsInstance(return_df, pd.DataFrame)
 
     @unittest.skipIf(
-        is_pandas_version_less_than("2.0.0rc1") is False,
+        is_pandas_version_less_than("2.0.0") is False,
         "This test only runs if pandas is < 2.0.0",
     )
     def test_with_old_supported_index(self):


### PR DESCRIPTION
## 📚 Context

Adds support for pandas 2.0. Closes #6413

 Pandas 2.0 has now been released for several weeks; however, streamlit's `setup.py` has a pin that prevents use with pandas 2. I believe the required code changes in streamlit to allow compatibility with pandas have already been implemented by #6378.

The remaining tasks seem to be to remove the prevous dependency constraint, and to ensure the test suite runs against the new version of pandas and passes.

  - [ ] Bugfix
  - [X] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

Adds support for pandas 2.0 by removing the pin in `setup.py`

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

As I understand, this change will mean the `py_version (MAX)` CI job will test against pandas 2.X, and the `py_version (MIN)` job will continue testing against 1.X.

However, in future perhaps it's worth expanding these tests to ensure that streamlit will always be tested against the different major versions of pandas, regardless of which python versions are supported? Or, more generally, expanding the CI to test streamlit against the lower bound versions of all dependencies? From a previous comment:

> We are checking with our Python min tests for older Pandas versions since it's still running on Python 3.7, and Pandas 2.x will not be available for 3.7. But this is only a side-effect of us supporting a mostly outdated Python version. I think we should prioritize implementing a way for automated tests with older versions of our dependency. We probably could get a simple approach implemented without too much effort.

_Originally posted by @LukasMasuch in https://github.com/streamlit/streamlit/pull/6378#discussion_r1151050840_

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6413
- Related: #6378
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
