### PR TITLE
Improve docstrings for `ttl` and `max_entries`

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -403,19 +403,23 @@ class CacheDataAPI:
             The function to cache. Streamlit hashes the function's source code.
 
         ttl : float, timedelta, str, or None
-            The maximum time to keep an entry in the cache, or None if cache
-            entries should not expire. The default is None. Note that ttl is
-            incompatible with ``persist="disk"`` - ``ttl`` will be ignored if
-            ``persist`` is specified.
+            The maximum time to keep an entry in the cache. Can be one of:
 
-            If ttl is a str, then it should be in a format supported by `Pandas's
-            Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_.
-            Examples of valid strings are: "1d", "1.5 days", and "1h23s".
+            * `None` if cache entries should never expire (default).
+            * A number specifying the time in seconds.
+            * A string specifying the time in a format supported by [Pandas's
+              Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html)`,
+              e.g. `"1d"`, `"1.5 days"`, or `"1h23s"`.
+            * A `timedelta` object from
+              [Python's built-in datetime library](https://docs.python.org/3/library/datetime.html#timedelta-objects),
+              e.g. `timedelta(days=1)`.
+
+            Note that `ttl` will be ignored if `persist="disk"` or `persist=True`.
 
         max_entries : int or None
             The maximum number of entries to keep in the cache, or None
-            for an unbounded cache. (When a new entry is added to a full cache,
-            the oldest cached entry will be removed.) The default is None.
+            for an unbounded cache. When a new entry is added to a full cache,
+            the oldest cached entry will be removed. Defaults to None.
 
         show_spinner : boolean or string
             Enable the spinner. Default is True to show a spinner when there is

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -405,16 +405,16 @@ class CacheDataAPI:
         ttl : float, timedelta, str, or None
             The maximum time to keep an entry in the cache. Can be one of:
 
-            * `None` if cache entries should never expire (default).
+            * ``None`` if cache entries should never expire (default).
             * A number specifying the time in seconds.
-            * A string specifying the time in a format supported by [Pandas's
-              Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html)`,
-              e.g. `"1d"`, `"1.5 days"`, or `"1h23s"`.
-            * A `timedelta` object from
-              [Python's built-in datetime library](https://docs.python.org/3/library/datetime.html#timedelta-objects),
-              e.g. `timedelta(days=1)`.
+            * A string specifying the time in a format supported by `Pandas's
+              Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_,
+              e.g. ``"1d"``, ``"1.5 days"``, or ``"1h23s"``.
+            * A ``timedelta`` object from `Python's built-in datetime library
+              <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_,
+              e.g. ``timedelta(days=1)``.
 
-            Note that `ttl` will be ignored if `persist="disk"` or `persist=True`.
+            Note that ``ttl`` will be ignored if ``persist="disk"`` or ``persist=True``.
 
         max_entries : int or None
             The maximum number of entries to keep in the cache, or None

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -285,17 +285,21 @@ class CacheResourceAPI:
             function's source code.
 
         ttl : float, timedelta, str, or None
-            The maximum time to keep an entry in the cache, or None if cache
-            entries should not expire. The default is None.
+            The maximum time to keep an entry in the cache. Can be one of:
 
-            If ttl is a str, then it should be in a format supported by `Pandas's
-            Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_.
-            Examples of valid strings are: "1d", "1.5 days", and "1h23s".
+            * `None` if cache entries should never expire (default).
+            * A number specifying the time in seconds.
+            * A string specifying the time in a format supported by [Pandas's
+              Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html)`,
+              e.g. `"1d"`, `"1.5 days"`, or `"1h23s"`.
+            * A `timedelta` object from
+              [Python's built-in datetime library](https://docs.python.org/3/library/datetime.html#timedelta-objects),
+              e.g. `timedelta(days=1)`.
 
         max_entries : int or None
             The maximum number of entries to keep in the cache, or None
-            for an unbounded cache. (When a new entry is added to a full cache,
-            the oldest cached entry will be removed.) The default is None.
+            for an unbounded cache. When a new entry is added to a full cache,
+            the oldest cached entry will be removed. Defaults to None.
 
         show_spinner : boolean or string
             Enable the spinner. Default is True to show a spinner when there is

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -287,14 +287,16 @@ class CacheResourceAPI:
         ttl : float, timedelta, str, or None
             The maximum time to keep an entry in the cache. Can be one of:
 
-            * `None` if cache entries should never expire (default).
+            * ``None`` if cache entries should never expire (default).
             * A number specifying the time in seconds.
-            * A string specifying the time in a format supported by [Pandas's
-              Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html)`,
-              e.g. `"1d"`, `"1.5 days"`, or `"1h23s"`.
-            * A `timedelta` object from
-              [Python's built-in datetime library](https://docs.python.org/3/library/datetime.html#timedelta-objects),
-              e.g. `timedelta(days=1)`.
+            * A string specifying the time in a format supported by `Pandas's
+              Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_,
+              e.g. ``"1d"``, ``"1.5 days"``, or ``"1h23s"``.
+            * A ``timedelta`` object from `Python's built-in datetime library
+              <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_,
+              e.g. ``timedelta(days=1)``.
+
+            Note that ``ttl`` will be ignored if ``persist="disk"`` or ``persist=True``.
 
         max_entries : int or None
             The maximum number of entries to keep in the cache, or None


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

Makes the docstring for `ttl` on `st.cache_data` and `st.cache_resource` a bit nicer to read by explicitly listing all options. I moved the new str option before timedelta because I think it will be used more (and we should promote it!). Also changed a few nits in the `max_entries` docstring while I was at it. 

## 📚 Context

- What kind of change does this PR introduce?

  - [x] Documentation

## 🧠 Description of Changes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
