### PR TITLE
Migrate datetime column formatting from date-fns to momentJS

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -7004,32 +7004,6 @@ Read more about MIT at [TLDRLegal](https://tldrlegal.com/license/mit-license).
 
 -----
 
-The following software may be included in this product: date-fns. A copy of the source code may be downloaded from https://github.com/date-fns/date-fns. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2021 Sasha Koss and Lesha Koss https://kossnocorp.mit-license.org
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: date-fns-tz. A copy of the source code may be downloaded from https://github.com/marnusw/date-fns-tz. This software contains the following license and notice below:
 
 The MIT License (MIT)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,8 +59,6 @@
     "copy-to-clipboard": "^3.3.3",
     "d3": "^7.8.2",
     "d3-graphviz": "^2.6.1",
-    "date-fns": "^2.29.3",
-    "date-fns-tz": "^2.0.0",
     "decamelize": "^4.0.0",
     "deck.gl": "^8.8.23",
     "dompurify": "^2.4.4",

--- a/frontend/src/lib/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
@@ -227,7 +227,7 @@ describe("DateTimeColumn", () => {
     const MOCK_DATETIME_COLUMN_CUSTOM_FORMAT = {
       ...MOCK_DATETIME_COLUMN_TEMPLATE,
       columnTypeOptions: {
-        format: "MMM do, yyyy - HH:mm",
+        format: "MMM Do, YYYY - HH:mm",
       },
     }
 
@@ -403,7 +403,7 @@ describe("DateColumn", () => {
     const MOCK_DATE_COLUMN_CUSTOM_FORMAT = {
       ...MOCK_DATE_COLUMN_TEMPLATE,
       columnTypeOptions: {
-        format: "MMM do, yyyy",
+        format: "MMM Do, YYYY",
       },
     }
 

--- a/frontend/src/lib/components/widgets/DataFrame/columns/DateTimeColumn.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/DateTimeColumn.ts
@@ -51,7 +51,7 @@ function applyTimezone(momentDate: Moment, timezone: string): Moment {
 }
 
 export interface DateTimeColumnParams {
-  // A date-fns formatting syntax to format the display value.
+  // A momentJS formatting syntax to format the display value.
   readonly format?: string
   // Specifies the granularity that the value must adhere.
   // For time and datetime, this is the number of seconds between each allowed value.
@@ -300,6 +300,14 @@ function BaseDateTimeColumn(
  * @returns The new column.
  */
 export default function DateTimeColumn(props: BaseColumnProps): BaseColumn {
+  // Do a smart selection of the default format based on the step size
+  let defaultFormat = "YYYY-MM-DD HH:mm:ss"
+  if (props.columnTypeOptions?.step >= 60) {
+    defaultFormat = "YYYY-MM-DD HH:mm"
+  } else if (props.columnTypeOptions?.step < 1) {
+    defaultFormat = "YYYY-MM-DD HH:mm:ss.SSS"
+  }
+
   const timezone: string | undefined = props.arrowType?.meta?.timezone
   const hasTimezone: boolean =
     notNullOrUndefined(timezone) ||
@@ -309,7 +317,7 @@ export default function DateTimeColumn(props: BaseColumnProps): BaseColumn {
   return BaseDateTimeColumn(
     "datetime",
     props,
-    hasTimezone ? "yyyy-MM-dd HH:mm:ssxxx" : "yyyy-MM-dd HH:mm:ss",
+    hasTimezone ? defaultFormat + "Z" : defaultFormat,
     1,
     "datetime-local",
     (date: Date): string => {
@@ -366,7 +374,7 @@ export function DateColumn(props: BaseColumnProps): BaseColumn {
   return BaseDateTimeColumn(
     "date",
     props,
-    "yyyy-MM-dd",
+    "YYYY-MM-DD",
     1,
     "date",
     (date: Date): string => {

--- a/frontend/src/lib/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/utils.test.ts
@@ -533,51 +533,51 @@ describe("formatMoment", () => {
 
   it.each([
     [
-      "yyyy-MM-dd HH:mm:ss zzz",
+      "YYYY-MM-DD HH:mm:ss z",
       moment.utc("2023-04-27T10:20:30Z"),
       "2023-04-27 10:20:30 UTC",
     ],
     [
-      "yyyy-MM-dd HH:mm:ss zzz",
+      "YYYY-MM-DD HH:mm:ss z",
       moment.utc("2023-04-27T10:20:30Z").tz("America/Los_Angeles"),
       "2023-04-27 03:20:30 PDT",
     ],
     [
-      "yyyy-MM-dd HH:mm:ss xxx",
+      "YYYY-MM-DD HH:mm:ss Z",
       moment.utc("2023-04-27T10:20:30Z").tz("America/Los_Angeles"),
       "2023-04-27 03:20:30 -07:00",
     ],
     [
-      "yyyy-MM-dd HH:mm:ss xxx",
+      "YYYY-MM-DD HH:mm:ss Z",
       moment.utc("2023-04-27T10:20:30Z").utcOffset("+04:00"),
       "2023-04-27 14:20:30 +04:00",
     ],
-    ["yyyy-MM-dd", moment.utc("2023-04-27T10:20:30Z"), "2023-04-27"],
+    ["YYYY-MM-DD", moment.utc("2023-04-27T10:20:30Z"), "2023-04-27"],
     [
-      "MMM do, yyyy 'at' h:mm aa",
+      "MMM Do, YYYY [at] h:mm A",
       moment.utc("2023-04-27T15:45:00Z"),
       "Apr 27th, 2023 at 3:45 PM",
     ],
     [
-      "MMMM do, yyyy xxxxx",
+      "MMMM Do, YYYY Z",
       moment.utc("2023-04-27T10:20:30Z").utcOffset("-02:30"),
       "April 27th, 2023 -02:30",
     ],
     // Distance:
-    ["distance", moment.utc("2022-04-10T20:20:30Z"), "2 weeks ago"],
+    ["distance", moment.utc("2022-04-10T20:20:30Z"), "17 days ago"],
     ["distance", moment.utc("2020-04-10T20:20:30Z"), "2 years ago"],
-    ["distance", moment.utc("2022-04-27T23:59:59Z"), "1 second ago"],
-    ["distance", moment.utc("2022-04-20T00:00:00Z"), "last week"],
-    ["distance", moment.utc("2022-05-27T23:59:59Z"), "in 4 weeks"],
+    ["distance", moment.utc("2022-04-27T23:59:59Z"), "a few seconds ago"],
+    ["distance", moment.utc("2022-04-20T00:00:00Z"), "8 days ago"],
+    ["distance", moment.utc("2022-05-27T23:59:59Z"), "in a month"],
     ["relative", moment.utc("2022-04-30T15:30:00Z"), "Saturday at 3:30 PM"],
     // Relative:
     [
       "relative",
       moment.utc("2022-04-24T12:20:30Z"),
-      "last Sunday at 12:20 PM",
+      "Last Sunday at 12:20 PM",
     ],
-    ["relative", moment.utc("2022-04-28T12:00:00Z"), "today at 12:00 PM"],
-    ["relative", moment.utc("2022-04-29T12:00:00Z"), "tomorrow at 12:00 PM"],
+    ["relative", moment.utc("2022-04-28T12:00:00Z"), "Today at 12:00 PM"],
+    ["relative", moment.utc("2022-04-29T12:00:00Z"), "Tomorrow at 12:00 PM"],
   ])(
     "uses %s format to format %p to %p",
     (format: string, momentDate: Moment, expected: string) => {

--- a/frontend/src/lib/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/utils.ts
@@ -465,13 +465,13 @@ export function formatNumber(
  *
  * @param momentDate The moment date to format.
  * @param format The format to use.
- *   If the format is `localized` the date will be formatted according to the user's locale.
+ *   If the format is `locale` the date will be formatted according to the user's locale.
  *   If the format is `relative` the date will be formatted as a relative time (e.g. "2 hours ago").
  *   Otherwise, it is interpreted as momentJS format string: https://momentjs.com/docs/#/displaying/format/
  * @returns The formatted date as a string.
  */
 export function formatMoment(momentDate: Moment, format: string): string {
-  if (format === "localized") {
+  if (format === "locale") {
     return new Intl.DateTimeFormat(undefined, {
       dateStyle: "medium",
       timeStyle: "medium",

--- a/frontend/src/lib/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/utils.ts
@@ -26,8 +26,6 @@ import {
 import { toString, merge, isArray } from "lodash"
 import numbro from "numbro"
 import { sprintf } from "sprintf-js"
-import { intlFormatDistance, formatRelative } from "date-fns"
-import { formatInTimeZone } from "date-fns-tz"
 import moment, { Moment } from "moment"
 import "moment-duration-format"
 import "moment-timezone"
@@ -469,7 +467,7 @@ export function formatNumber(
  * @param format The format to use.
  *   If the format is `localized` the date will be formatted according to the user's locale.
  *   If the format is `relative` the date will be formatted as a relative time (e.g. "2 hours ago").
- *   Otherwise, it is interpreted as date-fns format string: https://date-fns.org/v2.29.3/docs/format
+ *   Otherwise, it is interpreted as momentJS format string: https://momentjs.com/docs/#/displaying/format/
  * @returns The formatted date as a string.
  */
 export function formatMoment(momentDate: Moment, format: string): string {
@@ -479,26 +477,11 @@ export function formatMoment(momentDate: Moment, format: string): string {
       timeStyle: "medium",
     }).format(momentDate.toDate())
   } else if (format === "distance") {
-    return intlFormatDistance(momentDate.toDate(), new Date())
+    return momentDate.fromNow()
   } else if (format === "relative") {
-    return formatRelative(momentDate.toDate(), new Date())
+    return momentDate.calendar()
   }
-  const timezone = momentDate.tz()
-  if (notNullOrUndefined(timezone)) {
-    // Format based on the timezone IANA name:
-    return formatInTimeZone(momentDate.toDate(), timezone, format)
-  }
-
-  const utcOffset = momentDate.utcOffset()
-  if (utcOffset !== 0) {
-    // Format based on the UTC offset:
-    return formatInTimeZone(
-      momentDate.toDate(),
-      momentDate.format("Z"),
-      format
-    )
-  }
-  return formatInTimeZone(momentDate.toDate(), "UTC", format)
+  return momentDate.format(format)
 }
 
 /**

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6606,16 +6606,6 @@ date-fns-tz@^1.2.2:
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
   integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==
 
-date-fns-tz@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
-  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
-
-date-fns@^2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
-
 date-fns@^2.6.0:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"


### PR DESCRIPTION
## 📚 Context

We decided to move back to momentJS for datetime formatting. This PR migrates the formatting in the `datetime`, `date` and `time` back to momentJS.

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
