### PR TITLE
Start supporting configurable file upload URLs in StreamlitEndpoints and FileUploadClient

### DIFF
--- a/frontend/src/app/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/src/app/connection/DefaultStreamlitEndpoints.test.ts
@@ -344,13 +344,14 @@ describe("DefaultStreamlitEndpoints", () => {
         csrfEnabled: true,
       })
 
+      const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
       // @ts-expect-error
-      endpoints.csrfRequest("mockUrl", {})
+      endpoints.csrfRequest(url, {})
 
       expect(spyRequest).toHaveBeenCalledWith({
         headers: { "X-Xsrftoken": "mockXsrfCookie" },
         withCredentials: true,
-        url: buildHttpUri(MOCK_SERVER_URI, "mockUrl"),
+        url,
       })
     })
 
@@ -360,10 +361,12 @@ describe("DefaultStreamlitEndpoints", () => {
         csrfEnabled: false,
       })
 
+      const url = buildHttpUri(MOCK_SERVER_URI, "mockUrl")
       // @ts-expect-error
-      endpoints.csrfRequest("mockUrl", {})
+      endpoints.csrfRequest(url, {})
+
       expect(spyRequest).toHaveBeenCalledWith({
-        url: buildHttpUri(MOCK_SERVER_URI, "mockUrl"),
+        url,
       })
     })
   })

