### PR TITLE
Show warning for unsafe integer cells in `st.dataframe`

### DIFF
--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -193,14 +193,19 @@ describe("NumberColumn", () => {
     }
   )
 
-  it.each([[[]], ["foo"], [[1, 2]], ["123.124.123"], ["--123"], ["2,,2"]])(
-    "%p results in error cell",
-    (input: any) => {
-      const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE)
-      const cell = mockColumn.getCell(input)
-      expect(isErrorCell(cell)).toEqual(true)
-    }
-  )
+  it.each([
+    [[]],
+    ["foo"],
+    [[1, 2]],
+    ["123.124.123"],
+    ["--123"],
+    ["2,,2"],
+    ["12345678987654321"],
+  ])("%p results in error cell", (input: any) => {
+    const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE)
+    const cell = mockColumn.getCell(input)
+    expect(isErrorCell(cell)).toEqual(true)
+  })
 
   it("shows an error cell if the numeric value is too large", () => {
     const mockColumn = getNumberColumn(MOCK_INT_ARROW_TYPE)

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GridCellKind, NumberCell } from "@glideapps/glide-data-grid"
+import { GridCellKind, NumberCell, TextCell } from "@glideapps/glide-data-grid"
 
 import { DataType, Type as ArrowType } from "src/lib/Quiver"
 
@@ -201,4 +201,16 @@ describe("NumberColumn", () => {
       expect(isErrorCell(cell)).toEqual(true)
     }
   )
+
+  it("shows an error cell if the numeric value is too large", () => {
+    const mockColumn = getNumberColumn(MOCK_INT_ARROW_TYPE)
+    const unsafeCell = mockColumn.getCell("1234567898765432123")
+    expect(isErrorCell(unsafeCell)).toEqual(true)
+    expect((unsafeCell as TextCell)?.data).toEqual(
+      "⚠️ 1234567898765432123\n\nThe value is larger than the maximum supported integer values in number columns (2^53).\n"
+    )
+
+    const safeCell = mockColumn.getCell("1234567898765432")
+    expect(isErrorCell(safeCell)).toEqual(false)
+  })
 })

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -214,6 +214,10 @@ describe("NumberColumn", () => {
     expect((unsafeCell as TextCell)?.data).toEqual(
       "⚠️ 1234567898765432123\n\nThe value is larger than the maximum supported integer values in number columns (2^53).\n"
     )
+  })
+
+  it("doesn't show an error for large integers with a size up to 2^53", () => {
+    const mockColumn = getNumberColumn(MOCK_INT_ARROW_TYPE)
 
     const safeCell = mockColumn.getCell("1234567898765432")
     expect(isErrorCell(safeCell)).toEqual(false)

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -114,6 +114,7 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
           cellData = Math.min(cellData, parameters.max)
         }
 
+        // Check if the value is larger than the maximum supported value:
         if (Number.isInteger(cellData) && !Number.isSafeInteger(cellData)) {
           return getErrorCell(
             toSafeString(data),

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -113,6 +113,13 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
         if (notNullOrUndefined(parameters.max)) {
           cellData = Math.min(cellData, parameters.max)
         }
+
+        if (Number.isInteger(cellData) && !Number.isSafeInteger(cellData)) {
+          return getErrorCell(
+            toSafeString(data),
+            "The value is larger than the maximum supported integer values in number columns (2^53)."
+          )
+        }
       }
 
       return {


### PR DESCRIPTION
## 📚 Context

The number column of `st.dataframe` and `st.data_editor` is not able to handle numbers larger than `2^53` as explained in this issue: https://github.com/streamlit/streamlit/issues/6311

Unfortunately, we cannot easily fix this since we rely on `Number` in Javascript (which has this limit) in the number column implementation. Therefore, in this case, we are showing a warning to make it more obvious that the shown value cannot handle as a number value. However, we expect that this is only an issue in very very few situations since it is unlikely that users are using such big numbers. Another workaround for users is to convert the column to string, which will be able to show all numbers, regardless of size correctly. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🧠 Description of Changes

**Revised:**

<img width="285" alt="image" src="https://user-images.githubusercontent.com/2852129/233852474-3249cb77-b9cc-4144-8a1b-236bd41b29f4.png">

**Current:**

<img width="285" alt="image" src="https://user-images.githubusercontent.com/2852129/233852092-9c5bd3c8-4120-4918-91ec-14725ed6fc35.png">

The int64 value of 1009513310189256287 is shown as 1009513310189256300. This is caused by JavaScript not supporting these large integers with Number (see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), max is 9007199254740991).

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6311

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
