### PR TITLE
Fix text column validation

### DIFF
--- a/frontend/src/components/widgets/DataFrame/columns/TextColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/TextColumn.test.ts
@@ -125,6 +125,8 @@ describe("TextColumn", () => {
     expect(isErrorCell(mockColumn.getCell("abcdef", true))).toBe(false)
     // Applies the max chars limit
     expect((mockColumn.getCell("abcdef", true) as TextCell).data).toBe("abcde")
+    // But a too long input that is still wrong after fixing should result in error
+    expect(isErrorCell(mockColumn.getCell("1234567", true))).toBe(true)
   })
 
   it("handles invalid validate regex", () => {

--- a/frontend/src/components/widgets/DataFrame/columns/TextColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/TextColumn.ts
@@ -72,8 +72,9 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
     }
 
     let cellData = toSafeString(data)
-    // A flag to indicate if the cell data has been corrected.
+    // A flag to indicate whether the value has been auto-corrected.
     // This is used to decide if we should return the corrected value or true.
+    // But we still run all other validations on the corrected value below.
     let corrected = false
 
     if (parameters.max_chars) {

--- a/frontend/src/components/widgets/DataFrame/columns/TextColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/TextColumn.ts
@@ -71,7 +71,18 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
       return true
     }
 
-    const cellData = toSafeString(data)
+    let cellData = toSafeString(data)
+    // A flag to indicate if the cell data has been corrected.
+    // This is used to decide if we should return the corrected value or true.
+    let corrected = false
+
+    if (parameters.max_chars) {
+      if (cellData.length > parameters.max_chars) {
+        // Correct the value
+        cellData = cellData.slice(0, parameters.max_chars)
+        corrected = true
+      }
+    }
 
     if (
       validateRegex instanceof RegExp &&
@@ -80,13 +91,7 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
       return false
     }
 
-    if (parameters.max_chars) {
-      if (cellData.length > parameters.max_chars) {
-        // Return corrected value
-        return cellData.slice(0, parameters.max_chars)
-      }
-    }
-    return true
+    return corrected ? cellData : true
   }
 
   return {


### PR DESCRIPTION
## 📚 Context

The current text column validation has an issue if `max_chars` & `validate` is used. This allows the user to input invalid data when the pasted content exceeds the `max_chars` limit. This PR fixes this issue by applying the validation also on the corrected value.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
