### PR TITLE
Upgrade protobuf to be at least 4.21 to handle breaking Python protobuf change

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -33,7 +33,6 @@ runs:
       shell: bash --login -eo pipefail {0}
     - name: Install system dependencies
       run: |
-        echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/protobuf.list
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
         sudo apt update
         # protobuf, pyodbc, dot, & graphviz dependencies

--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -5,7 +5,7 @@ mypy>=0.981
 mypy-protobuf>=3.2
 parameterized
 # Lower protobuf versions cause mypy issues during development builds
-protobuf>=3.19, <4
+protobuf>=4.21, <5
 pytest
 pytest-cov
 requests-mock

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -39,7 +39,7 @@ INSTALL_REQUIRES = [
     "packaging>=14.1",
     "pandas<2,>=0.25",
     "pillow>=6.2.0",
-    "protobuf<4,>=3.12",
+    "protobuf<5",
     "pyarrow>=4.0",
     "pympler>=0.9",
     "python-dateutil",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -39,7 +39,7 @@ INSTALL_REQUIRES = [
     "packaging>=14.1",
     "pandas<2,>=0.25",
     "pillow>=6.2.0",
-    "protobuf<5",
+    "protobuf>=4.21.12,<5",
     "pyarrow>=4.0",
     "pympler>=0.9",
     "python-dateutil",


### PR DESCRIPTION
Protobuf was experiencing instability when it upgraded a Python's major version and caused a breaking change. It looks like it stabilized a little bit. I was motivated to update this, because I cannot install an ARM version of protobuf on my computer (Mac Silicon and homebrew) to align with the change.

I chose to add a <5 to avoid breaking changes since it's such a critical service.

To make sure your dev environment works, make sure you install the corresponding protobuf binaries. I did mine through `brew install protobuf` which produced 4.21, so I made sure I installed 4.21 on protobuf.

I wrote do not merge because the conda configuration is a bit tricky. conda-forge is on minor versions whereas main channel is on 3.x versioning (and doesn't have 4.y). A clearer resolution needs to occur. 