### PR TITLE
Only apply spinner stale fix if inside a `chat_message`

### DIFF
--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -82,10 +82,14 @@ def spinner(text: str = "In progress...") -> Iterator[None]:
                 display_message = False
         with legacy_caching.suppress_cached_st_function_warning():
             with caching.suppress_cached_st_function_warning():
-                # We are resetting the spinner placeholder to an empty container
-                # instead of an empty placeholder (st.empty) to have it removed from the
-                # delta path. Empty containers are ignored in the frontend since they
-                # are configured with allow_empty=False. This prevents issues with stale
-                # elements caused by the spinner being rendered only in some situations
-                # (e.g. for caching).
-                message.container()
+                if "chat_message" in set(message._active_dg._parent_block_types):
+                    # Temporary stale element fix:
+                    # For chat messages, we are resetting the spinner placeholder to an
+                    # empty container instead of an empty placeholder (st.empty) to have
+                    # it removed from the delta path. Empty containers are ignored in the
+                    # frontend since they are configured with allow_empty=False. This
+                    # prevents issues with stale elements caused by the spinner being
+                    # rendered only in some situations (e.g. for caching).
+                    message.container()
+                else:
+                    message.empty()

--- a/lib/tests/streamlit/spinner_test.py
+++ b/lib/tests/streamlit/spinner_test.py
@@ -26,6 +26,21 @@ class SpinnerTest(DeltaGeneratorTestCase):
             time.sleep(0.2)
             el = self.get_delta_from_queue().new_element
             self.assertEqual(el.spinner.text, "some text")
+        # Check if it gets reset to st.empty()
+        last_delta = self.get_delta_from_queue()
+        self.assertTrue(last_delta.HasField("new_element"))
+        self.assertEqual(last_delta.new_element.WhichOneof("type"), "empty")
+
+    def test_spinner_within_chat_message(self):
+        """Test st.spinner in st.chat_message resets to empty container block."""
+        import streamlit as st
+
+        with st.chat_message("user"):
+            with spinner("some text"):
+                # Without the timeout, the spinner is sometimes not available
+                time.sleep(0.2)
+                el = self.get_delta_from_queue().new_element
+                self.assertEqual(el.spinner.text, "some text")
         # Check that the element gets reset to an empty container block:
         last_delta = self.get_delta_from_queue()
         self.assertTrue(last_delta.HasField("add_block"))

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -327,7 +327,7 @@ class StreamlitWriteTest(unittest.TestCase):
         """Test st.spinner."""
         # TODO(armando): Test that the message is actually passed to
         # message.warning
-        with patch("streamlit.delta_generator.DeltaGenerator.container") as e:
+        with patch("streamlit.delta_generator.DeltaGenerator.empty") as e:
             with st.spinner("some message"):
                 time.sleep(0.15)
             e.assert_called_once_with()


### PR DESCRIPTION
## Describe your changes

We recently attempted to fix the stale element issue related to `st.spinner` here: https://github.com/streamlit/streamlit/pull/6859. However, this had some negative downsides to non-chat applications as reported here: https://github.com/streamlit/streamlit/issues/6920. This PR will revert the change only to apply it if the spinner is within a chat message. This is also a more temporary fix until we have a better way to resolve the stale element issue.

## GitHub Issue Link (if applicable)

Closes: https://github.com/streamlit/streamlit/issues/6920

## Testing Plan

- Updated the relevant unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
