### PR TITLE
Python requirements: pin to < NEXT_MAJOR_VERSION

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -26,34 +26,38 @@ VERSION = "1.22.0"  # PEP-440
 NAME = "streamlit"
 
 # IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
-# And if you do add one, make the required version as general as possible.
-# But include relevant lower bounds for any features we use from our dependencies.
+# And if you do add one, make the required version as general as possible:
+# - Include relevant lower bound for any features we use from our dependencies
+# - And include an upper bound that's < NEXT_MAJOR_VERSION
 INSTALL_REQUIRES = [
-    "altair<5,>=3.2.0",
-    "blinker>=1.0.0",
-    "cachetools>=4.0",
-    "click>=7.0",
+    "altair>=3.2.0, <5",
+    "blinker>=1.0.0, <2",
+    "cachetools>=4.0, <6",
+    "click>=7.0, <9",
     # 1.4 introduced the functionality found in python 3.8's importlib.metadata module
-    "importlib-metadata>=1.4",
-    "numpy",
-    "packaging>=14.1",
-    "pandas<3,>=0.25",
-    "pillow>=6.2.0",
+    "importlib-metadata>=1.4, <7",
+    "numpy>=1, <2",
+    "packaging>=14.1, <24",
+    "pandas>=0.25, <3",
+    "pillow>=6.2.0, <10",
     # Python protobuf 4.21 (the first 4.x version) is compatible with protobufs
     # generated from `protoc` >= 3.20. (`protoc` is installed separately from the Python
     # protobuf package, so this pin doesn't actually enforce a `protoc` minimum version.
     # Instead, the `protoc` min version is enforced in our Makefile.)
     "protobuf>=3.20, <5",
+    # pyarrow is not semantically versioned, gets new major versions frequently, and
+    # doesn't tend to break the API on major version upgrades, so we don't put an
+    # upper bound on it.
     "pyarrow>=4.0",
-    "pympler>=0.9",
-    "python-dateutil",
-    "requests>=2.4",
-    "rich>=10.11.0",
-    "tenacity<9,>=8.0.0",
-    "toml",
+    "pympler>=0.9, <2",
+    "python-dateutil>=2, <3",
+    "requests>=2.4, <3",
+    "rich>=10.11.0, <14",
+    "tenacity>=8.0.0, <9",
+    "toml<2",
     "typing-extensions>=3.10.0.0",
-    "tzlocal>=1.1",
-    "validators>=0.2",
+    "tzlocal>=1.1, <5",
+    "validators>=0.2, <1",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
     "watchdog; platform_system != 'Darwin'",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -68,11 +68,11 @@ INSTALL_REQUIRES = [
 # and PyPI builds (that is, for people installing streamlit using either
 # `pip install streamlit` or `conda install -c conda-forge streamlit`)
 SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
-    "gitpython!=3.1.19",
-    "pydeck>=0.1.dev5",
+    "gitpython>=3, <4, !=3.1.19",
+    "pydeck>=0.1.dev5, <1",
     # Tornado 6.0.3 was the current Tornado version when Python 3.8, our earliest supported Python version,
     # was released (Oct 14, 2019).
-    "tornado>=6.0.3",
+    "tornado>=6.0.3, <7",
 ]
 
 if not os.getenv("SNOWPARK_CONDA_BUILD"):


### PR DESCRIPTION
Traditionally, we've left our Python dependency version upper bounds unspecified, to support the broadest possible set of dependency versions (and also to get notified early, via CI, of breakages when new versions of our dependent libraries are released).

In practice, major dependency version upgrades frequently break Streamlit, and we end up retroactively adding an upper bound anyway. This leads to obvious frustrations! So we're changing the policy:

We now set an upper bound on _all_* Python dependencies. The default upper bound is `< NEXT_MAJOR_VERSION`, since major version upgrades generally mean "the API has breaking changes".

(*Not actually "all" - there are a few exceptions like pyarrow)