### PR TITLE
Allow file uploader URLs to be fetched via websocket

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -165,6 +165,7 @@
     "@types/styletron-engine-atomic": "^1.1.1",
     "@types/styletron-react": "^5.0.3",
     "@types/styletron-standard": "^2.0.2",
+    "@types/uuid": "^9.0.1",
     "@types/xxhashjs": "^0.2.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1540,6 +1540,54 @@ describe("App.handleDeltaMessage", () => {
   })
 })
 
+describe("App.requestFileURLs", () => {
+  let wrapper: ShallowWrapper
+  let instance: App
+
+  beforeEach(() => {
+    wrapper = shallow(<App {...getProps()} />)
+    instance = wrapper.instance() as App
+
+    // @ts-expect-error
+    instance.sendBackMsg = jest.fn()
+
+    // @ts-expect-error
+    instance.sessionInfo.setCurrent(mockSessionInfoProps())
+  })
+
+  it("properly constructs fileUrlsRequest BackMsg", () => {
+    instance.isServerConnected = jest.fn().mockReturnValue(true)
+
+    instance.requestFileURLs(
+      "myRequestId",
+      // @ts-expect-error
+      [{ name: "file1.txt" }, { name: "file2.txt" }, { name: "file3.txt" }]
+    )
+
+    // @ts-expect-error
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      fileUrlsRequest: {
+        fileNames: ["file1.txt", "file2.txt", "file3.txt"],
+        requestId: "myRequestId",
+        sessionId: "mockSessionId",
+      },
+    })
+  })
+
+  it("does nothing if server is disconnected", () => {
+    instance.isServerConnected = jest.fn().mockReturnValue(false)
+
+    instance.requestFileURLs(
+      "myRequestId",
+      // @ts-expect-error
+      [{ name: "file1.txt" }, { name: "file2.txt" }, { name: "file3.txt" }]
+    )
+
+    // @ts-expect-error
+    expect(instance.sendBackMsg).not.toHaveBeenCalled()
+  })
+})
+
 describe("Test Main Menu shortcut functionality", () => {
   let prevWindowLocation: Location
   beforeEach(() => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -70,6 +70,7 @@ import {
   Config,
   CustomThemeConfig,
   Delta,
+  FileURLsResponse,
   ForwardMsg,
   ForwardMsgMetadata,
   GitInfo,
@@ -287,6 +288,7 @@ export class App extends PureComponent<Props, State> {
       // reads the state.
       formsWithPendingRequestsChanged: formIds =>
         this.widgetMgr.setFormsWithUploads(formIds),
+      requestFileURLs: this.requestFileURLs,
     })
 
     this.componentRegistry = new ComponentRegistry(this.endpoints)
@@ -562,6 +564,8 @@ export class App extends PureComponent<Props, State> {
           this.handleScriptFinished(status),
         pageProfile: (pageProfile: PageProfile) =>
           this.handlePageProfileMsg(pageProfile),
+        fileUrlsResponse: (fileURLsResponse: FileURLsResponse) =>
+          this.uploadClient.onFileURLsResponse(fileURLsResponse),
       })
     } catch (e) {
       const err = ensureError(e)
@@ -1513,6 +1517,20 @@ export class App extends PureComponent<Props, State> {
     }
     this.sendLoadGitInfoBackMsg()
     this.openDeployDialog()
+  }
+
+  requestFileURLs = (requestId: string, files: File[]): void => {
+    if (this.isServerConnected()) {
+      const backMsg = new BackMsg({
+        fileUrlsRequest: {
+          requestId,
+          fileNames: files.map(f => f.name),
+          sessionId: this.sessionInfo.current.sessionId,
+        },
+      })
+      backMsg.type = "fileUrlsRequest"
+      this.sendBackMsg(backMsg)
+    }
   }
 
   render(): JSX.Element {

--- a/frontend/src/app/components/AppView/AppView.test.tsx
+++ b/frontend/src/app/components/AppView/AppView.test.tsx
@@ -50,6 +50,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
       sessionInfo: sessionInfo,
       endpoints: endpoints,
       formsWithPendingRequestsChanged: () => {},
+      requestFileURLs: jest.fn(),
     }),
     widgetsDisabled: true,
     componentRegistry: new ComponentRegistry(endpoints),

