### PR TITLE
`SQLConnection` and `ExperimentalBaseConnection` docstring improvements

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -45,8 +45,7 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         """Create an ExperimentalBaseConnection.
 
         This constructor is called by the connection factory machinery when a user
-        script calls ``st.experimental_connection()`` and when reconnecting after a
-        connection is reset.
+        script calls ``st.experimental_connection()``.
 
         Subclasses of ExperimentalBaseConnection that want to overwrite this method
         should take care to also call the base class' implementation.
@@ -107,7 +106,7 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     def _on_secrets_changed(self, _) -> None:
         """Reset the raw connection object when this connection's secrets change.
 
-        We don't expect either user scripts of connection authors to have to use or
+        We don't expect either user scripts or connection authors to have to use or
         overwrite this method.
         """
         new_hash = calc_md5(json.dumps(self._secrets.to_dict()))
@@ -172,7 +171,8 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         """Create an instance of an underlying connection object.
 
         This abstract method is the one method that we require subclasses of
-        ExperimentalBaseConnection to provide an implementation for.
+        ExperimentalBaseConnection to provide an implementation for. It is called when
+        first creating a connection and when reconnecting after a connection is reset.
 
         Parameters
         ----------

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -138,8 +138,10 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     def reset(self) -> None:
         """Reset this connection so that it gets reinitialized the next time it's used.
 
-        App developers can use this method when working with concrete connection class
-        instances, particularly in error handling code.
+        This method can be useful when a connection has become stale, an auth token has
+        expired, or in similar scenarios where a broken connection might be fixed by
+        reinitializing it. Note that some connection methods may already use ``reset()``
+        in their error handling code.
 
         Example
         -------
@@ -148,12 +150,11 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         >>> conn = st.experimental_connection("my_conn")
         >>>
         >>> # Reset the connection before using it if it isn't healthy
-        >>> # Note: is_healthy() is just shown for example here
+        >>> # Note: is_healthy() isn't a real method and is just shown for example here.
         >>> if not conn.is_healthy():
         ...     conn.reset()
         ...
-        >>> cursor = conn.query("...")
-        >>> # ...
+        >>> # Do stuff with conn...
         """
         self._raw_instance = None
 

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -191,8 +191,8 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
             done in a thread-safe manner. For most users, we recommend using the thread-safe
             safe_session() method and a ``with`` block.
 
