### PR TITLE
Add uuid as a dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,6 +115,7 @@
     "styletron-react": "^6.1.0",
     "typed-signals": "^2.5.0",
     "unist-util-visit": "^4.1.2",
+    "uuid": "^9.0.0",
     "vega": "^5.25.0",
     "vega-embed": "^6.22.1",
     "vega-interpreter": "^1.0.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16478,6 +16478,11 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 uvu@^0.5.0:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"


### PR DESCRIPTION
This PR adds the `uuid` package as an explicit dependency. Note that `v8.x.x` version of this package
is already a transitive dependency, but according to [bundlephobia](https://bundlephobia.com/package/uuid@9.0.0), adding v9 will only increase our bundle
size by a few kilobytes, so it seems reasonable to just add the newest version as a dependency rather than
adding the same version as the transitive dependency to shave down a trivial amount of bundle size.