### PR TITLE
Dont use constraints files in python-min-deps.yml workflow in canary builds

### DIFF
--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+          fetch-depth: 2
           submodules: "recursive"
 
       - name: Set Python version vars

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: Set Python version vars
         uses: ./.github/actions/build_info
-      - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
+      - name: Set up Python ${{ env.PYTHON_MIN_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: "${{ env.PYTHON_MAX_VERSION }}"
+          python-version: "${{ env.PYTHON_MIN_VERSION }}"
 
       # This section is an inlined copy of the make_init action
       # Both because we need to do some parts of it differently

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -31,32 +31,7 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  build_info:
-    runs-on: ubuntu-latest
-
-    name: "Build info"
-
-    steps:
-      - name: Checkout Streamlit code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-          persist-credentials: false
-          submodules: "recursive"
-          fetch-depth: 2
-      - name: Set Python version vars
-        id: build_info
-        uses: ./.github/actions/build_info
-        with:
-          force-canary: ${{ false }}
-
-    outputs:
-      PYTHON_MIN_VERSION: ${{ steps.build_info.outputs.PYTHON_MIN_VERSION }}
-
   py_version:
-    needs:
-      - build_info
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -76,10 +51,12 @@ jobs:
           persist-credentials: false
           submodules: "recursive"
 
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+      - name: Set up Python ${{ env.PYTHON_MAX_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "${{ env.PYTHON_MAX_VERSION }}"
 
       # This section is an inlined copy of the make_init action
       # Both because we need to do some parts of it differently
@@ -126,7 +103,7 @@ jobs:
       # Actions moves to a newer version of Ubunutu.
       - name: Add vendored `protoc` to $PATH
         run: |
-          echo "./vendor/protoc-3.20.3-linux-x86_64/bin" >> $GITHUB_PATH
+          echo "$PWD/vendor/protoc-3.20.3-linux-x86_64/bin" >> $GITHUB_PATH
       # Combine hashes of the Python interpreter, requirements files, and today's
       # date into a file whose hash will key the Python virtualenv.
       - name: Create Python environment cache key


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
We should run the build_info.py script in one job with the others steps, because we don't need to generate a matrix based on the results of the script because this workflow is run for one Python version.

If we run this script in one job, all necessary environment variables are set, in particular `USE_CONSTRAINTS_FILES`. This variable should be set for push events as this eliminates the need for constraints for [canary builds](https://github.com/streamlit/streamlit/wiki/CI-Environment#canary-builds).


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