-        Information on how to use Snowpark sessions can be found in the
-        [Snowpark documentation](https://docs.snowflake.com/en/developer-guide/snowpark/python/working-with-dataframes).
+        Information on how to use Snowpark sessions can be found in the `Snowpark documentation
+        <https://docs.snowflake.com/en/developer-guide/snowpark/python/working-with-dataframes>`_.
 
         Example
         -------
@@ -214,8 +214,8 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
         that access on this connection's underlying Session is done in a thread-safe
         manner.
 
-        Information on how to use Snowpark sessions can be found in the
-        `Snowpark documentation <https://docs.snowflake.com/en/developer-guide/snowpark/python/working-with-dataframes>`_.
+        Information on how to use Snowpark sessions can be found in the `Snowpark documentation
+        <https://docs.snowflake.com/en/developer-guide/snowpark/python/working-with-dataframes>`_.
 
         Example
         -------

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -43,31 +43,30 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
 class SQLConnection(ExperimentalBaseConnection["Engine"]):
-    """A connection to a SQL database using a SQLAlchemy Engine.
-    Initialize using ``st.experimental_connection("<name>", type="sql")``.
+    """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.experimental_connection("<name>", type="sql")``.
+
+    .. note::
+        SQLConnections should always be created using ``st.experimental_connection()``,
+        **not** initialized directly.
 
     SQLConnection provides the ``query()`` convenience method, which can be used to
     run simple read-only queries with both caching and simple error handling/retries.
-
     More complex DB interactions can be performed by using the ``.session`` property
     to receive a regular SQLAlchemy Session.
 
-    SQLConnections will typically use connection parameters specified via
-    ``st.secrets`` or ``**kwargs``. SQLConnections should always be created using
-    ``st.experimental_connection()``, **not** initialized directly.
+    SQLConnections commonly specify connection parameters using either ``st.secrets``
+    or ``**kwargs``. Some frequently used parameters include:
 
-    Particular parameters that may be frequently used:
+    - **url** or arguments for `sqlalchemy.engine.URL.create()
+      <https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create>`_.
+      Most commonly it includes a dialect, host, database, username and password.
 
-    **url** or arguments for `sqlalchemy.engine.URL.create()
-    <https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create>`_.
-    Most commonly it includes a dialect, host, database, username and password.
+    - **create_engine_kwargs** can be passed via ``st.secrets``, such as for
+      `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy#key-pair-authentication-support>`_
+      or `Google BigQuery <https://github.com/googleapis/python-bigquery-sqlalchemy#authentication>`_.
+      These can also be passed directly as ``**kwargs`` to experimental_connection().
 
-    **create_engine_kwargs** can be passed via ``st.secrets``, such as for
-    `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy#key-pair-authentication-support>`_
-    or `Google BigQuery <https://github.com/googleapis/python-bigquery-sqlalchemy#authentication>`_.
-    These can also be passed directly as ``**kwargs`` to experimental_connection().
-
-    **autocommit=True** to run with isolation level ``AUTOCOMMIT``. Default is False.
+    - **autocommit=True** to run with isolation level ``AUTOCOMMIT``. Default is False.
 
     Example
     -------

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -51,8 +51,9 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
     to receive a regular SQLAlchemy Session.
 
     SQLConnections should always be created using ``st.experimental_connection()``,
-    **not** initialized directly. SQLConnections commonly specify connection parameters
-    using either ``st.secrets`` or ``**kwargs``. Some frequently used parameters include:
+    **not** initialized directly. Connection parameters for a SQLConnection can be
+    specified using either ``st.secrets`` or ``**kwargs``. Some frequently used
+    parameters include:
 
     - **url** or arguments for `sqlalchemy.engine.URL.create()
       <https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create>`_.

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -45,17 +45,14 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 class SQLConnection(ExperimentalBaseConnection["Engine"]):
     """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.experimental_connection("<name>", type="sql")``.
 
-    .. note::
-        SQLConnections should always be created using ``st.experimental_connection()``,
-        **not** initialized directly.
-
     SQLConnection provides the ``query()`` convenience method, which can be used to
     run simple read-only queries with both caching and simple error handling/retries.
     More complex DB interactions can be performed by using the ``.session`` property
     to receive a regular SQLAlchemy Session.
 
-    SQLConnections commonly specify connection parameters using either ``st.secrets``
-    or ``**kwargs``. Some frequently used parameters include:
+    SQLConnections should always be created using ``st.experimental_connection()``,
+    **not** initialized directly. SQLConnections commonly specify connection parameters
+    using either ``st.secrets`` or ``**kwargs``. Some frequently used parameters include:
 
     - **url** or arguments for `sqlalchemy.engine.URL.create()
       <https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create>`_.

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -176,7 +176,7 @@ def connection_factory(
 ):
     """Create a new connection to a data store or API, or return an existing one.
 
-    Config options, credentials, secrets, etc. for connections are sourced from various
+    Config options, credentials, secrets, etc. for connections are taken from various
     sources:
 
     - Any connection-specific configuration files.
@@ -188,11 +188,12 @@ def connection_factory(
     name : str
         The connection name used for secrets lookup in ``[connections.<name>]``.
         Type will be inferred from passing ``"sql"`` or ``"snowpark"``.
-    type : str or connection class
+    type : str or connection class or None
         The type of connection to create. It can be a keyword (``"sql"`` or ``"snowpark"``),
         a path to an importable class, or an imported class reference. All classes
         must extend ``st.connections.ExperimentalBaseConnection`` and implement the
-        ``_connect()`` method.
+        ``_connect()`` method. If the type kwarg is None, a ``type`` field must be set
+        in the connection's section in ``secrets.toml``.
     max_entries : int or None
         The maximum number of connections to keep in the cache, or None
         for an unbounded cache. (When a new entry is added to a full cache,
@@ -218,12 +219,12 @@ def connection_factory(
     >>> conn = st.experimental_connection("sql") # Config section defined in [connections.sql] in secrets.toml.
 
     Creating a SQLConnection with a custom name requires you to explicitly specify the
-    type. If type is not passed in as a kwarg, we try to infer it from the contents of
-    your secrets.toml.
+    type. If type is not passed as a kwarg, it must be set in the appropriate section of
+    ``secrets.toml``.
 
     >>> import streamlit as st
     >>> conn1 = st.experimental_connection("my_sql_connection", type="sql") # Config section defined in [connections.my_sql_connection].
-    >>> conn2 = st.experimental_connection("my_other_sql_connection") # Type is inferred from [connections.my_other_sql_connection].
+    >>> conn2 = st.experimental_connection("my_other_sql_connection") # type must be set in [connections.my_other_sql_connection].
 
     Passing the full module path to the connection class that you want to use can be
     useful, especially when working with a custom connection:
@@ -231,7 +232,9 @@ def connection_factory(
     >>> import streamlit as st
     >>> conn = st.experimental_connection("my_sql_connection", type="streamlit.connections.SQLConnection")
 
-    Finally, you can even pass the connection class to use directly to this function.
+    Finally, you can pass the connection class to use directly to this function. Doing
+    so allows static type checking tools such as ``mypy`` to infer the exact return
+    type of ``st.experimental_connection``.
 
     >>> import streamlit as st
     >>> from streamlit.connections import SQLConnection

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -213,7 +213,7 @@ def connection_factory(
     Examples
     --------
     The easiest way to create a first-party (SQL or Snowpark) connection is to use their
-    default names and define corresponding sections in your config.toml file.
+    default names and define corresponding sections in your ``secrets.toml`` file.
 
     >>> import streamlit as st
     >>> conn = st.experimental_connection("sql") # Config section defined in [connections.sql] in secrets.toml.


### PR DESCRIPTION
## 🧠 Description of Changes

- Formats the frequently used parameters as an unordered list, and moves the sentence about "... not initialized directly" to a note section.

Notes:
- @vdonato @sfc-gh-jcarroll feel free to remove the note admonition and convert it into a sentence if you think the rendered note takes too much space
- The first line of the docstring cannot have line breaks. If we want to include this in the first line:
> `Initialize using ``st.experimental_connection("<name>", type="sql")``.`

it cannot be contain line breaks and be valid numpydoc. E.g. this will throw an error:

```
"""A connection to a SQL database using a SQLAlchemy Engine. Initialize using
``st.experimental_connection("<name>", type="sql")``.
```

- So we either keep it as-is or move the sentence into a separate paragraph.

TODO:
- Vincent to take another pass at docstrings, including `.reset()`.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/234303370-0c202935-57ba-46ab-926a-27da17c29c0a.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/234303185-37aba358-2514-475f-a43b-b7c78d09fe88.png)


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
