### PR TITLE
Change docstrings to list str options explicitly

### DIFF
--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -141,7 +141,7 @@ def set_page_config(
         How the page content should be laid out. Defaults to "centered",
         which constrains the elements into a centered column of fixed width;
         "wide" uses the entire screen.
-    initial_sidebar_state: "auto" or "expanded" or "collapsed"
+    initial_sidebar_state: "auto", "expanded", or "collapsed"
         How the sidebar should start out. Defaults to "auto",
         which hides the sidebar on mobile-sized devices, and shows it otherwise.
         "expanded" shows the sidebar initially; "collapsed" hides it.
@@ -226,7 +226,6 @@ def set_page_config(
 
 
 def get_random_emoji() -> str:
-
     # Weigh our emojis 10x, cuz we're awesome!
     # TODO: fix the random seed with a hash of the user's app code, for stability?
     return random.choice(RANDOM_EMOJIS + 10 * ENG_EMOJIS)

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -173,7 +173,7 @@ class CameraInputMixin:
             An optional boolean, which disables the camera input if set to
             True. The default is False. This argument can only be supplied by
             keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/checkbox.py
+++ b/lib/streamlit/elements/checkbox.py
@@ -108,7 +108,7 @@ class CheckboxMixin:
         disabled : bool
             An optional boolean, which disables the checkbox if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/color_picker.py
+++ b/lib/streamlit/elements/color_picker.py
@@ -114,7 +114,7 @@ class ColorPickerMixin:
             An optional boolean, which disables the color picker if set to
             True. The default is False. This argument can only be supplied by
             keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn’t show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -293,7 +293,7 @@ class FileUploaderMixin:
             An optional boolean, which disables the file uploader if set to
             True. The default is False. This argument can only be supplied by
             keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -117,28 +117,28 @@ class ImageMixin:
             Image width. None means use the image width,
             but do not exceed the width of the column.
             Should be set for SVG images, as they have no default image width.
-        use_column_width : 'auto' or 'always' or 'never' or bool
-            If 'auto', set the image's width to its natural size,
+        use_column_width : "auto", "always", "never", or bool
+            If "auto", set the image's width to its natural size,
             but do not exceed the width of the column.
-            If 'always' or True, set the image's width to the column width.
-            If 'never' or False, set the image's width to its natural size.
+            If "always" or True, set the image's width to the column width.
+            If "never" or False, set the image's width to its natural size.
             Note: if set, `use_column_width` takes precedence over the `width` parameter.
         clamp : bool
             Clamp image pixel values to a valid range ([0-255] per channel).
             This is only meaningful for byte array images; the parameter is
             ignored for image URLs. If this is not set, and an image has an
             out-of-range value, an error will be thrown.
-        channels : 'RGB' or 'BGR'
+        channels : "RGB" or "BGR"
             If image is an nd.array, this parameter denotes the format used to
-            represent color information. Defaults to 'RGB', meaning
+            represent color information. Defaults to "RGB", meaning
             `image[:, :, 0]` is the red channel, `image[:, :, 1]` is green, and
             `image[:, :, 2]` is blue. For images coming from libraries like
-            OpenCV you should set this to 'BGR', instead.
-        output_format : 'JPEG', 'PNG', or 'auto'
+            OpenCV you should set this to "BGR", instead.
+        output_format : "JPEG", "PNG", or "auto"
             This parameter specifies the format to use when transferring the
             image data. Photos should use the JPEG format for lossy compression
             while diagrams should use the PNG format for lossless compression.
-            Defaults to 'auto' which identifies the compression type based
+            Defaults to "auto" which identifies the compression type based
             on the type and format of the image argument.
 
         Example

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -107,7 +107,7 @@ class LayoutsMixin:
                 For example, `st.columns([3, 1, 2])` creates 3 columns where
                 the first column is 3 times the width of the second, and the last
                 column is 2 times that width.
-        gap : string ("small", "medium", or "large")
+        gap : "small", "medium", or "large"
             An optional string, which indicates the size of the gap between each column.
             The default is a small gap between columns. This argument can only be supplied by
             keyword.

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -92,7 +92,7 @@ class MetricMixin:
             sign (str), the arrow points down and the text is red; else the
             arrow points up and the text is green. If None (default), no delta
             indicator is shown.
-        delta_color : str
+        delta_color : "normal" or "inverse" or "off"
              If "normal" (default), the delta indicator is shown as described
              above. If "inverse", it is red when positive and green when
              negative. This is useful when a negative change is considered

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -92,7 +92,7 @@ class MetricMixin:
             sign (str), the arrow points down and the text is red; else the
             arrow points up and the text is green. If None (default), no delta
             indicator is shown.
-        delta_color : "normal" or "inverse" or "off"
+        delta_color : "normal", "inverse", or "off"
              If "normal" (default), the delta indicator is shown as described
              above. If "inverse", it is red when positive and green when
              negative. This is useful when a negative change is considered
@@ -100,7 +100,7 @@ class MetricMixin:
              regardless of its value.
         help : str
             An optional tooltip that gets displayed next to the metric label.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/multiselect.py
+++ b/lib/streamlit/elements/multiselect.py
@@ -217,7 +217,7 @@ class MultiSelectMixin:
             An optional boolean, which disables the multiselect widget if set
             to True. The default is False. This argument can only be supplied
             by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -111,16 +111,16 @@ class NumberInputMixin:
             For accessibility reasons, you should never set an empty label (label="")
             but hide it with label_visibility if needed. In the future, we may disallow
             empty labels by raising an exception.
-        min_value : int or float or None
+        min_value : int, float, or None
             The minimum permitted value.
             If None, there will be no minimum.
-        max_value : int or float or None
+        max_value : int, float, or None
             The maximum permitted value.
             If None, there will be no maximum.
-        value : int or float or None
+        value : int, float, or None
             The value of this widget when it first renders.
             Defaults to min_value, or 0.0 if min_value is None
-        step : int or float or None
+        step : int, float, or None
             The stepping interval.
             Defaults to 1 if the value is an int, 0.01 otherwise.
             If the value is not specified, the format parameter will be used.
@@ -145,7 +145,7 @@ class NumberInputMixin:
             An optional boolean, which disables the number input if set to
             True. The default is False. This argument can only be supplied by
             keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -107,8 +107,8 @@ class PlotlyMixin:
             If True, set the chart width to the column width. This takes
             precedence over the figure's native `width` value.
 
-        sharing : {'streamlit', 'private', 'secret', 'public'}
-            Use 'streamlit' to insert the plot and all its dependencies
+        sharing : "streamlit", "private", "secret", or "public"
+            Use "streamlit" to insert the plot and all its dependencies
             directly in the Streamlit app using plotly's offline mode (default).
             Use any other sharing mode to send the chart to Plotly chart studio, which
             requires an account. See https://plot.ly/python/chart-studio/ for more information.

--- a/lib/streamlit/elements/radio.py
+++ b/lib/streamlit/elements/radio.py
@@ -151,7 +151,7 @@ class RadioMixin:
             The default is false (vertical buttons). This argument can only
             be supplied by keyword.
 
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/select_slider.py
+++ b/lib/streamlit/elements/select_slider.py
@@ -188,7 +188,7 @@ class SelectSliderMixin:
         disabled : bool
             An optional boolean, which disables the select slider if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -138,7 +138,7 @@ class SelectboxMixin:
         disabled : bool
             An optional boolean, which disables the selectbox if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -245,7 +245,7 @@ class SliderMixin:
             and upper bounds is rendered. For example, if set to `(1, 10)` the
             slider will have a selectable range between 1 and 10.
             Defaults to min_value.
-        step : int/float/timedelta or None
+        step : int, float, timedelta, or None
             The stepping interval.
             Defaults to 1 if the value is an int, 0.01 if a float,
             timedelta(days=1) if a date/datetime, timedelta(minutes=15) if a time
@@ -272,7 +272,7 @@ class SliderMixin:
         disabled : bool
             An optional boolean, which disables the slider if set to True. The
             default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/text_widgets.py
+++ b/lib/streamlit/elements/text_widgets.py
@@ -149,7 +149,7 @@ class TextWidgetsMixin:
         disabled : bool
             An optional boolean, which disables the text input if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
@@ -345,7 +345,7 @@ class TextWidgetsMixin:
         disabled : bool
             An optional boolean, which disables the text area if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/elements/time_widgets.py
+++ b/lib/streamlit/elements/time_widgets.py
@@ -133,7 +133,6 @@ class _DateInputValues:
         min_value: SingleDateValue,
         max_value: SingleDateValue,
     ) -> "_DateInputValues":
-
         parsed_value, is_range = _parse_date_value(value=value)
         return cls(
             value=parsed_value,
@@ -275,7 +274,7 @@ class TimeWidgetsMixin:
         disabled : bool
             An optional boolean, which disables the time input if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
@@ -468,7 +467,7 @@ class TimeWidgetsMixin:
         disabled : bool
             An optional boolean, which disables the date input if set to True.
             The default is False. This argument can only be supplied by keyword.
-        label_visibility : "visible" or "hidden" or "collapsed"
+        label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -422,7 +422,7 @@ class CacheDataAPI:
             a "cache miss" and the cached data is being created. If string,
             value of show_spinner param will be used for spinner text.
 
-        persist : str or boolean or None
+        persist : "disk" or boolean or None
             Optional location to persist cached data to. Passing "disk" (or True)
             will persist the cached data to the local disk. None (or False) will disable
             persistence. The default is None.

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -402,7 +402,7 @@ class CacheDataAPI:
         func : callable
             The function to cache. Streamlit hashes the function's source code.
 
-        ttl : float or timedelta or str or None
+        ttl : float, timedelta, str, or None
             The maximum time to keep an entry in the cache, or None if cache
             entries should not expire. The default is None. Note that ttl is
             incompatible with ``persist="disk"`` - ``ttl`` will be ignored if
@@ -422,7 +422,7 @@ class CacheDataAPI:
             a "cache miss" and the cached data is being created. If string,
             value of show_spinner param will be used for spinner text.
 
-        persist : "disk" or boolean or None
+        persist : "disk", boolean, or None
             Optional location to persist cached data to. Passing "disk" (or True)
             will persist the cached data to the local disk. None (or False) will disable
             persistence. The default is None.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -284,7 +284,7 @@ class CacheResourceAPI:
             The function that creates the cached resource. Streamlit hashes the
             function's source code.
 
-        ttl : float or timedelta or str or None
+        ttl : float, timedelta, str, or None
             The maximum time to keep an entry in the cache, or None if cache
             entries should not expire. The default is None.
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -188,7 +188,7 @@ def connection_factory(
     name : str
         The connection name used for secrets lookup in ``[connections.<name>]``.
         Type will be inferred from passing ``"sql"`` or ``"snowpark"``.
-    type : str or connection class or None
+    type : str, connection class, or None
         The type of connection to create. It can be a keyword (``"sql"`` or ``"snowpark"``),
         a path to an importable class, or an imported class reference. All classes
         must extend ``st.connections.ExperimentalBaseConnection`` and implement the
@@ -198,7 +198,7 @@ def connection_factory(
         The maximum number of connections to keep in the cache, or None
         for an unbounded cache. (When a new entry is added to a full cache,
         the oldest cached entry will be removed.) The default is None.
-    ttl : float or timedelta or None
+    ttl : float, timedelta, or None
         The maximum number of seconds to keep results in the cache, or
         None if cached results should not expire. The default is None.
     **kwargs : any


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

_Please describe the project or issue background here_

Our docstrings are inconsistent in how they describe parameters that support multiple string options. Some parameters just give `str` as the type, while others do `"foo" or "bar"`, or even more extravagant formats. This PR changes them all to use `"foo" or "bar"`.

Note to reviewers: this PR neither adds nor updates any tests as the changes merely refactor docstrings.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Docstring

## 🧠 Description of Changes


  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
