### PR TITLE
Provide Scroll to Bottom functionality as a React Hook

### DIFF
--- a/frontend/src/lib/hooks/useScrollAnimation.test.ts
+++ b/frontend/src/lib/hooks/useScrollAnimation.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, act } from "@testing-library/react-hooks"
+import useScrollAnimation from "./useScrollAnimation"
+
+describe("useScrollAnimation", () => {
+  let targetElement: HTMLElement
+  let onEndMock: () => void
+  let scrollHeight: number
+  let offsetHeight: number
+
+  beforeEach(() => {
+    targetElement = document.createElement("div")
+    targetElement.scrollTop = 0
+    scrollHeight = 200
+    offsetHeight = 100
+    Object.defineProperty(targetElement, "scrollHeight", {
+      set: value => (scrollHeight = value),
+      get: () => scrollHeight,
+    })
+    Object.defineProperty(targetElement, "offsetHeight", {
+      set: value => (offsetHeight = value),
+      get: () => offsetHeight,
+    })
+    targetElement.addEventListener = jest.fn()
+    targetElement.removeEventListener = jest.fn()
+    onEndMock = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should animate scroll", () => {
+    jest.useFakeTimers()
+
+    renderHook(() => useScrollAnimation(targetElement, onEndMock, true))
+
+    // Simulate scroll animation
+    act(() => {
+      jest.advanceTimersByTime(5)
+      // Trigger the callback of requestAnimationFrame
+      act(() => {
+        jest.runOnlyPendingTimers()
+      })
+    })
+
+    // Assert the updated scrollTop value
+    expect(targetElement.scrollTop).toBeGreaterThan(0)
+
+    // Simulate reaching the end of animation
+    act(() => {
+      jest.advanceTimersByTime(100)
+      // Trigger the callback of requestAnimationFrame
+      act(() => {
+        jest.runOnlyPendingTimers()
+      })
+    })
+
+    // Assert that onEnd callback is called
+    expect(onEndMock).toHaveBeenCalled()
+
+    jest.useRealTimers()
+  })
+
+  it("should register and deregister the correct events", () => {
+    jest.useFakeTimers()
+
+    const { unmount } = renderHook(() =>
+      useScrollAnimation(targetElement, onEndMock, true)
+    )
+
+    expect(targetElement.addEventListener).toHaveBeenCalledTimes(2)
+    expect(targetElement.addEventListener).toHaveBeenCalledWith(
+      "pointerdown",
+      expect.any(Function),
+      { passive: true }
+    )
+    expect(targetElement.addEventListener).toHaveBeenCalledWith(
+      "wheel",
+      expect.any(Function),
+      { passive: true }
+    )
+
+    unmount()
+
+    // Cleanup
+    expect(targetElement.removeEventListener).toHaveBeenCalledTimes(2)
+    expect(targetElement.removeEventListener).toHaveBeenCalledWith(
+      "pointerdown",
+      expect.any(Function)
+    )
+    expect(targetElement.removeEventListener).toHaveBeenCalledWith(
+      "wheel",
+      expect.any(Function)
+    )
+
+    jest.useRealTimers()
+  })
+
+  it("should not animate scroll if target element is null", () => {
+    renderHook(() => useScrollAnimation(null, onEndMock, true))
+
+    expect(targetElement.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it("should not animate scroll if isAnimating is false", () => {
+    renderHook(() => useScrollAnimation(targetElement, onEndMock, false))
+
+    expect(targetElement.addEventListener).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/hooks/useScrollAnimation.ts
+++ b/frontend/src/lib/hooks/useScrollAnimation.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useLayoutEffect, useRef } from "react"
+
+function squareStepper(current: number, to: number): number {
+  const sign = Math.sign(to - current)
+  const step = Math.sqrt(Math.abs(to - current))
+  const next = current + step * sign
+
+  if (sign > 0) {
+    return Math.min(to, next)
+  }
+
+  return Math.max(to, next)
+}
+
+function step(
+  from: number,
+  to: number,
+  stepper: (x: number, y: number) => number,
+  index: number
+): number {
+  let next = from
+
+  for (let i = 0; i < index; i++) {
+    next = stepper(next, to)
+  }
+
+  return next
+}
+
+export default function useScrollAnimation(
+  target: HTMLElement | null,
+  onEnd: () => void,
+  isAnimating: boolean
+): void {
+  const animator = useRef(0)
+
+  const animate = useCallback(
+    (from, index, start = Date.now()) => {
+      cancelAnimationFrame(animator.current)
+
+      animator.current = requestAnimationFrame(() => {
+        if (target) {
+          const toNumber = target.scrollHeight - target.offsetHeight
+          let nextValue = step(
+            from,
+            toNumber,
+            squareStepper,
+            (Date.now() - start) / 5
+          )
+
+          if (Math.abs(toNumber - nextValue) < 1.5) {
+            nextValue = toNumber
+          }
+
+          target.scrollTop = nextValue
+
+          if (toNumber === nextValue) {
+            onEnd()
+          } else {
+            animate(from, index + 1, start)
+          }
+        }
+      })
+    },
+    [animator, onEnd, target]
+  )
+
+  const handleCancelAnimation = useCallback(() => {
+    cancelAnimationFrame(animator.current)
+    onEnd()
+  }, [onEnd])
+
+  useLayoutEffect(() => {
+    if (!target || !isAnimating) {
+      return
+    }
+    animate(target.scrollTop, 1)
+
+    if (target) {
+      target.addEventListener("pointerdown", handleCancelAnimation, {
+        passive: true,
+      })
+      target.addEventListener("wheel", handleCancelAnimation, {
+        passive: true,
+      })
+
+      return () => {
+        target.removeEventListener("pointerdown", handleCancelAnimation)
+        target.removeEventListener("wheel", handleCancelAnimation)
+        cancelAnimationFrame(animator.current)
+      }
+    }
+
+    return () => cancelAnimationFrame(animator.current)
+  }, [animate, animator, handleCancelAnimation, target, isAnimating])
+}

--- a/frontend/src/lib/hooks/useScrollAnimation.ts
+++ b/frontend/src/lib/hooks/useScrollAnimation.ts
@@ -16,6 +16,15 @@
 
 import { useCallback, useLayoutEffect, useRef } from "react"
 
+/**
+ * Computes next step in a square-root based animation sequence. Step size is
+ * square root of absolute difference between current and target values. Can be
+ * used as a stepper function for other higher-level stepping functions.
+ *
+ * @param {number} current - Current value in animation sequence.
+ * @param {number} to - Target value of animation sequence.
+ * @returns {number} Next value in animation sequence.
+ */
 function squareStepper(current: number, to: number): number {
   const sign = Math.sign(to - current)
   const step = Math.sqrt(Math.abs(to - current))
@@ -28,6 +37,17 @@ function squareStepper(current: number, to: number): number {
   return Math.max(to, next)
 }
 
+/**
+ * Computes sequence of steps in animation by repeatedly applying a stepper
+ * function.
+ *
+ * @param {number} from - Initial value in animation sequence.
+ * @param {number} to - Target value of animation sequence.
+ * @param {function} stepper - Function computing next value given current
+ *                             and target values.
+ * @param {number} index - Number of steps to compute.
+ * @returns {number} Value at given index in animation sequence.
+ */
 function step(
   from: number,
   to: number,
@@ -43,6 +63,20 @@ function step(
   return next
 }
 
+/**
+ * Handles scroll animation for a given target HTMLElement. Uses a square-root
+ * based stepping function to compute scroll animation. Stops animation if
+ * target's scrollTop has reached scrollHeight or if user interacts with target
+ * (mousedown or mousewheel). Can also be cancelled by caller.
+ *
+ * @export
+ * @param {HTMLElement | null} target - HTML element to animate scroll of. If
+ *                                      null, no animation is performed.
+ * @param {() => void} onEnd - Callback when animation ends or is cancelled.
+ * @param {boolean} isAnimating - Boolean to start or stop animation. If false,
+ *                                no animation is performed.
+ * @returns {void}
+ */
 export default function useScrollAnimation(
   target: HTMLElement | null,
   onEnd: () => void,

--- a/frontend/src/lib/hooks/useScrollSpy.test.ts
+++ b/frontend/src/lib/hooks/useScrollSpy.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, act } from "@testing-library/react-hooks"
+import useScrollSpy, { debounce } from "./useScrollSpy"
+
+describe("debounce function", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  it("should call the function immediately when no delay is provided", () => {
+    const fn = jest.fn()
+    const debouncedFn = debounce(fn, 0)
+
+    debouncedFn("arg1", "arg2")
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith("arg1", "arg2")
+  })
+
+  it("should delay the function call when a delay is provided", () => {
+    const fn = jest.fn()
+    const debouncedFn = debounce(fn, 100)
+    debouncedFn("arg1", "arg2")
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith("arg1", "arg2")
+
+    debouncedFn("arg3", "arg4")
+    expect(fn).not.toHaveBeenCalledWith("arg3", "arg4")
+    jest.advanceTimersByTime(99)
+    expect(fn).not.toHaveBeenCalledWith("arg3", "arg4")
+
+    jest.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenCalledWith("arg3", "arg4")
+  })
+
+  it("should cancel the delay when the function is called again", () => {
+    const fn = jest.fn()
+    const debouncedFn = debounce(fn, 100)
+    debouncedFn("arg1", "arg2")
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith("arg1", "arg2")
+
+    debouncedFn("arg3", "arg4")
+    jest.advanceTimersByTime(99)
+
+    debouncedFn("arg5", "arg6")
+    expect(fn).not.toHaveBeenCalledWith("arg5", "arg6")
+
+    jest.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenCalledWith("arg5", "arg6")
+  })
+})
+
+describe("useScrollSpy hook", () => {
+  let target: HTMLElement
+  let eventHandler: ({ timeStampLow }: any) => void
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    target = document.createElement("div")
+    eventHandler = jest.fn()
+
+    document.body.appendChild(target)
+    jest.spyOn(target, "addEventListener")
+    jest.spyOn(target, "removeEventListener")
+  })
+
+  afterEach(() => {
+    document.body.removeChild(target)
+    jest.clearAllMocks()
+  })
+
+  it("should set up and clean up event listeners", () => {
+    const { unmount } = renderHook(() => useScrollSpy(target, eventHandler))
+
+    expect(target.addEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      { passive: true }
+    )
+    expect(eventHandler).toHaveBeenCalledWith({
+      target,
+      timeStampLow: expect.any(Number),
+    })
+
+    unmount()
+
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function)
+    )
+  })
+
+  it("should not set up event listeners if no target is provided", () => {
+    renderHook(() => useScrollSpy(null, eventHandler))
+
+    expect(target.addEventListener).not.toHaveBeenCalled()
+    expect(eventHandler).not.toHaveBeenCalled()
+  })
+
+  it("should debounce events", () => {
+    renderHook(() => useScrollSpy(target, eventHandler))
+
+    const scrollEvent = new Event("scroll")
+    act(() => {
+      target.dispatchEvent(scrollEvent)
+    })
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      target.dispatchEvent(scrollEvent)
+    })
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(99)
+    expect(eventHandler).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(1)
+    expect(eventHandler).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/lib/hooks/useScrollSpy.ts
+++ b/frontend/src/lib/hooks/useScrollSpy.ts
@@ -38,7 +38,11 @@ import { useLayoutEffect, useMemo, useRef, useCallback } from "react"
  * is invoked again before the scheduled invocation, the scheduled
  * invocation is canceled and a new one is scheduled `ms` milliseconds
  * after the latest invocation.
-
+ *
+ * TODO: This has very similar but different behavior than our debounce function
+ * in utils.ts. This behavior ensures that the debounced function is called on
+ * some interval. Our other debounce function ensures that the function is
+ * delayed until the user stops calling it. We should probably unify these
  *
  * @returns A debounced version of the `fn` function.
  */

--- a/frontend/src/lib/hooks/useScrollSpy.ts
+++ b/frontend/src/lib/hooks/useScrollSpy.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useLayoutEffect, useMemo, useRef, useCallback } from "react"
+
+/**
+ * Creates a debounced function that delays invoking `fn` until after `ms`
+ * milliseconds have passed since the last time the debounced function was
+ * invoked.
+ *
+ * @param fn - A function to debounce. `fn` is called after the debounced
+ * function has not been called for `ms` milliseconds.
+ *
+ * @param ms - The delay in milliseconds before `fn` is executed.
+ *
+ * The debounced function behaves as follows:
+ * - It will be invoked immediately if 0 is passed for `ms`.
+ * - It will be invoked immediately for the first call in any case.
+ * - For subsequent calls, if less than `ms` milliseconds have passed since
+ * the last invocation, a new invocation of `fn` is scheduled for `ms`
+ * milliseconds after the last invocation.
+ * - If it is invoked and `ms` milliseconds have passed since the last
+ * invocation, `fn` is executed immediately and the timestamp is updated.
+ * - If a new invocation of the debounced function is scheduled and it
+ * is invoked again before the scheduled invocation, the scheduled
+ * invocation is canceled and a new one is scheduled `ms` milliseconds
+ * after the latest invocation.
+
+ *
+ * @returns A debounced version of the `fn` function.
+ */
+export function debounce(
+  fn: (...args: any[]) => void,
+  ms: number
+): (...args: any[]) => void {
+  if (!ms) {
+    return fn
+  }
+
+  let last = 0
+  let timeout: ReturnType<typeof setTimeout> | null = null
+
+  return (...args) => {
+    const now = Date.now()
+
+    if (now - last > ms) {
+      fn(...args)
+      last = now
+    } else {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+
+      timeout = setTimeout(() => {
+        fn(...args)
+        last = Date.now()
+      }, Math.max(0, ms - now + last))
+    }
+  }
+}
+const DEFAULT_DEBOUNCE_MS = 100
+
+/**
+ * A hook to add a scroll event listener to a target element with debouncing.
+ *
+ * @param target - The target HTMLElement to attach the scroll listener to.
+ * @param eventHandler - The callback function to execute on scroll.
+ *
+ * The hook behaves as follows:
+ * - The eventHandler callback is wrapped in a debounce function, which
+ * ensures the callback is not executed too frequently.
+ * - A scroll event listener is added to the target element on mount.
+ * - A 'timeStampLow' property is added to the event object before it's
+ * passed to the eventHandler.
+ * - The scroll event listener is removed from the target when the component
+ * unmounts.
+ *
+ * @returns void.
+ */
+export default function useScrollSpy(
+  target: HTMLElement | null,
+  eventHandler: ({ timeStampLow }: any) => void
+): void {
+  const onEventRef = useRef(eventHandler)
+
+  const debouncer = useMemo(
+    () =>
+      debounce(event => {
+        onEventRef.current(event)
+      }, DEFAULT_DEBOUNCE_MS),
+    [onEventRef]
+  )
+
+  const handleEvent = useCallback(
+    event => {
+      event.timeStampLow = Date.now()
+
+      debouncer(event)
+    },
+    [debouncer]
+  )
+
+  useLayoutEffect(() => {
+    if (!target) {
+      return () => {}
+    }
+
+    target.addEventListener("scroll", handleEvent, { passive: true })
+    handleEvent({ target })
+
+    return () => target.removeEventListener("scroll", handleEvent)
+  }, [handleEvent, target])
+}

--- a/frontend/src/lib/hooks/useScrollToBottom.test.ts
+++ b/frontend/src/lib/hooks/useScrollToBottom.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react-hooks"
+import useScrollToBottom from "./useScrollToBottom"
+import useStateRef from "./useStateRef"
+
+jest.mock("./useScrollSpy")
+jest.mock("./useScrollAnimation")
+jest.mock("./useStateRef")
+
+describe("useScrollToBottom", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should initialize with proper values", () => {
+    const mockedUseStateRef = useStateRef as jest.MockedFunction<
+      typeof useStateRef
+    >
+    mockedUseStateRef.mockImplementation(initialValue => [
+      initialValue,
+      jest.fn(),
+      { current: initialValue },
+    ])
+    const { result } = renderHook(() => useScrollToBottom())
+
+    expect(result.current).not.toBeNull()
+    expect(result.current.current).toBeNull()
+  })
+})

--- a/frontend/src/lib/hooks/useScrollToBottom.ts
+++ b/frontend/src/lib/hooks/useScrollToBottom.ts
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useCallback, RefObject } from "react"
+import useScrollSpy from "./useScrollSpy"
+import useScrollAnimation from "./useScrollAnimation"
+import useStateRef from "./useStateRef"
+
+export interface ScrollToBottomOptions {
+  bottomThreshold?: number
+  debounceMs?: number
+}
+
+const DEFAULT_BOTTOM_THRESHOLD = 1
+const SCROLL_DECISION_DURATION = 34 // 2 frames
+const MIN_CHECK_INTERVAL = 17 // 1 frame
+
+function setImmediateInterval(fn: () => void, ms: number): NodeJS.Timeout {
+  fn()
+
+  return setInterval(fn, ms)
+}
+
+function isAtBottom({
+  scrollHeight,
+  offsetHeight,
+  scrollTop,
+}: HTMLElement): boolean {
+  return scrollHeight - scrollTop - offsetHeight < DEFAULT_BOTTOM_THRESHOLD
+}
+
+/**
+ * useScrollToBottom is a custom React hook managing automatic
+ * scrolling behavior for an HTML element. It keeps the scroll view
+ * at the bottom unless a user scrolls up, then stops auto-scroll.
+ *
+ * This hook returns a ref object attached to the HTML element.
+ * It maintains several pieces of state:
+ * - isSticky: a boolean for whether the scroll position should
+ *   "stick" to the bottom.
+ * - isAnimating: a boolean for whether the scroll view is animating.
+ *
+ * It has two major functions:
+ * - handleScrollToBottomFinished: resets stickiness if necessary.
+ * - handleScroll: adjusts isSticky based on user scroll behavior.
+ *
+ * The hook includes side effects with the useEffect hook:
+ * - The first effect sets an interval to check the scroll position
+ *   and adjust stickiness and animating state.
+ * - The second effect attaches a focus event listener to update
+ *   the scrollHeight value.
+ */
+function useScrollToBottom<T extends HTMLElement>(): RefObject<T> {
+  const scrollableRef = useRef<T>(null)
+  const [isSticky, setIsSticky, isStickyRef] = useStateRef(false)
+  const [isAnimating, setIsAnimating, isAnimatingRef] = useStateRef(true)
+
+  // Internal context
+  const ignoreScrollEventBeforeRef = useRef(0)
+  const offsetHeightRef = useRef(0)
+  const scrollHeightRef = useRef(0)
+
+  // Once, we have determined we are at the bottom, we can reset
+  // the ignoring of scroll events.
+  const handleScrollToBottomFinished = useCallback(() => {
+    ignoreScrollEventBeforeRef.current = Date.now()
+
+    // handleScrollToBottomFinished may end at a position which should lose stickiness.
+    // In that case, we will need to set sticky to false to stop the interval check.
+    if (!isAnimatingRef.current) {
+      // Essentially we are not suppose to be animating cause a scroll
+      // occurred before we finished animating.
+      setIsSticky(false)
+    }
+
+    setIsAnimating(false)
+  }, [ignoreScrollEventBeforeRef, isAnimatingRef, setIsAnimating, setIsSticky])
+
+  const handleScroll = useCallback(
+    ({ timeStampLow }) => {
+      const { current: target } = scrollableRef
+      const animating = isAnimatingRef.current
+
+      // Currently, there are no reliable way to check if the "scroll" event is trigger due to
+      // user gesture, programmatic scrolling, or Chrome-synthesized "scroll" event to compensate size change.
+      // Thus, we use our best-effort to guess if it is triggered by user gesture, and disable sticky if it is heading towards the start direction.
+
+      if (timeStampLow <= ignoreScrollEventBeforeRef.current || !target) {
+        // Since we debounce "scroll" event, this handler might be called after spineTo.onEnd (a.k.a. artificial scrolling).
+        // We should ignore debounced event fired after scrollEnd, because without skipping them, the userInitiatedScroll calculated below will not be accurate.
+        // Thus, on a fast machine, adding elements super fast will lose the "stickiness".
+
+        return
+      }
+
+      const atBottom = isAtBottom(target)
+
+      // Chrome will emit "synthetic" scroll event if the container is resized or an element is added
+      // We need to ignore these "synthetic" events
+      const {
+        offsetHeight: nextOffsetHeight,
+        scrollHeight: nextScrollHeight,
+      } = target
+      const { current: offsetHeight } = offsetHeightRef
+      const { current: scrollHeight } = scrollHeightRef
+      const offsetHeightChanged = nextOffsetHeight !== offsetHeight
+      const scrollHeightChanged = nextScrollHeight !== scrollHeight
+
+      if (offsetHeightChanged) {
+        offsetHeightRef.current = nextOffsetHeight
+      }
+
+      if (scrollHeightChanged) {
+        scrollHeightRef.current = nextScrollHeight
+      }
+
+      // Sticky means:
+      // - If it is scrolled programatically, we are still in sticky mode
+      // - If it is scrolled by the user, then sticky means if we are at the end
+
+      // Only update stickiness if the scroll event is not due to synthetic scroll done by Chrome
+      if (!offsetHeightChanged && !scrollHeightChanged) {
+        // We are sticky if we are animating to the end, or we are already at the end.
+        // We can be "animating but not sticky" by calling "scrollTo(100)" where the container scrollHeight is 200px.
+        const nextSticky = animating || atBottom
+
+        if (isStickyRef.current !== nextSticky) {
+          setIsSticky(nextSticky)
+        }
+      } else if (isStickyRef.current) {
+        setIsAnimating(true)
+        setIsSticky(true)
+      }
+    },
+    [
+      ignoreScrollEventBeforeRef,
+      offsetHeightRef,
+      scrollHeightRef,
+      isAnimatingRef,
+      isStickyRef,
+      setIsAnimating,
+      setIsSticky,
+    ]
+  )
+
+  useEffect(() => {
+    if (scrollableRef.current) {
+      let stickyButNotAtEndSince = 0
+
+      const timeout = setImmediateInterval(() => {
+        const { current: target } = scrollableRef
+        const animating = isAnimatingRef.current
+
+        if (isStickyRef.current && target) {
+          if (!isAtBottom(target)) {
+            if (!stickyButNotAtEndSince) {
+              stickyButNotAtEndSince = Date.now()
+            } else if (
+              Date.now() - stickyButNotAtEndSince >
+              SCROLL_DECISION_DURATION
+            ) {
+              // Quirks: In Firefox, after user scroll down, Firefox do two things:
+              //         1. Set to a new "scrollTop"
+              //         2. Fire "scroll" event
+              //         For what we observed, #1 is fired about 20ms before #2. There is a chance that this stickyCheckTimeout is being scheduled between 1 and 2.
+              //         That means, if we just look at #1 to decide if we should scroll, we will always scroll, in oppose to the user's intention.
+              // Repro: Open Firefox, set checkInterval to a lower number, and try to scroll by dragging the scroll handler. It will jump back.
+
+              // The "animating" check will make sure stickiness is not lost when elements are adding at a very fast pace.
+              if (!animating) {
+                setIsAnimating(true)
+                setIsSticky(true)
+              }
+
+              stickyButNotAtEndSince = 0
+            }
+          } else {
+            stickyButNotAtEndSince = 0
+          }
+        } else if (
+          target &&
+          target.scrollHeight <= target.offsetHeight &&
+          !isStickyRef.current
+        ) {
+          // When the container is emptied, we will set sticky back to true.
+          setIsSticky(true)
+        }
+      }, MIN_CHECK_INTERVAL)
+
+      return () => clearInterval(timeout)
+    }
+  }, [
+    scrollableRef,
+    isSticky,
+    isAnimating,
+    isAnimatingRef,
+    isStickyRef,
+    setIsSticky,
+    setIsAnimating,
+  ])
+
+  useEffect(() => {
+    // We need to update the "scrollHeight" value to latest when the user do a focus inside the box.
+    //
+    // This is because:
+    // - In our code that mitigate Chrome synthetic scrolling, that code will look at whether "scrollHeight" value is latest or not.
+    // - That code only run on "scroll" event.
+    // - That means, on every "scroll" event, if the "scrollHeight" value is not latest, we will skip modifying the stickiness.
+    // - That means, if the user "focus" to an element that cause the scroll view to scroll to the bottom, the user agent will fire "scroll" event.
+    //   Since the "scrollHeight" is not latest value, this "scroll" event will be ignored and stickiness will not be modified.
+    // - That means, if the user "focus" to a newly added element that is at the end of the scroll view, the "scroll to bottom" button will continue to show.
+    const target = scrollableRef.current
+    if (target) {
+      const handleFocus = (): void => {
+        scrollHeightRef.current = target.scrollHeight
+      }
+
+      target.addEventListener("focus", handleFocus, {
+        capture: true,
+        passive: true,
+      })
+
+      return () => target.removeEventListener("focus", handleFocus)
+    }
+  }, [scrollableRef])
+
+  useScrollSpy(scrollableRef.current, handleScroll)
+  useScrollAnimation(
+    scrollableRef.current,
+    handleScrollToBottomFinished,
+    isAnimating
+  )
+
+  return scrollableRef
+}
+
+export default useScrollToBottom

