### PR TITLE
Fixed Chat Input Resizing Issues and Width

### DIFF
--- a/frontend/src/lib/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/src/lib/components/widgets/ChatInput/ChatInput.tsx
@@ -79,8 +79,11 @@ function ChatInput({ width, element, widgetMgr }: Props): React.ReactElement {
     let scrollHeight = 0
     const { current: textarea } = chatInputRef
     if (textarea) {
+      const placeholder = textarea.placeholder
+      textarea.placeholder = ""
       textarea.style.height = "auto"
       scrollHeight = textarea.scrollHeight
+      textarea.placeholder = placeholder
       textarea.style.height = ""
     }
 
@@ -132,11 +135,6 @@ function ChatInput({ width, element, widgetMgr }: Props): React.ReactElement {
       setDirty(val !== "")
     }
   }, [element])
-
-  useEffect(() => {
-    const scrollHeight = getScrollHeight()
-    setScrollHeight(scrollHeight)
-  }, [value])
 
   useEffect(() => {
     if (chatInputRef.current) {

--- a/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/src/lib/components/widgets/ChatInput/styled-components.ts
@@ -102,7 +102,6 @@ export const StyledFloatingChatInputContainer = styled.div(({ theme }) => ({
   bottom: "0px",
   paddingBottom: "70px",
   paddingTop: theme.spacing.lg,
-  width: "100%",
   backgroundColor: theme.colors.bgColor,
   zIndex: theme.zIndices.chatInput,
   [`@media (max-width: ${theme.breakpoints.md})`]: {
@@ -110,6 +109,7 @@ export const StyledFloatingChatInputContainer = styled.div(({ theme }) => ({
     flexDirection: "column",
     alignItems: "center",
     left: 0,
+    width: "100vw",
   },
 }))
 


### PR DESCRIPTION
## Describe your changes

This PR addresses three issues:
* Chat Input size can be quite large. This is a result of setting the scroll height on mount, which is strangely super large (this is likely due to a less-than-desired behavior on parent elements are not technically full height (they are 0px with overflow).
  * This change simply disables setting it on mount and relies on the change event, which seems to work well.
* The Placeholder presents a tricky problem where large placeholders of Text Areas when auto growing/shrinking, they expand the text area to show the full placeholder. We are still discussing the value of this, but it makes sense to restrict to one line. I opted to have the auto sizing _not_ take into account the placeholder to ensure it remains that way.
  * The side effect is that long placeholders make the text area scrollable, but that seems like the best solution for this abnormal case.
* The width of the text area (and bottom part) will be the width of the content, so it doesn't hover over the scrollbar. When in mobile/small tablet mode, it will extend the full view width.

## Testing Plan

There's no net new unit tests, but we will write E2E tests to capture this behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
