### PR TITLE
Fix stale element issue caused by spinners

### DIFF
--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -82,4 +82,9 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
                 display_message = False
         with legacy_caching.suppress_cached_st_function_warning():
             with caching.suppress_cached_st_function_warning():
-                message.empty()
+                # TODO(lukasmasuch): Set the spinner element to an empty container instead
+                # of an empty placeholder (st.empty) to have it removed from the delta
+                # path. Empty containers are ignored in the frontend since they are configured
+                # with allowEmpty=False. This prevents issues with stale elements caused
+                # by the spinner being rendered only in some situations (e.g. for caching).
+                message.container()

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -85,7 +85,7 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
                 # We are resetting the spinner placeholder to an empty container
                 # instead of an empty placeholder (st.empty) to have it removed from the
                 # delta path. Empty containers are ignored in the frontend since they
-                # are configured with allowEmpty=False. This prevents issues with stale
-                # elements caused by the spinner being rendered only in some
-                # situations (e.g. for caching).
+                # are configured with allow_empty=False. This prevents issues with stale
+                # elements caused by the spinner being rendered only in some situations
+                # (e.g. for caching).
                 message.container()

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -82,9 +82,10 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
                 display_message = False
         with legacy_caching.suppress_cached_st_function_warning():
             with caching.suppress_cached_st_function_warning():
-                # TODO(lukasmasuch): Set the spinner element to an empty container instead
-                # of an empty placeholder (st.empty) to have it removed from the delta
-                # path. Empty containers are ignored in the frontend since they are configured
-                # with allowEmpty=False. This prevents issues with stale elements caused
-                # by the spinner being rendered only in some situations (e.g. for caching).
+                # We are resetting the spinner placeholder to an empty container
+                # instead of an empty placeholder (st.empty) to have it removed from the
+                # delta path. Empty containers are ignored in the frontend since they
+                # are configured with allowEmpty=False. This prevents issues with stale
+                # elements caused by the spinner being rendered only in some
+                # situations (e.g. for caching).
                 message.container()

