### PR TITLE
Ignore new vendor paths for codeql

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -2,4 +2,5 @@ paths:
   - lib/streamlit
   - frontend/src
 paths-ignore:
-  - "frontend/src/vendor/**"
+  - "frontend/src/lib/vendor/**"
+  - "frontend/src/app/vendor/**"


### PR DESCRIPTION
## 📚 Context

The frontend split changed the paths of our vendor dependencies that we ignore in CodeQL. This PR corrects the paths.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
