### PR TITLE
Set default filename for if it missing in `st.download_button` widget.

### DIFF
--- a/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/src/lib/components/widgets/DownloadButton/DownloadButton.tsx
@@ -42,9 +42,7 @@ function DownloadButton(props: Props): ReactElement {
     // for the user.
     widgetMgr.setTriggerValue(element, { fromUi: true })
     const link = document.createElement("a")
-    const uri = `${endpoints.buildMediaURL(
-      element.url
-    )}?title=${encodeURIComponent(document.title)}`
+    const uri = endpoints.buildMediaURL(element.url)
     link.setAttribute("href", uri)
     link.setAttribute("target", "_blank")
     link.click()

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -14,7 +14,6 @@
 
 import re
 import textwrap
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Tuple, cast
 
 from streamlit.emojis import ALL_EMOJIS
@@ -92,57 +91,6 @@ def is_binary_string(inp):
     """Guess if an input bytesarray can be encoded as a string."""
     # From https://stackoverflow.com/a/7392391
     return bool(inp.translate(None, TEXTCHARS))
-
-
-def clean_filename(name: str) -> str:
-    """
-    Taken from https://github.com/django/django/blob/196a99da5d9c4c33a78259a58d38fb114a4d2ee8/django/utils/text.py#L225-L238
-
-    Return the given string converted to a string that can be used for a clean
-    filename. Remove leading and trailing spaces; convert other spaces to
-    underscores; and remove anything that is not an alphanumeric, dash,
-    underscore, or dot.
-    """
-    s = str(name).strip().replace(" ", "_")
-    s = re.sub(r"(?u)[^-\w.]", "", s)
-
-    if s in {"", ".", ".."}:
-        raise StreamlitAPIException("Could not derive file name from '%s'" % name)
-    return s
-
-
-def snake_case_to_camel_case(snake_case_string: str) -> str:
-    """Transform input string from snake_case to CamelCase."""
-    words = snake_case_string.split("_")
-    capitalized_words_arr = []
-
-    for word in words:
-        if word:
-            try:
-                capitalized_words_arr.append(word.title())
-            except Exception:
-                capitalized_words_arr.append(word)
-    return "".join(capitalized_words_arr)
-
-
-def append_date_time_to_string(input_string: str) -> str:
-    """Append datetime string to input string.
-    Returns datetime string if input is empty string.
-    """
-    now = datetime.now()
-
-    if not input_string:
-        return now.strftime("%Y-%m-%d_%H-%M-%S")
-    else:
-        return f'{input_string}_{now.strftime("%Y-%m-%d_%H-%M-%S")}'
-
-
-def generate_download_filename_from_title(title_string: str) -> str:
-    """Generated download filename from page title string."""
-    title_string = title_string.replace(" · Streamlit", "")
-    file_name_string = clean_filename(title_string)
-    title_string = snake_case_to_camel_case(file_name_string)
-    return append_date_time_to_string(title_string)
 
 
 def simplify_number(num: int) -> str:

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -61,9 +61,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
             filename = media_file.filename
 
             if not filename:
-                filename = (
-                    f"STREAMLIT_FILE{get_extension_for_mimetype(media_file.mimetype)}"
-                )
+                filename = f"streamlit_download{get_extension_for_mimetype(media_file.mimetype)}"
 
             try:
                 # Check that the value can be encoded in latin1. Latin1 is

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -62,7 +62,7 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
 
             if not filename:
                 filename = (
-                    f"StreamlitFile{get_extension_for_mimetype(media_file.mimetype)}"
+                    f"STREAMLIT_FILE{get_extension_for_mimetype(media_file.mimetype)}"
                 )
 
             try:

--- a/lib/streamlit/web/server/media_file_handler.py
+++ b/lib/streamlit/web/server/media_file_handler.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import Optional
-from urllib.parse import quote, unquote_plus
+from urllib.parse import quote
 
 import tornado.web
 
@@ -23,7 +23,6 @@ from streamlit.runtime.memory_media_file_storage import (
     MemoryMediaFileStorage,
     get_extension_for_mimetype,
 )
-from streamlit.string_util import generate_download_filename_from_title
 from streamlit.web.server import allow_cross_origin_requests
 
 _LOGGER = get_logger(__name__)
@@ -62,11 +61,8 @@ class MediaFileHandler(tornado.web.StaticFileHandler):
             filename = media_file.filename
 
             if not filename:
-                title = self.get_argument("title", "", True)
-                title = unquote_plus(title)
-                filename = generate_download_filename_from_title(title)
                 filename = (
-                    f"{filename}{get_extension_for_mimetype(media_file.mimetype)}"
+                    f"StreamlitFile{get_extension_for_mimetype(media_file.mimetype)}"
                 )
 
             try:

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -66,45 +66,6 @@ class StringUtilTest(unittest.TestCase):
     def test_extract_leading_emoji(self, text, expected):
         self.assertEqual(string_util.extract_leading_emoji(text), expected)
 
-    def test_snake_case_to_camel_case(self):
-        """Test streamlit.string_util.snake_case_to_camel_case."""
-        self.assertEqual(
-            "TestString.", string_util.snake_case_to_camel_case("test_string.")
-        )
-
-        self.assertEqual("Init", string_util.snake_case_to_camel_case("__init__"))
-
-    def test_clean_filename(self):
-        """Test streamlit.string_util.clean_filename."""
-        self.assertEqual("test_result", string_util.clean_filename("test re*su/lt;"))
-
-    def test_generate_download_filename_from_title(self):
-        """Test streamlit.string_util.generate_download_filename_from_title."""
-
-        self.assertTrue(
-            string_util.generate_download_filename_from_title(
-                "app · Streamlit"
-            ).startswith("App")
-        )
-
-        self.assertTrue(
-            string_util.generate_download_filename_from_title(
-                "app · Streamlit"
-            ).startswith("App")
-        )
-
-        self.assertTrue(
-            string_util.generate_download_filename_from_title(
-                "App title here"
-            ).startswith("AppTitleHere")
-        )
-
-        self.assertTrue(
-            string_util.generate_download_filename_from_title(
-                "Аптека, улица, фонарь"
-            ).startswith("АптекаУлицаФонарь")
-        )
-
     def test_simplify_number(self):
         """Test streamlit.string_util.simplify_number."""
 

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -58,10 +58,18 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     @parameterized.expand(
         [
-            ("MockVideo.mp4", 'attachment; filename="MockVideo.mp4"'),
+            ("MockVideo.mp4", "video/mp4", 'attachment; filename="MockVideo.mp4"'),
             (
                 b"\xe6\xbc\xa2\xe5\xad\x97.mp3".decode(),
+                "video/mp4",
                 "attachment; filename*=utf-8''%E6%BC%A2%E5%AD%97.mp3",
+            ),
+            (None, "text/plain", 'attachment; filename="StreamlitFile.txt"'),
+            (None, "video/mp4", 'attachment; filename="StreamlitFile.mp4"'),
+            (
+                None,
+                "application/octet-stream",
+                'attachment; filename="StreamlitFile.bin"',
             ),
         ]
     )
@@ -69,14 +77,17 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         "streamlit.runtime.media_file_manager._get_session_id",
         MagicMock(return_value="mock_session_id"),
     )
