### PR TITLE
Fix issue with file uploader dropping every other file

### DIFF
--- a/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
@@ -247,19 +247,19 @@ class FileUploader extends React.PureComponent<Props, State> {
       }
     }
 
-    // If this is a single-file uploader that already has a file,
-    // remove that file so that it can be replaced with our new one.
-    if (
-      !multipleFiles &&
-      acceptedFiles.length > 0 &&
-      this.state.files.length > 0
-    ) {
-      this.removeFile(this.state.files[0].id)
-    }
-
     this.props.uploadClient
       .fetchFileURLs(acceptedFiles)
       .then((fileURLsArray: IFileURLs[]) => {
+        // If this is a single-file uploader that already has a file,
+        // remove that file so that it can be replaced with our new one.
+        if (
+          !multipleFiles &&
+          acceptedFiles.length > 0 &&
+          this.state.files.length > 0
+        ) {
+          this.removeFile(this.state.files[0].id)
+        }
+
         _.zip(fileURLsArray, acceptedFiles).forEach(
           ([fileURLs, acceptedFile]) => {
             this.uploadFile(fileURLs as FileURLsProto, acceptedFile as File)


### PR DESCRIPTION
There's currently a bug in the file uploader feature branch where uploading a second
file to a file uploader accepting a single file (without clearing the first one) doesn't work
correctly.

The root cause of this issue is that the original file is removed from the FileUploader react
component's state before we've fetched new file URLs and started the file upload process.
This causes react to call the component's `componentDidUpdate` method too early, which
triggers a script rerun with an empty file uploader state.

The fix is to defer any state mutations until after we've fetched fileUrls + started uploading files.