### PR TITLE
Respect current existing env var in build_info.py

### DIFF
--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -282,7 +282,7 @@ def get_output_variables() -> Dict[str, str]:
     # Environment variables can be overridden at job level and we don't want
     # to change them then.
     for key, value in variables.copy().items():
-        variables[key] = os.environ.get(key)
+        variables[key] = os.environ.get(key, value)
     return variables
 
 

--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -273,12 +273,17 @@ def get_output_variables() -> Dict[str, str]:
             LABEL_UPGRADE_DEPENDENCIES, "Latest dependencies will be used"
         )
     )
-    return {
+    variables = {
         "PYTHON_MIN_VERSION": PYTHON_MIN_VERSION,
         "PYTHON_MAX_VERSION": PYTHON_MAX_VERSION,
         "PYTHON_VERSIONS": json.dumps(python_versions),
         "USE_CONSTRAINT_FILE": str(use_constraint_file).lower(),
     }
+    # Environment variables can be overridden at job level and we don't want
+    # to change them then.
+    for key, value in variables.copy().items():
+        variables[key] = os.environ.get(key)
+    return variables
 
 
 def save_output_variables(variables: Dict[str, str]) -> None:


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
If the variables are set in the workflow.yaml file, then we should no longer change them via the script.
https://github.com/streamlit/streamlit/blob/c7f9791106bb3cfa2d93b19e8f68a7bc1795945a/.github/workflows/release.yml#L61-L62

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
