### PR TITLE
Add watch lib script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,7 @@ connect-test-env:
 pre-commit-install:
 	pre-commit install
 
+# Watch the frontend lib for changes and run yarn buildLib whenever a change is detected
 .PHONY: watch-lib
 watch-lib:
 	python scripts/watch_frontend_lib.py

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ protobuf: check-protoc
 	cd frontend/ ; ( \
 		echo "/* eslint-disable */" ; \
 		echo ; \
-		yarn --silent pbts ./lib/src/proto.js \
+		yarn --silent pbts ../proto/streamlit/proto/*.proto -t \
 	) > ./lib/src/proto.d.ts
 
 .PHONY: react-init
@@ -408,3 +408,7 @@ connect-test-env:
 .PHONY: pre-commit-install
 pre-commit-install:
 	pre-commit install
+
+.PHONY: watch-lib
+watch-lib:
+	python scripts/watch_frontend_lib.py

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,6 @@ pre-commit-install:
 	pre-commit install
 
 # Watch the frontend lib for changes and run yarn buildLib whenever a change is detected
-.PHONY: watch-lib
-watch-lib:
+.PHONY: watch-fe-lib
+watch-fe-lib:
 	python scripts/watch_frontend_lib.py

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,6 @@ pre-commit-install:
 	pre-commit install
 
 # Watch the frontend lib for changes and run yarn buildLib whenever a change is detected
-.PHONY: watch-fe-lib
-watch-fe-lib:
+.PHONY: watch-frontend-lib
+watch-frontend-lib:
 	python scripts/watch_frontend_lib.py

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ protobuf: check-protoc
 	cd frontend/ ; ( \
 		echo "/* eslint-disable */" ; \
 		echo ; \
-		yarn --silent pbts ../proto/streamlit/proto/*.proto -t \
+		yarn --silent pbts ./lib/src/proto.js \
 	) > ./lib/src/proto.d.ts
 
 .PHONY: react-init

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "yarn workspace @streamlit/app start",
     "build": "yarn workspace @streamlit/lib build && yarn workspace @streamlit/app build",
     "buildFast": "yarn buildLib && yarn workspace @streamlit/app buildFast",
-    "buildLib": "echo If you want to hot reload lib code, from the frontend dir, run: \n echo \"yarn watchLib\" && yarn workspace @streamlit/lib build",
+    "buildLib": "echo If you want to hot reload lib code, from the frontend dir, run: \n echo \"cd ..; make watch-frontend-lib\" && yarn workspace @streamlit/lib build",
     "buildApp": "yarn workspace @streamlit/app build",
     "buildAppFast": "yarn workspace @streamlit/app buildFast",
     "typecheck": "yarn workspace @streamlit/lib typecheck && yarn workspace @streamlit/app typecheck",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "yarn workspace @streamlit/app start",
     "build": "yarn workspace @streamlit/lib build && yarn workspace @streamlit/app build",
     "buildFast": "yarn buildLib && yarn workspace @streamlit/app buildFast",
-    "buildLib": "echo If you want to hot reload lib code, from the frontend dir, run: \n echo \"cd ..; python scripts/rebuild_frontend_lib.py\" && yarn workspace @streamlit/lib build",
+    "buildLib": "echo If you want to hot reload lib code, from the frontend dir, run: \n echo \"yarn watchLib\" && yarn workspace @streamlit/lib build",
     "buildApp": "yarn workspace @streamlit/app build",
     "buildAppFast": "yarn workspace @streamlit/app buildFast",
     "typecheck": "yarn workspace @streamlit/lib typecheck && yarn workspace @streamlit/app typecheck",
@@ -20,7 +20,8 @@
     "testApp": "yarn workspace @streamlit/app testWatch",
     "cy:open": "unset NODE_OPTIONS && cypress open --env devicePixelRatio=1",
     "cy:run": "unset NODE_OPTIONS && cypress run",
-    "cy:run-flaky": "yarn cy:run --config integrationFolder=../e2e_flaky/specs"
+    "cy:run-flaky": "yarn cy:run --config integrationFolder=../e2e_flaky/specs",
+    "watchLib": "cd ..; python scripts/rebuild_frontend_lib.py"
   },
   "browserslist": [
     ">0.2%",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,8 +20,7 @@
     "testApp": "yarn workspace @streamlit/app testWatch",
     "cy:open": "unset NODE_OPTIONS && cypress open --env devicePixelRatio=1",
     "cy:run": "unset NODE_OPTIONS && cypress run",
-    "cy:run-flaky": "yarn cy:run --config integrationFolder=../e2e_flaky/specs",
-    "watchLib": "cd ..; python scripts/rebuild_frontend_lib.py"
+    "cy:run-flaky": "yarn cy:run --config integrationFolder=../e2e_flaky/specs"
   },
   "browserslist": [
     ">0.2%",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "yarn workspace @streamlit/app start",
     "build": "yarn workspace @streamlit/lib build && yarn workspace @streamlit/app build",
     "buildFast": "yarn buildLib && yarn workspace @streamlit/app buildFast",
-    "buildLib": "yarn workspace @streamlit/lib build",
+    "buildLib": "echo If you want to hot reload lib code, from the frontend dir, run: \n echo \"cd ..; python scripts/rebuild_frontend_lib.py\" && yarn workspace @streamlit/lib build",
     "buildApp": "yarn workspace @streamlit/app build",
     "buildAppFast": "yarn workspace @streamlit/app buildFast",
     "typecheck": "yarn workspace @streamlit/lib typecheck && yarn workspace @streamlit/app typecheck",

--- a/scripts/rebuild_frontend_lib.py
+++ b/scripts/rebuild_frontend_lib.py
@@ -1,0 +1,73 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+# Directory to monitor
+directory = "../frontend/lib"
+
+# Command to run on file change
+command = "cd ../frontend && yarn buildLib"
+
+# File extensions to monitor
+extensions = [".ts", ".tsx", ".js", ".jsx"]
+
+# Directories to ignore
+ignored_directories = ["dist"]
+
+
+class FileChangeHandler(FileSystemEventHandler):
+    def should_ignore_directory(self, directory):
+        for ignored_dir in ignored_directories:
+            if ignored_dir.lower() in directory.lower():
+                return True
+        return False
+
+    # when a new file is created
+    def on_created(self, event):
+        self.execute_command(event)
+
+    # when a new file is modified
+    def on_modified(self, event):
+        self.execute_command(event)
+
+    # rebuild the library
+    def execute_command(self, event):
+        if not event.is_directory:
+            _, file_extension = os.path.splitext(event.src_path)
+            if (
+                file_extension.lower() in extensions
+                and not self.should_ignore_directory(event.src_path)
+            ):
+                print(f"File {event.src_path} changed. Running {command}...")
+                subprocess.call(command, shell=True)
+
+
+if __name__ == "__main__":
+    event_handler = FileChangeHandler()
+    observer = Observer()
+    observer.schedule(event_handler, directory, recursive=True)
+    observer.start()
+
+    try:
+        print(f"Watching directory '{directory}' for file changes...")
+        observer.join()
+    except KeyboardInterrupt:
+        observer.stop()
+
+    observer.join()

--- a/scripts/rebuild_frontend_lib.py
+++ b/scripts/rebuild_frontend_lib.py
@@ -22,7 +22,7 @@ from watchdog.observers import Observer
 directory = "../frontend/lib"
 
 # Command to run on file change
-command = "cd ../frontend && yarn buildLib"
+command = "cd ../frontend/lib && yarn build"
 
 # File extensions to monitor
 extensions = [".ts", ".tsx", ".js", ".jsx"]

--- a/scripts/watch_frontend_lib.py
+++ b/scripts/watch_frontend_lib.py
@@ -25,7 +25,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 # Directory to monitor
-DIRECTORY = os.path.dirname(__file__).join("../frontend/lib")
+DIRECTORY = os.path.dirname(__file__).join(["./frontend/lib"])
 
 # Command to run on file change
 command = f"cd {DIRECTORY} && yarn build"

--- a/scripts/watch_frontend_lib.py
+++ b/scripts/watch_frontend_lib.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# This script watches for files changes and files created with the .ts, .tsx, .js, and .jsx
+# extensions. If any of those events occurs, this will automatically rebuild the frontend streamlit library.
+# This script is useful if you're mainly changing code within frontend/lib/src and you don't want to constantly
+# run yarn buildLib and this will automatically "hot reload" your code by rebuilding the library.
+
 import os
 import subprocess
 
@@ -19,10 +25,10 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 # Directory to monitor
-directory = "../frontend/lib"
+DIRECTORY = os.path.dirname(__file__).join("../frontend/lib")
 
 # Command to run on file change
-command = "cd ../frontend/lib && yarn build"
+command = f"cd {DIRECTORY} && yarn build"
 
 # File extensions to monitor
 extensions = [".ts", ".tsx", ".js", ".jsx"]
@@ -61,11 +67,11 @@ class FileChangeHandler(FileSystemEventHandler):
 if __name__ == "__main__":
     event_handler = FileChangeHandler()
     observer = Observer()
-    observer.schedule(event_handler, directory, recursive=True)
+    observer.schedule(event_handler, DIRECTORY, recursive=True)
     observer.start()
 
     try:
-        print(f"Watching directory '{directory}' for file changes...")
+        print(f"Watching directory '{DIRECTORY}' for file changes...")
         observer.join()
     except KeyboardInterrupt:
         observer.stop()


### PR DESCRIPTION
Since `@streamlit/lib` is separated out to be its own separate lib, we need a script to constantly rebuild when the files change.

Will also need to update the contributing wiki after this is merged to develop.

Here is what the package.json command look like when running `yarn buildLib`
<img width="1010" alt="Screenshot 2023-05-23 at 9 41 40 AM" src="https://github.com/streamlit/streamlit/assets/16749069/4e21ad47-4846-444b-a7d1-908f5d344284">
