### PR TITLE
Make st.write pretty-print dataclasses using st.help

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import inspect
 import json as json
 import types
@@ -204,6 +205,9 @@ class WriteMixin:
                 flush_buffer()
                 self.dg.exception(arg)
             elif isinstance(arg, HELP_TYPES):
+                flush_buffer()
+                self.dg.help(arg)
+            elif dataclasses.is_dataclass(arg):
                 flush_buffer()
                 self.dg.help(arg)
             elif type_util.is_altair_chart(arg):

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -236,7 +236,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         self.assertEqual("class", ds.type)
         self.assertEqual("", ds.doc_string)
 
-    def test_padding_an_instance(self):
+    def test_passing_an_instance(self):
         """When the type of the object is type and no docs are defined,
         we expect docs to be None."""
 
@@ -251,7 +251,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         self.assertEqual("MyClass", ds.name)
         self.assertEqual(
             "tests.streamlit.elements.help_test.StHelpTest."
-            "test_padding_an_instance.<locals>.MyClass()",
+            "test_passing_an_instance.<locals>.MyClass()",
             ds.value,
         )
         self.assertEqual("class", ds.type)

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -14,6 +14,7 @@
 
 """Streamlit Unit test."""
 
+import dataclasses
 import time
 import unittest
 from collections import namedtuple
@@ -265,6 +266,20 @@ class StreamlitWriteTest(unittest.TestCase):
     def test_obj_instance(self):
         """Test st.write with an object instance that doesn't know how to str()."""
 
+        class SomeClass:
+            pass
+
+        my_instance = SomeClass()
+
+        with patch("streamlit.delta_generator.DeltaGenerator.help") as p:
+            st.write(my_instance)
+
+            p.assert_called_once_with(my_instance)
+
+    def test_dataclass_instance(self):
+        """Test st.write with a dataclass instance."""
+
+        @dataclasses.dataclass
         class SomeClass:
             pass
 


### PR DESCRIPTION
## 📚 Context

`st.write()` does something awesome with classes and generic object instances: it passes them to `st.help()` so the user can see that class's/object's docstring, member variables, methods, and much more.

However, if the user called `st.write()` on an instance of a Python dataclass, all that would be displayed was the class's name. This PR fixes that, by making the behavior for dataclass instances match the one described above.

- What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

- _Add bullet points summarizing your changes here_

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

## 👁️ What it looks like

### Given this code...
```python
import streamlit as st
from dataclasses import dataclass


@dataclass
class Vector:
    """A little 2D vector class."""
    x = 0
    y = 0

    def length(self):
        return x**2 + y**2


v = Vector()
v.x = 10
v.y = 20

st.write(v)
```

### ...this is what you get today

<img width="79" alt="Screenshot 2023-05-25 at 16 31 48" src="https://github.com/streamlit/streamlit/assets/103002884/3de99bfc-ef30-446c-8a50-6ae4054f7f1e">

### ...and this is what you get after this PR

<img width="717" alt="Screenshot 2023-05-25 at 16 48 00" src="https://github.com/streamlit/streamlit/assets/103002884/51c6ad2d-fab3-42c0-a372-04a3ad515e3e">


## 🧪 Testing Done

- [x] Screenshots included
- [x] Added/Updated unit tests
- [ ] Added/Updated e2e tests - No need. This change doesn't impact any of the rendering logic beyond what's already caught in the unit test.

## 🌐 References

None

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
