### PR TITLE
Fix: SidebarNav expansion

### DIFF
--- a/frontend/src/lib/util/Hooks.ts
+++ b/frontend/src/lib/util/Hooks.ts
@@ -38,7 +38,7 @@ export const useIsOverflowing = (
 
       setIsOverflowing(scrollHeight > clientHeight)
     }
-  }, [setIsOverflowing, current])
+  }, [setIsOverflowing, current, current?.clientHeight])
 
   return isOverflowing
 }


### PR DESCRIPTION
## 📚 Context

Incomplete dependency array for `useIsOverflowing` causes the SidebarNav's expansion button not to display
  - [x] Bugfix

## 🌐 References

- **Issue**: Closes #6721 
