### PR TITLE
Add docstring and synthetic examples for `hash_funcs`

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -356,6 +356,7 @@ class CacheDataAPI:
         show_spinner: bool | str = True,
         persist: CachePersistType | bool = None,
         experimental_allow_widgets: bool = False,
+        hash_funcs: HashFuncsDict | None = None,
     ) -> Callable[[F], F]:
         ...
 
@@ -444,6 +445,14 @@ class CacheDataAPI:
             widget value is treated as an additional input parameter to the cache.
             We may remove support for this option at any time without notice.
 
+        hash_funcs : dict or None
+            Mapping of types or fully qualified names to hash functions.
+            This is used to override the behavior of the hasher inside Streamlit's
+            caching mechanism: when the hasher encounters an object, it will first
+            check to see if its type matches a key in this dict and, if so, will use
+            the provided function to generate a hash for it. See below for an example
+            of how this can be used.
+
         Example
         -------
         >>> import streamlit as st
@@ -506,6 +515,27 @@ class CacheDataAPI:
         ...
         >>> fetch_and_clean_data.clear()
         >>> # Clear all cached entries for this function.
+
+        To override the default hashing behavior, pass a custom hash function.
+        You can do that by mapping a type (e.g. ``datetime.datetime``) to a hash
+        function (``lambda dt: dt.isoformat()``) like this:
+
+        >>> import streamlit as st
+        >>> import datetime
+        >>>
+        >>> @st.cache_data(hash_funcs={datetime.datetime: lambda dt: dt.isoformat()})
+        ... def convert_to_utc(dt: datetime.datetime):
+        ...     return dt.astimezone(datetime.timezone.utc)
+
+        Alternatively, you can map the type's fully-qualified name
+        (e.g. ``"datetime.datetime"``) to the hash function instead:
+
+        >>> import streamlit as st
+        >>> import datetime
+        >>>
+        >>> @st.cache_data(hash_funcs={"datetime.datetime": lambda dt: dt.isoformat()})
+        ... def convert_to_utc(dt: datetime.datetime):
+        ...     return dt.astimezone(datetime.timezone.utc)
 
         """
 

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -392,7 +392,7 @@ class CacheResourceAPI:
 
         To override the default hashing behavior, pass a custom hash function.
         You can do that by mapping a type (e.g. ``Person``) to a hash
-        function (``lambda x: x.json()``) like this:
+        function (``str``) like this:
 
         >>> import streamlit as st
         >>> from pydantic import BaseModel
@@ -400,7 +400,7 @@ class CacheResourceAPI:
         >>> class Person(BaseModel):
         ...     name: str
         >>>
-        >>> @st.cache_resource(hash_funcs={Person: lambda x: x.json()})
+        >>> @st.cache_resource(hash_funcs={Person: str})
         ... def get_person_name(person: Person):
         ...     return person.name
 
@@ -408,12 +408,12 @@ class CacheResourceAPI:
         (e.g. ``"__main__.Person"``) to the hash function instead:
 
         >>> import streamlit as st
-        >>> import datetime
+        >>> from pydantic import BaseModel
         >>>
         >>> class Person(BaseModel):
         ...     name: str
         >>>
-        >>> @st.cache_resource(hash_funcs={"__main__.Person": lambda x: x.json()})
+        >>> @st.cache_resource(hash_funcs={"__main__.Person": str})
         ... def get_person_name(person: Person):
         ...     return person.name
         """

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -236,6 +236,7 @@ class CacheResourceAPI:
         show_spinner: bool | str = True,
         validate: ValidateFunc | None = None,
         experimental_allow_widgets: bool = False,
+        hash_funcs: HashFuncsDict | None = None,
     ) -> Callable[[F], F]:
         ...
 
@@ -329,6 +330,14 @@ class CacheResourceAPI:
             widget value is treated as an additional input parameter to the cache.
             We may remove support for this option at any time without notice.
 
+        hash_funcs : dict or None
+            Mapping of types or fully qualified names to hash functions.
+            This is used to override the behavior of the hasher inside Streamlit's
+            caching mechanism: when the hasher encounters an object, it will first
+            check to see if its type matches a key in this dict and, if so, will use
+            the provided function to generate a hash for it. See below for an example
+            of how this can be used.
+
         Example
         -------
         >>> import streamlit as st
@@ -381,6 +390,32 @@ class CacheResourceAPI:
         >>> get_database_session.clear()
         >>> # Clear all cached entries for this function.
 
+        To override the default hashing behavior, pass a custom hash function.
+        You can do that by mapping a type (e.g. ``Person``) to a hash
+        function (``lambda x: x.json()``) like this:
+
+        >>> import streamlit as st
+        >>> from pydantic import BaseModel
+        >>>
+        >>> class Person(BaseModel):
+        ...     name: str
+        >>>
+        >>> @st.cache_resource(hash_funcs={Person: lambda x: x.json()})
+        ... def get_person_name(person: Person):
+        ...     return person.name
+
+        Alternatively, you can map the type's fully-qualified name
+        (e.g. ``"__main__.Person"``) to the hash function instead:
+
+        >>> import streamlit as st
+        >>> import datetime
+        >>>
+        >>> class Person(BaseModel):
+        ...     name: str
+        >>>
+        >>> @st.cache_resource(hash_funcs={"__main__.Person": lambda x: x.json()})
+        ... def get_person_name(person: Person):
+        ...     return person.name
         """
         self._maybe_show_deprecation_warning()
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Add docstrings for the `hash_funcs` parameter, and fix override function typing. 

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
