### PR TITLE
Document integer size limit for number_input and slider

### DIFF
--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -86,7 +86,7 @@ class NumberInputMixin:
         .. note::
             Integer values larger in magnitude than `+/- (1<<53) - 1` cannot be
             stored or returned correctly by the widget due to limitations when
-            serializing values between the Python server and Javascript client.
+            serializing values between the Python server and JavaScript client.
             Numbers larger than this must be represented as floats and will
             consequently lose precision.
 

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -83,6 +83,13 @@ class NumberInputMixin:
     ) -> Number:
         r"""Display a numeric input widget.
 
+        .. note::
+            Integer values larger in magnitude than `+/- (1<<53) - 1` cannot be
+            stored or returned correctly by the widget due to limitations when
+            serializing values between the Python server and Javascript client.
+            Numbers larger than this must be represented as floats and will
+            consequently lose precision.
+
         Parameters
         ----------
         label : str

--- a/lib/streamlit/elements/number_input.py
+++ b/lib/streamlit/elements/number_input.py
@@ -84,11 +84,10 @@ class NumberInputMixin:
         r"""Display a numeric input widget.
 
         .. note::
-            Integer values larger in magnitude than `+/- (1<<53) - 1` cannot be
-            stored or returned correctly by the widget due to limitations when
-            serializing values between the Python server and JavaScript client.
-            Numbers larger than this must be represented as floats and will
-            consequently lose precision.
+            Integer values exceeding +/- ``(1<<53) - 1`` cannot be accurately
+            stored or returned by the widget due to serialization contstraints
+            between the Python server and JavaScript client. You must handle
+            such numbers as floats, leading to a loss in precision.
 
         Parameters
         ----------

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -203,6 +203,13 @@ class SliderMixin:
         input, while `select_slider` accepts any datatype and takes an iterable
         set of options.
 
+        .. note::
+            Integer values larger in magnitude than `+/- (1<<53) - 1` cannot be
+            stored or returned correctly by the widget due to limitations when
+            serializing values between the Python server and Javascript client.
+            Numbers larger than this must be represented as floats and will
+            consequently lose precision.
+
         Parameters
         ----------
         label : str

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -206,7 +206,7 @@ class SliderMixin:
         .. note::
             Integer values larger in magnitude than `+/- (1<<53) - 1` cannot be
             stored or returned correctly by the widget due to limitations when
-            serializing values between the Python server and Javascript client.
+            serializing values between the Python server and JavaScript client.
             Numbers larger than this must be represented as floats and will
             consequently lose precision.
 

--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -204,11 +204,10 @@ class SliderMixin:
         set of options.
 
         .. note::
-            Integer values larger in magnitude than `+/- (1<<53) - 1` cannot be
-            stored or returned correctly by the widget due to limitations when
-            serializing values between the Python server and JavaScript client.
-            Numbers larger than this must be represented as floats and will
-            consequently lose precision.
+            Integer values exceeding +/- ``(1<<53) - 1`` cannot be accurately
+            stored or returned by the widget due to serialization contstraints
+            between the Python server and JavaScript client. You must handle
+            such numbers as floats, leading to a loss in precision.
 
         Parameters
         ----------


### PR DESCRIPTION
Added note to docstrings for `number_input` and `slider` to clarify limitations for storing and returning large integers. Closes streamlit/docs#106

## 📚 Context
Programmatic limits exists for arguments in `st.number_input` and `st.slider` to prevent creating widgets having values larger in magnitude than `+/- (1<<53) -1`. These limits can be silently encountered if not passed as an argument upon creation. In that instance, incorrect integers will be stored and returned. Per a stale issue in streamlit/docs, a note has been added to the docstrings.

- What kind of change does this PR introduce?
  - [X] Documentation

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
