### PR TITLE
Strong typing for `withExpandable` HOC

### DIFF
--- a/frontend/src/lib/components/core/Block/Block.tsx
+++ b/frontend/src/lib/components/core/Block/Block.tsx
@@ -18,6 +18,7 @@ import React, { ReactElement } from "react"
 import { AutoSizer } from "react-virtualized"
 
 import { Block as BlockProto } from "src/lib/proto"
+import ExpandableProto = BlockProto.Expandable
 import { BlockNode, AppNode, ElementNode } from "src/lib/AppNode"
 import { getElementWidgetID } from "src/lib/util/utils"
 import withExpandable from "src/lib/hocs/withExpandable"
@@ -72,21 +73,21 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
     props.scriptRunId
   )
 
-  const optionalProps = node.deltaBlock.expandable
-    ? {
-        empty: node.isEmpty,
-        isStale,
-        ...node.deltaBlock.expandable,
-      }
-    : {}
-
-  const childProps = { ...props, ...optionalProps, ...{ node } }
-
-  const child = node.deltaBlock.expandable ? (
-    <ExpandableLayoutBlock {...childProps} />
-  ) : (
-    <LayoutBlock {...childProps} />
-  )
+  let child: ReactElement
+  const childProps = { ...props, ...{ node } }
+  if (node.deltaBlock.expandable) {
+    // Handle expandable blocks
+    const expandableProps = {
+      ...childProps,
+      empty: node.isEmpty,
+      isStale,
+      expandable: true,
+      ...(node.deltaBlock.expandable as ExpandableProto),
+    }
+    child = <ExpandableLayoutBlock {...expandableProps} />
+  } else {
+    child = <LayoutBlock {...childProps} />
+  }
 
   if (node.deltaBlock.type === "form") {
     const { formId, clearOnSubmit } = node.deltaBlock.form as BlockProto.Form

--- a/frontend/src/lib/hocs/withExpandable/withExpandable.test.tsx
+++ b/frontend/src/lib/hocs/withExpandable/withExpandable.test.tsx
@@ -18,11 +18,11 @@ import React, { ComponentType } from "react"
 import { mount } from "src/lib/test_util"
 import StreamlitMarkdown from "src/lib/components/shared/StreamlitMarkdown"
 import { StatelessAccordion } from "baseui/accordion"
-import withExpandable, { Props } from "./withExpandable"
+import withExpandable, { ExpandableProps } from "./withExpandable"
 
 const testComponent: ComponentType = () => <div>test</div>
 
-const getProps = (props?: Partial<Props>): Props =>
+const getProps = (props?: Partial<ExpandableProps>): ExpandableProps =>
   Object({
     label: "hi",
     expandable: true,

--- a/frontend/src/lib/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/lib/hocs/withExpandable/withExpandable.tsx
@@ -40,6 +40,9 @@ export interface ExpandableProps {
 // Our wrapper takes the wrapped component's props plus ExpandableProps
 type WrapperProps<P> = P & ExpandableProps
 
+// TODO: there's no reason for this to be a HOC. Adapt it to follow the same
+//  pattern as the `Tabs` and `ChatMessage` containers that simply parent their
+//  children.
 function withExpandable<P>(
   WrappedComponent: ComponentType<P>
 ): ComponentType<WrapperProps<P>> {

--- a/frontend/src/lib/hocs/withExpandable/withExpandable.tsx
+++ b/frontend/src/lib/hocs/withExpandable/withExpandable.tsx
@@ -28,7 +28,7 @@ import {
 import { useTheme } from "@emotion/react"
 import { StyledExpandableContainer } from "./styled-components"
 
-export interface Props {
+export interface ExpandableProps {
   expandable: boolean
   label: string
   expanded: boolean
@@ -37,10 +37,13 @@ export interface Props {
   isStale: boolean
 }
 
-function withExpandable(
-  WrappedComponent: ComponentType<any>
-): ComponentType<any> {
-  const ExpandableComponent = (props: Props): ReactElement => {
+// Our wrapper takes the wrapped component's props plus ExpandableProps
+type WrapperProps<P> = P & ExpandableProps
+
+function withExpandable<P>(
+  WrappedComponent: ComponentType<P>
+): ComponentType<WrapperProps<P>> {
+  const ExpandableComponent = (props: WrapperProps<P>): ReactElement => {
     const {
       label,
       expanded: initialExpanded,
@@ -181,7 +184,12 @@ function withExpandable(
             }
             key="panel"
           >
-            <WrappedComponent {...componentProps} disabled={widgetsDisabled} />
+            <WrappedComponent
+              // (this.props as unknown as P) is required to work around a TS issue:
+              // https://github.com/microsoft/TypeScript/issues/28938#issuecomment-450636046
+              {...(componentProps as unknown as P)}
+              disabled={widgetsDisabled}
+            />
           </Panel>
         </Accordion>
       </StyledExpandableContainer>


### PR DESCRIPTION
`withExpandable` currently discards type information for its wrapped component. This PR modifies the HOC to retain its wrapped component's types. (No behavior change.)