### PR TITLE
Refactor `st.dataframe` and `st.data_editor` number formatting

### DIFF
--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -48,6 +48,7 @@ import {
   getColumnFromArrow,
   getAllColumnsFromArrow,
   getCellFromArrow,
+  isIntegerType,
 } from "./arrowUtils"
 
 const MOCK_TEXT_COLUMN = TextColumn({
@@ -813,6 +814,72 @@ describe("getColumnTypeFromArrow", () => {
     "interprets %p as column type: %p",
     (arrowType: ArrowType, expectedType: ColumnCreator) => {
       expect(getColumnTypeFromArrow(arrowType)).toEqual(expectedType)
+    }
+  )
+})
+
+describe("isIntegerType", () => {
+  it.each([
+    [
+      {
+        pandas_type: "float64",
+        numpy_type: "float64",
+      },
+      false,
+    ],
+    [
+      {
+        pandas_type: "int64",
+        numpy_type: "int64",
+      },
+      true,
+    ],
+    [
+      {
+        pandas_type: "object",
+        numpy_type: "int16",
+      },
+      true,
+    ],
+    [
+      {
+        pandas_type: "uint64",
+        numpy_type: "uint64",
+      },
+      true,
+    ],
+    [
+      {
+        pandas_type: "unicode",
+        numpy_type: "object",
+      },
+      false,
+    ],
+    [
+      {
+        pandas_type: "bool",
+        numpy_type: "bool",
+      },
+      false,
+    ],
+    [
+      {
+        pandas_type: "categorical",
+        numpy_type: "int8",
+      },
+      false,
+    ],
+    [
+      {
+        pandas_type: "object",
+        numpy_type: "interval[int64, both]",
+      },
+      false,
+    ],
+  ])(
+    "interprets %p as integer type: %p",
+    (arrowType: ArrowType, expected: boolean) => {
+      expect(isIntegerType(Quiver.getTypeName(arrowType))).toEqual(expected)
     }
   )
 })

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -843,6 +843,13 @@ describe("isIntegerType", () => {
     ],
     [
       {
+        pandas_type: "range",
+        numpy_type: "range",
+      },
+      true,
+    ],
+    [
+      {
         pandas_type: "uint64",
         numpy_type: "uint64",
       },

--- a/frontend/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/src/components/widgets/DataFrame/arrowUtils.ts
@@ -420,3 +420,15 @@ export function getCellFromArrow(
   }
   return cellTemplate
 }
+
+/**
+ * Returns true if a given arrow type name is an integer type.
+ */
+export function isIntegerType(arrowTypeName: string): boolean {
+  return (
+    (arrowTypeName.startsWith("int") &&
+      !arrowTypeName.startsWith("interval")) ||
+    arrowTypeName === "range" ||
+    arrowTypeName.startsWith("uint")
+  )
+}

--- a/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -162,7 +162,7 @@ function BaseChartColumn(
         data: {
           ...cellTemplate.data,
           values: normalizedChartData,
-          displayValues: convertedChartData.map(v => formatNumber(v, 3)),
+          displayValues: convertedChartData.map(v => formatNumber(v)),
         },
         isMissingValue: isNullOrUndefined(data),
       } as SparklineCellType

--- a/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -245,6 +245,9 @@ describe("NumberColumn", () => {
   })
 
   it.each([
+    // This should support everything that is supported by formatNumber
+    // So we are not testing all the cases here, just a few to make sure it works
+    // All other cases are tested for formatNumber in utils.test.ts
     [10.123, "%d", "10"],
     [10.123, "%i", "10"],
     [10.123, "%u", "10"],
@@ -258,33 +261,8 @@ describe("NumberColumn", () => {
     [1234567898765432, "%d ⭐", "1234567898765432 ⭐"],
     [72.3, "%.1f%%", "72.3%"],
     [-5.678, "%.1f", "-5.7"],
-    [0.123456, "%.4f", "0.1235"],
-    [0.123456, "%.4g", "0.1235"],
-    // Test boolean formatting:
-    [1, "%t", "true"],
-    [0, "%t", "false"],
-    // Test zero-padding for integers
-    [42, "%05d", "00042"],
-    // Test scientific notations:
-    [1234.5678, "%.2e", "1.23e+3"],
-    [0.000123456, "%.2e", "1.23e-4"],
-    // Test hexadecimal representation:
-    [255, "%x", "ff"],
-    [255, "%X", "FF"],
-    [4096, "%X", "1000"],
-    // Test octal representation:
-    [8, "%o", "10"],
-    [64, "%o", "100"],
-    // Test fixed width formatting:
-    [12345, "%8d", "   12345"],
-    [12.34, "%8.2f", "   12.34"],
-    [12345, "%'_8d", "___12345"],
-    // Test left-justified formatting:
-    [12345, "%-8d", "12345   "],
-    [12.34, "%-8.2f", "12.34   "],
-    // Test prefixing with plus sign:
-    [42, "%+d", "+42"],
-    [-42, "%+d", "-42"],
+    [0.12, "percent", "12.00%"],
+    [1100, "compact", "1.1K"],
   ])(
     "formats %p to %p based on the sprintf format %p",
     (input: number, format: string, displayValue: string) => {

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -24,8 +24,8 @@ import {
   BaseGridCell,
 } from "@glideapps/glide-data-grid"
 import { toString, merge, isArray } from "lodash"
-import moment from "moment"
 import numbro from "numbro"
+import { sprintf } from "sprintf-js"
 
 import { Type as ArrowType } from "src/lib/Quiver"
 import { notNullOrUndefined, isNullOrUndefined } from "src/lib/utils"
@@ -405,31 +405,49 @@ export function toSafeNumber(value: any): number | null {
 }
 
 /**
- * Formats the given number to a string with the given maximum precision.
+ * Formats the given number to a string based on a provided format or the default format.
  *
  * @param value - The number to format.
- * @param maxPrecision - The maximum number of decimals to show.
- * @param keepTrailingZeros - Whether to keep trailing zeros.
+ * @param format - The format to use. If not provided, the default format is used.
+ * @param maxPrecision - The maximum number of decimals to show. This is only used by the default format.
+ *                     If not provided, the default is 4 decimals and trailing zeros are hidden.
  *
  * @returns The formatted number as a string.
  */
 export function formatNumber(
   value: number,
-  maxPrecision = 4,
-  keepTrailingZeros = false
-): string {
-  if (!Number.isNaN(value) && Number.isFinite(value)) {
+  format?: string | undefined,
+  maxPrecision?: number | undefined
+) {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return ""
+  }
+
+  if (isNullOrUndefined(format) || format === "") {
     if (maxPrecision === 0) {
       // Numbro is unable to format the number with 0 decimals.
       value = Math.round(value)
     }
     return numbro(value).format(
-      keepTrailingZeros
+      notNullOrUndefined(maxPrecision)
         ? `0,0.${"0".repeat(maxPrecision)}`
-        : `0,0.[${"0".repeat(maxPrecision)}]`
+        : `0,0.[0000]` // If no precision is given, use 4 decimals and hide trailing zeros
     )
   }
-  return ""
+
+  if (format === "percent") {
+    // return numbro(value).format("3%")
+    return new Intl.NumberFormat(undefined, {
+      style: "percent",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value)
+  } else if (["compact", "scientific", "engineering"].includes(format)) {
+    return new Intl.NumberFormat(undefined, {
+      notation: format as any,
+    }).format(value)
+  }
+  return sprintf(format, value)
 }
 
 /**

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -437,7 +437,6 @@ export function formatNumber(
   }
 
   if (format === "percent") {
-    // return numbro(value).format("3%")
     return new Intl.NumberFormat(undefined, {
       style: "percent",
       minimumFractionDigits: 2,

--- a/frontend/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/components/widgets/DataFrame/columns/utils.ts
@@ -26,6 +26,7 @@ import {
 import { toString, merge, isArray } from "lodash"
 import numbro from "numbro"
 import { sprintf } from "sprintf-js"
+import moment from "moment"
 
 import { Type as ArrowType } from "src/lib/Quiver"
 import { notNullOrUndefined, isNullOrUndefined } from "src/lib/utils"
@@ -418,7 +419,7 @@ export function formatNumber(
   value: number,
   format?: string | undefined,
   maxPrecision?: number | undefined
-) {
+): string {
   if (Number.isNaN(value) || !Number.isFinite(value)) {
     return ""
   }


### PR DESCRIPTION
## 📚 Context

This PR refactors the number formatting used in some column types for `st.dataframe` and `st.data_editor` into a shared function. This combines our default formatting, the formatting via sprintf, and a couple of extra formatting types (e.g. percent). It will also be used by the progress column (WIP).

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
