### PR TITLE
Better test script loading

### DIFF
--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -524,7 +524,6 @@ class NumberInput(Widget):
     min_value: Number
     max_value: Number
     step: Number
-    placeholder: str
 
     def __init__(self, proto: NumberInputProto, root: ElementTree):
         self.proto = proto

--- a/lib/streamlit/testing/script_interactions.py
+++ b/lib/streamlit/testing/script_interactions.py
@@ -66,7 +66,7 @@ class InteractiveScriptTests(unittest.TestCase):
         # set unconditionally for whole process, since we are just running tests
         config.set_option("runner.postScriptGC", False)
 
-    def script_from_string(self, script_name: str, script: str) -> LocalScriptRunner:
+    def script_from_string(self, script: str) -> LocalScriptRunner:
         """Create a runner for a script with the contents from a string.
 
         Useful for testing short scripts that fit comfortably as an inline

--- a/lib/streamlit/testing/script_interactions.py
+++ b/lib/streamlit/testing/script_interactions.py
@@ -37,6 +37,13 @@ class InteractiveScriptTests(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # To allow loading scripts to be relative to the test class's directory,
+        # we do this in the init so it will run in the subclass's module.
+        # `__file__` refers to the base class's file, and `self.__module__`
+        # contains not enough information to get the directory, so instead
+        # we get the module object using importlib machinery, which does have
+        # that information.
+        # Based on https://stackoverflow.com/a/54142935
         m = importlib.import_module(self.__module__)
         assert m.__file__
         self.dir_path = pathlib.Path(m.__file__).parent

--- a/lib/streamlit/testing/script_interactions.py
+++ b/lib/streamlit/testing/script_interactions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import os
+import importlib
 import pathlib
 import tempfile
 import textwrap
@@ -32,6 +32,12 @@ from streamlit.testing.local_script_runner import LocalScriptRunner
 
 class InteractiveScriptTests(unittest.TestCase):
     tmp_script_dir: tempfile.TemporaryDirectory[str]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        m = importlib.import_module(self.__module__)
+        self.dir_path = pathlib.Path(m.__file__).parent
 
     def setUp(self) -> None:
         super().setUp()
@@ -71,9 +77,6 @@ class InteractiveScriptTests(unittest.TestCase):
         path.write_text(aligned_script)
         return LocalScriptRunner(str(path))
 
-    def script_from_filename(
-        self, test_dir: str, script_name: str
-    ) -> LocalScriptRunner:
+    def script_from_filename(self, script_path: str) -> LocalScriptRunner:
         """Create a runner for the script with the given name, for testing."""
-        script_path = os.path.join(os.path.dirname(test_dir), "test_data", script_name)
-        return LocalScriptRunner(script_path)
+        return LocalScriptRunner(str(self.dir_path / script_path))

--- a/lib/streamlit/testing/script_interactions.py
+++ b/lib/streamlit/testing/script_interactions.py
@@ -38,6 +38,7 @@ class InteractiveScriptTests(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
         m = importlib.import_module(self.__module__)
+        assert m.__file__
         self.dir_path = pathlib.Path(m.__file__).parent
 
     def setUp(self) -> None:
@@ -73,7 +74,7 @@ class InteractiveScriptTests(unittest.TestCase):
         string in the test itself, without having to create a separate file
         for it.
         """
-        hasher = hashlib.md5(bytes(script, "utf-8"), usedforsecurity=False)
+        hasher = hashlib.md5(bytes(script, "utf-8"))
         script_name = hasher.hexdigest()
 
         path = pathlib.Path(self.tmp_script_dir.name, script_name)

--- a/lib/streamlit/testing/script_interactions.py
+++ b/lib/streamlit/testing/script_interactions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import hashlib
 import importlib
 import pathlib
 import tempfile
@@ -72,6 +73,9 @@ class InteractiveScriptTests(unittest.TestCase):
         string in the test itself, without having to create a separate file
         for it.
         """
+        hasher = hashlib.md5(bytes(script, "utf-8"), usedforsecurity=False)
+        script_name = hasher.hexdigest()
+
         path = pathlib.Path(self.tmp_script_dir.name, script_name)
         aligned_script = textwrap.dedent(script)
         path.write_text(aligned_script)

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -990,7 +990,7 @@ class CommonCacheThreadingTest(unittest.TestCase):
 
 class WidgetReplayInteractionTest(InteractiveScriptTests):
     def test_dynamic_widget_replay(self):
-        script = self.script_from_filename(__file__, "cached_widget_replay_dynamic.py")
+        script = self.script_from_filename("test_data/cached_widget_replay_dynamic.py")
 
         sr = script.run()
         assert len(sr.get("checkbox")) == 1
@@ -1011,7 +1011,7 @@ class WidgetReplayInteractionTest(InteractiveScriptTests):
 class WidgetReplayTest(InteractiveScriptTests):
     def test_arrow_replay(self):
         """Regression test for https://github.com/streamlit/streamlit/issues/6103"""
