### PR TITLE
Add tenacity as dependency

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -45,6 +45,7 @@ INSTALL_REQUIRES = [
     "python-dateutil",
     "requests>=2.4",
     "rich>=10.11.0",
+    "tenacity>=8.0.0",
     "toml",
     "typing-extensions>=3.10.0.0",
     "tzlocal>=1.1",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -45,7 +45,7 @@ INSTALL_REQUIRES = [
     "python-dateutil",
     "requests>=2.4",
     "rich>=10.11.0",
-    "tenacity>=8.0.0",
+    "tenacity<9,>=8.0.0",
     "toml",
     "typing-extensions>=3.10.0.0",
     "tzlocal>=1.1",


### PR DESCRIPTION
## 📚 Context

After trying a decent amount to avoid adding this as a core dependency because it's only used
for a few first-party connections in the upcoming `st.experimental_connection` feature (see
https://github.com/streamlit/streamlit/pull/6487), we decided that this package is sufficiently
small and self-contained that we might as well just add it as a requirement.