### PR TITLE
Fix: description of config options

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -467,10 +467,10 @@ _create_option(
         Streamlit displays app exceptions and associated tracebacks, and
         deprecation warnings, in the browser.
 
-        If set to False, exceptions will display in the browser with the
-        exception type and traceback, along with a generic error message.
-        Deprecation warnings and full exception messages will be printed to the
-        console only.""",
+        If set to False, deprecation warnings and full exception messages 
+        will be printed to the console only. Exceptions will still display in the 
+        browser with the exception type and traceback, along with a generic 
+        error message.""",
     default_val=True,
     type_=bool,
     scriptable=True,

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -465,9 +465,10 @@ _create_option(
         Streamlit displays app exceptions and associated tracebacks, and
         deprecation warnings, in the browser.
 
-        If set to False, an exception or deprecation warning will result in
-        a generic message being shown in the browser, and exceptions, tracebacks,
-        and deprecation warnings will be printed to the console only.""",
+        If set to False, exceptions will display in the browser with the
+        exception type and traceback, along with a generic error message.
+        Deprecation warnings and full exception messages will be printed to the
+        console only.""",
     default_val=True,
     type_=bool,
     scriptable=True,

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -467,8 +467,8 @@ _create_option(
         Streamlit displays app exceptions and associated tracebacks, and
         deprecation warnings, in the browser.
         
-        If set to False, deprecation warnings and full exception messages 
-        will print to the console only. Exceptions will still display in the 
+        If set to False, deprecation warnings and full exception messages
+        will print to the console only. Exceptions will still display in the
         browser with a generic error message. For now, the exception type and
         traceback show in the browser also, but they will be removed in the
         future.""",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -442,7 +442,9 @@ _create_section("client", "Settings for scripts that use Streamlit.")
 
 _create_option(
     "client.caching",
-    description="Whether to enable st.cache.",
+    description="""
+        Whether to enable st.cache. This does not affect st.cache_data or
+        st.cache_resource.""",
     default_val=True,
     type_=bool,
     scriptable=True,

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -466,11 +466,12 @@ _create_option(
         are displayed in the browser. By default, this is set to True and
         Streamlit displays app exceptions and associated tracebacks, and
         deprecation warnings, in the browser.
-
+        
         If set to False, deprecation warnings and full exception messages 
-        will be printed to the console only. Exceptions will still display in the 
-        browser with the exception type and traceback, along with a generic 
-        error message.""",
+        will print to the console only. Exceptions will still display in the 
+        browser with a generic error message. For now, the exception type and
+        traceback show in the browser also, but they will be removed in the
+        future.""",
     default_val=True,
     type_=bool,
     scriptable=True,
@@ -484,7 +485,8 @@ _create_option(
 
         Allowed values:
         * "auto"      : Show the developer options if the app is accessed through
-                        localhost and hide them otherwise.
+                        localhost or through Streamlit Community Cloud as a developer.
+                        Hide them otherwise.
         * "developer" : Show the developer options.
         * "viewer"    : Hide the developer options.
         * "minimal"   : Show only options set externally (e.g. through

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -466,7 +466,7 @@ _create_option(
         are displayed in the browser. By default, this is set to True and
         Streamlit displays app exceptions and associated tracebacks, and
         deprecation warnings, in the browser.
-        
+
         If set to False, deprecation warnings and full exception messages
         will print to the console only. Exceptions will still display in the
         browser with a generic error message. For now, the exception type and


### PR DESCRIPTION
`client.showErrorDetails` does not hide the traceback when set to false. This is [expected behavior](https://github.com/streamlit/streamlit/issues/4519#issuecomment-1232782294) currently.

`client.caching` only applies to deprecated `st.cache`. It should be clear that it does not apply to `st.cache_data` and `st.cache_resource`.

`client.toolbarMode` is also affected by Streamlit Community Cloud when set to "auto."

## Describe your changes
Updated description string for configuration option.

## Context
Per @jrieke for `client.showErrorDetails`
Slack: [for client.caching](https://snowflake.slack.com/archives/C039V2A2USJ/p1688132966000539?thread_ts=1688064601.745639&cid=C039V2A2USJ)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.