### PR TITLE
Improve `st.columns` docstring

### DIFF
--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -14,7 +14,6 @@
 
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 
-from streamlit.deprecation_util import deprecate_func_name
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -94,23 +93,19 @@ class LayoutsMixin:
 
         Parameters
         ----------
-        spec : int or list of numbers
-            If an int
-                Specifies the number of columns to insert, and all columns
-                have equal width.
+        spec : int or iterable of numbers
+            Controls the number and width of columns to insert. Can be one of:
 
-            If a list of numbers
-                Creates a column for each number, and each
-                column's width is proportional to the number provided. Numbers can
-                be ints or floats, but they must be positive.
-
-                For example, `st.columns([3, 1, 2])` creates 3 columns where
-                the first column is 3 times the width of the second, and the last
-                column is 2 times that width.
+            * An integer that specifies the number of columns. All columns have equal
+              width in this case.
+            * An iterable of numbers (int or float) that specify the relative width of
+              each column. E.g. `[0.7, 0.3]` creates two columns where the first
+              one takes up 70% of the available with and the second one takes up 30%.
+              Or `[1, 2, 3]` creates three columns where the second one is two times
+              the width of the first one, and the third one is three times that width.
         gap : "small", "medium", or "large"
-            An optional string, which indicates the size of the gap between each column.
-            The default is a small gap between columns. This argument can only be supplied by
-            keyword.
+            The size of the gap between the columns. Defaults to "small". This
+            argument can only be supplied by keyword.
 
         Returns
         -------
@@ -301,7 +296,7 @@ class LayoutsMixin:
                 "The input argument to st.tabs must contain at least one tab label."
             )
 
-        if any(isinstance(tab, str) == False for tab in tabs):
+        if any(isinstance(tab, str) is False for tab in tabs):
             raise StreamlitAPIException(
                 "The tabs input list to st.tabs is only allowed to contain strings."
             )

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -103,6 +103,7 @@ class LayoutsMixin:
               one takes up 70% of the available with and the second one takes up 30%.
               Or `[1, 2, 3]` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
+
         gap : "small", "medium", or "large"
             The size of the gap between the columns. Defaults to "small". This
             argument can only be supplied by keyword.

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -14,6 +14,7 @@
 
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 
+from streamlit.deprecation_util import deprecate_func_name
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -297,7 +298,7 @@ class LayoutsMixin:
                 "The input argument to st.tabs must contain at least one tab label."
             )
 
-        if any(isinstance(tab, str) is False for tab in tabs):
+        if any(isinstance(tab, str) == False for tab in tabs):
             raise StreamlitAPIException(
                 "The tabs input list to st.tabs is only allowed to contain strings."
             )

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -100,9 +100,9 @@ class LayoutsMixin:
             * An integer that specifies the number of columns. All columns have equal
               width in this case.
             * An iterable of numbers (int or float) that specify the relative width of
-              each column. E.g. `[0.7, 0.3]` creates two columns where the first
+              each column. E.g. ``[0.7, 0.3]`` creates two columns where the first
               one takes up 70% of the available with and the second one takes up 30%.
-              Or `[1, 2, 3]` creates three columns where the second one is two times
+              Or ``[1, 2, 3]`` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
 
         gap : "small", "medium", or "large"


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

Makes the `st.columns` docstring a bit nicer to read. Just found a note in an old customer interview that the current description is confusing, and I agree! Plus, the docstring of the `spec` parameter has a few formatting issues, see the current [docs page](https://docs.streamlit.io/library/api-reference/layout/st.columns).

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Documentation

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