--- a/frontend/src/lib/hooks/useStateRef.test.ts
+++ b/frontend/src/lib/hooks/useStateRef.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react-hooks"
+import useStateRef from "./useStateRef" // import the hook
+
+describe("useStateRef hook", () => {
+  it("should initialize correctly with initial state", () => {
+    const { result } = renderHook(() => useStateRef(10))
+
+    const [state, , stateRef] = result.current
+
+    // Initial state is set correctly
+    expect(state).toEqual(10)
+    expect(stateRef.current).toEqual(10)
+  })
+
+  it("should set state correctly", () => {
+    const { result } = renderHook(() => useStateRef(10))
+    const [, setState, stateRef] = result.current
+
+    act(() => {
+      setState(20)
+    })
+
+    // State is updated
+    const state = result.current[0]
+    expect(state).toEqual(20)
+    expect(stateRef.current).toEqual(20)
+  })
+
+  it("should handle function update correctly", () => {
+    const { result } = renderHook(() => useStateRef(10))
+    const [, setState, stateRef] = result.current
+
+    act(() => {
+      setState(prev => prev + 10)
+    })
+
+    // State is updated
+    const state = result.current[0]
+    expect(state).toEqual(20)
+    expect(stateRef.current).toEqual(20)
+  })
+
+  it("should maintain reference correctly when state changes", () => {
+    const { result } = renderHook(() => useStateRef(10))
+    const [, setValue, initialRef] = result.current
+
+    act(() => {
+      setValue(20)
+    })
+
+    // Reference has not changed
+    expect(result.current[2]).toBe(initialRef)
+  })
+
+  it("should allow ref to be set independently from state", () => {
+    const { result } = renderHook(() => useStateRef(10))
+    const [, setState, stateRef] = result.current
+
+    act(() => {
+      stateRef.current = 20
+    })
+
+    let state = result.current[0]
+    expect(state).toEqual(10)
+    expect(stateRef.current).toEqual(20)
+
+    act(() => {
+      setState(20)
+    })
+
+    // State is updated
+    state = result.current[0]
+    expect(state).toEqual(20)
+    expect(stateRef.current).toEqual(20)
+  })
+})

