### PR TITLE
Clarify set_page_config docstring and exception message

### DIFF
--- a/e2e/specs/st_set_page_config.spec.js
+++ b/e2e/specs/st_set_page_config.spec.js
@@ -71,7 +71,7 @@ describe("st.set_page_config", () => {
       cy.getIndexed(".stButton button", 2).click();
 
       cy.get(".stException")
-        .contains("set_page_config() can only be called once per app")
+        .contains("set_page_config() can only be called once per app page")
         .should("exist");
       // Ensure that the first set_page_config worked
       cy.title().should("eq", "Change 1");
@@ -81,7 +81,7 @@ describe("st.set_page_config", () => {
       cy.getIndexed(".stButton button", 3).click();
 
       cy.get(".stException")
-        .contains("set_page_config() can only be called once per app")
+        .contains("set_page_config() can only be called once per app page")
         .should("exist");
       // Ensure that the first set_page_config worked
       cy.title().should("eq", "Change 3");

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -123,8 +123,8 @@ def set_page_config(
     Configures the default settings of the page.
 
     .. note::
-        This must be the first Streamlit command used in your app, and must only
-        be set once.
+        This must be the first Streamlit command used on an app page, and must only
+        be set once per page.
 
     Parameters
     ----------

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -88,7 +88,7 @@ class ScriptRunContext:
         """Enqueue a ForwardMsg for this context's session."""
         if msg.HasField("page_config_changed") and not self._set_page_config_allowed:
             raise StreamlitAPIException(
-                "`set_page_config()` can only be called once per app, "
+                "`set_page_config()` can only be called once per app page, "
                 + "and must be called as the first Streamlit command in your script.\n\n"
                 + "For more information refer to the [docs]"
                 + "(https://docs.streamlit.io/library/api-reference/utilities/st.set_page_config)."


### PR DESCRIPTION
## 📚 Context
Added documentation and exception clarification per Issue #6572

## 🧠 Description of Changes
Updated a few words in the `set_page_config` docstring.
Fixed associated exception message and tests to reflect being restricted to one call per page instead of per (whole) app.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
