### PR TITLE
Show empty chat messages

### DIFF
--- a/e2e/scripts/st_chat_message.py
+++ b/e2e/scripts/st_chat_message.py
@@ -66,4 +66,4 @@ with st.chat_message("Bot"):
     with st.expander("See more", expanded=True):
         st.write("Lorem ipsum dolor sit amet")
 
-st.chat_message("user").write("")
+st.chat_message("user")

--- a/frontend/src/lib/components/core/Block/Block.tsx
+++ b/frontend/src/lib/components/core/Block/Block.tsx
@@ -55,7 +55,11 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const { node } = props
 
   // Allow columns to create the specified space regardless of empty state
-  if (node.isEmpty && !node.deltaBlock.column) {
+  if (
+    node.isEmpty &&
+    !node.deltaBlock.column &&
+    !node.deltaBlock.chatMessage
+  ) {
     return <></>
   }
 

--- a/frontend/src/lib/components/core/Block/Block.tsx
+++ b/frontend/src/lib/components/core/Block/Block.tsx
@@ -55,6 +55,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const { node } = props
 
   // Allow columns and chat messages to create the specified space regardless of empty state
+  // TODO: Maybe we can simplify this to: node.isEmpty && !node.deltaBlock.allowEmpty?
   if (
     node.isEmpty &&
     !node.deltaBlock.column &&

--- a/frontend/src/lib/components/core/Block/Block.tsx
+++ b/frontend/src/lib/components/core/Block/Block.tsx
@@ -54,7 +54,7 @@ interface BlockPropsWithWidth extends BaseBlockProps {
 const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const { node } = props
 
-  // Allow columns to create the specified space regardless of empty state
+  // Allow columns and chat messages to create the specified space regardless of empty state
   if (
     node.isEmpty &&
     !node.deltaBlock.column &&


### PR DESCRIPTION
## Describe your changes

Currently, empty chat message containers are not shown (default container behaviour). But for chat messages, we would like to show even if empty.

## Testing Plan

Update e2e test for empty chat message.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
