### PR TITLE
Fix top padding on sidebar when embed is true

### DIFF
--- a/frontend/src/components/core/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/core/Sidebar/Sidebar.tsx
@@ -37,6 +37,8 @@ import {
 import IsSidebarContext from "./IsSidebarContext"
 import SidebarNav from "./SidebarNav"
 
+import { isEmbed, isColoredLineDisplayed } from "src/lib/utils"
+
 export interface SidebarProps {
   endpoints: StreamlitEndpoints
   chevronDownshift: number
@@ -248,6 +250,7 @@ class Sidebar extends PureComponent<SidebarProps, State> {
           // Props part of StyledSidebar, but not Resizable component
           // @ts-expect-error
           isCollapsed={collapsedSidebar}
+          isEmbed={isEmbed() && !isColoredLineDisplayed()}
           sidebarWidth={sidebarWidth}
         >
           <StyledSidebarContent

--- a/frontend/src/components/core/Sidebar/styled-components.ts
+++ b/frontend/src/components/core/Sidebar/styled-components.ts
@@ -20,18 +20,19 @@ import { transparentize } from "color2k"
 
 export interface StyledSidebarProps {
   isCollapsed: boolean
+  isEmbed: boolean
   sidebarWidth: string
 }
 
 export const StyledSidebar = styled.section<StyledSidebarProps>(
-  ({ theme, isCollapsed, sidebarWidth }) => {
+  ({ theme, isCollapsed, isEmbed, sidebarWidth }) => {
     const minWidth = isCollapsed ? 0 : Math.min(244, window.innerWidth)
     const maxWidth = isCollapsed ? 0 : Math.min(550, window.innerWidth * 0.9)
 
     return {
       // Nudge the sidebar by 2px so the header decoration doesn't go below it
       position: "relative",
-      top: "2px",
+      top: isEmbed ? "0px" : "2px",
       backgroundColor: theme.colors.bgColor,
       zIndex: theme.zIndices.header + 1,
 


### PR DESCRIPTION
## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Bugfix

## 🧠 Description of Changes

This PR closes [Issue-#6057](https://github.com/streamlit/streamlit/issues/6057). It removes `2px` empty space between sidebar and browser bar, when `?embed=true` query param is enabled.

- _Add bullet points summarizing your changes here_

  - [x] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Notice there is no empty space between sidebar and browser topbar**

![image](https://user-images.githubusercontent.com/78742618/234329102-3d01fb88-3856-447e-84b8-8e9904c3c4fc.png)


**Current:**

**Notice small 2px empty space between sidebar and browser topbar, this should disappear after this PR is merged**

![image](https://user-images.githubusercontent.com/78742618/234329298-4808f77a-5266-41fa-a151-f3cb063e7f69.png)


_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [x] Screenshots included

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes [Issue-#6057](https://github.com/streamlit/streamlit/issues/6057)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
