### PR TITLE
Dataframe docstring

### DIFF
--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -124,8 +124,6 @@ class DataFrameSelectorMixin:
            https://doc-dataframe.streamlitapp.com/
            height: 410px
 
-        >>> st.dataframe(df, 200, 100)
-
         You can also pass a Pandas Styler object to change the style of
         the rendered DataFrame:
 


### PR DESCRIPTION
## 📚 Context
There is an orphaned line within the examples in the `st.dataframe` docstring. A standalone line, not associated to an explanation on syntax or an example reads:
```
  >>> st.dataframe(df, 200, 100)
```
The orphaned line appears to have existed since the file was created/renamed.

- What kind of change does this PR introduce?
  - [X] Documentation 

## 🧠 Description of Changes
The orphaned line is removed from the docstring.

## 🌐 References
- **Issue**: Closes Streamlit/Docs#373

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
