### PR TITLE
[Draft] Add st.toast widget

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1230,6 +1230,7 @@ export class App extends PureComponent<Props, State> {
       pageScriptHash = ""
     }
 
+    console.log("-------- RERUN SCRIPT REQUESTED ----------")
     this.sendBackMsg(
       new BackMsg({
         rerunScript: { queryString, widgetStates, pageScriptHash, pageName },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1500,6 +1500,8 @@ export class App extends PureComponent<Props, State> {
           showFooter: !isEmbed() || isFooterDisplayed(),
           showToolbar: !isEmbed() || isToolbarDisplayed(),
           showColoredLine: !isEmbed() || isColoredLineDisplayed(),
+          communityCloud:
+            this.props.hostCommunication.currentState.toolbarItems.length > 0,
         }}
       >
         <HotKeys

--- a/frontend/src/components/core/AppContext/index.tsx
+++ b/frontend/src/components/core/AppContext/index.tsx
@@ -38,6 +38,7 @@ export interface Props {
   setTheme: (theme: ThemeConfig) => void
   availableThemes: ThemeConfig[]
   addThemes: (themes: ThemeConfig[]) => void
+  communityCloud: boolean
   sidebarChevronDownshift: number
   getBaseUriParts: () => BaseUriParts | undefined
 }
@@ -60,6 +61,7 @@ export default React.createContext<Props>({
   setTheme: () => {},
   availableThemes: [],
   addThemes: () => {},
+  communityCloud: false,
   sidebarChevronDownshift: 0,
   getBaseUriParts: getWindowBaseUriParts,
 })

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -26,6 +26,8 @@ import { ComponentRegistry } from "src/components/widgets/CustomComponent"
 import { sendMessageToHost } from "src/hocs/withHostCommunication"
 
 import AppContext from "src/components/core/AppContext"
+import ToastRenderer from "src/components/core/ToastRenderer"
+
 import { BlockNode, AppRoot } from "src/lib/AppNode"
 import { SessionInfo } from "src/lib/SessionInfo"
 
@@ -166,6 +168,8 @@ function AppView(props: AppViewProps): ReactElement {
         className="main"
       >
         {renderBlock(elements.main)}
+        {/* Container for all app toasts */}
+        <ToastRenderer />
         {/* Anchor indicates to the iframe resizer that this is the lowest
         possible point to determine height */}
         <StyledIFrameResizerAnchor

--- a/frontend/src/components/core/AppView/AppView.tsx
+++ b/frontend/src/components/core/AppView/AppView.tsx
@@ -168,7 +168,7 @@ function AppView(props: AppViewProps): ReactElement {
         className="main"
       >
         {renderBlock(elements.main)}
-        {/* Container for all app toasts */}
+        {/* Container consolidating all toasts within an app */}
         <ToastRenderer />
         {/* Anchor indicates to the iframe resizer that this is the lowest
         possible point to determine height */}

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -37,6 +37,7 @@ import {
   TextArea as TextAreaProto,
   TextInput as TextInputProto,
   TimeInput as TimeInputProto,
+  Toast as ToastProto,
   DeckGlJsonChart as DeckGlJsonChartProto,
   DocString as DocStringProto,
   Exception as ExceptionProto,
@@ -69,6 +70,8 @@ import Markdown from "src/components/elements/Markdown/"
 import Metric from "src/components/elements/Metric/"
 import Table from "src/components/elements/Table/"
 import Text from "src/components/elements/Text/"
+import Toast from "src/components/elements/Toast/"
+
 import { ComponentInstance } from "src/components/widgets/CustomComponent/"
 import { Kind } from "src/components/shared/AlertContainer"
 import { VegaLiteChartElement } from "src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart"
@@ -361,6 +364,16 @@ const RawElementNodeRenderer = (
 
     case "text":
       return <Text width={width} element={node.element.text as TextProto} />
+
+    case "toast":
+      const toastProto = node.element.toast as ToastProto
+      return (
+        <Toast
+          text={toastProto.text}
+          icon={toastProto.icon}
+          type={toastProto.type}
+        />
+      )
 
     case "metric":
       return <Metric element={node.element.metric as MetricProto} />

--- a/frontend/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/components/core/Block/ElementNodeRenderer.tsx
@@ -367,7 +367,8 @@ const RawElementNodeRenderer = (
 
     case "toast":
       const toastProto = node.element.toast as ToastProto
-      return (
+      return hideIfStale(
+        props.isStale,
         <Toast
           text={toastProto.text}
           icon={toastProto.icon}

--- a/frontend/src/components/core/Block/styled-components.ts
+++ b/frontend/src/components/core/Block/styled-components.ts
@@ -80,6 +80,12 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
           display: "none",
         }
       : {}),
+    ...(elementType === "toast"
+      ? {
+          // Use display: none for empty elements to avoid the flexbox gap.
+          display: "none",
+        }
+      : {}),
     ...(elementType === "balloons"
       ? {
           // Apply negative bottom margin to remove the flexbox gap.

--- a/frontend/src/components/core/ToastRenderer/ToastRenderer.tsx
+++ b/frontend/src/components/core/ToastRenderer/ToastRenderer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactElement } from "react"
+import React, { ReactElement, useEffect } from "react"
 import { ToasterContainer, PLACEMENT } from "baseui/toast"
 
 import AppContext from "src/components/core/AppContext"
@@ -22,6 +22,15 @@ import AppContext from "src/components/core/AppContext"
 // Toasts should all be rendered under one ToasterContainer
 export function ToastRenderer(): ReactElement {
   const { communityCloud } = React.useContext(AppContext)
+
+  useEffect(() => {
+    let mounted = true
+    console.log("CONTAINER STATE: ", mounted)
+    return () => {
+      mounted = false
+      console.log("CONTAINER STATE: ", mounted)
+    }
+  })
 
   return (
     <ToasterContainer

--- a/frontend/src/components/core/ToastRenderer/ToastRenderer.tsx
+++ b/frontend/src/components/core/ToastRenderer/ToastRenderer.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement } from "react"
+import { ToasterContainer, PLACEMENT } from "baseui/toast"
+
+import AppContext from "src/components/core/AppContext"
+
+// Toasts should all be rendered under one ToasterContainer
+export function ToastRenderer(): ReactElement {
+  const { communityCloud } = React.useContext(AppContext)
+
+  return (
+    <ToasterContainer
+      placement={PLACEMENT.bottomRight}
+      autoHideDuration={4000}
+      overrides={{
+        Root: {
+          style: {
+            // If deployed in Community Cloud, move toasts up to avoid blocking Manage App button
+            bottom: communityCloud ? "45px" : "0px",
+          },
+        },
+      }}
+    />
+  )
+}
+
+export default ToastRenderer

--- a/frontend/src/components/core/ToastRenderer/index.tsx
+++ b/frontend/src/components/core/ToastRenderer/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./ToastRenderer"

--- a/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/frontend/src/components/elements/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><i class=\\"css-55asu9-ThemedStyledSpinner e17lx80j1 \\"></i><div data-testid=\\"stMarkdownContainer\\" class=\\"css-1cwy3ln-StyledStreamlitMarkdown e16nr0p34\\"><p>Loading...</p></div></div>"`;
+exports[`Spinner component renders without crashing 1`] = `"<div class=\\"css-yprxax-StyledSpinnerContainer e17lx80j0\\"><i class=\\"css-55asu9-ThemedStyledSpinner e17lx80j1 \\"></i><div data-testid=\\"stMarkdownContainer\\" class=\\"css-1sq3h9r-StyledStreamlitMarkdown e16nr0p34\\"><p>Loading...</p></div></div>"`;

--- a/frontend/src/components/elements/Toast/Toast.tsx
+++ b/frontend/src/components/elements/Toast/Toast.tsx
@@ -35,16 +35,6 @@ export interface ToastProps {
   type: string
 }
 
-function shortenMessage(icon: string | undefined, text: string): string {
-  let characterLimit = 110
-  const adjustment = icon ? 0 : 6
-  characterLimit += adjustment
-  if (text.length > characterLimit) {
-    return text.replace(/^(.{120}[^\s]*).*/, "$1")
-  }
-  return text
-}
-
 function generateToastOverrides(
   expanded: boolean,
   toastType: string,
@@ -78,6 +68,19 @@ function generateToastOverrides(
   }
 }
 
+function shortenMessage(
+  icon: string | undefined,
+  fullMessage: string
+): string {
+  // const characterLimit = icon ? 116 : 118
+  const characterLimit = 116
+  if (fullMessage.length > characterLimit) {
+    // if (characterLimit === 118) return fullMessage.replace(/^(.{118}[^\s]*).*/, "$1")
+    return fullMessage.replace(/^(.{116}[^\s]*).*/, "$1")
+  }
+  return fullMessage
+}
+
 export function Toast({ theme, text, icon, type }: ToastProps): ReactElement {
   const fullMessage = icon ? `${icon}&ensp;${text}` : text
   const displayMessage = shortenMessage(icon, fullMessage)
@@ -87,6 +90,7 @@ export function Toast({ theme, text, icon, type }: ToastProps): ReactElement {
   const [toastKey, setToastKey] = useState<React.Key>(1000)
 
   function handleClick(): void {
+    console.log("CLICK:", toastKey)
     setExpanded(!expanded)
   }
 
@@ -94,7 +98,11 @@ export function Toast({ theme, text, icon, type }: ToastProps): ReactElement {
     return (
       <>
         <StyledToastMessage expanded={expanded}>
-          <StreamlitMarkdown source={fullMessage} allowHTML={false} isToast />
+          <StreamlitMarkdown
+            source={expanded ? fullMessage : displayMessage}
+            allowHTML={false}
+            isToast
+          />
         </StyledToastMessage>
         {shortened && (
           <StyledViewButton onClick={handleClick}>
@@ -124,12 +132,16 @@ export function Toast({ theme, text, icon, type }: ToastProps): ReactElement {
   }
 
   useEffect(() => {
-    createToast()
+    const key = createToast()
+    console.log("--- Toast MOUNTED ---", key)
 
     // Remove the toast on unmount
-    // return () => {
-    //   toaster.clear(key)
-    // }
+    return () => {
+      toaster.clear(key)
+      // toaster.getRef()?.clearAll
+
+      console.log("--- UNMOUNT Toast ---", key)
+    }
   }, [])
 
   useEffect(() => {

--- a/frontend/src/components/elements/Toast/Toast.tsx
+++ b/frontend/src/components/elements/Toast/Toast.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, useRef, useState, useEffect } from "react"
+
+import { withTheme } from "@emotion/react"
+import {
+  toaster,
+  Toast as UIToast,
+  ToasterContainer,
+  KIND,
+  PLACEMENT,
+} from "baseui/toast"
+
+import { Theme } from "src/theme"
+import {
+  toastColoration,
+  StyledViewMoreButton,
+  StyledToastMessage,
+} from "./styled-components"
+
+// TODO List:
+// Handle isOwner scenario (moves Toast to accomodate for terminal button)
+// Handle concatenation of toast message if longer than 3 lines & view more button
+// Handle Styling for themes
+// Clean up styling
+export interface ToastProps {
+  theme: Theme
+  text: string
+  icon?: string
+  type: string
+}
+
+export function Toast({ theme, text, icon, type }: ToastProps): ReactElement {
+  const source = icon ? `${icon} ${text}` : text
+
+  useEffect(() => {
+    const content = (
+      <>
+        <StyledToastMessage>{source}</StyledToastMessage>
+        <StyledViewMoreButton>view more</StyledViewMoreButton>
+      </>
+    )
+
+    const styleOverrides = {
+      overrides: {
+        Body: {
+          style: {
+            width: "288px",
+            boxShadow:
+              "0px 3px 10px rgba(0, 0, 0, 0.1), 0px 1px 2px rgba(0, 0, 0, 0.25)",
+            marginTop: "0px",
+            borderRadius: "4px",
+            transitionProperty: "all",
+            transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
+            transitionDuration: "500ms",
+            ...toastColoration(type, theme),
+          },
+        },
+      },
+    }
+
+    switch (type) {
+      case "success":
+        toaster.positive(content, styleOverrides)
+        break
+      case "warning":
+        toaster.warning(content, styleOverrides)
+        break
+      case "error":
+        toaster.negative(content, styleOverrides)
+        break
+      default:
+        toaster.info(content, styleOverrides)
+    }
+  }, [theme])
+
+  return (
+    <ToasterContainer
+      placement={PLACEMENT.bottomRight}
+      autoHideDuration={40000}
+      overrides={{
+        Root: {
+          props: {
+            "class-name": "toast-container",
+          },
+        },
+        ToastCloseIcon: {
+          style: () => ({
+            marginLeft: "5px",
+            width: "1.2rem",
+            height: "1.2rem",
+          }),
+        },
+      }}
+    ></ToasterContainer>
+  )
+}
+
+export default withTheme(Toast)

--- a/frontend/src/components/elements/Toast/Toast.tsx
+++ b/frontend/src/components/elements/Toast/Toast.tsx
@@ -14,100 +14,141 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useRef, useState, useEffect } from "react"
-
+import React, { ReactElement, useState, useEffect } from "react"
 import { withTheme } from "@emotion/react"
-import {
-  toaster,
-  Toast as UIToast,
-  ToasterContainer,
-  KIND,
-  PLACEMENT,
-} from "baseui/toast"
+import { toaster, ToasterContainer, PLACEMENT } from "baseui/toast"
 
 import { Theme } from "src/theme"
+import withHostCommunication, {
+  HostCommunicationHOC,
+} from "src/hocs/withHostCommunication"
+import StreamlitMarkdown from "src/components/shared/StreamlitMarkdown"
+
 import {
   toastColoration,
-  StyledViewMoreButton,
+  StyledViewButton,
   StyledToastMessage,
 } from "./styled-components"
 
-// TODO List:
-// Handle isOwner scenario (moves Toast to accomodate for terminal button)
-// Handle concatenation of toast message if longer than 3 lines & view more button
-// Handle Styling for themes
-// Clean up styling
 export interface ToastProps {
+  hostCommunication: HostCommunicationHOC
   theme: Theme
   text: string
   icon?: string
   type: string
 }
 
-export function Toast({ theme, text, icon, type }: ToastProps): ReactElement {
-  const source = icon ? `${icon} ${text}` : text
+function shortenMessage(text: string): string {
+  const threeLineCharcterCount = 120
+  let checkedText = text
+  if (text.length > threeLineCharcterCount) {
+    checkedText = text.replace(/^(.{120}[^\s]*).*/, "$1")
+  }
+  return checkedText
+}
 
-  useEffect(() => {
-    const content = (
-      <>
-        <StyledToastMessage>{source}</StyledToastMessage>
-        <StyledViewMoreButton>view more</StyledViewMoreButton>
-      </>
-    )
-
-    const styleOverrides = {
-      overrides: {
-        Body: {
-          style: {
-            width: "288px",
-            boxShadow:
-              "0px 3px 10px rgba(0, 0, 0, 0.1), 0px 1px 2px rgba(0, 0, 0, 0.25)",
-            marginTop: "0px",
-            borderRadius: "4px",
-            transitionProperty: "all",
-            transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
-            transitionDuration: "500ms",
-            ...toastColoration(type, theme),
-          },
+function generateToastStyleOverrides(toastType: string, theme: Theme): object {
+  return {
+    overrides: {
+      Body: {
+        style: {
+          width: "288px",
+          marginTop: "8px",
+          borderRadius: "4px",
+          ...toastColoration(toastType, theme),
         },
       },
-    }
+    },
+  }
+}
 
-    switch (type) {
-      case "success":
-        toaster.positive(content, styleOverrides)
-        break
-      case "warning":
-        toaster.warning(content, styleOverrides)
-        break
-      case "error":
-        toaster.negative(content, styleOverrides)
-        break
-      default:
-        toaster.info(content, styleOverrides)
+export function Toast({
+  hostCommunication,
+  theme,
+  text,
+  icon,
+  type,
+}: ToastProps): ReactElement {
+  const fullMessage = icon ? `${icon}&ensp;${text}` : text
+  const displayMessage = shortenMessage(fullMessage)
+  const shortened = fullMessage !== displayMessage
+
+  const [expanded, setExpanded] = useState(!shortened)
+  const [toastKey, setToastKey] = useState<React.Key>(1000)
+
+  function handleClick(): void {
+    setExpanded(!expanded)
+  }
+
+  function toastContent(): ReactElement {
+    return (
+      <>
+        <StyledToastMessage expanded={expanded}>
+          <StreamlitMarkdown
+            source={expanded ? fullMessage : displayMessage}
+            allowHTML={false}
+            isToast
+          />
+        </StyledToastMessage>
+        {shortened && (
+          <StyledViewButton onClick={handleClick}>
+            {expanded ? "view less" : "view more"}
+          </StyledViewButton>
+        )}
+      </>
+    )
+  }
+
+  function createToast(): void {
+    const content = toastContent()
+    const styleOverrides = generateToastStyleOverrides(type, theme)
+
+    let key
+    if (type === "success") {
+      key = toaster.positive(content, styleOverrides)
+    } else if (type === "warning") {
+      key = toaster.warning(content, styleOverrides)
+    } else if (type === "error") {
+      key = toaster.negative(content, styleOverrides)
+    } else {
+      key = toaster.info(content, styleOverrides)
     }
-  }, [theme])
+    setToastKey(key)
+  }
+
+  useEffect(() => {
+    createToast()
+  }, [])
+
+  useEffect(() => {
+    const content = toastContent()
+    toaster.update(toastKey, { children: content })
+  }, [expanded, theme])
+
+  const streamlitCloud = hostCommunication.currentState.isOwner
 
   return (
     <ToasterContainer
       placement={PLACEMENT.bottomRight}
-      autoHideDuration={40000}
+      autoHideDuration={4000}
       overrides={{
         Root: {
-          props: {
-            "class-name": "toast-container",
-          },
+          style: () => ({
+            // If deployed in Community Cloud, move toasts up to avoid blocking Manage App button
+            bottom: streamlitCloud ? "45px" : "0px",
+          }),
         },
         ToastCloseIcon: {
           style: () => ({
+            color: theme.colors.bodyText,
             marginLeft: "5px",
             width: "1.2rem",
             height: "1.2rem",
           }),
         },
       }}
-    ></ToasterContainer>
+    />
   )
 }
 
-export default withTheme(Toast)
+export default withHostCommunication(withTheme(Toast))

--- a/frontend/src/components/elements/Toast/index.tsx
+++ b/frontend/src/components/elements/Toast/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./Toast"

--- a/frontend/src/components/elements/Toast/styled-components.tsx
+++ b/frontend/src/components/elements/Toast/styled-components.tsx
@@ -82,16 +82,14 @@ export const StyledViewButton = styled.button(({ theme }) => ({
   },
 }))
 
-export interface StyledToastMessageProps {
+interface StyledToastMessageProps {
   expanded: boolean
 }
 
 export const StyledToastMessage = styled.div<StyledToastMessageProps>(
-  ({ theme, expanded }) => ({
-    display: "flex",
-    maxHeight: expanded ? "" : "68px",
+  ({ expanded }) => ({
+    maxHeight: expanded ? "none" : "68px",
     overflow: "hidden",
-    fontSize: theme.fontSizes.sm,
-    lineHeight: "1.4rem",
+    display: "flex",
   })
 )

--- a/frontend/src/components/elements/Toast/styled-components.tsx
+++ b/frontend/src/components/elements/Toast/styled-components.tsx
@@ -16,39 +16,55 @@
 
 import { CSSProperties } from "@emotion/serialize"
 import styled from "@emotion/styled"
-import { Theme } from "src/theme"
+import { darken, lighten } from "color2k"
 
-// TODO: Handle light/dark theme cases
-export function toastColoration(kind: string, theme: Theme): CSSProperties {
+import { hasLightBackgroundColor, Theme } from "src/theme"
+
+export function toastColoration(
+  toastType: string,
+  theme: Theme
+): CSSProperties {
+  const lightTheme = hasLightBackgroundColor(theme)
+  const inSidebar = theme.inSidebar
+
   const defaultStyle = {
-    backgroundColor: theme.colors.gray10,
+    backgroundColor: inSidebar
+      ? theme.colors.bgColor
+      : theme.colors.secondaryBg,
     color: theme.colors.bodyText,
   }
   const successStyle = {
-    backgroundColor: "rgba(33, 195, 84, 0.1)",
-    color: "rgb(23, 114, 51)",
+    backgroundColor: lightTheme
+      ? lighten(theme.colors.green10, 0.03)
+      : darken(theme.colors.green100, 0.15),
+    color: lightTheme ? theme.colors.green100 : theme.colors.green10,
   }
   const warningStyle = {
-    backgroundColor: "rgba(255, 227, 18, 0.1)",
-    color: "rgb(146, 108, 5)",
+    backgroundColor: lightTheme
+      ? theme.colors.yellow10
+      : darken(theme.colors.yellow110, 0.16),
+    color: lightTheme ? theme.colors.yellow110 : theme.colors.yellow20,
   }
   const errorStyle = {
-    backgroundColor: "rgba(255, 43, 43, 0.09)",
-    color: "rgb(125, 53, 59)",
+    backgroundColor: lightTheme
+      ? theme.colors.red10
+      : darken(theme.colors.red100, 0.2),
+    color: lightTheme ? theme.colors.red100 : theme.colors.red20,
   }
 
-  if (kind === "success") {
-    return successStyle
-  } else if (kind === "warning") {
-    return warningStyle
-  } else if (kind === "error") {
-    return errorStyle
+  switch (toastType) {
+    case "success":
+      return successStyle
+    case "warning":
+      return warningStyle
+    case "error":
+      return errorStyle
+    default:
+      return defaultStyle
   }
-
-  return defaultStyle
 }
 
-export const StyledViewMoreButton = styled.button(({ theme }) => ({
+export const StyledViewButton = styled.button(({ theme }) => ({
   fontSize: theme.fontSizes.sm,
   lineHeight: "1.4rem",
   color: theme.colors.gray60,
@@ -57,15 +73,25 @@ export const StyledViewMoreButton = styled.button(({ theme }) => ({
   boxShadow: "none",
   padding: "0px",
   "&:hover, &:active, &:focus": {
+    border: "none",
+    outline: "none",
+    boxShadow: "none",
+  },
+  "&:hover": {
     color: theme.colors.primary,
   },
 }))
 
-export const StyledToastMessage = styled.div(({ theme }) => ({
-  display: "flex",
-  maxHeight: "68px",
-  marginBottom: "8px",
-  overflow: "hidden",
-  fontSize: theme.fontSizes.sm,
-  lineHeight: "1.4rem",
-}))
+export interface StyledToastMessageProps {
+  expanded: boolean
+}
+
+export const StyledToastMessage = styled.div<StyledToastMessageProps>(
+  ({ theme, expanded }) => ({
+    display: "flex",
+    maxHeight: expanded ? "" : "68px",
+    overflow: "hidden",
+    fontSize: theme.fontSizes.sm,
+    lineHeight: "1.4rem",
+  })
+)

--- a/frontend/src/components/elements/Toast/styled-components.tsx
+++ b/frontend/src/components/elements/Toast/styled-components.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CSSProperties } from "@emotion/serialize"
+import styled from "@emotion/styled"
+import { Theme } from "src/theme"
+
+// TODO: Handle light/dark theme cases
+export function toastColoration(kind: string, theme: Theme): CSSProperties {
+  const defaultStyle = {
+    backgroundColor: theme.colors.gray10,
+    color: theme.colors.bodyText,
+  }
+  const successStyle = {
+    backgroundColor: "rgba(33, 195, 84, 0.1)",
+    color: "rgb(23, 114, 51)",
+  }
+  const warningStyle = {
+    backgroundColor: "rgba(255, 227, 18, 0.1)",
+    color: "rgb(146, 108, 5)",
+  }
+  const errorStyle = {
+    backgroundColor: "rgba(255, 43, 43, 0.09)",
+    color: "rgb(125, 53, 59)",
+  }
+
+  if (kind === "success") {
+    return successStyle
+  } else if (kind === "warning") {
+    return warningStyle
+  } else if (kind === "error") {
+    return errorStyle
+  }
+
+  return defaultStyle
+}
+
+export const StyledViewMoreButton = styled.button(({ theme }) => ({
+  fontSize: theme.fontSizes.sm,
+  lineHeight: "1.4rem",
+  color: theme.colors.gray60,
+  backgroundColor: theme.colors.transparent,
+  border: "none",
+  boxShadow: "none",
+  padding: "0px",
+  "&:hover, &:active, &:focus": {
+    color: theme.colors.primary,
+  },
+}))
+
+export const StyledToastMessage = styled.div(({ theme }) => ({
+  display: "flex",
+  maxHeight: "68px",
+  marginBottom: "8px",
+  overflow: "hidden",
+  fontSize: theme.fontSizes.sm,
+  lineHeight: "1.4rem",
+}))

--- a/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -104,6 +104,11 @@ export interface Props {
    * Checkbox has larger label font sizing
    */
   isCheckbox?: boolean
+
+  /**
+   * Toast has smaller font sizing & doesn't allow colored text
+   */
+  isToast?: boolean
 }
 
 /**
@@ -246,6 +251,11 @@ export interface RenderedMarkdownProps {
    * Does not allow links
    */
   isButton?: boolean
+
+  /**
+   * Does not allow colored text
+   */
+  isToast?: boolean
 }
 
 export type CustomCodeTagProps = JSX.IntrinsicElements["code"] &
@@ -288,6 +298,7 @@ export function RenderedMarkdown({
   overrideComponents,
   isLabel,
   isButton,
+  isToast,
 }: RenderedMarkdownProps): ReactElement {
   const renderers: Components = {
     pre: CodeBlock,
@@ -334,6 +345,12 @@ export function RenderedMarkdown({
     remarkDirective,
     remarkColoring,
   ]
+
+  if (isToast) {
+    // Removes remarkColoring plugin
+    plugins.pop()
+  }
+
   const rehypePlugins: PluggableList = [rehypeKatex]
 
   if (allowHTML) {
@@ -412,6 +429,7 @@ class StreamlitMarkdown extends PureComponent<Props> {
       isLabel,
       isButton,
       isCheckbox,
+      isToast,
     } = this.props
     const isInSidebar = this.context
 
@@ -422,6 +440,7 @@ class StreamlitMarkdown extends PureComponent<Props> {
         isLabel={isLabel}
         isButton={isButton}
         isCheckbox={isCheckbox}
+        isToast={isToast}
         style={style}
         data-testid={isCaption ? "stCaptionContainer" : "stMarkdownContainer"}
       >
@@ -430,6 +449,7 @@ class StreamlitMarkdown extends PureComponent<Props> {
           allowHTML={allowHTML}
           isLabel={isLabel}
           isButton={isButton}
+          isToast={isToast}
         />
       </StyledStreamlitMarkdown>
     )

--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -62,6 +62,7 @@ export const StyledStreamlitMarkdown =
         p: {
           wordBreak: "break-word",
           marginBottom: isLabel ? 0 : "",
+          // overflow: isToast ? "hidden" : "",
 
           ...(labelFontSize ? { fontSize: theme.fontSizes.sm } : {}),
         },

--- a/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -23,6 +23,7 @@ export interface StyledStreamlitMarkdownProps {
   isLabel?: boolean
   isButton?: boolean
   isCheckbox?: boolean
+  isToast?: boolean
 }
 
 function convertRemToEm(s: string): string {
@@ -39,16 +40,29 @@ function sharedMarkdownStyle(theme: Theme): any {
 
 export const StyledStreamlitMarkdown =
   styled.div<StyledStreamlitMarkdownProps>(
-    ({ theme, isCaption, isInSidebar, isLabel, isButton, isCheckbox }) => {
+    ({
+      theme,
+      isCaption,
+      isInSidebar,
+      isLabel,
+      isButton,
+      isCheckbox,
+      isToast,
+    }) => {
       // Widget Labels have smaller font size with exception of Buttons/Checkboxes
-      const labelFontSize = isLabel && !isCheckbox && !isButton
+      // Toasts also have smaller font size
+      const labelFontSize = (isLabel && !isCheckbox && !isButton) || isToast
       return {
         fontFamily: theme.genericFonts.bodyFont,
         marginBottom: isLabel ? "" : `-${theme.spacing.lg}`,
         ...sharedMarkdownStyle(theme),
+        div: {
+          display: isToast ? "inline-flex" : "",
+        },
         p: {
           wordBreak: "break-word",
           marginBottom: isLabel ? 0 : "",
+
           ...(labelFontSize ? { fontSize: theme.fontSizes.sm } : {}),
         },
 

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -161,6 +161,7 @@ text_area = _main.text_area
 text_input = _main.text_input
 time_input = _main.time_input
 title = _main.title
+toast = _main.toast
 vega_lite_chart = _main.vega_lite_chart
 video = _main.video
 warning = _main.warning

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -83,6 +83,7 @@ from streamlit.elements.snow import SnowMixin
 from streamlit.elements.text import TextMixin
 from streamlit.elements.text_widgets import TextWidgetsMixin
 from streamlit.elements.time_widgets import TimeWidgetsMixin
+from streamlit.elements.toast import ToastMixin
 from streamlit.elements.write import WriteMixin
 from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.logger import get_logger
@@ -188,6 +189,7 @@ class DeltaGenerator(
     TextMixin,
     TextWidgetsMixin,
     TimeWidgetsMixin,
+    ToastMixin,
     WriteMixin,
     ArrowMixin,
     ArrowAltairMixin,

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -17,22 +17,11 @@ from typing import TYPE_CHECKING, Optional, cast
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text, is_emoji
+from streamlit.string_util import clean_text, validate_emoji
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.type_util import SupportsStr
-
-
-def validate_emoji(maybe_emoji: Optional[str]) -> str:
-    if maybe_emoji is None:
-        return ""
-    elif is_emoji(maybe_emoji):
-        return maybe_emoji
-    else:
-        raise StreamlitAPIException(
-            f'The value "{maybe_emoji}" is not a valid emoji. Shortcodes are not allowed, please use a single character instead.'
-        )
 
 
 class AlertMixin:

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -32,7 +32,7 @@ class ToastProtoType(Enum):
     ERROR = "error"
 
 
-def validate_type(toast_type: str) -> ToastProtoType:
+def validate_type(toast_type: str) -> str:
     valid_types = [type.value for type in ToastProtoType]
 
     if toast_type is None:
@@ -59,7 +59,7 @@ class ToastMixin:
         text: SupportsStr,
         *,  # keyword-only args:
         icon: Optional[str] = None,
-        type: ToastProtoType = None,
+        type: Optional[ToastProtoType] = None,
     ) -> "DeltaGenerator":
         """Display a toast in the bottom right corner of the screen. Will disappear after four seconds.
 

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -1,0 +1,95 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import TYPE_CHECKING, Optional, cast
+
+from streamlit.proto.Toast_pb2 import Toast as ToastProto
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.string_util import clean_text, validate_emoji
+from streamlit.type_util import SupportsStr
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+class ToastProtoType(Enum):
+    DEFAULT = "default"
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+def validate_type(toast_type: str) -> ToastProtoType:
+    valid_types = [type.value for type in ToastProtoType]
+
+    if toast_type is None:
+        return ToastProtoType.DEFAULT.value
+
+    toast_type = toast_type.lower()
+    if toast_type in valid_types:
+        if toast_type == "success":
+            return ToastProtoType.SUCCESS.value
+        elif toast_type == "warning":
+            return ToastProtoType.WARNING.value
+        else:
+            return ToastProtoType.ERROR.value
+    else:
+        raise StreamlitAPIException(
+            f"Invalid toast type: {toast_type}. Valid types are: {ToastProtoType}"
+        )
+
+
+class ToastMixin:
+    @gather_metrics("toast")
+    def toast(
+        self,
+        text: SupportsStr,
+        *,  # keyword-only args:
+        icon: Optional[str] = None,
+        type: ToastProtoType = None,
+    ) -> "DeltaGenerator":
+        """Display a toast in the bottom right corner of the screen. Will disappear after four seconds.
+
+        Parameters
+        ----------
+        text : str
+            Short message for the toast.
+        icon : str or None
+            An optional, keyword-only argument that specifies an emoji to use as
+            the icon for the toast. Shortcodes are not allowed, please use a
+            single character instead. E.g. "🚨", "🔥", "🤖", etc.
+            Defaults to None, which means no icon is displayed.
+        type : “success”, “warning”, “error”, or None
+            An optional, keyword-only argument that specifies the type of toast.
+            Defaults to None.
+
+
+        Example
+        -------
+        >>> import streamlit as st
+        >>>
+        >>> st.toast('Your edited image was saved!', icon='😍', type='success')
+
+        """
+        toast_proto = ToastProto()
+        toast_proto.text = clean_text(text)
+        toast_proto.icon = validate_emoji(icon)
+        toast_proto.type = validate_type(type)
+        return self.dg._enqueue("toast", toast_proto)
+
+    @property
+    def dg(self) -> "DeltaGenerator":
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
 from typing import TYPE_CHECKING, Optional, cast
 
 from streamlit.errors import StreamlitAPIException
@@ -25,27 +24,15 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
-class ToastProtoType(Enum):
-    DEFAULT = "default"
-    SUCCESS = "success"
-    WARNING = "warning"
-    ERROR = "error"
-
-
-def validate_type(toast_type: str) -> str:
-    valid_types = [type.value for type in ToastProtoType]
+def validate_type(toast_type: Optional[str]) -> str:
+    valid_types = ["success", "warning", "error"]
 
     if toast_type is None:
-        return ToastProtoType.DEFAULT.value
+        return ""
 
     toast_type = toast_type.lower()
     if toast_type in valid_types:
-        if toast_type == "success":
-            return ToastProtoType.SUCCESS.value
-        elif toast_type == "warning":
-            return ToastProtoType.WARNING.value
-        else:
-            return ToastProtoType.ERROR.value
+        return toast_type
     else:
         raise StreamlitAPIException(
             f"Invalid toast type: {toast_type}. Valid types are “success”, “warning”, “error”, or None"
@@ -59,7 +46,7 @@ class ToastMixin:
         text: SupportsStr,
         *,  # keyword-only args:
         icon: Optional[str] = None,
-        type: Optional[ToastProtoType] = None,
+        type: Optional[str] = None,
     ) -> "DeltaGenerator":
         """Display a toast in the bottom right corner of the screen. Will disappear after four seconds.
 

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -15,6 +15,7 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, cast
 
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Toast_pb2 import Toast as ToastProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text, validate_emoji
@@ -47,7 +48,7 @@ def validate_type(toast_type: str) -> ToastProtoType:
             return ToastProtoType.ERROR.value
     else:
         raise StreamlitAPIException(
-            f"Invalid toast type: {toast_type}. Valid types are: {ToastProtoType}"
+            f"Invalid toast type: {toast_type}. Valid types are “success”, “warning”, “error”, or None"
         )
 
 

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -15,7 +15,7 @@
 import re
 import textwrap
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Tuple, cast
+from typing import TYPE_CHECKING, Any, Optional, Tuple, cast
 
 from streamlit.emojis import ALL_EMOJIS
 from streamlit.errors import StreamlitAPIException
@@ -44,6 +44,18 @@ def clean_text(text: "SupportsStr") -> str:
 def is_emoji(text: str) -> bool:
     """Check if input string is a valid emoji."""
     return text.replace("\U0000FE0F", "") in ALL_EMOJIS
+
+
+def validate_emoji(maybe_emoji: Optional[str]) -> str:
+    """Check input string & raise error if invalid icon input."""
+    if maybe_emoji is None:
+        return ""
+    elif is_emoji(maybe_emoji):
+        return maybe_emoji
+    else:
+        raise StreamlitAPIException(
+            f'The value "{maybe_emoji}" is not a valid emoji. Shortcodes are not allowed, please use a single character instead.'
+        )
 
 
 def extract_leading_emoji(text: str) -> Tuple[str, str]:

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -149,6 +149,7 @@ class RunWarningTest(unittest.TestCase):
                 "text_input",
                 "time_input",
                 "title",
+                "toast",
                 "vega_lite_chart",
                 "video",
                 "warning",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -129,6 +129,7 @@ class StreamlitTest(unittest.TestCase):
                 "text_input",
                 "time_input",
                 "title",
+                "toast",
                 "vega_lite_chart",
                 "video",
                 "warning",

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -56,6 +56,7 @@ import "streamlit/proto/Text.proto";
 import "streamlit/proto/TextArea.proto";
 import "streamlit/proto/TextInput.proto";
 import "streamlit/proto/TimeInput.proto";
+import "streamlit/proto/Toast.proto";
 import "streamlit/proto/VegaLiteChart.proto";
 import "streamlit/proto/Video.proto";
 import "streamlit/proto/Heading.proto";
@@ -106,11 +107,12 @@ message Element {
     TextArea text_area = 22;
     TextInput text_input = 24;
     TimeInput time_input = 26;
+    Toast toast = 49;
     VegaLiteChart vega_lite_chart = 10;
     Video video = 14;
     Heading heading = 47;
     Code code = 48;
-    // Next ID: 49
+    // Next ID: 50
   }
 
   reserved 9;

--- a/proto/streamlit/proto/Toast.proto
+++ b/proto/streamlit/proto/Toast.proto
@@ -1,0 +1,28 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+message Toast {
+    // Display message
+    string text = 1;
+
+    // Emoji
+    string icon = 2;
+
+    // Type of Toast - default, success, warning, or error
+    string type = 3;
+}


### PR DESCRIPTION
## 📚 Context

Adds a new widget for notification toasts using `st.toast` - covers the use case for notifications that don't disrupt the flow/organization of the existing app. This is distinct from the existing `st.warning`, `st.error`, `st.success` & `st.info`, which are inline. `st.toast` params are as follows:
**text**(*str*) - Short message for the toast.
**icon**(None or str) - An optional, keyword-only argument that specifies an emoji to use as the icon for the toast. Shortcodes are not allowed, please use a single character instead. E.g. "🚨", "🔥", "🤖", etc. Defaults to None, which means no icon is displayed.
**type**(None or “success” or “warning” or “error”) - An optional, keyword-only argument that specifies the type of toast. Default to None. 

- What kind of change does this PR introduce?
  - [x] Feature

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

- **Demo App:** [link](https://streamlit-feature-demos-toaststreamlit-app-88hm6y.streamlit.app/)
- **Product Spec:** [link](https://www.notion.so/snowflake-corp/Product-Spec-ffebbc53f9404ddabd3474413d9e4859)
- **Figma Mocks:** [link](https://www.figma.com/file/pCztHVGtAUMhR1G8VyGMmm/st.toast?node-id=0-1&t=jXL328F3igykApsJ-0)