### PR TITLE
ESLint: use `--cache` flag (30x speedup!)

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -32,7 +32,7 @@
     "sourceType": "module"
   },
   // Ignore our auto-generated and vendored code
-  "ignorePatterns": ["src/autogen/*", "**/vendor/*", "**/node_modules/*"],
+  "ignorePatterns": ["src/autogen/*", "**/vendor/*"],
   "plugins": ["no-relative-import-paths"],
   // Place to specify ESLint rules.
   // Can be used to overwrite rules specified from the extended configs

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -32,7 +32,7 @@
     "sourceType": "module"
   },
   // Ignore our auto-generated and vendored code
-  "ignorePatterns": ["src/autogen/*", "**/vendor/*"],
+  "ignorePatterns": ["src/autogen/*", "**/vendor/*", "**/node_modules/*"],
   "plugins": ["no-relative-import-paths"],
   // Place to specify ESLint rules.
   // Can be used to overwrite rules specified from the extended configs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "cy:run": "unset NODE_OPTIONS && cypress run",
     "cy:run-flaky": "yarn cy:run --config integrationFolder=../e2e_flaky/specs",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx --max-warnings 0 src"
+    "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx --max-warnings 0 --cache src"
   },
   "jest": {
     "resetMocks": false,


### PR DESCRIPTION
`yarn lint`: use the ESLint `--cache` flag, so that only modified files get linted.

With a warm ESLint cache on my machine, this change reduces `yarn lint`'s running time from 26.98s -> 0.91s.