--- a/frontend/src/app/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/src/app/connection/DefaultStreamlitEndpoints.test.ts
@@ -192,7 +192,6 @@ describe("DefaultStreamlitEndpoints", () => {
         endpoints.uploadFileUploaderFile(
           "/_stcore/upload_file/file_1",
           MOCK_FILE,
-          "mockWidgetId",
           "mockSessionId",
           mockOnUploadProgress,
           mockCancelToken
@@ -201,7 +200,6 @@ describe("DefaultStreamlitEndpoints", () => {
 
       const expectedData = new FormData()
       expectedData.append("sessionId", "mockSessionId")
-      expectedData.append("widgetId", "mockWidgetId")
       expectedData.append(MOCK_FILE.name, MOCK_FILE)
 
       expect(spyRequest).toHaveBeenCalledWith({
@@ -226,7 +224,6 @@ describe("DefaultStreamlitEndpoints", () => {
         endpoints.uploadFileUploaderFile(
           "http://example.com/upload_file/file_2",
           MOCK_FILE,
-          "mockWidgetId",
           "mockSessionId",
           mockOnUploadProgress,
           mockCancelToken
@@ -235,7 +232,6 @@ describe("DefaultStreamlitEndpoints", () => {
 
       const expectedData = new FormData()
       expectedData.append("sessionId", "mockSessionId")
-      expectedData.append("widgetId", "mockWidgetId")
       expectedData.append(MOCK_FILE.name, MOCK_FILE)
 
       expect(spyRequest).toHaveBeenCalledWith({
@@ -257,12 +253,7 @@ describe("DefaultStreamlitEndpoints", () => {
         .reply(() => [200, "invalidFileId"])
 
       await expect(
-        endpoints.uploadFileUploaderFile(
-          "unused",
-          MOCK_FILE,
-          "mockWidgetId",
-          "mockSessionId"
-        )
+        endpoints.uploadFileUploaderFile("unused", MOCK_FILE, "mockSessionId")
       ).rejects.toEqual(
         new Error(
           "Bad uploadFile response: expected a number but got 'invalidFileId'"
@@ -279,7 +270,6 @@ describe("DefaultStreamlitEndpoints", () => {
         endpoints.uploadFileUploaderFile(
           "/_stcore/upload_file",
           MOCK_FILE,
-          "mockWidgetId",
           "mockSessionId"
         )
       ).rejects.toEqual(new Error("Request failed with status code 400"))

--- a/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
@@ -192,19 +192,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     url: string,
     params: AxiosRequestConfig
   ): Promise<R> {
-    // If the URL starts with a scheme, assume it's an absolute URL and don't
-    // change it. Otherwise, it's a relative URL that needs to be made
-    // absolute.
-    //
-    // TODO(vdonato): Think about whether this is a reasonable long-term
-    // solution before this feature branch is merged into `develop`. If it is,
-    // then add some unit tests for this.
-    if (/^[a-z0-9]+:\/\//.test(url)) {
-      params.url = url
-    } else {
-      const serverURI = this.requireServerUri()
-      params.url = buildHttpUri(serverURI, url)
-    }
+    params.url = url
 
     if (this.csrfEnabled) {
       const xsrfCookie = getCookie("_xsrf")

--- a/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
@@ -110,7 +110,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   public async uploadFileUploaderFile(
     fileUploadUrl: string,
     file: File,
-    widgetId: string,
     sessionId: string,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
@@ -119,7 +118,6 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   ): Promise<number> {
     const form = new FormData()
     form.append("sessionId", sessionId)
-    form.append("widgetId", widgetId)
     form.append(file.name, file)
 
     return this.csrfRequest<number>(this.buildFileUploadURL(fileUploadUrl), {

--- a/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
@@ -69,6 +69,19 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       : url
   }
 
+  /**
+   * Construct a URL for uploading a file. If the url is relative and starts
+   * with "/_stcore/upload_file", assume we're uploading the file to the
+   * Streamlit Tornado server and construct it appropriately. Otherwise, we're
+   * probably uploading the file to some external service, so we leave the URL
+   * alone.
+   */
+  public buildFileUploadURL(url: string): string {
+    return url.startsWith(UPLOAD_FILE_ENDPOINT)
+      ? buildHttpUri(this.requireServerUri(), url)
+      : url
+  }
+
   /** Construct a URL for an app page in a multi-page app. */
   public buildAppPageURL(
     pageLinkBaseURL: string | undefined,
@@ -95,18 +108,21 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   }
 
   public async uploadFileUploaderFile(
+    fileUploadUrl: string,
     file: File,
     widgetId: string,
     sessionId: string,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
+    // TODO(vdonato): Eventually change this type to Promise<void> once we've
+    // removed numerical file IDs.
   ): Promise<number> {
     const form = new FormData()
     form.append("sessionId", sessionId)
     form.append("widgetId", widgetId)
     form.append(file.name, file)
 
-    return this.csrfRequest<number>(UPLOAD_FILE_ENDPOINT, {
+    return this.csrfRequest<number>(this.buildFileUploadURL(fileUploadUrl), {
       cancelToken,
       method: "POST",
       data: form,
@@ -122,6 +138,19 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
         `Bad uploadFile response: expected a number but got '${response.data}'`
       )
     })
+  }
+
+  /**
+   * Send an HTTP DELETE request to the given URL.
+   */
+  public async deleteFileAtURL(
+    fileUrl: string,
+    sessionId: string
+  ): Promise<void> {
+    return this.csrfRequest<number>(this.buildFileUploadURL(fileUrl), {
+      method: "DELETE",
+      data: { sessionId },
+    }).then(() => undefined) // If the request succeeds, we don't care about the response body
   }
 
   public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
@@ -165,8 +194,15 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     url: string,
     params: AxiosRequestConfig
   ): Promise<R> {
-    const serverURI = this.requireServerUri()
-    params.url = buildHttpUri(serverURI, url)
+    // TODO(vdonato): Think about whether this is a reasonable long-term
+    // solution before this feature branch is merged into `develop`. If it is,
+    // then add some unit tests for this.
+    if (/^[a-z0-9]+:\/\//.test(url)) {
+      params.url = url
+    } else {
+      const serverURI = this.requireServerUri()
+      params.url = buildHttpUri(serverURI, url)
+    }
 
     if (this.csrfEnabled) {
       const xsrfCookie = getCookie("_xsrf")

--- a/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/src/app/connection/DefaultStreamlitEndpoints.ts
@@ -70,11 +70,11 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   }
 
   /**
-   * Construct a URL for uploading a file. If the url is relative and starts
+   * Construct a URL for uploading a file. If the URL is relative and starts
    * with "/_stcore/upload_file", assume we're uploading the file to the
-   * Streamlit Tornado server and construct it appropriately. Otherwise, we're
-   * probably uploading the file to some external service, so we leave the URL
-   * alone.
+   * Streamlit Tornado server and construct the URL appropriately. Otherwise,
+   * we're probably uploading the file to some external service, so we leave
+   * the URL alone.
    */
   public buildFileUploadURL(url: string): string {
     return url.startsWith(UPLOAD_FILE_ENDPOINT)
@@ -194,6 +194,10 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     url: string,
     params: AxiosRequestConfig
   ): Promise<R> {
+    // If the URL starts with a scheme, assume it's an absolute URL and don't
+    // change it. Otherwise, it's a relative URL that needs to be made
+    // absolute.
+    //
     // TODO(vdonato): Think about whether this is a reasonable long-term
     // solution before this feature branch is merged into `develop`. If it is,
     // then add some unit tests for this.

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -33,8 +33,10 @@ describe("FileUploadClient Upload", () => {
       endpoints: {
         buildComponentURL: jest.fn(),
         buildMediaURL: jest.fn(),
+        buildFileUploadURL: jest.fn(),
         buildAppPageURL: jest.fn(),
         uploadFileUploaderFile: uploadFileUploaderFile,
+        deleteFileAtURL: jest.fn(),
         fetchCachedForwardMsg: jest.fn(),
       },
       formsWithPendingRequestsChanged,
@@ -45,7 +47,11 @@ describe("FileUploadClient Upload", () => {
     uploadFileUploaderFile.mockResolvedValue(MOCK_FILE_ID)
 
     await expect(
-      uploader.uploadFile({ id: "widgetId", formId: "" }, MOCK_FILE)
+      uploader.uploadFile(
+        { id: "widgetId", formId: "" },
+        "/_stcore/upload_file/file_1",
+        MOCK_FILE
+      )
     ).resolves.toBe(MOCK_FILE_ID)
 
     expect(formsWithPendingRequestsChanged).not.toHaveBeenCalled()
@@ -57,6 +63,7 @@ describe("FileUploadClient Upload", () => {
     // Upload a file with an attached form ID.
     const uploadFilePromise = uploader.uploadFile(
       { id: "widgetId", formId: "mockFormId" },
+      "/_stcore/upload_file/file_1",
       MOCK_FILE
     )
 
@@ -80,7 +87,12 @@ describe("FileUploadClient Upload", () => {
     uploadFileUploaderFile.mockRejectedValue(new Error("oh no!"))
 
     await expect(
-      uploader.uploadFile({ id: "widgetId", formId: "" }, MOCK_FILE)
+      uploader.uploadFile(
+        { id: "widgetId", formId: "" },
+
+        "/_stcore/upload_file/file_1",
+        MOCK_FILE
+      )
     ).rejects.toEqual(new Error("oh no!"))
 
     expect(formsWithPendingRequestsChanged).not.toHaveBeenCalled()
@@ -92,6 +104,7 @@ describe("FileUploadClient Upload", () => {
     // Upload a file with an attached form ID.
     const uploadFilePromise = uploader.uploadFile(
       { id: "widgetId", formId: "mockFormId" },
+      "/_stcore/upload_file/file_1",
       MOCK_FILE
     )
 

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -89,7 +89,6 @@ describe("FileUploadClient Upload", () => {
     await expect(
       uploader.uploadFile(
         { id: "widgetId", formId: "" },
-
         "/_stcore/upload_file/file_1",
         MOCK_FILE
       )

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -59,9 +59,11 @@ export class FileUploadClient {
   }
 
   /**
-   * Upload a file to the server. It will be associated with this browser's sessionID.
+   * Upload a file to the given URL. It will be associated with this browser's
+   * sessionID.
    *
    * @param widget: the FileUploader widget that's doing the upload.
+   * @param fileUploadUrl: the URL to upload the file to.
    * @param file: the files to upload.
    * @param onUploadProgress: an optional function that will be called repeatedly with progress events during the upload.
    * @param cancelToken: an optional axios CancelToken that can be used to cancel the in-progress upload.
@@ -70,13 +72,17 @@ export class FileUploadClient {
    */
   public async uploadFile(
     widget: WidgetInfo,
+    fileUploadUrl: string,
     file: File,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
+    // TODO(vdonato): Change the return type to Promise<void> once we've gotten
+    // rid of numerical file IDs.
   ): Promise<number> {
     this.offsetPendingRequestCount(widget.formId, 1)
     return this.endpoints
       .uploadFileUploaderFile(
+        fileUploadUrl,
         file,
         widget.id,
         this.sessionInfo.current.sessionId,
@@ -84,6 +90,17 @@ export class FileUploadClient {
         cancelToken
       )
       .finally(() => this.offsetPendingRequestCount(widget.formId, -1))
+  }
+
+  /**
+   * Request that the file at the given URL is deleted.
+   * @param fileUrl: the URL of the file to delete.
+   */
+  public deleteFile(fileUrl: string): Promise<void> {
+    return this.endpoints.deleteFileAtURL(
+      fileUrl,
+      this.sessionInfo.current.sessionId
+    )
   }
 
   private getFormIdSet(): Set<string> {

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -84,7 +84,6 @@ export class FileUploadClient {
       .uploadFileUploaderFile(
         fileUploadUrl,
         file,
-        widget.id,
         this.sessionInfo.current.sessionId,
         onUploadProgress,
         cancelToken

--- a/frontend/src/lib/ForwardMessageCache.test.ts
+++ b/frontend/src/lib/ForwardMessageCache.test.ts
@@ -29,8 +29,10 @@ function createCache(): MockCache {
   const cache = new ForwardMsgCache({
     buildComponentURL: jest.fn(),
     buildMediaURL: jest.fn(),
+    buildFileUploadURL: jest.fn(),
     buildAppPageURL: jest.fn(),
     uploadFileUploaderFile: jest.fn(),
+    deleteFileAtURL: jest.fn(),
     fetchCachedForwardMsg: mockFetchCachedForwardMsg,
   })
 

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -58,7 +58,6 @@ export interface StreamlitEndpoints {
    * Upload a file to the FileUploader endpoint.
    *
    * @param file The file to upload
-   * @param widgetId the widget ID of the FileUploader associated with the file.
    * @param sessionId the current sessionID. The file will be associated with this ID.
    * @param onUploadProgress optional function that will be called repeatedly with progress events during the upload
    * @param cancelToken optional axios CancelToken that can be used to cancel the in-progress upload.
@@ -68,7 +67,6 @@ export interface StreamlitEndpoints {
   uploadFileUploaderFile(
     fileUploadUrl: string,
     file: File,
-    widgetId: string,
     sessionId: string,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken

--- a/frontend/src/lib/StreamlitEndpoints.ts
+++ b/frontend/src/lib/StreamlitEndpoints.ts
@@ -35,6 +35,14 @@ export interface StreamlitEndpoints {
   buildMediaURL(url: string): string
 
   /**
+   * Construct a URL for uploading a file.
+   * @param url a relative or absolute URL. If `url` is absolute, it will be
+   * returned unchanged. Otherwise, the return value will be a URL for fetching
+   * the media file from the connected Streamlit instance.
+   */
+  buildFileUploadURL(url: string): string
+
+  /**
    * Construct a URL for an app page in a multi-page app.
    * @param pageLinkBaseURL the optional pageLinkBaseURL set by the host communication layer.
    * @param page the page's AppPage protobuf properties
@@ -58,12 +66,23 @@ export interface StreamlitEndpoints {
    * @return a Promise<number> that resolves with the file's unique ID, as assigned by the server.
    */
   uploadFileUploaderFile(
+    fileUploadUrl: string,
     file: File,
     widgetId: string,
     sessionId: string,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
+    // TODO(vdonato): Eventually change the return type to Promise<void> since
+    // we'll be getting rid of numerical file IDs.
   ): Promise<number>
+
+  /**
+   * Request that the file at the given URL be deleted.
+   *
+   * @param fileUrl: The URL of the file to delete.
+   * @param sessionId the current sessionID.
+   */
+  deleteFileAtURL(fileUrl: string, sessionId: string): Promise<void>
 
   /**
    * Fetch a cached ForwardMsg from the server.

--- a/frontend/src/lib/StreamlitLib.test.tsx
+++ b/frontend/src/lib/StreamlitLib.test.tsx
@@ -55,6 +55,10 @@ class Endpoints implements StreamlitEndpoints {
     return url
   }
 
+  public buildFileUploadURL(url: string): string {
+    return url
+  }
+
   public buildAppPageURL(
     pageLinkBaseURL: string | undefined,
     page: IAppPage,
@@ -64,12 +68,17 @@ class Endpoints implements StreamlitEndpoints {
   }
 
   public uploadFileUploaderFile(
+    fileUploadUrl: string,
     file: File,
     widgetId: string,
     sessionId: string,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken
   ): Promise<number> {
+    return Promise.reject(new Error("Unimplemented"))
+  }
+
+  public deleteFileAtURL(fileUrl: string, sessionId: string): Promise<void> {
     return Promise.reject(new Error("Unimplemented"))
   }
 

--- a/frontend/src/lib/StreamlitLib.test.tsx
+++ b/frontend/src/lib/StreamlitLib.test.tsx
@@ -70,7 +70,6 @@ class Endpoints implements StreamlitEndpoints {
   public uploadFileUploaderFile(
     fileUploadUrl: string,
     file: File,
-    widgetId: string,
     sessionId: string,
     onUploadProgress?: (progressEvent: any) => void,
     cancelToken?: CancelToken

--- a/frontend/src/lib/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/lib/components/widgets/CameraInput/CameraInput.tsx
@@ -569,6 +569,8 @@ class CameraInput extends React.PureComponent<Props, State> {
     this.props.uploadClient
       .uploadFile(
         this.props.element,
+        // TODO(vdonato): Use the file upload URL received from the server.
+        "/_stcore/upload_file",
         file,
         e => this.onUploadProgress(e, uploadingFileInfo.id),
         cancelToken.token

--- a/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
@@ -319,6 +319,8 @@ class FileUploader extends React.PureComponent<Props, State> {
     this.props.uploadClient
       .uploadFile(
         this.props.element,
+        // TODO(vdonato): Use the file upload URL received from the server.
+        "/_stcore/upload_file",
         file,
         e => this.onUploadProgress(e, uploadingFileInfo.id),
         cancelToken.token

--- a/frontend/src/lib/mocks/mocks.ts
+++ b/frontend/src/lib/mocks/mocks.ts
@@ -51,8 +51,12 @@ export function mockEndpoints(
   return {
     buildComponentURL: jest.fn(),
     buildMediaURL: jest.fn(),
+    buildFileUploadURL: jest.fn(),
     buildAppPageURL: jest.fn(),
     uploadFileUploaderFile: jest
+      .fn()
+      .mockRejectedValue(new Error("unimplemented mock endpoint")),
+    deleteFileAtURL: jest
       .fn()
       .mockRejectedValue(new Error("unimplemented mock endpoint")),
     fetchCachedForwardMsg: jest


### PR DESCRIPTION
NOTE: This PR is being merged into the `feature/file_uploader_abstractions` branch

## 📚 Context

As part of the changes we're making to the `st.file_uploader` widget, we'll need to make it possible for
the URL that a file is being uploaded to to be configurable. This PR starts this work by adding a new parameter
to the relevant `StreamlitEndpoints` and `FileUploadClient` method signatures. It also adds methods for sending
an `HTTP DELETE` request to a given URL.

Note that there are a bunch of TODOs in the code at the moment since fully completing much of this work will
require a bunch of changes on the server side to be finished. We'll have all of these TODO comments addressed
by the time we're looking to merge the feature branch into `develop`.