### PR TITLE
Clean up and reorganize element tree module

### DIFF
--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -1334,10 +1334,11 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
         delta = msg.delta
         if delta.WhichOneof("type") == "new_element":
             elt = delta.new_element
+            ty = elt.WhichOneof("type")
             new_node: Node
-            if elt.WhichOneof("type") == "text":
+            if ty == "text":
                 new_node = Text(elt.text, root=root)
-            elif elt.WhichOneof("type") == "markdown":
+            elif ty == "markdown":
                 if elt.markdown.element_type == MarkdownProto.Type.NATIVE:
                     new_node = Markdown(elt.markdown, root=root)
                 elif elt.markdown.element_type == MarkdownProto.Type.CAPTION:
@@ -1350,7 +1351,7 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                     raise ValueError(
                         f"Unknown markdown type {elt.markdown.element_type}"
                     )
-            elif elt.WhichOneof("type") == "heading":
+            elif ty == "heading":
                 if elt.heading.tag == HeadingProtoTag.TITLE_TAG.value:
                     new_node = Title(elt.heading, root=root)
                 elif elt.heading.tag == HeadingProtoTag.HEADER_TAG.value:
@@ -1359,38 +1360,38 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                     new_node = Subheader(elt.heading, root=root)
                 else:
                     raise ValueError(f"Unknown heading type with tag {elt.heading.tag}")
-            elif elt.WhichOneof("type") == "exception":
+            elif ty == "exception":
                 new_node = Exception(elt.exception, root=root)
-            elif elt.WhichOneof("type") == "radio":
+            elif ty == "radio":
                 new_node = Radio(elt.radio, root=root)
-            elif elt.WhichOneof("type") == "checkbox":
+            elif ty == "checkbox":
                 new_node = Checkbox(elt.checkbox, root=root)
-            elif elt.WhichOneof("type") == "multiselect":
+            elif ty == "multiselect":
                 new_node = Multiselect(elt.multiselect, root=root)
-            elif elt.WhichOneof("type") == "selectbox":
+            elif ty == "selectbox":
                 new_node = Selectbox(elt.selectbox, root=root)
-            elif elt.WhichOneof("type") == "slider":
+            elif ty == "slider":
                 if elt.slider.type == SliderProto.Type.SLIDER:
                     new_node = Slider(elt.slider, root=root)
                 elif elt.slider.type == SliderProto.Type.SELECT_SLIDER:
                     new_node = SelectSlider(elt.slider, root=root)
                 else:
                     raise ValueError(f"Slider with unknown type {elt.slider}")
-            elif elt.WhichOneof("type") == "button":
+            elif ty == "button":
                 new_node = Button(elt.button, root=root)
-            elif elt.WhichOneof("type") == "text_input":
+            elif ty == "text_input":
                 new_node = TextInput(elt.text_input, root=root)
-            elif elt.WhichOneof("type") == "text_area":
+            elif ty == "text_area":
                 new_node = TextArea(elt.text_area, root=root)
-            elif elt.WhichOneof("type") == "number_input":
+            elif ty == "number_input":
                 new_node = NumberInput(elt.number_input, root=root)
-            elif elt.WhichOneof("type") == "code":
+            elif ty == "code":
                 new_node = Code(elt.code, root=root)
-            elif elt.WhichOneof("type") == "color_picker":
+            elif ty == "color_picker":
                 new_node = ColorPicker(elt.color_picker, root=root)
-            elif elt.WhichOneof("type") == "date_input":
+            elif ty == "date_input":
                 new_node = DateInput(elt.date_input, root=root)
-            elif elt.WhichOneof("type") == "time_input":
+            elif ty == "time_input":
                 new_node = TimeInput(elt.time_input, root=root)
             else:
                 new_node = Element(elt, root=root)

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -1336,8 +1336,27 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
             elt = delta.new_element
             ty = elt.WhichOneof("type")
             new_node: Node
-            if ty == "text":
-                new_node = Text(elt.text, root=root)
+            if ty == "button":
+                new_node = Button(elt.button, root=root)
+            elif ty == "checkbox":
+                new_node = Checkbox(elt.checkbox, root=root)
+            elif ty == "code":
+                new_node = Code(elt.code, root=root)
+            elif ty == "color_picker":
+                new_node = ColorPicker(elt.color_picker, root=root)
+            elif ty == "date_input":
+                new_node = DateInput(elt.date_input, root=root)
+            elif ty == "exception":
+                new_node = Exception(elt.exception, root=root)
+            elif ty == "heading":
+                if elt.heading.tag == HeadingProtoTag.TITLE_TAG.value:
+                    new_node = Title(elt.heading, root=root)
+                elif elt.heading.tag == HeadingProtoTag.HEADER_TAG.value:
+                    new_node = Header(elt.heading, root=root)
+                elif elt.heading.tag == HeadingProtoTag.SUBHEADER_TAG.value:
+                    new_node = Subheader(elt.heading, root=root)
+                else:
+                    raise ValueError(f"Unknown heading type with tag {elt.heading.tag}")
             elif ty == "markdown":
                 if elt.markdown.element_type == MarkdownProto.Type.NATIVE:
                     new_node = Markdown(elt.markdown, root=root)
@@ -1351,23 +1370,12 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                     raise ValueError(
                         f"Unknown markdown type {elt.markdown.element_type}"
                     )
-            elif ty == "heading":
-                if elt.heading.tag == HeadingProtoTag.TITLE_TAG.value:
-                    new_node = Title(elt.heading, root=root)
-                elif elt.heading.tag == HeadingProtoTag.HEADER_TAG.value:
-                    new_node = Header(elt.heading, root=root)
-                elif elt.heading.tag == HeadingProtoTag.SUBHEADER_TAG.value:
-                    new_node = Subheader(elt.heading, root=root)
-                else:
-                    raise ValueError(f"Unknown heading type with tag {elt.heading.tag}")
-            elif ty == "exception":
-                new_node = Exception(elt.exception, root=root)
-            elif ty == "radio":
-                new_node = Radio(elt.radio, root=root)
-            elif ty == "checkbox":
-                new_node = Checkbox(elt.checkbox, root=root)
             elif ty == "multiselect":
                 new_node = Multiselect(elt.multiselect, root=root)
+            elif ty == "number_input":
+                new_node = NumberInput(elt.number_input, root=root)
+            elif ty == "radio":
+                new_node = Radio(elt.radio, root=root)
             elif ty == "selectbox":
                 new_node = Selectbox(elt.selectbox, root=root)
             elif ty == "slider":
@@ -1377,20 +1385,12 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                     new_node = SelectSlider(elt.slider, root=root)
                 else:
                     raise ValueError(f"Slider with unknown type {elt.slider}")
