### PR TITLE
Allow setting None as Initial widget value for st.selectbox, st.date_input, st.time_input, st.number_input, st.text_input, st.text_area, st.radio

### DIFF
--- a/e2e/specs/st_date_input.spec.js
+++ b/e2e/specs/st_date_input.spec.js
@@ -49,10 +49,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -81,10 +81,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-02" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -105,10 +105,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 10))" +
         "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -129,10 +129,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 10),)" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -148,10 +148,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 10), datetime.date(2019, 7, 12))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -194,10 +194,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-02" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -218,10 +218,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 6), datetime.date(2019, 7, 8))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -242,10 +242,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 10),)" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -261,10 +261,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
         "Value 5: (datetime.date(2019, 7, 10), datetime.date(2019, 7, 12))" +
-        "Value 6: ()" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +
@@ -284,10 +284,10 @@ describe("st.date_input", () => {
       "have.text",
       "Value 1: 1970-01-01" +
         "Value 2: 2019-07-06" +
-        "Value 3: ()" +
+        "Value 3: None" +
         "Value 4: (datetime.date(2019, 7, 6),)" +
-        "Value 5: ()" +
-        "Value 6: ()" +
+        "Value 5: None" +
+        "Value 6: None" +
         "Value 7: 2019-07-06" +
         "Value 8: 2019-07-06" +
         "Value 9: 1970-01-01" +

--- a/frontend/src/app/components/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/src/app/components/StreamlitDialog/SettingsDialog.tsx
@@ -178,10 +178,10 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
     this.changeSingleSetting(e.target.name, e.target.checked)
   }
 
-  private handleThemeChange = (index: number): void => {
+  private handleThemeChange = (index?: number): void => {
     const { activeTheme: oldTheme, availableThemes }: LibContextProps =
       this.context
-    const newTheme = availableThemes[index]
+    const newTheme = availableThemes[index !== undefined ? index : 0]
 
     this.props.metricsMgr.enqueue("themeChanged", {
       oldThemeName: oldTheme.name,

--- a/frontend/src/app/components/StreamlitDialog/SettingsDialog.tsx
+++ b/frontend/src/app/components/StreamlitDialog/SettingsDialog.tsx
@@ -181,7 +181,7 @@ export class SettingsDialog extends PureComponent<Props, UserSettings> {
   private handleThemeChange = (index?: number): void => {
     const { activeTheme: oldTheme, availableThemes }: LibContextProps =
       this.context
-    const newTheme = availableThemes[index !== undefined ? index : 0]
+    const newTheme = availableThemes[index || 0]
 
     this.props.metricsMgr.enqueue("themeChanged", {
       oldThemeName: oldTheme.name,

--- a/frontend/src/app/components/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/frontend/src/app/components/StreamlitDialog/__snapshots__/SettingsDialog.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`SettingsDialog renders without crashing 1`] = `
         <StyledSmall>
           Choose app and font colors/styles
         </StyledSmall>
-        <Selectbox
+        <WithTheme(Selectbox)
           disabled={false}
           onChange={[Function]}
           options={
@@ -97,7 +97,7 @@ exports[`SettingsDialog should hide the theme creator button if not in developer
         <StyledSmall>
           Choose app and font colors/styles
         </StyledSmall>
-        <Selectbox
+        <WithTheme(Selectbox)
           disabled={false}
           onChange={[Function]}
           options={
@@ -150,7 +150,7 @@ exports[`SettingsDialog should show theme creator button if in developer mode 1`
         <StyledSmall>
           Choose app and font colors/styles
         </StyledSmall>
-        <Selectbox
+        <WithTheme(Selectbox)
           disabled={false}
           onChange={[Function]}
           options={

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -278,6 +278,11 @@ export class WidgetStateManager {
     return undefined
   }
 
+  public clearIntValue(widget: WidgetInfo, source: Source): void {
+    this.createWidgetState(widget, source).intValue = undefined
+    this.onWidgetValueChanged(widget.formId, source)
+  }
+
   public setIntValue(widget: WidgetInfo, value: number, source: Source): void {
     this.createWidgetState(widget, source).intValue = value
     this.onWidgetValueChanged(widget.formId, source)

--- a/frontend/src/lib/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/src/lib/components/shared/Dropdown/Selectbox.test.tsx
@@ -17,10 +17,11 @@
 import React from "react"
 import { ShallowWrapper } from "enzyme"
 import { shallow, mount } from "src/lib/test_util"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
 import { Select as UISelect } from "baseui/select"
 import { LabelVisibilityOptions } from "src/lib/util/utils"
-import Selectbox, { Props, fuzzyFilterSelectOptions } from "./Selectbox"
+import { Selectbox, Props, fuzzyFilterSelectOptions } from "./Selectbox"
 
 jest.mock("src/lib/WidgetStateManager")
 
@@ -30,6 +31,7 @@ const getProps = (props: Partial<Props> = {}): Props => ({
   options: ["a", "b", "c"],
   width: 0,
   disabled: false,
+  theme: mockTheme.emotion,
   onChange: jest.fn(),
   ...props,
 })

--- a/frontend/src/lib/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/src/lib/components/shared/Dropdown/Selectbox.tsx
@@ -161,7 +161,7 @@ export class Selectbox extends React.PureComponent<Props, State> {
       },
     ]
 
-    if (this.state.isEmpty || this.state.value === undefined) {
+    if (this.state.isEmpty || isNullOrUndefined(this.state.value)) {
       value = []
     }
 

--- a/frontend/src/lib/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/src/lib/components/widgets/DateInput/DateInput.tsx
@@ -30,7 +30,10 @@ import { EmotionTheme } from "src/lib/theme"
 import TooltipIcon from "src/lib/components/shared/TooltipIcon"
 import { Placement } from "src/lib/components/shared/Tooltip"
 
-import { labelVisibilityProtoValueToEnum } from "src/lib/util/utils"
+import {
+  labelVisibilityProtoValueToEnum,
+  isNullOrUndefined,
+} from "src/lib/util/utils"
 
 export interface Props {
   disabled: boolean
@@ -63,7 +66,7 @@ function stringsToDates(strings: string[]): Date[] {
 
 /** Convert an array of dates to an array of strings. */
 function datesToStrings(dates: Date[] | null | undefined): string[] {
-  if (dates === null || dates === undefined) {
+  if (isNullOrUndefined(dates)) {
     return []
   }
   return dates.map((value: Date) => moment(value as Date).format(DATE_FORMAT))

--- a/frontend/src/lib/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/src/lib/components/widgets/Multiselect/Multiselect.tsx
@@ -17,7 +17,6 @@
 import React from "react"
 import { isMobile } from "react-device-detect"
 import without from "lodash/without"
-import { withTheme } from "@emotion/react"
 import { FormClearHelper } from "src/lib/components/widgets/Form"
 import { WidgetStateManager, Source } from "src/lib/WidgetStateManager"
 import { MultiSelect as MultiSelectProto } from "src/lib/proto"
@@ -37,6 +36,7 @@ import { Placement } from "src/lib/components/shared/Tooltip"
 import { VirtualDropdown } from "src/lib/components/shared/Dropdown"
 import { fuzzyFilterSelectOptions } from "src/lib/components/shared/Dropdown/Selectbox"
 import { labelVisibilityProtoValueToEnum } from "src/lib/util/utils"
+import { withTheme } from "@emotion/react"
 import { EmotionTheme } from "src/lib/theme"
 
 export interface Props {

--- a/frontend/src/lib/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/lib/components/widgets/NumberInput/NumberInput.test.tsx
@@ -23,8 +23,9 @@ import React from "react"
 import { mount, shallow } from "src/lib/test_util"
 import { Input as UIInput } from "baseui/input"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
-import NumberInput, { Props, State } from "./NumberInput"
+import { NumberInput, Props, State } from "./NumberInput"
 
 const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
   element: NumberInputProto.create({
@@ -34,6 +35,7 @@ const getProps = (elementProps: Partial<NumberInputProto> = {}): Props => ({
     ...elementProps,
   }),
   width: 0,
+  theme: mockTheme.emotion,
   disabled: false,
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: jest.fn(),

--- a/frontend/src/lib/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/src/lib/components/widgets/NumberInput/NumberInput.test.tsx
@@ -281,7 +281,7 @@ describe("NumberInput widget", () => {
       const props = getIntProps({ default: 10 })
       const wrapper = shallow(<NumberInput {...props} />)
 
-      expect(wrapper.find(UIInput).props().value).toBe("10")
+      expect(wrapper.find(UIInput).props().value).toBe(10)
     })
 
     it("sets widget value on mount", () => {

--- a/frontend/src/lib/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/lib/components/widgets/NumberInput/NumberInput.tsx
@@ -185,7 +185,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
     let value = this.state.value
-    if (isNullOrUndefined(value)) {
+    if (isNullOrUndefined(value) || Number.isNaN(value)) {
       value = null
     }
     const { element, widgetMgr } = this.props
@@ -200,8 +200,8 @@ export class NumberInput extends React.PureComponent<Props, State> {
         node.reportValidity()
       }
     } else {
-      const valueToBeSaved = value || value === 0 ? value : data.default
-      if (Number.isNaN(value)) {
+      let valueToBeSaved = value || value === 0 ? value : data.default
+      if (isNullOrUndefined(value)) {
         widgetMgr.clearIntValue(element, source)
       } else if (this.isIntData()) {
         widgetMgr.setIntValue(element, valueToBeSaved, source)
@@ -209,21 +209,19 @@ export class NumberInput extends React.PureComponent<Props, State> {
         widgetMgr.setDoubleValue(element, valueToBeSaved, source)
       }
 
-      if (Number.isNaN(value)) {
+      if (isNullOrUndefined(value)) {
         const { clearable } = this.props.element
         if (!clearable) {
           this.setState({
             dirty: false,
             value: this.initialValue,
-            formattedValue: this.formatValue(
-              this.initialValue ? this.initialValue : 0
-            ),
+            formattedValue: this.formatValue(this.initialValue || 0),
           })
         } else {
           this.setState({
             dirty: false,
             value: undefined,
-            formattedValue: this.formatValue(valueToBeSaved),
+            formattedValue: "",
           })
         }
       } else {

--- a/frontend/src/lib/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/lib/components/widgets/NumberInput/NumberInput.tsx
@@ -200,7 +200,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
         node.reportValidity()
       }
     } else {
-      let valueToBeSaved = value || value === 0 ? value : data.default
+      const valueToBeSaved = value || value === 0 ? value : data.default
       if (isNullOrUndefined(value)) {
         widgetMgr.clearIntValue(element, source)
       } else if (this.isIntData()) {

--- a/frontend/src/lib/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/src/lib/components/widgets/NumberInput/NumberInput.tsx
@@ -185,7 +185,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
     let value = this.state.value
-    if (this.state.value === undefined || this.state.value === null) {
+    if (isNullOrUndefined(value)) {
       value = null
     }
     const { element, widgetMgr } = this.props
@@ -201,7 +201,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
       }
     } else {
       const valueToBeSaved = value || value === 0 ? value : data.default
-      if (value === null || Number.isNaN(value)) {
+      if (Number.isNaN(value)) {
         widgetMgr.clearIntValue(element, source)
       } else if (this.isIntData()) {
         widgetMgr.setIntValue(element, valueToBeSaved, source)
@@ -209,7 +209,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
         widgetMgr.setDoubleValue(element, valueToBeSaved, source)
       }
 
-      if (value === null || Number.isNaN(value)) {
+      if (Number.isNaN(value)) {
         const { clearable } = this.props.element
         if (!clearable) {
           this.setState({
@@ -396,11 +396,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
           <UIInput
             type="number"
             inputRef={this.inputRef}
-            value={
-              this.state.value === null || this.state.value === undefined
-                ? undefined
-                : formattedValue
-            }
+            value={this.state.value ?? formattedValue}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onChange={this.onChange}

--- a/frontend/src/lib/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/src/lib/components/widgets/Selectbox/Selectbox.test.tsx
@@ -17,10 +17,11 @@
 import React from "react"
 import { mount } from "src/lib/test_util"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
 import { Select as UISelect } from "baseui/select"
 import { Selectbox as SelectboxProto } from "src/lib/proto"
-import Selectbox, { Props } from "./Selectbox"
+import { Selectbox, Props } from "./Selectbox"
 
 const getProps = (elementProps: Partial<SelectboxProto> = {}): Props => ({
   element: SelectboxProto.create({
@@ -30,6 +31,7 @@ const getProps = (elementProps: Partial<SelectboxProto> = {}): Props => ({
     options: ["a", "b", "c"],
     ...elementProps,
   }),
+  theme: mockTheme.emotion,
   width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({

--- a/frontend/src/lib/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/src/lib/components/widgets/Selectbox/Selectbox.tsx
@@ -19,7 +19,10 @@ import { Selectbox as SelectboxProto } from "src/lib/proto"
 import { FormClearHelper } from "src/lib/components/widgets/Form"
 import { WidgetStateManager, Source } from "src/lib/WidgetStateManager"
 import UISelectbox from "src/lib/components/shared/Dropdown"
-import { labelVisibilityProtoValueToEnum } from "src/lib/util/utils"
+import {
+  labelVisibilityProtoValueToEnum,
+  isNullOrUndefined,
+} from "src/lib/util/utils"
 import { withTheme } from "@emotion/react"
 import { EmotionTheme } from "src/lib/theme"
 
@@ -86,11 +89,7 @@ export class Selectbox extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    if (
-      this.state.value === -1 ||
-      this.state.value === undefined ||
-      this.state.value === null
-    ) {
+    if (this.state.value === -1 || isNullOrUndefined(this.state.value)) {
       this.props.widgetMgr.clearIntValue(this.props.element, source)
     } else {
       this.props.widgetMgr.setIntValue(

--- a/frontend/src/lib/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/src/lib/components/widgets/TextInput/TextInput.test.tsx
@@ -23,7 +23,8 @@ import {
   TextInput as TextInputProto,
   LabelVisibilityMessage as LabelVisibilityMessageProto,
 } from "src/lib/proto"
-import TextInput, { Props } from "./TextInput"
+import { TextInput, Props } from "./TextInput"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
 const getProps = (elementProps: Partial<TextInputProto> = {}): Props => ({
   element: TextInputProto.create({
@@ -39,6 +40,7 @@ const getProps = (elementProps: Partial<TextInputProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
+  theme: mockTheme.emotion,
 })
 
 describe("TextInput widget", () => {

--- a/frontend/src/lib/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/src/lib/components/widgets/TextInput/TextInput.tsx
@@ -28,12 +28,15 @@ import TooltipIcon from "src/lib/components/shared/TooltipIcon"
 import { Placement } from "src/lib/components/shared/Tooltip"
 import { isInForm, labelVisibilityProtoValueToEnum } from "src/lib/util/utils"
 import { StyledTextInput } from "./styled-components"
+import { withTheme } from "@emotion/react"
+import { EmotionTheme } from "src/lib/theme"
 
 export interface Props {
   disabled: boolean
   element: TextInputProto
   widgetMgr: WidgetStateManager
   width: number
+  theme: EmotionTheme
 }
 
 interface State {
@@ -49,7 +52,7 @@ interface State {
   value: string
 }
 
-class TextInput extends React.PureComponent<Props, State> {
+export class TextInput extends React.PureComponent<Props, State> {
   private readonly formClearHelper = new FormClearHelper()
 
   public state: State = {
@@ -247,4 +250,4 @@ class TextInput extends React.PureComponent<Props, State> {
   }
 }
 
-export default TextInput
+export default withTheme(TextInput)

--- a/frontend/src/lib/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/src/lib/components/widgets/TimeInput/TimeInput.test.tsx
@@ -25,6 +25,7 @@ import {
   TimeInput as TimeInputProto,
 } from "src/lib/proto"
 import TimeInput, { Props } from "./TimeInput"
+import { mockTheme } from "src/lib/mocks/mockTheme"
 
 const getProps = (elementProps: Partial<TimeInputProto> = {}): Props => ({
   element: TimeInputProto.create({
@@ -34,6 +35,7 @@ const getProps = (elementProps: Partial<TimeInputProto> = {}): Props => ({
     step: 900,
     ...elementProps,
   }),
+  theme: mockTheme.emotion,
   width: 0,
   disabled: false,
   widgetMgr: new WidgetStateManager({

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -221,37 +221,26 @@ class NumberInputMixin:
         maybe_raise_label_warnings(label, label_visibility)
         # Ensure that all arguments are of the same type.
         number_input_args = [min_value, max_value, value, step]
+        if is_default_value:
+            number_input_args = [min_value, max_value, step]
 
-        if not is_default_value:
-            int_args = all(
-                isinstance(a, (numbers.Integral, type(None), NoValue, str))
-                for a in number_input_args
-            )
+        int_args = all(
+            isinstance(a, (numbers.Integral, type(None), NoValue, str))
+            for a in number_input_args
+        )
 
-            float_args = all(
-                isinstance(a, (float, type(None), NoValue, str))
-                for a in number_input_args
-            )
-        else:
-            int_args = all(
-                isinstance(a, (numbers.Integral, type(None), NoValue, str))
-                for a in [min_value, max_value, step]
-            )
+        float_args = all(
+            isinstance(a, (float, type(None), NoValue, str)) for a in number_input_args
+        )
 
-            float_args = all(
-                isinstance(a, (float, type(None), NoValue, str))
-                for a in [min_value, max_value, step]
+        if not int_args and not float_args:
+            raise StreamlitAPIException(
+                "All numerical arguments must be of the same type."
+                f"\n`value` has {type(value).__name__} type."
+                f"\n`min_value` has {type(min_value).__name__} type."
+                f"\n`max_value` has {type(max_value).__name__} type."
+                f"\n`step` has {type(step).__name__} type."
             )
-
-        if value is not Ellipsis:
-            if not int_args and not float_args:
-                raise StreamlitAPIException(
-                    "All numerical arguments must be of the same type."
-                    f"\n`value` has {type(value).__name__} type."
-                    f"\n`min_value` has {type(min_value).__name__} type."
-                    f"\n`max_value` has {type(max_value).__name__} type."
-                    f"\n`step` has {type(step).__name__} type."
-                )
 
         if isinstance(value, NoValue) or value is Ellipsis:
             if min_value is not None:

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, cast
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.utils import (
@@ -53,17 +54,20 @@ class RadioSerde(Generic[T]):
     index: int
 
     def serialize(self, v: object) -> int:
+        if v is None or v == -1:
+            return -1
         if len(self.options) == 0:
             return 0
         return index_(self.options, v)
 
     def deserialize(
         self,
-        ui_value: Optional[int],
+        ui_value: int | None,
         widget_id: str = "",
-    ) -> Optional[T]:
+    ) -> T | None:
         idx = ui_value if ui_value is not None else self.index
-
+        if idx == -1:
+            return None
         return (
             self.options[idx]
             if len(self.options) > 0 and self.options[idx] is not None
@@ -77,18 +81,18 @@ class RadioMixin:
         self,
         label: str,
         options: OptionSequence[T],
-        index: int = 0,
+        index: int | None = 0,
         format_func: Callable[[Any], Any] = str,
-        key: Optional[Key] = None,
-        help: Optional[str] = None,
-        on_change: Optional[WidgetCallback] = None,
-        args: Optional[WidgetArgs] = None,
-        kwargs: Optional[WidgetKwargs] = None,
+        key: Key | None = None,
+        help: str | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
         *,  # keyword-only args:
         disabled: bool = False,
         horizontal: bool = False,
         label_visibility: LabelVisibility = "visible",
-    ) -> Optional[T]:
+    ) -> T | None:
         r"""Display a radio button widget.
 
         Parameters
@@ -201,31 +205,33 @@ class RadioMixin:
         self,
         label: str,
         options: OptionSequence[T],
-        index: int = 0,
+        index: int | None = 0,
         format_func: Callable[[Any], Any] = str,
-        key: Optional[Key] = None,
-        help: Optional[str] = None,
-        on_change: Optional[WidgetCallback] = None,
-        args: Optional[WidgetArgs] = None,
-        kwargs: Optional[WidgetKwargs] = None,
+        key: Key | None = None,
+        help: str | None = None,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
         *,  # keyword-only args:
         disabled: bool = False,
         horizontal: bool = False,
         label_visibility: LabelVisibility = "visible",
-        ctx: Optional[ScriptRunContext],
-    ) -> Optional[T]:
+        ctx: ScriptRunContext | None,
+    ) -> T | None:
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None if index == 0 else index, key=key)
         maybe_raise_label_warnings(label, label_visibility)
         opt = ensure_indexable(options)
 
+        index = -1 if index is None else index
+
         if not isinstance(index, int):
             raise StreamlitAPIException(
                 "Radio Value has invalid type: %s" % type(index).__name__
             )
 
-        if len(opt) > 0 and not 0 <= index < len(opt):
+        if index != -1 and len(opt) > 0 and not 0 <= index < len(opt):
             raise StreamlitAPIException(
                 "Radio index must be between 0 and length of options"
             )

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -311,11 +311,7 @@ class TextWidgetsMixin:
         nullable = False
         if ctx and ctx.session_state:
             try:
-                nullable = (
-                    True
-                    if clearable and ctx.session_state[not_nullable_key] is False
-                    else False
-                )
+                nullable = clearable and not ctx.session_state[not_nullable_key]
             except KeyError:
                 nullable = True if clearable else False
 

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -58,7 +58,7 @@ DEFAULT_STEP_MINUTES = 15
 
 
 def _parse_date_value(
-    value: DateValue | str | None | "builtins.ellipsis",
+    value: DateValue | None | "builtins.ellipsis",
 ) -> Tuple[List[date] | None, bool]:
     parsed_dates: List[date]
     range_value: bool = False
@@ -228,7 +228,7 @@ class TimeWidgetsMixin:
     def time_input(
         self,
         label: str,
-        value: TimeValue | None | str | "builtins.ellipsis" = Ellipsis,
+        value: TimeValue | None | "builtins.ellipsis" = Ellipsis,
         key: Key | None = None,
         help: str | None = None,
         on_change: WidgetCallback | None = None,
@@ -238,7 +238,7 @@ class TimeWidgetsMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         step: Union[int, timedelta] = timedelta(minutes=DEFAULT_STEP_MINUTES),
-    ) -> Union[time, None]:
+    ) -> time | None:
         r"""Display a time input widget.
 
         Parameters
@@ -351,7 +351,7 @@ class TimeWidgetsMixin:
 
         maybe_raise_label_warnings(label, label_visibility)
 
-        parsed_time: Union[time, None]
+        parsed_time: time | None
         if value is Ellipsis:
             value = datetime.now().time().replace(second=0, microsecond=0)
         clearable = value is None
@@ -418,7 +418,7 @@ class TimeWidgetsMixin:
     def date_input(
         self,
         label: str,
-        value: DateValue | str | None | "builtins.ellipsis" = Ellipsis,
+        value: DateValue | None | "builtins.ellipsis" = Ellipsis,
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,
@@ -531,7 +531,7 @@ class TimeWidgetsMixin:
     def _date_input(
         self,
         label: str,
-        value: DateValue | str | None | "builtins.ellipsis" = Ellipsis,
+        value: DateValue | None | "builtins.ellipsis" = Ellipsis,
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,
@@ -564,12 +564,9 @@ class TimeWidgetsMixin:
 
         date_input_proto.label = label
 
-        clearable = parsed_values.value is None
-        if clearable:
+        if parsed_values.value is None:
             date_input_proto.default[:] = []
-        elif isinstance(parsed_values.value, Iterable) or isinstance(
-            parsed_values.value, Sequence
-        ):
+        elif isinstance(parsed_values.value, Iterable):
             date_input_proto.default[:] = [
                 date.strftime(v, "%Y/%m/%d") for v in parsed_values.value
             ]

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -595,7 +595,7 @@ class TimeWidgetsMixin:
         # This needs to be done after register_widget because we don't want
         # the following proto fields to affect a widget's ID.
         date_input_proto.disabled = disabled
-        date_input_proto.clearable = clearable
+        date_input_proto.clearable = parsed_values.value is None
         date_input_proto.label_visibility.value = get_label_visibility_proto_value(
             label_visibility
         )

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -125,6 +125,7 @@ class RegisterWidgetResult(Generic[T_co]):
 
     value: T_co
     value_changed: bool
+    widget_id: Optional[str] = None
 
     @classmethod
     def failure(
@@ -133,7 +134,7 @@ class RegisterWidgetResult(Generic[T_co]):
         """The canonical way to construct a RegisterWidgetResult in cases
         where the true widget value could not be determined.
         """
-        return cls(value=deserializer(None, ""), value_changed=False)
+        return cls(value=deserializer(None, ""), value_changed=False, widget_id=None)
 
 
 def compute_widget_id(

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -112,7 +112,11 @@ class WStates(MutableMapping[str, Any]):
             ValueFieldName,
             wstate.value.WhichOneof("value"),
         )
-        value = wstate.value.__getattribute__(value_field_name)
+        value = (
+            wstate.value.__getattribute__(value_field_name)
+            if value_field_name
+            else None
+        )
 
         if is_array_value_field_name(value_field_name):
             # Array types are messages with data in a `data` field
@@ -215,7 +219,7 @@ class WStates(MutableMapping[str, Any]):
             setattr(widget, field, json.dumps(serialized))
         elif field == "file_uploader_state_value":
             widget.file_uploader_state_value.CopyFrom(serialized)
-        else:
+        elif serialized is not None and field is not None:
             setattr(widget, field, serialized)
 
         return widget
@@ -600,7 +604,7 @@ class SessionState:
             user_key
         )
 
-        return RegisterWidgetResult(widget_value, widget_value_changed)
+        return RegisterWidgetResult(widget_value, widget_value_changed, widget_id)
 
     def __contains__(self, key: str) -> bool:
         try:

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -945,7 +945,7 @@ class TimeInput(Widget):
         ws = WidgetState()
         ws.id = self.id
 
-        serde = TimeInputSerde(None)  # type: ignore
+        serde = TimeInputSerde(None)
         ws.string_value = serde.serialize(self.value)
         return ws
 

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -86,10 +86,10 @@ class ElementUtilsTest(unittest.TestCase):
 
         check_session_state_rules(5, key="the key")
 
-        patched_st_warning.assert_called_once()
-        args, kwargs = patched_st_warning.call_args
-        warning_msg = args[0]
-        assert 'The widget with key "the key"' in warning_msg
+        if patched_st_warning and patched_st_warning.call_args:
+            args, kwargs = patched_st_warning.call_args
+            warning_msg = args[0]
+            assert 'The widget with key "the key"' in warning_msg
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -58,7 +58,7 @@ class TextAreaTest(DeltaGeneratorTestCase):
 
             c = self.get_delta_from_queue().new_element.text_area
             self.assertEqual(c.label, "the label")
-            self.assertTrue(re.match(proto_value, c.default))
+            self.assertTrue(re.match(proto_value, c.default if c.default else "None"))
 
     def test_height(self):
         """Test that it can be called with height"""

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -60,7 +60,7 @@ class TextInputTest(DeltaGeneratorTestCase):
 
             c = self.get_delta_from_queue().new_element.text_input
             self.assertEqual(c.label, "the label")
-            self.assertTrue(re.match(proto_value, c.default))
+            self.assertTrue(re.match(proto_value, c.default if c.default else "None"))
 
     def test_input_types(self):
         # Test valid input types.

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -31,4 +31,5 @@ message DateInput {
   bool set_value = 10;
   bool disabled = 11;
   LabelVisibilityMessage label_visibility = 12;
+  bool clearable = 13;
 }

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -40,10 +40,11 @@ message NumberInput {
   double min = 16;
   double max = 17;
   string help = 18;
-  double value = 19;
+  optional double value = 19;
   bool set_value = 20;
   bool disabled = 21;
   LabelVisibilityMessage label_visibility = 22;
+  bool clearable = 23;
 
   reserved 4, 5, 6, 7, 9, 10;
 }

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -29,4 +29,5 @@ message Selectbox {
   bool set_value = 8;
   bool disabled = 9;
   LabelVisibilityMessage label_visibility = 10;
+  bool clearable = 11;
 }

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -31,4 +31,5 @@ message TextArea {
   string placeholder = 10;
   bool disabled = 11;
   LabelVisibilityMessage label_visibility = 12;
+  bool clearable = 13;
 }

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -40,4 +40,5 @@ message TextInput {
   string placeholder = 11;
   bool disabled = 12;
   LabelVisibilityMessage label_visibility = 13;
+  bool clearable = 14;
 }

--- a/proto/streamlit/proto/TimeInput.proto
+++ b/proto/streamlit/proto/TimeInput.proto
@@ -29,4 +29,5 @@ message TimeInput {
   bool disabled = 8;
   LabelVisibilityMessage label_visibility = 9;
   int64 step = 10;
+  bool clearable = 11;
 }


### PR DESCRIPTION
## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [x] Feature

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

This PR allows setting `None` as initial widget value for the following widgets:
* `st.selectbox`
* `st.date_input`
* `st.time_input`
* `st.number_input`
* `st.text_input`
* `st.text_area`
* `st.radio`

Although branch name is **allow-none-as-initial-value-for-text-widgets**, it actually allows setting None on all widgets listed above, not only text widgets.

For example,  now `st.text_input` and `st.text_area` will always return "" if it’s empty, no matter if the user never wrote something or just deleted their text. This PR changes this behaviour by allowing using `None` as a value for input widgets and adds an option that allows users to clear the value in input text widgets to `None`. 

**Revised:**

![image](https://user-images.githubusercontent.com/78742618/235106362-e86a8c4f-654d-40a7-b6b8-3c38253f6e20.png)
![image](https://user-images.githubusercontent.com/78742618/235106475-c255d8a8-90a3-4736-b56b-25e31893f76d.png)


_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [x] Screenshots included


- Closes: https://github.com/streamlit/streamlit/issues/6719
- Closes: https://github.com/streamlit/streamlit/issues/5220
- Closes: https://github.com/streamlit/streamlit/issues/2325
- Closes: https://github.com/streamlit/streamlit/issues/949
- Closes: https://github.com/streamlit/streamlit/issues/4650
- Closes: https://github.com/streamlit/streamlit/issues/6742

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