--- a/frontend/src/lib/hooks/useStateRef.ts
+++ b/frontend/src/lib/hooks/useStateRef.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useCallback,
+  useRef,
+  useState,
+  MutableRefObject,
+  Dispatch,
+  SetStateAction,
+} from "react"
+
+/**
+ * A custom React Hook that extends useState by providing a mutable ref object
+ * to track the current state value.
+ *
+ * @template T The type of the state value.
+ * @param {T} initialState The initial state value.
+ * @returns {[T, Dispatch<SetStateAction<T>>, MutableRefObject<T>]} A tuple containing the
+ *   current state value, a function to update the state, and a mutable ref object.
+ *
+ * @example
+ * // Usage inside a component:
+ * const [count, setCount, countRef] = useStateRef(0);
+ *
+ * // Accessing the current state value:
+ * console.log(count); // Output: 0
+ * console.log(countRef.current); // Output: 0
+ *
+ * // Modifying the state value and updating the ref:
+ * setCount(10);
+ * console.log(count); // Output: 10
+ * console.log(countRef.current); // Output: 10
+ *
+ * // Comparing previous and current state values:
+ * const previousCount = useRef(countRef.current);
+ * console.log(previousCount.current); // Output: 10
+ * console.log(previousCount.current === countRef.current); // Output: true
+ *
+ * // Sharing the state value with other components:
+ * <ChildComponent countRef={countRef} />
+ */
+export default function useStateRef<T>(
+  initialState: T
+): [T, Dispatch<SetStateAction<T>>, MutableRefObject<T>] {
+  const [state, setState] = useState<T>(initialState)
+  const ref = useRef<T>(initialState)
+  const setValue = useCallback(
+    nextValue => {
+      if (typeof nextValue === "function") {
+        setValue((state: T): T => {
+          nextValue = nextValue(state)
+          ref.current = nextValue
+
+          return nextValue
+        })
+      } else {
+        ref.current = nextValue
+
+        setValue(nextValue)
+      }
+    },
+    [ref]
+  )
+  ref.current = state
+
+  return [state, setState, ref]
+}

