### PR TITLE
Fix rendering of line chart column

### DIFF
--- a/frontend/src/lib/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -137,6 +137,13 @@ function BaseChartColumn(
         convertedChartData.push(convertedValue)
       }
 
+      if (chart_type === "line" && convertedChartData.length <= 2) {
+        // TODO(lukasmasuch): This is only a temporary workaround to prevent
+        // an error in glide-data-grid that occurs during cell drawing when the
+        // line chart has less than 3 values. This needs to a fix in glide-data-grid.
+        return getEmptyCell()
+      }
+
       if (
         convertedChartData.length > 0 &&
         (maxValue > parameters.y_max || minValue < parameters.y_min)


### PR DESCRIPTION
## 📚 Context

The line chart column runs into an error in case any of the cells has under 3 items in the list:

<img width="464" alt="Untitled" src="https://user-images.githubusercontent.com/2852129/235979931-89689e5e-64e8-434a-b920-8aed15ee185d.png">


This is due to a bug in the glide-data-grid dependency and needs a fix there. As a workaround, we will return an empty cell for all cells that have < 3 items, so that the table won't run into this error. 

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
