### PR TITLE
Don't forget only-name connection_factory overloads

### DIFF
--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -30,7 +30,8 @@ from streamlit.runtime.secrets import secrets_singleton
 
 # NOTE: Adding support for a new first party connection requires:
 #   1. Adding the new connection name and class to this dict.
-#   2. Writing a new @overload for connection_factory.
+#   2. Writing two new @overloads for connection_factory (one for the case where the
+#      only the connection name is specified and another when both name and type are).
 #   3. Updating test_get_first_party_connection_helper in connection_factory_test.py.
 FIRST_PARTY_CONNECTIONS = {
     "snowpark": Snowpark,
@@ -93,6 +94,17 @@ def _get_first_party_connection(connection_class: str):
 
 @overload
 def connection_factory(
+    name: Literal["sql"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
+) -> SQL:
+    pass
+
+
+@overload
+def connection_factory(
     name: str,
     type: Literal["sql"],
     max_entries: int | None = None,
@@ -100,6 +112,16 @@ def connection_factory(
     autocommit: bool = False,
     **kwargs,
 ) -> SQL:
+    pass
+
+
+@overload
+def connection_factory(
+    name: Literal["snowpark"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    **kwargs,
+) -> Snowpark:
     pass
 
 


### PR DESCRIPTION
## 📚 Context

I forgot to write type overloads for the case where a developer writes `st.experimental_connection("sql")`,
which we want to be equivalent to `st.experimental_connection("sql", type="sql")`. 