--- a/frontend/src/lib/hooks/useStateRef.ts
+++ b/frontend/src/lib/hooks/useStateRef.ts
@@ -58,23 +58,6 @@ export default function useStateRef<T>(
 ): [T, Dispatch<SetStateAction<T>>, MutableRefObject<T>] {
   const [state, setState] = useState<T>(initialState)
   const ref = useRef<T>(initialState)
-  const setValue = useCallback(
-    nextValue => {
-      if (typeof nextValue === "function") {
-        setValue((state: T): T => {
-          nextValue = nextValue(state)
-          ref.current = nextValue
-
-          return nextValue
-        })
-      } else {
-        ref.current = nextValue
-
-        setValue(nextValue)
-      }
-    },
-    [ref]
-  )
   ref.current = state
 
   return [state, setState, ref]

--- a/frontend/src/lib/hooks/useStateRef.ts
+++ b/frontend/src/lib/hooks/useStateRef.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  useCallback,
   useRef,
   useState,
   MutableRefObject,


### PR DESCRIPTION
## Describe your changes

The following adds logic for scroll to bottom support. This is heavily inspired by [react-scroll-to-bottom](https://github.com/compulim/react-scroll-to-bottom) ([MIT License](https://github.com/compulim/react-scroll-to-bottom/blob/main/LICENSE)) but focuses solely on providing scrolling to bottom functionality.

## Testing Plan

I've added unit tests where necessary, but honestly, it's hard to test for two reasons:
- Scrolling is difficult/near impossible in JSDOM where heights are always 0.
- We will have to reserve for E2E tests and snapshots to ensure we can deliver

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
