### PR TITLE
Avoid thread safety mishap

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -228,7 +228,6 @@ class AppSession:
                 rt = runtime.get_instance()
                 rt.media_file_mgr.clear_session_refs(self.id)
                 rt.media_file_mgr.remove_orphaned_files()
-                rt.message_cache.remove_refs_for_session(self)
 
             # Shut down the ScriptRunner, if one is active.
             # self._state must not be set to SHUTDOWN_REQUESTED until

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -220,7 +220,7 @@ class ForwardMsgCache(CacheStatsProvider):
     def remove_refs_for_session(self, session: "AppSession") -> None:
         """Remove refs for all entries for the given session.
 
-        This should be called when an AppSession is being shut down.
+        This should be called when an AppSession is disconnected or closed.
 
         Parameters
         ----------

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -411,7 +411,10 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        self._session_mgr.close_session(session_id)
+        session_info = self._session_mgr.get_session_info(session_id)
+        if session_info:
+            self._message_cache.remove_refs_for_session(session_info.session)
+            self._session_mgr.close_session(session_id)
         self._on_session_disconnected()
 
     def disconnect_session(self, session_id: str) -> None:
@@ -433,7 +436,17 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        self._session_mgr.disconnect_session(session_id)
+        session_info = self._session_mgr.get_active_session_info(session_id)
+        if session_info:
+            # NOTE: Ideally, we'd like to keep ForwardMsgCache refs for a session around
+            # when a session is disconnected (and defer their cleanup until the session
+            # is garbage collected), but this would be difficult to do as the
+            # ForwardMsgCache is not thread safe, and we have no guarantee that the
+            # garbage collector will only run on the eventloop thread. Because of this,
+            # we clean up refs now and accept the risk that we're deleting cache entries
+            # that will be useful once the browser tab reconnects.
+            self._message_cache.remove_refs_for_session(session_info.session)
+            self._session_mgr.disconnect_session(session_id)
         self._on_session_disconnected()
 
     def handle_backmsg(self, session_id: str, msg: BackMsg) -> None:

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -101,18 +101,15 @@ class AppSessionTest(unittest.TestCase):
 
         mock_file_mgr = MagicMock(spec=UploadedFileManager)
         session._uploaded_file_mgr = mock_file_mgr
-        mock_message_cache = Runtime._instance.message_cache
 
         session.shutdown()
         self.assertEqual(AppSessionState.SHUTDOWN_REQUESTED, session._state)
         mock_file_mgr.remove_session_files.assert_called_once_with(session.id)
         patched_disconnect.assert_called_once_with(session._on_secrets_file_changed)
-        mock_message_cache.remove_refs_for_session.assert_called_once_with(session)
 
         # A 2nd shutdown call should have no effect.
         session.shutdown()
         self.assertEqual(AppSessionState.SHUTDOWN_REQUESTED, session._state)
-        mock_message_cache.remove_refs_for_session.assert_called_once_with(session)
 
         mock_file_mgr.remove_session_files.assert_called_once_with(session.id)
 

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -186,15 +186,19 @@ class RuntimeTest(RuntimeTestCase):
         session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
+        session = self.runtime._session_mgr.get_session_info(session_id).session
 
         with patch.object(
             self.runtime._session_mgr, "disconnect_session", new=MagicMock()
         ) as patched_disconnect_session, patch.object(
             self.runtime, "_on_session_disconnected", new=MagicMock()
-        ) as patched_on_session_disconnected:
+        ) as patched_on_session_disconnected, patch.object(
+            self.runtime._message_cache, "remove_refs_for_session", new=MagicMock()
+        ) as patched_remove_refs_for_session:
             self.runtime.disconnect_session(session_id)
-            patched_disconnect_session.assert_called_with(session_id)
+            patched_disconnect_session.assert_called_once_with(session_id)
             patched_on_session_disconnected.assert_called_once()
+            patched_remove_refs_for_session.assert_called_once_with(session)
 
     async def test_close_session_closes_appsession(self):
         await self.runtime.start()
@@ -202,15 +206,19 @@ class RuntimeTest(RuntimeTestCase):
         session_id = self.runtime.connect_session(
             client=MockSessionClient(), user_info=MagicMock()
         )
+        session = self.runtime._session_mgr.get_session_info(session_id).session
 
         with patch.object(
             self.runtime._session_mgr, "close_session", new=MagicMock()
         ) as patched_close_session, patch.object(
             self.runtime, "_on_session_disconnected", new=MagicMock()
-        ) as patched_on_session_disconnected:
+        ) as patched_on_session_disconnected, patch.object(
+            self.runtime._message_cache, "remove_refs_for_session", new=MagicMock()
+        ) as patched_remove_refs_for_session:
             self.runtime.close_session(session_id)
-            patched_close_session.assert_called_with(session_id)
+            patched_close_session.assert_called_once_with(session_id)
             patched_on_session_disconnected.assert_called_once()
+            patched_remove_refs_for_session.assert_called_once_with(session)
 
     async def test_multiple_sessions(self):
         """Multiple sessions can be connected."""


### PR DESCRIPTION
Shortly after clicking merge on #6617, I remembered that `ForwardMsgCache` operations
aren't thread safe, so calling the new `remove_refs_for_session` method when a session is
garbage collected is unsafe. While this is unlikely to be an issue in practice thanks to our
good friend the GIL, we should still avoid it to be safe / for good practice's sake.

This PR cleans up refs for a session on both disconnect and close, which isn't totally ideal for
disconnects because in the case of a transient disconnect, it'd be better to keep those refs / cache
entries around. This is probably still fine since transient disconnects should be relatively rare, and
making `ForwardMsgCache` operations thread safe seems like far more work than it's worth to keep
around an optimization for best-effort reconnects.