-            elif ty == "button":
-                new_node = Button(elt.button, root=root)
-            elif ty == "text_input":
-                new_node = TextInput(elt.text_input, root=root)
+            elif ty == "text":
+                new_node = Text(elt.text, root=root)
             elif ty == "text_area":
                 new_node = TextArea(elt.text_area, root=root)
-            elif ty == "number_input":
-                new_node = NumberInput(elt.number_input, root=root)
-            elif ty == "code":
-                new_node = Code(elt.code, root=root)
-            elif ty == "color_picker":
-                new_node = ColorPicker(elt.color_picker, root=root)
-            elif ty == "date_input":
-                new_node = DateInput(elt.date_input, root=root)
+            elif ty == "text_input":
+                new_node = TextInput(elt.text_input, root=root)
             elif ty == "time_input":
                 new_node = TimeInput(elt.time_input, root=root)
             else:

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -64,7 +64,7 @@ from streamlit.runtime.state.session_state import SessionState
 # WidgetState and provide higher level interaction interfaces, and other elements
 # have enough variation in how to get their values that most will need their
 # own classes too.
-@dataclass(init=False)
+@dataclass
 class Element:
     type: str
     proto: Any = field(repr=False)
@@ -103,7 +103,7 @@ class Element:
         return util.repr_(self)
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Text(Element):
     proto: TextProto
 
@@ -121,7 +121,7 @@ class Text(Element):
         return self.proto.body
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class HeadingBase(Element, ABC):
     proto: HeadingProto
 
@@ -146,25 +146,25 @@ class HeadingBase(Element, ABC):
         return self.proto.body
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Title(HeadingBase):
     def __init__(self, proto: HeadingProto, root: ElementTree):
         super().__init__(proto, root, "title")
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Header(HeadingBase):
     def __init__(self, proto: HeadingProto, root: ElementTree):
         super().__init__(proto, root, "header")
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Subheader(HeadingBase):
     def __init__(self, proto: HeadingProto, root: ElementTree):
         super().__init__(proto, root, "subheader")
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Markdown(Element):
     proto: MarkdownProto
 
@@ -187,21 +187,21 @@ class Markdown(Element):
         return self.proto.body
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Caption(Markdown):
     def __init__(self, proto: MarkdownProto, root: ElementTree):
         super().__init__(proto, root)
         self.type = "caption"
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Latex(Markdown):
     def __init__(self, proto: MarkdownProto, root: ElementTree):
         super().__init__(proto, root)
         self.type = "latex"
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Code(Element):
     proto: CodeProto
 
@@ -248,7 +248,7 @@ class Exception(Element):
         return self.message
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Divider(Markdown):
     def __init__(self, proto: MarkdownProto, root: ElementTree):
         super().__init__(proto, root)
@@ -325,7 +325,7 @@ class ColorPicker(Element, Widget):
         return self.set_value(v)
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Radio(Element, Widget, Generic[T]):
     _value: T | None
 
@@ -386,7 +386,7 @@ class Radio(Element, Widget, Generic[T]):
         return ws
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Checkbox(Element, Widget):
     _value: bool | None
 
@@ -440,7 +440,7 @@ class Checkbox(Element, Widget):
         return self.set_value(False)
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Multiselect(Element, Widget, Generic[T]):
     _value: list[T] | None
 
@@ -529,7 +529,7 @@ class Multiselect(Element, Widget, Generic[T]):
             return self
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Selectbox(Element, Widget, Generic[T]):
     _value: T | None
 
@@ -602,7 +602,7 @@ class Selectbox(Element, Widget, Generic[T]):
         return ws
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Button(Element, Widget):
     _value: bool
 
@@ -653,7 +653,7 @@ class Button(Element, Widget):
         return self.set_value(True)
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Slider(Element, Widget, Generic[SliderScalarT]):
     _value: SliderScalarT | Sequence[SliderScalarT] | None
 
@@ -722,7 +722,7 @@ class Slider(Element, Widget, Generic[SliderScalarT]):
         return self.set_value([lower, upper])
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class SelectSlider(Element, Widget, Generic[T]):
     _value: T | Sequence[T] | None
 
@@ -1093,7 +1093,7 @@ class TimeInput(Element, Widget):
         return self.set_value(dt.time())
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class Block:
     type: str
     children: dict[int, Node]
@@ -1252,7 +1252,7 @@ class Block:
 Node: TypeAlias = Union[Element, Block]
 
 
