### PR TITLE
Remove redundant BaseWeb ThemeProvider

### DIFF
--- a/frontend/src/app/ThemedApp.test.tsx
+++ b/frontend/src/app/ThemedApp.test.tsx
@@ -26,6 +26,7 @@ import {
   setCachedTheme,
   ThemeConfig,
 } from "src/lib/theme"
+import { ThemeProvider as BaseUIThemeProvider } from "baseui"
 
 import AppWithScreencast from "./App"
 import ThemedApp from "./ThemedApp"
@@ -79,7 +80,12 @@ describe("ThemedApp", () => {
     expect(wrapper.html()).not.toBeNull()
   })
 
-  it("updates theme", () => {
+  it.only("only renders a single instance of BaseWeb <ThemeProvider>", () => {
+    const wrapper = mount(<ThemedApp />)
+    expect(wrapper.find(BaseUIThemeProvider)).toHaveLength(1)
+  })
+
+  it("updates the theme", () => {
     const wrapper = shallow(<ThemedApp />)
     wrapper.find(AppWithScreencast).props().theme.setTheme(darkTheme)
     const updatedTheme: ThemeConfig = wrapper.find(AppWithScreencast).props()

--- a/frontend/src/app/ThemedApp.tsx
+++ b/frontend/src/app/ThemedApp.tsx
@@ -16,12 +16,11 @@
 
 import React from "react"
 import { BaseProvider } from "baseui"
-import { Global } from "@emotion/react"
+import { Global, ThemeProvider as EmotionThemeProvider } from "@emotion/react"
 
 import { CustomThemeConfig, ICustomThemeConfig } from "src/lib/proto"
 
 import FontFaceDeclaration from "src/app/components/FontFaceDeclaration"
-import ThemeProvider from "src/lib/components/core/ThemeProvider"
 import {
   AUTO_THEME_NAME,
   CUSTOM_THEME_NAME,
@@ -103,10 +102,10 @@ const ThemedApp = (): JSX.Element => {
 
   return (
     <BaseProvider
-      theme={theme.baseweb}
+      theme={theme.basewebTheme}
       zIndex={theme.emotion.zIndices.popupMenu}
     >
-      <ThemeProvider theme={theme.emotion} baseuiTheme={theme.basewebTheme}>
+      <EmotionThemeProvider theme={theme.emotion}>
         <Global styles={globalStyles} />
         {theme.name === CUSTOM_THEME_NAME && fontFaces && (
           <FontFaceDeclaration fontFaces={fontFaces} />
@@ -122,7 +121,7 @@ const ThemedApp = (): JSX.Element => {
         />
         {/* The data grid requires one root level portal element for rendering cell overlays */}
         <StyledDataFrameOverlay id="portal" />
-      </ThemeProvider>
+      </EmotionThemeProvider>
     </BaseProvider>
   )
 }

--- a/frontend/src/lib/mocks/mockTheme.ts
+++ b/frontend/src/lib/mocks/mockTheme.ts
@@ -16,7 +16,7 @@
 
 /** A mock theme definition for use in unit tests. */
 
-import { LightTheme, lightThemePrimitives } from "baseui"
+import { lightThemePrimitives } from "baseui"
 import { transparentize } from "color2k"
 import { ThemeConfig } from "src/lib/theme"
 import { createEmotionColors } from "src/lib/theme/getColors"
@@ -101,7 +101,6 @@ const baseuiMockTheme = createBaseUiTheme(
 export const mockTheme: ThemeConfig = {
   name: "MockTheme",
   emotion: emotionMockTheme,
-  baseweb: LightTheme,
   basewebTheme: baseuiMockTheme,
   primitives: lightThemePrimitives,
 }

--- a/frontend/src/lib/theme/themeConfigs.ts
+++ b/frontend/src/lib/theme/themeConfigs.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  LightTheme,
-  DarkTheme,
-  lightThemePrimitives,
-  darkThemePrimitives,
-} from "baseui"
+import { lightThemePrimitives, darkThemePrimitives } from "baseui"
 import { baseuiLightTheme, baseuiDarkTheme } from "./baseui"
 import emotionBaseTheme from "./emotionBaseTheme"
 import emotionLightTheme from "./emotionLightTheme"
@@ -29,7 +24,6 @@ import { ThemeConfig } from "./types"
 export const baseTheme: ThemeConfig = {
   name: "base",
   emotion: emotionBaseTheme,
-  baseweb: LightTheme,
   basewebTheme: baseuiLightTheme,
   primitives: lightThemePrimitives,
 }
@@ -37,7 +31,6 @@ export const baseTheme: ThemeConfig = {
 export const darkTheme: ThemeConfig = {
   name: "Dark",
   emotion: emotionDarkTheme,
-  baseweb: DarkTheme,
   basewebTheme: baseuiDarkTheme,
   primitives: darkThemePrimitives,
 }
@@ -45,7 +38,6 @@ export const darkTheme: ThemeConfig = {
 export const lightTheme: ThemeConfig = {
   name: "Light",
   emotion: emotionLightTheme,
-  baseweb: LightTheme,
   basewebTheme: baseuiLightTheme,
   primitives: lightThemePrimitives,
 }

--- a/frontend/src/lib/theme/types.ts
+++ b/frontend/src/lib/theme/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { LightTheme, lightThemePrimitives } from "baseui"
+import { lightThemePrimitives } from "baseui"
 
 import { CustomThemeConfig } from "src/lib/proto"
 
@@ -26,9 +26,6 @@ export type EmotionTheme = typeof emotionBaseTheme
 export type ThemeConfig = {
   name: string
   emotion: EmotionTheme
-  // For use with the BaseProvider that adds a LayersManager and ThemeProvider.
-  // Unfortunately Theme is required.
-  baseweb: typeof LightTheme
   // For use with Baseweb's ThemeProvider. This is required in order for us to
   // create separate themes for in the children. Currently required to accommodate
   // sidebar theming.


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [X] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

There are three `<ThemeProvider>`s
(1) base-ui `<ThemeProvider>`
(2) emotion `<ThemeProvider>`
(3) wrapper streamlit `<ThemeProvider>` that includes (1) and (2)

Currently, at the top-level (in `<ThemedApp>`), base-ui `<ThemeProvider>` is rendered twice, once through `<BaseProvider>` ([see](https://github.com/uber/baseweb/blob/master/src/helpers/base-provider.tsx#L13)) and once through (3). In practice, theme is only being read from the latter, the provider closest to children content.

While it doesn't break behavior, this adds unnecessary bloat to component tree and ThemeConfig objects. ThemeConfig.baseweb is not really used but requires having to import base-ui's LightTheme/DarkTheme. 

This PR removes the redundant base-ui `<ThemeProvider>` by just including emotion `<ThemeProvider>` instead of (3) in `<ThemedApp>` and passing baseWebTheme directly to `<BaseProvider>`. 

(3) is still not deleted because it is still handy for overriding just the theme somewhere lower in the component tree (i.e. in Sidebar) and for testing. 

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

This is not a user-facing change and doesn't affect API. 
(It will affect experimental streamlit library integration but it will not be disruptive)

**Revised:**

_Insert screenshot of your updated UI/code here_


**Current:**

_Insert screenshot of existing UI/code here_

Content is themed properly and changing theme continues to work as expected. 
<img width="1689" alt="Screenshot 2023-05-02 at 4 10 19 PM" src="https://user-images.githubusercontent.com/106615738/235805754-9d7e7065-5743-45c3-88a9-ba13bfbcb18d.png">

## 🧪 Testing Done

- [X] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests


## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
