### PR TITLE
Replace curly with straight quotes in docstring examples

### DIFF
--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -112,7 +112,7 @@ class ArrowMixin:
             * A string to set the display label of the column.
 
             * One of the column types defined under ``st.column_config``, e.g.
-              ``st.column_config.NumberColumn(”Dollar values”, format=”$ %d”)`` to show
+              ``st.column_config.NumberColumn("Dollar values”, format=”$ %d")`` to show
               a column as dollar amounts. See more info on the available column types
               and config options `here <https://docs.streamlit.io/library/api-reference/data/st.column_config>`_.
 

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -599,7 +599,7 @@ class DataEditorMixin:
             * A string to set the display label of the column.
 
             * One of the column types defined under ``st.column_config``, e.g.
-              ``st.column_config.NumberColumn(”Dollar values”, format=”$ %d”)`` to show
+              ``st.column_config.NumberColumn("Dollar values”, format=”$ %d")`` to show
               a column as dollar amounts. See more info on the available column types
               and config options `here <https://docs.streamlit.io/library/api-reference/data/st.column_config>`_.
 

--- a/lib/streamlit/elements/dataframe_selector.py
+++ b/lib/streamlit/elements/dataframe_selector.py
@@ -101,7 +101,7 @@ class DataFrameSelectorMixin:
             * A string to set the display label of the column.
 
             * One of the column types defined under ``st.column_config``, e.g.
-              ``st.column_config.NumberColumn(”Dollar values”, format=”$ %d”)`` to show
+              ``st.column_config.NumberColumn("Dollar values”, format=”$ %d")`` to show
               a column as dollar amounts. See more info on the available column types
               and config options `here <https://docs.streamlit.io/library/api-reference/data/st.column_config>`_.
 

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -77,7 +77,7 @@ class MarkdownMixin:
         >>> import streamlit as st
         >>>
         >>> st.markdown('Streamlit is **_really_ cool**.')
-        >>> st.markdown(”This text is :red[colored red], and this is **:blue[colored]** and bold.”)
+        >>> st.markdown("This text is :red[colored red], and this is **:blue[colored]** and bold.")
         >>> st.markdown(":green[$\sqrt{x^2+y^2}=1$] is a Pythagorean identity. :pencil:")
 
         """


### PR DESCRIPTION
<!--
Before contributing (PLEASE READ!)

⚠️ If your contribution is more than a few lines of code, then prior to starting to code on it please post in the issue saying you want to volunteer, then wait for a positive response. And if there is no issue for it yet, create it first.

This helps make sure:

  1. Two people aren't working on the same thing
  2. This is something Streamlit's maintainers believe should be implemented/fixed
  3. Any API, UI, or deeper architectural changes that need to be implemented have been fully thought through by Streamlit's maintainers
  4. Your time is well spent!

More information in our wiki: https://github.com/streamlit/streamlit/wiki/Contributing
-->

## 📚 Context

@sfc-gh-cwargnier alerted the Docs team about the use of `”` in the `st.markdown` docstring example that caused syntax highlighting to break on the docs site. This PR replaces `”` with `"`.

- What kind of change does this PR introduce?

  - [x] Other, please describe: Documentation improvement

## 🧠 Description of Changes

- This PR replaces `”` with `"` in docstring examples to prevent incorrect rendering on the docs site.
- Note this PR neither adds nor updates any tests as it merely edits docstring text.

  - [ ] This is a breaking API change
  - [x] This is a visible (user-facing) change

**Revised:**

![image](https://github.com/streamlit/streamlit/assets/20672874/50ff59b6-c098-4317-a3a6-a3dbde0cc50f)

**Current:**

![image](https://github.com/streamlit/streamlit/assets/20672874/93fd2cc0-f0c4-4ba1-916a-edde4bfeb229)

## 🧪 Testing Done

- [x] Screenshots included

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
