### PR TITLE
Improve editing on touch devices for `st.data_editor`

### DIFF
--- a/frontend/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -29,18 +29,22 @@ import { StyledResizableContainer } from "./styled-components"
 
 const getProps = (
   data: Quiver,
-  useContainerWidth = false
+  useContainerWidth = false,
+  editingMode: ArrowProto.EditingMode = ArrowProto.EditingMode.READ_ONLY
 ): DataFrameProps => ({
   element: ArrowProto.create({
     data: new Uint8Array(),
     useContainerWidth,
     width: 400,
     height: 400,
+    editingMode,
   }),
   data,
   width: 700,
   disabled: false,
-  widgetMgr: {} as any,
+  widgetMgr: {
+    getStringValue: jest.fn(),
+  } as any,
 })
 
 const { ResizeObserver } = window
@@ -91,5 +95,25 @@ describe("DataFrame widget", () => {
     const dataFrameContainer = wrapper.find(Resizable).props() as any
     expect(dataFrameContainer.size.width).toBe(400)
     expect(dataFrameContainer.size.height).toBe(400)
+  })
+
+  it("Touch detection correctly deactivates some features", () => {
+    // Set window.matchMedia to simulate a touch device
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: true,
+    }))
+
+    const wrapper = mount(
+      <DataFrame
+        {...getProps(
+          new Quiver({ data: TEN_BY_TEN }),
+          true,
+          ArrowProto.EditingMode.FIXED
+        )}
+      />
+    )
+    const glideDataEditorProps = wrapper.find(GlideDataEditor).props()
+    expect(glideDataEditorProps.rangeSelect).toBe("none")
+    expect(glideDataEditorProps.fillHandle).toBe(false)
   })
 })

--- a/frontend/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/src/components/widgets/DataFrame/DataFrame.tsx
@@ -137,6 +137,7 @@ function DataFrame({
 
   const [isFocused, setIsFocused] = React.useState<boolean>(true)
 
+  // Determine if the device is primary using touch as input:
   const isTouchDevice = React.useMemo<boolean>(
     () => window.matchMedia && window.matchMedia("(pointer: coarse)").matches,
     []


### PR DESCRIPTION
## 📚 Context

This PR improves the editing support on touch devices by deactivating `fillHandle` and `rangeSelect`. It also prevents the clearing of selections when the table container loses focus since it would lead to strange effects on mobile. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

- I would also love to test this on some e2e tests. However, using playwright web would make this much easier, so not implementing this here via Cypress. 


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
