### PR TITLE
[Fix] Cypress snapshot upload

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -100,6 +100,12 @@ jobs:
             echo "${js_specs[@]:${startIndex}:${currentIntervalLength}}"
             scripts/run_e2e_tests.py -a "${js_specs[@]:${startIndex}:${currentIntervalLength}}"
           fi
+      - name: Store Snapshots
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress_snapshots
+          path: frontend/cypress/snapshots
       - name: Check that all screenshot have been committed
         run: |
           set -x;
@@ -117,12 +123,6 @@ jobs:
         with:
           name: cypress_videos
           path: frontend/cypress/videos
-      - name: Store Snapshots
-        uses: actions/upload-artifact@v3
-        if: ${{ matrix.specs == 22 }}
-        with:
-          name: cypress_snapshots
-          path: frontend/cypress/snapshots
 
   cypress_summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -111,6 +111,12 @@ jobs:
             git ls-files --others --exclude-standard | grep cypress;
             exit 1;
           fi
+      - name: Store Snapshots
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress_snapshots
+          path: frontend/cypress/snapshots
       - name: Store Videos
         uses: actions/upload-artifact@v3
         if: always()
@@ -130,12 +136,6 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-      - name: Store Snapshots
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cypress_snapshots
-          path: frontend/cypress/snapshots
       - name: Check Cypress test matrix status
         if: ${{ needs.test.result == 'failure' }}
         run: exit 1

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -100,12 +100,6 @@ jobs:
             echo "${js_specs[@]:${startIndex}:${currentIntervalLength}}"
             scripts/run_e2e_tests.py -a "${js_specs[@]:${startIndex}:${currentIntervalLength}}"
           fi
-      - name: Store Snapshots
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cypress_snapshots
-          path: frontend/cypress/snapshots
       - name: Check that all screenshot have been committed
         run: |
           set -x;
@@ -136,6 +130,12 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
+      - name: Store Snapshots
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress_snapshots
+          path: frontend/cypress/snapshots
       - name: Check Cypress test matrix status
         if: ${{ needs.test.result == 'failure' }}
         run: exit 1

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -118,8 +118,10 @@ jobs:
           name: cypress_videos
           path: frontend/cypress/videos
       - name: Store Snapshots
+        env:
+          CURRENT_RUN: ${{matrix.specs}}
         uses: actions/upload-artifact@v3
-        if: always()
+        if: ${{ $CURRENT_RUN == 22 }}
         with:
           name: cypress_snapshots
           path: frontend/cypress/snapshots

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -118,10 +118,8 @@ jobs:
           name: cypress_videos
           path: frontend/cypress/videos
       - name: Store Snapshots
-        env:
-          CURRENT_RUN: ${{matrix.specs}}
         uses: actions/upload-artifact@v3
-        if: ${{ $CURRENT_RUN == 22 }}
+        if: ${{ matrix.specs == 22 }}
         with:
           name: cypress_snapshots
           path: frontend/cypress/snapshots


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Currently, Cypress GHA workflow is uploading every snapshot on each runner - this PR updates the job to only upload the full suite of snapshots on the final runner (once)
