### PR TITLE
Make type=jpg and type=jpeg mean type=[jpg, jpeg] in file uploader.

### DIFF
--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -390,11 +390,19 @@ class FileUploaderMixin:
                 for file_type in type
             ]
 
-            if ".jpg" in type and ".jpeg" not in type:
-                type.append(".jpeg")
+            type_pairs = [
+                (".jpg", ".jpeg"),
+                (".mpg", ".mpeg"),
+                (".mp4", ".mpeg4"),
+                (".tif", ".tiff"),
+                (".htm", ".html"),
+            ]
 
-            if ".jpeg" in type and ".jpg" not in type:
-                type.append(".jpg")
+            for x, y in type_pairs:
+                if x in type and y not in type:
+                    type.append(y)
+                if y in type and x not in type:
+                    type.append(x)
 
         file_uploader_proto = FileUploaderProto()
         file_uploader_proto.label = label

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -390,6 +390,12 @@ class FileUploaderMixin:
                 for file_type in type
             ]
 
+            if ".jpg" in type and ".jpeg" not in type:
+                type.append(".jpeg")
+
+            if ".jpeg" in type and ".jpg" not in type:
+                type.append(".jpg")
+
         file_uploader_proto = FileUploaderProto()
         file_uploader_proto.label = label
         file_uploader_proto.type[:] = type if type is not None else []

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -43,6 +43,15 @@ from streamlit.type_util import Key, LabelVisibility, maybe_raise_label_warnings
 SomeUploadedFiles = Optional[Union[UploadedFile, List[UploadedFile]]]
 
 
+TYPE_PAIRS = [
+    (".jpg", ".jpeg"),
+    (".mpg", ".mpeg"),
+    (".mp4", ".mpeg4"),
+    (".tif", ".tiff"),
+    (".htm", ".html"),
+]
+
+
 def _get_file_recs(
     widget_id: str, widget_value: Optional[FileUploaderStateProto]
 ) -> List[UploadedFileRec]:
@@ -390,15 +399,9 @@ class FileUploaderMixin:
                 for file_type in type
             ]
 
-            type_pairs = [
-                (".jpg", ".jpeg"),
-                (".mpg", ".mpeg"),
-                (".mp4", ".mpeg4"),
-                (".tif", ".tiff"),
-                (".htm", ".html"),
-            ]
+            type = [t.lower() for t in type]
 
-            for x, y in type_pairs:
+            for x, y in TYPE_PAIRS:
                 if x in type and y not in type:
                     type.append(y)
                 if y in type and x not in type:

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -61,8 +61,8 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, [".png", ".svg", ".foo"])
 
-    def test_jpg_replacement(self):
-        """Test that it can be called using an array for type parameter."""
+    def test_jpg_expansion(self):
+        """Test that it adds jpg when passing in just jpeg (and vice versa)."""
         st.file_uploader("the label", type=["png", ".jpg"])
 
         c = self.get_delta_from_queue().new_element.file_uploader
@@ -72,6 +72,13 @@ class FileUploaderTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, [".png", ".jpeg", ".jpg"])
+
+    def test_uppercase_expansion(self):
+        """Test that it can expand jpg to jpeg even when uppercase."""
+        st.file_uploader("the label", type=["png", ".JpG"])
+
+        c = self.get_delta_from_queue().new_element.file_uploader
+        self.assertEqual(c.type, [".png", ".jpg", ".jpeg"])
 
     @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_multiple_files(self, get_file_recs_patch):

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -56,10 +56,22 @@ class FileUploaderTest(DeltaGeneratorTestCase):
 
     def test_multiple_types(self):
         """Test that it can be called using an array for type parameter."""
-        st.file_uploader("the label", type=["png", ".svg", "jpeg"])
+        st.file_uploader("the label", type=["png", ".svg", "foo"])
 
         c = self.get_delta_from_queue().new_element.file_uploader
-        self.assertEqual(c.type, [".png", ".svg", ".jpeg"])
+        self.assertEqual(c.type, [".png", ".svg", ".foo"])
+
+    def test_jpg_replacement(self):
+        """Test that it can be called using an array for type parameter."""
+        st.file_uploader("the label", type=["png", ".jpg"])
+
+        c = self.get_delta_from_queue().new_element.file_uploader
+        self.assertEqual(c.type, [".png", ".jpg", ".jpeg"])
+
+        st.file_uploader("the label", type=["png", ".jpeg"])
+
+        c = self.get_delta_from_queue().new_element.file_uploader
+        self.assertEqual(c.type, [".png", ".jpeg", ".jpg"])
 
     @patch("streamlit.elements.file_uploader._get_file_recs")
     def test_multiple_files(self, get_file_recs_patch):


### PR DESCRIPTION
## 📚 Context

`st.file_uploader` has a `type` param that supports a str like `"svg"` or `".svg"`, or list like `[".png", "svg", "jpg"]`.

The problem is that `.jpg` means "anything ending in .jpg", rather than "anything jpg-formatted file". These two are difference because the latter also includes anything ending in ".jpeg". 

So this PR makes "jpg" really mean "jpg or jpeg". (And it does that same for "jpeg", and for the variants that have a `.` at the start of the extension, of course) 

Update: this now also does the same for mpeg/mpg, tiff/tif, html/htm, mpeg4/mp4. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

_N/A_

**Current:**

_N/A_

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_N/A_

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
