### PR TITLE
Show a better exception for invalid avatar value

### DIFF
--- a/lib/streamlit/elements/chat.py
+++ b/lib/streamlit/elements/chat.py
@@ -74,16 +74,21 @@ def _process_avatar_input(
     elif isinstance(avatar, str) and is_emoji(avatar):
         return AvatarType.EMOJI, avatar
     else:
-        # TODO(lukasmasuch): Pure SVGs are not yet supported here.
-        # They have a special handling in `st.image` and might require some refactoring.
-        return AvatarType.IMAGE, image_to_url(
-            avatar,
-            width=WidthBehaviour.ORIGINAL,
-            clamp=False,
-            channels="RGB",
-            output_format="auto",
-            image_id="",
-        )
+        try:
+            # TODO(lukasmasuch): Pure SVGs are not yet supported here.
+            # They have a special handling in `st.image` and might require some refactoring.
+            return AvatarType.IMAGE, image_to_url(
+                avatar,
+                width=WidthBehaviour.ORIGINAL,
+                clamp=False,
+                channels="RGB",
+                output_format="auto",
+                image_id="",
+            )
+        except Exception as ex:
+            raise StreamlitAPIException(
+                "Failed to load the provided avatar value as an image."
+            ) from ex
 
 
 DISALLOWED_CONTAINERS_ERROR_TEXT = "`st.chat_input()` can't be used inside an `st.expander`, `st.form`, `st.tabs`, `st.columns`, or `st.sidebar`."

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -112,6 +112,11 @@ class ChatTest(DeltaGeneratorTestCase):
             BlockProto.ChatMessage.AvatarType.IMAGE,
         )
 
+    def test_throws_invalid_avatar_exception(self):
+        """Test that chat_message throws an StreamlitAPIException on invalid avatar input."""
+        with pytest.raises(StreamlitAPIException):
+            st.chat_message("user", avatar="FOOO")
+
     def test_chat_input(self):
         """Test that it can be called."""
         st.chat_input("Placeholder")


### PR DESCRIPTION
## Describe your changes

We will throw a `StreamlitAPIException` if anything goes wrong when loading the avatar value as image. 

## Testing Plan

Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