-@dataclass(init=False, repr=False)
+@dataclass(repr=False)
 class ElementTree(Block):
     """A tree of the elements produced by running a streamlit script.
 

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -119,15 +119,11 @@ class Button(Element, Widget):
     _value: bool
 
     proto: ButtonProto
-    type: str
     id: str
     label: str
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: ButtonProto, root: ElementTree):
         self.proto = proto
@@ -170,15 +166,11 @@ class Checkbox(Element, Widget):
     _value: bool | None
 
     proto: CheckboxProto
-    type: str
     id: str
     label: str
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: CheckboxProto, root: ElementTree):
         self.proto = proto
@@ -223,10 +215,8 @@ class Checkbox(Element, Widget):
 class Code(Element):
     proto: CodeProto
 
-    type: str
     language: str
     show_line_numbers: bool
-    root: ElementTree = field(repr=False)
     key: None
 
     def __init__(self, proto: CodeProto, root: ElementTree):
@@ -247,15 +237,11 @@ class ColorPicker(Element, Widget):
     _value: str | None
 
     proto: ColorPickerProto
-    type: str
     id: str
     label: str
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: ColorPickerProto, root: ElementTree):
         self.proto = proto
@@ -308,7 +294,6 @@ DateValue: TypeAlias = Union[SingleDateValue, Sequence[SingleDateValue]]
 class DateInput(Element, Widget):
     _value: DateValue | None
     proto: DateInputProto
-    type: str
     id: str
     label: str
     min: date
@@ -317,9 +302,6 @@ class DateInput(Element, Widget):
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: DateInputProto, root: ElementTree):
         self.proto = proto
@@ -362,7 +344,6 @@ class DateInput(Element, Widget):
 
 @dataclass(repr=False)
 class Exception(Element):
-    type: str
     message: str
     is_markdown: bool
     stack_trace: list[str]
@@ -388,11 +369,9 @@ class Exception(Element):
 class HeadingBase(Element, ABC):
     proto: HeadingProto
 
-    type: str
     tag: str
     anchor: str | None
     hide_anchor: bool
-    root: ElementTree = field(repr=False)
     key: None
 
     def __init__(self, proto: HeadingProto, root: ElementTree, type_: str):
@@ -431,10 +410,8 @@ class Title(HeadingBase):
 class Markdown(Element):
     proto: MarkdownProto
 
-    type: str
     is_caption: bool
     allow_html: bool
-    root: ElementTree = field(repr=False)
     key: None
 
     def __init__(self, proto: MarkdownProto, root: ElementTree):
@@ -476,7 +453,6 @@ class Multiselect(Element, Widget, Generic[T]):
     _value: list[T] | None
 
     proto: MultiSelectProto
-    type: str
     id: str
     label: str
     options: list[str]
@@ -484,9 +460,6 @@ class Multiselect(Element, Widget, Generic[T]):
     form_id: str
     disabled: bool
     max_selections: int
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: MultiSelectProto, root: ElementTree):
         self.proto = proto
@@ -567,7 +540,6 @@ Number = Union[int, float]
 class NumberInput(Element, Widget):
     _value: Number | None
     proto: NumberInputProto
-    type: str
     id: str
     label: str
     min_value: Number
@@ -577,9 +549,6 @@ class NumberInput(Element, Widget):
     form_id: str
     placeholder: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: NumberInputProto, root: ElementTree):
         self.proto = proto
@@ -632,16 +601,12 @@ class Radio(Element, Widget, Generic[T]):
 
     proto: RadioProto
     type: str
-    id: str
     label: str
     options: list[str]
     help: str
     form_id: str
     disabled: bool
     horizontal: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: RadioProto, root: ElementTree):
         self.proto = proto
@@ -692,16 +657,12 @@ class Selectbox(Element, Widget, Generic[T]):
     _value: T | None
 
     proto: SelectboxProto = field(repr=False)
-    type: str
     id: str
     label: str
     options: list[str]
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: SelectboxProto, root: ElementTree):
         self.proto = proto
@@ -765,7 +726,6 @@ class SelectSlider(Element, Widget, Generic[T]):
     _value: T | Sequence[T] | None
 
     proto: SliderProto
-    type: str
     data_type: SliderProto.DataType.ValueType
     id: str
     label: str
@@ -773,9 +733,6 @@ class SelectSlider(Element, Widget, Generic[T]):
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: SliderProto, root: ElementTree):
         self.proto = proto
@@ -825,7 +782,6 @@ class Slider(Element, Widget, Generic[SliderScalarT]):
     _value: SliderScalarT | Sequence[SliderScalarT] | None
 
     proto: SliderProto
-    type: str
     data_type: SliderProto.DataType.ValueType
     id: str
     label: str
@@ -835,9 +791,6 @@ class Slider(Element, Widget, Generic[SliderScalarT]):
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: SliderProto, root: ElementTree):
         self.proto = proto
@@ -893,8 +846,6 @@ class Slider(Element, Widget, Generic[SliderScalarT]):
 class Text(Element):
     proto: TextProto
 
-    type: str
-    root: ElementTree = field(repr=False)
     key: None = None
 
     def __init__(self, proto: TextProto, root: ElementTree):
@@ -912,7 +863,6 @@ class TextArea(Element, Widget):
     _value: str | None
 
     proto: TextAreaProto
-    type: str
     id: str
     label: str
     max_chars: int
@@ -920,9 +870,6 @@ class TextArea(Element, Widget):
     form_id: str
     placeholder: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: TextAreaProto, root: ElementTree):
         self.proto = proto
@@ -970,7 +917,6 @@ class TextArea(Element, Widget):
 class TextInput(Element, Widget):
     _value: str | None
     proto: TextInputProto
-    type: str
     id: str
     label: str
     max_chars: int
@@ -979,9 +925,6 @@ class TextInput(Element, Widget):
     autocomplete: str
     placeholder: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: TextInputProto, root: ElementTree):
         self.proto = proto
@@ -1033,16 +976,12 @@ TimeValue: TypeAlias = Union[time, datetime]
 class TimeInput(Element, Widget):
     _value: TimeValue | None
     proto: TimeInputProto
-    type: str
     id: str
     label: str
     step: int
     help: str
     form_id: str
     disabled: bool
-    key: str | None
-
-    root: ElementTree = field(repr=False)
 
     def __init__(self, proto: TimeInputProto, root: ElementTree):
         self.proto = proto
@@ -1278,8 +1217,6 @@ class ElementTree(Block):
     After an interaction, calling `.run()` will return the ElementTree for
     the rerun.
     """
-
-    type: str
 
     script_path: str | None = field(repr=False, default=None)
     _session_state: SessionState | None = field(repr=False, default=None)

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -1136,11 +1136,7 @@ class Block:
         return None
 
     @overload
-    def get(self, element_type: Literal["text"]) -> Sequence[Text]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["markdown"]) -> Sequence[Markdown]:
+    def get(self, element_type: Literal["button"]) -> Sequence[Button]:
         ...
 
     @overload
@@ -1148,7 +1144,7 @@ class Block:
         ...
 
     @overload
-    def get(self, element_type: Literal["latex"]) -> Sequence[Latex]:
+    def get(self, element_type: Literal["checkbox"]) -> Sequence[Checkbox]:
         ...
 
     @overload
@@ -1156,19 +1152,15 @@ class Block:
         ...
 
     @overload
+    def get(self, element_type: Literal["color_picker"]) -> Sequence[ColorPicker]:
+        ...
+
+    @overload
+    def get(self, element_type: Literal["date_input"]) -> Sequence[DateInput]:
+        ...
+
+    @overload
     def get(self, element_type: Literal["divider"]) -> Sequence[Divider]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["title"]) -> Sequence[Title]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["header"]) -> Sequence[Header]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["subheader"]) -> Sequence[Subheader]:
         ...
 
     @overload
@@ -1176,15 +1168,33 @@ class Block:
         ...
 
     @overload
-    def get(self, element_type: Literal["radio"]) -> Sequence[Radio[Any]]:
+    def get(self, element_type: Literal["header"]) -> Sequence[Header]:
         ...
 
     @overload
-    def get(self, element_type: Literal["checkbox"]) -> Sequence[Checkbox]:
+    def get(self, element_type: Literal["latex"]) -> Sequence[Latex]:
+        ...
+
+    @overload
+    def get(self, element_type: Literal["markdown"]) -> Sequence[Markdown]:
         ...
 
     @overload
     def get(self, element_type: Literal["multiselect"]) -> Sequence[Multiselect[Any]]:
+        ...
+
+    @overload
+    def get(self, element_type: Literal["number_input"]) -> Sequence[NumberInput]:
+        ...
+
+    @overload
+    def get(self, element_type: Literal["radio"]) -> Sequence[Radio[Any]]:
+        ...
+
+    @overload
+    def get(
+        self, element_type: Literal["select_slider"]
+    ) -> Sequence[SelectSlider[Any]]:
         ...
 
     @overload
