### PR TITLE
Fix issue with deprecated asyncio test variable

### DIFF
--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -515,7 +515,6 @@ class ScriptCheckEndpointExistsTest(tornado.testing.AsyncHTTPTestCase):
             self.does_script_run_without_error
         )
         server._runtime._eventloop = self.io_loop.asyncio_loop
-
         return server._create_app()
 
     def test_endpoint(self):

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -515,6 +515,7 @@ class ScriptCheckEndpointExistsTest(tornado.testing.AsyncHTTPTestCase):
             self.does_script_run_without_error
         )
         server._runtime._eventloop = self.io_loop.asyncio_loop
+
         return server._create_app()
 
     def test_endpoint(self):

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -514,7 +514,7 @@ class ScriptCheckEndpointExistsTest(tornado.testing.AsyncHTTPTestCase):
         server._runtime.does_script_run_without_error = (
             self.does_script_run_without_error
         )
-        server._runtime._eventloop = self.asyncio_loop
+        server._runtime._eventloop = self.io_loop.asyncio_loop
         return server._create_app()
 
     def test_endpoint(self):


### PR DESCRIPTION
## 📚 Context

Our CI pipeline is currently broken since `self.asyncio_loop` seems to have been removed from `AsyncHTTPTestCase`. But it is accessible form `self.io_loop.asyncio_loop`. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
