### PR TITLE
Fix pytest warnings

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -33,7 +33,6 @@ from streamlit.proto.NewSession_pb2 import (
 )
 from streamlit.proto.PagesChanged_pb2 import PagesChanged
 from streamlit.runtime import caching, legacy_caching
-from streamlit.runtime.credentials import Credentials
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.metrics_util import Installation
 from streamlit.runtime.script_data import ScriptData

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -16,7 +16,6 @@
 Global pytest fixtures. This file is automatically run by pytest before tests
 are executed.
 """
-import logging
 import os
 import sys
 from unittest.mock import mock_open, patch
@@ -64,17 +63,6 @@ with patch(
     # source_util.get_pages to depend on the filesystem can patch this value
     # back to None.
     source_util._cached_pages = {}
-
-
-def pytest_sessionfinish():
-    # We're not waiting for scriptrunner threads to cleanly close before ending the PyTest,
-    # which results in raised exception ValueError: I/O operation on closed file.
-    # This is well known issue in PyTest, check out these discussions for more:
-    # * https://github.com/pytest-dev/pytest/issues/5502
-    # * https://github.com/pytest-dev/pytest/issues/5282
-    # To prevent the exception from being raised on pytest_sessionfinish
-    # we disable exception raising in logging module
-    logging.raiseExceptions = False
 
 
 def pytest_addoption(parser: pytest.Parser):

--- a/lib/tests/delta_generator_test_case.py
+++ b/lib/tests/delta_generator_test_case.py
@@ -22,7 +22,6 @@ from unittest.mock import MagicMock
 from streamlit.proto.Delta_pb2 import Delta
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime
-from streamlit.runtime.app_session import AppSession
 from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
@@ -37,11 +36,6 @@ from streamlit.runtime.scriptrunner import (
 from streamlit.runtime.state import SafeSessionState, SessionState
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.web.server.server import MEDIA_ENDPOINT
-
-
-class FakeAppSession(AppSession):
-    def __init__(self):
-        self._session_state = SessionState()
 
 
 class DeltaGeneratorTestCase(unittest.TestCase):
@@ -62,8 +56,6 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             user_info={"email": "test@test.com"},
         )
         add_script_run_ctx(threading.current_thread(), self.script_run_ctx)
-
-        self.app_session = FakeAppSession()
 
         # Create a MemoryMediaFileStorage instance, and the MediaFileManager
         # singleton.

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -33,6 +33,7 @@ class TestCaseMetadata(NamedTuple):
     expected_rows: int
     expected_cols: int
     expected_data_format: DataFormat
+    __test__ = False  # Tell pytest that this is not a test class
 
 
 SHARED_TEST_CASES = [

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -93,7 +93,7 @@ def create_gif(size):
         frame = im.copy()
         draw = ImageDraw.Draw(frame)
         pos = (random.randrange(0, size), random.randrange(0, size))
-        circle_size = random.randrange(10, size / 2)
+        circle_size = random.randrange(10, int(size / 2))
         draw.ellipse([pos, tuple(p + circle_size for p in pos)], "black")
         images.append(frame.copy())
 

--- a/lib/tests/streamlit/elements/media_test.py
+++ b/lib/tests/streamlit/elements/media_test.py
@@ -26,7 +26,7 @@ from streamlit.proto.RootContainer_pb2 import RootContainer
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
-class TestMediaKind(Enum):
+class MockMediaKind(Enum):
     AUDIO = "audio"
     VIDEO = "video"
 
@@ -34,21 +34,21 @@ class TestMediaKind(Enum):
 class MediaTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
-            ("foo.wav", "audio/wav", TestMediaKind.AUDIO, False),
-            ("path/to/foo.wav", "audio/wav", TestMediaKind.AUDIO, False),
-            (b"fake_audio_data", "audio/wav", TestMediaKind.AUDIO, False),
-            ("https://foo.com/foo.wav", "audio/wav", TestMediaKind.AUDIO, True),
-            ("foo.mp4", "video/mp4", TestMediaKind.VIDEO, False),
-            ("path/to/foo.mp4", "video/mp4", TestMediaKind.VIDEO, False),
-            (b"fake_video_data", "video/mp4", TestMediaKind.VIDEO, False),
-            ("https://foo.com/foo.mp4", "video/mp4", TestMediaKind.VIDEO, True),
+            ("foo.wav", "audio/wav", MockMediaKind.AUDIO, False),
+            ("path/to/foo.wav", "audio/wav", MockMediaKind.AUDIO, False),
+            (b"fake_audio_data", "audio/wav", MockMediaKind.AUDIO, False),
+            ("https://foo.com/foo.wav", "audio/wav", MockMediaKind.AUDIO, True),
+            ("foo.mp4", "video/mp4", MockMediaKind.VIDEO, False),
+            ("path/to/foo.mp4", "video/mp4", MockMediaKind.VIDEO, False),
+            (b"fake_video_data", "video/mp4", MockMediaKind.VIDEO, False),
+            ("https://foo.com/foo.mp4", "video/mp4", MockMediaKind.VIDEO, True),
         ]
     )
     def test_add_bytes_and_filenames_to_mediafilemanager(
         self,
         media_data: MediaData,
         mimetype: str,
-        media_kind: TestMediaKind,
+        media_kind: MockMediaKind,
         is_url: bool,
     ):
         """st.audio + st.video should register bytes and filenames with the
