### PR TITLE
Add basic widget rule checks to `st.data_editor`

### DIFF
--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -49,6 +49,7 @@ from streamlit.elements.lib.column_config_utils import (
     update_column_config,
 )
 from streamlit.elements.lib.pandas_styler_utils import marshall_styler
+from streamlit.elements.utils import check_callback_rules, check_session_state_rules
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -563,6 +564,10 @@ class DataEditorMixin:
 
         """
 
+        key = to_key(key)
+        check_callback_rules(self.dg, on_change)
+        check_session_state_rules(default_value=None, key=key, writes_allowed=False)
+
         columns_config: ColumnConfigMapping = {}
 
         data_format = type_util.determine_data_format(data)
@@ -655,7 +660,7 @@ class DataEditorMixin:
         widget_state = register_widget(
             "data_editor",
             proto,
-            user_key=to_key(key),
+            user_key=key,
             on_change_handler=on_change,
             args=args,
             kwargs=kwargs,

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -65,8 +65,8 @@ def check_session_state_rules(
 
     if not writes_allowed:
         raise StreamlitAPIException(
-            "Values for st.button, st.download_button, st.file_uploader, and "
-            "st.form cannot be set using st.session_state."
+            "Values for st.button, st.download_button, st.file_uploader, st.data_editor"
+            " and st.form cannot be set using st.session_state."
         )
 
     if default_value is not None and not _shown_default_value_warning:


### PR DESCRIPTION
## 📚 Context

This PR adds the `check_callback_rules` and `check_session_state_rules` checks that are also used on all other widgets to `st.data_editor`. This will prevent editing the session state of `st.data_editor`.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