--- a/lib/tests/streamlit/runtime/caching/test_data/arrow_replay.py
+++ b/lib/tests/streamlit/runtime/caching/test_data/arrow_replay.py
@@ -24,7 +24,7 @@ df = pd.DataFrame(
 st.write(df)
 
 
-@st.cache_resource
+@st.cache_resource(show_spinner=False)
 def stampa_df(df_param: pd.DataFrame) -> None:
     st.write(df_param)
 

--- a/lib/tests/streamlit/runtime/caching/test_data/cached_widget_replay_dynamic.py
+++ b/lib/tests/streamlit/runtime/caching/test_data/cached_widget_replay_dynamic.py
@@ -23,7 +23,7 @@ if st.button("click to rerun"):
     irrelevant_value = 1
 
 
-@st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
+@st.cache_data(experimental_allow_widgets=True, show_spinner=False)
 def cached(irrelevant):
     options = ["foo", "bar", "baz"]
     if st.checkbox("custom filters"):

--- a/lib/tests/streamlit/runtime/caching/test_data/cached_widget_replay_dynamic.py
+++ b/lib/tests/streamlit/runtime/caching/test_data/cached_widget_replay_dynamic.py
@@ -23,7 +23,7 @@ if st.button("click to rerun"):
     irrelevant_value = 1
 
 
-@st.experimental_memo(experimental_allow_widgets=True)
+@st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
 def cached(irrelevant):
     options = ["foo", "bar", "baz"]
     if st.checkbox("custom filters"):

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -64,7 +64,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """
             import streamlit as st
 
-            @st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
+            @st.cache_data(experimental_allow_widgets=True, show_spinner=False)
             def foo(i):
                 options = ["foo", "bar", "baz", "qux"]
                 r = st.radio("radio", options, index=i)
@@ -85,7 +85,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """
             import streamlit as st
 
-            @st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
+            @st.cache_data(experimental_allow_widgets=True, show_spinner=False)
             def foo(i):
                 options = ["foo", "bar", "baz", "qux"]
                 r = st.radio("radio", options, index=i)

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -64,7 +64,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """
             import streamlit as st
 
-            @st.experimental_memo(experimental_allow_widgets=True)
+            @st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
             def foo(i):
                 options = ["foo", "bar", "baz", "qux"]
                 r = st.radio("radio", options, index=i)
@@ -85,7 +85,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """
             import streamlit as st
 
-            @st.experimental_memo(experimental_allow_widgets=True)
+            @st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
             def foo(i):
                 options = ["foo", "bar", "baz", "qux"]
                 r = st.radio("radio", options, index=i)

--- a/lib/tests/streamlit/spinner_test.py
+++ b/lib/tests/streamlit/spinner_test.py
@@ -26,3 +26,7 @@ class SpinnerTest(DeltaGeneratorTestCase):
             time.sleep(0.2)
             el = self.get_delta_from_queue().new_element
             self.assertEqual(el.spinner.text, "some text")
+        # Check that the element gets reset to an empty container block:
+        last_delta = self.get_delta_from_queue()
+        self.assertTrue(last_delta.HasField("add_block"))
+        self.assertFalse(last_delta.add_block.allow_empty)

--- a/lib/tests/streamlit/spinner_test.py
+++ b/lib/tests/streamlit/spinner_test.py
@@ -29,4 +29,8 @@ class SpinnerTest(DeltaGeneratorTestCase):
         # Check that the element gets reset to an empty container block:
         last_delta = self.get_delta_from_queue()
         self.assertTrue(last_delta.HasField("add_block"))
+        # The block should have `allow_empty` set to false,
+        # which means that it will be ignored on the frontend in case
+        # it the container is empty. This is the desired behavior
+        # for spinner
         self.assertFalse(last_delta.add_block.allow_empty)

--- a/lib/tests/streamlit/test_data/cached_widget_replay.py
+++ b/lib/tests/streamlit/test_data/cached_widget_replay.py
@@ -17,7 +17,7 @@ import streamlit as st
 st.button("click to rerun")
 
 
-@st.experimental_memo(experimental_allow_widgets=True)
+@st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
 def foo(i):
     options = ["foo", "bar", "baz", "qux"]
     r = st.radio("radio", options, index=i)

--- a/lib/tests/streamlit/test_data/cached_widget_replay.py
+++ b/lib/tests/streamlit/test_data/cached_widget_replay.py
@@ -17,7 +17,7 @@ import streamlit as st
 st.button("click to rerun")
 
 
-@st.cache_resource(experimental_allow_widgets=True, show_spinner=False)
+@st.cache_data(experimental_allow_widgets=True, show_spinner=False)
 def foo(i):
     options = ["foo", "bar", "baz", "qux"]
     r = st.radio("radio", options, index=i)

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -327,7 +327,7 @@ class StreamlitWriteTest(unittest.TestCase):
         """Test st.spinner."""
         # TODO(armando): Test that the message is actually passed to
         # message.warning
-        with patch("streamlit.delta_generator.DeltaGenerator.empty") as e:
+        with patch("streamlit.delta_generator.DeltaGenerator.container") as e:
             with st.spinner("some message"):
                 time.sleep(0.15)
             e.assert_called_once_with()


### PR DESCRIPTION
## Describe your changes

This PR attempts to fix the behavior of `st.spinner` so that it does not cause stale elements. Instead of hiding the spinner in the frontend via `dg.empty()`, this PR uses `dg.container()`. An empty container gets ignored on the frontend; in comparison, an `dg.empty()` placeholder is treated as an empty element in the front end, resulting in unwanted stale elements in some situations. The stale issue is caused by a scenario where in the first run, we are using a spinner, but in the second run, we are just showing the data, for example:

[![Open in Streamlit Cloud](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://issues.streamlitapp.com/?issue=gh-6859)

```python
import streamlit as st
import pandas as pd
import time

if "df" not in st.session_state:
    with st.spinner("Load data"):
        time.sleep(5)
        df = pd.DataFrame({"A": [1, 2, 3]})
        st.session_state.df = df

st.dataframe(st.session_state.df)

# Do something else that takes some time:
time.sleep(5)
```

The first run uses two elements, while the second one uses only one. This will cause a duplicated greyed-out version of the dataframe until the script has fully finished. 

Alternatively, we could introduce some kind of `dg.clear()` or `dg.empty(clear=True)` command that removes the current element from the frontend.

## Testing Plan

Updated unit tests related to `st.spinner`. I also had to deactivate the spinners in some caching tests since the testing utility does not work yet with `st.container` as mentioned here:

https://github.com/streamlit/streamlit/blob/3407ec723cd6c12c085907bf743c1a27e96e3ac2/lib/streamlit/testing/element_tree.py#L991

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
