### PR TITLE
Backend changes

### DIFF
--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -67,7 +67,6 @@ def _get_file_recs_for_camera_input_widget(
 
 @dataclass
 class CameraInputSerde:
-
     file_delete_urls: Dict[str, str] = field(default_factory=dict)
 
     def serialize(

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from textwrap import dedent
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
 from streamlit.elements.form import current_form_id
 from streamlit.elements.utils import (
@@ -56,17 +56,20 @@ def _get_file_recs_for_camera_input_widget(
     if len(uploaded_file_info) == 0:
         return []
 
-    active_file_urls = [f.file_url for f in uploaded_file_info]
+    active_file_ids = [f.file_id for f in uploaded_file_info]
 
     # Grab the files that correspond to our active file IDs.
     return ctx.uploaded_file_mgr.get_files(
         session_id=ctx.session_id,
-        file_urls=active_file_urls,
+        file_ids=active_file_ids,
     )
 
 
 @dataclass
 class CameraInputSerde:
+
+    file_delete_urls: Dict[str, str] = field(default_factory=dict)
+
     def serialize(
         self,
         snapshot: SomeUploadedSnapshotFile,
@@ -77,9 +80,10 @@ class CameraInputSerde:
             return state_proto
 
         file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
-        file_info.file_url = snapshot.file_url
+        file_info.file_id = snapshot.file_id
         file_info.name = snapshot.name
         file_info.size = snapshot.size
+        file_info.file_delete_url = self.file_delete_urls[snapshot.file_id]
 
         return state_proto
 
@@ -87,6 +91,12 @@ class CameraInputSerde:
         self, ui_value: Optional[FileUploaderStateProto], widget_id: str
     ) -> SomeUploadedSnapshotFile:
         file_recs = _get_file_recs_for_camera_input_widget(ui_value)
+
+        if ui_value is not None:
+            uploaded_file_info = ui_value.uploaded_file_info
+
+            for f in uploaded_file_info:
+                self.file_delete_urls[f.file_id] = f.file_delete_url
 
         if len(file_recs) == 0:
             return_value = None

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -84,6 +84,8 @@ class FileUploaderSerde:
     ) -> SomeUploadedFiles:
         file_recs = _get_file_recs(ui_value)
 
+        # TODO[KAREN] Extract this logic for file_uploader and camera_input into
+        #  separate method.
         if ui_value is not None:
             uploaded_file_info = ui_value.uploaded_file_info
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -746,22 +746,16 @@ class AppSession:
         msg = ForwardMsg()
         msg.file_urls_response.response_id = file_urls_request.request_id
 
-        # TODO(vdonato / kajarenc): Figure out how to get rid of this type error:
-        #   We currently don't have the get_upload_urls method as part of the
-        #   UploadedFileManager protocol (it's only defined in the
-        #   MemoryUploadedFileManager implementation), so mypy gets angry at the line
-        #   below. We may want to consider adding it to the protocol even if it does end
-        #   up being a no-op depending on the runtime environment.
-        upload_urls = self._uploaded_file_mgr.get_upload_urls(  # type: ignore
-            self.id, len(file_urls_request.file_names)
+        upload_url_infos = self._uploaded_file_mgr.get_upload_urls(
+            self.id, file_urls_request.file_names
         )
 
-        for url in upload_urls:
+        for upload_url_info in upload_url_infos:
             msg.file_urls_response.file_urls.append(
                 FileURLsResponse.FileURLs(
-                    file_id=url,
-                    upload_url=url,
-                    delete_url=url,
+                    file_id=upload_url_info.file_id,
+                    upload_url=upload_url_info.upload_url,
+                    delete_url=upload_url_info.delete_url,
                 )
             )
 

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -78,7 +78,6 @@ class UploadedFileManager(CacheStatsProvider, Protocol):
     def remove_session_files(self, session_id: str) -> None:
         raise NotImplementedError
 
-    @abstractmethod
     def get_upload_urls(
         self, session_id: str, file_names: Sequence[str]
     ) -> List[UploadFileUrlInfo]:

--- a/lib/streamlit/web/server/upload_file_request_handler.py
+++ b/lib/streamlit/web/server/upload_file_request_handler.py
@@ -88,7 +88,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
         files: Dict[str, List[Any]] = {}
 
         session_id = self.path_kwargs["session_id"]
-        file_url = self.request.full_url()
+        file_id = self.path_kwargs["file_id"]
 
         tornado.httputil.parse_body_arguments(
             content_type=self.request.headers["Content-Type"],
@@ -110,7 +110,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
             for file in flist:
                 uploaded_files.append(
                     UploadedFileRec(
-                        file_url=file_url,
+                        file_id=file_id,
                         name=file["filename"],
                         type=file["content_type"],
                         data=file["body"],
@@ -129,7 +129,7 @@ class UploadFileRequestHandler(tornado.web.RequestHandler):
     def delete(self, **kwargs):
         """DELETE FILE"""
         session_id = self.path_kwargs["session_id"]
-        file_url = self.request.full_url()
+        file_id = self.path_kwargs["file_id"]
 
-        self._file_mgr.remove_file(session_id=session_id, file_url=file_url)
+        self._file_mgr.remove_file(session_id=session_id, file_id=file_id)
         self.set_status(204)

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -75,8 +75,11 @@ message UploadedFileInfo {
   // The size of this file in bytes.
   uint32 size = 3;
 
-  // URL that this file was uploaded to.
-  string file_url = 4;
+  // File id that can be used to retrieve a file.
+  string file_id = 4;
+
+  // File url to delete the file
+  string file_delete_url = 5;
 }
 
 message FileUploaderState {


### PR DESCRIPTION
Implement backend changes we discussed previously

-  get_upload_url now part of `UploadedFileManager` protocol
- `MemoryUploadedFileStorage` file use `file_id` as a key for file in storage
- add `file_delete_url` to `UploadedFileInfo` proto, and we store it now outside of session_state (to not expose it to streamlit app developer)

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
