### PR TITLE
Add a config option to disable warning for setting both a widget default and its key in session_state

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -286,6 +286,20 @@ _create_option(
 
 
 _create_option(
+    "global.disableWidgetStateDuplicationWarning",
+    description="""
+        By default, Streamlit displays a warning when a user sets both a widget
+        default value in the function defining the widget and a widget value via
+        the widget's key in `st.session_state`.
+
+        If you'd like to turn off this warning, set this to True.
+        """,
+    default_val=False,
+    type_=bool,
+)
+
+
+_create_option(
     "global.showWarningOnDirectExecution",
     description="""
         If True, will show a warning when you run a Streamlit-enabled script

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -15,7 +15,7 @@
 from typing import TYPE_CHECKING, Any, Hashable, Optional, Union, cast
 
 import streamlit
-from streamlit import runtime, type_util
+from streamlit import config, runtime, type_util
 from streamlit.elements.form import is_in_form
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
@@ -69,7 +69,11 @@ def check_session_state_rules(
             "st.form cannot be set using st.session_state."
         )
 
-    if default_value is not None and not _shown_default_value_warning:
+    if (
+        default_value is not None
+        and not _shown_default_value_warning
+        and not config.get_option("global.disableWidgetStateDuplicationWarning")
+    ):
         streamlit.warning(
             f'The widget with key "{key}" was created with a default value but'
             " also had its value set via the Session State API."

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -351,6 +351,7 @@ class ConfigTest(unittest.TestCase):
                 "deprecation.showPyplotGlobalUse",
                 "global.developmentMode",
                 "global.disableWatchdogWarning",
+                "global.disableWidgetStateDuplicationWarning",
                 "global.logLevel",
                 "global.maxCachedMessageAge",
                 "global.minCachedMessageSize",

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from streamlit import config
 from streamlit.elements.utils import check_callback_rules, check_session_state_rules
 from streamlit.errors import StreamlitAPIException
 
@@ -90,6 +91,22 @@ class ElementUtilsTest(unittest.TestCase):
         args, kwargs = patched_st_warning.call_args
         warning_msg = args[0]
         assert 'The widget with key "the key"' in warning_msg
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    @patch("streamlit.elements.utils.get_session_state")
+    @patch("streamlit.warning")
+    def test_check_session_state_rules_hide_warning_if_state_duplication_disabled(
+        self, patched_st_warning, patched_get_session_state
+    ):
+        config._set_option("global.disableWidgetStateDuplicationWarning", True, "test")
+
+        mock_session_state = MagicMock()
+        mock_session_state.is_new_state_value.return_value = True
+        patched_get_session_state.return_value = mock_session_state
+
+        check_session_state_rules(5, key="the key")
+
+        patched_st_warning.assert_not_called()
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.utils.get_session_state")

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -21,8 +23,29 @@ from streamlit import config
 from streamlit.elements.utils import check_callback_rules, check_session_state_rules
 from streamlit.errors import StreamlitAPIException
 
+SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
+CONFIG_OPTIONS = copy.deepcopy(config._config_options)
+
 
 class ElementUtilsTest(unittest.TestCase):
+    def setUp(self):
+        self.patches = [
+            patch.object(
+                config, "_section_descriptions", new=copy.deepcopy(SECTION_DESCRIPTIONS)
+            ),
+            patch.object(config, "_config_options", new=copy.deepcopy(CONFIG_OPTIONS)),
+            patch.dict(os.environ),
+        ]
+
+        for p in self.patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self.patches:
+            p.stop()
+
+        config._delete_option("_test.tomlTest")
+
     @patch("streamlit.elements.utils.is_in_form", MagicMock(return_value=False))
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_check_callback_rules_not_in_form(self):


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Current:**

https://user-images.githubusercontent.com/22917736/236952180-2ec90665-0820-42fe-979d-6be2d95d370c.mp4

## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #3605

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
