### PR TITLE
Add support for classes as argument type

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -51,6 +51,8 @@ _OBJECT_NAME_MAPPING: Final = {
     "pandas.io.formats.style.Styler": "PandasStyler",
     "pandas.core.indexes.base.Index": "PandasIndex",
     "pandas.core.series.Series": "PandasSeries",
+    "streamlit.connections.snowpark_connection.SnowparkConnection": "SnowparkConnection",
+    "streamlit.connections.sql_connection.SQLConnection": "SQLConnection",
 }
 
 # A list of dependencies to check for attribution

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -163,7 +163,7 @@ class Installation:
 def _get_type_name(obj: object) -> str:
     """Get a simplified name for the type of the given object."""
     with contextlib.suppress(Exception):
-        obj_type = type(obj)
+        obj_type = obj if inspect.isclass(obj) else type(obj)
         type_name = "unknown"
         if hasattr(obj_type, "__qualname__"):
             type_name = obj_type.__qualname__

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -16,7 +16,7 @@ import contextlib
 import datetime
 import unittest
 from collections import Counter
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import MagicMock, mock_open, patch
 
 import pandas as pd
@@ -24,6 +24,7 @@ from parameterized import parameterized
 
 import streamlit as st
 import streamlit.components.v1 as components
+from streamlit.connections import SnowparkConnection
 from streamlit.runtime import metrics_util
 from streamlit.runtime.caching import cache_data_api, cache_resource_api
 from streamlit.runtime.legacy_caching import caching
@@ -93,6 +94,8 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
     def setUp(self):
         super().setUp()
         ctx = get_script_run_ctx()
+        assert ctx is not None
+
         ctx.reset()
         ctx.gather_usage_stats = True
 
@@ -109,6 +112,10 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
             (datetime.datetime.today().time(), "datetime.time"),
             (pd.DataFrame(), "DataFrame"),
             (pd.Series(), "PandasSeries"),
+            # Also support classes as input
+            (datetime.date, "datetime.date"),
+            (pd.DataFrame, "DataFrame"),
+            (SnowparkConnection, "SnowparkConnection"),
         ]
     )
     def test_get_type_name(self, obj: object, expected_type: str):
@@ -173,6 +180,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
     def test_gather_metrics_decorator(self):
         """The gather_metrics decorator works as expected."""
         ctx = get_script_run_ctx()
+        assert ctx is not None
 
         @metrics_util.gather_metrics("test_function")
         def test_function(param1: int, param2: str, param3: float = 0.1) -> str:
@@ -218,9 +226,12 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
             (components.iframe, "_iframe"),
         ]
     )
-    def test_internal_api_commands(self, command: Callable, expected_name: str):
+    def test_internal_api_commands(
+        self, command: Callable[..., Any], expected_name: str
+    ):
         """Some internal functions are also tracked and should use the correct name."""
         ctx = get_script_run_ctx()
+        assert ctx is not None
 
         # This will always throw an exception because of missing arguments
         # This is fine since the command still get tracked
@@ -277,6 +288,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
 
             # Reset tracked stats from previous calls.
             ctx = get_script_run_ctx()
+            assert ctx is not None
             ctx.reset()
             ctx.gather_usage_stats = True
 
@@ -303,6 +315,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         Current limits are 25 per unique command and 200 in total.
         """
         ctx = get_script_run_ctx()
+        assert ctx is not None
         ctx.reset()
         ctx.gather_usage_stats = True
 

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 
 import streamlit as st
 import streamlit.components.v1 as components
-from streamlit.connections import SnowparkConnection
+from streamlit.connections import SnowparkConnection, SQLConnection
 from streamlit.runtime import metrics_util
 from streamlit.runtime.caching import cache_data_api, cache_resource_api
 from streamlit.runtime.legacy_caching import caching
@@ -116,6 +116,7 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
             (datetime.date, "datetime.date"),
             (pd.DataFrame, "DataFrame"),
             (SnowparkConnection, "SnowparkConnection"),
+            (SQLConnection, "SQLConnection"),
         ]
     )
     def test_get_type_name(self, obj: object, expected_type: str):


### PR DESCRIPTION
## 📚 Context

This PR adds support correctly resolving class names in telemetry if a class is used as a parameter instead of a class instance. This is mainly required for `st.connection`. Also, it adds a couple of asserts to resolve typing issues within the metrics_util_test. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
