### PR TITLE
Get rid of yarn start warnings and clean Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ protobuf: check-protoc
 
 .PHONY: react-init
 react-init:
-	cd frontend/ ; yarn install --frozen-lockfile; yarn buildLib
+	cd frontend/ ; yarn install --frozen-lockfile
 
 .PHONY: react-build
 react-build:

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ clean:
 	rm -f frontend/lib/src/proto.js
 	rm -f frontend/lib/src/proto.d.ts
 	rm -rf frontend/public/reports
+	rm -rf frontend/lib/dist
 	rm -rf ~/.cache/pre-commit
 	find . -name .streamlit -type d -exec rm -rfv {} \; || true
 	cd lib; rm -rf .coverage .coverage\.*
@@ -275,7 +276,7 @@ protobuf: check-protoc
 
 .PHONY: react-init
 react-init:
-	cd frontend/ ; yarn install --frozen-lockfile
+	cd frontend/ ; yarn install --frozen-lockfile; yarn buildLib
 
 .PHONY: react-build
 react-build:

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -152,7 +152,12 @@
     },
     // Check for import violation in all JS-like files
     "import/resolver": {
-      "typescript": true
+      "typescript": true,
+      // tell eslint to look at these tsconfigs for import statements
+      "project": [
+        "lib/tsconfig.json",
+        "app/tsconfig.json"
+      ]
     }
   }
 }

--- a/frontend/app/craco.config.js
+++ b/frontend/app/craco.config.js
@@ -45,6 +45,8 @@ module.exports = {
   },
   webpack: {
     configure: webpackConfig => {
+      // ignore webpack warnings by source-map-loader https://github.com/facebook/create-react-app/pull/11752
+      webpackConfig.ignoreWarnings = [/Failed to parse source map from/]
       webpackConfig.resolve.mainFields = ["module", "main"]
       // Webpack 5 requires polyfills. We don't need them, so resolve to an empty module
       webpackConfig.resolve.fallback ||= {}


### PR DESCRIPTION
These fixes are to get rid of the warnings in yarn start. They were happening because eslint didn't know where to look for tsconfigs (https://www.npmjs.com/package/eslint-import-resolver-typescript) and also cra has annoying warnings that show up (https://github.com/facebook/create-react-app/pull/11752).