-    def test_downloadable_file(self, file_name, content_disposition_header) -> None:
+    def test_downloadable_file(
+        self, file_name, mimetype, content_disposition_header
+    ) -> None:
         """Downloadable files get an additional 'Content-Disposition' header
-        that includes their user-specified filename.
+        that includes their user-specified filename or
+        generic filename if filename is not specified.
         """
-        # Add a downloadable file with a filename
+        # Add a downloadable file with an optional filename
         url = self.media_file_manager.add(
             b"mock_data",
-            "video/mp4",
+            mimetype,
             "mock_coords",
             file_name=file_name,
             is_for_static_download=True,
@@ -85,7 +96,7 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         self.assertEqual(200, rsp.code)
         self.assertEqual(b"mock_data", rsp.body)
-        self.assertEqual("video/mp4", rsp.headers["Content-Type"])
+        self.assertEqual(mimetype, rsp.headers["Content-Type"])
         self.assertEqual(str(len(b"mock_data")), rsp.headers["Content-Length"])
         self.assertEqual(content_disposition_header, rsp.headers["Content-Disposition"])
 

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -64,12 +64,12 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "video/mp4",
                 "attachment; filename*=utf-8''%E6%BC%A2%E5%AD%97.mp3",
             ),
-            (None, "text/plain", 'attachment; filename="StreamlitFile.txt"'),
-            (None, "video/mp4", 'attachment; filename="StreamlitFile.mp4"'),
+            (None, "text/plain", 'attachment; filename="STREAMLIT_FILE.txt"'),
+            (None, "video/mp4", 'attachment; filename="STREAMLIT_FILE.mp4"'),
             (
                 None,
                 "application/octet-stream",
-                'attachment; filename="StreamlitFile.bin"',
+                'attachment; filename="STREAMLIT_FILE.bin"',
             ),
         ]
     )

--- a/lib/tests/streamlit/web/server/media_file_handler_test.py
+++ b/lib/tests/streamlit/web/server/media_file_handler_test.py
@@ -64,12 +64,12 @@ class MediaFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "video/mp4",
                 "attachment; filename*=utf-8''%E6%BC%A2%E5%AD%97.mp3",
             ),
-            (None, "text/plain", 'attachment; filename="STREAMLIT_FILE.txt"'),
-            (None, "video/mp4", 'attachment; filename="STREAMLIT_FILE.mp4"'),
+            (None, "text/plain", 'attachment; filename="streamlit_download.txt"'),
+            (None, "video/mp4", 'attachment; filename="streamlit_download.mp4"'),
             (
                 None,
                 "application/octet-stream",
-                'attachment; filename="STREAMLIT_FILE.bin"',
+                'attachment; filename="streamlit_download.bin"',
             ),
         ]
     )


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Previously in case of missing filename, we computed it based on the page title, and in order to have it in the endpoint we added the `title` query param to download_url. 

This could lead to undesired results (for example in the case of AWS S3 pre-signed URL modification breaks the link). So this PR removes this logic completely and uses a generic filename instead when filename is not provided by a user. 


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE!
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
