### PR TITLE
Correct version number in setup.py

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.install import install
 
 THIS_DIRECTORY = Path(__file__).parent
 
-VERSION = "1.23.1"  # PEP-440
+VERSION = "1.24.0"  # PEP-440
 
 NAME = "streamlit"
 


### PR DESCRIPTION
Noticed that the version number in `setup.py` hasn't been bumped as part of the latest release.