@@ -1196,17 +1206,11 @@ class Block:
         ...
 
     @overload
-    def get(
-        self, element_type: Literal["select_slider"]
-    ) -> Sequence[SelectSlider[Any]]:
+    def get(self, element_type: Literal["subheader"]) -> Sequence[Subheader]:
         ...
 
     @overload
-    def get(self, element_type: Literal["button"]) -> Sequence[Button]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["text_input"]) -> Sequence[TextInput]:
+    def get(self, element_type: Literal["text"]) -> Sequence[Text]:
         ...
 
     @overload
@@ -1214,19 +1218,15 @@ class Block:
         ...
 
     @overload
-    def get(self, element_type: Literal["color_picker"]) -> Sequence[ColorPicker]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["number_input"]) -> Sequence[NumberInput]:
-        ...
-
-    @overload
-    def get(self, element_type: Literal["date_input"]) -> Sequence[DateInput]:
+    def get(self, element_type: Literal["text_input"]) -> Sequence[TextInput]:
         ...
 
     @overload
     def get(self, element_type: Literal["time_input"]) -> Sequence[TimeInput]:
+        ...
+
+    @overload
+    def get(self, element_type: Literal["title"]) -> Sequence[Title]:
         ...
 
     def get(self, element_type: str) -> Sequence[Node]:

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from typing import Any, Generic, List, Sequence, TypeVar, Union, cast, overload
 
-from typing_extensions import Literal, Protocol, TypeAlias, runtime_checkable
+from typing_extensions import Literal, Self, TypeAlias
 
 from streamlit import util
 from streamlit.elements.heading import HeadingProtoTag
@@ -105,25 +105,26 @@ class Element:
         return util.repr_(self)
 
 
-@runtime_checkable
-class Widget(Protocol):
-    id: str
-    key: str | None
-
-    def set_value(self, v: Any):
-        ...
-
-
 @dataclass(repr=False)
-class Button(Element, Widget):
-    _value: bool
-
-    proto: ButtonProto
+class Widget(ABC, Element):
     id: str
     label: str
     help: str
     form_id: str
     disabled: bool
+    key: str | None
+    _value: Any
+
+    def set_value(self, v: Any) -> Self:
+        self._value = v
+        return self
+
+
+@dataclass(repr=False)
+class Button(Widget):
+    _value: bool
+
+    proto: ButtonProto
 
     def __init__(self, proto: ButtonProto, root: ElementTree):
         self.proto = proto
@@ -162,15 +163,10 @@ class Button(Element, Widget):
 
 
 @dataclass(repr=False)
-class Checkbox(Element, Widget):
+class Checkbox(Widget):
     _value: bool | None
 
     proto: CheckboxProto
-    id: str
-    label: str
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: CheckboxProto, root: ElementTree):
         self.proto = proto
@@ -233,15 +229,10 @@ class Code(Element):
 
 
 @dataclass(repr=False)
-class ColorPicker(Element, Widget):
+class ColorPicker(Widget):
     _value: str | None
 
     proto: ColorPickerProto
-    id: str
-    label: str
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: ColorPickerProto, root: ElementTree):
         self.proto = proto
@@ -291,17 +282,12 @@ DateValue: TypeAlias = Union[SingleDateValue, Sequence[SingleDateValue]]
 
 
 @dataclass(repr=False)
-class DateInput(Element, Widget):
+class DateInput(Widget):
     _value: DateValue | None
     proto: DateInputProto
-    id: str
-    label: str
     min: date
     max: date
     is_range: bool
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: DateInputProto, root: ElementTree):
         self.proto = proto
@@ -449,16 +435,11 @@ class Latex(Markdown):
 
 
 @dataclass(repr=False)
-class Multiselect(Element, Widget, Generic[T]):
+class Multiselect(Widget, Generic[T]):
     _value: list[T] | None
 
     proto: MultiSelectProto
-    id: str
-    label: str
     options: list[str]
-    help: str
-    form_id: str
-    disabled: bool
     max_selections: int
 
     def __init__(self, proto: MultiSelectProto, root: ElementTree):
@@ -537,18 +518,13 @@ Number = Union[int, float]
 
 
 @dataclass(repr=False)
-class NumberInput(Element, Widget):
+class NumberInput(Widget):
     _value: Number | None
     proto: NumberInputProto
-    id: str
-    label: str
     min_value: Number
     max_value: Number
     step: Number
-    help: str
-    form_id: str
     placeholder: str
-    disabled: bool
 
     def __init__(self, proto: NumberInputProto, root: ElementTree):
         self.proto = proto
@@ -596,16 +572,11 @@ class NumberInput(Element, Widget):
 
 
 @dataclass(repr=False)
-class Radio(Element, Widget, Generic[T]):
+class Radio(Widget, Generic[T]):
     _value: T | None
 
     proto: RadioProto
-    type: str
-    label: str
     options: list[str]
-    help: str
-    form_id: str
-    disabled: bool
     horizontal: bool
 
     def __init__(self, proto: RadioProto, root: ElementTree):
@@ -653,16 +624,11 @@ class Radio(Element, Widget, Generic[T]):
 
 
 @dataclass(repr=False)
-class Selectbox(Element, Widget, Generic[T]):
+class Selectbox(Widget, Generic[T]):
     _value: T | None
 
     proto: SelectboxProto = field(repr=False)
-    id: str
-    label: str
     options: list[str]
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: SelectboxProto, root: ElementTree):
         self.proto = proto
@@ -722,17 +688,12 @@ class Selectbox(Element, Widget, Generic[T]):
 
 
 @dataclass(repr=False)
-class SelectSlider(Element, Widget, Generic[T]):
+class SelectSlider(Widget, Generic[T]):
     _value: T | Sequence[T] | None
 
     proto: SliderProto
     data_type: SliderProto.DataType.ValueType
-    id: str
-    label: str
     options: list[str]
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: SliderProto, root: ElementTree):
         self.proto = proto
@@ -778,19 +739,14 @@ class SelectSlider(Element, Widget, Generic[T]):
 
 
 @dataclass(repr=False)
-class Slider(Element, Widget, Generic[SliderScalarT]):
+class Slider(Widget, Generic[SliderScalarT]):
     _value: SliderScalarT | Sequence[SliderScalarT] | None
 
     proto: SliderProto
     data_type: SliderProto.DataType.ValueType
-    id: str
-    label: str
     min_value: SliderScalar
     max_value: SliderScalar
     step: Step
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: SliderProto, root: ElementTree):
         self.proto = proto
@@ -859,17 +815,12 @@ class Text(Element):
 
 
 @dataclass(repr=False)
-class TextArea(Element, Widget):
+class TextArea(Widget):
     _value: str | None
 
     proto: TextAreaProto
