### PR TITLE
Chat Input Widget

### DIFF
--- a/frontend/src/app/components/AppView/AppView.test.tsx
+++ b/frontend/src/app/components/AppView/AppView.test.tsx
@@ -15,7 +15,19 @@
  */
 
 import React from "react"
-import { Block as BlockProto, ForwardMsgMetadata } from "src/lib/proto"
+import { screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import {
+  AppContext,
+  Props as AppContextProps,
+} from "src/app/components/AppContext"
+import {
+  Block as BlockProto,
+  ForwardMsgMetadata,
+  PageConfig,
+  Element,
+  ChatInput as ChatInputProto,
+} from "src/lib/proto"
 import { ScriptRunState } from "src/lib/ScriptRunState"
 import { BlockNode, ElementNode, AppRoot } from "src/lib/AppNode"
 import { FileUploadClient } from "src/lib/FileUploadClient"
@@ -26,8 +38,24 @@ import {
 import { makeElementWithInfoText } from "src/lib/util/utils"
 import { ComponentRegistry } from "src/lib/components/widgets/CustomComponent"
 import { mockEndpoints, mockSessionInfo } from "src/lib/mocks/mocks"
-import { render, shallow } from "src/lib/test_util"
+import { render } from "src/lib/test_util"
 import AppView, { AppViewProps } from "./AppView"
+
+function getContextOutput(context: Partial<AppContextProps>): AppContextProps {
+  return {
+    wideMode: false,
+    initialSidebarState: PageConfig.SidebarState.AUTO,
+    embedded: false,
+    showPadding: false,
+    disableScrolling: false,
+    showFooter: false,
+    showToolbar: false,
+    showColoredLine: false,
+    pageLinkBaseUrl: "",
+    sidebarChevronDownshift: 0,
+    ...context,
+  }
+}
 
 function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
   const formsData = createFormsData()
@@ -68,17 +96,15 @@ describe("AppView element", () => {
   })
 
   it("renders without crashing", () => {
-    const props = getProps()
-    const wrapper = shallow(<AppView {...props} />)
-
-    expect(wrapper).toBeDefined()
+    render(<AppView {...getProps()} />)
   })
 
   it("does not render a sidebar when there are no elements and only one page", () => {
     const props = getProps()
-    const wrapper = shallow(<AppView {...props} />)
+    render(<AppView {...props} />)
 
-    expect(wrapper.find("[data-testid='stSidebar']").exists()).toBe(false)
+    const sidebar = screen.queryByTestId("stSidebar")
+    expect(sidebar).not.toBeInTheDocument()
   })
 
   it("renders a sidebar when there are elements and only one page", () => {
@@ -98,14 +124,10 @@ describe("AppView element", () => {
     const props = getProps({
       elements: new AppRoot(new BlockNode([main, sidebar])),
     })
-    const wrapper = shallow(<AppView {...props} />)
+    render(<AppView {...props} />)
 
-    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
-    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
-    expect(wrapper.find("ThemedSidebar").prop("appPages")).toHaveLength(1)
-    expect(wrapper.find("ThemedSidebar").prop("currentPageScriptHash")).toBe(
-      "main_page_script_hash"
-    )
+    const sidebarDOMElement = screen.queryByTestId("stSidebar")
+    expect(sidebarDOMElement).toBeInTheDocument()
   })
 
   it("renders a sidebar when there are no elements but multiple pages", () => {
@@ -113,11 +135,10 @@ describe("AppView element", () => {
       { pageName: "streamlit_app", pageScriptHash: "page_hash" },
       { pageName: "streamlit_app2", pageScriptHash: "page_hash2" },
     ]
-    const wrapper = shallow(<AppView {...getProps({ appPages })} />)
+    render(<AppView {...getProps({ appPages })} />)
 
-    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
-    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(false)
-    expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+    const sidebarDOMElement = screen.queryByTestId("stSidebar")
+    expect(sidebarDOMElement).toBeInTheDocument()
   })
 
   it("renders a sidebar when there are elements and multiple pages", () => {
@@ -142,11 +163,10 @@ describe("AppView element", () => {
       elements: new AppRoot(new BlockNode([main, sidebar])),
       appPages,
     })
-    const wrapper = shallow(<AppView {...props} />)
+    render(<AppView {...props} />)
 
-    expect(wrapper.find("ThemedSidebar").exists()).toBe(true)
-    expect(wrapper.find("ThemedSidebar").prop("hasElements")).toBe(true)
-    expect(wrapper.find("ThemedSidebar").prop("appPages")).toEqual(appPages)
+    const sidebarDOMElement = screen.queryByTestId("stSidebar")
+    expect(sidebarDOMElement).toBeInTheDocument()
   })
 
   it("does not render the sidebar if there are no elements, multiple pages but hideSidebarNav is true", () => {
@@ -158,65 +178,86 @@ describe("AppView element", () => {
       appPages,
       hideSidebarNav: true,
     })
-    const wrapper = shallow(<AppView {...props} />)
+    render(<AppView {...props} />)
 
-    expect(wrapper.find("ThemedSidebar").exists()).toBe(false)
+    const sidebar = screen.queryByTestId("stSidebar")
+    expect(sidebar).not.toBeInTheDocument()
   })
 
   it("does not render the wide class", () => {
-    jest
-      .spyOn(React, "useContext")
-      .mockImplementation(() => ({ wideMode: false, embedded: false }))
-    const wrapper = shallow(<AppView {...getProps()} />)
+    const realUseContext = React.useContext
+    jest.spyOn(React, "useContext").mockImplementation(input => {
+      if (input === AppContext) {
+        return getContextOutput({ wideMode: false, embedded: false })
+      }
 
-    expect(
-      wrapper.find("StyledAppViewBlockContainer").prop("isWideMode")
-    ).toBe(false)
+      return realUseContext(input)
+    })
 
-    expect(wrapper.find("StyledAppViewFooter").prop("isWideMode")).toBe(false)
+    const main = new BlockNode([], new BlockProto({ allowEmpty: true }))
+    const sidebar = new BlockNode([], new BlockProto({ allowEmpty: true }))
+
+    const props = getProps({
+      elements: new AppRoot(new BlockNode([main, sidebar])),
+    })
+    const { getByTestId } = render(<AppView {...props} />)
+
+    const style = window.getComputedStyle(getByTestId("block-container"))
+    expect(style.maxWidth).not.toEqual("initial")
   })
 
   it("does render the wide class when specified", () => {
-    jest
-      .spyOn(React, "useContext")
-      .mockImplementation(() => ({ wideMode: true, embedded: false }))
-    const wrapper = shallow(<AppView {...getProps()} />)
+    const realUseContext = React.useContext
+    jest.spyOn(React, "useContext").mockImplementation(input => {
+      if (input === AppContext) {
+        return getContextOutput({ wideMode: true, embedded: false })
+      }
 
-    expect(
-      wrapper.find("StyledAppViewBlockContainer").prop("isWideMode")
-    ).toBe(true)
+      return realUseContext(input)
+    })
+    const { getByTestId } = render(<AppView {...getProps()} />)
+    const style = window.getComputedStyle(getByTestId("block-container"))
 
-    expect(wrapper.find("StyledAppViewFooter").prop("isWideMode")).toBe(true)
+    expect(style.maxWidth).toEqual("initial")
   })
 
   it("opens link to streamlit.io in new tab", () => {
-    const wrapper = shallow(<AppView {...getProps()} />)
-    expect(wrapper.find("StyledAppViewFooterLink").props()).toEqual(
-      expect.objectContaining({
-        href: "//streamlit.io",
-        target: "_blank",
-      })
-    )
+    render(<AppView {...getProps()} />)
+    const link = screen.getByRole("link", { name: "Streamlit" })
+    expect(link).toHaveAttribute("href", "//streamlit.io")
+    expect(link).toHaveAttribute("target", "_blank")
   })
 
   it("renders the Spacer and Footer when not embedded", () => {
-    jest
-      .spyOn(React, "useContext")
-      .mockImplementation(() => ({ wideMode: false, embedded: false }))
-    const wrapper = shallow(<AppView {...getProps()} />)
+    const realUseContext = React.useContext
+    jest.spyOn(React, "useContext").mockImplementation(input => {
+      if (input === AppContext) {
+        return getContextOutput({ wideMode: false, embedded: false })
+      }
 
-    expect(wrapper.find("StyledAppViewBlockSpacer").exists()).toBe(true)
-    expect(wrapper.find("StyledAppViewFooter").exists()).toBe(true)
+      return realUseContext(input)
+    })
+
+    const { getByRole, getByTestId } = render(<AppView {...getProps()} />)
+
+    expect(getByTestId("AppViewBlockSpacer")).toBeInTheDocument()
+    expect(getByRole("contentinfo")).toBeInTheDocument()
   })
 
   it("does not render the Spacer and Footer when embedded", () => {
-    jest
-      .spyOn(React, "useContext")
-      .mockImplementation(() => ({ wideMode: false, embedded: true }))
-    const wrapper = shallow(<AppView {...getProps()} />)
+    const realUseContext = React.useContext
+    jest.spyOn(React, "useContext").mockImplementation(input => {
+      if (input === AppContext) {
+        return getContextOutput({ wideMode: false, embedded: true })
+      }
 
-    expect(wrapper.find("StyledAppViewBlockSpacer").exists()).toBe(false)
-    expect(wrapper.find("StyledAppViewFooter").exists()).toBe(false)
+      return realUseContext(input)
+    })
+
+    const { queryByRole, queryByTestId } = render(<AppView {...getProps()} />)
+
+    expect(queryByTestId("AppViewBlockSpacer")).not.toBeInTheDocument()
+    expect(queryByRole("contentinfo")).not.toBeInTheDocument()
   })
 
   describe("when window.location.hash changes", () => {
@@ -235,5 +276,44 @@ describe("AppView element", () => {
         type: "UPDATE_HASH",
       })
     })
+  })
+
+  it("does not render a Scroll To Bottom container when no chat input is present", () => {
+    const props = getProps()
+    render(<AppView {...props} />)
+
+    const stbContainer = screen.queryByTestId("ScrollToBottomContainer")
+    expect(stbContainer).not.toBeInTheDocument()
+  })
+
+  it("renders a Scroll To Bottom container when a chat input is present", () => {
+    const chatInputElement = new ElementNode(
+      new Element({
+        chatInput: {
+          id: "123",
+          placeholder: "Enter Text Here",
+          disabled: false,
+          default: "",
+          position: ChatInputProto.Position.BOTTOM,
+        },
+      }),
+      ForwardMsgMetadata.create({}),
+      "no script run id"
+    )
+
+    const sidebar = new BlockNode([], new BlockProto({ allowEmpty: true }))
+
+    const main = new BlockNode(
+      [chatInputElement],
+      new BlockProto({ allowEmpty: true })
+    )
+    const props = getProps({
+      elements: new AppRoot(new BlockNode([main, sidebar])),
+    })
+
+    render(<AppView {...props} />)
+
+    const stbContainer = screen.queryByTestId("ScrollToBottomContainer")
+    expect(stbContainer).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/components/AppView/AppView.tsx
+++ b/frontend/src/app/components/AppView/AppView.tsx
@@ -39,6 +39,7 @@ import {
   StyledIFrameResizerAnchor,
   StyledAppViewBlockSpacer,
 } from "./styled-components"
+import ScrollToBottomContainer from "./ScrollToBottomContainer"
 
 export interface AppViewProps {
   elements: AppRoot
@@ -96,6 +97,16 @@ function AppView(props: AppViewProps): ReactElement {
     endpoints,
   } = props
 
+  // TODO: This works for scroll to bottom, but we will need
+  // to revisit this when we support multiple position options
+  const containsChatInput =
+    Array.from(elements.main.getElements()).find(element => {
+      return element.type === "chatInput"
+    }) !== undefined
+  const Component = containsChatInput
+    ? ScrollToBottomContainer
+    : StyledAppViewMain
+
   React.useEffect(() => {
     const listener = (): void => {
       sendMessageToHost({
@@ -120,6 +131,7 @@ function AppView(props: AppViewProps): ReactElement {
   const renderBlock = (node: BlockNode): ReactElement => (
     <StyledAppViewBlockContainer
       className="block-container"
+      data-testid="block-container"
       isWideMode={wideMode}
       showPadding={showPadding}
       addPaddingForHeader={showToolbar || showColoredLine}
@@ -164,7 +176,7 @@ function AppView(props: AppViewProps): ReactElement {
           {renderBlock(elements.sidebar)}
         </ThemedSidebar>
       )}
-      <StyledAppViewMain
+      <Component
         tabIndex={0}
         isEmbedded={embedded}
         disableScrolling={disableScrolling}
@@ -179,8 +191,10 @@ function AppView(props: AppViewProps): ReactElement {
         />
         {/* Spacer fills up dead space to ensure the footer remains at the
         bottom of the page in larger views */}
-        {(!embedded || showFooter) && <StyledAppViewBlockSpacer />}
         {(!embedded || showFooter) && (
+          <StyledAppViewBlockSpacer data-testid="AppViewBlockSpacer" />
+        )}
+        {(!embedded || showFooter) && !containsChatInput && (
           <StyledAppViewFooter isWideMode={wideMode}>
             Made with{" "}
             <StyledAppViewFooterLink href="//streamlit.io" target="_blank">
@@ -188,7 +202,7 @@ function AppView(props: AppViewProps): ReactElement {
             </StyledAppViewFooterLink>
           </StyledAppViewFooter>
         )}
-      </StyledAppViewMain>
+      </Component>
     </StyledAppViewContainer>
   )
 }

--- a/frontend/src/app/components/AppView/ScrollToBottomContainer.tsx
+++ b/frontend/src/app/components/AppView/ScrollToBottomContainer.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, ReactNode } from "react"
+import { StyledAppViewMain } from "./styled-components"
+import useScrollToBottom from "src/lib/hooks/useScrollToBottom"
+
+export interface Props {
+  className: string
+  tabIndex: number
+  isEmbedded: boolean
+  disableScrolling: boolean
+  children: ReactNode
+}
+
+export default function ScrollToBottomContainer(props: Props): ReactElement {
+  const { className, tabIndex, children, isEmbedded, disableScrolling } = props
+  const scrollContainerRef = useScrollToBottom()
+
+  return (
+    <StyledAppViewMain
+      tabIndex={tabIndex}
+      className={className}
+      isEmbedded={isEmbedded}
+      disableScrolling={disableScrolling}
+      ref={scrollContainerRef}
+      data-testid="ScrollToBottomContainer"
+    >
+      {children}
+    </StyledAppViewMain>
+  )
+}

--- a/frontend/src/lib/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/src/lib/components/core/Block/ElementNodeRenderer.tsx
@@ -22,6 +22,7 @@ import {
   Button as ButtonProto,
   DownloadButton as DownloadButtonProto,
   CameraInput as CameraInputProto,
+  ChatInput as ChatInputProto,
   Checkbox as CheckboxProto,
   Code as CodeProto,
   ColorPicker as ColorPickerProto,
@@ -106,6 +107,7 @@ const ArrowVegaLiteChart = React.lazy(
 const BokehChart = React.lazy(
   () => import("src/lib/components/elements/BokehChart")
 )
+
 const DebouncedBokehChart = debounceRender(BokehChart, 100)
 
 const DataFrame = React.lazy(
@@ -136,6 +138,9 @@ const DownloadButton = React.lazy(
 )
 const CameraInput = React.lazy(
   () => import("src/lib/components/widgets/CameraInput")
+)
+const ChatInput = React.lazy(
+  () => import("src/lib/components/widgets/ChatInput")
 )
 const Checkbox = React.lazy(
   () => import("src/lib/components/widgets/Checkbox")
@@ -475,6 +480,19 @@ const RawElementNodeRenderer = (
           key={cameraInputProto.id}
           element={cameraInputProto}
           uploadClient={props.uploadClient}
+          width={width}
+          {...widgetProps}
+        />
+      )
+    }
+
+    case "chatInput": {
+      const chatInputProto = node.element.chatInput as ChatInputProto
+      widgetProps.disabled = widgetProps.disabled || chatInputProto.disabled
+      return (
+        <ChatInput
+          key={chatInputProto.id}
+          element={chatInputProto}
           width={width}
           {...widgetProps}
         />

--- a/frontend/src/lib/components/core/Block/styled-components.ts
+++ b/frontend/src/lib/components/core/Block/styled-components.ts
@@ -54,6 +54,7 @@ export interface StyledElementContainerProps {
   elementType: string
 }
 
+const GLOBAL_ELEMENTS = ["balloons", "snow", "chatInput"]
 export const StyledElementContainer = styled.div<StyledElementContainerProps>(
   ({ theme, isStale, width, elementType }) => ({
     width,
@@ -80,10 +81,12 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
           display: "none",
         }
       : {}),
-    ...(elementType === "balloons"
+    ...(GLOBAL_ELEMENTS.includes(elementType)
       ? {
-          // Apply negative bottom margin to remove the flexbox gap.
-          // display: none does not work for balloons, since it needs to be visible.
+          // Global elements are rendered in their delta position, but they
+          // are not part of the flexbox layout. We apply a negative margin
+          // to remove the flexbox gap. display: none does not work for these,
+          // since they needs to be visible.
           marginBottom: `-${theme.spacing.lg}`,
         }
       : {}),

--- a/frontend/src/lib/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/src/lib/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from "react"
-import { shallow } from "src/lib/test_util"
+import { render } from "src/lib/test_util"
 
 import InputInstructions, { Props } from "./InputInstructions"
 
@@ -27,24 +27,31 @@ const getProps = (props: Partial<Props> = {}): Props => ({
 
 describe("InputInstructions", () => {
   const props = getProps()
-  const wrapper = shallow(<InputInstructions {...props} />)
 
   it("renders without crashing", () => {
-    expect(wrapper.text()).toBeDefined()
+    const { getByTestId } = render(<InputInstructions {...props} />)
+
+    expect(getByTestId("InputInstructions").textContent).toBeDefined()
   })
 
   it("should show Enter instructions", () => {
-    expect(wrapper.text()).toBe("Press Enter to apply")
+    const { getByTestId } = render(<InputInstructions {...props} />)
+
+    expect(getByTestId("InputInstructions").textContent).toBe(
+      "Press Enter to apply"
+    )
   })
 
   describe("Multiline type", () => {
     const props = getProps({
       type: "multiline",
     })
-    const wrapper = shallow(<InputInstructions {...props} />)
 
     it("should show Ctrl+Enter instructions", () => {
-      expect(wrapper.text()).toBe("Press Ctrl+Enter to apply")
+      const { getByTestId } = render(<InputInstructions {...props} />)
+      expect(getByTestId("InputInstructions").textContent).toBe(
+        "Press Ctrl+Enter to apply"
+      )
     })
 
     it("show ⌘+Enter instructions", () => {
@@ -56,9 +63,11 @@ describe("InputInstructions", () => {
       const props = getProps({
         type: "multiline",
       })
-      const wrapper = shallow(<InputInstructions {...props} />)
+      const { getByTestId } = render(<InputInstructions {...props} />)
 
-      expect(wrapper.text()).toBe("Press ⌘+Enter to apply")
+      expect(getByTestId("InputInstructions").textContent).toBe(
+        "Press ⌘+Enter to apply"
+      )
     })
 
     it("should show instructions for max length", () => {
@@ -66,9 +75,11 @@ describe("InputInstructions", () => {
         type: "multiline",
         maxLength: 3,
       })
-      const wrapper = shallow(<InputInstructions {...props} />)
+      const { getByTestId } = render(<InputInstructions {...props} />)
 
-      expect(wrapper.text()).toBe("Press ⌘+Enter to apply3/3")
+      expect(getByTestId("InputInstructions").textContent).toBe(
+        "Press ⌘+Enter to apply3/3"
+      )
     })
   })
 
@@ -76,8 +87,31 @@ describe("InputInstructions", () => {
     const props = getProps({
       maxLength: 3,
     })
-    const wrapper = shallow(<InputInstructions {...props} />)
+    const { getByTestId } = render(<InputInstructions {...props} />)
 
-    expect(wrapper.text()).toBe("Press Enter to apply3/3")
+    expect(getByTestId("InputInstructions").textContent).toBe(
+      "Press Enter to apply3/3"
+    )
+  })
+
+  describe("Chat type", () => {
+    const props = getProps({
+      type: "chat",
+    })
+
+    it("should not show instructions", () => {
+      const { getByTestId } = render(<InputInstructions {...props} />)
+      expect(getByTestId("InputInstructions").textContent).toBe("")
+    })
+
+    it("should show instructions for max length", () => {
+      const props = getProps({
+        type: "chat",
+        maxLength: 3,
+      })
+      const { getByTestId } = render(<InputInstructions {...props} />)
+
+      expect(getByTestId("InputInstructions").textContent).toBe("3/3")
+    })
   })
 })

--- a/frontend/src/lib/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/src/lib/components/shared/InputInstructions/InputInstructions.tsx
@@ -24,7 +24,7 @@ export interface Props {
   value: string
   maxLength?: number
   className?: string
-  type?: "multiline" | "single"
+  type?: "multiline" | "single" | "chat"
 }
 
 const InputInstructions = ({
@@ -54,12 +54,12 @@ const InputInstructions = ({
       } else {
         addMessage("Press Ctrl+Enter to apply")
       }
-    } else {
+    } else if (type === "single") {
       addMessage("Press Enter to apply")
     }
   }
 
-  if (maxLength) {
+  if (maxLength && (type !== "chat" || dirty)) {
     addMessage(
       `${value.length}/${maxLength}`,
       dirty && value.length >= maxLength
@@ -67,7 +67,10 @@ const InputInstructions = ({
   }
 
   return (
-    <StyledWidgetInstructions className={className}>
+    <StyledWidgetInstructions
+      data-testid="InputInstructions"
+      className={className}
+    >
       {messages}
     </StyledWidgetInstructions>
   )

--- a/frontend/src/lib/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/src/lib/components/widgets/ChatInput/ChatInput.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import "@testing-library/jest-dom"
+import { fireEvent } from "@testing-library/react"
+import { render } from "src/lib/test_util"
+import { ChatInput as ChatInputProto } from "src/lib/proto"
+import { WidgetStateManager } from "src/lib/WidgetStateManager"
+
+import ChatInput, { Props } from "./ChatInput"
+
+const getProps = (elementProps: Partial<ChatInputProto> = {}): Props => ({
+  element: ChatInputProto.create({
+    id: "123",
+    placeholder: "Enter Text Here",
+    disabled: false,
+    default: "",
+    position: ChatInputProto.Position.BOTTOM,
+    ...elementProps,
+  }),
+  width: 0,
+  disabled: false,
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: jest.fn(),
+    formsDataChanged: jest.fn(),
+  }),
+})
+
+describe("ChatInput widget", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("renders without crashing", () => {
+    const props = getProps()
+    const rtlResults = render(<ChatInput {...props} />)
+    expect(rtlResults).toBeDefined()
+  })
+
+  it("shows a placeholder", () => {
+    const props = getProps()
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    expect(textareas[0].placeholder).toEqual(props.element.placeholder)
+  })
+
+  it("sets the aria label to the placeholder", () => {
+    const props = getProps()
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    expect(textareas[0].getAttribute("aria-label")).toEqual(
+      props.element.placeholder
+    )
+  })
+
+  it("sets the value intially to the element default", () => {
+    const props = getProps()
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    expect(textareas[0].value).toEqual(props.element.default)
+  })
+
+  it("sets the value when values are typed in", () => {
+    const props = getProps()
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.change(textareas[0], { target: { value: "Sample text" } })
+    expect(textareas[0].value).toEqual("Sample text")
+  })
+
+  it("does not increase text value when maxChars is set", () => {
+    const props = getProps({ maxChars: 10 })
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.change(textareas[0], { target: { value: "1234567890" } })
+    expect(textareas[0].value).toEqual("1234567890")
+    fireEvent.change(textareas[0], { target: { value: "12345678901" } })
+    expect(textareas[0].value).toEqual("1234567890")
+  })
+
+  it("sends and resets the value on enter", () => {
+    const props = getProps()
+    const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.change(textareas[0], { target: { value: "1234567890" } })
+    expect(textareas[0].value).toEqual("1234567890")
+    fireEvent.keyDown(textareas[0], { key: "Enter" })
+    expect(spy).toHaveBeenCalledWith(props.element, "1234567890", {
+      fromUi: true,
+    })
+    expect(textareas[0].value).toEqual("")
+  })
+
+  it("will not send an empty value on enter if empty", () => {
+    const props = getProps()
+    const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.keyDown(textareas[0], { key: "Enter" })
+    expect(spy).not.toHaveBeenCalledWith(props.element, "", {
+      fromUi: true,
+    })
+    expect(textareas[0].value).toEqual("")
+  })
+
+  it("will not show instructions when the text has changed", () => {
+    const props = getProps()
+    const { container, getAllByTestId } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    const instructions = getAllByTestId("InputInstructions")
+    expect(instructions.length).toEqual(1)
+    expect(instructions[0].textContent).toEqual("")
+    fireEvent.change(textareas[0], { target: { value: "1234567890" } })
+    expect(instructions[0].textContent).toEqual("")
+  })
+
+  it("does not send/clear on shift + enter", () => {
+    const props = getProps()
+    const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.change(textareas[0], { target: { value: "1234567890" } })
+    expect(textareas[0].value).toEqual("1234567890")
+    fireEvent.keyDown(textareas[0], { key: "Enter", shiftKey: true })
+    // We cannot test the value to be changed cause that is essentially a
+    // change event.
+    expect(textareas[0].value).not.toEqual("")
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("does not send/clear on ctrl + enter", () => {
+    const props = getProps()
+    const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.change(textareas[0], { target: { value: "1234567890" } })
+    expect(textareas[0].value).toEqual("1234567890")
+    fireEvent.keyDown(textareas[0], { key: "Enter", ctrlKey: true })
+    // We cannot test the value to be changed cause that is essentially a
+    // change event.
+    expect(textareas[0].value).not.toEqual("")
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("does not send/clear on meta + enter", () => {
+    const props = getProps()
+    const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    fireEvent.change(textareas[0], { target: { value: "1234567890" } })
+    expect(textareas[0].value).toEqual("1234567890")
+    fireEvent.keyDown(textareas[0], { key: "Enter", metaKey: true })
+    // We cannot test the value to be changed cause that is essentially a
+    // change event.
+    expect(textareas[0].value).not.toEqual("")
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("does sets the value if specified from protobuf to set it", () => {
+    const props = getProps({ value: "12345", setValue: true })
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    expect(textareas[0].value).toEqual("12345")
+  })
+
+  it("does not set the value if protobuf does not specify to set it", () => {
+    const props = getProps({ value: "12345", setValue: false })
+    const { container } = render(<ChatInput {...props} />)
+    const textareas = container.getElementsByTagName("textarea")
+    expect(textareas.length).toEqual(1)
+    expect(textareas[0].value).toEqual("")
+  })
+})

--- a/frontend/src/lib/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/src/lib/components/widgets/ChatInput/ChatInput.tsx
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  ChangeEvent,
+  KeyboardEvent,
+} from "react"
+import { useTheme } from "@emotion/react"
+import { Send } from "@emotion-icons/material-rounded"
+import { Textarea as UITextArea } from "baseui/textarea"
+
+import { ChatInput as ChatInputProto } from "src/lib/proto"
+import { WidgetStateManager } from "src/lib/WidgetStateManager"
+import Icon from "src/lib/components/shared/Icon"
+import InputInstructions from "src/lib/components/shared/InputInstructions/InputInstructions"
+import { hasLightBackgroundColor } from "src/lib/theme"
+
+import {
+  StyledChatInputContainer,
+  StyledChatInput,
+  StyledFloatingChatInputContainer,
+  StyledInputInstructionsContainer,
+  StyledSendIconButton,
+  StyledSendIconButtonContainer,
+} from "./styled-components"
+
+export interface Props {
+  disabled: boolean
+  element: ChatInputProto
+  widgetMgr: WidgetStateManager
+  width: number
+}
+
+// We want to show easily that there's scrolling so we deliberately choose
+// a half size.
+const MAX_VISIBLE_NUM_LINES = 6.5
+// Rounding errors can arbitrarily create scrollbars. We add a rounding offset
+// to manage it better.
+const ROUNDING_OFFSET = 1
+
+const isEnterKeyPressed = (
+  event: KeyboardEvent<HTMLTextAreaElement>
+): boolean => {
+  // Using keyCode as well due to some different behaviors on Windows
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
+
+  const { keyCode, key } = event
+  return key === "Enter" || keyCode === 13 || keyCode === 10
+}
+
+function ChatInput({ width, element, widgetMgr }: Props): React.ReactElement {
+  const theme = useTheme()
+  // True if the user-specified state.value has not yet been synced to the WidgetStateManager.
+  const [dirty, setDirty] = useState(false)
+  // The value specified by the user via the UI. If the user didn't touch this widget's UI, the default value is used.
+  const [value, setValue] = useState(element.default)
+  // The value of the height of the textarea. It depends on a variety of factors including the default height, and autogrowing
+  const [scrollHeight, setScrollHeight] = useState(0)
+  const chatInputRef = useRef<HTMLTextAreaElement>(null)
+  const heightGuidance = useRef({ minHeight: 0, maxHeight: 0 })
+
+  const getScrollHeight = (): number => {
+    let scrollHeight = 0
+    const { current: textarea } = chatInputRef
+    if (textarea) {
+      textarea.style.height = "auto"
+      scrollHeight = textarea.scrollHeight
+      textarea.style.height = ""
+    }
+
+    return scrollHeight
+  }
+
+  const handleSubmit = (): void => {
+    if (!value) {
+      return
+    }
+
+    widgetMgr.setStringTriggerValue(element, value, { fromUi: true })
+    setDirty(false)
+    setValue("")
+    setScrollHeight(0)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    const { metaKey, ctrlKey, shiftKey } = e
+    const shouldSubmit =
+      isEnterKeyPressed(e) && !shiftKey && !ctrlKey && !metaKey
+
+    if (shouldSubmit) {
+      e.preventDefault()
+
+      handleSubmit()
+    }
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>): void => {
+    const { value } = e.target
+    const { maxChars } = element
+
+    if (maxChars !== 0 && value.length > maxChars) {
+      return
+    }
+
+    setDirty(value !== "")
+    setValue(value)
+    setScrollHeight(getScrollHeight())
+  }
+
+  useEffect(() => {
+    if (element.setValue) {
+      // We are intentionally setting this to avoid regularly calling this effect.
+      element.setValue = false
+      const val = element.value || ""
+      setValue(val)
+      setDirty(val !== "")
+    }
+  }, [element])
+
+  useEffect(() => {
+    const scrollHeight = getScrollHeight()
+    setScrollHeight(scrollHeight)
+  }, [value])
+
+  useEffect(() => {
+    if (chatInputRef.current) {
+      const { offsetHeight } = chatInputRef.current
+      heightGuidance.current.minHeight = offsetHeight
+      heightGuidance.current.maxHeight = offsetHeight * MAX_VISIBLE_NUM_LINES
+    }
+  }, [chatInputRef])
+
+  const lightTheme = hasLightBackgroundColor(theme)
+  const { minHeight, maxHeight } = heightGuidance.current
+  const placeholderColor = lightTheme
+    ? theme.colors.gray70
+    : theme.colors.gray80
+
+  const isInputExtended =
+    scrollHeight > 0 && chatInputRef.current
+      ? Math.abs(scrollHeight - minHeight) > ROUNDING_OFFSET
+      : false
+
+  return (
+    <StyledFloatingChatInputContainer className="stChatFloatingInputContainer">
+      <StyledChatInputContainer
+        className="stChatInputContainer"
+        width={width}
+        position={element.position}
+      >
+        <StyledChatInput>
+          <UITextArea
+            data-testid="stChatInput"
+            inputRef={chatInputRef}
+            value={value}
+            placeholder={element.placeholder}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            aria-label={element.placeholder}
+            disabled={element.disabled}
+            rows={1}
+            overrides={{
+              Root: {
+                style: {
+                  outline: "none",
+                  backgroundColor: theme.colors.transparent,
+                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                  borderLeftWidth: "1px",
+                  borderRightWidth: "1px",
+                  borderTopWidth: "1px",
+                  borderBottomWidth: "1px",
+                  width: `${width}px`,
+                },
+              },
+              InputContainer: {
+                style: {
+                  backgroundColor: theme.colors.transparent,
+                },
+              },
+              Input: {
+                style: {
+                  lineHeight: "1.4",
+                  backgroundColor: theme.colors.transparent,
+                  "::placeholder": {
+                    color: placeholderColor,
+                  },
+                  height: isInputExtended
+                    ? `${scrollHeight + ROUNDING_OFFSET}px`
+                    : "auto",
+                  maxHeight: maxHeight ? `${maxHeight}px` : "none",
+                  // Baseweb requires long-hand props, short-hand leads to weird bugs & warnings.
+                  paddingRight: "3rem",
+                  paddingLeft: theme.spacing.sm,
+                  paddingBottom: theme.spacing.sm,
+                  paddingTop: theme.spacing.sm,
+                },
+              },
+            }}
+          />
+          <StyledInputInstructionsContainer>
+            <InputInstructions
+              dirty={dirty}
+              value={value}
+              maxLength={element.maxChars}
+              type="chat"
+            />
+          </StyledInputInstructionsContainer>
+          <StyledSendIconButtonContainer>
+            <StyledSendIconButton
+              onClick={handleSubmit}
+              disabled={!dirty}
+              extended={isInputExtended}
+            >
+              <Icon content={Send} size="xl" color="inherit" />
+            </StyledSendIconButton>
+          </StyledSendIconButtonContainer>
+        </StyledChatInput>
+      </StyledChatInputContainer>
+    </StyledFloatingChatInputContainer>
+  )
+}
+
+export default ChatInput

--- a/frontend/src/lib/components/widgets/ChatInput/index.tsx
+++ b/frontend/src/lib/components/widgets/ChatInput/index.tsx
@@ -13,28 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-const sidebar = 100
-const menuButton = sidebar + 10
-const balloons = 1000000
-const header = balloons - 10
-const chatInput = sidebar - 1
-const sidebarMobile = balloons - 5
-const popupMenu = balloons + 40
-const fullscreenWrapper = balloons + 50
-const tablePortal = fullscreenWrapper + 60
-
-export const zIndices = {
-  hide: -1,
-  auto: "auto",
-  base: 0,
-  sidebar,
-  menuButton,
-  balloons,
-  header,
-  sidebarMobile,
-  popupMenu,
-  fullscreenWrapper,
-  tablePortal,
-  chatInput,
-}
+export { default } from "./ChatInput"

--- a/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
@@ -105,6 +105,12 @@ export const StyledFloatingChatInputContainer = styled.div(({ theme }) => ({
   width: "100%",
   backgroundColor: theme.colors.bgColor,
   zIndex: theme.zIndices.chatInput,
+  [`@media (max-width: ${theme.breakpoints.md})`]: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    left: 0,
+  },
 }))
 
 export const StyledSendIconButtonContainer = styled.div(() => ({

--- a/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import styled from "@emotion/styled"
+import { ChatInput as ChatInputProto } from "src/lib/proto"
+import { hasLightBackgroundColor } from "src/lib/theme"
+
+export interface StyledChatInputContainerProps {
+  width: number
+  position: ChatInputProto.Position
+}
+
+export const StyledChatInputContainer =
+  styled.div<StyledChatInputContainerProps>(({ theme, width, position }) => {
+    const lightTheme = hasLightBackgroundColor(theme)
+    return {
+      borderRadius: theme.radii.lg,
+      display: "flex",
+      ...(position === ChatInputProto.Position.BOTTOM && {
+        backgroundColor: lightTheme
+          ? theme.colors.gray20
+          : theme.colors.gray90,
+      }),
+      width: `${width}px`,
+    }
+  })
+
+export const StyledChatInput = styled.div(({ theme }) => {
+  return {
+    backgroundColor: theme.colors.transparent,
+    position: "relative",
+    flexGrow: 1,
+    borderRadius: theme.radii.lg,
+    display: "flex",
+    alignItems: "center",
+  }
+})
+
+interface StyledSendIconButtonProps {
+  disabled: boolean
+  extended: boolean
+}
+
+export const StyledSendIconButton = styled.button<StyledSendIconButtonProps>(
+  ({ theme, disabled, extended }) => {
+    const lightTheme = hasLightBackgroundColor(theme)
+    const [cleanIconColor, dirtyIconColor] = lightTheme
+      ? [theme.colors.gray60, theme.colors.gray80]
+      : [theme.colors.gray80, theme.colors.gray40]
+    return {
+      border: "none",
+      backgroundColor: theme.colors.transparent,
+      borderTopRightRadius: extended ? theme.radii.none : theme.radii.lg,
+      borderTopLeftRadius: extended ? theme.radii.lg : theme.radii.none,
+      borderBottomRightRadius: theme.radii.lg,
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      lineHeight: 1,
+      margin: 0,
+      padding: theme.spacing.sm,
+      color: disabled ? cleanIconColor : dirtyIconColor,
+      pointerEvents: "auto",
+      "&:focus": {
+        outline: "none",
+      },
+      ":focus": {
+        outline: "none",
+      },
+      "&:focus-visible": {
+        backgroundColor: lightTheme
+          ? theme.colors.gray10
+          : theme.colors.gray90,
+      },
+      "&:hover": {
+        backgroundColor: theme.colors.primary,
+        color: theme.colors.white,
+      },
+      "&:disabled, &:disabled:hover, &:disabled:active": {
+        backgroundColor: theme.colors.transparent,
+        borderColor: theme.colors.transparent,
+        color: theme.colors.gray,
+      },
+    }
+  }
+)
+
+export const StyledFloatingChatInputContainer = styled.div(({ theme }) => ({
+  position: "fixed",
+  bottom: "0px",
+  left: "0px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  paddingBottom: "70px",
+  paddingTop: theme.spacing.lg,
+  width: "100vw",
+  backgroundColor: theme.colors.bgColor,
+  zIndex: theme.zIndices.chatInput,
+}))
+
+export const StyledSendIconButtonContainer = styled.div(() => ({
+  display: "flex",
+  alignItems: "flex-end",
+  height: "100%",
+  position: "absolute",
+  right: "0px",
+  pointerEvents: "none",
+}))
+
+export const StyledInputInstructionsContainer = styled.div({
+  position: "absolute",
+  bottom: "0px",
+  right: "3rem",
+})

--- a/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
@@ -106,7 +106,7 @@ export const StyledFloatingChatInputContainer = styled.div(({ theme }) => ({
   alignItems: "center",
   paddingBottom: "70px",
   paddingTop: theme.spacing.lg,
-  width: "100vw",
+  width: "100%",
   backgroundColor: theme.colors.bgColor,
   zIndex: theme.zIndices.chatInput,
 }))

--- a/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
@@ -100,10 +100,6 @@ export const StyledSendIconButton = styled.button<StyledSendIconButtonProps>(
 export const StyledFloatingChatInputContainer = styled.div(({ theme }) => ({
   position: "fixed",
   bottom: "0px",
-  left: "0px",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
   paddingBottom: "70px",
   paddingTop: theme.spacing.lg,
   width: "100%",

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -119,6 +119,7 @@ button = _main.button
 caption = _main.caption
 camera_input = _main.camera_input
 chat_message = _main.chat_message
+chat_input = _main.chat_input
 checkbox = _main.checkbox
 code = _main.code
 columns = _main.columns

--- a/lib/streamlit/elements/__init__.py
+++ b/lib/streamlit/elements/__init__.py
@@ -15,6 +15,7 @@
 WIDGETS = [
     "button",
     "camera_input",
+    "chat_input",
     "checkbox",
     "color_picker",
     "component_instance",

--- a/lib/streamlit/elements/chat.py
+++ b/lib/streamlit/elements/chat.py
@@ -13,22 +13,17 @@
 # limitations under the License.
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Tuple, cast
+from typing import TYPE_CHECKING, Optional, Tuple, cast
 
 from typing_extensions import Literal
 
-from streamlit.elements.image import AtomicImage, WidthBehaviour, image_to_url
-from streamlit.errors import StreamlitAPIException
-from streamlit.proto.Block_pb2 import Block as BlockProto
-from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import is_emoji
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, cast
-
 from streamlit import runtime
+from streamlit.elements.image import AtomicImage, WidthBehaviour, image_to_url
 from streamlit.elements.utils import check_callback_rules, check_session_state_rules
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ChatInput_pb2 import ChatInput as ChatInputProto
 from streamlit.proto.Common_pb2 import StringTriggerValue as StringTriggerValueProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
@@ -40,6 +35,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
+from streamlit.string_util import is_emoji
 from streamlit.type_util import Key, to_key
 
 if TYPE_CHECKING:
@@ -217,10 +213,9 @@ class ChatMixin:
             empty string.
         max_chars : int or None
             The maximum number of characters that can be entered. If None
-            (default), there will be no maximum. Can be supplied by keyword only.
+            (default), there will be no maximum.
         disabled : bool
-            Whether the chat input should be disabled. Defaults to False. Can
-            be supplied by keyword only.
+            Whether the chat input should be disabled. Defaults to False.
         key : str or int
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget based on

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -50,6 +50,11 @@ def check_callback_rules(
 
 _shown_default_value_warning: bool = False
 
+SESSION_STATE_WRITES_NOT_ALLOWED_ERROR_TEXT = """
+Values for st.button, st.download_button, st.file_uploader, st.data_editor,
+st.chat_input, and st.form cannot be set using st.session_state.
+"""
+
 
 def check_session_state_rules(
     default_value: Any, key: Optional[str], writes_allowed: bool = True
@@ -64,10 +69,7 @@ def check_session_state_rules(
         return
 
     if not writes_allowed:
-        raise StreamlitAPIException(
-            "Values for st.button, st.download_button, st.file_uploader, st.data_editor"
-            " and st.form cannot be set using st.session_state."
-        )
+        raise StreamlitAPIException(SESSION_STATE_WRITES_NOT_ALLOWED_ERROR_TEXT)
 
     if (
         default_value is not None

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -26,6 +26,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow
 from streamlit.proto.Button_pb2 import Button
 from streamlit.proto.CameraInput_pb2 import CameraInput
+from streamlit.proto.ChatInput_pb2 import ChatInput
 from streamlit.proto.Checkbox_pb2 import Checkbox
 from streamlit.proto.ColorPicker_pb2 import ColorPicker
 from streamlit.proto.Components_pb2 import ComponentInstance
@@ -47,6 +48,7 @@ WidgetProto: TypeAlias = Union[
     Arrow,
     Button,
     CameraInput,
+    ChatInput,
     Checkbox,
     ColorPicker,
     ComponentInstance,

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -53,6 +53,7 @@ ELEMENT_TYPE_TO_VALUE_TYPE: Final[
         "button": "trigger_value",
         "download_button": "trigger_value",
         "checkbox": "bool_value",
+        "chat_input": "string_trigger_value",
         "camera_input": "file_uploader_state_value",
         "color_picker": "string_value",
         "date_input": "string_array_value",

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -96,6 +96,7 @@ class RunWarningTest(unittest.TestCase):
                 "button",
                 "camera_input",
                 "caption",
+                "chat_input",
                 "chat_message",
                 "checkbox",
                 "code",

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""checkbox unit tests."""
+"""chat input and message unit tests."""
 
 from parameterized import parameterized
 
@@ -20,9 +20,20 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+import pytest
+from parameterized import parameterized
+
+import streamlit as st
+from streamlit.elements.chat import DISALLOWED_CONTAINERS_ERROR_TEXT
+from streamlit.elements.utils import SESSION_STATE_WRITES_NOT_ALLOWED_ERROR_TEXT
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto.ChatInput_pb2 import ChatInput as ChatInputProto
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
-class ChatMessageTest(DeltaGeneratorTestCase):
+class ChatTest(DeltaGeneratorTestCase):
+    """Test ability to marshall ChatInput and ChatMessage protos."""
+
     def test_label_required(self):
         """Test that label is required"""
         with self.assertRaises(TypeError):
@@ -104,4 +115,93 @@ class ChatMessageTest(DeltaGeneratorTestCase):
         self.assertEqual(
             message_block.add_block.chat_message.avatar_type,
             BlockProto.ChatMessage.AvatarType.IMAGE,
+        )
+
+    def test_chat_input(self):
+        """Test that it can be called."""
+        st.chat_input("Placeholder")
+
+        c = self.get_delta_from_queue().new_element.chat_input
+        self.assertEqual(c.placeholder, "Placeholder")
+        self.assertEqual(c.default, "")
+        self.assertEqual(c.value, "")
+        self.assertEqual(c.set_value, False)
+        self.assertEqual(c.max_chars, 0)
+        self.assertEqual(c.disabled, False)
+        self.assertEqual(c.position, ChatInputProto.Position.BOTTOM)
+
+    def test_chat_input_disabled(self):
+        """Test that it sets disabled correctly."""
+        st.chat_input("Placeholder", disabled=True)
+
+        c = self.get_delta_from_queue().new_element.chat_input
+        self.assertEqual(c.placeholder, "Placeholder")
+        self.assertEqual(c.default, "")
+        self.assertEqual(c.value, "")
+        self.assertEqual(c.set_value, False)
+        self.assertEqual(c.max_chars, 0)
+        self.assertEqual(c.disabled, True)
+        self.assertEqual(c.position, ChatInputProto.Position.BOTTOM)
+
+    def test_chat_input_max_chars(self):
+        """Test that it sets max chars correctly."""
+        st.chat_input("Placeholder", max_chars=100)
+
+        c = self.get_delta_from_queue().new_element.chat_input
+        self.assertEqual(c.placeholder, "Placeholder")
+        self.assertEqual(c.default, "")
+        self.assertEqual(c.value, "")
+        self.assertEqual(c.set_value, False)
+        self.assertEqual(c.max_chars, 100)
+        self.assertEqual(c.disabled, False)
+        self.assertEqual(c.position, ChatInputProto.Position.BOTTOM)
+
+    @parameterized.expand(
+        [
+            lambda: st.columns(2)[0],
+            lambda: st.tabs(["Tab1", "Tab2"])[0],
+            lambda: st.expander("Expand Me"),
+            lambda: st.form("Form Key"),
+            lambda: st.sidebar,
+        ]
+    )
+    def test_chat_not_allowed_in_containers(self, container_call):
+        """Test that it disallows being called in containers."""
+        with pytest.raises(StreamlitAPIException) as exception_message:
+            container_call().chat_input("Placeholder")
+
+        self.assertEqual(
+            DISALLOWED_CONTAINERS_ERROR_TEXT,
+            str(exception_message.value),
+        )
+
+    @parameterized.expand(
+        [
+            lambda: st.columns(2)[0],
+            lambda: st.tabs(["Tab1", "Tab2"])[0],
+            lambda: st.expander("Expand Me"),
+            lambda: st.form("Form Key"),
+            lambda: st.sidebar,
+        ]
+    )
+    def test_chat_not_allowed_in_with_containers(self, container_call):
+        """Test that it disallows being called in containers (using with syntax)."""
+        with pytest.raises(StreamlitAPIException) as exception_message:
+            with container_call():
+                st.chat_input("Placeholder")
+
+        self.assertEqual(
+            DISALLOWED_CONTAINERS_ERROR_TEXT,
+            str(exception_message.value),
+        )
+
+    def test_session_state_rules(self):
+        """Test that it disallows being called in containers (using with syntax)."""
+        with pytest.raises(StreamlitAPIException) as exception_message:
+            st.session_state.my_key = "Foo"
+            st.chat_input("Placeholder", key="my_key")
+
+        self.assertEqual(
+            SESSION_STATE_WRITES_NOT_ALLOWED_ERROR_TEXT,
+            str(exception_message.value),
         )

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -14,12 +14,6 @@
 
 """chat input and message unit tests."""
 
-from parameterized import parameterized
-
-import streamlit as st
-from streamlit.errors import StreamlitAPIException
-from streamlit.proto.Block_pb2 import Block as BlockProto
-from tests.delta_generator_test_case import DeltaGeneratorTestCase
 import pytest
 from parameterized import parameterized
 
@@ -27,6 +21,7 @@ import streamlit as st
 from streamlit.elements.chat import DISALLOWED_CONTAINERS_ERROR_TEXT
 from streamlit.elements.utils import SESSION_STATE_WRITES_NOT_ALLOWED_ERROR_TEXT
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ChatInput_pb2 import ChatInput as ChatInputProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -70,6 +70,7 @@ class StreamlitTest(unittest.TestCase):
                 "button",
                 "caption",
                 "camera_input",
+                "chat_input",
                 "chat_message",
                 "checkbox",
                 "code",

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -1,4 +1,4 @@
-/**
+/**!
  * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,19 @@
  * limitations under the License.
  */
 
-const sidebar = 100
-const menuButton = sidebar + 10
-const balloons = 1000000
-const header = balloons - 10
-const chatInput = sidebar - 1
-const sidebarMobile = balloons - 5
-const popupMenu = balloons + 40
-const fullscreenWrapper = balloons + 50
-const tablePortal = fullscreenWrapper + 60
+syntax = "proto3";
 
-export const zIndices = {
-  hide: -1,
-  auto: "auto",
-  base: 0,
-  sidebar,
-  menuButton,
-  balloons,
-  header,
-  sidebarMobile,
-  popupMenu,
-  fullscreenWrapper,
-  tablePortal,
-  chatInput,
+message ChatInput {
+  enum Position {
+    BOTTOM = 0;
+  }
+
+  string id = 1;
+  string placeholder = 2;
+  uint32 max_chars = 3;
+  bool disabled = 4;
+  string value = 5;
+  bool set_value = 6;
+  string default = 7;
+  Position position = 8;
 }

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -25,6 +25,7 @@ import "streamlit/proto/BokehChart.proto";
 import "streamlit/proto/Button.proto";
 import "streamlit/proto/DownloadButton.proto";
 import "streamlit/proto/CameraInput.proto";
+import "streamlit/proto/ChatInput.proto";
 import "streamlit/proto/Checkbox.proto";
 import "streamlit/proto/Code.proto";
 import "streamlit/proto/ColorPicker.proto";
@@ -75,6 +76,7 @@ message Element {
     Button button = 19;
     DownloadButton download_button = 43;
     CameraInput camera_input = 45;
+    ChatInput chat_input = 49;
     Checkbox checkbox = 20;
     ColorPicker color_picker = 35;
     ComponentInstance component_instance = 37;
@@ -110,7 +112,7 @@ message Element {
     Video video = 14;
     Heading heading = 47;
     Code code = 48;
-    // Next ID: 49
+    // Next ID: 50
   }
 
   reserved 9;


### PR DESCRIPTION
## Describe your changes

This PR implements the chat input widget to be a floating text box at the bottom of the page. The change includes:

- converts the app to scroll to the bottom if visible
- autogrows/shrinks with input
- floats at the bottom of the page
- is disallowed outside of the main container

## Testing Plan

Python and TypeScript unit tests are provided. We will implement E2E tests in a separate PR.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
