### PR TITLE
Expose script timeout in testing API

### DIFF
--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -98,8 +98,11 @@ class Element:
     def widget_state(self) -> WidgetState | None:
         return None
 
-    def run(self) -> ElementTree:
-        return self.root.run()
+    def run(self, timeout: float = 3) -> ElementTree:
+        """Run the script with updated widget values.
+        Timeout is a number of seconds.
+        """
+        return self.root.run(timeout=timeout)
 
     def __repr__(self):
         return util.repr_(self)
@@ -1215,8 +1218,11 @@ class Block:
     def widget_state(self) -> WidgetState | None:
         return None
 
-    def run(self) -> ElementTree:
-        return self.root.run()
+    def run(self, timeout: float = 3) -> ElementTree:
+        """Run the script with updated widget values.
+        Timeout is a number of seconds.
+        """
+        return self.root.run(timeout=timeout)
 
     def __repr__(self):
         return util.repr_(self)
@@ -1288,13 +1294,16 @@ class ElementTree(Block):
 
         return ws
 
-    def run(self) -> ElementTree:
+    def run(self, timeout: float = 3) -> ElementTree:
+        """Run the script with updated widget values.
+        Timeout is a number of seconds.
+        """
         assert self.script_path is not None
         from streamlit.testing.local_script_runner import LocalScriptRunner
 
         widget_states = self.get_widget_states()
         runner = LocalScriptRunner(self.script_path, self.session_state)
-        return runner.run(widget_states)
+        return runner.run(widget_states, timeout=timeout)
 
 
 def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -566,3 +566,19 @@ class TimeInputTest(InteractiveScriptTests):
             time(16),
             time(2, 1),
         ]
+
+
+class TimeoutTest(InteractiveScriptTests):
+    def test_short_timeout(self):
+        script = self.script_from_string(
+            """
+            import time
+            import streamlit as st
+
+            st.write("start")
+            time.sleep(0.5)
+            st.write("end")
+            """
+        )
+        with pytest.raises(RuntimeError):
+            sr = script.run(timeout=0.2)


### PR DESCRIPTION
## Describe your changes
Add a timeout parameter that gets passed through to the script runner, so users can test longer scripts.

I honestly thought I had already merged this a while ago, but probably I had it locally as part of a bigger changeset that got dropped at some point.

## GitHub Issue Link (if applicable)
#6843 

## Testing Plan

- Unit Tests (JS and/or Python)
1 basic unit test for functionality. Deliberately didn't implement a test for a long timeout working, to avoid unduly slowing down the test suite.
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
