### PR TITLE
Add chart column types for `st.dataframe` and `st.data_editor`

### DIFF
--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GridCellKind } from "@glideapps/glide-data-grid"
+import { SparklineCellType } from "@glideapps/glide-data-grid-cells"
+
+import { BaseColumnProps, isErrorCell } from "./utils"
+import {
+  ChartColumnParams,
+  LineChartColumn,
+  BarChartColumn,
+} from "./ChartColumn"
+
+const CHART_COLUMN_TEMPLATE = {
+  id: "1",
+  name: "chart_column",
+  title: "Chart column",
+  indexNumber: 0,
+  isEditable: false,
+  isHidden: false,
+  isIndex: false,
+  isStretched: false,
+  arrowType: {
+    // The arrow type of the underlying data is
+    // not used for anything inside the column.
+    pandas_type: "object",
+    numpy_type: "list[float64]",
+  },
+} as BaseColumnProps
+
+function getLineChartColumn(
+  params?: ChartColumnParams
+): ReturnType<typeof LineChartColumn> {
+  return LineChartColumn({
+    ...CHART_COLUMN_TEMPLATE,
+    columnTypeOptions: params,
+  } as BaseColumnProps)
+}
+
+function getBarChartColumn(
+  params?: ChartColumnParams
+): ReturnType<typeof BarChartColumn> {
+  return BarChartColumn({
+    ...CHART_COLUMN_TEMPLATE,
+    columnTypeOptions: params,
+  } as BaseColumnProps)
+}
+
+describe("ChartColumn", () => {
+  it("creates a valid column instance", () => {
+    const mockColumn = getLineChartColumn()
+    expect(mockColumn.kind).toEqual("line_chart")
+    expect(mockColumn.title).toEqual(CHART_COLUMN_TEMPLATE.title)
+    expect(mockColumn.id).toEqual(CHART_COLUMN_TEMPLATE.id)
+    expect(mockColumn.sortMode).toEqual("default")
+
+    // Column should be readonly:
+    expect(mockColumn.isEditable).toEqual(false)
+
+    const mockCell = mockColumn.getCell([0.1, 0.2])
+    expect(mockCell.kind).toEqual(GridCellKind.Custom)
+    expect((mockCell as SparklineCellType).data?.values).toEqual([0.1, 0.2])
+    expect((mockCell as SparklineCellType).data?.displayValues).toEqual([
+      "0.1",
+      "0.2",
+    ])
+  })
+
+  it("supports configuring the chart type", () => {
+    const mockColumn = getLineChartColumn()
+    expect(mockColumn.kind).toEqual("line_chart")
+    const mockCell = mockColumn.getCell([0.1, 0.2])
+    // Default chart type is line
+    expect((mockCell as SparklineCellType).data?.graphKind).toEqual("line")
+
+    const mockBarChartColumn = getBarChartColumn()
+    expect(mockBarChartColumn.kind).toEqual("bar_chart")
+    const mockBarChartCell = mockBarChartColumn.getCell([0.1, 0.2])
+    // Chart type should be bar
+    expect((mockBarChartCell as SparklineCellType).data?.graphKind).toEqual(
+      "bar"
+    )
+  })
+
+  it("supports configuring min/max scale", () => {
+    const mockColumn = getLineChartColumn()
+    const mockCell = mockColumn.getCell([-100, 0, 100])
+    // Default min/max scale is 0/1 so the values should be normalized:
+    expect((mockCell as SparklineCellType).data?.values).toEqual([0, 0.5, 1])
+
+    // Use a different scale
+    const mockColumn1 = getLineChartColumn({
+      y_min: -100,
+      y_max: 100,
+    })
+    const mockCell1 = mockColumn1.getCell([-100, 0, 100])
+    expect((mockCell1 as SparklineCellType).data?.values).toEqual([
+      -100, 0, 100,
+    ])
+
+    // Use a different scale
+    const mockColumn2 = getLineChartColumn({
+      y_min: -1,
+      y_max: 1,
+    })
+    const mockCell2 = mockColumn2.getCell([-100, 0, 100])
+    // This should automatically normalize the values to the min/max scale:
+    expect((mockCell2 as SparklineCellType).data?.values).toEqual([-1, 0, 1])
+
+    // Use a different scale
+    const mockColumn3 = getLineChartColumn({
+      y_min: 0,
+      y_max: 200,
+    })
+    const mockCell3 = mockColumn3.getCell([-100, 0, 100])
+    // This should automatically normalize the values to the min/max scale:
+    expect((mockCell3 as SparklineCellType).data?.values).toEqual([
+      0, 100, 200,
+    ])
+
+    // Use a different scale
+    const mockColumn4 = getLineChartColumn({
+      y_min: -200,
+      y_max: 200,
+    })
+    const mockCell4 = mockColumn4.getCell([-100, 0, 100])
+    // The values fit into the scale, so don't do anything:
+    expect((mockCell4 as SparklineCellType).data?.values).toEqual([
+      -100, 0, 100,
+    ])
+
+    // Use a different scale
+    const mockColumn5 = getLineChartColumn({
+      y_min: 100,
+      y_max: -100,
+    })
+    const mockCell5 = mockColumn5.getCell([-100, 0, 100])
+    // min needs to be bigger than max, so this should be an error cell:
+    expect(isErrorCell(mockCell5)).toEqual(true)
+
+    // Use a different scale
+    const mockColumn6 = getLineChartColumn({
+      y_min: undefined,
+      y_max: -100,
+    })
+    const mockCell6 = mockColumn6.getCell([-100, 0, 100])
+    // min and max need to be defined, so this should be an error cell:
+    expect(isErrorCell(mockCell6)).toEqual(true)
+  })
+
+  it.each([
+    // Supports almost the same as toSafeArray
+    [null, null],
+    [undefined, null],
+    ["", null],
+    [[], null],
+    // Comma separated syntax
+    ["0.1,0.2", [0.1, 0.2]],
+    // JSON Array syntax
+    [`["0.1","0.2"]`, [0.1, 0.2]],
+    ["1", [1]],
+    [0, [0]],
+    [1, [1]],
+    [
+      [0, 0.2, 0.1],
+      [0, 0.2, 0.1],
+    ],
+    [true, [1]],
+    [false, [0]],
+  ])(
+    "supports numerical array-compatible value (%p parsed as %p)",
+    (input: any, value: any[] | null) => {
+      const mockColumn = getLineChartColumn()
+      const cell = mockColumn.getCell(input)
+      expect(mockColumn.getCellValue(cell)).toEqual(value)
+    }
+  )
+
+  it.each([
+    ["foo"],
+    ["foo, bar"],
+    ["0.1,0.4,foo"],
+    ["0.1,0.4,"],
+    [["foo", "bar"]],
+    [[0.1, 0.4, "foo"]],
+    [[0.1, 0.4, null]],
+  ])("%p results in error cell", (input: any) => {
+    const mockColumn = getLineChartColumn()
+    const cell = mockColumn.getCell(input)
+    expect(isErrorCell(cell)).toEqual(true)
+  })
+})

