### PR TITLE
Fix styler support for data editor

### DIFF
--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -812,9 +812,9 @@ class DataEditorMixin:
 
         if type_util.is_pandas_styler(data):
             # Pandas styler will only work for non-editable/disabled columns.
-            # Get first 5 chars of md5 hash of delta path as styler uuid
+            # Get first 5 chars of md5 hash of the key or delta path as styler uuid
             # and set it as styler uuid.
-            styler_uuid = calc_md5(self.dg._get_delta_path_str())[:5]
+            styler_uuid = calc_md5(key or self.dg._get_delta_path_str())[:5]
             data.set_uuid(styler_uuid)
             marshall_styler(proto, data, styler_uuid)
 

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -66,6 +66,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.type_util import DataFormat, DataFrameGenericAlias, Key, is_type, to_key
+from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     import numpy as np
@@ -811,9 +812,11 @@ class DataEditorMixin:
 
         if type_util.is_pandas_styler(data):
             # Pandas styler will only work for non-editable/disabled columns.
-            delta_path = self.dg._get_delta_path_str()
-            default_uuid = str(hash(delta_path))
-            marshall_styler(proto, data, default_uuid)
+            # Get first 5 chars of md5 hash of delta path as styler uuid
+            # and set it as styler uuid.
+            styler_uuid = calc_md5(self.dg._get_delta_path_str())[:5]
+            data.set_uuid(styler_uuid)
+            marshall_styler(proto, data, styler_uuid)
 
         proto.data = type_util.pyarrow_table_to_bytes(arrow_table)
 

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -812,9 +812,15 @@ class DataEditorMixin:
 
         if type_util.is_pandas_styler(data):
             # Pandas styler will only work for non-editable/disabled columns.
-            # Get first 5 chars of md5 hash of the key or delta path as styler uuid
+            # Get first 10 chars of md5 hash of the key or delta path as styler uuid
             # and set it as styler uuid.
-            styler_uuid = calc_md5(key or self.dg._get_delta_path_str())[:5]
+            # We are only using the first 10 chars to keep the uuid short since
+            # it will be used for all the cells in the dataframe. Therefore, this
+            # might have a significant impact on the message size. 10 chars
+            # should be good enough to avoid  potential collisions in this case.
+            # Even on collisions, there should not be a big issue with the
+            # rendering in the data editor.
+            styler_uuid = calc_md5(key or self.dg._get_delta_path_str())[:10]
             data.set_uuid(styler_uuid)
             marshall_styler(proto, data, styler_uuid)
 

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -570,7 +570,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(
-            proto.styler.styles, "#T_29028row1_col2 { background-color: yellow }"
+            proto.styler.styles, "#T_29028a0632row1_col2 { background-color: yellow }"
         )
 
         # Check that different delta paths lead to different element ids
@@ -578,14 +578,14 @@ class DataEditorTest(DeltaGeneratorTestCase):
         # delta path is: [0, 1, 0]
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(
-            proto.styler.styles, "#T_e94cdrow1_col2 { background-color: yellow }"
+            proto.styler.styles, "#T_e94cd2b42erow1_col2 { background-color: yellow }"
         )
 
         st.container().container().data_editor(styler, width=100)
         # delta path is: [0, 2, 0, 0]
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(
-            proto.styler.styles, "#T_9e33arow1_col2 { background-color: yellow }"
+            proto.styler.styles, "#T_9e33af1e69row1_col2 { background-color: yellow }"
         )
 
     def test_duplicate_column_names_raise_exception(self):

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -565,14 +565,12 @@ class DataEditorTest(DeltaGeneratorTestCase):
             data=np.arange(0, 6, 1).reshape(2, 3),
         )
         styler = df.style
-        # NOTE: If UUID is not set - a random UUID will be generated.
-        styler.set_uuid("FAKE_UUID")
         styler.highlight_max(axis=None)
-        st.data_editor(styler)
+        st.data_editor(styler, key="styler_editor")
 
         proto = self.get_delta_from_queue().new_element.arrow_data_frame
         self.assertEqual(
-            proto.styler.styles, "#T_FAKE_UUIDrow1_col2 { background-color: yellow }"
+            proto.styler.styles, "#T_29028row1_col2 { background-color: yellow }"
         )
 
     def test_duplicate_column_names_raise_exception(self):

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -573,6 +573,21 @@ class DataEditorTest(DeltaGeneratorTestCase):
             proto.styler.styles, "#T_29028row1_col2 { background-color: yellow }"
         )
 
+        # Check that different delta paths lead to different element ids
+        st.container().data_editor(styler, width=99)
+        # delta path is: [0, 1, 0]
+        proto = self.get_delta_from_queue().new_element.arrow_data_frame
+        self.assertEqual(
+            proto.styler.styles, "#T_e94cdrow1_col2 { background-color: yellow }"
+        )
+
+        st.container().container().data_editor(styler, width=100)
+        # delta path is: [0, 2, 0, 0]
+        proto = self.get_delta_from_queue().new_element.arrow_data_frame
+        self.assertEqual(
+            proto.styler.styles, "#T_9e33arow1_col2 { background-color: yellow }"
+        )
+
     def test_duplicate_column_names_raise_exception(self):
         """Test that duplicate column names raise an exception."""
         # create a dataframe with duplicate columns


### PR DESCRIPTION
## Describe your changes

This PR fixes the styler support for data editor by making sure that the styler uuid stays stable across reruns. Therefore, we are using an md5 hash based on the key (or delta path if no key is set)

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/6898

## Testing Plan

We are currently not testing the interactive editing process with styler, and it would be a huge effort to get that in (because it's using canvas). Therefore, there are no tests to adapt for this fix.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
