### PR TITLE
Point out that editable columns cannot be styled via Pandas Styler

### DIFF
--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -545,7 +545,7 @@ class DataEditorMixin:
     ) -> DataTypes:
         """Display a data editor widget.
 
-        The data editor widget allows you to edit dataframes and many other data structures in a table-like UI.
+        The data editor widget allows you to edit dataframes and many other data structures in a table-like UI. 
 
         .. warning::
             When going from ``st.experimental_data_editor`` to ``st.data_editor`` in
@@ -558,7 +558,8 @@ class DataEditorMixin:
         Parameters
         ----------
         data : pandas.DataFrame, pandas.Series, pandas.Styler, pandas.Index, pyarrow.Table, numpy.ndarray, pyspark.sql.DataFrame, snowflake.snowpark.DataFrame, list, set, tuple, dict, or None
-            The data to edit in the data editor.
+            The data to edit in the data editor. Note that styles from `pandas.Styler` will
+            not be applied (unlike with `st.dataframe`). 
 
             .. note::
                 Mixing data types within a column can make the column uneditable.

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -545,7 +545,7 @@ class DataEditorMixin:
     ) -> DataTypes:
         """Display a data editor widget.
 
-        The data editor widget allows you to edit dataframes and many other data structures in a table-like UI. 
+        The data editor widget allows you to edit dataframes and many other data structures in a table-like UI.
 
         .. warning::
             When going from ``st.experimental_data_editor`` to ``st.data_editor`` in
@@ -558,17 +558,15 @@ class DataEditorMixin:
         Parameters
         ----------
         data : pandas.DataFrame, pandas.Series, pandas.Styler, pandas.Index, pyarrow.Table, numpy.ndarray, pyspark.sql.DataFrame, snowflake.snowpark.DataFrame, list, set, tuple, dict, or None
-            The data to edit in the data editor. 
-            
-            .. note::
-                Styles from ``pandas.Styler`` will only be applied to non-editable columns. 
+            The data to edit in the data editor.
 
             .. note::
-                Mixing data types within a column can make the column uneditable.
-                Additionally, the following data types are not yet supported for editing:
-                complex, list, tuple, bytes, bytearray, memoryview, dict, set, frozenset,
-                datetime.timedelta, decimal.Decimal, fractions.Fraction, pandas.Interval,
-                pandas.Period, pandas.Timedelta.
+                - Styles from ``pandas.Styler`` will only be applied to non-editable columns.
+                - Mixing data types within a column can make the column uneditable.
+                - Additionally, the following data types are not yet supported for editing:
+                  complex, list, tuple, bytes, bytearray, memoryview, dict, set, frozenset,
+                  datetime.timedelta, decimal.Decimal, fractions.Fraction, pandas.Interval,
+                  pandas.Period, pandas.Timedelta.
 
         width : int or None
             Desired width of the data editor expressed in pixels. If None, the width will

--- a/lib/streamlit/elements/data_editor.py
+++ b/lib/streamlit/elements/data_editor.py
@@ -558,8 +558,10 @@ class DataEditorMixin:
         Parameters
         ----------
         data : pandas.DataFrame, pandas.Series, pandas.Styler, pandas.Index, pyarrow.Table, numpy.ndarray, pyspark.sql.DataFrame, snowflake.snowpark.DataFrame, list, set, tuple, dict, or None
-            The data to edit in the data editor. Note that styles from `pandas.Styler` will
-            not be applied (unlike with `st.dataframe`). 
+            The data to edit in the data editor. 
+            
+            .. note::
+                Styles from ``pandas.Styler`` will only be applied to non-editable columns. 
 
             .. note::
                 Mixing data types within a column can make the column uneditable.


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Added a sentence to data editor docstring to point out it doesn't support styles from Pandas Styler. @LukasMasuch afaik it doesn't support any Styler stuff, correct? If it does, feel free to update my sentence. 

## GitHub Issue Link (if applicable)

In response to #6928

## Testing Plan

Only docstring change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
