### PR TITLE
Remove experimental prefix from `st.data_editor`

### DIFF
--- a/e2e/scripts/st_data_editor_column_types.py
+++ b/e2e/scripts/st_data_editor_column_types.py
@@ -34,25 +34,25 @@ random.seed(0)
 st.set_page_config(layout="wide")
 
 st.subheader("Base types")
-st.experimental_data_editor(BASE_TYPES_DF, use_container_width=True)
+st.data_editor(BASE_TYPES_DF, use_container_width=True)
 
 st.subheader("Number types")
-st.experimental_data_editor(NUMBER_TYPES_DF, use_container_width=True)
+st.data_editor(NUMBER_TYPES_DF, use_container_width=True)
 
 st.subheader("Date, time and datetime types")
-st.experimental_data_editor(DATETIME_TYPES_DF, use_container_width=True)
+st.data_editor(DATETIME_TYPES_DF, use_container_width=True)
 
 st.subheader("List types")
-st.experimental_data_editor(LIST_TYPES_DF, use_container_width=True)
+st.data_editor(LIST_TYPES_DF, use_container_width=True)
 
 st.subheader("Interval dtypes in pd.DataFrame")
-st.experimental_data_editor(INTERVAL_TYPES_DF, use_container_width=True)
+st.data_editor(INTERVAL_TYPES_DF, use_container_width=True)
 
 st.subheader("Special types")
-st.experimental_data_editor(SPECIAL_TYPES_DF, use_container_width=True)
+st.data_editor(SPECIAL_TYPES_DF, use_container_width=True)
 
 st.subheader("Period dtypes in pd.DataFrame")
-st.experimental_data_editor(PERIOD_TYPES_DF, use_container_width=True)
+st.data_editor(PERIOD_TYPES_DF, use_container_width=True)
 
 st.subheader("Unsupported types")
-st.experimental_data_editor(UNSUPPORTED_TYPES_DF, use_container_width=True)
+st.data_editor(UNSUPPORTED_TYPES_DF, use_container_width=True)

--- a/e2e/scripts/st_data_editor_config.py
+++ b/e2e/scripts/st_data_editor_config.py
@@ -32,18 +32,18 @@ df = pd.DataFrame(
 )
 
 st.header("Disabled parameter:")
-st.experimental_data_editor(df, disabled=True)
-st.experimental_data_editor(df, disabled=["col_4", "col_1"])
+st.data_editor(df, disabled=True)
+st.data_editor(df, disabled=["col_4", "col_1"])
 
 st.header("Hide index parameter:")
-st.experimental_data_editor(df, hide_index=True)
-st.experimental_data_editor(df, hide_index=False)
+st.data_editor(df, hide_index=True)
+st.data_editor(df, hide_index=False)
 
 st.header("Column order parameter:")
-st.experimental_data_editor(df, column_order=["col_4", "col_3", "col_0"])
+st.data_editor(df, column_order=["col_4", "col_3", "col_0"])
 
 st.header("Set column labels:")
