### PR TITLE
Fix memory leak in ForwardMsgCache

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -225,8 +225,10 @@ class AppSession:
             self._uploaded_file_mgr.remove_session_files(self.id)
 
             if runtime.exists():
-                runtime.get_instance().media_file_mgr.clear_session_refs(self.id)
-                runtime.get_instance().media_file_mgr.remove_orphaned_files()
+                rt = runtime.get_instance()
+                rt.media_file_mgr.clear_session_refs(self.id)
+                rt.media_file_mgr.remove_orphaned_files()
+                rt.message_cache.remove_refs_for_session(self)
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -217,6 +217,27 @@ class ForwardMsgCache(CacheStatsProvider):
         age = entry.get_session_ref_age(session, script_run_count)
         return age <= int(config.get_option("global.maxCachedMessageAge"))
 
+    def remove_refs_for_session(self, session: "AppSession") -> None:
+        """Remove refs for all entries for the given session.
+
+        This should be called when an AppSession is being shut down.
+
+        Parameters
+        ----------
+        session : AppSession
+        """
+
+        # Operate on a copy of our entries dict.
+        # We may be deleting from it.
+        for msg_hash, entry in self._entries.copy().items():
+            if entry.has_session_ref(session):
+                entry.remove_session_ref(session)
+
+            if not entry.has_refs():
+                # The entry has no more references. Remove it from
+                # the cache completely.
+                del self._entries[msg_hash]
+
     def remove_expired_entries_for_session(
         self, session: "AppSession", script_run_count: int
     ) -> None:

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -217,7 +217,7 @@ class ForwardMsgCache(CacheStatsProvider):
         age = entry.get_session_ref_age(session, script_run_count)
         return age <= int(config.get_option("global.maxCachedMessageAge"))
 
-    def remove_expired_session_entries(
+    def remove_expired_entries_for_session(
         self, session: "AppSession", script_run_count: int
     ) -> None:
         """Remove any cached messages that have expired from the given session.

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -687,7 +687,7 @@ Please report this bug at https://github.com/streamlit/streamlit/issues.
                 config.get_option("global.maxCachedMessageAge"),
             )
             session_info.script_run_count += 1
-            self._message_cache.remove_expired_session_entries(
+            self._message_cache.remove_expired_entries_for_session(
                 session_info.session, session_info.script_run_count
             )
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import streamlit.runtime.app_session as app_session
-from streamlit import config, runtime
+from streamlit import config
 from streamlit.proto.AppPage_pb2 import AppPage
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg

--- a/lib/tests/streamlit/runtime/forward_msg_cache_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_cache_test.py
@@ -131,14 +131,14 @@ class ForwardMsgCacheTest(unittest.TestCase):
 
         # Remove session1's expired entries. This should not remove the
         # entry from the cache, because session2 still has a reference to it.
-        cache.remove_expired_session_entries(session1, runcount1)
+        cache.remove_expired_entries_for_session(session1, runcount1)
         self.assertFalse(cache.has_message_reference(msg, session1, runcount1))
         self.assertTrue(cache.has_message_reference(msg, session2, runcount2))
 
         # Expire session2's reference. The message should no longer be
         # in the cache at all.
         runcount2 += 2
-        cache.remove_expired_session_entries(session2, runcount2)
+        cache.remove_expired_entries_for_session(session2, runcount2)
         self.assertIsNone(cache.get_message(msg_hash))
 
     def test_cache_stats_provider(self):


### PR DESCRIPTION
## 📚 Context

I managed to discover a few things while investigating some potential memory leaks that were pointed out in #6354 and #6510:

* In #6354, there's not a "true" memory leak going on, but instead the observed behavior is a combination of
   * streamlit not supporting use-cases where a script runs indefinitely very well (we only clean up the memory used by a session after the session is shut down)
   * heap space being reclaimed as expected, but the OS not always reclaiming the memory from the process. This is out of our control and is something done by the OS kernel.
   * (see the comments on the issue for more info / evidence as to why we came to this conclusion)
* #6510, while also partially caused by streamlit not supporting the long-running script use-case very well, also has a real memory leak as part of the cause: our `ForwardMsgCache` does not always properly remove entries for sessions that are shut down, meaning that it's possible for entries corresponding to expired sessions to live in the cache forever.

This PR fixes this memory leak by removing all remaining refs for a session on shutdown.

## Graphs

The memory graphs below were generated using [memray](https://github.com/bloomberg/memray) by:
1. Letting a slightly modified version of the test script in #6510 run for ~1 minute
    * the script is identical aside from making the `time.sleep` only wait for 0.1 seconds to cause the memory usage to grow at a much higher rate
2. Closing the browser tab and waiting ~2 minutes to allow its session to expire
3. Opening and immediately closing a new browser tab
     * This is done to cause our old session to get cleaned up since expired entries in our session storage aren't actually garbage collected until the next time the backing `TTLCache` is mutated.
4.  Opening a final new tab and allowing the test script to run for another ~1 minute.

Note that, before the fix, heap space is not reclaimed when the old session is cleaned up at the end of the long period of constant memory usage.

### Memory graph before fix:
<img width="1138" alt="without fix" src="https://user-images.githubusercontent.com/3144420/236078240-36f51b97-a4cd-4e7e-a924-4306593ee5b0.png">


### Memory graph after fix:
<img width="1138" alt="with fix" src="https://user-images.githubusercontent.com/3144420/236076714-0ff4a302-012c-405c-92d0-53c324000b1e.png">


Closes #6354, #6510