### PR TITLE
Use .genericFonts instead of .fonts to fix bug with theme postMessage.

### DIFF
--- a/frontend/src/app/components/AppView/styled-components.ts
+++ b/frontend/src/app/components/AppView/styled-components.ts
@@ -120,7 +120,7 @@ export const StyledAppViewBlockSpacer = styled.div(({ theme }) => {
 export const StyledAppViewFooterLink = styled.a(({ theme }) => ({
   color: theme.colors.fadedText60,
   // We do not want to change the font for this based on theme.
-  fontFamily: theme.fonts.sansSerif,
+  fontFamily: theme.genericFonts.bodyFont,
   textDecoration: "none",
   transition: "color 300ms",
   "&:hover": {

--- a/frontend/src/app/components/StreamlitDialog/DeployDialog/styled-components.tsx
+++ b/frontend/src/app/components/StreamlitDialog/DeployDialog/styled-components.tsx
@@ -17,6 +17,7 @@
 import styled from "@emotion/styled"
 
 export const StyledSubheader = styled.div(({ theme }) => ({
+  // We do not want to change the font for this based on theme.
   fontFamily: theme.fonts.sansSerif,
   fontWeight: theme.fontWeights.bold,
   fontSize: theme.fontSizes.xl,
@@ -35,6 +36,7 @@ export const StyledElement = styled.div<StyledElementProps>(
     marginTop: extraSpacing ? "9px" : theme.spacing.smPx,
 
     "& > span": {
+      // We do not want to change the font for this based on theme.
       fontFamily: theme.fonts.sansSerif,
       fontWeight: theme.fontWeights.normal,
       fontSize: theme.fontSizes.md,

--- a/frontend/src/lib/components/elements/ArrowTable/styled-components.ts
+++ b/frontend/src/lib/components/elements/ArrowTable/styled-components.ts
@@ -19,7 +19,7 @@ import { EmotionTheme } from "src/lib/theme"
 
 export const StyledTableContainer = styled.div(({ theme }) => ({
   fontSize: theme.fontSizes.md,
-  fontFamily: theme.fonts.sansSerif,
+  fontFamily: theme.genericFonts.bodyFont,
   padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
   lineHeight: theme.lineHeights.table,
   overflow: ["auto", "overlay"],

--- a/frontend/src/lib/components/elements/DataFrame/styled-components.ts
+++ b/frontend/src/lib/components/elements/DataFrame/styled-components.ts
@@ -61,7 +61,7 @@ const StyledDataFrameCell = styled.div(({ theme }) => ({
   borderBottom: `1px solid ${theme.colors.fadedText05}`,
   borderRight: `1px solid ${theme.colors.fadedText05}`,
   fontSize: theme.fontSizes.md,
-  fontFamily: theme.fonts.sansSerif,
+  fontFamily: theme.genericFonts.bodyFont,
   lineHeight: theme.lineHeights.table,
   display: "flex",
   alignItems: "center",
@@ -130,7 +130,7 @@ export const StyledFixup = styled.div<StyledFixupProps>(
 )
 
 export const StyledEmptyDataframe = styled.div(({ theme }) => ({
-  fontFamily: theme.fonts.monospace,
+  fontFamily: theme.genericFonts.codeFont,
   color: theme.colors.fadedText60,
   fontStyle: "italic",
   fontSize: theme.fontSizes.md,

--- a/frontend/src/lib/components/elements/DocString/styled-components.ts
+++ b/frontend/src/lib/components/elements/DocString/styled-components.ts
@@ -42,7 +42,7 @@ export const StyledDocContainer = styled.span<StyledDocContainerProps>(
     flexDirection: "column",
     borderRadius: theme.radii.md,
     border: `1px solid ${theme.colors.fadedText05}`,
-    fontFamily: theme.fonts.monospace,
+    fontFamily: theme.genericFonts.codeFont,
     fontSize: theme.fontSizes.sm,
   })
 )

--- a/frontend/src/lib/components/elements/Table/styled-components.ts
+++ b/frontend/src/lib/components/elements/Table/styled-components.ts
@@ -19,7 +19,7 @@ import { EmotionTheme } from "src/lib/theme"
 
 export const StyledTableContainer = styled.div(({ theme }) => ({
   fontSize: theme.fontSizes.md,
-  fontFamily: theme.fonts.sansSerif,
+  fontFamily: theme.genericFonts.bodyFont,
   padding: `${theme.spacing.twoXS} ${theme.spacing.md}`,
   lineHeight: theme.lineHeights.table,
   overflow: ["auto", "overlay"],

--- a/frontend/src/lib/components/elements/TextElement/styled-components.ts
+++ b/frontend/src/lib/components/elements/TextElement/styled-components.ts
@@ -17,7 +17,7 @@
 import styled from "@emotion/styled"
 
 export const StyledText = styled.div(({ theme }) => ({
-  fontFamily: theme.fonts.monospace,
+  fontFamily: theme.genericFonts.codeFont,
   whiteSpace: "pre",
   fontSize: theme.fontSizes.sm,
   overflowX: "auto",

--- a/frontend/src/lib/components/widgets/Slider/styled-components.ts
+++ b/frontend/src/lib/components/widgets/Slider/styled-components.ts
@@ -49,7 +49,7 @@ export const StyledThumb = styled.div<StyledSliderProps>(
 
 export const StyledThumbValue = styled.div<StyledSliderProps>(
   ({ disabled, theme }) => ({
-    fontFamily: theme.fonts.monospace,
+    fontFamily: theme.genericFonts.codeFont,
     fontSize: theme.fontSizes.sm,
     paddingBottom: theme.spacing.twoThirdsSmFont,
     color: disabled ? theme.colors.gray : theme.colors.primary,
@@ -77,7 +77,7 @@ export const StyledTickBarItem = styled.div<StyledSliderProps>(
     lineHeight: theme.lineHeights.base,
     fontWeight: "normal",
     fontSize: theme.fontSizes.sm,
-    fontFamily: theme.fonts.monospace,
+    fontFamily: theme.genericFonts.codeFont,
     color: disabled ? theme.colors.fadedText40 : "inherit",
   })
 )


### PR DESCRIPTION
## 📚 Context

Apparently the functionality introduced in #6393 contains a bug where the bodyFont and codeFont attributes don't propagate to all elements properly.

From ~10min of debugging there seem to be 2 problems:
1. Fixed in this PR: A trivial issue where many of our styles referenced the wrong font property in our theme.
2. Still unsolved: the font for some things inside the sidebar doesn't update correctly (e.g. st.sidebar.info). This seems to be a theme propagation problem, potentially related to `createEmotionTheme()`. But this part requires more debugging.

Since 1 is so easy to fix, I thought it was worth fixing already even though 2 is still at large. Hence this PR!

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 🧪 Testing Done

- [ ] Screenshots included
- [ ] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
