### PR TITLE
Improve number column type for `st.dataframe` and `st.data_editor`

### DIFF
--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -123,6 +123,16 @@ describe("NumberColumn", () => {
     }
   )
 
+  it("properly configures the column for unsigned integers", () => {
+    const mockColumn = getNumberColumn(MOCK_UINT_ARROW_TYPE)
+    expect(mockColumn.kind).toEqual("number")
+
+    const mockCell = mockColumn.getCell("104")
+    expect(mockCell.kind).toEqual(GridCellKind.Number)
+    expect((mockCell as NumberCell).fixedDecimals).toEqual(0)
+    expect((mockCell as NumberCell).allowNegative).toEqual(false)
+  })
+
   it.each([
     [100, true],
     [-100, false],

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -138,24 +138,24 @@ describe("NumberColumn", () => {
     "supports unsigned integer value (%p parsed as %p)",
     (input: DataType | null, value: number | null) => {
       const mockColumn = getNumberColumn(MOCK_UINT_ARROW_TYPE)
-      const cell = mockColumn.getCell(input)
+      const cell = mockColumn.getCell(input, true)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
     }
   )
 
   it.each([
     [0, 1.234567, 1],
-    [1, 1.234567, 1.2],
-    [2, 1.234567, 1.23],
-    [3, 1.234567, 1.234],
-    [4, 1.234567, 1.2345],
-    [3, 1.1, 1.1],
-    [100, 1, 1],
+    [0.1, 1.234567, 1.2],
+    [0.01, 1.234567, 1.23],
+    [0.001, 1.234567, 1.234],
+    [0.0001, 1.234567, 1.2345],
+    [0.001, 1.1, 1.1],
+    [0.00000001, 1, 1],
   ])(
-    "converts value to precision %p (%p parsed to %p)",
-    (precision: number, input: DataType, value: number | null) => {
+    "converts value to precision from step %p (%p parsed to %p)",
+    (step: number, input: DataType, value: number | null) => {
       const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE, {
-        precision,
+        step,
       })
       const mockCell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(mockCell)).toEqual(value)
@@ -169,9 +169,9 @@ describe("NumberColumn", () => {
     [10, -5, 10],
   ])(
     "supports minimal value %p (%p parsed to %p)",
-    (min: number, input: DataType, value: number | null) => {
+    (min_value: number, input: DataType, value: number | null) => {
       const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE, {
-        min,
+        min_value,
       })
       const mockCell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(mockCell)).toEqual(value)
@@ -185,9 +185,9 @@ describe("NumberColumn", () => {
     [10, -5, -5],
   ])(
     "supports maximal value %p (%p parsed to %p)",
-    (max: number, input: DataType, value: number | null) => {
+    (max_value: number, input: DataType, value: number | null) => {
       const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE, {
-        max,
+        max_value,
       })
       const mockCell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(mockCell)).toEqual(value)

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
 
 import { GridCellKind, NumberCell, TextCell } from "@glideapps/glide-data-grid"
 
@@ -223,6 +224,7 @@ describe("NumberColumn", () => {
     [10, "$%.2f", "$10.00"],
     [10.126, "$%.2f", "$10.13"],
     [10.123, "%.2f€", "10.12€"],
+    [10.126, "($%.2f)", "($10.13)"],
     [65, "%d years", "65 years"],
     [1234567898765432, "%d ⭐", "1234567898765432 ⭐"],
     [72.3, "%.1f%%", "72.3%"],

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -129,8 +129,8 @@ describe("NumberColumn", () => {
 
     const mockCell = mockColumn.getCell("104")
     expect(mockCell.kind).toEqual(GridCellKind.Number)
-    expect((mockCell as NumberCell).fixedDecimals).toEqual(0)
-    expect((mockCell as NumberCell).allowNegative).toEqual(false)
+    expect((mockCell as any).fixedDecimals).toEqual(0)
+    expect((mockCell as any).allowNegative).toEqual(false)
   })
 
   it.each([

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -155,13 +155,32 @@ describe("NumberColumn", () => {
     [0.001, 1.1, 1.1],
     [0.00000001, 1, 1],
   ])(
-    "converts value to precision from step %p (%p parsed to %p)",
+    "converts value to precision from step %p (%p converted to %p)",
     (step: number, input: DataType, value: number | null) => {
       const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE, {
         step,
       })
       const mockCell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(mockCell)).toEqual(value)
+    }
+  )
+
+  it.each([
+    [0, 1.234567, "1"],
+    [0.1, 1.234567, "1.2"],
+    [0.01, 1.234567, "1.23"],
+    [0.001, 1.234567, "1.234"],
+    [0.0001, 1.234567, "1.2345"],
+    [0.001, 1.1, "1.100"],
+    [0.00000001, 1, "1.00000000"],
+  ])(
+    "correctly adapts default value to precision from step %p (%p displayed as %p)",
+    (step: number, input: DataType, displayValue: string) => {
+      const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE, {
+        step,
+      })
+      const mockCell = mockColumn.getCell(input)
+      expect((mockCell as NumberCell).displayData).toEqual(displayValue)
     }
   )
 

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -42,6 +42,8 @@ export interface NumberColumnParams {
   // This can be used for adding prefix or suffix, or changing the number of decimals of the display value.
   readonly format?: string
   // Specifies the granularity that the value must adhere.
+  // This will also influence the maximum precision. This will impact the number of decimals
+  // allowed to be entered as well as the number of decimals displayed (if format is not specified).
   // This is set to 1 for integer types.
   readonly step?: number
 }

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -15,6 +15,7 @@
  */
 
 import { GridCell, GridCellKind, NumberCell } from "@glideapps/glide-data-grid"
+import { sprintf } from "sprintf-js"
 
 import { Quiver } from "src/lib/Quiver"
 import { notNullOrUndefined, isNullOrUndefined } from "src/lib/utils"
@@ -28,16 +29,21 @@ import {
   mergeColumnParameters,
   toSafeNumber,
   formatNumber,
+  countDecimals,
+  truncateDecimals,
 } from "./utils"
 
 export interface NumberColumnParams {
-  // Floating point precision to limit the number of digits after the decimal point.
-  // This is set to 0 for integer columns.
-  readonly precision?: number
   // The minimum allowed value for editing. Is set to 0 for unsigned values.
-  readonly min?: number
+  readonly min_value?: number
   // The maximum allowed value for editing.
-  readonly max?: number
+  readonly max_value?: number
+  // A formatting syntax (e.g. sprintf) to format the display value.
+  // This can be used for adding prefix or suffix, or changing the number of decimals of the display value.
+  readonly format?: string
+  // Specifies the granularity that the value must adhere.
+  // This is set to 1 for integer types.
+  readonly step?: number
 }
 
 /**
@@ -50,23 +56,27 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
   const parameters = mergeColumnParameters(
     // Default parameters:
     {
-      precision:
+      // Set step to 1 for integer types
+      step:
         arrowTypeName.startsWith("int") ||
         arrowTypeName === "range" ||
         arrowTypeName.startsWith("uint")
-          ? 0
+          ? 1
           : undefined,
       // if uint (unsigned int), only positive numbers are allowed
-      min: arrowTypeName.startsWith("uint") ? 0 : undefined,
-    },
+      min_value: arrowTypeName.startsWith("uint") ? 0 : undefined,
+    } as NumberColumnParams,
     // User parameters:
     props.columnTypeOptions
   ) as NumberColumnParams
 
-  const allowNegative = isNullOrUndefined(parameters.min) || parameters.min < 0
-  const fixedDecimals = notNullOrUndefined(parameters.precision)
-    ? parameters.precision
-    : undefined
+  const allowNegative =
+    isNullOrUndefined(parameters.min_value) || parameters.min_value < 0
+
+  const fixedDecimals =
+    notNullOrUndefined(parameters.step) && !Number.isNaN(parameters.step)
+      ? countDecimals(parameters.step)
+      : undefined
 
   const cellTemplate = {
     kind: GridCellKind.Number,
@@ -80,12 +90,73 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
     fixedDecimals,
   } as NumberCell
 
+  const validateInput = (data?: any): boolean | number => {
+    let cellData: number | null = toSafeNumber(data)
+
+    if (isNullOrUndefined(cellData)) {
+      if (props.isRequired) {
+        return false
+      }
+      return true
+    }
+
+    if (Number.isNaN(cellData)) {
+      return false
+    }
+
+    // A flag to indicate whether the value has been auto-corrected.
+    // This is used to decide if we should return the corrected value or true.
+    // But we still run all other validations on the corrected value below.
+    let corrected = false
+
+    // Apply max_value configuration option:
+    if (
+      notNullOrUndefined(parameters.max_value) &&
+      cellData > parameters.max_value
+    ) {
+      cellData = parameters.max_value
+      corrected = true
+    }
+
+    // Apply min_value configuration option:
+    if (
+      notNullOrUndefined(parameters.min_value) &&
+      cellData < parameters.min_value
+    ) {
+      // Only return false, since correcting it negatively impacts
+      // the user experience.
+      return false
+    }
+
+    // TODO(lukasmasuch): validate step size?
+    // if (notNullOrUndefined(parameters.step) && parameters.step !== 1)
+
+    return corrected ? cellData : true
+  }
+
   return {
     ...props,
     kind: "number",
     sortMode: "smart",
-    getCell(data?: any): GridCell {
+    validateInput,
+    getCell(data?: any, validate?: boolean): GridCell {
+      if (validate === true) {
+        const validationResult = validateInput(data)
+        if (validationResult === false) {
+          // The input is invalid, we return an error cell which will
+          // prevent this cell to be inserted into the table.
+          // This cell should never be actually displayed to the user.
+          // It's mostly used internally to prevent invalid input to be
+          // inserted into the table.
+          return getErrorCell(toSafeString(data), "Invalid input.")
+        } else if (typeof validationResult === "number") {
+          // Apply corrections:
+          data = validationResult
+        }
+      }
+
       let cellData: number | null = toSafeNumber(data)
+      let displayData: string | undefined
 
       if (notNullOrUndefined(cellData)) {
         if (Number.isNaN(cellData)) {
@@ -95,23 +166,9 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
           )
         }
 
-        // Apply precision parameter
-        if (notNullOrUndefined(parameters.precision)) {
-          cellData =
-            parameters.precision === 0
-              ? Math.trunc(cellData)
-              : Math.trunc(cellData * 10 ** parameters.precision) /
-                10 ** parameters.precision
-        }
-
-        // Apply min parameter
-        if (notNullOrUndefined(parameters.min)) {
-          cellData = Math.max(cellData, parameters.min)
-        }
-
-        // Apply max parameter
-        if (notNullOrUndefined(parameters.max)) {
-          cellData = Math.min(cellData, parameters.max)
+        // Cut decimals:
+        if (notNullOrUndefined(fixedDecimals)) {
+          cellData = truncateDecimals(cellData, fixedDecimals)
         }
 
         // Check if the value is larger than the maximum supported value:
@@ -121,14 +178,34 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
             "The value is larger than the maximum supported integer values in number columns (2^53)."
           )
         }
+
+        // Apply format configuration option:
+        if (notNullOrUndefined(parameters.format)) {
+          try {
+            displayData = sprintf(parameters.format, cellData)
+          } catch (error) {
+            return getErrorCell(
+              toSafeString(cellData),
+              `Format configuration (${parameters.format}) is not sprintf compatible. Error: ${error}`
+            )
+          }
+        }
+      }
+
+      if (displayData === undefined) {
+        if (isNullOrUndefined(cellData)) {
+          displayData = ""
+        } else if (notNullOrUndefined(fixedDecimals)) {
+          displayData = formatNumber(cellData, fixedDecimals, true)
+        } else {
+          displayData = formatNumber(cellData)
+        }
       }
 
       return {
         ...cellTemplate,
         data: cellData,
-        displayData: notNullOrUndefined(cellData)
-          ? formatNumber(cellData)
-          : "",
+        displayData,
         isMissingValue: isNullOrUndefined(cellData),
       } as NumberCell
     },

--- a/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -30,6 +30,8 @@ import {
   toSafeBoolean,
   toGlideColumn,
   toSafeDate,
+  countDecimals,
+  truncateDecimals,
 } from "./utils"
 import { TextColumn } from "."
 
@@ -376,4 +378,49 @@ describe("toSafeDate", () => {
   ])("converts input %p to the correct date %p", (input, expectedOutput) => {
     expect(toSafeDate(input)).toEqual(expectedOutput)
   })
+})
+
+describe("countDecimals", () => {
+  it.each([
+    [0, 0],
+    [1, 0],
+    [0.1, 1],
+    [0.01, 2],
+    [0.123456789, 9],
+    [0.000001, 6],
+    [0.0000001, 7],
+    [1.23456789e-10, 18],
+    [0.0000000000000000001, 19],
+    [-0.12345, 5],
+    [123456789432, 0],
+    [123456789876543212312313, 0],
+    // It is expected that very large and small numbers won't work correctly:
+    [1234567898765432.1, 0],
+    [0.0000000000000000000001, 0],
+    [1.234567890123456e-20, 20],
+  ])("should return correct decimal count for %d", (value, expected) => {
+    const result = countDecimals(value)
+    expect(result).toEqual(expected)
+  })
+})
+
+describe("truncateDecimals", () => {
+  it.each([
+    [3.14159265, 2, 3.14],
+    [123.456, 1, 123.4],
+    [-3.14159265, 2, -3.14],
+    [-123.456, 1, -123.4],
+    [3.14159265, 0, 3],
+    [123.456, 0, 123],
+    [-3.14159265, 0, -3],
+    [-123.456, 0, -123],
+    [42, 0, 42],
+    [-42, 0, -42],
+    [0.1 + 0.2, 2, 0.3],
+  ])(
+    "truncates value %f to %i decimal places, resulting in %f",
+    (value, decimals, expected) => {
+      expect(truncateDecimals(value, decimals)).toBe(expected)
+    }
+  )
 })

--- a/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -393,8 +393,10 @@ describe("countDecimals", () => {
     [0.0000000000000000001, 19],
     [-0.12345, 5],
     [123456789432, 0],
+    // eslint-disable-next-line  @typescript-eslint/no-loss-of-precision
     [123456789876543212312313, 0],
     // It is expected that very large and small numbers won't work correctly:
+    // eslint-disable-next-line  @typescript-eslint/no-loss-of-precision
     [1234567898765432.1, 0],
     [0.0000000000000000000001, 0],
     [1.234567890123456e-20, 20],

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -515,3 +515,52 @@ export function toSafeDate(value: any): Date | null | undefined {
   // Unable to interpret this value as a date:
   return undefined
 }
+
+/**
+ * Count the number of decimals in a number.
+ *
+ * @param {number} value - The number to count the decimals for.
+ *
+ * @returns {number} The number of decimals.
+ */
+export function countDecimals(value: number): number {
+  if (value % 1 === 0) {
+    return 0
+  }
+
+  let numberStr = value.toString()
+
+  if (numberStr.indexOf("e") !== -1) {
+    // Handle scientific notation
+    numberStr = value.toLocaleString("fullwide", {
+      useGrouping: false,
+      maximumFractionDigits: 20,
+    })
+  }
+
+  if (numberStr.indexOf(".") === -1) {
+    // Fallback to 0 decimals, this can happen with
+    // extremely large or small numbers
+    return 0
+  }
+
+  return numberStr.split(".")[1].length
+}
+
+/**
+ * Truncates a number to a specified number of decimal places without rounding.
+ *
+ * @param {number} value - The number to be truncated.
+ * @param {number} decimals - The number of decimal places to preserve after truncation.
+ *
+ * @returns {number} The truncated number.
+ *
+ * @example
+ * truncateDecimals(3.14159265, 2); // returns 3.14
+ * truncateDecimals(123.456, 0); // returns 123
+ */
+export function truncateDecimals(value: number, decimals: number): number {
+  return decimals === 0
+    ? Math.trunc(value)
+    : Math.trunc(value * 10 ** decimals) / 10 ** decimals
+}


### PR DESCRIPTION
## 📚 Context

This PR adds various improvements and changes to the number column type used with `st.dataframe` and `st.data_editor`:

- Rename min/max to min_value/max_value to be closer aligned to Streamlit widgets.
- Introduce the `format` configuration option based on `sprintf` syntax.
- Add `step` parameter that allows to set a granularity and define the precision of the value. This influences what the user can enter and also adapts the display to the given precision.
- Add the new `validate` functionality to validate the user input based on the configured config options.
- Adds two additional utils methods used in NumberColumn: `countDecimals` and `truncateDecimals`.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