-    id: str
-    label: str
     max_chars: int
-    help: str
-    form_id: str
     placeholder: str
-    disabled: bool
 
     def __init__(self, proto: TextAreaProto, root: ElementTree):
         self.proto = proto
@@ -914,17 +865,12 @@ class TextArea(Element, Widget):
 
 
 @dataclass(repr=False)
-class TextInput(Element, Widget):
+class TextInput(Widget):
     _value: str | None
     proto: TextInputProto
-    id: str
-    label: str
     max_chars: int
-    help: str
-    form_id: str
     autocomplete: str
     placeholder: str
-    disabled: bool
 
     def __init__(self, proto: TextInputProto, root: ElementTree):
         self.proto = proto
@@ -973,15 +919,10 @@ TimeValue: TypeAlias = Union[time, datetime]
 
 
 @dataclass(repr=False)
-class TimeInput(Element, Widget):
+class TimeInput(Widget):
     _value: TimeValue | None
     proto: TimeInputProto
-    id: str
-    label: str
     step: int
-    help: str
-    form_id: str
-    disabled: bool
 
     def __init__(self, proto: TimeInputProto, root: ElementTree):
         self.proto = proto

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -20,31 +20,6 @@ from streamlit.elements.markdown import MARKDOWN_HORIZONTAL_RULE_EXPRESSION
 from streamlit.testing.script_interactions import InteractiveScriptTests
 
 
-class CheckboxTest(InteractiveScriptTests):
-    def test_value(self):
-        script = self.script_from_string(
-            "checkbox_test.py",
-            """
-            import streamlit as st
-
-            st.checkbox("defaults")
-            st.checkbox("defaulted on", True)
-            """,
-        )
-        sr = script.run()
-        assert sr.get("checkbox")
-        assert sr.get("checkbox")[0].value == False
-        assert sr.get("checkbox")[1].value == True
-
-        sr2 = sr.get("checkbox")[0].check().run()
-        assert sr2.get("checkbox")[0].value == True
-        assert sr2.get("checkbox")[1].value == True
-
-        sr3 = sr2.get("checkbox")[1].uncheck().run()
-        assert sr3.get("checkbox")[0].value == True
-        assert sr3.get("checkbox")[1].value == False
-
-
 @pytest.mark.xfail(reason="button does not work correctly with session state")
 class ButtonTest(InteractiveScriptTests):
     def test_value(self):
@@ -70,32 +45,194 @@ class ButtonTest(InteractiveScriptTests):
         assert sr3.get("button")[1].value == False
 
 
-class MultiselectTest(InteractiveScriptTests):
+class CheckboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "multiselect_test.py",
+            "checkbox_test.py",
             """
             import streamlit as st
 
-            st.multiselect("one", options=["a", "b", "c"])
-            st.multiselect("two", options=["zero", "one", "two"], default=["two"])
+            st.checkbox("defaults")
+            st.checkbox("defaulted on", True)
             """,
         )
         sr = script.run()
-        assert sr.get("multiselect")[0].value == []
-        assert sr.get("multiselect")[1].value == ["two"]
+        assert sr.get("checkbox")
+        assert sr.get("checkbox")[0].value == False
+        assert sr.get("checkbox")[1].value == True
 
-        sr2 = sr.get("multiselect")[0].select("b").run()
-        assert sr2.get("multiselect")[0].value == ["b"]
-        assert sr2.get("multiselect")[1].value == ["two"]
+        sr2 = sr.get("checkbox")[0].check().run()
+        assert sr2.get("checkbox")[0].value == True
+        assert sr2.get("checkbox")[1].value == True
 
-        sr3 = sr2.get("multiselect")[1].select("zero").select("one").run()
-        assert sr3.get("multiselect")[0].value == ["b"]
-        assert set(sr3.get("multiselect")[1].value) == set(["zero", "one", "two"])
+        sr3 = sr2.get("checkbox")[1].uncheck().run()
+        assert sr3.get("checkbox")[0].value == True
+        assert sr3.get("checkbox")[1].value == False
 
-        sr4 = sr3.get("multiselect")[0].unselect("b").run()
-        assert sr4.get("multiselect")[0].value == []
-        assert set(sr3.get("multiselect")[1].value) == set(["zero", "one", "two"])
+
+class ColorPickerTest(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "color_picker.py",
+            """
+            import streamlit as st
+
+            st.color_picker("what is your favorite color?")
+            st.color_picker("short hex", value="#ABC")
+            st.color_picker("invalid", value="blue")
+            """,
+        )
+        sr = script.run()
+        assert len(sr.get("color_picker")) == 2
+        assert [c.value for c in sr.get("color_picker")] == ["#000000", "#ABC"]
+        assert "blue" in sr.get("exception")[0].value
+
+        sr2 = sr.get("color_picker")[0].pick("#123456").run()
+        assert sr2.get("color_picker")[0].value == "#123456"
+
+
+class DateInputTest(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "date_input.py",
+            """
+            import streamlit as st
+            import datetime
+
+            st.date_input("date", value=datetime.date(2023, 4, 17))
+            st.date_input("datetime", value=datetime.datetime(2023, 4, 17, 11))
+            st.date_input("range", value=(datetime.date(2020, 1, 1), datetime.date(2030, 1, 1)))
+            """,
+        )
+        sr = script.run()
+        assert not sr.get("exception")
+        assert [d.value for d in sr.get("date_input")] == [
+            date(2023, 4, 17),
+            datetime(2023, 4, 17).date(),
+            (date(2020, 1, 1), date(2030, 1, 1)),
+        ]
+        ds = sr.get("date_input")
+        ds[0].set_value(date(2023, 5, 1))
+        ds[1].set_value(datetime(2023, 1, 1))
+        ds[2].set_value((date(2023, 1, 1), date(2024, 1, 1)))
+
+        sr2 = sr.run()
+        assert [d.value for d in sr2.get("date_input")] == [
+            date(2023, 5, 1),
+            date(2023, 1, 1),
+            (date(2023, 1, 1), date(2024, 1, 1)),
+        ]
+
+
+class ExceptionTest(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "exception.py",
+            """
+            import streamlit as st
+
+            st.exception(RuntimeError("foo"))
+            """,
+        )
+        sr = script.run()
+
+        assert sr.get("exception")[0].value == "foo"
+
+    def test_markdown(self):
+        script = self.script_from_string(
+            "exception2.py",
+            """
+            import streamlit as st
+
+            st.exception(st.errors.MarkdownFormattedException("# Oh no"))
+            """,
+        )
+        sr = script.run()
+
+        assert sr.get("exception")[0].is_markdown
+
+
+class HeadingTest(InteractiveScriptTests):
+    def test_title(self):
+        script = self.script_from_string(
+            "title_element.py",
+            """
+            import streamlit as st
+
+            st.title("This is a title")
+            st.title("This is a title with anchor", anchor="anchor text")
+            st.title("This is a title with hidden anchor", anchor=False)
+            """,
+        )
+        sr = script.run()
+
+        assert len(sr.get("title")) == 3
+        assert sr.get("title")[1].tag == "h1"
+        assert sr.get("title")[1].anchor == "anchor text"
+        assert sr.get("title")[1].value == "This is a title with anchor"
+        assert sr.get("title")[2].hide_anchor
+
+    def test_header(self):
+        script = self.script_from_string(
+            "header_element.py",
+            """
+            import streamlit as st
+
+            st.header("This is a header")
+            st.header("This is a header with anchor", anchor="header anchor text")
+            st.header("This is a header with hidden anchor", anchor=False)
+            """,
+        )
+        sr = script.run()
+
+        assert len(sr.get("header")) == 3
+        assert sr.get("header")[1].tag == "h2"
+        assert sr.get("header")[1].anchor == "header anchor text"
+        assert sr.get("header")[1].value == "This is a header with anchor"
+        assert sr.get("header")[2].hide_anchor
+
+    def test_subheader(self):
+        script = self.script_from_string(
+            "subheader_element.py",
+            """
+            import streamlit as st
+
+            st.subheader("This is a subheader")
+            st.subheader(
+                "This is a subheader with anchor",
+                anchor="subheader anchor text"
+            )
+            st.subheader("This is a subheader with hidden anchor", anchor=False)
+            """,
+        )
+        sr = script.run()
+
+        assert len(sr.get("subheader")) == 3
+        assert sr.get("subheader")[1].tag == "h3"
+        assert sr.get("subheader")[1].anchor == "subheader anchor text"
+        assert sr.get("subheader")[1].value == "This is a subheader with anchor"
+        assert sr.get("subheader")[2].hide_anchor
+
+    def test_heading_elements_by_type(self):
+        script = self.script_from_string(
+            "heading_elements.py",
+            """
+            import streamlit as st
+
+            st.title("title1")
+            st.header("header1")
+            st.subheader("subheader1")
+
+            st.title("title2")
+            st.header("header2")
+            st.subheader("subheader2")
+            """,
+        )
+        sr = script.run()
+
+        assert len(sr.get("title")) == 2
+        assert len(sr.get("header")) == 2
+        assert len(sr.get("subheader")) == 2
 
 
 class MarkdownTest(InteractiveScriptTests):
