### PR TITLE
Decouple MetricsManager from AppNode

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -24,6 +24,7 @@ import { mockWindowLocation, mount, shallow } from "src/lib/test_util"
 import {
   Config,
   CustomThemeConfig,
+  Delta,
   ForwardMsg,
   ForwardMsgMetadata,
   ICustomThemeConfig,
@@ -33,7 +34,6 @@ import {
   PageInfo,
   PageNotFound,
   PagesChanged,
-  Delta,
 } from "src/autogen/proto"
 import { HostCommunicationHOC } from "src/hocs/withHostCommunication"
 import {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -25,6 +25,7 @@ import {
   Config,
   CustomThemeConfig,
   ForwardMsg,
+  ForwardMsgMetadata,
   ICustomThemeConfig,
   INewSession,
   NewSession,
@@ -32,6 +33,7 @@ import {
   PageInfo,
   PageNotFound,
   PagesChanged,
+  Delta,
 } from "src/autogen/proto"
 import { HostCommunicationHOC } from "src/hocs/withHostCommunication"
 import {
@@ -1512,6 +1514,23 @@ describe("App.handlePageNotFound", () => {
       currentPageName: "",
       currentPageScriptHash: "page_hash",
     })
+  })
+})
+
+describe("App.handleDeltaMessage", () => {
+  it("calls MetricsManager", () => {
+    const mockHandleDeltaMessage = jest.fn()
+
+    const wrapper = shallow(<App {...getProps()} />)
+    const instance = wrapper.instance() as App
+    // @ts-expect-error
+    instance.metricsMgr.handleDeltaMessage = mockHandleDeltaMessage
+
+    const delta = Delta.create({ newElement: {} })
+    const metadata = ForwardMsgMetadata.create({ deltaPath: [0, 1] })
+    instance.handleDeltaMsg(delta, metadata)
+
+    expect(mockHandleDeltaMessage).toHaveBeenCalledWith(delta, metadata)
   })
 })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1123,6 +1123,9 @@ export class App extends PureComponent<Props, State> {
       metadataMsg
     )
 
