### PR TITLE
Add `to_pandas` method to convert inputs to pandas DataFrames

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -530,8 +530,8 @@ def convert_anything_to_df(
             )
         return data
 
-    # This is inefficient as the data will be converted back to Arrow
-    # when marshalled to protobuf, but area/bar/line charts need
+    # This is inefficient when data is a pyarrow.Table as it will be converted
+    # back to Arrow when marshalled to protobuf, but area/bar/line charts need
     # DataFrame magic to generate the correct output.
     if hasattr(data, "to_pandas"):
         return data.to_pandas()

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -503,12 +503,6 @@ def convert_anything_to_df(
     pandas.DataFrame
 
     """
-    # This is inefficient as the data will be converted back to Arrow
-    # when marshalled to protobuf, but area/bar/line charts need
-    # DataFrame magic to generate the correct output.
-    if hasattr(data, "to_pandas"):
-        return data.to_pandas()
-
     if is_type(data, _PANDAS_DF_TYPE_STR):
         return data.copy() if ensure_copy else data
 
@@ -535,6 +529,12 @@ def convert_anything_to_df(
                 "Call `collect()` on the dataframe to show more."
             )
         return data
+
+    # This is inefficient as the data will be converted back to Arrow
+    # when marshalled to protobuf, but area/bar/line charts need
+    # DataFrame magic to generate the correct output.
+    if hasattr(data, "to_pandas"):
+        return data.to_pandas()
 
     # Try to convert to pandas.DataFrame. This will raise an error is df is not
     # compatible with the pandas.DataFrame constructor.

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -506,7 +506,7 @@ def convert_anything_to_df(
     # This is inefficient as the data will be converted back to Arrow
     # when marshalled to protobuf, but area/bar/line charts need
     # DataFrame magic to generate the correct output.
-    if isinstance(data, pa.Table):
+    if hasattr(data, "to_pandas"):
         return data.to_pandas()
 
     if is_type(data, _PANDAS_DF_TYPE_STR):

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -178,6 +178,15 @@ class TypeUtilTest(unittest.TestCase):
         df = convert_anything_to_df(data)
         pd.testing.assert_frame_equal(df, pd.DataFrame.from_dict(data, orient="index"))
 
+    def test_convert_anything_to_df_calls_to_pandas_when_available(self):
+        class DataFrameIsh:
+            def to_pandas(self):
+                return pd.DataFrame([])
+
+        converted = convert_anything_to_df(DataFrameIsh())
+        assert isinstance(converted, pd.DataFrame)
+        assert converted.empty
+
     @parameterized.expand(
         [
             # Complex numbers:


### PR DESCRIPTION
- Use to_pandas method to convert inputs to dataframes if the method is available

<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

I'd like to be able to pass an ibis table expression into streamlit APIs that
accept other kinds of table objects (pandas DataFrames, pyarrow Tables, etc).

This PR implements that based on discussion and suggestions from #6467.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- Adds `to_pandas` to support ibis table expression inputs as well as
  other ecosystem objects that implement this API.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://github.com/streamlit/streamlit/assets/417981/fe2d4d69-14da-418e-b785-5856e0e425b3)

**Current:**

![image](https://github.com/streamlit/streamlit/assets/417981/edf9209b-b586-40a7-a30e-82282dc187f5)

## 🧪 Testing Done

- [x] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #6467

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