--- a/frontend/src/lib/FileUploadClient.test.ts
+++ b/frontend/src/lib/FileUploadClient.test.ts
@@ -141,8 +141,6 @@ describe("FileUploadClient Upload", () => {
   })
 
   it("onFileURLsResponse rejects promise on errorMsg", () => {
-    const fileURLsPromise = uploader.fetchFileURLs([])
-
     // @ts-expect-error
     const pendingReqs = uploader.pendingFileURLsRequests
     const reqId = pendingReqs.keys().next().value
@@ -157,8 +155,6 @@ describe("FileUploadClient Upload", () => {
   })
 
   it("onFileURLsResponse resolves promise on success", () => {
-    const fileURLsPromise = uploader.fetchFileURLs([])
-
     // @ts-expect-error
     const pendingReqs = uploader.pendingFileURLsRequests
     const reqId = pendingReqs.keys().next().value

--- a/frontend/src/lib/FileUploadClient.ts
+++ b/frontend/src/lib/FileUploadClient.ts
@@ -15,8 +15,13 @@
  */
 
 import { CancelToken } from "axios"
-import { SessionInfo } from "src/lib/SessionInfo"
 import _ from "lodash"
+import { v4 as uuidv4 } from "uuid"
+
+import { FileURLsResponse, IFileURLsResponse } from "src/lib/proto"
+import { SessionInfo } from "src/lib/SessionInfo"
+import { logWarning } from "src/lib/util/log"
+import Resolver from "src/lib/util/Resolver"
 import { StreamlitEndpoints } from "./StreamlitEndpoints"
 import { isValidFormId } from "./util/utils"
 
@@ -31,10 +36,11 @@ interface Props {
   sessionInfo: SessionInfo
   endpoints: StreamlitEndpoints
   formsWithPendingRequestsChanged: (formIds: Set<string>) => void
+  requestFileURLs: (requestId: string, files: File[]) => void
 }
 
 /**
- * Handles uploading files to the server.
+ * Handles operations related to the st.file_uploader widget.
  */
 export class FileUploadClient {
   private readonly sessionInfo: SessionInfo
@@ -52,10 +58,31 @@ export class FileUploadClient {
    */
   private readonly pendingFormUploadsChanged: (formIds: Set<string>) => void
 
+  /**
+   * Function to ask the app to request file URLs for getting/uploading/deleting
+   * files. Currently, this is only done by App.tsx via a BackMsg sent over the
+   * browser tab's websocket connection, but the FileUploadClient is
+   * indifferent to the exact mechanism used.
+   *
+   * Upon receiving the requested file URLs, the app should call this class'
+   * onFileURLsResponse method.
+   */
+  private readonly requestFileURLs: (requestId: string, files: File[]) => void
+
+  /**
+   * A map from request ID (a uuidv4) to the Resolver that should resolve once
+   * the requested file URLs are received.
+   */
+  private readonly pendingFileURLsRequests = new Map<
+    string,
+    Resolver<FileURLsResponse.IFileURLs[]>
+  >()
+
   public constructor(props: Props) {
     this.sessionInfo = props.sessionInfo
     this.endpoints = props.endpoints
     this.pendingFormUploadsChanged = props.formsWithPendingRequestsChanged
+    this.requestFileURLs = props.requestFileURLs
   }
 
   /**
@@ -100,6 +127,53 @@ export class FileUploadClient {
       fileUrl,
       this.sessionInfo.current.sessionId
     )
+  }
+
+  /**
+   * Request that the app fetch URLs to upload/delete/get the given files. Once
+   * this is done, the app should call this class' onFileURLsResponse to
+   * signify completion.
+   *
+   * @param files: An array of files.
+   *
+   * @return a Promise<FileURLsResponse.IFileURLs[]> resolving to the
+   */
+  // TODO(vdonato): Implement timeouts and improve error handling.
+  // TODO(vdonato): Look into how awkward a pattern like this will be for
+  //                the notebooks team / where else the code to fetch file URLs
+  //                via websocket can live.
+  public fetchFileURLs(files: File[]): Promise<FileURLsResponse.IFileURLs[]> {
+    const resolver = new Resolver<FileURLsResponse.IFileURLs[]>()
+
+    const requestId = uuidv4()
+    this.pendingFileURLsRequests.set(requestId, resolver)
+    this.requestFileURLs(requestId, files)
+
+    return resolver.promise
+  }
+
+  /**
+   * Callback to be called by the app once the file URLs corresponding to a
+   * call to this.requestFileURLs has been received.
+   *
+   * @param resp: the FileURLsResponse corresponding to a call to
+   * this.requestFileURLs.
+   */
+  public onFileURLsResponse(resp: IFileURLsResponse): void {
+    const id = resp.responseId as string
+    const resolver = this.pendingFileURLsRequests.get(id)
+    if (resolver) {
+      if (resp.errorMsg) {
+        resolver.reject(resp.errorMsg)
+      } else {
+        resolver.resolve(resp.fileUrls || [])
+      }
+      this.pendingFileURLsRequests.delete(id)
+    } else {
+      logWarning(
+        "fileURLsResponse received for nonexistent request, ignoring."
+      )
+    }
   }
 
   private getFormIdSet(): Set<string> {

--- a/frontend/src/lib/StreamlitLib.test.tsx
+++ b/frontend/src/lib/StreamlitLib.test.tsx
@@ -125,6 +125,7 @@ class StreamlitLibExample extends PureComponent<Props, State> {
       // reads the state.
       formsWithPendingRequestsChanged: formIds =>
         this.widgetMgr.setFormsWithUploads(formIds),
+      requestFileURLs: jest.fn(),
     })
 
     this.sessionInfo.setCurrent({

--- a/frontend/src/lib/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/src/lib/components/core/Block/ElementNodeRenderer.test.tsx
@@ -78,6 +78,7 @@ function getProps(
       sessionInfo: sessionInfo,
       endpoints,
       formsWithPendingRequestsChanged: () => {},
+      requestFileURLs: jest.fn(),
     }),
     componentRegistry: new ComponentRegistry(endpoints),
     formsData: createFormsData(),

--- a/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
@@ -276,6 +276,10 @@ class FileUploader extends React.PureComponent<Props, State> {
       this.removeFile(this.state.files[0].id)
     }
 
+    this.props.uploadClient.fetchFileURLs(acceptedFiles).then((resp: any) => {
+      console.error(resp)
+    })
+
     // Upload each accepted file.
     acceptedFiles.forEach(this.uploadFile)
 

--- a/frontend/src/lib/util/Resolver.ts
+++ b/frontend/src/lib/util/Resolver.ts
@@ -18,19 +18,26 @@
  * A promise wrapper that makes resolve/reject functions public.
  */
 export default class Resolver<T> {
-  public resolve: (value: T | PromiseLike<T>) => void
+  public readonly resolve: (value: T | PromiseLike<T>) => void
 
-  public reject: (reason?: any) => void | Promise<any>
+  public readonly reject: (reason?: any) => void | Promise<any>
 
-  public promise: Promise<T>
+  public readonly promise: Promise<T>
 
   constructor() {
-    // Initialize to something so TS is happy.
+    // Initialize to something so that TS is happy, then use @ts-expect-error
+    // so that we can assign the actually desired values to resolve and reject.
+    //
+    // This is necessary because TS isn't able to deduce that resolve and
+    // reject will always be set in the callback passed to the Promise
+    // constructor below.
     this.resolve = () => {}
     this.reject = () => {}
 
     this.promise = new Promise<T>((resFn, rejFn) => {
+      // @ts-expect-error
       this.resolve = resFn
+      // @ts-expect-error
       this.reject = rejFn
     })
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3778,6 +3778,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
+
 "@types/viewport-mercator-project@*":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@types/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#07cd2ae62e0d54a1265274c8b112d376550b031a"

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -746,7 +746,13 @@ class AppSession:
         msg = ForwardMsg()
         msg.file_urls_response.response_id = file_urls_request.request_id
 
-        upload_urls = self._uploaded_file_mgr.get_upload_urls(
+        # TODO(vdonato / kajarenc): Figure out how to get rid of this type error:
+        #   We currently don't have the get_upload_urls method as part of the
+        #   UploadedFileManager protocol (it's only defined in the
+        #   MemoryUploadedFileManager implementation), so mypy gets angry at the line
+        #   below. We may want to consider adding it to the protocol even if it does end
+        #   up being a no-op depending on the runtime environment.
+        upload_urls = self._uploaded_file_mgr.get_upload_urls(  # type: ignore
             self.id, len(file_urls_request.file_names)
         )
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -23,7 +23,7 @@ from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ClientState_pb2 import ClientState
-from streamlit.proto.Common_pb2 import FileUrlsRequest, FileUrlsResponse
+from streamlit.proto.Common_pb2 import FileURLsRequest, FileURLsResponse
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.GitInfo_pb2 import GitInfo
 from streamlit.proto.NewSession_pb2 import (
@@ -741,7 +741,7 @@ class AppSession:
         self._run_on_save = new_value
         self._enqueue_forward_msg(self._create_session_status_changed_message())
 
-    def _handle_file_urls_request(self, file_urls_request: FileUrlsRequest) -> None:
+    def _handle_file_urls_request(self, file_urls_request: FileURLsRequest) -> None:
         """TODO(vdonato): docstring"""
         msg = ForwardMsg()
         msg.file_urls_response.response_id = file_urls_request.request_id
@@ -752,7 +752,7 @@ class AppSession:
 
         for url in upload_urls:
             msg.file_urls_response.file_urls.append(
-                FileUrlsResponse.FileUrls(
+                FileURLsResponse.FileURLs(
                     file_id=url,
                     upload_url=url,
                     delete_url=url,

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -742,7 +742,7 @@ class AppSession:
         self._enqueue_forward_msg(self._create_session_status_changed_message())
 
     def _handle_file_urls_request(self, file_urls_request: FileURLsRequest) -> None:
-        """TODO(vdonato): docstring"""
+        """Handle a file_urls_request BackMsg sent by the client."""
         msg = ForwardMsg()
         msg.file_urls_response.response_id = file_urls_request.request_id
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -23,6 +23,7 @@ from streamlit.case_converters import to_snake_case
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
 from streamlit.proto.ClientState_pb2 import ClientState
+from streamlit.proto.Common_pb2 import FileUrlsRequest, FileUrlsResponse
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.GitInfo_pb2 import GitInfo
 from streamlit.proto.NewSession_pb2 import (
@@ -287,6 +288,8 @@ class AppSession:
                 self._handle_set_run_on_save_request(msg.set_run_on_save)
             elif msg_type == "stop_script":
                 self._handle_stop_script_request()
+            elif msg_type == "file_urls_request":
+                self._handle_file_urls_request(msg.file_urls_request)
             else:
                 LOGGER.warning('No handler for "%s"', msg_type)
 
@@ -737,6 +740,26 @@ class AppSession:
         """
         self._run_on_save = new_value
         self._enqueue_forward_msg(self._create_session_status_changed_message())
+
+    def _handle_file_urls_request(self, file_urls_request: FileUrlsRequest) -> None:
+        """TODO(vdonato): docstring"""
+        msg = ForwardMsg()
+        msg.file_urls_response.response_id = file_urls_request.request_id
+
+        upload_urls = self._uploaded_file_mgr.get_upload_urls(
+            self.id, len(file_urls_request.file_names)
+        )
+
+        for url in upload_urls:
+            msg.file_urls_response.file_urls.append(
+                FileUrlsResponse.FileUrls(
+                    file_id=url,
+                    upload_url=url,
+                    delete_url=url,
+                )
+            )
+
+        self._enqueue_forward_msg(msg)
 
 
 # Config.ToolbarMode.ValueType does not exist at runtime (only in the pyi stubs), so

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -78,15 +78,14 @@ class MemoryUploadedFileManager(UploadedFileManager):
         session_storage = self.file_storage[session_id]
         session_storage.pop(file_url, None)
 
-    def get_upload_urls(self, session_id: str, number_of_files: int):
-        file_urls = []
-
-        for i in range(number_of_files):
-            file_id = str(uuid.uuid4())
-            file_url = f"{self.endpoint}/{session_id}/{file_id}"
-            file_urls.append({"presigned_url": file_url})
-
-        return file_urls
+    # TODO(vdonato / kajarenc): Maybe change this function signature to take a list of
+    # file names rather than number_of_files.
+    # TODO(vdonato / kajarenc): Unit tests for this
+    def get_upload_urls(self, session_id: str, number_of_files: int) -> List[str]:
+        return [
+            f"{self.endpoint}/{session_id}/{str(uuid.uuid4())}"
+            for _ in range(number_of_files)
+        ]
 
     def get_stats(self) -> List[CacheStat]:
         """Return the manager's CacheStats.

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -54,11 +54,7 @@ from streamlit.web.server.routes import (
 )
 from streamlit.web.server.server_util import make_url_path_regex
 from streamlit.web.server.stats_request_handler import StatsRequestHandler
-from streamlit.web.server.upload_file_request_handler import (
-    UPLOAD_FILE_URLS_ROUTE,
-    UploadFileRequestHandler,
-    UploadFileUrlsRequestHandler,
-)
+from streamlit.web.server.upload_file_request_handler import UploadFileRequestHandler
 
 LOGGER = get_logger(__name__)
 
@@ -313,18 +309,6 @@ class Server:
                 dict(
                     file_mgr=self._runtime.uploaded_file_mgr,
                     is_active_session=self._runtime.is_active_session,
-                ),
-            ),
-            # TODO(vdonato): Remove this if we finalize the decision to use websockets
-            # to fetch this info.
-            (
-                make_url_path_regex(
-                    base,
-                    UPLOAD_FILE_URLS_ROUTE,
-                ),
-                UploadFileUrlsRequestHandler,
-                dict(
-                    file_mgr=self._runtime.uploaded_file_mgr,
                 ),
             ),
             (

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -26,7 +26,7 @@ import streamlit.runtime.app_session as app_session
 from streamlit import config
 from streamlit.proto.AppPage_pb2 import AppPage
 from streamlit.proto.BackMsg_pb2 import BackMsg
-from streamlit.proto.Common_pb2 import FileUrlsRequest, FileUrlsResponse
+from streamlit.proto.Common_pb2 import FileURLsRequest, FileURLsResponse
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import Runtime
 from streamlit.runtime.app_session import AppSession, AppSessionState
@@ -489,7 +489,7 @@ class AppSessionTest(unittest.TestCase):
         session._uploaded_file_mgr.get_upload_urls.return_value = upload_file_urls
 
         session._handle_file_urls_request(
-            FileUrlsRequest(
+            FileURLsRequest(
                 request_id="my_id",
                 file_names=["file_1", "file_2", "file_3"],
                 session_id=session.id,
@@ -501,10 +501,10 @@ class AppSessionTest(unittest.TestCase):
         )
 
         expected_msg = ForwardMsg(
-            file_urls_response=FileUrlsResponse(
+            file_urls_response=FileURLsResponse(
                 response_id="my_id",
                 file_urls=[
-                    FileUrlsResponse.FileUrls(
+                    FileURLsResponse.FileURLs(
                         file_id=url,
                         upload_url=url,
                         delete_url=url,

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -64,7 +64,8 @@ message BackMsg {
     // global.developmentMode = True.
     bool debug_shutdown_runtime = 15;
 
-    // TODO(vdonato): Explanatory comment
+    // Requests that the server generate URLs for getting/uploading/deleting
+    // files for the `st.file_uploader` widget
     FileURLsRequest file_urls_request = 16;
   }
 

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -65,7 +65,7 @@ message BackMsg {
     bool debug_shutdown_runtime = 15;
 
     // TODO(vdonato): Explanatory comment
-    FileUrlsRequest file_urls_request = 16;
+    FileURLsRequest file_urls_request = 16;
   }
 
   // An ID used to associate this BackMsg with the corresponding ForwardMsgs

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -17,6 +17,7 @@
 syntax = "proto3";
 
 import "streamlit/proto/ClientState.proto";
+import "streamlit/proto/Common.proto";
 
 // A message from the browser to the server.
 message BackMsg {
@@ -62,6 +63,9 @@ message BackMsg {
     // runtime. This message is IGNORED unless the runtime is configured with
     // global.developmentMode = True.
     bool debug_shutdown_runtime = 15;
+
+    // TODO(vdonato): Explanatory comment
+    FileUrlsRequest file_urls_request = 16;
   }
 
   // An ID used to associate this BackMsg with the corresponding ForwardMsgs
@@ -71,5 +75,5 @@ message BackMsg {
 
   reserved 1, 2, 3, 4, 8, 9, 10;
 
-  // Next: 16
+  // Next: 17
 }

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -46,22 +46,22 @@ message UInt32Array {
 // information here to support pure OS use cases, but we'll need to coordinate
 // with the SiS team to verify that we're passing enough file metadata back for
 // them.
-message FileUrlsRequest {
+message FileURLsRequest {
   string request_id = 1;
   repeated string file_names = 2;
   string session_id = 3;
 }
 
-message FileUrlsResponse {
+message FileURLsResponse {
   // TODO(vdonato): Maybe come up with a better name for this proto type.
-  message FileUrls {
+  message FileURLs {
     string file_id = 1;
     string upload_url = 2;
     string delete_url = 3;
   }
 
   string response_id = 1;
-  repeated FileUrls file_urls = 2;
+  repeated FileURLs file_urls = 2;
   string error_msg = 3;
 }
 

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -42,6 +42,29 @@ message UInt32Array {
   repeated uint32 data = 1;
 }
 
+// TODO(vdonato): Finalize the next two proto types. We currently have enough
+// information here to support pure OS use cases, but we'll need to coordinate
+// with the SiS team to verify that we're passing enough file metadata back for
+// them.
+message FileUrlsRequest {
+  string request_id = 1;
+  repeated string file_names = 2;
+  string session_id = 3;
+}
+
+message FileUrlsResponse {
+  // TODO(vdonato): Maybe come up with a better name for this proto type.
+  message FileUrls {
+    string file_id = 1;
+    string upload_url = 2;
+    string delete_url = 3;
+  }
+
+  string response_id = 1;
+  repeated FileUrls file_urls = 2;
+  string error_msg = 3;
+}
+
 // Information on a file uploaded via the file_uploader widget.
 message UploadedFileInfo {
   // TO DEPRECATE:

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -16,6 +16,7 @@
 
 syntax = "proto3";
 
+import "streamlit/proto/Common.proto";
 import "streamlit/proto/Delta.proto";
 import "streamlit/proto/GitInfo.proto";
 import "streamlit/proto/NewSession.proto";
@@ -71,6 +72,9 @@ message ForwardMsg {
     // for this one. If the client does not have the referenced message
     // in its cache, it can retrieve it from the server.
     string ref_hash = 11;
+
+    // TODO(vdonato): Explanatory comment
+    FileUrlsResponse file_urls_response = 19;
   }
 
   // The ID of the last BackMsg that we received before sending this
@@ -79,7 +83,7 @@ message ForwardMsg {
   string debug_last_backmsg_id = 17;
 
   reserved 7, 8;
-  // Next: 19
+  // Next: 20
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -66,15 +66,13 @@ message ForwardMsg {
     // Other messages.
     PageNotFound page_not_found = 15;
     PagesChanged pages_changed = 16;
+    FileURLsResponse file_urls_response = 19;
 
     // A reference to a ForwardMsg that has already been delivered.
     // The client should substitute the message with the given hash
     // for this one. If the client does not have the referenced message
     // in its cache, it can retrieve it from the server.
     string ref_hash = 11;
-
-    // TODO(vdonato): Explanatory comment
-    FileURLsResponse file_urls_response = 19;
   }
 
   // The ID of the last BackMsg that we received before sending this

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -74,7 +74,7 @@ message ForwardMsg {
     string ref_hash = 11;
 
     // TODO(vdonato): Explanatory comment
-    FileUrlsResponse file_urls_response = 19;
+    FileURLsResponse file_urls_response = 19;
   }
 
   // The ID of the last BackMsg that we received before sending this


### PR DESCRIPTION
NOTE: This PR is being merged into the `feature/file_uploader_abstractions` branch

## 📚 Context

This PR adds a mechanism allowing a Streamlit app to use a `BackMsg` to request that the server
generate and return URLs for the `st.file_uploader` widget to use to upload/delete/get files.

It does so by adding the `fetchFileURLs` and `onFileURLsResponse` methods to the `FileUploadClient`
class, which will be used by the `FileUploader` and `CameraInput` react components in an upcoming PR.
It also removes the HTTP endpoint meant for the same purpose that was added earlier when we were less
certain about the exact mechanism that would be used to do this.