### PR TITLE
Setup String Trigger Value type for Widget State

### DIFF
--- a/frontend/src/lib/WidgetStateManager.test.ts
+++ b/frontend/src/lib/WidgetStateManager.test.ts
@@ -152,6 +152,18 @@ describe("Widget State Manager", () => {
     assertCallbacks({ insideForm: false })
   })
 
+  /**
+   * String Triggers can't be used within forms, so this test
+   * is not parameterized on insideForm.
+   */
+  it("sets string trigger value correctly", () => {
+    const widget = getWidget({ insideForm: false })
+    widgetMgr.setStringTriggerValue(widget, "sample string", { fromUi: true })
+    // @ts-expect-error
+    expect(widgetMgr.getWidgetState(widget)).toBe(undefined)
+    assertCallbacks({ insideForm: false })
+  })
+
   it.each([false, true])(
     "sets string array value correctly (insideForm=%p)",
     insideForm => {

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -23,6 +23,7 @@ import {
   IFileUploaderState,
   SInt64Array,
   StringArray,
+  StringTriggerValue,
   WidgetState,
   WidgetStates,
 } from "src/lib/proto"
@@ -36,7 +37,7 @@ export interface Source {
 /** Common widget protobuf fields that are used by the WidgetStateManager. */
 export interface WidgetInfo {
   id: string
-  formId: string
+  formId?: string
 }
 
 /**
@@ -239,6 +240,21 @@ export class WidgetStateManager {
     if (form.clearOnSubmit) {
       form.formCleared.emit()
     }
+  }
+
+  /**
+   * Sets the trigger value for the given widget ID to true, sends a rerunScript message
+   * to the server, and then immediately unsets the trigger value.
+   */
+  public setStringTriggerValue(
+    widget: WidgetInfo,
+    value: string,
+    source: Source
+  ): void {
+    this.createWidgetState(widget, source).stringTriggerValue =
+      new StringTriggerValue({ data: value })
+    this.onWidgetValueChanged(widget.formId, source)
+    this.deleteWidgetState(widget.id)
   }
 
   /**
@@ -527,7 +543,7 @@ export class WidgetStateManager {
   private createWidgetState(widget: WidgetInfo, source: Source): WidgetState {
     const addToForm = isValidFormId(widget.formId) && source.fromUi
     const widgetStateDict = addToForm
-      ? this.getOrCreateFormState(widget.formId).widgetStates
+      ? this.getOrCreateFormState(widget.formId as string).widgetStates
       : this.widgetStates
 
     return widgetStateDict.createState(widget.id)

--- a/frontend/src/lib/WidgetStateManager.ts
+++ b/frontend/src/lib/WidgetStateManager.ts
@@ -243,8 +243,9 @@ export class WidgetStateManager {
   }
 
   /**
-   * Sets the trigger value for the given widget ID to true, sends a rerunScript message
-   * to the server, and then immediately unsets the trigger value.
+   * Sets the string trigger value for the given widget ID to a string value,
+   * sends a rerunScript message to the server, and then immediately unsets the
+   * string trigger value to None/null.
    */
   public setStringTriggerValue(
     widget: WidgetInfo,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -215,6 +215,8 @@ class WStates(MutableMapping[str, Any]):
             setattr(widget, field, json.dumps(serialized))
         elif field == "file_uploader_state_value":
             widget.file_uploader_state_value.CopyFrom(serialized)
+        elif field == "string_trigger_value":
+            widget.string_trigger_value.CopyFrom(serialized)
         else:
             setattr(widget, field, serialized)
 
@@ -525,13 +527,19 @@ class SessionState:
         """Set all trigger values in our state dictionary to False."""
         for state_id in self._new_widget_state:
             metadata = self._new_widget_state.widget_metadata.get(state_id)
-            if metadata is not None and metadata.value_type == "trigger_value":
-                self._new_widget_state[state_id] = Value(False)
+            if metadata is not None:
+                if metadata.value_type == "trigger_value":
+                    self._new_widget_state[state_id] = Value(False)
+                elif metadata.value_type == "string_trigger_value":
+                    self._new_widget_state[state_id] = Value(None)
 
         for state_id in self._old_state:
             metadata = self._new_widget_state.widget_metadata.get(state_id)
-            if metadata is not None and metadata.value_type == "trigger_value":
-                self._old_state[state_id] = False
+            if metadata is not None:
+                if metadata.value_type == "trigger_value":
+                    self._old_state[state_id] = False
+                elif metadata.value_type == "string_trigger_value":
+                    self._old_state[state_id] = None
 
     def _remove_stale_widgets(self, active_widget_ids: set[str]) -> None:
         """Remove widget state for widgets whose ids aren't in `active_widget_ids`."""

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -232,18 +232,22 @@ def coalesce_widget_states(
         wstate.id: wstate for wstate in new_states.widgets
     }
 
+    trigger_value_types = [("trigger_value", False), ("string_trigger_value", None)]
     for old_state in old_states.widgets:
-        if old_state.WhichOneof("value") == "trigger_value" and old_state.trigger_value:
-
-            # Ensure the corresponding new_state is also a trigger;
-            # otherwise, a widget that was previously a button but no longer is
-            # could get a bad value.
-            new_trigger_val = states_by_id.get(old_state.id)
+        for trigger_value_type, unset_value in trigger_value_types:
             if (
-                new_trigger_val
-                and new_trigger_val.WhichOneof("value") == "trigger_value"
+                old_state.WhichOneof("value") == trigger_value_type
+                and old_state.trigger_value != unset_value
             ):
-                states_by_id[old_state.id] = old_state
+                # Ensure the corresponding new_state is also a trigger;
+                # otherwise, a widget that was previously a button but no longer is
+                # could get a bad value.
+                new_trigger_val = states_by_id.get(old_state.id)
+                if (
+                    new_trigger_val
+                    and new_trigger_val.WhichOneof("value") == trigger_value_type
+                ):
+                    states_by_id[old_state.id] = old_state
 
     coalesced = WidgetStates()
     coalesced.widgets.extend(states_by_id.values())

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -102,6 +102,7 @@ ValueFieldName: TypeAlias = Literal[
     "json_value",
     "string_value",
     "trigger_value",
+    "string_trigger_value",
 ]
 
 V_co = TypeVar(

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -22,6 +22,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit import errors
 from streamlit.proto.Button_pb2 import Button as ButtonProto
+from streamlit.proto.Common_pb2 import StringTriggerValue as StringTriggerValueProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import coalesce_widget_states
@@ -181,6 +182,32 @@ class WidgetManagerTests(unittest.TestCase):
         self.assertFalse(session_state["trigger"])
         self.assertEqual(123, session_state["int"])
 
+    def test_reset_string_triggers(self):
+        states = WidgetStates()
+        session_state = SessionState()
+
+        _create_widget("string_trigger", states).string_trigger_value.CopyFrom(
+            StringTriggerValueProto(data="Some Value")
+        )
+        _create_widget("int", states).int_value = 123
+        session_state.set_widgets_from_proto(states)
+        session_state._set_widget_metadata(
+            WidgetMetadata(
+                "string_trigger", lambda x, s: x, None, "string_trigger_value"
+            )
+        )
+        session_state._set_widget_metadata(
+            WidgetMetadata("int", lambda x, s: x, None, "int_value")
+        )
+
+        self.assertEqual("Some Value", session_state["string_trigger"].data)
+        self.assertEqual(123, session_state["int"])
+
+        session_state._reset_triggers()
+
+        self.assertIsNone(session_state["string_trigger"])
+        self.assertEqual(123, session_state["int"])
+
     def test_coalesce_widget_states(self):
         session_state = SessionState()
 
@@ -188,6 +215,15 @@ class WidgetManagerTests(unittest.TestCase):
 
         _create_widget("old_set_trigger", old_states).trigger_value = True
         _create_widget("old_unset_trigger", old_states).trigger_value = False
+        _create_widget(
+            "old_set_string_trigger", old_states
+        ).string_trigger_value.CopyFrom(StringTriggerValueProto(data="Some String"))
+        _create_widget(
+            "old_set_empty_string_trigger", old_states
+        ).string_trigger_value.CopyFrom(StringTriggerValueProto(data=""))
+        _create_widget(
+            "old_unset_string_trigger", old_states
+        ).string_trigger_value.CopyFrom(StringTriggerValueProto(data=None))
         _create_widget("missing_in_new", old_states).int_value = 123
         _create_widget("shape_changing_trigger", old_states).trigger_value = True
 
@@ -196,6 +232,15 @@ class WidgetManagerTests(unittest.TestCase):
         )
         session_state._set_widget_metadata(
             create_metadata("old_unset_trigger", "trigger_value")
+        )
+        session_state._set_widget_metadata(
+            create_metadata("old_set_string_trigger", "string_trigger_value")
+        )
+        session_state._set_widget_metadata(
+            create_metadata("old_set_empty_string_trigger", "string_trigger_value")
+        )
+        session_state._set_widget_metadata(
+            create_metadata("old_unset_string_trigger", "string_trigger_value")
         )
         session_state._set_widget_metadata(
             create_metadata("missing_in_new", "int_value")
@@ -208,10 +253,24 @@ class WidgetManagerTests(unittest.TestCase):
 
         _create_widget("old_set_trigger", new_states).trigger_value = False
         _create_widget("new_set_trigger", new_states).trigger_value = True
+        _create_widget(
+            "old_set_string_trigger", new_states
+        ).string_trigger_value.CopyFrom(StringTriggerValueProto(data=None))
+        _create_widget(
+            "old_set_empty_string_trigger", new_states
+        ).string_trigger_value.CopyFrom(StringTriggerValueProto(data=None))
+        _create_widget(
+            "new_set_string_trigger", new_states
+        ).string_trigger_value.CopyFrom(
+            StringTriggerValueProto(data="Some other string")
+        )
         _create_widget("added_in_new", new_states).int_value = 456
         _create_widget("shape_changing_trigger", new_states).int_value = 3
         session_state._set_widget_metadata(
             create_metadata("new_set_trigger", "trigger_value")
+        )
+        session_state._set_widget_metadata(
+            create_metadata("new_set_string_trigger", "string_trigger_value")
         )
         session_state._set_widget_metadata(create_metadata("added_in_new", "int_value"))
         session_state._set_widget_metadata(
@@ -224,10 +283,16 @@ class WidgetManagerTests(unittest.TestCase):
 
         self.assertRaises(KeyError, lambda: session_state["old_unset_trigger"])
         self.assertRaises(KeyError, lambda: session_state["missing_in_new"])
+        self.assertRaises(KeyError, lambda: session_state["old_unset_string_trigger"])
 
         self.assertEqual(True, session_state["old_set_trigger"])
         self.assertEqual(True, session_state["new_set_trigger"])
         self.assertEqual(456, session_state["added_in_new"])
+        self.assertEqual("Some String", session_state["old_set_string_trigger"].data)
+        self.assertEqual("", session_state["old_set_empty_string_trigger"].data)
+        self.assertEqual(
+            "Some other string", session_state["new_set_string_trigger"].data
+        )
 
         # Widgets that were triggers before, but no longer are, will *not*
         # be coalesced

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -42,6 +42,10 @@ message UInt32Array {
   repeated uint32 data = 1;
 }
 
+message StringTriggerValue {
+  optional string data = 1;
+}
+
 // Information on a file uploaded via the file_uploader widget.
 message UploadedFileInfo {
   sint64 id = 1;

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -48,5 +48,8 @@ message WidgetState {
     ArrowTable arrow_value = 11;
     bytes bytes_value = 12;
     FileUploaderState file_uploader_state_value = 13;
+    // String value that resets itself to empty after the script has been run.
+    // This is used for the chat_input widget.
+    StringTriggerValue string_trigger_value = 14;
   }
 }


### PR DESCRIPTION
## Describe your changes

Chat Input will behave similarly to a button but with a string value. It will return the string value (even empty string), and it will reset to None. This PR implements a "string trigger" type to perform this operation.

## Testing Plan

The changes will be a part of the Chat Input feature, so we only have unit tests to do the following:
- Test reset session state for the trigger
- Test setting the frontend String Trigger Value
- Test widget coalescing for widget state updates

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