-        script = self.script_from_filename(__file__, "arrow_replay.py")
+        script = self.script_from_filename("test_data/arrow_replay.py")
 
         sr = script.run()
         assert len(sr.get("exception")) == 0

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -289,7 +289,7 @@ class SessionStateTest(DeltaGeneratorTestCase):
 
 class SessionStateInteractionTest(InteractiveScriptTests):
     def test_updates(self):
-        script = self.script_from_filename(__file__, "linked_sliders.py")
+        script = self.script_from_filename("test_data/linked_sliders.py")
         sr = script.run()
         assert sr.get("slider")[0].value == -100.0
         assert sr.get("markdown")[0].value == "Celsius `-100.0`"

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -324,7 +324,6 @@ class SessionStateInteractionTest(InteractiveScriptTests):
         """
         with patch_config_options({"runner.enforceSerializableSessionState": True}):
             script = self.script_from_string(
-                "unserializable.py",
                 """
                 import streamlit as st
 
@@ -344,7 +343,6 @@ class SessionStateInteractionTest(InteractiveScriptTests):
         """
         with patch_config_options({"runner.enforceSerializableSessionState": False}):
             script = self.script_from_string(
-                "unserializable.py",
                 """
                 import streamlit as st
 

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -61,7 +61,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_cached_widget_replay_rerun(self):
         script = self.script_from_string(
-            "cached_widget_replay.py",
             """
             import streamlit as st
 
@@ -83,7 +82,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_cached_widget_replay_interaction(self):
         script = self.script_from_string(
-            "cached_widget_replay.py",
             """
             import streamlit as st
 
@@ -107,7 +105,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_radio_interaction(self):
         script = self.script_from_string(
-            "radio_interaction.py",
             """
             import streamlit as st
 
@@ -129,7 +126,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_widget_key_lookup(self):
         script = self.script_from_string(
-            "widget_keys.py",
             """
             import streamlit as st
 
@@ -148,7 +144,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
         appropriately, as the widget is added and removed from the script execution.
         """
         script = self.script_from_string(
-            "widget_added_and_removed.py",
             """
             import streamlit as st
 
@@ -179,7 +174,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_query_narrowing(self):
         script = self.script_from_string(
-            "narrowing.py",
             """
             import streamlit as st
 
@@ -197,7 +191,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_session_state_immutable(self):
         script = self.script_from_string(
-            "session_state_copy.py",
             """
             import streamlit as st
 
@@ -229,7 +222,6 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_radio_option_types(self):
         script = self.script_from_string(
-            "radio_options.py",
             """
             import streamlit as st
 

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -18,7 +18,7 @@ from streamlit.testing.script_interactions import InteractiveScriptTests
 
 class InteractiveScriptTest(InteractiveScriptTests):
     def test_widgets_script(self):
-        script = self.script_from_filename(__file__, "widgets_script.py")
+        script = self.script_from_filename("test_data/widgets_script.py")
         sr = script.run()
 
         # main and sidebar
@@ -246,4 +246,4 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
     def test_script_not_found(self):
         with pytest.raises(AssertionError):
-            self.script_from_filename(__file__, "doesntexist.py")
+            self.script_from_filename("doesntexist.py")

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -24,7 +24,6 @@ from streamlit.testing.script_interactions import InteractiveScriptTests
 class ButtonTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "button_test.py",
             """
             import streamlit as st
 
@@ -48,7 +47,6 @@ class ButtonTest(InteractiveScriptTests):
 class CheckboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "checkbox_test.py",
             """
             import streamlit as st
 
@@ -73,7 +71,6 @@ class CheckboxTest(InteractiveScriptTests):
 class ColorPickerTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "color_picker.py",
             """
             import streamlit as st
 
@@ -94,7 +91,6 @@ class ColorPickerTest(InteractiveScriptTests):
 class DateInputTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "date_input.py",
             """
             import streamlit as st
             import datetime
@@ -127,7 +123,6 @@ class DateInputTest(InteractiveScriptTests):
 class ExceptionTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "exception.py",
             """
             import streamlit as st
 
@@ -140,7 +135,6 @@ class ExceptionTest(InteractiveScriptTests):
 
     def test_markdown(self):
         script = self.script_from_string(
-            "exception2.py",
             """
             import streamlit as st
 
@@ -155,7 +149,6 @@ class ExceptionTest(InteractiveScriptTests):
 class HeadingTest(InteractiveScriptTests):
     def test_title(self):
         script = self.script_from_string(
-            "title_element.py",
             """
             import streamlit as st
 
@@ -174,7 +167,6 @@ class HeadingTest(InteractiveScriptTests):
 
     def test_header(self):
         script = self.script_from_string(
-            "header_element.py",
             """
             import streamlit as st
 
@@ -193,7 +185,6 @@ class HeadingTest(InteractiveScriptTests):
 
     def test_subheader(self):
         script = self.script_from_string(
-            "subheader_element.py",
             """
             import streamlit as st
 
@@ -215,7 +206,6 @@ class HeadingTest(InteractiveScriptTests):
 
     def test_heading_elements_by_type(self):
         script = self.script_from_string(
-            "heading_elements.py",
             """
             import streamlit as st
 
@@ -238,7 +228,6 @@ class HeadingTest(InteractiveScriptTests):
 class MarkdownTest(InteractiveScriptTests):
     def test_markdown(self):
         script = self.script_from_string(
-            "markdown_element.py",
             """
             import streamlit as st
 
@@ -253,7 +242,6 @@ class MarkdownTest(InteractiveScriptTests):
 
     def test_caption(self):
         script = self.script_from_string(
-            "caption_element.py",
             """
             import streamlit as st
 
@@ -269,7 +257,6 @@ class MarkdownTest(InteractiveScriptTests):
 
     def test_code(self):
         script = self.script_from_string(
-            "code_element.py",
             """
             import streamlit as st
 
@@ -284,7 +271,6 @@ class MarkdownTest(InteractiveScriptTests):
 
     def test_latex(self):
         script = self.script_from_string(
-            "latex_element.py",
             """
             import streamlit as st
 
@@ -299,7 +285,6 @@ class MarkdownTest(InteractiveScriptTests):
 
     def test_divider(self):
         script = self.script_from_string(
-            "divider_element.py",
             """
             import streamlit as st
 
@@ -314,7 +299,6 @@ class MarkdownTest(InteractiveScriptTests):
 
     def test_markdown_elements_by_type(self):
         script = self.script_from_string(
-            "markdown_element.py",
             """
             import streamlit as st
 
@@ -340,7 +324,6 @@ class MarkdownTest(InteractiveScriptTests):
 class MultiselectTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "multiselect_test.py",
             """
             import streamlit as st
 
@@ -368,7 +351,6 @@ class MultiselectTest(InteractiveScriptTests):
 class NumberInputTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "number_input.py",
             """
             import streamlit as st
 
@@ -396,7 +378,6 @@ class NumberInputTest(InteractiveScriptTests):
 class SelectboxTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "select_slider_test.py",
             """
             import pandas as pd
             import streamlit as st
@@ -441,7 +422,6 @@ class SelectboxTest(InteractiveScriptTests):
 class SelectSliderTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "select_slider_test.py",
             """
             import streamlit as st
 
@@ -463,7 +443,6 @@ class SelectSliderTest(InteractiveScriptTests):
 class SidebarTest(InteractiveScriptTests):
     def test_access(self):
         script = self.script_from_string(
-            "sidebar.py",
             """
             import streamlit as st
 
@@ -480,7 +459,6 @@ class SidebarTest(InteractiveScriptTests):
 class SliderTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "slider_test.py",
             """
             import streamlit as st
             from datetime import datetime, time
@@ -515,7 +493,6 @@ class SliderTest(InteractiveScriptTests):
 class TextAreaTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "text_area.py",
             """
             import streamlit as st
 
@@ -539,7 +516,6 @@ class TextAreaTest(InteractiveScriptTests):
 class TextInputTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "text_input.py",
             """
             import streamlit as st
 
@@ -564,7 +540,6 @@ class TextInputTest(InteractiveScriptTests):
 class TimeInputTest(InteractiveScriptTests):
     def test_value(self):
         script = self.script_from_string(
-            "time_input.py",
             """
             import streamlit as st
             import datetime


### PR DESCRIPTION
Not having a hardcoded test dir structure for loading scripts by filename is a longstanding request for the testing framework, which this change implements.

We also now generate a script name for inline scripts, since they don't matter and this is more convenient.