### PR TITLE
Update dataframe column properties on frontend

### DIFF
--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -49,6 +49,7 @@ import {
 
 const MOCK_TEXT_COLUMN = TextColumn({
   id: "1",
+  name: "text_column",
   title: "Text column",
   indexNumber: 0,
   isEditable: false,
@@ -63,6 +64,7 @@ const MOCK_TEXT_COLUMN = TextColumn({
 
 const MOCK_NUMBER_COLUMN = NumberColumn({
   id: "1",
+  name: "number_column",
   title: "Number column",
   indexNumber: 0,
   isEditable: false,
@@ -334,7 +336,7 @@ describe("getColumnFromArrow", () => {
       },
       isIndex: false,
       isHidden: false,
-      columnTypeMetadata: {
+      columnTypeOptions: {
         options: ["bar", "foo"],
       },
     })
@@ -368,7 +370,7 @@ describe("getAllColumnsFromArrow", () => {
           numpy_type: "object",
           pandas_type: "unicode",
         },
-        columnTypeMetadata: undefined,
+        columnTypeOptions: undefined,
         id: "column-c1-0",
         indexNumber: 1,
         isEditable: true,
@@ -382,7 +384,7 @@ describe("getAllColumnsFromArrow", () => {
           numpy_type: "object",
           pandas_type: "unicode",
         },
-        columnTypeMetadata: undefined,
+        columnTypeOptions: undefined,
         id: "column-c2-1",
         indexNumber: 2,
         isEditable: true,
@@ -442,6 +444,7 @@ describe("getCellFromArrow", () => {
   it("uses quiver formatting for object cells", () => {
     const objectColumn = ObjectColumn({
       id: "1",
+      name: "object_column",
       title: "Object column",
       indexNumber: 0,
       isEditable: false,

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -246,6 +246,7 @@ describe("getIndexFromArrow", () => {
     expect(indexColumn).toEqual({
       id: `index-0`,
       isEditable: true,
+      name: "",
       title: "",
       arrowType: {
         meta: null,
@@ -267,6 +268,7 @@ describe("getIndexFromArrow", () => {
     expect(indexColumn1).toEqual({
       id: `index-0`,
       isEditable: true,
+      name: "number",
       title: "number",
       arrowType: {
         meta: null,
@@ -281,6 +283,7 @@ describe("getIndexFromArrow", () => {
     expect(indexColumn2).toEqual({
       id: `index-1`,
       isEditable: true,
+      name: "color",
       title: "color",
       arrowType: {
         meta: null,
@@ -303,6 +306,7 @@ describe("getColumnFromArrow", () => {
     const column = getColumnFromArrow(data, 0)
     expect(column).toEqual({
       id: "column-c1-0",
+      name: "c1",
       title: "c1",
       isEditable: true,
       arrowType: {
@@ -324,6 +328,7 @@ describe("getColumnFromArrow", () => {
     const column = getColumnFromArrow(data, 0)
     expect(column).toEqual({
       id: "column-c1-0",
+      name: "c1",
       title: "c1",
       isEditable: true,
       arrowType: {
@@ -362,6 +367,7 @@ describe("getAllColumnsFromArrow", () => {
         isEditable: true,
         isHidden: false,
         isIndex: true,
+        name: "",
         title: "",
       },
       {
@@ -376,6 +382,7 @@ describe("getAllColumnsFromArrow", () => {
         isEditable: true,
         isHidden: false,
         isIndex: false,
+        name: "c1",
         title: "c1",
       },
       {
@@ -390,6 +397,7 @@ describe("getAllColumnsFromArrow", () => {
         isEditable: true,
         isHidden: false,
         isIndex: false,
+        name: "c2",
         title: "c2",
       },
     ])
@@ -415,6 +423,7 @@ describe("getAllColumnsFromArrow", () => {
         isEditable: true,
         isHidden: false,
         isIndex: true,
+        name: "",
         title: "",
       },
     ])

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -209,8 +209,9 @@ export function getIndexFromArrow(
 
   return {
     id: `index-${indexPosition}`,
-    isEditable,
+    name: title,
     title,
+    isEditable,
     arrowType,
     isIndex: true,
     isHidden: false,
@@ -241,12 +242,12 @@ export function getColumnFromArrow(
     } as ArrowType
   }
 
-  let columnTypeMetadata
+  let columnTypeOptions
   if (Quiver.getTypeName(arrowType) === "categorical") {
     // Get the available categories and use it in column type metadata
     const options = data.getCategoricalOptions(columnPosition)
     if (notNullOrUndefined(options)) {
-      columnTypeMetadata = {
+      columnTypeOptions = {
         options,
       }
     }
@@ -254,10 +255,11 @@ export function getColumnFromArrow(
 
   return {
     id: `column-${title}-${columnPosition}`,
-    isEditable: true,
+    name: title,
     title,
+    isEditable: true,
     arrowType,
-    columnTypeMetadata,
+    columnTypeOptions,
     isIndex: false,
     isHidden: false,
   } as BaseColumnProps

--- a/frontend/src/components/widgets/DataFrame/columns/BooleanColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/BooleanColumn.test.ts
@@ -21,6 +21,7 @@ import BooleanColumn from "./BooleanColumn"
 
 const MOCK_BOOLEAN_COLUMN_PROPS = {
   id: "1",
+  name: "boolean_column",
   title: "Boolean column",
   indexNumber: 0,
   isEditable: false,

--- a/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
@@ -35,6 +35,7 @@ const MOCK_BOOLEAN_ARROW_TYPE: ArrowType = {
 
 const CATEGORICAL_COLUMN_TEMPLATE: Partial<BaseColumnProps> = {
   id: "1",
+  name: "categorical_column",
   title: "Categorical column",
   indexNumber: 0,
   isEditable: false,
@@ -50,7 +51,7 @@ function getCategoricalColumn(
   return CategoricalColumn({
     ...CATEGORICAL_COLUMN_TEMPLATE,
     arrowType,
-    columnTypeMetadata: params,
+    columnTypeOptions: params,
   } as BaseColumnProps)
 }
 

--- a/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
@@ -128,6 +128,9 @@ describe("CategoricalColumn", () => {
       "foo",
       "bar",
     ])
+
+    const errorCell = mockColumn.getCell(undefined)
+    expect(isErrorCell(errorCell)).toEqual(true)
   })
 
   it("creates error cell if value is not in options", () => {

--- a/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { GridCellKind } from "@glideapps/glide-data-grid"
+import { DropdownCellType } from "@glideapps/glide-data-grid-cells"
 
 import { Type as ArrowType } from "src/lib/Quiver"
 
@@ -46,10 +47,12 @@ const CATEGORICAL_COLUMN_TEMPLATE: Partial<BaseColumnProps> = {
 
 function getCategoricalColumn(
   arrowType: ArrowType,
-  params?: CategoricalColumnParams
+  params?: CategoricalColumnParams,
+  column_props_overwrites?: Partial<BaseColumnProps>
 ): ReturnType<typeof CategoricalColumn> {
   return CategoricalColumn({
     ...CATEGORICAL_COLUMN_TEMPLATE,
+    ...column_props_overwrites,
     arrowType,
     columnTypeOptions: params,
   } as BaseColumnProps)
@@ -68,6 +71,12 @@ describe("CategoricalColumn", () => {
     const mockCell = mockColumn.getCell("foo")
     expect(mockCell.kind).toEqual(GridCellKind.Custom)
     expect(mockColumn.getCellValue(mockCell)).toEqual("foo")
+
+    expect((mockCell as DropdownCellType).data.allowedValues).toEqual([
+      "",
+      "foo",
+      "bar",
+    ])
   })
 
   it("creates a valid column instance number values", () => {
@@ -82,6 +91,13 @@ describe("CategoricalColumn", () => {
     const mockCell = mockColumn.getCell(1)
     expect(mockCell.kind).toEqual(GridCellKind.Custom)
     expect(mockColumn.getCellValue(mockCell)).toEqual(1)
+
+    expect((mockCell as DropdownCellType).data.allowedValues).toEqual([
+      "",
+      "1",
+      "2",
+      "3",
+    ])
   })
 
   it("creates a valid column instance from boolean type", () => {
@@ -92,6 +108,26 @@ describe("CategoricalColumn", () => {
     const mockCell = mockColumn.getCell(true)
     expect(mockCell.kind).toEqual(GridCellKind.Custom)
     expect(mockColumn.getCellValue(mockCell)).toEqual(true)
+    expect((mockCell as DropdownCellType).data.allowedValues).toEqual([
+      "",
+      "true",
+      "false",
+    ])
+  })
+
+  it("creates a required column that does not add the empty value", () => {
+    const mockColumn = getCategoricalColumn(
+      MOCK_CATEGORICAL_TYPE,
+      {
+        options: ["foo", "bar"],
+      },
+      { isRequired: true }
+    )
+    const mockCell = mockColumn.getCell("foo")
+    expect((mockCell as DropdownCellType).data.allowedValues).toEqual([
+      "foo",
+      "bar",
+    ])
   })
 
   it("creates error cell if value is not in options", () => {

--- a/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.test.ts
@@ -129,7 +129,7 @@ describe("CategoricalColumn", () => {
       "bar",
     ])
 
-    const errorCell = mockColumn.getCell(undefined)
+    const errorCell = mockColumn.getCell(null)
     expect(isErrorCell(errorCell)).toEqual(true)
   })
 

--- a/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CategoricalColumn.ts
@@ -54,7 +54,7 @@ function CategoricalColumn(props: BaseColumnProps): BaseColumn {
         Quiver.getTypeName(props.arrowType) === "bool" ? [true, false] : [],
     },
     // User parameters:
-    props.columnTypeMetadata
+    props.columnTypeOptions
   ) as CategoricalColumnParams
 
   const uniqueTypes = new Set(parameters.options.map(x => typeof x))
@@ -75,7 +75,7 @@ function CategoricalColumn(props: BaseColumnProps): BaseColumn {
     data: {
       kind: "dropdown-cell",
       allowedValues: [
-        "", // Enforce the empty option
+        ...(props.isRequired !== true ? [""] : []),
         ...parameters.options
           .filter(opt => opt !== "") // ignore empty option if it exists
           .map(opt => toSafeString(opt)), // convert everything to string

--- a/frontend/src/components/widgets/DataFrame/columns/ListColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ListColumn.test.ts
@@ -20,6 +20,7 @@ import ListColumn from "./ListColumn"
 
 const MOCK_LIST_COLUMN_PROPS = {
   id: "1",
+  name: "list_column",
   title: "List column",
   indexNumber: 0,
   isEditable: false,

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -38,6 +38,7 @@ const MOCK_UINT_ARROW_TYPE: ArrowType = {
 
 const NUMBER_COLUMN_TEMPLATE: Partial<BaseColumnProps> = {
   id: "1",
+  name: "number_column",
   title: "Number column",
   indexNumber: 0,
   isEditable: false,
@@ -53,7 +54,7 @@ function getNumberColumn(
   return NumberColumn({
     ...NUMBER_COLUMN_TEMPLATE,
     arrowType,
-    columnTypeMetadata: params,
+    columnTypeOptions: params,
   } as BaseColumnProps)
 }
 

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -60,7 +60,7 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
       min: arrowTypeName.startsWith("uint") ? 0 : undefined,
     },
     // User parameters:
-    props.columnTypeMetadata
+    props.columnTypeOptions
   ) as NumberColumnParams
 
   const allowNegative = isNullOrUndefined(parameters.min) || parameters.min < 0

--- a/frontend/src/components/widgets/DataFrame/columns/ObjectColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ObjectColumn.test.ts
@@ -20,6 +20,7 @@ import ObjectColumn from "./ObjectColumn"
 
 const MOCK_OBJECT_COLUMN_PROPS = {
   id: "1",
+  name: "object_column",
   title: "Object column",
   indexNumber: 0,
   isEditable: false,

--- a/frontend/src/components/widgets/DataFrame/columns/TextColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/TextColumn.test.ts
@@ -20,6 +20,7 @@ import TextColumn from "./TextColumn"
 
 const MOCK_TEXT_COLUMN_PROPS = {
   id: "1",
+  name: "text_column",
   title: "Text column",
   indexNumber: 0,
   isEditable: false,

--- a/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -34,6 +34,7 @@ import { TextColumn } from "."
 
 const MOCK_TEXT_COLUMN_PROPS = {
   id: "column_1",
+  name: "column_1",
   title: "column_1",
   indexNumber: 0,
   arrowType: {

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -35,7 +35,9 @@ import { notNullOrUndefined, isNullOrUndefined } from "src/lib/utils"
 export interface BaseColumnProps {
   // The id of the column:
   readonly id: string
-  // The title of the column:
+  // The name of the column from the original data:
+  readonly name: string
+  // The display title of the column:
   readonly title: string
   // The index number of the column:
   readonly indexNumber: number
@@ -49,14 +51,20 @@ export interface BaseColumnProps {
   readonly isIndex: boolean
   // If `True`, the column is a stretched:
   readonly isStretched: boolean
+  // If `True`, a value is required before the cell or row can be submitted:
+  readonly isRequired?: boolean
   // The initial width of the column:
   readonly width?: number
+  // A help text that is displayed on hovering the column header.
+  readonly help?: string
   // Column type selected via column config:
   readonly customType?: string
   // Additional metadata related to the column type:
-  readonly columnTypeMetadata?: Record<string, any>
+  readonly columnTypeOptions?: Record<string, any>
   // The content alignment of the column:
   readonly contentAlignment?: "left" | "center" | "right"
+  // The default value of the column used when adding a new row:
+  readonly defaultValue?: string | number | boolean
   // Theme overrides for this column:
   readonly themeOverride?: Partial<GlideTheme>
 }
@@ -389,7 +397,7 @@ export function formatNumber(
 ): string {
   if (!Number.isNaN(value) && Number.isFinite(value)) {
     if (maxPrecision === 0) {
-      // Numbro is unable to format the numb with 0 decimals.
+      // Numbro is unable to format the number with 0 decimals.
       value = Math.round(value)
     }
     return numbro(value).format(

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -55,8 +55,6 @@ export interface BaseColumnProps {
   readonly isRequired?: boolean
   // The initial width of the column:
   readonly width?: number
-  // A help text that is displayed on hovering the column header.
-  readonly help?: string
   // Column type selected via column config:
   readonly customType?: string
   // Additional metadata related to the column type:

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -102,6 +102,8 @@ describe("applyColumnConfig", () => {
           disabled: true,
           hidden: true,
           alignment: "center",
+          required: true,
+          default: "this is the default",
         } as ColumnConfigProps,
       ],
     ])
@@ -122,6 +124,8 @@ describe("applyColumnConfig", () => {
     expect(column2.width).toBe(undefined)
     expect(column2.contentAlignment).toBe("center")
     expect(column2.isHidden).toBe(true)
+    expect(column2.isRequired).toBe(true)
+    expect(column2.defaultValue).toBe("this is the default")
     expect(column2).toEqual({
       ...MOCK_COLUMNS[2],
       isHidden: true,

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -37,11 +37,13 @@ import useColumnLoader, {
   getColumnType,
   INDEX_IDENTIFIER,
   COLUMN_POSITION_PREFIX,
+  COLUMN_WIDTH_MAPPING,
 } from "./useColumnLoader"
 
 const MOCK_COLUMNS: BaseColumn[] = [
   NumberColumn({
     id: "index_col",
+    name: "",
     title: "",
     indexNumber: 0,
     arrowType: {
@@ -55,6 +57,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   }),
   NumberColumn({
     id: "column_1",
+    name: "column_1",
     title: "column_1",
     indexNumber: 1,
     arrowType: {
@@ -68,6 +71,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   }),
   TextColumn({
     id: "column_2",
+    name: "column_2",
     title: "column_2",
     indexNumber: 2,
     arrowType: {
@@ -87,27 +91,27 @@ describe("applyColumnConfig", () => {
       [
         "column_1",
         {
-          width: 100,
-          editable: true,
+          width: "small",
+          disabled: false,
           type: "text",
-        },
+        } as ColumnConfigProps,
       ],
       [
         "column_2",
         {
           hidden: true,
           alignment: "center",
-        },
+        } as ColumnConfigProps,
       ],
     ])
 
     const column1 = applyColumnConfig(MOCK_COLUMNS[1], columnConfig)
     expect(column1.isEditable).toBe(true)
-    expect(column1.width).toBe(100)
+    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING["small"])
     expect(column1.customType).toBe("text")
     expect(column1).toEqual({
       ...MOCK_COLUMNS[1],
-      width: 100,
+      width: COLUMN_WIDTH_MAPPING["small"],
       isEditable: true,
       customType: "text",
     })
@@ -129,13 +133,13 @@ describe("applyColumnConfig", () => {
       [
         INDEX_IDENTIFIER,
         {
-          width: 123,
+          width: "small",
         },
       ],
     ])
 
     const column1 = applyColumnConfig(MOCK_COLUMNS[0], columnConfig)
-    expect(column1.width).toBe(123)
+    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING["small"])
     expect(column1.isIndex).toBe(true)
 
     const column2 = applyColumnConfig(MOCK_COLUMNS[1], columnConfig)
@@ -148,13 +152,13 @@ describe("applyColumnConfig", () => {
       [
         `${COLUMN_POSITION_PREFIX}0`,
         {
-          width: 123,
+          width: "small",
         },
       ],
     ])
 
     const column1 = applyColumnConfig(MOCK_COLUMNS[0], columnConfig)
-    expect(column1.width).toBe(123)
+    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING["small"])
   })
 
   it("works with empty column configs", () => {
@@ -173,11 +177,11 @@ describe("getColumnConfig", () => {
       data: UNICODE,
       columns: JSON.stringify({
         c1: {
-          width: 100,
+          width: "small",
           hidden: true,
         },
         c2: {
-          width: 123,
+          width: "medium",
           alignment: "center",
         },
       }),
@@ -186,11 +190,11 @@ describe("getColumnConfig", () => {
     const columnConfig = getColumnConfig(element)
     expect(columnConfig.size).toBe(2)
     expect(columnConfig.get("c1")).toEqual({
-      width: 100,
+      width: "small",
       hidden: true,
     })
     expect(columnConfig.get("c2")).toEqual({
-      width: 123,
+      width: "medium",
       alignment: "center",
     })
   })
@@ -217,6 +221,7 @@ describe("getColumnType", () => {
     (typeName: string, columnCreator: ColumnCreator) => {
       const columnType = getColumnType({
         id: "column_1",
+        name: "column_1",
         title: "column_1",
         indexNumber: 1,
         arrowType: {

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -107,11 +107,11 @@ describe("applyColumnConfig", () => {
 
     const column1 = applyColumnConfig(MOCK_COLUMNS[1], columnConfig)
     expect(column1.isEditable).toBe(true)
-    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING["small"])
+    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING.small)
     expect(column1.customType).toBe("text")
     expect(column1).toEqual({
       ...MOCK_COLUMNS[1],
-      width: COLUMN_WIDTH_MAPPING["small"],
+      width: COLUMN_WIDTH_MAPPING.small,
       isEditable: true,
       customType: "text",
     })
@@ -139,7 +139,7 @@ describe("applyColumnConfig", () => {
     ])
 
     const column1 = applyColumnConfig(MOCK_COLUMNS[0], columnConfig)
-    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING["small"])
+    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING.small)
     expect(column1.isIndex).toBe(true)
 
     const column2 = applyColumnConfig(MOCK_COLUMNS[1], columnConfig)
@@ -158,7 +158,7 @@ describe("applyColumnConfig", () => {
     ])
 
     const column1 = applyColumnConfig(MOCK_COLUMNS[0], columnConfig)
-    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING["small"])
+    expect(column1.width).toBe(COLUMN_WIDTH_MAPPING.small)
   })
 
   it("works with empty column configs", () => {

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -130,6 +130,8 @@ describe("applyColumnConfig", () => {
       ...MOCK_COLUMNS[2],
       isHidden: true,
       contentAlignment: "center",
+      defaultValue: "this is the default",
+      isRequired: true,
     })
   })
 

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -99,6 +99,7 @@ describe("applyColumnConfig", () => {
       [
         "column_2",
         {
+          disabled: true,
           hidden: true,
           alignment: "center",
         } as ColumnConfigProps,

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -38,17 +38,30 @@ export const INDEX_IDENTIFIER = "index"
 // Prefix used in the config column mapping when referring to a column via the numeric position
 export const COLUMN_POSITION_PREFIX = "col:"
 
+export const COLUMN_WIDTH_MAPPING = {
+  small: 75,
+  medium: 200,
+  large: 400,
+}
+
 /**
  * Options to configure columns.
+ *
+ * This needs to be kept in sync with the ColumnConfig TypeDict in the backend.
+ * This will eventually replaced with a proto message.
  */
 export interface ColumnConfigProps {
-  width?: number
   title?: string
-  type?: string
+  width?: "small" | "medium" | "large"
+  help?: string
   hidden?: boolean
-  editable?: boolean
-  metadata?: Record<string, unknown>
-  alignment?: string
+  disabled?: boolean
+  required?: boolean
+  default?: number | string | boolean
+  type?: string
+  // uses snake_case to match the property names in the backend:
+  type_options?: Record<string, unknown>
+  alignment?: "left" | "center" | "right"
 }
 
 /**
@@ -69,9 +82,9 @@ export function applyColumnConfig(
   }
 
   let columnConfig
-  if (columnConfigMapping.has(columnProps.title)) {
-    // Config is configured based on the column title
-    columnConfig = columnConfigMapping.get(columnProps.title)
+  if (columnConfigMapping.has(columnProps.name)) {
+    // Config is configured based on the column name
+    columnConfig = columnConfigMapping.get(columnProps.name)
   } else if (
     columnConfigMapping.has(
       `${COLUMN_POSITION_PREFIX}${columnProps.indexNumber}`
@@ -95,19 +108,25 @@ export function applyColumnConfig(
   }
 
   // This will update all column props with the user-defined config for all
-  // configuration option that are not undefined:
-  return merge(
-    { ...columnProps },
-    {
-      title: columnConfig.title,
-      width: columnConfig.width,
-      customType: columnConfig.type?.toLowerCase().trim(),
-      isEditable: columnConfig.editable,
-      isHidden: columnConfig.hidden,
-      columnTypeMetadata: columnConfig.metadata,
-      contentAlignment: columnConfig.alignment,
-    }
-  ) as BaseColumnProps
+  // configuration options that are not undefined:
+  return merge({ ...columnProps }, {
+    title: columnConfig.title,
+    width:
+      notNullOrUndefined(columnConfig.width) &&
+      columnConfig.width in COLUMN_WIDTH_MAPPING
+        ? COLUMN_WIDTH_MAPPING[columnConfig.width]
+        : undefined,
+    customType: columnConfig.type?.toLowerCase().trim(),
+    isEditable: notNullOrUndefined(columnConfig.disabled)
+      ? !columnConfig.disabled
+      : undefined,
+    isHidden: columnConfig.hidden,
+    isRequired: columnConfig.required,
+    columnTypeOptions: columnConfig.type_options,
+    contentAlignment: columnConfig.alignment,
+    help: columnConfig.help,
+    defaultValue: columnConfig.default,
+  } as BaseColumnProps) as BaseColumnProps
 }
 
 /**

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -48,7 +48,7 @@ export const COLUMN_WIDTH_MAPPING = {
  * Options to configure columns.
  *
  * This needs to be kept in sync with the ColumnConfig TypeDict in the backend.
- * This will eventually replaced with a proto message.
+ * This will be eventually replaced with a proto message.
  */
 export interface ColumnConfigProps {
   title?: string

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -53,7 +53,6 @@ export const COLUMN_WIDTH_MAPPING = {
 export interface ColumnConfigProps {
   title?: string
   width?: "small" | "medium" | "large"
-  help?: string
   hidden?: boolean
   disabled?: boolean
   required?: boolean
@@ -124,7 +123,6 @@ export function applyColumnConfig(
     isRequired: columnConfig.required,
     columnTypeOptions: columnConfig.type_options,
     contentAlignment: columnConfig.alignment,
-    help: columnConfig.help,
     defaultValue: columnConfig.default,
   } as BaseColumnProps) as BaseColumnProps
 }

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnSort.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnSort.test.ts
@@ -28,6 +28,7 @@ import useColumnSort from "./useColumnSort"
 const MOCK_COLUMNS: BaseColumn[] = [
   NumberColumn({
     id: "column_1",
+    name: "column_1",
     title: "column_1",
     indexNumber: 0,
     arrowType: {
@@ -41,6 +42,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   }),
   TextColumn({
     id: "column_2",
+    name: "column_2",
     title: "column_2",
     indexNumber: 1,
     arrowType: {

--- a/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
@@ -59,6 +59,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
     isHidden: false,
     isIndex: false,
     isStretched: false,
+    defaultValue: "foo",
   }),
 ]
 
@@ -279,6 +280,34 @@ describe("useDataEditor hook", () => {
     expect(editingState.current.getNumRows()).toEqual(INITIAL_NUM_ROWS + 1)
 
     expect(applyEditsMock).toHaveBeenCalledWith(false, false)
+  })
+
+  it("uses default values for new rows in onRowAppended", () => {
+    const editingState = {
+      current: new EditingState(INITIAL_NUM_ROWS),
+    }
+    const { result } = renderHook(() => {
+      return useDataEditor(
+        MOCK_COLUMNS,
+        false, // activates addition & deletion of rows
+        editingState,
+        getCellContentMock,
+        getOriginalIndexMock,
+        refreshCellsMock,
+        applyEditsMock
+      )
+    })
+
+    if (typeof result.current.onRowAppended !== "function") {
+      throw new Error("onRowAppended is expected to be a function")
+    }
+
+    result.current.onRowAppended()
+
+    // Check with full editing state:
+    expect(editingState.current.toJson(MOCK_COLUMNS)).toEqual(
+      `{"edited_cells":{},"added_rows":[{"1":"foo"}],"deleted_rows":[]}`
+    )
   })
 
   it("doesn't allow to add new rows via onRowAppended if fix num rows", () => {

--- a/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
@@ -34,6 +34,7 @@ import useDataEditor from "./useDataEditor"
 const MOCK_COLUMNS: BaseColumn[] = [
   NumberColumn({
     id: "column_1",
+    name: "column_1",
     title: "column_1",
     indexNumber: 0,
     arrowType: {
@@ -47,6 +48,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   }),
   TextColumn({
     id: "column_2",
+    name: "column_2",
     title: "column_2",
     indexNumber: 1,
     arrowType: {

--- a/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.ts
@@ -153,7 +153,7 @@ function useDataEditor(
           ) {
             const column = columns[col]
             // Only allow deletion if the column is editable and not configured as required
-            if (column.isEditable === true && column.isRequired !== true) {
+            if (column.isEditable && !column.isRequired) {
               updatedCells.push({
                 cell: [col, row],
               })

--- a/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useDataEditor.ts
@@ -23,6 +23,7 @@ import {
   Item,
 } from "@glideapps/glide-data-grid"
 
+import { notNullOrUndefined } from "src/lib/utils"
 import {
   BaseColumn,
   isErrorCell,
@@ -109,7 +110,9 @@ function useDataEditor(
 
     const newRow: Map<number, GridCell> = new Map()
     columns.forEach(column => {
-      newRow.set(column.indexNumber, column.getCell(undefined))
+      // For the default value, we trust the developer to make a valid choice,
+      // so we do not validate the value here.
+      newRow.set(column.indexNumber, column.getCell(column.defaultValue))
     })
     editingState.current.addRow(newRow)
     applyEdits(false, false)
@@ -149,7 +152,8 @@ function useDataEditor(
             col++
           ) {
             const column = columns[col]
-            if (column.isEditable) {
+            // Only allow deletion if the column is editable and not configured as required
+            if (column.isEditable === true && column.isRequired !== true) {
               updatedCells.push({
                 cell: [col, row],
               })
@@ -213,7 +217,7 @@ function useDataEditor(
           if (column.isEditable) {
             const newCell = column.getCell(pasteDataValue)
             // We are not editing cells if the pasted value leads to an error:
-            if (!isErrorCell(newCell)) {
+            if (notNullOrUndefined(newCell) && !isErrorCell(newCell)) {
               const originalCol = column.indexNumber
               const originalRow = editingState.current.getOriginalRowIndex(
                 getOriginalIndex(rowIndex)

--- a/frontend/src/components/widgets/DataFrame/hooks/useDataLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useDataLoader.test.ts
@@ -55,7 +55,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   }),
   TextColumn({
     arrowType: { meta: null, numpy_type: "object", pandas_type: "unicode" },
-    columnTypeMetadata: undefined,
+    columnTypeOptions: undefined,
     id: "column-c2-1",
     indexNumber: 2,
     isEditable: true,

--- a/frontend/src/components/widgets/DataFrame/hooks/useDataLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useDataLoader.test.ts
@@ -36,6 +36,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   TextColumn({
     arrowType: { meta: null, numpy_type: "object", pandas_type: "unicode" },
     id: "index-0",
+    name: "",
     indexNumber: 0,
     isEditable: true,
     isHidden: false,
@@ -46,6 +47,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
   TextColumn({
     arrowType: { meta: null, numpy_type: "object", pandas_type: "unicode" },
     id: "column-c1-0",
+    name: "c1",
     indexNumber: 1,
     isEditable: true,
     isHidden: false,
@@ -57,6 +59,7 @@ const MOCK_COLUMNS: BaseColumn[] = [
     arrowType: { meta: null, numpy_type: "object", pandas_type: "unicode" },
     columnTypeOptions: undefined,
     id: "column-c2-1",
+    name: "c2",
     indexNumber: 2,
     isEditable: true,
     isHidden: false,

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -92,8 +92,12 @@ DataTypes: TypeAlias = Union[
 
 
 class ColumnConfig(TypedDict, total=False):
-    width: Optional[int]
     title: Optional[str]
+    width: Optional[Literal["small", "medium", "large"]]
+    hidden: Optional[bool]
+    disabled: Optional[bool]
+    required: Optional[bool]
+    alignment: Optional[Literal["left", "center", "right"]]
     type: Optional[
         Literal[
             "text",
@@ -103,11 +107,7 @@ class ColumnConfig(TypedDict, total=False):
             "categorical",
         ]
     ]
-    hidden: Optional[bool]
-    editable: Optional[bool]
-    alignment: Optional[Literal["left", "center", "right"]]
-    metadata: Optional[Dict[str, Any]]
-    column: Optional[Union[str, int]]
+    type_options: Optional[Dict[str, Any]]
 
 
 class EditingState(TypedDict, total=False):
@@ -376,7 +376,7 @@ def _apply_data_specific_configs(
         if type_util.is_colum_type_arrow_incompatible(column_data):
             if column_name not in columns_config:
                 columns_config[column_name] = {}
-            columns_config[column_name]["editable"] = False
+            columns_config[column_name]["disabled"] = True
             # Convert incompatible type to string
             data_df[column_name] = column_data.astype(str)
 

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -250,8 +250,8 @@ class DataEditorUtilTest(unittest.TestCase):
         )
         self.assertNotIn("a", columns_config)
         self.assertNotIn("b", columns_config)
-        self.assertFalse(columns_config["c"]["editable"])
-        self.assertFalse(columns_config["d"]["editable"])
+        self.assertTrue(columns_config["c"]["disabled"])
+        self.assertTrue(columns_config["d"]["disabled"])
 
 
 class DataEditorTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## 📚 Context

This PR adds and updates some internal column properties (`BaseColumnProps`) as a preparation for the column config feature:
- add `name`: this is the column name from the original data. We need this in addition to the `title` since the title is something that can be changed by the user.
- rename `columnTypeMetadata` to `columnTypeOptions`
- add `defaultValue` and use it in `useDataEditor` when a user adds a new row.
- add `isRequired` and use it in `useDataEditor` to prevent cell deletions and in BooleanColumn to not show the empty option. 
- Introduce `small`, `medium`, `large` options for column width instead of a numerical value. 
 - Update the user-provided `ColumnConfigProps` to reflect the changes.
 - Update the `ColumnConfig` in backend to reflect the changes.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
