### PR TITLE
Make Chat Input remain opaque when stale

### DIFF
--- a/frontend/src/lib/components/core/Block/styled-components.ts
+++ b/frontend/src/lib/components/core/Block/styled-components.ts
@@ -69,7 +69,7 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
       overflow: "visible",
     },
 
-    ...(isStale
+    ...(isStale && elementType !== "chatInput"
       ? {
           opacity: 0.33,
           transition: "opacity 1s ease-in 0.5s",

--- a/frontend/src/lib/components/core/Block/styled-components.ts
+++ b/frontend/src/lib/components/core/Block/styled-components.ts
@@ -70,7 +70,7 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
     },
 
     // We do not want the chat input to be faded out.
-    // TODO: Reconsider this when we implement fixed sized chat inputs
+    // TODO: Reconsider this when we implement fixed-sized chat containers
     ...(isStale && elementType !== "chatInput"
       ? {
           opacity: 0.33,

--- a/frontend/src/lib/components/core/Block/styled-components.ts
+++ b/frontend/src/lib/components/core/Block/styled-components.ts
@@ -69,6 +69,8 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
       overflow: "visible",
     },
 
+    // We do not want the chat input to be faded out.
+    // TODO: Reconsider this when we implement fixed sized chat inputs
     ...(isStale && elementType !== "chatInput"
       ? {
           opacity: 0.33,


### PR DESCRIPTION
## Describe your changes

When long-running scripts occur in Streamlit, elements become stale. It does not make sense for the Chat Input to be stale and in the semi transparent state. This change ensures that does not happen.

## Testing Plan

Stale Elements are tough to test because we need to make the script execute a long time and grab screenshots when it's happening. This is probably best for manual tesitng.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
