### PR TITLE
Rename boolean and categorical columns

### DIFF
--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -30,7 +30,7 @@ import {
   getTextCell,
   ColumnCreator,
   ObjectColumn,
-  BooleanColumn,
+  CheckboxColumn,
   NumberColumn,
   TextColumn,
   CategoricalColumn,
@@ -625,14 +625,14 @@ describe("getColumnTypeFromArrow", () => {
         pandas_type: "bool",
         numpy_type: "bool",
       },
-      BooleanColumn,
+      CheckboxColumn,
     ],
     [
       {
         pandas_type: "bool",
         numpy_type: "boolean",
       },
-      BooleanColumn,
+      CheckboxColumn,
     ],
     [
       {

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -33,7 +33,7 @@ import {
   CheckboxColumn,
   NumberColumn,
   TextColumn,
-  CategoricalColumn,
+  SelectboxColumn,
   ListColumn,
 } from "./columns"
 import {
@@ -639,7 +639,7 @@ describe("getColumnTypeFromArrow", () => {
         pandas_type: "categorical",
         numpy_type: "int8",
       },
-      CategoricalColumn,
+      SelectboxColumn,
     ],
     [
       {

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -33,7 +33,7 @@ import {
   CheckboxColumn,
   NumberColumn,
   TextColumn,
-  CategoricalColumn,
+  SelectboxColumn,
   ListColumn,
   isErrorCell,
 } from "./columns"
@@ -177,7 +177,7 @@ export function getColumnTypeFromArrow(arrowType: ArrowType): ColumnCreator {
     return NumberColumn
   }
   if (typeName === "categorical") {
-    return CategoricalColumn
+    return SelectboxColumn
   }
   if (typeName.startsWith("list")) {
     return ListColumn

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -30,7 +30,7 @@ import {
   BaseColumnProps,
   ColumnCreator,
   ObjectColumn,
-  BooleanColumn,
+  CheckboxColumn,
   NumberColumn,
   TextColumn,
   CategoricalColumn,
@@ -154,7 +154,7 @@ export function getColumnTypeFromArrow(arrowType: ArrowType): ColumnCreator {
     return ObjectColumn
   }
   if (["bool"].includes(typeName)) {
-    return BooleanColumn
+    return CheckboxColumn
   }
   if (
     [

--- a/frontend/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
@@ -17,12 +17,12 @@
 import { BooleanCell, GridCellKind } from "@glideapps/glide-data-grid"
 
 import { isErrorCell } from "./utils"
-import BooleanColumn from "./BooleanColumn"
+import CheckboxColumn from "./CheckboxColumn"
 
-const MOCK_BOOLEAN_COLUMN_PROPS = {
+const MOCK_CHECKBOX_COLUMN_PROPS = {
   id: "1",
-  name: "boolean_column",
-  title: "Boolean column",
+  name: "checkbox_column",
+  title: "Checkbox column",
   indexNumber: 0,
   isEditable: false,
   isHidden: false,
@@ -36,12 +36,12 @@ const MOCK_BOOLEAN_COLUMN_PROPS = {
   },
 }
 
-describe("BooleanColumn", () => {
+describe("CheckboxColumn", () => {
   it("creates a valid column instance", () => {
-    const mockColumn = BooleanColumn(MOCK_BOOLEAN_COLUMN_PROPS)
-    expect(mockColumn.kind).toEqual("boolean")
-    expect(mockColumn.title).toEqual(MOCK_BOOLEAN_COLUMN_PROPS.title)
-    expect(mockColumn.id).toEqual(MOCK_BOOLEAN_COLUMN_PROPS.id)
+    const mockColumn = CheckboxColumn(MOCK_CHECKBOX_COLUMN_PROPS)
+    expect(mockColumn.kind).toEqual("checkbox")
+    expect(mockColumn.title).toEqual(MOCK_CHECKBOX_COLUMN_PROPS.title)
+    expect(mockColumn.id).toEqual(MOCK_CHECKBOX_COLUMN_PROPS.id)
     expect(mockColumn.sortMode).toEqual("default")
 
     const mockCell = mockColumn.getCell(true)
@@ -73,7 +73,7 @@ describe("BooleanColumn", () => {
   ])(
     "supports boolean compatible value (%p parsed as %p)",
     (input: any, value: boolean | null) => {
-      const mockColumn = BooleanColumn(MOCK_BOOLEAN_COLUMN_PROPS)
+      const mockColumn = CheckboxColumn(MOCK_CHECKBOX_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
       expect(isErrorCell(cell)).toEqual(false)
@@ -83,7 +83,7 @@ describe("BooleanColumn", () => {
   it.each([["foo"], [12345], [0.1], [["foo", "bar"]]])(
     "%p results in error cell: %p",
     (input: any) => {
-      const mockColumn = BooleanColumn(MOCK_BOOLEAN_COLUMN_PROPS)
+      const mockColumn = CheckboxColumn(MOCK_CHECKBOX_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(isErrorCell(cell)).toEqual(true)
     }

--- a/frontend/src/components/widgets/DataFrame/columns/CheckboxColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/CheckboxColumn.ts
@@ -33,7 +33,7 @@ import {
  * A column type that supports optimized rendering and editing for boolean values
  * by using checkboxes.
  */
-function BooleanColumn(props: BaseColumnProps): BaseColumn {
+function CheckboxColumn(props: BaseColumnProps): BaseColumn {
   const cellTemplate = {
     kind: GridCellKind.Boolean,
     data: false,
@@ -45,7 +45,7 @@ function BooleanColumn(props: BaseColumnProps): BaseColumn {
 
   return {
     ...props,
-    kind: "boolean",
+    kind: "checkbox",
     sortMode: "default",
     getCell(data?: any): GridCell {
       let cellData = null
@@ -71,6 +71,6 @@ function BooleanColumn(props: BaseColumnProps): BaseColumn {
   }
 }
 
-BooleanColumn.isEditableType = true
+CheckboxColumn.isEditableType = true
 
-export default BooleanColumn as ColumnCreator
+export default CheckboxColumn as ColumnCreator

--- a/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
@@ -56,7 +56,7 @@ function getSelectboxColumn(
   } as BaseColumnProps)
 }
 
-describe("SelectColumn", () => {
+describe("SelectboxColumn", () => {
   it("creates a valid column instance with string values", () => {
     const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
       options: ["foo", "bar"],
@@ -81,7 +81,7 @@ describe("SelectColumn", () => {
     const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
       options: [1, 2, 3],
     })
-    expect(mockColumn.kind).toEqual("select")
+    expect(mockColumn.kind).toEqual("selectbox")
     expect(mockColumn.title).toEqual(SELECTBOX_COLUMN_TEMPLATE.title)
     expect(mockColumn.id).toEqual(SELECTBOX_COLUMN_TEMPLATE.id)
     expect(mockColumn.sortMode).toEqual("default")
@@ -100,7 +100,7 @@ describe("SelectColumn", () => {
 
   it("creates a valid column instance from boolean type", () => {
     const mockColumn = getSelectboxColumn(MOCK_BOOLEAN_ARROW_TYPE)
-    expect(mockColumn.kind).toEqual("select")
+    expect(mockColumn.kind).toEqual("selectbox")
     expect(mockColumn.title).toEqual(SELECTBOX_COLUMN_TEMPLATE.title)
 
     const mockCell = mockColumn.getCell(true)

--- a/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
@@ -128,7 +128,7 @@ describe("SelectboxColumn", () => {
       "bar",
     ])
 
-    const errorCell = mockColumn.getCell(null)
+    const errorCell = mockColumn.getCell(null, true)
     expect(isErrorCell(errorCell)).toEqual(true)
   })
 
@@ -136,7 +136,7 @@ describe("SelectboxColumn", () => {
     const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
       options: ["foo", "bar"],
     })
-    const mockCell = mockColumn.getCell("baz")
+    const mockCell = mockColumn.getCell("baz", true)
     expect(isErrorCell(mockCell)).toEqual(true)
   })
 

--- a/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
@@ -20,9 +20,7 @@ import { DropdownCellType } from "@glideapps/glide-data-grid-cells"
 import { Type as ArrowType } from "src/lib/Quiver"
 
 import { BaseColumnProps, isErrorCell, isMissingValueCell } from "./utils"
-import CategoricalColumn, {
-  CategoricalColumnParams,
-} from "./CategoricalColumn"
+import SelectboxColumn, { SelectboxColumnParams } from "./SelectboxColumn"
 
 const MOCK_CATEGORICAL_TYPE: ArrowType = {
   pandas_type: "int8",
@@ -34,10 +32,10 @@ const MOCK_BOOLEAN_ARROW_TYPE: ArrowType = {
   numpy_type: "bool",
 }
 
-const CATEGORICAL_COLUMN_TEMPLATE: Partial<BaseColumnProps> = {
+const SELECTBOX_COLUMN_TEMPLATE: Partial<BaseColumnProps> = {
   id: "1",
-  name: "categorical_column",
-  title: "Categorical column",
+  name: "selectbox_column",
+  title: "Selectbox column",
   indexNumber: 0,
   isEditable: false,
   isHidden: false,
@@ -45,27 +43,27 @@ const CATEGORICAL_COLUMN_TEMPLATE: Partial<BaseColumnProps> = {
   isStretched: false,
 }
 
-function getCategoricalColumn(
+function getSelectboxColumn(
   arrowType: ArrowType,
-  params?: CategoricalColumnParams,
+  params?: SelectboxColumnParams,
   column_props_overwrites?: Partial<BaseColumnProps>
-): ReturnType<typeof CategoricalColumn> {
-  return CategoricalColumn({
-    ...CATEGORICAL_COLUMN_TEMPLATE,
+): ReturnType<typeof SelectboxColumn> {
+  return SelectboxColumn({
+    ...SELECTBOX_COLUMN_TEMPLATE,
     ...column_props_overwrites,
     arrowType,
     columnTypeOptions: params,
   } as BaseColumnProps)
 }
 
-describe("CategoricalColumn", () => {
+describe("SelectColumn", () => {
   it("creates a valid column instance with string values", () => {
-    const mockColumn = getCategoricalColumn(MOCK_CATEGORICAL_TYPE, {
+    const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
       options: ["foo", "bar"],
     })
-    expect(mockColumn.kind).toEqual("categorical")
-    expect(mockColumn.title).toEqual(CATEGORICAL_COLUMN_TEMPLATE.title)
-    expect(mockColumn.id).toEqual(CATEGORICAL_COLUMN_TEMPLATE.id)
+    expect(mockColumn.kind).toEqual("selectbox")
+    expect(mockColumn.title).toEqual(SELECTBOX_COLUMN_TEMPLATE.title)
+    expect(mockColumn.id).toEqual(SELECTBOX_COLUMN_TEMPLATE.id)
     expect(mockColumn.sortMode).toEqual("default")
 
     const mockCell = mockColumn.getCell("foo")
@@ -80,12 +78,12 @@ describe("CategoricalColumn", () => {
   })
 
   it("creates a valid column instance number values", () => {
-    const mockColumn = getCategoricalColumn(MOCK_CATEGORICAL_TYPE, {
+    const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
       options: [1, 2, 3],
     })
-    expect(mockColumn.kind).toEqual("categorical")
-    expect(mockColumn.title).toEqual(CATEGORICAL_COLUMN_TEMPLATE.title)
-    expect(mockColumn.id).toEqual(CATEGORICAL_COLUMN_TEMPLATE.id)
+    expect(mockColumn.kind).toEqual("select")
+    expect(mockColumn.title).toEqual(SELECTBOX_COLUMN_TEMPLATE.title)
+    expect(mockColumn.id).toEqual(SELECTBOX_COLUMN_TEMPLATE.id)
     expect(mockColumn.sortMode).toEqual("default")
 
     const mockCell = mockColumn.getCell(1)
@@ -101,13 +99,14 @@ describe("CategoricalColumn", () => {
   })
 
   it("creates a valid column instance from boolean type", () => {
-    const mockColumn = getCategoricalColumn(MOCK_BOOLEAN_ARROW_TYPE)
-    expect(mockColumn.kind).toEqual("categorical")
-    expect(mockColumn.title).toEqual(CATEGORICAL_COLUMN_TEMPLATE.title)
+    const mockColumn = getSelectboxColumn(MOCK_BOOLEAN_ARROW_TYPE)
+    expect(mockColumn.kind).toEqual("select")
+    expect(mockColumn.title).toEqual(SELECTBOX_COLUMN_TEMPLATE.title)
 
     const mockCell = mockColumn.getCell(true)
     expect(mockCell.kind).toEqual(GridCellKind.Custom)
     expect(mockColumn.getCellValue(mockCell)).toEqual(true)
+
     expect((mockCell as DropdownCellType).data.allowedValues).toEqual([
       "",
       "true",
@@ -116,7 +115,7 @@ describe("CategoricalColumn", () => {
   })
 
   it("creates a required column that does not add the empty value", () => {
-    const mockColumn = getCategoricalColumn(
+    const mockColumn = getSelectboxColumn(
       MOCK_CATEGORICAL_TYPE,
       {
         options: ["foo", "bar"],
@@ -134,7 +133,7 @@ describe("CategoricalColumn", () => {
   })
 
   it("creates error cell if value is not in options", () => {
-    const mockColumn = getCategoricalColumn(MOCK_CATEGORICAL_TYPE, {
+    const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
       options: ["foo", "bar"],
     })
     const mockCell = mockColumn.getCell("baz")
@@ -144,7 +143,7 @@ describe("CategoricalColumn", () => {
   it.each([[null], [undefined], [""]])(
     "%p is interpreted as missing value",
     (input: any) => {
-      const mockColumn = getCategoricalColumn(MOCK_CATEGORICAL_TYPE, {
+      const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
         options: ["foo", "bar"],
       })
       const mockCell = mockColumn.getCell(input)

--- a/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
@@ -44,7 +44,8 @@ export interface SelectboxColumnParams {
  *
  */
 function SelectboxColumn(props: BaseColumnProps): BaseColumn {
-  // Select column can be either string, number or boolean type based on the options
+  // The selectbox column can be either string, number or boolean type
+  // based on the options type.
   let dataType: "number" | "boolean" | "string" = "string"
 
   const parameters = mergeColumnParameters(

--- a/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
@@ -31,8 +31,8 @@ import {
   toSafeBoolean,
 } from "./utils"
 
-export interface CategoricalColumnParams {
-  /** A list of options available in the dropdown.
+export interface SelectboxColumnParams {
+  /** A list of options available in the selectbox.
    * Every value in the column needs to match one of the options.
    */
   readonly options: (string | number | boolean)[]
@@ -40,11 +40,11 @@ export interface CategoricalColumnParams {
 
 /**
  * A column type that supports optimized rendering and editing for categorical values
- * by using a dropdown. This is automatically used by categorical columns (Pandas).
+ * by using a selectbox. This is automatically used by categorical columns (Pandas).
  *
  */
-function CategoricalColumn(props: BaseColumnProps): BaseColumn {
-  // Categorical column can be either string, number or boolean type based on the options
+function SelectboxColumn(props: BaseColumnProps): BaseColumn {
+  // Select column can be either string, number or boolean type based on the options
   let dataType: "number" | "boolean" | "string" = "string"
 
   const parameters = mergeColumnParameters(
@@ -55,7 +55,7 @@ function CategoricalColumn(props: BaseColumnProps): BaseColumn {
     },
     // User parameters:
     props.columnTypeOptions
-  ) as CategoricalColumnParams
+  ) as SelectboxColumnParams
 
   const uniqueTypes = new Set(parameters.options.map(x => typeof x))
   if (uniqueTypes.size === 1) {
@@ -75,6 +75,7 @@ function CategoricalColumn(props: BaseColumnProps): BaseColumn {
     data: {
       kind: "dropdown-cell",
       allowedValues: [
+        // Add empty option if the column is not configured as required:
         ...(props.isRequired !== true ? [""] : []),
         ...parameters.options
           .filter(opt => opt !== "") // ignore empty option if it exists
@@ -87,16 +88,16 @@ function CategoricalColumn(props: BaseColumnProps): BaseColumn {
 
   return {
     ...props,
-    kind: "categorical",
+    kind: "selectbox",
     sortMode: "default",
-    getCell(data?: any): GridCell {
+    getCell(data?: any, validate?: boolean): GridCell {
       // Empty string refers to a missing value
       let cellData = ""
       if (notNullOrUndefined(data)) {
         cellData = toSafeString(data)
       }
 
-      if (!cellTemplate.data.allowedValues.includes(cellData)) {
+      if (validate && !cellTemplate.data.allowedValues.includes(cellData)) {
         return getErrorCell(
           toSafeString(cellData),
           `The value is not part of the allowed options.`
@@ -126,6 +127,6 @@ function CategoricalColumn(props: BaseColumnProps): BaseColumn {
   }
 }
 
-CategoricalColumn.isEditableType = true
+SelectboxColumn.isEditableType = true
 
-export default CategoricalColumn as ColumnCreator
+export default SelectboxColumn as ColumnCreator

--- a/frontend/src/components/widgets/DataFrame/columns/index.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/index.ts
@@ -16,7 +16,7 @@
 
 import ObjectColumn from "./ObjectColumn"
 import TextColumn from "./TextColumn"
-import BooleanColumn from "./BooleanColumn"
+import CheckboxColumn from "./CheckboxColumn"
 import CategoricalColumn from "./CategoricalColumn"
 import ListColumn from "./ListColumn"
 import NumberColumn from "./NumberColumn"
@@ -32,7 +32,7 @@ export const ColumnTypes = new Map<string, ColumnCreator>(
   Object.entries({
     object: ObjectColumn,
     text: TextColumn,
-    boolean: BooleanColumn,
+    checkbox: CheckboxColumn,
     categorical: CategoricalColumn,
     list: ListColumn,
     number: NumberColumn,
@@ -42,7 +42,7 @@ export const ColumnTypes = new Map<string, ColumnCreator>(
 export {
   ObjectColumn,
   TextColumn,
-  BooleanColumn,
+  CheckboxColumn,
   CategoricalColumn,
   ListColumn,
   NumberColumn,

--- a/frontend/src/components/widgets/DataFrame/columns/index.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/index.ts
@@ -17,7 +17,7 @@
 import ObjectColumn from "./ObjectColumn"
 import TextColumn from "./TextColumn"
 import CheckboxColumn from "./CheckboxColumn"
-import CategoricalColumn from "./CategoricalColumn"
+import SelectboxColumn from "./SelectboxColumn"
 import ListColumn from "./ListColumn"
 import NumberColumn from "./NumberColumn"
 
@@ -33,7 +33,7 @@ export const ColumnTypes = new Map<string, ColumnCreator>(
     object: ObjectColumn,
     text: TextColumn,
     checkbox: CheckboxColumn,
-    categorical: CategoricalColumn,
+    selectbox: SelectboxColumn,
     list: ListColumn,
     number: NumberColumn,
   })
@@ -43,7 +43,7 @@ export {
   ObjectColumn,
   TextColumn,
   CheckboxColumn,
-  CategoricalColumn,
+  SelectboxColumn,
   ListColumn,
   NumberColumn,
 }

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -80,7 +80,7 @@ export interface BaseColumn extends BaseColumnProps {
   // raw: Sorts based on the actual type of the cell data value.
   readonly sortMode: "default" | "raw" | "smart"
   // Get a cell with the provided data for the column type:
-  getCell(data?: any): GridCell
+  getCell(data?: any, validate?: boolean): GridCell
   // Get the raw cell of a provided cell:
   getCellValue(cell: GridCell): any | null
 }

--- a/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -23,8 +23,8 @@ import {
   BaseColumn,
   ObjectColumn,
   TextColumn,
-  BooleanColumn,
-  CategoricalColumn,
+  CheckboxColumn,
+  SelectboxColumn,
   ListColumn,
   NumberColumn,
   ColumnCreator,
@@ -219,8 +219,8 @@ describe("getColumnType", () => {
   it.each([
     ["object", ObjectColumn],
     ["text", TextColumn],
-    ["boolean", BooleanColumn],
-    ["categorical", CategoricalColumn],
+    ["checkbox", CheckboxColumn],
+    ["selectbox", SelectboxColumn],
     ["list", ListColumn],
     ["number", NumberColumn],
   ])(

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -102,7 +102,7 @@ class ColumnConfig(TypedDict, total=False):
         Literal[
             "text",
             "number",
-            "boolean",
+            "checkbox",
             "list",
             "categorical",
         ]

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -103,8 +103,8 @@ class ColumnConfig(TypedDict, total=False):
             "text",
             "number",
             "checkbox",
+            "selectbox",
             "list",
-            "categorical",
         ]
     ]
     type_options: Optional[Dict[str, Any]]


### PR DESCRIPTION
## 📚 Context

This PR renames the boolean column to checkbox column and the categorical column to selectbox column. This is done to closer align the column implementations with the existing set of widgets in Streamlit. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
