### PR TITLE
Change datetime column formatting to date-fns

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -7004,6 +7004,32 @@ Read more about MIT at [TLDRLegal](https://tldrlegal.com/license/mit-license).
 
 -----
 
+The following software may be included in this product: date-fns. A copy of the source code may be downloaded from https://github.com/date-fns/date-fns. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2021 Sasha Koss and Lesha Koss https://kossnocorp.mit-license.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: date-fns-tz. A copy of the source code may be downloaded from https://github.com/marnusw/date-fns-tz. This software contains the following license and notice below:
 
 The MIT License (MIT)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,8 @@
     "copy-to-clipboard": "^3.3.3",
     "d3": "^7.8.2",
     "d3-graphviz": "^2.6.1",
+    "date-fns": "^2.29.3",
+    "date-fns-tz": "^2.0.0",
     "decamelize": "^4.0.0",
     "deck.gl": "^8.8.23",
     "dompurify": "^2.4.4",

--- a/frontend/src/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
@@ -227,7 +227,7 @@ describe("DateTimeColumn", () => {
     const MOCK_DATETIME_COLUMN_CUSTOM_FORMAT = {
       ...MOCK_DATETIME_COLUMN_TEMPLATE,
       columnTypeOptions: {
-        format: "MMM Do, YYYY - HH:mm",
+        format: "MMM do, yyyy - HH:mm",
       },
     }
 
@@ -403,7 +403,7 @@ describe("DateColumn", () => {
     const MOCK_DATE_COLUMN_CUSTOM_FORMAT = {
       ...MOCK_DATE_COLUMN_TEMPLATE,
       columnTypeOptions: {
-        format: "MMM Do, YYYY",
+        format: "MMM do, yyyy",
       },
     }
 

--- a/frontend/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
@@ -51,7 +51,7 @@ function applyTimezone(momentDate: Moment, timezone: string): Moment {
 }
 
 export interface DateTimeColumnParams {
-  // A MomentJS formatting syntax to format the display value.
+  // A date-fns formatting syntax to format the display value.
   readonly format?: string
   // Specifies the granularity that the value must adhere.
   // For time and datetime, this is the number of seconds between each allowed value.

--- a/frontend/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
@@ -16,6 +16,9 @@
 
 import { GridCell, GridCellKind, TextCell } from "@glideapps/glide-data-grid"
 import moment, { Moment } from "moment"
+import "moment-timezone"
+
+import { notNullOrUndefined, isNullOrUndefined } from "src/lib/utils"
 
 import {
   BaseColumn,
@@ -24,9 +27,8 @@ import {
   toSafeDate,
   getErrorCell,
   toSafeString,
-} from "src/components/widgets/DataFrame/columns/utils"
-import { notNullOrUndefined, isNullOrUndefined } from "src/lib/utils"
-
+  formatMoment,
+} from "./utils"
 import { DateTimeCell } from "./cells/DateTimeCell"
 
 /**
@@ -233,7 +235,10 @@ function BaseDateTimeColumn(
         }
 
         try {
-          displayDate = momentDate.format(parameters.format)
+          displayDate = formatMoment(
+            momentDate,
+            parameters.format || defaultFormat
+          )
         } catch (error) {
           return getErrorCell(
             momentDate.toISOString(),
@@ -241,7 +246,7 @@ function BaseDateTimeColumn(
           )
         }
         // Copy data should always use the default format
-        copyData = momentDate.format(defaultFormat)
+        copyData = formatMoment(momentDate, defaultFormat)
       }
 
       if (!props.isEditable) {
@@ -304,7 +309,7 @@ export default function DateTimeColumn(props: BaseColumnProps): BaseColumn {
   return BaseDateTimeColumn(
     "datetime",
     props,
-    hasTimezone ? "YYYY-MM-DD HH:mm:ssZ" : "YYYY-MM-DD HH:mm:ss",
+    hasTimezone ? "yyyy-MM-dd HH:mm:ssxxx" : "yyyy-MM-dd HH:mm:ss",
     1,
     "datetime-local",
     (date: Date): string => {
@@ -361,7 +366,7 @@ export function DateColumn(props: BaseColumnProps): BaseColumn {
   return BaseDateTimeColumn(
     "date",
     props,
-    "YYYY-MM-DD",
+    "yyyy-MM-dd",
     1,
     "date",
     (date: Date): string => {

--- a/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -433,7 +433,7 @@ describe("truncateDecimals", () => {
 describe("formatMoment", () => {
   beforeAll(() => {
     jest.useFakeTimers("modern")
-    jest.setSystemTime(new Date("2023-04-28T00:00:00Z"))
+    jest.setSystemTime(new Date("2022-04-28T00:00:00Z"))
     timezoneMock.register("UTC")
   })
 
@@ -475,20 +475,20 @@ describe("formatMoment", () => {
       "April 27th, 2023 -02:30",
     ],
     // Distance:
-    ["distance", moment.utc("2023-04-10T20:20:30Z"), "2 weeks ago"],
-    ["distance", moment.utc("2021-04-10T20:20:30Z"), "2 years ago"],
-    ["distance", moment.utc("2023-04-27T23:59:59Z"), "1 second ago"],
-    ["distance", moment.utc("2023-04-20T00:00:00Z"), "last week"],
-    ["distance", moment.utc("2023-05-27T23:59:59Z"), "in 4 weeks"],
-    ["relative", moment.utc("2023-04-30T15:30:00Z"), "Sunday at 3:30 PM"],
+    ["distance", moment.utc("2022-04-10T20:20:30Z"), "2 weeks ago"],
+    ["distance", moment.utc("2020-04-10T20:20:30Z"), "2 years ago"],
+    ["distance", moment.utc("2022-04-27T23:59:59Z"), "1 second ago"],
+    ["distance", moment.utc("2022-04-20T00:00:00Z"), "last week"],
+    ["distance", moment.utc("2022-05-27T23:59:59Z"), "in 4 weeks"],
+    ["relative", moment.utc("2022-04-30T15:30:00Z"), "Saturday at 3:30 PM"],
     // Relative:
     [
       "relative",
-      moment.utc("2023-04-24T12:20:30Z"),
-      "last Monday at 12:20 PM",
+      moment.utc("2022-04-24T12:20:30Z"),
+      "last Sunday at 12:20 PM",
     ],
-    ["relative", moment.utc("2023-04-28T12:00:00Z"), "today at 12:00 PM"],
-    ["relative", moment.utc("2023-04-29T12:00:00Z"), "tomorrow at 12:00 PM"],
+    ["relative", moment.utc("2022-04-28T12:00:00Z"), "today at 12:00 PM"],
+    ["relative", moment.utc("2022-04-29T12:00:00Z"), "tomorrow at 12:00 PM"],
   ])(
     "uses %s format to format %p to %p",
     (format: string, momentDate: Moment, expected: string) => {

--- a/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -433,13 +433,13 @@ describe("truncateDecimals", () => {
 describe("formatMoment", () => {
   beforeAll(() => {
     jest.useFakeTimers("modern")
-    timezoneMock.register("UTC")
     jest.setSystemTime(new Date("2023-04-28T00:00:00Z"))
+    timezoneMock.register("UTC")
   })
 
   afterAll(() => {
-    timezoneMock.unregister()
     jest.useRealTimers()
+    timezoneMock.unregister()
   })
 
   it.each([
@@ -474,17 +474,6 @@ describe("formatMoment", () => {
       moment.utc("2023-04-27T10:20:30Z").utcOffset("-02:30"),
       "April 27th, 2023 -02:30",
     ],
-    // Localized:
-    [
-      "localized",
-      moment.utc("2023-04-10T10:20:30Z"),
-      "Apr 10, 2023, 12:20:30 PM",
-    ],
-    [
-      "localized",
-      moment.utc("2019-05-01T00:00:00Z"),
-      "May 1, 2019, 2:00:00 AM",
-    ],
     // Distance:
     ["distance", moment.utc("2023-04-10T20:20:30Z"), "2 weeks ago"],
     ["distance", moment.utc("2021-04-10T20:20:30Z"), "2 years ago"],
@@ -501,7 +490,7 @@ describe("formatMoment", () => {
     ["relative", moment.utc("2023-04-28T12:00:00Z"), "today at 12:00 PM"],
     ["relative", moment.utc("2023-04-29T12:00:00Z"), "tomorrow at 12:00 PM"],
   ])(
-    "formats date as %s",
+    "uses %s format to format %p to %p",
     (format: string, momentDate: Moment, expected: string) => {
       expect(formatMoment(momentDate, format)).toBe(expected)
     }

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -448,28 +448,23 @@ export function formatNumber(
  */
 export function formatMoment(momentDate: Moment, format: string): string {
   if (format === "localized") {
-    // date-fns intlFormat()
     return new Intl.DateTimeFormat(undefined, {
       dateStyle: "medium",
       timeStyle: "medium",
     }).format(momentDate.toDate())
   } else if (format === "distance") {
-    // return momentDate.fromNow()
     return intlFormatDistance(momentDate.toDate(), new Date())
   } else if (format === "relative") {
-    // return moment().calendar()
     return formatRelative(momentDate.toDate(), new Date())
   }
   const timezone = momentDate.tz()
   if (notNullOrUndefined(timezone)) {
-    console.log("timezone", timezone)
     // Format based on the timezone IANA name:
     return formatInTimeZone(momentDate.toDate(), timezone, format)
   }
 
   const utcOffset = momentDate.utcOffset()
   if (utcOffset !== 0) {
-    console.log("utcOffset", utcOffset)
     // Format based on the UTC offset:
     return formatInTimeZone(
       momentDate.toDate(),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6546,6 +6546,16 @@ date-fns-tz@^1.2.2:
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
   integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==
 
+date-fns-tz@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 date-fns@^2.6.0:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"


### PR DESCRIPTION
## 📚 Context

This PR migrates the datetime formatting for the date/time/datetime columns from momentJS to date-fns. We will still use momentJS for most datetime handling, but the formatting part will be done by date-fns. The reason is that we want to unify datetime formatting across all our widgets, and baseweb UI is using date-fns for some formatting parts. Also, momentJS is a custom sytnax while date-fns uses the [Unicode Technical Standard](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table). Since baseweb UI uses date-fns, we anyways have that already as a transitive dependency.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