@@ -200,266 +337,32 @@ class MarkdownTest(InteractiveScriptTests):
         assert len(sr.get("latex")) == 2
 
 
-class HeadingTest(InteractiveScriptTests):
-    def test_title(self):
-        script = self.script_from_string(
-            "title_element.py",
-            """
-            import streamlit as st
-
-            st.title("This is a title")
-            st.title("This is a title with anchor", anchor="anchor text")
-            st.title("This is a title with hidden anchor", anchor=False)
-            """,
-        )
-        sr = script.run()
-
-        assert len(sr.get("title")) == 3
-        assert sr.get("title")[1].tag == "h1"
-        assert sr.get("title")[1].anchor == "anchor text"
-        assert sr.get("title")[1].value == "This is a title with anchor"
-        assert sr.get("title")[2].hide_anchor
-
-    def test_header(self):
-        script = self.script_from_string(
-            "header_element.py",
-            """
-            import streamlit as st
-
-            st.header("This is a header")
-            st.header("This is a header with anchor", anchor="header anchor text")
-            st.header("This is a header with hidden anchor", anchor=False)
-            """,
-        )
-        sr = script.run()
-
-        assert len(sr.get("header")) == 3
-        assert sr.get("header")[1].tag == "h2"
-        assert sr.get("header")[1].anchor == "header anchor text"
-        assert sr.get("header")[1].value == "This is a header with anchor"
-        assert sr.get("header")[2].hide_anchor
-
-    def test_subheader(self):
-        script = self.script_from_string(
-            "subheader_element.py",
-            """
-            import streamlit as st
-
-            st.subheader("This is a subheader")
-            st.subheader(
-                "This is a subheader with anchor",
-                anchor="subheader anchor text"
-            )
-            st.subheader("This is a subheader with hidden anchor", anchor=False)
-            """,
-        )
-        sr = script.run()
-
-        assert len(sr.get("subheader")) == 3
-        assert sr.get("subheader")[1].tag == "h3"
-        assert sr.get("subheader")[1].anchor == "subheader anchor text"
-        assert sr.get("subheader")[1].value == "This is a subheader with anchor"
-        assert sr.get("subheader")[2].hide_anchor
-
-    def test_heading_elements_by_type(self):
-        script = self.script_from_string(
-            "heading_elements.py",
-            """
-            import streamlit as st
-
-            st.title("title1")
-            st.header("header1")
-            st.subheader("subheader1")
-
-            st.title("title2")
-            st.header("header2")
-            st.subheader("subheader2")
-            """,
-        )
-        sr = script.run()
-
-        assert len(sr.get("title")) == 2
-        assert len(sr.get("header")) == 2
-        assert len(sr.get("subheader")) == 2
-
-
-class SliderTest(InteractiveScriptTests):
+class MultiselectTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "slider_test.py",
-            """
-            import streamlit as st
-            from datetime import datetime, time
-
-            st.slider("defaults")
-            st.slider("int", min_value=-100, max_value=100, step=5, value=10)
-            st.slider("time", value=(time(11, 30), time(12, 45)))
-            st.slider("datetime", value=datetime(2020, 1, 1, 9, 30))
-            st.slider("float", min_value=0.0, max_value=1.0, step=0.01)
-            """,
-        )
-        sr = script.run()
-        s = sr.get("slider")
-        assert s[0].value == 0
-        assert s[1].value == 10
-        assert s[2].value == (time(11, 30), time(12, 45))
-        assert s[3].value == datetime(2020, 1, 1, 9, 30)
-        assert s[4].value == 0.0
-
-        sr2 = sr.get("slider")[1].set_value(50).run()
-        sr3 = sr2.get("slider")[2].set_range(time(12, 0), time(12, 15)).run()
-        sr4 = sr3.get("slider")[3].set_value(datetime(2020, 1, 10, 8, 0)).run()
-        sr5 = sr4.get("slider")[4].set_value(0.1).run()
-        s = sr5.get("slider")
-        assert s[0].value == 0
-        assert s[1].value == 50
-        assert s[2].value == (time(12, 0), time(12, 15))
-        assert s[3].value == datetime(2020, 1, 10, 8, 0)
-        assert s[4].value == 0.1
-
-
-class SelectSliderTest(InteractiveScriptTests):
-    def test_value(self):
-        script = self.script_from_string(
-            "select_slider_test.py",
+            "multiselect_test.py",
             """
             import streamlit as st
 
-            options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']
-            st.select_slider("single", options=options, value='green')
-            st.select_slider("range", options=options, value=['red', 'blue'])
+            st.multiselect("one", options=["a", "b", "c"])
+            st.multiselect("two", options=["zero", "one", "two"], default=["two"])
             """,
         )
         sr = script.run()
