### PR TITLE
Don't always retry on .query() errors for SQL and Snowpark connections

### DIFF
--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -118,12 +118,21 @@ class SQL(ExperimentalBaseConnection["Engine"]):
         """
 
         from sqlalchemy import text
-        from tenacity import retry, stop_after_attempt, wait_fixed
+        from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
+        from tenacity import (
+            retry,
+            retry_if_exception_type,
+            stop_after_attempt,
+            wait_fixed,
+        )
 
         @retry(
             after=lambda _: self.reset(),
             stop=stop_after_attempt(3),
             reraise=True,
+            retry=retry_if_exception_type(
+                (DatabaseError, InternalError, OperationalError)
+            ),
             wait=wait_fixed(1),
         )
         @cache_data(ttl=ttl)


### PR DESCRIPTION
## 📚 Context

I initially implemented the retry logic for the `.query()` method of both the `SQL` and `Snowpark`
connections to always retry regardless of the exception type, which isn't great because tons of
exceptions are due to non-transient errors that won't go away just by trying again. This PR restricts
the exception types that we retry on for both connections.