### PR TITLE
Delay slider `thumbValueAlignment` to allow page layout to complete

### DIFF
--- a/e2e/scripts/st_select_slider.py
+++ b/e2e/scripts/st_select_slider.py
@@ -88,3 +88,7 @@ if runtime.exists():
     )
     st.write("Value 8:", st.session_state.select_slider8)
     st.write("Select slider changed:", "select_slider_changed" in st.session_state)
+
+with st.expander("Expander", expanded=True):
+    r2 = st.slider("Label 9", 10000, 25000, [10000, 25000])
+    st.write("Value 9:", r2)

--- a/e2e/scripts/st_select_slider.py
+++ b/e2e/scripts/st_select_slider.py
@@ -90,11 +90,10 @@ if runtime.exists():
     st.write("Select slider changed:", "select_slider_changed" in st.session_state)
 
 with st.expander("Expander", expanded=True):
-    st.select_slider(
+    w9 = st.select_slider(
         label="Label 9",
         options=["foo", "bar", "baz", "This is a very, very long option"],
         value="This is a very, very long option",
-        key="select_slider9",
     )
 
-    st.write("Value 9:", st.session_state.select_slider9)
+    st.write("Value 9:", w9)

--- a/e2e/scripts/st_select_slider.py
+++ b/e2e/scripts/st_select_slider.py
@@ -90,5 +90,11 @@ if runtime.exists():
     st.write("Select slider changed:", "select_slider_changed" in st.session_state)
 
 with st.expander("Expander", expanded=True):
-    r2 = st.slider("Label 9", 10000, 25000, [10000, 25000])
-    st.write("Value 9:", r2)
+    st.select_slider(
+        label="Label 9",
+        options=["foo", "bar", "baz", "This is a very, very long option"],
+        value="This is a very, very long option",
+        key="select_slider9",
+    )
+
+    st.write("Value 9:", st.session_state.select_slider9)

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -176,6 +176,6 @@ describe("st.select_slider", () => {
 
     // Positioning error occurs on overflow of expander container
     // which occurs when position left set to 0px
-    cy.getIndexed(".StyledThumbValue", 12).should("not.have.css", "left", "0px")
+    cy.getIndexed(".StyledThumbValue", 11).should("not.have.css", "left", "0px")
   });
 });

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -21,7 +21,7 @@ describe("st.select_slider", () => {
   });
 
   it("displays correct number of elements", () => {
-    cy.get(".element-container .stSlider").should("have.length", 8);
+    cy.get(".element-container .stSlider").should("have.length", 9);
   });
 
   it("looks right when disabled", () => {

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -166,4 +166,16 @@ describe("st.select_slider", () => {
       "Value 8: 2" + "Select slider changed: True"
     );
   });
+
+  it("realigns label values when expander re-opened", () => {
+    // Closes the expander
+    cy.get(".streamlit-expanderHeader").click();
+
+    // Reopens the expander
+    cy.get(".streamlit-expanderHeader").click();
+
+    // Positioning error occurs on overflow of expander container
+    // which occurs when position left set to 0px
+    cy.getIndexed(".StyledThumbValue", 12).should("not.have.css", "left", "0px")
+  });
 });

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -43,16 +43,16 @@ describe("st.slider", () => {
     cy.get(".stSlider label").should(
       "have.text",
       "Label A" +
-        "Range A" +
-        "Label B" +
-        "Range B" +
-        "Label 1" +
-        "Label 2" +
-        "Label 3 - This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long label" +
-        "Label 4" +
-        "Label 5" +
-        "Label 6" +
-        "Label 7"
+      "Range A" +
+      "Label B" +
+      "Range B" +
+      "Label 1" +
+      "Label 2" +
+      "Label 3 - This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long label" +
+      "Label 4" +
+      "Label 5" +
+      "Label 6" +
+      "Label 7"
     );
   });
 
@@ -82,21 +82,33 @@ describe("st.slider", () => {
     );
   });
 
+  it("realigns label values when expander re-opened", () => {
+    // Closes the expander
+    cy.get(".streamlit-expanderHeader").click();
+
+    // Reopens the expander
+    cy.get(".streamlit-expanderHeader").click();
+
+    // Positioning error occurs on overflow of expander container
+    // which occurs when position left set to 0px
+    cy.getIndexed(".StyledThumbValue", 5).should("not.have.css", "left", "0px")
+  });
+
   it("has correct values", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "Value A: 12345678" +
-        "Range Value A: (10000, 25000)" +
-        "Value B: 10000" +
-        "Range Value B: (10000, 25000)" +
-        "Value 1: 25" +
-        "Value 2: (25.0, 75.0)" +
-        "Value 3: 1" +
-        "Value 4: 10000" +
-        "Value 5: 25" +
-        "Value 6: 36" +
-        "Value 7: 25" +
-        "Slider changed: False"
+      "Range Value A: (10000, 25000)" +
+      "Value B: 10000" +
+      "Range Value B: (10000, 25000)" +
+      "Value 1: 25" +
+      "Value 2: (25.0, 75.0)" +
+      "Value 3: 1" +
+      "Value 4: 10000" +
+      "Value 5: 25" +
+      "Value 6: 36" +
+      "Value 7: 25" +
+      "Slider changed: False"
     );
   });
 

--- a/frontend/src/lib/components/widgets/Slider/Slider.tsx
+++ b/frontend/src/lib/components/widgets/Slider/Slider.tsx
@@ -92,10 +92,13 @@ class Slider extends React.PureComponent<Props, State> {
       i < Math.min(this.thumbRef.length, this.thumbValueRef.length);
       i++
     ) {
-      this.thumbValueAlignment(
-        this.thumbRef[i].current,
-        this.thumbValueRef[i].current
-      )
+      // Delay the alignment to allow the page layout to complete
+      setTimeout(() => {
+        this.thumbValueAlignment(
+          this.thumbRef[i].current,
+          this.thumbValueRef[i].current
+        )
+      }, 0)
     }
 
     if (this.props.element.setValue) {


### PR DESCRIPTION
## Describe your changes

#5913 fixed sliders to adjust the label if it appears outside of the screen, and for ranges where there are two thumb values. That solution is 99% of the way there. But as #6297 demonstrates, it doesn't consider how the slider and select_slider widgets behave when the expander is expanded and collapsed multiple times. 

My best guess of the observed behavior: When the expander is collapsed, the sliders are hidden and their layout may be invalidated. Upon re-expansion, the thumb values might be painted before the container sets its final width.

This PR fixes this by using `setTimeout(() => { ... }, 0)`, which delays the execution of the `thumbValueAlignment` method until the sliders are fully rendered with their final widths. This ensures correct alignment and prevents the thumb values from overflowing in subsequent expander expansions.

## GitHub Issue Link (if applicable)

Closes #6297.

## Testing Plan

~- TODO: e2e tests need to be updated. I need to figure out how to get cypress to expand -> collapse -> re-expand an `st.expander` with nested sliders before taking a snapshot.~
- Updated e2e tests for `st_slider.spec.js`, `st_select_slider.spec.js`, and `st_select_slider.py`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