-        assert sr.get("select_slider")[0].value == "green"
-        assert sr.get("select_slider")[1].value == ("red", "blue")
+        assert sr.get("multiselect")[0].value == []
+        assert sr.get("multiselect")[1].value == ["two"]
 
-        sr2 = sr.get("select_slider")[0].set_value("violet").run()
-        sr3 = sr2.get("select_slider")[1].set_range("yellow", "orange").run()
-        assert sr3.get("select_slider")[0].value == "violet"
-        assert sr3.get("select_slider")[1].value == ("orange", "yellow")
+        sr2 = sr.get("multiselect")[0].select("b").run()
+        assert sr2.get("multiselect")[0].value == ["b"]
+        assert sr2.get("multiselect")[1].value == ["two"]
 
+        sr3 = sr2.get("multiselect")[1].select("zero").select("one").run()
+        assert sr3.get("multiselect")[0].value == ["b"]
+        assert set(sr3.get("multiselect")[1].value) == set(["zero", "one", "two"])
 
-class SelectboxTest(InteractiveScriptTests):
-    def test_value(self):
-        script = self.script_from_string(
-            "select_slider_test.py",
-            """
-            import pandas as pd
-            import streamlit as st
-
-            options = ("male", "female")
-            st.selectbox("selectbox 1", options, 1)
-            st.selectbox("selectbox 2", options, 0)
-            st.selectbox("selectbox 3", [])
-
-            lst = ['Python', 'C', 'C++', 'Java', 'Scala', 'Lisp', 'JavaScript', 'Go']
-            df = pd.DataFrame(lst)
-            st.selectbox("selectbox 4", df)
-            """,
-        )
-        sr = script.run()
-        assert sr.get("selectbox")[0].value == "female"
-        assert sr.get("selectbox")[1].value == "male"
-        assert sr.get("selectbox")[2].value is None
-        assert sr.get("selectbox")[3].value == "Python"
-
-        sr2 = sr.get("selectbox")[0].select("female").run()
-        sr3 = sr2.get("selectbox")[1].select("female").run()
-        sr4 = sr3.get("selectbox")[3].select("JavaScript").run()
-
-        assert sr4.get("selectbox")[0].value == "female"
-        assert sr4.get("selectbox")[1].value == "female"
-        assert sr4.get("selectbox")[2].value is None
-        assert sr4.get("selectbox")[3].value == "JavaScript"
-
-        sr5 = sr4.get("selectbox")[0].select_index(0).run()
-        sr6 = sr5.get("selectbox")[3].select_index(5).run()
-        assert sr6.get("selectbox")[0].value == "male"
-        assert sr6.get("selectbox")[3].value == "Lisp"
-
-        with pytest.raises(ValueError):
-            sr6.get("selectbox")[0].select("invalid").run()
-
-        with pytest.raises(IndexError):
-            sr6.get("selectbox")[0].select_index(42).run()
-
-
-class ExceptionTest(InteractiveScriptTests):
-    def test_value(self):
-        script = self.script_from_string(
-            "exception.py",
-            """
-            import streamlit as st
-
-            st.exception(RuntimeError("foo"))
-            """,
-        )
-        sr = script.run()
-
-        assert sr.get("exception")[0].value == "foo"
-
-    def test_markdown(self):
-        script = self.script_from_string(
-            "exception2.py",
-            """
-            import streamlit as st
-
-            st.exception(st.errors.MarkdownFormattedException("# Oh no"))
-            """,
-        )
-        sr = script.run()
-
-        assert sr.get("exception")[0].is_markdown
-
-
-class TextInputTest(InteractiveScriptTests):
-    def test_value(self):
-        script = self.script_from_string(
-            "text_input.py",
-            """
-            import streamlit as st
-
-            st.text_input("label")
-            st.text_input("with default", value="default", max_chars=20)
-            """,
-        )
-        sr = script.run()
-
-        assert sr.get("text_input")[0].value == ""
-        assert sr.get("text_input")[1].value == "default"
-
-        long_string = "".join(["this is a long string fragment."] * 10)
-        sr.get("text_input")[0].input(long_string)
-        sr2 = sr.get("text_input")[1].input(long_string).run()
-
-        assert sr2.get("text_input")[0].value == long_string
-        assert sr2.get("text_input")[1].value == "default"
-        # assert sr2.get("text_input")[1].value == long_string[:20]
-
-
-class TextAreaTest(InteractiveScriptTests):
-    def test_value(self):
-        script = self.script_from_string(
-            "text_area.py",
-            """
-            import streamlit as st
-
-            st.text_area("label")
-            st.text_area("with default", value="default", max_chars=20)
-            """,
-        )
-        sr = script.run()
-
-        assert sr.get("text_area")[0].value == ""
-        assert sr.get("text_area")[1].value == "default"
-
-        long_string = "".join(["this is a long string fragment."] * 10)
-        sr.get("text_area")[0].input(long_string)
-        sr2 = sr.get("text_area")[1].input(long_string).run()
-
-        assert sr2.get("text_area")[0].value == long_string
-        assert sr2.get("text_area")[1].value == "default"
+        sr4 = sr3.get("multiselect")[0].unselect("b").run()
+        assert sr4.get("multiselect")[0].value == []
+        assert set(sr3.get("multiselect")[1].value) == set(["zero", "one", "two"])
 
 
 class NumberInputTest(InteractiveScriptTests):
@@ -511,58 +414,155 @@ class NumberInputTest(InteractiveScriptTests):
         assert sr4.get("number_input")[1].value == -1.0
 
 
-class ColorPickerTest(InteractiveScriptTests):
+class SelectboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "color_picker.py",
+            "select_slider_test.py",
             """
+            import pandas as pd
             import streamlit as st
 
-            st.color_picker("what is your favorite color?")
-            st.color_picker("short hex", value="#ABC")
-            st.color_picker("invalid", value="blue")
+            options = ("male", "female")
+            st.selectbox("selectbox 1", options, 1)
+            st.selectbox("selectbox 2", options, 0)
+            st.selectbox("selectbox 3", [])
+
+            lst = ['Python', 'C', 'C++', 'Java', 'Scala', 'Lisp', 'JavaScript', 'Go']
+            df = pd.DataFrame(lst)
+            st.selectbox("selectbox 4", df)
             """,
         )
         sr = script.run()
