### PR TITLE
Fix import name

### DIFF
--- a/frontend/src/app/components/StreamlitDialog/ThemeCreatorDialog.test.tsx
+++ b/frontend/src/app/components/StreamlitDialog/ThemeCreatorDialog.test.tsx
@@ -17,7 +17,7 @@
 import React from "react"
 import { CustomThemeConfig } from "src/lib/proto"
 import { shallow } from "src/lib/test_util"
-import ColorPicker from "src/lib/components/shared/BaseColorPicker"
+import BaseColorPicker from "src/lib/components/shared/BaseColorPicker"
 import UISelectbox from "src/lib/components/shared/Dropdown"
 import { baseTheme, darkTheme, lightTheme, toThemeInput } from "src/lib/theme"
 import { fonts } from "src/lib/theme/primitives/typography"
@@ -174,7 +174,7 @@ describe("Opened ThemeCreatorDialog", () => {
       .first()
       .dive()
 
-    const colorpicker = wrapper.find(ColorPicker)
+    const colorpicker = wrapper.find(BaseColorPicker)
     expect(colorpicker).toHaveLength(1)
 
     colorpicker.at(0).prop("onChange")("pink")

--- a/frontend/src/app/components/StreamlitDialog/ThemeCreatorDialog.tsx
+++ b/frontend/src/app/components/StreamlitDialog/ThemeCreatorDialog.tsx
@@ -24,7 +24,7 @@ import { CustomThemeConfig } from "src/lib/proto"
 import BaseButton, {
   BaseButtonKind,
 } from "src/lib/components/shared/BaseButton"
-import ColorPicker from "src/lib/components/shared/BaseColorPicker"
+import BaseColorPicker from "src/lib/components/shared/BaseColorPicker"
 import Modal, { ModalHeader, ModalBody } from "src/lib/components/shared/Modal"
 import UISelectbox from "src/lib/components/shared/Dropdown"
 import Icon from "src/lib/components/shared/Icon"
@@ -68,25 +68,25 @@ const themeBuilder: Record<string, ThemeOptionBuilder> = {
   primaryColor: {
     help: "Primary accent color for interactive elements.",
     title: "Primary color",
-    component: ColorPicker,
+    component: BaseColorPicker,
     getValue: valueToColor,
   },
   backgroundColor: {
     help: "Background color for the main content area.",
     title: "Background color",
-    component: ColorPicker,
+    component: BaseColorPicker,
     getValue: valueToColor,
   },
   secondaryBackgroundColor: {
     help: "Background color used for the sidebar and most interactive widgets.",
     title: "Secondary background color",
-    component: ColorPicker,
+    component: BaseColorPicker,
     getValue: valueToColor,
   },
   textColor: {
     help: "Color used for almost all text.",
     title: "Text color",
-    component: ColorPicker,
+    component: BaseColorPicker,
     getValue: valueToColor,
   },
   font: {
@@ -223,7 +223,7 @@ const ThemeCreatorDialog = (props: Props): ReactElement => {
     value: string
   }): ReactElement | null => {
     const themeOptionConfig = themeBuilder[name]
-    const isColor = themeOptionConfig.component === ColorPicker
+    const isColor = themeOptionConfig.component === BaseColorPicker
     // Props that vary based on component type
     const variableProps = {
       options: themeOptionConfig.options || undefined,

--- a/frontend/src/lib/components/widgets/Button/Button.test.tsx
+++ b/frontend/src/lib/components/widgets/Button/Button.test.tsx
@@ -18,7 +18,7 @@ import React from "react"
 import { shallow } from "src/lib/test_util"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 
-import UIButton from "src/lib/components/shared/BaseButton"
+import BaseButton from "src/lib/components/shared/BaseButton"
 import StreamlitMarkdown from "src/lib/components/shared/StreamlitMarkdown"
 
 import { Button as ButtonProto } from "src/lib/proto"
@@ -66,22 +66,24 @@ describe("Button widget", () => {
   it("should render a label within the button", () => {
     const wrapper = shallow(<Button {...getProps()} />)
 
-    const wrappedUIButton = wrapper.find(UIButton)
-    const wrappedButtonLabel = wrappedUIButton.find(StreamlitMarkdown)
+    const wrappedBaseButton = wrapper.find(BaseButton)
+    const wrappedBaseButtonlabel = wrappedBaseButton.find(StreamlitMarkdown)
 
-    expect(wrappedUIButton.length).toBe(1)
-    expect(wrappedButtonLabel.props().source).toBe(getProps().element.label)
-    expect(wrappedButtonLabel.props().isButton).toBe(true)
+    expect(wrappedBaseButton.length).toBe(1)
+    expect(wrappedBaseButtonlabel.props().source).toBe(
+      getProps().element.label
+    )
+    expect(wrappedBaseButtonlabel.props().isButton).toBe(true)
   })
 
-  describe("UIButton props should work", () => {
+  describe("BaseButton props should work", () => {
     it("onClick prop", () => {
       const props = getProps()
       const wrapper = shallow(<Button {...props} />)
 
-      const wrappedUIButton = wrapper.find(UIButton)
+      const wrappedBaseButton = wrapper.find(BaseButton)
 
-      wrappedUIButton.simulate("click")
+      wrappedBaseButton.simulate("click")
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,
@@ -93,17 +95,17 @@ describe("Button widget", () => {
       const props = getProps()
       const wrapper = shallow(<Button {...props} />)
 
-      const wrappedUIButton = wrapper.find(UIButton)
+      const wrappedBaseButton = wrapper.find(BaseButton)
 
-      expect(wrappedUIButton.props().disabled).toBe(props.disabled)
+      expect(wrappedBaseButton.props().disabled).toBe(props.disabled)
     })
   })
 
   it("does not use container width by default", () => {
     const wrapper = shallow(<Button {...getProps()}>Hello</Button>)
 
-    const wrappedUIButton = wrapper.find(UIButton)
-    expect(wrappedUIButton.props().fluidWidth).toBe(false)
+    const wrappedBaseButton = wrapper.find(BaseButton)
+    expect(wrappedBaseButton.props().fluidWidth).toBe(false)
   })
 
   it("passes useContainerWidth property correctly", () => {
@@ -111,7 +113,7 @@ describe("Button widget", () => {
       <Button {...getProps({ useContainerWidth: true })}>Hello</Button>
     )
 
-    const wrappedUIButton = wrapper.find(UIButton)
-    expect(wrappedUIButton.props().fluidWidth).toBe(true)
+    const wrappedBaseButton = wrapper.find(BaseButton)
+    expect(wrappedBaseButton.props().fluidWidth).toBe(true)
   })
 })

--- a/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -18,7 +18,7 @@ import React from "react"
 import { shallow } from "src/lib/test_util"
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 
-import UIButton from "src/lib/components/shared/BaseButton"
+import BaseButton from "src/lib/components/shared/BaseButton"
 import StreamlitMarkdown from "src/lib/components/shared/StreamlitMarkdown"
 
 import { DownloadButton as DownloadButtonProto } from "src/lib/proto"
@@ -70,22 +70,24 @@ describe("DownloadButton widget", () => {
   it("renders a label within the button", () => {
     const wrapper = shallow(<DownloadButton {...getProps()} />)
 
-    const wrappedUIButton = wrapper.find(UIButton)
-    const wrappedButtonLabel = wrappedUIButton.find(StreamlitMarkdown)
+    const wrappedBaseButton = wrapper.find(BaseButton)
+    const wrappedBaseButtonLabel = wrappedBaseButton.find(StreamlitMarkdown)
 
-    expect(wrappedUIButton.length).toBe(1)
-    expect(wrappedButtonLabel.props().source).toBe(getProps().element.label)
-    expect(wrappedButtonLabel.props().isButton).toBe(true)
+    expect(wrappedBaseButton.length).toBe(1)
+    expect(wrappedBaseButtonLabel.props().source).toBe(
+      getProps().element.label
+    )
+    expect(wrappedBaseButtonLabel.props().isButton).toBe(true)
   })
 
-  describe("wrapped UIButton", () => {
+  describe("wrapped BaseButton", () => {
     it("sets widget triggerValue and creates a download URL on click", () => {
       const props = getProps()
       const wrapper = shallow(<DownloadButton {...props} />)
 
-      const wrappedUIButton = wrapper.find(UIButton)
+      const wrappedBaseButton = wrapper.find(BaseButton)
 
-      wrappedUIButton.simulate("click")
+      wrappedBaseButton.simulate("click")
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,
@@ -101,9 +103,9 @@ describe("DownloadButton widget", () => {
       const props = getProps()
       const wrapper = shallow(<DownloadButton {...props} />)
 
-      const wrappedUIButton = wrapper.find(UIButton)
+      const wrappedBaseButton = wrapper.find(BaseButton)
 
-      expect(wrappedUIButton.props().disabled).toBe(props.disabled)
+      expect(wrappedBaseButton.props().disabled).toBe(props.disabled)
     })
 
     it("does not use container width by default", () => {
@@ -111,8 +113,8 @@ describe("DownloadButton widget", () => {
         <DownloadButton {...getProps()}>Hello</DownloadButton>
       )
 
-      const wrappedUIButton = wrapper.find(UIButton)
-      expect(wrappedUIButton.props().fluidWidth).toBe(false)
+      const wrappedBaseButton = wrapper.find(BaseButton)
+      expect(wrappedBaseButton.props().fluidWidth).toBe(false)
     })
 
     it("passes useContainerWidth property correctly", () => {
@@ -122,8 +124,8 @@ describe("DownloadButton widget", () => {
         </DownloadButton>
       )
 
-      const wrappedUIButton = wrapper.find(UIButton)
-      expect(wrappedUIButton.props().fluidWidth).toBe(true)
+      const wrappedBaseButton = wrapper.find(BaseButton)
+      expect(wrappedBaseButton.props().fluidWidth).toBe(true)
     })
   })
 })

--- a/frontend/src/lib/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/src/lib/components/widgets/Form/FormSubmitButton.test.tsx
@@ -93,9 +93,9 @@ describe("FormSubmitButton", () => {
     const wrappedBaseButton = wrapper.find(BaseButton)
 
     expect(wrappedBaseButton.length).toBe(1)
-    const markdownInsideWrappedUIButton =
+    const markdownInsideWrappedBaseButton =
       wrappedBaseButton.find(StreamlitMarkdown)
-    expect(markdownInsideWrappedUIButton.props().source).toBe(
+    expect(markdownInsideWrappedBaseButton.props().source).toBe(
       getProps().element.label
     )
   })


### PR DESCRIPTION
It looks like when you do `export { default } from "./BaseColorPicker"`, you can import the default as any name it looks like. As a result, `ColorPicker` needs to be renamed to `BaseColorPicker` for styling sake. 
It looks like there is a rule to resolve this:
https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md

However, it was turned off and when I turned it back on, it had 182 warnings so I'm not going to turn it back on but I am going to resolve the ones that I missed.
```
tsx
  52:25  warning  Caution: `React` also has a named export `PureComponent`. Check if you meant to write `import {PureComponent} from 'react'` instead  import/no-named-as-default-member

/Users/wihuang/actual_streamlit/streamlit/frontend/src/lib/hocs/withMapboxToken/withMapboxToken.test.tsx
  30:29  warning  Caution: `React` also has a named export `PureComponent`. Check if you meant to write `import {PureComponent} from 'react'` instead  import/no-named-as-default-member

/Users/wihuang/actual_streamlit/streamlit/frontend/src/lib/util/format.test.ts
  62:18  warning  Caution: `moment` also has a named export `parseZone`. Check if you meant to write `import {parseZone} from 'moment'` instead  import/no-named-as-default-member

/Users/wihuang/actual_streamlit/streamlit/frontend/src/lib/util/format.ts
  49:9   warning  Caution: `moment` also has a named export `parseZone`. Check if you meant to write `import {parseZone} from 'moment'` instead  import/no-named-as-default-member
  67:16  warning  Caution: `moment` also has a named export `duration`. Check if you meant to write `import {duration} from 'moment'` instead    import/no-named-as-default-member
  68:12  warning  Caution: `moment` also has a named export `utc`. Check if you meant to write `import {utc} from 'moment'` instead              import/no-named-as-default-member
  76:7   warning  Caution: `moment` also has a named export `isMoment`. Check if you meant to write `import {isMoment} from 'moment'` instead    import/no-named-as-default-member

/Users/wihuang/actual_streamlit/streamlit/frontend/src/lib/util/utils.ts
  197:10  warning  Caution: `xxhash` also has a named export `h32`. Check if you meant to write `import {h32} from 'xxhashjs'` instead  import/no-named-as-default-member

✖ 182 problems (0 errors, 182 warnings)
```