### PR TITLE
Unify missing values to None in the returned datastructure by `st.data_editor`. 

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -852,7 +852,7 @@ def _unify_missing_values(df: DataFrame) -> DataFrame:
     """Unify all missing values in a DataFrame to None.
 
     Pandas uses a variety of values to represent missing values, including np.nan,
-    NaT, None, and pd.NA. This function replaces all of these values with  None,
+    NaT, None, and pd.NA. This function replaces all of these values with None,
     which is the only missing value type that is supported by all data
     """
 

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -533,8 +533,8 @@ dtype: object""",
             )
 
     def test_convert_df_with_missing_values(self):
-        """Test that `convert_df_to_data_format` raises a ValueError when
-        passed an unknown data format.
+        """Test that `convert_df_to_data_format` correctly converts
+        all types of missing values to None.
         """
 
         # Add dataframe with different missing values:

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -531,3 +531,60 @@ dtype: object""",
             type_util.convert_df_to_data_format(
                 pd.DataFrame({"a": [1, 2, 3]}), DataFormat.UNKNOWN
             )
+
+    def test_convert_df_with_missing_values(self):
+        """Test that `convert_df_to_data_format` raises a ValueError when
+        passed an unknown data format.
+        """
+
+        # Add dataframe with different missing values:
+        df = pd.DataFrame(
+            {
+                "missing": [None, pd.NA, np.nan, pd.NaT],
+            }
+        )
+
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.LIST_OF_VALUES),
+            [None, None, None, None],
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.TUPLE_OF_VALUES),
+            (None, None, None, None),
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.SET_OF_VALUES),
+            {None},
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.LIST_OF_ROWS),
+            [
+                [None],
+                [None],
+                [None],
+                [None],
+            ],
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.LIST_OF_RECORDS),
+            [
+                {"missing": None},
+                {"missing": None},
+                {"missing": None},
+                {"missing": None},
+            ],
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.COLUMN_VALUE_MAPPING),
+            {
+                "missing": [None, None, None, None],
+            },
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.COLUMN_INDEX_MAPPING),
+            {"missing": {0: None, 1: None, 2: None, 3: None}},
+        )
+        self.assertEqual(
+            type_util.convert_df_to_data_format(df, DataFormat.KEY_VALUE_DICT),
+            {0: None, 1: None, 2: None, 3: None},
+        )


### PR DESCRIPTION
## 📚 Context

A user expects that if you input a list or some other kind of non-dataframe data structure in `data_editor` missing values are represented as `None` and not some other types of missing values used inside Pandas (e.g. `np.nan`, `pd.NaT`, `pd.NA`...). This unifies all missing values to `None` in the output for some of the supported data formats: LIST_OF_RECORDS, LIST_OF_ROWS, COLUMN_INDEX_MAPPING, COLUMN_VALUE_MAPPING, LIST_OF_VALUES, TUPLE_OF_VALUES, SET_OF_VALUES,  KEY_VALUE_DICT.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
