### PR TITLE
Run build_info script in conda build workflow

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           persist-credentials: false
           submodules: "recursive"
+          fetch-depth: 2
+      - name: Set build config env vars
+        uses: ./.github/actions/build_info
       # We need to install Python 3.9 here because it's the latest version
       # supported by the miniconda installer as of 2022/10/11.
       - name: Set up Python 3.9


### PR DESCRIPTION
I noticed the conda build workflow failing after #6622 was merged. This solved itself
on its own (it seems like it just took a bit of time for the updated constraint files to be
picked up), but it did have me realize that we're not setting build info in the conda build
job, which means we won't ignore the constraint files in the situations we're supposed to.