### PR TITLE
[WIP] Fix broken url when url for download button contains query param

### DIFF
--- a/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -28,6 +28,8 @@ import DownloadButton, { Props } from "./DownloadButton"
 jest.mock("src/lib/WidgetStateManager")
 jest.mock("src/lib/StreamlitEndpoints")
 
+const buildMediaURL = jest.fn().mockReturnValue("https://mock.media.url")
+
 const getProps = (elementProps: Partial<DownloadButtonProto> = {}): Props => ({
   element: DownloadButtonProto.create({
     id: "1",
@@ -41,7 +43,7 @@ const getProps = (elementProps: Partial<DownloadButtonProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
-  endpoints: mockEndpoints(),
+  endpoints: mockEndpoints({ buildMediaURL }),
 })
 
 describe("DownloadButton widget", () => {

--- a/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.tsx
@@ -24,6 +24,7 @@ import BaseButton, {
 import { WidgetStateManager } from "src/lib/WidgetStateManager"
 import StreamlitMarkdown from "src/lib/components/shared/StreamlitMarkdown"
 import { StreamlitEndpoints } from "src/lib/StreamlitEndpoints"
+import { extendUrlQueryParams } from "src/lib/util/UriUtil"
 
 export interface Props {
   endpoints: StreamlitEndpoints
@@ -42,9 +43,11 @@ function DownloadButton(props: Props): ReactElement {
     // for the user.
     widgetMgr.setTriggerValue(element, { fromUi: true })
     const link = document.createElement("a")
-    const uri = `${endpoints.buildMediaURL(
-      element.url
-    )}?title=${encodeURIComponent(document.title)}`
+
+    const uri = extendUrlQueryParams(endpoints.buildMediaURL(element.url), {
+      title: document.title,
+    })
+
     link.setAttribute("href", uri)
     link.setAttribute("target", "_blank")
     link.click()

--- a/frontend/src/lib/util/UriUtil.test.ts
+++ b/frontend/src/lib/util/UriUtil.test.ts
@@ -21,6 +21,7 @@ import {
   getWindowBaseUriParts,
   isValidOrigin,
   xssSanitizeSvg,
+  extendUrlQueryParams,
 } from "./UriUtil"
 
 const location: Partial<Location> = {}
@@ -264,5 +265,43 @@ describe("getPossibleBaseUris", () => {
         expectedBasePaths
       )
     })
+  })
+})
+
+describe("extendUrlQueryParams", () => {
+  it("should add non-existent query param to url", () => {
+    expect(
+      extendUrlQueryParams("http://devel.streamlit.io", {
+        title: "streamlit",
+      })
+    ).toEqual("http://devel.streamlit.io/?title=streamlit")
+  })
+  it("should override existent query param in url", () => {
+    expect(
+      extendUrlQueryParams("http://devel.streamlit.io/?title=random", {
+        title: "streamlit",
+      })
+    ).toEqual("http://devel.streamlit.io/?title=streamlit")
+  })
+  it("should add new query param in url with query params", () => {
+    expect(
+      extendUrlQueryParams("http://devel.streamlit.io/?title=Streamlit", {
+        subtitle: "A faster way to build and share data apps",
+      })
+    ).toEqual(
+      "http://devel.streamlit.io/?title=Streamlit&subtitle=A+faster+way+to+build+and+share+data+apps"
+    )
+  })
+  it("should not affect exiting encoded uri components", () => {
+    expect(
+      extendUrlQueryParams(
+        "http://devel.streamlit.io/?title=A+faster%2F+way+to+build",
+        {
+          subtitle: "Streamlit",
+        }
+      )
+    ).toEqual(
+      "http://devel.streamlit.io/?title=A+faster%2F+way+to+build&subtitle=Streamlit"
+    )
   })
 })

--- a/frontend/src/lib/util/UriUtil.ts
+++ b/frontend/src/lib/util/UriUtil.ts
@@ -201,3 +201,23 @@ export function isValidOrigin(
     return el === splitHostname[index]
   })
 }
+
+/**
+ * Add new query params, or replace existing params
+ * with key-value pairs in `queryParams` object.
+ *
+ * NOTE: URL.searchParams already encodes passing params,
+ * so we don't need to do this for `queryParams` object
+ * to avoid double enconding
+ */
+export function extendUrlQueryParams(
+  url: string,
+  queryParams: Record<string, string>
+): string {
+  const parsedUrl = new URL(url)
+
+  Object.entries(queryParams).forEach(([param, value]) => {
+    parsedUrl.searchParams.set(param, value)
+  })
+  return parsedUrl.toString()
+}


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

Previously we concatenate `?title={title}` ad media URL for download button. 
This leads to error when URL already contains query params (and question mark). 

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- This change adds the `title` query param via `URL.searchParams.set` which fix that problem. 

  - [ ] This is a breaking API change
  - [ ] This is a visible (user-facing) change

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 🧪 Testing Done

- [ ] Screenshots included
- [X] Added/Updated unit tests
- [ ] Added/Updated e2e tests

## 🌐 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