--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
@@ -161,6 +161,25 @@ describe("ChartColumn", () => {
     expect(isErrorCell(mockCell6)).toEqual(true)
   })
 
+  it("works with single values or only same values without running into division by zero", () => {
+    const mockColumn = getLineChartColumn({
+      y_min: 0,
+      y_max: 100,
+    })
+
+    const mockCell1 = mockColumn.getCell([101])
+    // The value should be normalized to 100:
+    expect((mockCell1 as SparklineCellType).data?.values).toEqual([100])
+
+    const mockCell2 = mockColumn.getCell([101, 101])
+    // All values should be normalized to 100:
+    expect((mockCell2 as SparklineCellType).data?.values).toEqual([100, 100])
+
+    const mockCell3 = mockColumn.getCell([-1, -1])
+    // All values should be normalized to 0:
+    expect((mockCell3 as SparklineCellType).data?.values).toEqual([0, 0])
+  })
+
   it.each([
     // Supports almost the same as toSafeArray
     [null, null],

--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -45,7 +45,6 @@ export interface ChartColumnParams {
 /**
  * Base class for chart columns. This class is not meant to be used directly.
  * Instead, use the LineChartColumn and BarChartColumn classes.
- *
  */
 function BaseChartColumn(
   kind: string,

--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  GridCell,
+  GridCellKind,
+  LoadingCell,
+} from "@glideapps/glide-data-grid"
+import { SparklineCellType } from "@glideapps/glide-data-grid-cells"
+
+import { isNullOrUndefined } from "src/lib/utils"
+
+import {
+  BaseColumn,
+  BaseColumnProps,
+  getErrorCell,
+  getEmptyCell,
+  toSafeString,
+  toSafeArray,
+  mergeColumnParameters,
+  toSafeNumber,
+  formatNumber,
+} from "./utils"
+
+export interface ChartColumnParams {
+  // The minimum value used for plotting the chart. Defaults to 0.
+  readonly y_min?: number
+  // The maximum value used for plotting the chart. Defaults to 1.
+  readonly y_max?: number
+}
+
+/**
+ * Base class for chart columns. This class is not meant to be used directly.
+ * Instead, use the LineChartColumn and BarChartColumn classes.
+ *
+ */
+function BaseChartColumn(
+  kind: string,
+  props: BaseColumnProps,
+  chart_type: "line" | "bar"
+): BaseColumn {
+  const parameters = mergeColumnParameters(
+    // Default parameters:
+    {
+      y_min: 0,
+      y_max: 1,
+    },
+    // User parameters:
+    props.columnTypeOptions
+  ) as ChartColumnParams
+
+  const cellTemplate = {
+    kind: GridCellKind.Custom,
+    allowOverlay: false,
+    copyData: "",
+    contentAlign: props.contentAlignment,
+    data: {
+      kind: "sparkline-cell",
+      values: [],
+      displayValues: [],
+      graphKind: chart_type,
+      yAxis: [parameters.y_min, parameters.y_max],
+    },
+  } as SparklineCellType
+
+  return {
+    ...props,
+    kind,
+    sortMode: "default",
+    isEditable: false, // Chart column is always read-only
+    getCell(data?: any): GridCell {
+      if (
+        isNullOrUndefined(parameters.y_min) ||
+        isNullOrUndefined(parameters.y_max) ||
+        Number.isNaN(parameters.y_min) ||
+        Number.isNaN(parameters.y_max) ||
+        parameters.y_min >= parameters.y_max
+      ) {
+        return getErrorCell(
+          "Invalid min/max y-axis configuration",
+          `The y_min (${parameters.y_min}) and y_max (${parameters.y_max}) configuration options must be valid numbers.`
+        )
+      }
+
+      if (isNullOrUndefined(data)) {
+        // TODO(lukasmasuch): Use a missing cell?
+        return getEmptyCell()
+      }
+
+      const chartData = toSafeArray(data)
+
+      const convertedChartData: number[] = []
+      let normalizedChartData: number[] = []
+      if (chartData.length === 0) {
+        return getEmptyCell()
+      }
+
+      // Initialize with smallest and biggest number
+      let maxValue = Number.MIN_SAFE_INTEGER
+      let minValue = Number.MAX_SAFE_INTEGER
+
+      // Try to convert all values to numbers and find min/max
+      for (let i = 0; i < chartData.length; i++) {
+        const convertedValue = toSafeNumber(chartData[i])
+        if (
+          Number.isNaN(convertedValue) ||
+          isNullOrUndefined(convertedValue)
+        ) {
+          return getErrorCell(
+            toSafeString(chartData),
+            `The value cannot be interpreted as a numeric array. ${toSafeString(
+              convertedValue
+            )} is not a number.`
+          )
+        }
+
+        if (convertedValue > maxValue) {
+          maxValue = convertedValue
+        }
+
+        if (convertedValue < minValue) {
+          minValue = convertedValue
+        }
+
+        convertedChartData.push(convertedValue)
+      }
+
+      if (
+        convertedChartData.length > 0 &&
+        (maxValue > parameters.y_max || minValue < parameters.y_min)
+      ) {
+        // Normalize values between the configured range
+        normalizedChartData = convertedChartData.map(
+          v =>
+            ((parameters.y_max || 1) - (parameters.y_min || 0)) *
+              ((v - minValue) / (maxValue - minValue)) +
+            (parameters.y_min || 0)
+        )
+      } else {
+        // Values are already in the configured range
+        normalizedChartData = convertedChartData
+      }
+
+      return {
+        ...cellTemplate,
+        copyData: convertedChartData.join(","), // Column sorting is done via the copyData value
+        data: {
+          ...cellTemplate.data,
+          values: normalizedChartData,
+          displayValues: convertedChartData.map(v => formatNumber(v, 3)),
+        },
+        isMissingValue: isNullOrUndefined(data),
+      } as SparklineCellType
+    },
+    getCellValue(
+      cell: SparklineCellType | LoadingCell
+    ): readonly number[] | null {
+      if (cell.kind === GridCellKind.Loading) {
+        return null
+      }
+
+      return cell.data?.values === undefined ? null : cell.data?.values
+    },
+  }
+}
+
+/**
+ * A column type that renders the cell value as a line-chart.
+ * The data is expected to be a numeric array.
+ *
+ * This column type is currently read-only.
+ */
+export function LineChartColumn(props: BaseColumnProps): BaseColumn {
+  return BaseChartColumn("line_chart", props, "line")
+}
+
+LineChartColumn.isEditableType = false
+
+/**
+ * A column type that renders the cell value as a bar-chart.
+ * The data is expected to be a numeric array.
+ *
+ * This column type is currently read-only.
+ */
+export function BarChartColumn(props: BaseColumnProps): BaseColumn {
+  return BaseChartColumn("bar_chart", props, "bar")
+}
+
+BarChartColumn.isEditableType = false

--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -144,7 +144,9 @@ function BaseChartColumn(
         // Normalize values between the configured range
         normalizedChartData = convertedChartData.map(v =>
           maxValue - minValue === 0 // Prevent division by zero
-            ? parameters.y_min || 0
+            ? maxValue > (parameters.y_max || 1)
+              ? parameters.y_max || 1 // Use max value
+              : parameters.y_min || 0 // Use min value
             : ((parameters.y_max || 1) - (parameters.y_min || 0)) *
                 ((v - minValue) / (maxValue - minValue)) +
               (parameters.y_min || 0)

--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -142,11 +142,12 @@ function BaseChartColumn(
         (maxValue > parameters.y_max || minValue < parameters.y_min)
       ) {
         // Normalize values between the configured range
-        normalizedChartData = convertedChartData.map(
-          v =>
-            ((parameters.y_max || 1) - (parameters.y_min || 0)) *
-              ((v - minValue) / (maxValue - minValue)) +
-            (parameters.y_min || 0)
+        normalizedChartData = convertedChartData.map(v =>
+          maxValue - minValue === 0 // Prevent division by zero
+            ? parameters.y_min || 0
+            : ((parameters.y_max || 1) - (parameters.y_min || 0)) *
+                ((v - minValue) / (maxValue - minValue)) +
+              (parameters.y_min || 0)
         )
       } else {
         // Values are already in the configured range

--- a/frontend/src/components/widgets/DataFrame/columns/index.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/index.ts
@@ -22,6 +22,7 @@ import ListColumn from "./ListColumn"
 import NumberColumn from "./NumberColumn"
 import LinkColumn from "./LinkColumn"
 import DateTimeColumn, { DateColumn, TimeColumn } from "./DateTimeColumn"
+import { LineChartColumn, BarChartColumn } from "./ChartColumn"
 
 import { DateTimeCellRenderer } from "./cells/DateTimeCell"
 
@@ -46,6 +47,8 @@ export const ColumnTypes = new Map<string, ColumnCreator>(
     datetime: DateTimeColumn,
     date: DateColumn,
     time: TimeColumn,
+    line_chart: LineChartColumn,
+    bar_chart: BarChartColumn,
   })
 )
 
@@ -62,4 +65,6 @@ export {
   DateTimeColumn,
   DateColumn,
   TimeColumn,
+  LineChartColumn,
+  BarChartColumn,
 }

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -48,6 +48,8 @@ ColumnType: TypeAlias = Literal[
     "date",
     "time",
     "link",
+    "line_chart",
+    "bar_chart",
 ]
 
 


### PR DESCRIPTION
## 📚 Context

This PR adds the bar_chart and line_chart column types for `st.dataframe` and `st.data_editor`. These column types are able to render a numeric array in a cell as a line or bar chart. 

<img width="610" alt="image" src="https://user-images.githubusercontent.com/2852129/234861876-afb46009-4693-4711-a273-2cc9199452dd.png">

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- e2e tests will be added with a later column config PR.

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
