### PR TITLE
target="_blank" to README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,32 +50,32 @@ Streamlit comes in with [a ton of additional powerful elements](https://docs.str
 <table border="0">
   <tr>
     <td>
-      <a href="https://docs.streamlit.io/library/api-reference/widgets">
+      <a target="_blank" href="https://docs.streamlit.io/library/api-reference/widgets">
         <img src="https://user-images.githubusercontent.com/7164864/217936099-12c16f8c-7fe4-44b1-889a-1ac9ee6a1b44.png" style="max-height:150px; width:auto; display:block;">
       </a>
     </td>
     <td>
-      <a href="https://docs.streamlit.io/library/api-reference/data/st.dataframe">
+      <a target="_blank" href="https://docs.streamlit.io/library/api-reference/data/st.dataframe">
         <img src="https://user-images.githubusercontent.com/7164864/215110064-5eb4e294-8f30-4933-9563-0275230e52b5.gif" style="max-height:150px; width:auto; display:block;">
       </a>
     </td>
     <td>
-      <a href="https://docs.streamlit.io/library/api-reference/charts">
+      <a target="_blank" href="https://docs.streamlit.io/library/api-reference/charts">
         <img src="https://user-images.githubusercontent.com/7164864/215174472-bca8a0d7-cf4b-4268-9c3b-8c03dad50bcd.gif" style="max-height:150px; width:auto; display:block;">
       </a>
     </td>
     <td>
-      <a href="https://docs.streamlit.io/library/api-reference/layout">
+      <a target="_blank" href="https://docs.streamlit.io/library/api-reference/layout">
         <img src="https://user-images.githubusercontent.com/7164864/217936149-a35c35be-0d96-4c63-8c6a-1c4b52aa8f60.png" style="max-height:150px; width:auto; display:block;">
       </a>
     </td>
     <td>
-      <a href="https://docs.streamlit.io/library/get-started/multipage-apps">
+      <a target="_blank" href="https://docs.streamlit.io/library/get-started/multipage-apps">
         <img src="https://user-images.githubusercontent.com/7164864/215173883-eae0de69-7c1d-4d78-97d0-3bc1ab865e5b.gif" style="max-height:150px; width:auto; display:block;">
       </a>
     </td>
     <td>
-      <a href="https://streamlit.io/gallery">
+      <a target="_blank" href="https://streamlit.io/gallery">
         <img src="https://user-images.githubusercontent.com/7164864/215109229-6ae9111f-e5c1-4f0b-b3a2-87a79268ccc9.gif" style="max-height:150px; width:auto; display:block;">
       </a>
     </td>


### PR DESCRIPTION
## Describe your changes
Add the `target="_blank"` attribute for README links so they open in new tab

## Testing Plan
- No tests needed -> changes isolated to README