### PR TITLE
Allow the use of general number types in st.slider

### DIFF
--- a/lib/streamlit/elements/slider.py
+++ b/lib/streamlit/elements/slider.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from numbers import Integral, Real
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -389,8 +390,8 @@ class SliderMixin:
                 value = min_value if min_value is not None else 0
 
         SUPPORTED_TYPES = {
-            int: SliderProto.INT,
-            float: SliderProto.FLOAT,
+            Integral: SliderProto.INT,
+            Real: SliderProto.FLOAT,
             datetime: SliderProto.DATETIME,
             date: SliderProto.DATE,
             time: SliderProto.TIME,
@@ -410,8 +411,16 @@ class SliderMixin:
         if single_value:
             value = [value]
 
+        def value_to_generic_type(v):
+            if isinstance(v, Integral):
+                return SUPPORTED_TYPES[Integral]
+            elif isinstance(v, Real):
+                return SUPPORTED_TYPES[Real]
+            else:
+                return SUPPORTED_TYPES[type(v)]
+
         def all_same_type(items):
-            return len(set(map(type, items))) < 2
+            return len(set(map(value_to_generic_type, items))) < 2
 
         if not all_same_type(value):
             raise StreamlitAPIException(
@@ -422,7 +431,7 @@ class SliderMixin:
         if len(value) == 0:
             data_type = SliderProto.INT
         else:
-            data_type = SUPPORTED_TYPES[type(value[0])]
+            data_type = value_to_generic_type(value[0])
 
         datetime_min = time.min
         datetime_max = time.max
@@ -487,8 +496,13 @@ class SliderMixin:
 
         # Ensure that all arguments are of the same type.
         slider_args = [min_value, max_value, step]
-        int_args = all(map(lambda a: isinstance(a, int), slider_args))
-        float_args = all(map(lambda a: isinstance(a, float), slider_args))
+        int_args = all(map(lambda a: isinstance(a, Integral), slider_args))
+        float_args = all(
+            map(
+                lambda a: isinstance(a, Real) and not isinstance(a, Integral),
+                slider_args,
+            )
+        )
         # When min and max_value are the same timelike, step should be a timedelta
         timelike_args = (
             data_type in TIMELIKE_TYPES


### PR DESCRIPTION
NumPy and Pandas numerical types such as [`np.int64`](https://numpy.org/doc/stable/user/basics.types.html) were being rejected as valid values. This generalises the type check using the [`numbers`](https://docs.python.org/3/library/numbers.html) module.

## Describe your changes

Instead of checking the passed in types explicitly against `int` and `float`, this instead uses `numbers.Real` and `number.Integral`. There's a slight niggle that integrals are a subset of the reals, so the ordering of the checks are important.

## GitHub Issue Link (if applicable)

This fixes #6815

## Testing Plan

I have added appropriate test examples to `lib/tests/streamlit/elements/slider_test.py::test_value_types` to ensure that NumPy types are accepted.

I have also added two new tests:
1. `test_value_types`: now that we're not only accepting exactly `int` and `float`, there's a danger that unexpected types might slip through the net. For example, there's a chance that things like complex numbers or `bytes` could match a `numbers.Real` type check. This makes sure that they still raise an exception.
2. `test_matching_types`: There's an error raised at the moment if you pass in a mixture of floats and integers to `st.slider`. This new test checks that that exception is not raised if passing a mixture of pure Python and NumPy types. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
