### PR TITLE
Fix code block font change

### DIFF
--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -479,11 +479,11 @@ export const createEmotionTheme = (
     genericColors: newGenericColors,
     genericFonts: {
       ...genericFonts,
-      ...(parsedFont && {
-        bodyFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
-        headingFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
-        codeFont: themeInput.codeFont ? themeInput.codeFont : parsedFont,
-      }),
+      bodyFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
+      headingFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
+      codeFont: themeInput.codeFont
+        ? themeInput.codeFont
+        : genericFonts.codeFont,
     },
     ...conditionalOverrides,
   }

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -479,11 +479,13 @@ export const createEmotionTheme = (
     genericColors: newGenericColors,
     genericFonts: {
       ...genericFonts,
-      bodyFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
-      headingFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
-      codeFont: themeInput.codeFont
-        ? themeInput.codeFont
-        : genericFonts.codeFont,
+      ...(parsedFont && {
+        bodyFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
+        headingFont: themeInput.bodyFont ? themeInput.bodyFont : parsedFont,
+        codeFont: themeInput.codeFont
+          ? themeInput.codeFont
+          : genericFonts.codeFont,
+      }),
     },
     ...conditionalOverrides,
   }


### PR DESCRIPTION
## 📚 Context

This PR fixes a regression where the font config setting in custom themes is being applied to code blocks (see [this bug report](https://github.com/streamlit/streamlit/issues/6484)).

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

  - Updated the fallback `codeFont` being to applied in `createEmotionTheme` under `theme/utils.ts`;

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![Screenshot 2023-04-21 at 11 35 38 AM](https://user-images.githubusercontent.com/103376966/233665156-c7f557ed-d121-41e9-b952-3fcceb528e60.png)

![Screenshot 2023-04-21 at 11 35 28 AM](https://user-images.githubusercontent.com/103376966/233665159-0e1e8ea9-3895-42af-ab70-727d8792cab6.png)

![Screenshot 2023-04-21 at 11 35 17 AM](https://user-images.githubusercontent.com/103376966/233665163-e41f1a55-f9d3-4dc7-9a23-05e50b9b3c42.png)

**Current:**

https://user-images.githubusercontent.com/103376966/233665462-4f7220c5-a4d1-4809-a03f-10e46eb3d134.mov

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Issue**: Closes #6484 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