@@ -59,7 +59,7 @@ class MediaTest(DeltaGeneratorTestCase):
         ) as mock_mfm_add, mock.patch("streamlit.runtime.caching.save_media_data"):
             mock_mfm_add.return_value = "https://mockoutputurl.com"
 
-            if media_kind is TestMediaKind.AUDIO:
+            if media_kind is MockMediaKind.AUDIO:
                 st.audio(media_data, mimetype)
                 element = self.get_delta_from_queue().new_element
                 element_url = element.audio.url


### PR DESCRIPTION
When pytest finishes running, it prints out a "warnings summary". Our warnings summary currently contains hundreds of warnings. 

This PR fixes all the warnings that originate from Streamlit test code.

---

Before (hundreds of warnings, mostly in our code):
```
========================================== warnings summary ==========================================
tests/streamlit/data_mocks.py:32
  /Users/tconkling/export/streamlit/lib/tests/streamlit/data_mocks.py:32: PytestCollectionWarning: cannot collect test class 'TestCaseMetadata' because it has a __new__ constructor (from: tests/streamlit/type_util_test.py)
    class TestCaseMetadata(NamedTuple):

../../../.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/bokeh/core/property/primitive.py:37
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/bokeh/core/property/primitive.py:37: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
    bokeh_bool_types += (np.bool8,)

tests/streamlit/data_mocks.py:32
  /Users/tconkling/export/streamlit/lib/tests/streamlit/data_mocks.py:32: PytestCollectionWarning: cannot collect test class 'TestCaseMetadata' because it has a __new__ constructor (from: tests/streamlit/elements/data_editor_test.py)
    class TestCaseMetadata(NamedTuple):

tests/streamlit/elements/image_test.py:96: 10 warnings
  /Users/tconkling/export/streamlit/lib/tests/streamlit/elements/image_test.py:96: DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
    circle_size = random.randrange(10, size / 2)

tests/streamlit/elements/media_test.py:29
  /Users/tconkling/export/streamlit/lib/tests/streamlit/elements/media_test.py:29: PytestCollectionWarning: cannot collect test class 'TestMediaKind' because it has a __new__ constructor (from: tests/streamlit/elements/media_test.py)
    class TestMediaKind(Enum):

tests/streamlit/components_test.py: 5 warnings
tests/streamlit/config_option_test.py: 1 warning
tests/streamlit/delta_generator_test.py: 36 warnings
tests/streamlit/form_test.py: 25 warnings
tests/streamlit/layouts_test.py: 8 warnings
tests/streamlit/spinner_test.py: 1 warning
tests/streamlit/string_util_test.py: 1 warning
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <function AppSession.__del__ at 0x126f6d120>

  Traceback (most recent call last):
    File "/Users/tconkling/export/streamlit/lib/streamlit/runtime/app_session.py", line 153, in __del__
      self.shutdown()
    File "/Users/tconkling/export/streamlit/lib/streamlit/runtime/app_session.py", line 221, in shutdown
      if self._state != AppSessionState.SHUTDOWN_REQUESTED:
  AttributeError: 'FakeAppSession' object has no attribute '_state'

    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))

tests/streamlit/user_info_test.py: 9 warnings
tests/streamlit/commands/page_config_test.py: 27 warnings
tests/streamlit/commands/query_params_test.py: 2 warnings
tests/streamlit/elements/alert_test.py: 7 warnings
tests/streamlit/elements/arrow_add_rows_test.py: 1 warning
tests/streamlit/elements/arrow_altair_test.py: 22 warnings
tests/streamlit/elements/arrow_dataframe_dimensions_test.py: 3 warnings
tests/streamlit/elements/arrow_dataframe_test.py: 12 warnings
tests/streamlit/elements/arrow_table_test.py: 8 warnings
tests/streamlit/elements/arrow_vega_lite_test.py: 16 warnings
tests/streamlit/elements/audio_test.py: 19 warnings
tests/streamlit/elements/balllons_test.py: 1 warning
tests/streamlit/elements/bokeh_test.py: 1 warning
tests/streamlit/elements/button_test.py: 4 warnings
tests/streamlit/elements/cache_spinner_test.py: 1 warning
tests/streamlit/elements/camera_input_test.py: 5 warnings
tests/streamlit/elements/checkbox_test.py: 15 warnings
tests/streamlit/elements/code_test.py: 4 warnings
tests/streamlit/elements/color_picker_test.py: 10 warnings
tests/streamlit/elements/data_editor_test.py: 62 warnings
tests/streamlit/elements/date_input_test.py: 22 warnings
tests/streamlit/elements/divider_test.py: 1 warning
tests/streamlit/elements/doc_string_test.py: 1 warning
tests/streamlit/elements/download_button_test.py: 5 warnings
tests/streamlit/elements/echo_test.py: 3 warnings
tests/streamlit/elements/empty_test.py: 1 warning
tests/streamlit/elements/exception_test.py: 1 warning
tests/streamlit/elements/file_uploader_test.py: 13 warnings
tests/streamlit/elements/graphviz_test.py: 2 warnings
tests/streamlit/elements/heading_test.py: 12 warnings
tests/streamlit/elements/help_test.py: 13 warnings
tests/streamlit/elements/image_test.py: 46 warnings
tests/streamlit/elements/json_test.py: 1 warning
tests/streamlit/elements/latex_test.py: 1 warning
tests/streamlit/elements/legacy_add_rows_test.py: 11 warnings
tests/streamlit/elements/legacy_altair_test.py: 8 warnings
tests/streamlit/elements/legacy_data_frame_test.py: 2 warnings
tests/streamlit/elements/legacy_dataframe_dimensions_test.py: 3 warnings
tests/streamlit/elements/legacy_dataframe_styling_test.py: 15 warnings
tests/streamlit/elements/legacy_vega_lite_test.py: 11 warnings
tests/streamlit/elements/map_test.py: 26 warnings
tests/streamlit/elements/markdown_test.py: 3 warnings
tests/streamlit/elements/media_test.py: 7 warnings
tests/streamlit/elements/metric_test.py: 16 warnings
tests/streamlit/elements/multiselect_test.py: 50 warnings
tests/streamlit/elements/number_input_test.py: 23 warnings
tests/streamlit/elements/plotly_chart_test.py: 6 warnings
tests/streamlit/elements/progress_test.py: 4 warnings
tests/streamlit/elements/pydeck_test.py: 4 warnings
tests/streamlit/elements/pyplot_test.py: 8 warnings
tests/streamlit/elements/radio_test.py: 26 warnings
tests/streamlit/elements/select_slider_test.py: 29 warnings
tests/streamlit/elements/selectbox_test.py: 24 warnings
tests/streamlit/elements/slider_test.py: 33 warnings
tests/streamlit/elements/text_area_test.py: 12 warnings
tests/streamlit/elements/text_input_test.py: 13 warnings
tests/streamlit/elements/text_test.py: 1 warning
tests/streamlit/elements/time_input_test.py: 8 warnings
tests/streamlit/elements/time_widgets_test.py: 2 warnings
tests/streamlit/elements/video_test.py: 6 warnings
tests/streamlit/runtime/metrics_util_test.py: 30 warnings
tests/streamlit/runtime/runtime_test.py: 1 warning
tests/streamlit/runtime/caching/cache_data_api_test.py: 13 warnings
tests/streamlit/runtime/caching/cache_errors_test.py: 3 warnings
tests/streamlit/runtime/caching/cache_resource_api_test.py: 1 warning
tests/streamlit/runtime/caching/common_cache_test.py: 43 warnings
tests/streamlit/runtime/legacy_caching/caching_test.py: 17 warnings
tests/streamlit/runtime/legacy_caching/hashing_test.py: 1 warning
tests/streamlit/runtime/state/session_state_test.py: 16 warnings
tests/streamlit/runtime/state/widgets_test.py: 18 warnings
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning:

  Exception ignored in: <function AppSession.__del__ at 0x126f6d120>

  Traceback (most recent call last):
    File "/Users/tconkling/export/streamlit/lib/streamlit/runtime/app_session.py", line 153, in __del__
      self.shutdown()
    File "/Users/tconkling/export/streamlit/lib/streamlit/runtime/app_session.py", line 221, in shutdown
      if self._state != AppSessionState.SHUTDOWN_REQUESTED:
  AttributeError: 'FakeAppSession' object has no attribute '_state'

tests/streamlit/elements/legacy_data_frame_test.py::LegacyDataFrameProtoTest::test_marshall_any_array
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/pandas/core/dtypes/common.py:1691: DeprecationWarning:

  Converting `np.inexact` or `np.floating` to a dtype is deprecated. The current result is `float64` which is not strictly correct.

tests/streamlit/elements/map_test.py::StMapTest::test_pyspark_dataframe
tests/streamlit/elements/map_test.py::StMapTest::test_pyspark_dataframe
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/pyspark/sql/pandas/utils.py:37: DeprecationWarning:

  distutils Version classes are deprecated. Use packaging.version instead.
```

After (3 warnings, all in 3rd party code):

```
========================================== warnings summary ==========================================
../../../.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/bokeh/core/property/primitive.py:37
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/bokeh/core/property/primitive.py:37: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
    bokeh_bool_types += (np.bool8,)

tests/streamlit/elements/legacy_data_frame_test.py::LegacyDataFrameProtoTest::test_marshall_any_array
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/pandas/core/dtypes/common.py:1691: DeprecationWarning:

  Converting `np.inexact` or `np.floating` to a dtype is deprecated. The current result is `float64` which is not strictly correct.

tests/streamlit/elements/map_test.py::StMapTest::test_pyspark_dataframe
tests/streamlit/elements/map_test.py::StMapTest::test_pyspark_dataframe
  /Users/tconkling/.local/share/virtualenvs/lib-evmbwHn2/lib/python3.10/site-packages/pyspark/sql/pandas/utils.py:37: DeprecationWarning:

  distutils Version classes are deprecated. Use packaging.version instead.
```