### PR TITLE
Fix protobuf gen in min deps workflow

### DIFF
--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -150,12 +150,12 @@ jobs:
           deactivate
       - name: Activate virtualenv
         run: echo 'source venv/bin/activate' >> $HOME/.bash_profile
+      - name: Install deps
+        run: make python-init-test-min-deps
       - name: Generate Protobufs
         run: make protobuf
       # End of inlined make_init action
 
-      - name: Install deps
-        run: make python-init-test-min-deps
       - name: Run Python Tests
         run: make pytest
       - name: Run Integration Tests

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -156,6 +156,8 @@ jobs:
         run: make protobuf
       # End of inlined make_init action
 
+      - name: Make local modules visible
+        run: pip install --editable lib --no-deps
       - name: Run Python Tests
         run: make pytest
       - name: Run Integration Tests


### PR DESCRIPTION
Moving the package install to before proto generation should ensure we have the needed mypy proto package installed. Don't know how it passed previously.


## Testing Plan

- Explanation of why no additional tests are needed
CI change
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
