### PR TITLE
Bump version dependency for typing-extensions to >= 4.0

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -55,7 +55,7 @@ INSTALL_REQUIRES = [
     "rich>=10.11.0, <14",
     "tenacity>=8.0.0, <9",
     "toml<2",
-    "typing-extensions>=3.10.0.0",
+    "typing-extensions>=4.0",
     "tzlocal>=1.1, <5",
     "validators>=0.2, <1",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.


### PR DESCRIPTION
## 📚 Context

- What kind of change does this PR introduce?

  - [X] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧠 Description of Changes

Streamlit 1.23.0 breaks with typing-extensions 3.10.0.2: see [issue #6774 ](https://github.com/streamlit/streamlit/issues/6774).

This patch fixes the issue by specifying the correct minimum version dependency.