-        assert len(sr.get("color_picker")) == 2
-        assert [c.value for c in sr.get("color_picker")] == ["#000000", "#ABC"]
-        assert "blue" in sr.get("exception")[0].value
+        assert sr.get("selectbox")[0].value == "female"
+        assert sr.get("selectbox")[1].value == "male"
+        assert sr.get("selectbox")[2].value is None
+        assert sr.get("selectbox")[3].value == "Python"
 
-        sr2 = sr.get("color_picker")[0].pick("#123456").run()
-        assert sr2.get("color_picker")[0].value == "#123456"
+        sr2 = sr.get("selectbox")[0].select("female").run()
+        sr3 = sr2.get("selectbox")[1].select("female").run()
+        sr4 = sr3.get("selectbox")[3].select("JavaScript").run()
+
+        assert sr4.get("selectbox")[0].value == "female"
+        assert sr4.get("selectbox")[1].value == "female"
+        assert sr4.get("selectbox")[2].value is None
+        assert sr4.get("selectbox")[3].value == "JavaScript"
+
+        sr5 = sr4.get("selectbox")[0].select_index(0).run()
+        sr6 = sr5.get("selectbox")[3].select_index(5).run()
+        assert sr6.get("selectbox")[0].value == "male"
+        assert sr6.get("selectbox")[3].value == "Lisp"
+
+        with pytest.raises(ValueError):
+            sr6.get("selectbox")[0].select("invalid").run()
+
+        with pytest.raises(IndexError):
+            sr6.get("selectbox")[0].select_index(42).run()
 
 
-class DateInputTest(InteractiveScriptTests):
+class SelectSliderTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "date_input.py",
+            "select_slider_test.py",
             """
             import streamlit as st
-            import datetime
 
-            st.date_input("date", value=datetime.date(2023, 4, 17))
-            st.date_input("datetime", value=datetime.datetime(2023, 4, 17, 11))
-            st.date_input("range", value=(datetime.date(2020, 1, 1), datetime.date(2030, 1, 1)))
+            options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']
+            st.select_slider("single", options=options, value='green')
+            st.select_slider("range", options=options, value=['red', 'blue'])
             """,
         )
         sr = script.run()
-        assert not sr.get("exception")
-        assert [d.value for d in sr.get("date_input")] == [
-            date(2023, 4, 17),
-            datetime(2023, 4, 17).date(),
-            (date(2020, 1, 1), date(2030, 1, 1)),
-        ]
-        ds = sr.get("date_input")
-        ds[0].set_value(date(2023, 5, 1))
-        ds[1].set_value(datetime(2023, 1, 1))
-        ds[2].set_value((date(2023, 1, 1), date(2024, 1, 1)))
+        assert sr.get("select_slider")[0].value == "green"
+        assert sr.get("select_slider")[1].value == ("red", "blue")
 
-        sr2 = sr.run()
-        assert [d.value for d in sr2.get("date_input")] == [
-            date(2023, 5, 1),
-            date(2023, 1, 1),
-            (date(2023, 1, 1), date(2024, 1, 1)),
-        ]
+        sr2 = sr.get("select_slider")[0].set_value("violet").run()
+        sr3 = sr2.get("select_slider")[1].set_range("yellow", "orange").run()
+        assert sr3.get("select_slider")[0].value == "violet"
+        assert sr3.get("select_slider")[1].value == ("orange", "yellow")
+
+
+class SliderTest(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "slider_test.py",
+            """
+            import streamlit as st
+            from datetime import datetime, time
+
+            st.slider("defaults")
+            st.slider("int", min_value=-100, max_value=100, step=5, value=10)
+            st.slider("time", value=(time(11, 30), time(12, 45)))
+            st.slider("datetime", value=datetime(2020, 1, 1, 9, 30))
+            st.slider("float", min_value=0.0, max_value=1.0, step=0.01)
+            """,
+        )
+        sr = script.run()
+        s = sr.get("slider")
+        assert s[0].value == 0
+        assert s[1].value == 10
+        assert s[2].value == (time(11, 30), time(12, 45))
+        assert s[3].value == datetime(2020, 1, 1, 9, 30)
+        assert s[4].value == 0.0
+
+        sr2 = sr.get("slider")[1].set_value(50).run()
+        sr3 = sr2.get("slider")[2].set_range(time(12, 0), time(12, 15)).run()
+        sr4 = sr3.get("slider")[3].set_value(datetime(2020, 1, 10, 8, 0)).run()
+        sr5 = sr4.get("slider")[4].set_value(0.1).run()
+        s = sr5.get("slider")
+        assert s[0].value == 0
+        assert s[1].value == 50
+        assert s[2].value == (time(12, 0), time(12, 15))
+        assert s[3].value == datetime(2020, 1, 10, 8, 0)
+        assert s[4].value == 0.1
+
+
+class TextAreaTest(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "text_area.py",
+            """
+            import streamlit as st
+
+            st.text_area("label")
+            st.text_area("with default", value="default", max_chars=20)
+            """,
+        )
+        sr = script.run()
+
+        assert sr.get("text_area")[0].value == ""
+        assert sr.get("text_area")[1].value == "default"
+
+        long_string = "".join(["this is a long string fragment."] * 10)
+        sr.get("text_area")[0].input(long_string)
+        sr2 = sr.get("text_area")[1].input(long_string).run()
+
+        assert sr2.get("text_area")[0].value == long_string
+        assert sr2.get("text_area")[1].value == "default"
+
+
+class TextInputTest(InteractiveScriptTests):
+    def test_value(self):
+        script = self.script_from_string(
+            "text_input.py",
+            """
+            import streamlit as st
+
+            st.text_input("label")
+            st.text_input("with default", value="default", max_chars=20)
+            """,
+        )
+        sr = script.run()
+
+        assert sr.get("text_input")[0].value == ""
+        assert sr.get("text_input")[1].value == "default"
+
+        long_string = "".join(["this is a long string fragment."] * 10)
+        sr.get("text_input")[0].input(long_string)
+        sr2 = sr.get("text_input")[1].input(long_string).run()
+
+        assert sr2.get("text_input")[0].value == long_string
+        assert sr2.get("text_input")[1].value == "default"
+        # assert sr2.get("text_input")[1].value == long_string[:20]
 
 
 class TimeInputTest(InteractiveScriptTests):


### PR DESCRIPTION
We added implementations to the file pretty haphazardly, so now that widgets are done I wanted to both make it alphabetical, and remove some redundancy in the implementations.

I recommend looking at each commit sequentially, since they are very focused and self-contained but the full set of changes is much harder to follow.