+    // Update metrics
+    this.metricsMgr.handleDeltaMessage(deltaMsg, metadataMsg)
+
     if (!this.pendingElementsTimerRunning) {
       this.pendingElementsTimerRunning = true
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -234,7 +234,7 @@ export class App extends PureComponent<Props, State> {
 
     this.state = {
       connectionState: ConnectionState.INITIAL,
-      elements: AppRoot.empty(this.metricsMgr, "Please wait..."),
+      elements: AppRoot.empty("Please wait..."),
       isFullScreen: false,
       scriptName: "",
       scriptRunId: "<null>",
@@ -1068,7 +1068,7 @@ export class App extends PureComponent<Props, State> {
         scriptRunId,
         scriptName,
         appHash,
-        elements: AppRoot.empty(this.metricsMgr),
+        elements: AppRoot.empty(),
       },
       () => {
         this.pendingElementsBuffer = this.state.elements

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -41,7 +41,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
 
   return {
     endpoints: endpoints,
-    elements: AppRoot.empty(new MockMetricsManager()),
+    elements: AppRoot.empty(),
     sendMessageToHost: jest.fn(),
     sessionInfo: sessionInfo,
     scriptRunId: "script run 123",
@@ -101,10 +101,7 @@ describe("AppView element", () => {
     const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
 
     const props = getProps({
-      elements: new AppRoot(
-        new MockMetricsManager(),
-        new BlockNode([main, sidebar])
-      ),
+      elements: new AppRoot(new BlockNode([main, sidebar])),
     })
     const wrapper = shallow(<AppView {...props} />)
 
@@ -147,10 +144,7 @@ describe("AppView element", () => {
       { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
     const props = getProps({
-      elements: new AppRoot(
-        new MockMetricsManager(),
-        new BlockNode([main, sidebar])
-      ),
+      elements: new AppRoot(new BlockNode([main, sidebar])),
       appPages,
     })
     const wrapper = shallow(<AppView {...props} />)

--- a/frontend/src/components/core/AppView/AppView.test.tsx
+++ b/frontend/src/components/core/AppView/AppView.test.tsx
@@ -25,11 +25,7 @@ import {
 } from "src/lib/WidgetStateManager"
 import { makeElementWithInfoText } from "src/lib/utils"
 import { ComponentRegistry } from "src/components/widgets/CustomComponent"
-import {
-  MockMetricsManager,
-  mockEndpoints,
-  mockSessionInfo,
-} from "src/lib/mocks/mocks"
+import { mockEndpoints, mockSessionInfo } from "src/lib/mocks/mocks"
 import { render, shallow } from "src/lib/test_util"
 import AppView, { AppViewProps } from "./AppView"
 

--- a/frontend/src/lib/AppNode.test.ts
+++ b/frontend/src/lib/AppNode.test.ts
@@ -31,7 +31,6 @@ import { addRows } from "./dataFrameProto"
 import { toImmutableProto } from "./immutableProto"
 import { BlockNode, ElementNode, AppNode, AppRoot } from "./AppNode"
 import { UNICODE } from "./mocks/arrow"
-import { MockMetricsManager } from "./mocks/mocks"
 
 const NO_SCRIPT_RUN_ID = "NO_SCRIPT_RUN_ID"
 
@@ -43,10 +42,7 @@ const BLOCK = block([
   ]),
 ])
 
-const ROOT = new AppRoot(
-  new MockMetricsManager(),
-  new BlockNode([BLOCK, new BlockNode()])
-)
+const ROOT = new AppRoot(new BlockNode([BLOCK, new BlockNode()]))
 
 describe("AppNode.getIn", () => {
   it("handles shallow paths", () => {
@@ -814,13 +810,13 @@ describe("ElementNode.arrowAddRows", () => {
 
 describe("AppRoot.empty", () => {
   it("creates an empty tree", () => {
-    const empty = AppRoot.empty(new MockMetricsManager())
+    const empty = AppRoot.empty()
     expect(empty.main.isEmpty).toBe(true)
     expect(empty.sidebar.isEmpty).toBe(true)
   })
 
   it("creates placeholder alert", () => {
-    const empty = AppRoot.empty(new MockMetricsManager(), "placeholder text!")
+    const empty = AppRoot.empty("placeholder text!")
 
     expect(empty.main.children.length).toBe(1)
     const child = empty.main.getIn([0]) as ElementNode
@@ -876,7 +872,7 @@ describe("AppRoot.applyDelta", () => {
   const addRowsTypes = ["dataFrame", "table", "vegaLiteChart"]
   it.each(addRowsTypes)("handles 'addRows' for %s", elementType => {
     // Create an app with a dataframe node
-    const root = AppRoot.empty(new MockMetricsManager()).applyDelta(
+    const root = AppRoot.empty().applyDelta(
       "preAddRows",
       makeProto(DeltaProto, {
         newElement: { [elementType]: mockDataFrameData },
@@ -930,7 +926,7 @@ describe("AppRoot.clearStaleNodes", () => {
   it("handles `allowEmpty` blocks correctly", () => {
     // Create a tree with two blocks, one with allowEmpty: true, and the other
     // with allowEmpty: false
-    const newRoot = AppRoot.empty(new MockMetricsManager())
+    const newRoot = AppRoot.empty()
       .applyDelta(
         "new_session_id",
         makeProto(DeltaProto, { addBlock: { allowEmpty: true } }),

--- a/frontend/src/lib/AppNode.ts
+++ b/frontend/src/lib/AppNode.ts
@@ -504,29 +504,13 @@ export class AppRoot {
     // Used to find and update the element node specified by this Delta.
     const { deltaPath } = metadata
 
-    // Update Metrics
-    this.metricsMgr.incrementDeltaCounter(getRootContainerName(deltaPath))
-
     switch (delta.type) {
       case "newElement": {
         const element = delta.newElement as Element
-        if (element.type != null) {
-          this.metricsMgr.incrementDeltaCounter(element.type)
-        }
-
-        // Track component instance name.
-        if (element.type === "componentInstance") {
-          const componentName = element.componentInstance?.componentName
-          if (componentName != null) {
-            this.metricsMgr.incrementCustomComponentCounter(componentName)
-          }
-        }
-
         return this.addElement(deltaPath, scriptRunId, element, metadata)
       }
 
       case "addBlock": {
-        this.metricsMgr.incrementDeltaCounter("new block")
         return this.addBlock(
           deltaPath,
           delta.addBlock as BlockProto,
@@ -535,7 +519,6 @@ export class AppRoot {
       }
 
       case "addRows": {
-        this.metricsMgr.incrementDeltaCounter("add rows")
         return this.addRows(
           deltaPath,
           delta.addRows as NamedDataSet,
@@ -544,7 +527,6 @@ export class AppRoot {
       }
 
       case "arrowAddRows": {
-        this.metricsMgr.incrementDeltaCounter("arrow add rows")
         try {
           return this.arrowAddRows(
             deltaPath,
@@ -647,21 +629,6 @@ export class AppRoot {
     const elementNode = existingNode.arrowAddRows(namedDataSet, scriptRunId)
     return new AppRoot(this.root.setIn(deltaPath, elementNode, scriptRunId))
   }
-}
-
-function getRootContainerName(deltaPath: number[]): string {
-  if (deltaPath.length > 0) {
-    switch (deltaPath[0]) {
-      case Protobuf.RootContainer.MAIN:
-        return "main"
-      case Protobuf.RootContainer.SIDEBAR:
-        return "sidebar"
-      default:
-        break
-    }
-  }
-
-  throw new Error(`Unrecognized RootContainer in deltaPath: ${deltaPath}`)
 }
 
 /** Iterates over datasets and converts data to Quiver. */

--- a/frontend/src/lib/AppNode.ts
+++ b/frontend/src/lib/AppNode.ts
@@ -36,7 +36,6 @@ import { Quiver } from "src/lib/Quiver"
 import { addRows } from "./dataFrameProto"
 import { ensureError } from "./ErrorHandling"
 import { toImmutableProto } from "./immutableProto"
-import { MetricsManager } from "./MetricsManager"
 import {
   makeElementWithInfoText,
   makeElementWithErrorText,
@@ -443,15 +442,10 @@ export class BlockNode implements AppNode {
 export class AppRoot {
   private readonly root: BlockNode
 
-  private readonly metricsMgr: MetricsManager
-
   /**
    * Create an empty AppRoot with an optional placeholder element.
    */
-  public static empty(
-    metricsMgr: MetricsManager,
-    placeholderText?: string
-  ): AppRoot {
+  public static empty(placeholderText?: string): AppRoot {
     let mainNodes: AppNode[]
     if (placeholderText != null) {
       const waitNode = new ElementNode(
@@ -476,12 +470,11 @@ export class AppRoot {
       NO_SCRIPT_RUN_ID
     )
 
-    return new AppRoot(metricsMgr, new BlockNode([main, sidebar]))
+    return new AppRoot(new BlockNode([main, sidebar]))
   }
 
-  public constructor(metricsMgr: MetricsManager, root: BlockNode) {
+  public constructor(root: BlockNode) {
     this.root = root
-    this.metricsMgr = metricsMgr
 
     // Verify that our root node has exactly 2 children: a 'main' block and
     // a 'sidebar' block.
@@ -584,7 +577,6 @@ export class AppRoot {
       this.sidebar.clearStaleNodes(currentScriptRunId) || new BlockNode()
 
     return new AppRoot(
-      this.metricsMgr,
       new BlockNode(
         [main, sidebar],
         new BlockProto({ allowEmpty: true }),
@@ -608,10 +600,7 @@ export class AppRoot {
     metadata: ForwardMsgMetadata
   ): AppRoot {
     const elementNode = new ElementNode(element, metadata, scriptRunId)
-    return new AppRoot(
-      this.metricsMgr,
-      this.root.setIn(deltaPath, elementNode, scriptRunId)
-    )
+    return new AppRoot(this.root.setIn(deltaPath, elementNode, scriptRunId))
   }
 
   private addBlock(
@@ -628,10 +617,7 @@ export class AppRoot {
       existingNode instanceof BlockNode ? existingNode.children : []
 
     const blockNode = new BlockNode(children, block, scriptRunId)
-    return new AppRoot(
-      this.metricsMgr,
-      this.root.setIn(deltaPath, blockNode, scriptRunId)
-    )
+    return new AppRoot(this.root.setIn(deltaPath, blockNode, scriptRunId))
   }
 
   private addRows(
@@ -645,10 +631,7 @@ export class AppRoot {
     }
 
     const elementNode = existingNode.addRows(namedDataSet, scriptRunId)
-    return new AppRoot(
-      this.metricsMgr,
-      this.root.setIn(deltaPath, elementNode, scriptRunId)
-    )
+    return new AppRoot(this.root.setIn(deltaPath, elementNode, scriptRunId))
   }
 
   private arrowAddRows(
@@ -662,10 +645,7 @@ export class AppRoot {
     }
 
     const elementNode = existingNode.arrowAddRows(namedDataSet, scriptRunId)
-    return new AppRoot(
-      this.metricsMgr,
-      this.root.setIn(deltaPath, elementNode, scriptRunId)
-    )
+    return new AppRoot(this.root.setIn(deltaPath, elementNode, scriptRunId))
   }
 }
 

--- a/frontend/src/lib/MetricsManager.ts
+++ b/frontend/src/lib/MetricsManager.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Delta, ForwardMsgMetadata } from "src/autogen/proto"
+
 /**
  * A mapping of [delta type] -> [count] which is used to upload delta stats
  * when the app is idle.
@@ -38,14 +40,8 @@ export interface MetricsManager {
   /** Record a new event with the manager. */
   enqueue(evName: string, evData: Record<string, any>): void
 
-  /**
-   * Increment a counter that tracks the number of times a Delta message
-   * of the given type has been processed by the frontend.
-   *
-   * No event is recorded for this. Instead, call `getAndResetDeltaCounter`
-   * periodically, and enqueue an event with the result.
-   */
-  incrementDeltaCounter(deltaType: string): void
+  /** Record all appropriate events for a delta message. */
+  handleDeltaMessage(delta: Delta, metadata: ForwardMsgMetadata): void
 
   /**
    * Get a copy of the pending DeltaCounter object, and reset it, and
@@ -57,20 +53,8 @@ export interface MetricsManager {
   clearDeltaCounter(): void
 
   /**
-   * Increment a counter that tracks the number of times a CustomComponent
-   * of the given type has been used by the frontend.
-   *
-   * No event is recorded for this. Instead, call `getAndResetCustomComponentCounter`
-   * periodically, and enqueue an event with the result.
-   */
-  incrementCustomComponentCounter(customInstanceName: string): void
-
-  /**
    * Get a copy of the pending CustomComponentCounter object, and reset it, and
    * clear the manager's copy.
    */
   getAndResetCustomComponentCounter(): CustomComponentCounter
-
-  /** Clear the manager's pending CustomComponentCounter object. */
-  clearCustomComponentCounter(): void
 }

--- a/frontend/src/lib/SegmentMetricsManager.ts
+++ b/frontend/src/lib/SegmentMetricsManager.ts
@@ -151,10 +151,6 @@ export class SegmentMetricsManager implements MetricsManager {
       case "arrowAddRows":
         this.incrementDeltaCounter("arrow add rows")
         break
-
-      default: {
-        throw new Error(`Unrecognized deltaType: '${delta.type}'`)
-      }
     }
   }
 

--- a/frontend/src/lib/SegmentMetricsManager.ts
+++ b/frontend/src/lib/SegmentMetricsManager.ts
@@ -18,6 +18,11 @@ import { pick } from "lodash"
 import { SessionInfo } from "src/lib/SessionInfo"
 import { initializeSegment } from "src/vendor/Segment"
 import { DeployedAppMetadata } from "src/hocs/withHostCommunication/types"
+import Protobuf, {
+  Delta,
+  Element,
+  ForwardMsgMetadata,
+} from "src/autogen/proto"
 import { IS_DEV_ENV } from "./baseconsts"
 import { logAlways } from "./log"
 import {
@@ -111,10 +116,59 @@ export class SegmentMetricsManager implements MetricsManager {
     this.send(evName, evData)
   }
 
+  public handleDeltaMessage(delta: Delta, metadata: ForwardMsgMetadata): void {
+    // The full path to the AppNode within the element tree.
+    // Used to find and update the element node specified by this Delta.
+    const deltaPath = metadata.deltaPath
+
+    this.incrementDeltaCounter(getRootContainerName(deltaPath))
+
+    switch (delta.type) {
+      case "newElement": {
+        const element = delta.newElement as Element
+        if (element.type != null) {
+          this.incrementDeltaCounter(element.type)
+        }
+
+        // Track component instance name.
+        if (element.type === "componentInstance") {
+          const componentName = element.componentInstance?.componentName
+          if (componentName != null) {
+            this.incrementCustomComponentCounter(componentName)
+          }
+        }
+        break
+      }
+
+      case "addBlock":
+        this.incrementDeltaCounter("new block")
+        break
+
+      case "addRows":
+        this.incrementDeltaCounter("add rows")
+        break
+
+      case "arrowAddRows":
+        this.incrementDeltaCounter("arrow add rows")
+        break
+
+      default: {
+        throw new Error(`Unrecognized deltaType: '${delta.type}'`)
+      }
+    }
+  }
+
   public clearDeltaCounter(): void {
     this.pendingDeltaCounter = {}
   }
 
+  /**
+   * Increment a counter that tracks the number of times a Delta message
+   * of the given type has been processed by the frontend.
+   *
+   * No event is recorded for this. Instead, call `getAndResetDeltaCounter`
+   * periodically, and enqueue an event with the result.
+   */
   public incrementDeltaCounter(deltaType: string): void {
     if (this.pendingDeltaCounter[deltaType] == null) {
       this.pendingDeltaCounter[deltaType] = 1
@@ -129,11 +183,14 @@ export class SegmentMetricsManager implements MetricsManager {
     return deltaCounter
   }
 
-  public clearCustomComponentCounter(): void {
-    this.pendingCustomComponentCounter = {}
-  }
-
-  public incrementCustomComponentCounter(customInstanceName: string): void {
+  /**
+   * Increment a counter that tracks the number of times a CustomComponent
+   * of the given type has been used by the frontend.
+   *
+   * No event is recorded for this. Instead, call `getAndResetCustomComponentCounter`
+   * periodically, and enqueue an event with the result.
+   */
+  private incrementCustomComponentCounter(customInstanceName: string): void {
     if (this.pendingCustomComponentCounter[customInstanceName] == null) {
       this.pendingCustomComponentCounter[customInstanceName] = 1
     } else {
@@ -145,6 +202,10 @@ export class SegmentMetricsManager implements MetricsManager {
     const customComponentCounter = this.pendingCustomComponentCounter
     this.clearCustomComponentCounter()
     return customComponentCounter
+  }
+
+  private clearCustomComponentCounter(): void {
+    this.pendingCustomComponentCounter = {}
   }
 
   // App hash gets set when updateReport happens.
@@ -228,4 +289,19 @@ export class SegmentMetricsManager implements MetricsManager {
     }
     return {}
   }
+}
+
+function getRootContainerName(deltaPath: number[]): string {
+  if (deltaPath.length > 0) {
+    switch (deltaPath[0]) {
+      case Protobuf.RootContainer.MAIN:
+        return "main"
+      case Protobuf.RootContainer.SIDEBAR:
+        return "sidebar"
+      default:
+        break
+    }
+  }
+
+  throw new Error(`Unrecognized RootContainer in deltaPath: ${deltaPath}`)
 }

--- a/frontend/src/lib/mocks/mocks.ts
+++ b/frontend/src/lib/mocks/mocks.ts
@@ -66,15 +66,11 @@ export function mockEndpoints(
 export class MockMetricsManager implements MetricsManager {
   public enqueue = jest.fn()
 
-  public incrementDeltaCounter = jest.fn()
+  public handleDeltaMessage = jest.fn()
 
   public getAndResetDeltaCounter = jest.fn()
 
   public clearDeltaCounter = jest.fn()
 
-  public incrementCustomComponentCounter = jest.fn()
-
   public getAndResetCustomComponentCounter = jest.fn()
-
-  public clearCustomComponentCounter = jest.fn()
 }


### PR DESCRIPTION
`AppNode` currently depends on `MetricsManager`. If we release the upcoming "StreamlitLib" project as is, StreamlitLib users will have to supply their own MetricsManager implementation. With this PR, `MetricsManager` no longer needs to be part of StreamlitLib.

- `AppNode` no longer knows about `MetricsManager`
- Instead, `App.handleDeltaMessage` sends Deltas to `MetricsManager`
- Removed several no-longer-necessary functions from the `MetricsManager` public API
- Added a bunch of previously-unimplemented `SegmentMetricsManager` tests