-st.experimental_data_editor(
+st.data_editor(
     df,
     column_config={
         "index": "Index column",
@@ -53,12 +53,10 @@ st.experimental_data_editor(
 )
 
 st.header("Hide columns:")
-st.experimental_data_editor(
-    df, column_config={"col_1": None, "col_3": {"hidden": True}}
-)
+st.data_editor(df, column_config={"col_1": None, "col_3": {"hidden": True}})
 
 st.header("Set column width:")
-st.experimental_data_editor(
+st.data_editor(
     df,
     column_config={
         "col_0": st.column_config.Column(width="small"),
@@ -69,7 +67,7 @@ st.experimental_data_editor(
 
 st.header("Set help tooltips:")
 st.caption("Hover over the column headers to see the tooltips.")
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": ["a", "b", "c", None],
@@ -83,7 +81,7 @@ st.experimental_data_editor(
 
 
 st.header("Ignore editing-only config options:")
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": ["a", "b", "c", None],
@@ -97,7 +95,7 @@ st.header("Text column:")
 st.caption(
     "Editing the first column should only allow 5 characters. The second column should only allow numerical characters."
 )
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": ["Hello World", "Lorem ipsum", "", None],
@@ -124,7 +122,7 @@ st.header("Number column:")
 st.caption(
     "Editing the first column should only allow to submit numbers between 0 and 5. And only a maximum of 2 decimals."
 )
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [1, 2, 3, None],
@@ -150,7 +148,7 @@ st.experimental_data_editor(
 )
 
 st.header("Checkbox column:")
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [True, False, False, None],
@@ -172,7 +170,7 @@ st.experimental_data_editor(
 
 st.header("Selectbox column:")
 
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [1, 2, 3, None],
@@ -197,7 +195,7 @@ st.header("Link column:")
 st.caption(
     "Editing the first column should only submitting values starting with http and a maximum of 50 characters."
 )
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [
@@ -228,7 +226,7 @@ st.header("Datetime column:")
 st.caption(
     "Editing the first column should only allow datetime values between 2021-01-01 and 2022-01-01."
 )
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [
@@ -259,7 +257,7 @@ st.header("Date column:")
 st.caption(
     "Editing the first column should only allow picking every second day and between 2021-01-01 and 2022-01-01."
 )
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [
@@ -289,7 +287,7 @@ st.header("Time column:")
 st.caption(
     "Editing the first column should only allow datetime values between 01:02 and 01:03."
 )
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [
@@ -317,7 +315,7 @@ st.experimental_data_editor(
 
 st.header("Progress column:")
 
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [0.1, 0.4, 1.1, None],
@@ -338,7 +336,7 @@ st.experimental_data_editor(
 
 st.header("List column:")
 
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [[1, 2], [2, 3, 4], [], None],
@@ -357,7 +355,7 @@ st.experimental_data_editor(
 
 st.header("Bar chart column:")
 
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [[1, 5, 2], [2, 3, 5, -4, -5], [], None],
@@ -379,7 +377,7 @@ st.experimental_data_editor(
 
 st.header("Line chart column:")
 
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [[1, 5, 2], [2, 3, 5, -4, -5], [], None],
@@ -400,7 +398,7 @@ st.experimental_data_editor(
 
 st.header("Image column:")
 
-st.experimental_data_editor(
+st.data_editor(
     pd.DataFrame(
         {
             "col_0": [

--- a/e2e/scripts/st_data_editor_input_data.py
+++ b/e2e/scripts/st_data_editor_input_data.py
@@ -29,5 +29,5 @@ for i, test_case in enumerate(SHARED_TEST_CASES):
     data = test_case[0]
     data_format = str(test_case[1].expected_data_format)
     st.subheader(data_format)
-    st.experimental_data_editor(data, key=f"{i}-fixed")
-    st.experimental_data_editor(data, num_rows="dynamic", key=f"{i}-dynamic")
+    st.data_editor(data, key=f"{i}-fixed")
+    st.data_editor(data, num_rows="dynamic", key=f"{i}-dynamic")

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -124,6 +124,7 @@ columns = _main.columns
 tabs = _main.tabs
 container = _main.container
 dataframe = _main.dataframe
+data_editor = _main.data_editor
 date_input = _main.date_input
 divider = _main.divider
 download_button = _main.download_button

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -38,6 +38,7 @@ from typing_extensions import Literal, TypeAlias, TypedDict
 
 from streamlit import logger as _logger
 from streamlit import type_util
+from streamlit.deprecation_util import deprecate_func_name
 from streamlit.elements.form import current_form_id
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
@@ -447,7 +448,7 @@ def _check_type_compatibilities(
 
 class DataEditorMixin:
     @overload
-    def experimental_data_editor(
+    def data_editor(
         self,
         data: EditableData,
         *,
@@ -467,7 +468,7 @@ class DataEditorMixin:
         pass
 
     @overload
-    def experimental_data_editor(
+    def data_editor(
         self,
         data: Any,
         *,
@@ -486,8 +487,8 @@ class DataEditorMixin:
     ) -> pd.DataFrame:
         pass
 
-    @gather_metrics("experimental_data_editor")
-    def experimental_data_editor(
+    @gather_metrics("data_editor")
+    def data_editor(
         self,
         data: DataTypes,
         *,
@@ -605,7 +606,7 @@ class DataEditorMixin:
         >>>        {"command": "st.time_input", "rating": 3, "is_widget": True},
         >>>    ]
         >>> )
-        >>> edited_df = st.experimental_data_editor(df)
+        >>> edited_df = st.data_editor(df)
         >>>
         >>> favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
         >>> st.markdown(f"Your favorite command is **{favorite_command}** 🎈")
@@ -626,7 +627,7 @@ class DataEditorMixin:
         >>>        {"command": "st.time_input", "rating": 3, "is_widget": True},
         >>>    ]
         >>> )
-        >>> edited_df = st.experimental_data_editor(df, num_rows="dynamic")
+        >>> edited_df = st.data_editor(df, num_rows="dynamic")
         >>>
         >>> favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
         >>> st.markdown(f"Your favorite command is **{favorite_command}** 🎈")
@@ -647,7 +648,7 @@ class DataEditorMixin:
         >>>         {"command": "st.time_input", "rating": 3, "is_widget": True},
         >>>     ]
         >>> )
-        >>> edited_df = st.experimental_data_editor(
+        >>> edited_df = st.data_editor(
         >>>     df,
         >>>     column_config={
         >>>         "command": "Streamlit Command",
@@ -792,3 +793,10 @@ class DataEditorMixin:
     def dg(self) -> "DeltaGenerator":
         """Get our DeltaGenerator."""
         return cast("DeltaGenerator", self)
+
+    # TODO(lukasmasuch): Remove the deprecated function name after 2023-08-20:
+    experimental_data_editor = deprecate_func_name(
+        gather_metrics("experimental_data_editor", data_editor),
+        "experimental_data_editor",
+        "2023-08-20",
+    )

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -235,7 +235,7 @@ def Column(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "widgets": st.column_config.Column(
@@ -331,7 +331,7 @@ def NumberColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "price": st.column_config.NumberColumn(
@@ -430,7 +430,7 @@ def TextColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "widgets": st.column_config.TextColumn(
@@ -530,7 +530,7 @@ def LinkColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "apps": st.column_config.LinkColumn(
@@ -614,7 +614,7 @@ def CheckboxColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "favorite": st.column_config.CheckboxColumn(
@@ -706,7 +706,7 @@ def SelectboxColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "category": st.column_config.SelectboxColumn(
@@ -795,7 +795,7 @@ def BarChartColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "sales": st.column_config.BarChartColumn(
@@ -875,7 +875,7 @@ def LineChartColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "sales": st.column_config.LineChartColumn(
@@ -954,7 +954,7 @@ def ImageColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "apps": st.column_config.ImageColumn(
@@ -1017,7 +1017,7 @@ def ListColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "sales": st.column_config.ListColumn(
@@ -1122,7 +1122,7 @@ def DatetimeColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "appointment": st.column_config.DatetimeColumn(
@@ -1237,7 +1237,7 @@ def TimeColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "appointment": st.column_config.TimeColumn(
@@ -1351,7 +1351,7 @@ def DateColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "birthday": st.column_config.DateColumn(
@@ -1440,7 +1440,7 @@ def ProgressColumn(
     >>>     }
     >>> )
     >>>
-    >>> st.experimental_data_editor(
+    >>> st.data_editor(
     >>>     data_df,
     >>>     column_config={
     >>>         "sales": st.column_config.ProgressColumn(

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -102,6 +102,7 @@ class RunWarningTest(unittest.TestCase):
                 "columns",
                 "container",
                 "dataframe",
+                "data_editor",
                 "date_input",
                 "dg",
                 "divider",

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -248,21 +248,21 @@ class DataEditorUtilTest(unittest.TestCase):
 class DataEditorTest(DeltaGeneratorTestCase):
     def test_just_disabled_true(self):
         """Test that it can be called with disabled=True param."""
-        st.experimental_data_editor(pd.DataFrame(), disabled=True)
+        st.data_editor(pd.DataFrame(), disabled=True)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.disabled, True)
 
     def test_just_disabled_false(self):
         """Test that it can be called with disabled=False param."""
-        st.experimental_data_editor(pd.DataFrame(), disabled=False)
+        st.data_editor(pd.DataFrame(), disabled=False)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.disabled, False)
 
     def test_just_width_height(self):
         """Test that it can be called with width and height."""
-        st.experimental_data_editor(pd.DataFrame(), width=300, height=400)
+        st.data_editor(pd.DataFrame(), width=300, height=400)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.width, 300)
@@ -270,28 +270,28 @@ class DataEditorTest(DeltaGeneratorTestCase):
 
     def test_num_rows_fixed(self):
         """Test that it can be called with num_rows fixed."""
-        st.experimental_data_editor(pd.DataFrame(), num_rows="fixed")
+        st.data_editor(pd.DataFrame(), num_rows="fixed")
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.editing_mode, ArrowProto.EditingMode.FIXED)
 
     def test_num_rows_dynamic(self):
         """Test that it can be called with num_rows dynamic."""
-        st.experimental_data_editor(pd.DataFrame(), num_rows="dynamic")
+        st.data_editor(pd.DataFrame(), num_rows="dynamic")
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.editing_mode, ArrowProto.EditingMode.DYNAMIC)
 
     def test_column_order_parameter(self):
         """Test that it can be called with column_order."""
-        st.experimental_data_editor(pd.DataFrame(), column_order=["a", "b"])
+        st.data_editor(pd.DataFrame(), column_order=["a", "b"])
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.column_order, ["a", "b"])
 
     def test_just_use_container_width(self):
         """Test that it can be called with use_container_width."""
-        st.experimental_data_editor(pd.DataFrame(), use_container_width=True)
+        st.data_editor(pd.DataFrame(), use_container_width=True)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.use_container_width, True)
@@ -307,7 +307,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
             }
         )
 
-        st.experimental_data_editor(data_df, disabled=["a", "b"])
+        st.data_editor(data_df, disabled=["a", "b"])
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.disabled, False)
@@ -318,7 +318,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
 
     def test_outside_form(self):
         """Test that form id is marshalled correctly outside of a form."""
-        st.experimental_data_editor(pd.DataFrame())
+        st.data_editor(pd.DataFrame())
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(proto.form_id, "")
@@ -332,7 +332,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
             }
         )
 
-        st.experimental_data_editor(data_df, hide_index=True)
+        st.data_editor(data_df, hide_index=True)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(
@@ -349,7 +349,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
             }
         )
 
-        st.experimental_data_editor(data_df, hide_index=False)
+        st.data_editor(data_df, hide_index=False)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(
@@ -361,7 +361,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
     def test_inside_form(self):
         """Test that form id is marshalled correctly inside of a form."""
         with st.form("form"):
-            st.experimental_data_editor(pd.DataFrame())
+            st.data_editor(pd.DataFrame())
 
         # 2 elements will be created: form block, widget
         self.assertEqual(len(self.get_all_deltas_from_queue()), 2)
@@ -380,7 +380,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
             }
         )
 
-        return_df = st.experimental_data_editor(df)
+        return_df = st.data_editor(df)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         pd.testing.assert_frame_equal(bytes_to_data_frame(proto.data), df)
@@ -393,7 +393,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         metadata: TestCaseMetadata,
     ):
         """Test that it can be called with compatible data."""
-        return_data = st.experimental_data_editor(input_data)
+        return_data = st.data_editor(input_data)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         reconstructed_df = bytes_to_data_frame(proto.data)
@@ -430,7 +430,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
     def test_with_invalid_data(self, input_data: Any):
         """Test that it raises an exception when called with invalid data."""
         with self.assertRaises(StreamlitAPIException):
-            st.experimental_data_editor(input_data)
+            st.data_editor(input_data)
 
     @parameterized.expand(
         [
@@ -453,7 +453,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         df.set_index(index, inplace=True)
 
         with self.assertRaises(StreamlitAPIException):
-            st.experimental_data_editor(df)
+            st.data_editor(df)
 
     @parameterized.expand(
         [
@@ -475,7 +475,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         )
         df.set_index(index, inplace=True)
         # This should run without an issue and return a valid dataframe
-        return_df = st.experimental_data_editor(df)
+        return_df = st.data_editor(df)
         self.assertIsInstance(return_df, pd.DataFrame)
 
     def test_check_type_compatibilities(self):
@@ -539,7 +539,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
             )
             df.set_index(index, inplace=True)
             # This should run without an issue and return a valid dataframe
-            return_df = st.experimental_data_editor(df)
+            return_df = st.data_editor(df)
             self.assertIsInstance(return_df, pd.DataFrame)
 
     def test_pandas_styler_support(self):
@@ -553,7 +553,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         # NOTE: If UUID is not set - a random UUID will be generated.
         styler.set_uuid("FAKE_UUID")
         styler.highlight_max(axis=None)
-        st.experimental_data_editor(styler)
+        st.data_editor(styler)
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -76,6 +76,7 @@ class StreamlitTest(unittest.TestCase):
                 "tabs",
                 "container",
                 "dataframe",
+                "data_editor",
                 "date_input",
                 "divider",
                 "download_button",


### PR DESCRIPTION
## 📚 Context

This PR removes the `experimental_` prefix from the `st.data_editor`. This means that `st.data_editor` is considered stable from now on. 

- What kind of change does this PR introduce?

  - [ ] Bugfix
  - [x] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧪 Testing Done

- [ ] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
