### PR TITLE
Change default theme hash on app init

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -640,6 +640,7 @@ describe("App.handleNewSession", () => {
   it("removes the custom theme from theme options if one is not received from the server", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "customThemeHash" })
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
@@ -655,6 +656,7 @@ describe("App.handleNewSession", () => {
   it("Does not change dark/light/auto user preferences when removing a custom theme", () => {
     const props = getProps()
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "customThemeHash" })
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
 
@@ -678,6 +680,7 @@ describe("App.handleNewSession", () => {
       name: CUSTOM_THEME_NAME,
     }
     const wrapper = shallow(<App {...props} />)
+    wrapper.setState({ themeHash: "customThemeHash" })
 
     const newSessionJson = cloneDeep(NEW_SESSION_JSON)
     newSessionJson.customTheme = null

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -158,7 +158,7 @@ interface State {
   allowRunOnSave: boolean
   scriptFinishedHandlers: (() => void)[]
   toolbarMode: Config.ToolbarMode
-  themeHash: string | null
+  themeHash: string
   gitInfo: IGitInfo | null
   formsData: FormsData
   hideTopBar: boolean
@@ -249,7 +249,7 @@ export class App extends PureComponent<Props, State> {
       menuItems: undefined,
       allowRunOnSave: true,
       scriptFinishedHandlers: [],
-      themeHash: null,
+      themeHash: this.createThemeHash(),
       gitInfo: null,
       formsData: createFormsData(),
       appPages: [],
@@ -921,7 +921,7 @@ export class App extends PureComponent<Props, State> {
     })
   }
 
-  createThemeHash = (themeInput: CustomThemeConfig): string => {
+  createThemeHash = (themeInput?: CustomThemeConfig): string => {
     if (!themeInput) {
       // If themeInput is null, then we didn't receive a custom theme for this
       // app from the server. We use a hardcoded string literal for the


### PR DESCRIPTION
In #6393, we added support for the host of an embedded Streamlit app to set the app's theme.
This currently conflicts with some of the theme caching code + custom theme code in the following
way:
1. The Streamlit client initially loads, and its `themeHash` state variable is set to `null`
2. The parent frame of the Streamlit app sets the theme of the app via a `postMessage`
3. On the first script run for a browser tab, the client compares its current `themeHash` (`null`)
    with the hash used when it doesn't receive a custom theme from the server (the literal value
    (`"hash_for_undefined_custom_theme"`). 
4. Because the two values in the previous step don't match, the client decides to reset the active
    theme to the system default (this handles the case where the developer removes a custom theme).

This can be fixed by simply initializing our `themeHash` to `"hash_for_undefined_custom_theme"` instead
of `null`, which will keep the behavior the same in all other cases but won't inadvertently revert themes set by
the parent frame.