### PR TITLE
File uploader/docs and tests

### DIFF
--- a/frontend/src/lib/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/src/lib/components/widgets/CameraInput/CameraInput.tsx
@@ -442,7 +442,6 @@ class CameraInput extends React.PureComponent<Props, State> {
     if (file.status.type === "uploaded" && file.status.fileUrls.deleteUrl) {
       this.props.uploadClient.deleteFile(file.status.fileUrls.deleteUrl)
     }
-
     this.removeFile(fileId)
   }
 

--- a/frontend/src/lib/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/lib/components/widgets/FileUploader/FileUploader.test.tsx
@@ -30,6 +30,7 @@ import { notUndefined } from "src/lib/util/utils"
 import FileDropzone from "./FileDropzone"
 import FileUploader, { Props } from "./FileUploader"
 import { ErrorStatus, UploadFileInfo, UploadingStatus } from "./UploadFileInfo"
+import { FileURLs } from "src/lib/proto"
 
 const createFile = (): File => {
   return new File(["Text in a file!"], "filename.txt", {
@@ -92,6 +93,17 @@ const getProps = (elementProps: Partial<FileUploaderProto> = {}): Props => {
       uploadFile: jest.fn().mockImplementation(() => {
         // Mock UploadClient to return an incremented ID for each upload.
         return Promise.resolve(mockServerFileIdCounter++)
+      }),
+      fetchFileURLs: jest.fn().mockImplementation((acceptedFiles: File[]) => {
+        return Promise.resolve(
+          acceptedFiles.map(file => {
+            return new FileURLs({
+              fileId: file.name,
+              uploadUrl: file.name,
+              deleteUrl: file.name,
+            })
+          })
+        )
       }),
     },
   }

--- a/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/src/lib/components/widgets/FileUploader/FileUploader.tsx
@@ -257,7 +257,7 @@ class FileUploader extends React.PureComponent<Props, State> {
           acceptedFiles.length > 0 &&
           this.state.files.length > 0
         ) {
-          this.removeFile(this.state.files[0].id)
+          this.deleteFile(this.state.files[0].id)
         }
 
         _.zip(fileURLsArray, acceptedFiles).forEach(

--- a/lib/streamlit/elements/camera_input.py
+++ b/lib/streamlit/elements/camera_input.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
@@ -69,10 +68,10 @@ def _get_upload_files(
     for f in uploaded_file_info:
         maybe_file_rec = file_recs.get(f.file_id)
         if maybe_file_rec is not None:
-            uploaded_file = UploadedFile(file_recs[f.file_id], f.file_urls)
+            uploaded_file = UploadedFile(maybe_file_rec, f.file_urls)
             collected_files.append(uploaded_file)
         else:
-            collected_files.append(DeletedFile())
+            collected_files.append(DeletedFile(f.file_id))
 
     return collected_files
 

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -36,10 +36,12 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
-from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
+from streamlit.runtime.uploaded_file_manager import DeletedFile, UploadedFile
 from streamlit.type_util import Key, LabelVisibility, maybe_raise_label_warnings, to_key
 
-SomeUploadedFiles = Optional[Union[UploadedFile, List[UploadedFile]]]
+SomeUploadedFiles = Optional[
+    Union[UploadedFile, DeletedFile, List[Union[UploadedFile, DeletedFile]]]
+]
 
 TYPE_PAIRS = [
     (".jpg", ".jpeg"),
@@ -52,7 +54,7 @@ TYPE_PAIRS = [
 
 def _get_upload_files(
     widget_value: Optional[FileUploaderStateProto],
-) -> List[UploadedFile]:
+) -> List[Union[UploadedFile, DeletedFile]]:
     if widget_value is None:
         return []
 
@@ -64,15 +66,24 @@ def _get_upload_files(
     if len(uploaded_file_info) == 0:
         return []
 
-    active_files = {f.file_id: f.file_urls for f in uploaded_file_info}
-
-    file_recs = ctx.uploaded_file_mgr.get_files(
+    file_recs_list = ctx.uploaded_file_mgr.get_files(
         session_id=ctx.session_id,
-        file_ids=list(active_files.keys()),
+        file_ids=[f.file_id for f in uploaded_file_info],
     )
-    return [
-        UploadedFile(file_rec, active_files[file_rec.file_id]) for file_rec in file_recs
-    ]
+
+    file_recs = {f.file_id: f for f in file_recs_list}
+
+    collected_files: List[Union[UploadedFile, DeletedFile]] = []
+
+    for f in uploaded_file_info:
+        maybe_file_rec = file_recs.get(f.file_id)
+        if maybe_file_rec is not None:
+            uploaded_file = UploadedFile(file_recs[f.file_id], f.file_urls)
+            collected_files.append(uploaded_file)
+        else:
+            collected_files.append(DeletedFile())
+
+    return collected_files
 
 
 @dataclass
@@ -86,9 +97,7 @@ class FileUploaderSerde:
         upload_files = _get_upload_files(ui_value)
 
         if len(upload_files) == 0:
-            return_value: Optional[Union[List[UploadedFile], UploadedFile]] = (
-                [] if self.accept_multiple_files else None
-            )
+            return_value: SomeUploadedFiles = [] if self.accept_multiple_files else None
         else:
             return_value = (
                 upload_files if self.accept_multiple_files else upload_files[0]
@@ -104,6 +113,8 @@ class FileUploaderSerde:
             files = [files]
 
         for f in files:
+            if isinstance(f, DeletedFile):
+                continue
             file_info: UploadedFileInfoProto = state_proto.uploaded_file_info.add()
             file_info.file_id = f.file_id
             file_info.name = f.name
@@ -219,7 +230,7 @@ class FileUploaderMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
-    ) -> SomeUploadedFiles:
+    ) -> Optional[Union[UploadedFile, List[UploadedFile]]]:
         r"""Display a file uploader widget.
         By default, uploaded files are limited to 200MB. You can configure
         this using the `server.maxUploadSize` config option. For more info
@@ -376,7 +387,7 @@ class FileUploaderMixin:
         label_visibility: LabelVisibility = "visible",
         disabled: bool = False,
         ctx: Optional[ScriptRunContext] = None,
-    ) -> SomeUploadedFiles:
+    ) -> Optional[Union[UploadedFile, List[UploadedFile]]]:
         key = to_key(key)
         check_callback_rules(self.dg, on_change)
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)
@@ -437,7 +448,19 @@ class FileUploaderMixin:
         )
 
         self.dg._enqueue("file_uploader", file_uploader_proto)
-        return widget_state.value
+
+        filtered_value: Union[UploadedFile, List[UploadedFile], None]
+
+        if isinstance(widget_state.value, DeletedFile):
+            filtered_value = None
+        elif isinstance(widget_state.value, list):
+            filtered_value = [
+                f for f in widget_state.value if not isinstance(f, DeletedFile)
+            ]
+        else:
+            filtered_value = widget_state.value
+
+        return filtered_value
 
     @property
     def dg(self) -> "streamlit.delta_generator.DeltaGenerator":

--- a/lib/streamlit/elements/file_uploader.py
+++ b/lib/streamlit/elements/file_uploader.py
@@ -78,10 +78,10 @@ def _get_upload_files(
     for f in uploaded_file_info:
         maybe_file_rec = file_recs.get(f.file_id)
         if maybe_file_rec is not None:
-            uploaded_file = UploadedFile(file_recs[f.file_id], f.file_urls)
+            uploaded_file = UploadedFile(maybe_file_rec, f.file_urls)
             collected_files.append(uploaded_file)
         else:
-            collected_files.append(DeletedFile())
+            collected_files.append(DeletedFile(f.file_id))
 
     return collected_files
 

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -42,6 +42,21 @@ class MemoryUploadedFileManager(UploadedFileManager):
     def get_files(
         self, session_id: str, file_ids: Sequence[str]
     ) -> List[UploadedFileRec]:
+        """Return a  list of UploadedFileRec for a given sequence of file_ids.
+
+        Parameters
+        ----------
+        session_id
+            The ID of the session that owns the files.
+        file_ids
+            The sequence of ids associated with files to retrieve.
+
+        Returns
+        -------
+        List[UploadedFileRec]
+            A list of URL UploadedFileRec instances, each instance contains information
+            about uploaded file.
+        """
         session_storage = self.file_storage[session_id]
         file_recs = []
 
@@ -53,12 +68,11 @@ class MemoryUploadedFileManager(UploadedFileManager):
         return file_recs
 
     def remove_session_files(self, session_id: str) -> None:
+        """Remove all files associated with a given session."""
         self.file_storage.pop(session_id, None)
 
     def __repr__(self) -> str:
         return util.repr_(self)
-
-    # MEMORY UPLOADED FILE MANAGER SPECIFIC METHODS
 
     def add_file(
         self,
@@ -79,12 +93,14 @@ class MemoryUploadedFileManager(UploadedFileManager):
         self.file_storage[session_id][file.file_id] = file
 
     def remove_file(self, session_id, file_id):
+        """Remove file with given file_id associated with a given session."""
         session_storage = self.file_storage[session_id]
         session_storage.pop(file_id, None)
 
     def get_upload_urls(
         self, session_id: str, file_names: Sequence[str]
     ) -> List[UploadFileUrlInfo]:
+        """Return a list of UploadFileUrlInfo for a given sequence of file_names."""
         result = []
         for _ in file_names:
             file_id = str(uuid.uuid4())

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -39,6 +39,16 @@ class UploadFileUrlInfo(NamedTuple):
     delete_url: str
 
 
+class DeletedFile:
+    """Return this from st.file_uploader and st.camera_input deserialize (so they can
+    be used in session_state), when widget value contains file record that is missing
+    from the storage.
+    DeleteFile instances filtered out before return final value to the user in script,
+    or before sending to frontend."""
+
+    pass
+
+
 class UploadedFile(io.BytesIO):
     """A mutable uploaded file.
 

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -61,7 +61,7 @@ class UploadedFile(io.BytesIO):
         # the Python docs - possibly because it's a CPython-only optimization
         # and not guaranteed to be in other Python runtimes. But it's detailed
         # here: https://hg.python.org/cpython/rev/79a5fbe2c78f
-        super(UploadedFile, self).__init__(record.data)
+        super().__init__(record.data)
         self.file_id = record.file_id
         self.name = record.name
         self.type = record.type

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -105,9 +105,12 @@ class UploadedFileManager(CacheStatsProvider, Protocol):
 
     @abstractmethod
     def remove_session_files(self, session_id: str) -> None:
+        """Remove all files associated with a given session."""
         raise NotImplementedError
 
     def get_upload_urls(
         self, session_id: str, file_names: Sequence[str]
     ) -> List[UploadFileUrlInfo]:
+        """Return a list of UploadFileUrlInfo for a given sequence of file_names.
+        Optional to implement, issuing of URLs could be done by other service."""
         raise NotImplementedError

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -77,12 +77,30 @@ class UploadedFileManager(CacheStatsProvider, Protocol):
         - cleaning up uploaded files associated with session on session end
 
     It should be created during Runtime initialization.
+
+    Optionally UploadedFileManager could be responsible for issuing URLs which will be
+    used by frontend to upload files to.
     """
 
     @abstractmethod
     def get_files(
         self, session_id: str, file_ids: Sequence[str]
     ) -> List[UploadedFileRec]:
+        """Return a  list of UploadedFileRec for a given sequence of file_ids.
+
+        Parameters
+        ----------
+        session_id
+            The ID of the session that owns the files.
+        file_ids
+            The sequence of ids associated with files to retrieve.
+
+        Returns
+        -------
+        List[UploadedFileRec]
+            A list of URL UploadedFileRec instances, each instance contains information
+            about uploaded file.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -40,7 +40,9 @@ class UploadFileUrlInfo(NamedTuple):
 
 
 class DeletedFile:
-    """Return this from st.file_uploader and st.camera_input deserialize (so they can
+    """Represents a deleted file in deserialized values for st.file_uploader and
+    st.camera_input
+    Return this from st.file_uploader and st.camera_input deserialize (so they can
     be used in session_state), when widget value contains file record that is missing
     from the storage.
     DeleteFile instances filtered out before return final value to the user in script,

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -68,7 +68,16 @@ class UploadedFile(io.BytesIO):
 
 
 class UploadedFileManager(CacheStatsProvider, Protocol):
-    """# TODO(kajarenc): Docstrings for this protocol + its methods."""
+    """UploadedFileManager protocol, that should be implemented by the concrete
+    cache storage managers.
+
+    It is responsible for:
+        - retrieving files by session_id and file_id for st.file_uploader and
+            st.camera_input
+        - cleaning up uploaded files associated with session on session end
+
+    It should be created during Runtime initialization.
+    """
 
     @abstractmethod
     def get_files(

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -79,7 +79,7 @@ class UploadedFile(io.BytesIO):
 
 class UploadedFileManager(CacheStatsProvider, Protocol):
     """UploadedFileManager protocol, that should be implemented by the concrete
-    cache storage managers.
+    uploaded file managers.
 
     It is responsible for:
         - retrieving files by session_id and file_id for st.file_uploader and

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -39,7 +39,7 @@ class UploadFileUrlInfo(NamedTuple):
     delete_url: str
 
 
-class DeletedFile:
+class DeletedFile(NamedTuple):
     """Represents a deleted file in deserialized values for st.file_uploader and
     st.camera_input
     Return this from st.file_uploader and st.camera_input deserialize (so they can
@@ -48,7 +48,7 @@ class DeletedFile:
     DeleteFile instances filtered out before return final value to the user in script,
     or before sending to frontend."""
 
-    pass
+    file_id: str
 
 
 class UploadedFile(io.BytesIO):

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -121,11 +121,12 @@ class FileUploaderTest(DeltaGeneratorTestCase):
                     self.assertEqual(actual.size, expected.size)
                     self.assertEqual(actual.getvalue(), expected.getvalue())
             else:
-                self.assertEqual(return_val, uploaded_files[0])
-                self.assertEqual(return_val.name, uploaded_files[0].name)
-                self.assertEqual(return_val.type, uploaded_files[0].type)
-                self.assertEqual(return_val.size, uploaded_files[0].size)
-                self.assertEqual(return_val.getvalue(), uploaded_files[0].getvalue())
+                first_uploaded_file = uploaded_files[0]
+                self.assertEqual(return_val, first_uploaded_file)
+                self.assertEqual(return_val.name, first_uploaded_file.name)
+                self.assertEqual(return_val.type, first_uploaded_file.type)
+                self.assertEqual(return_val.size, first_uploaded_file.size)
+                self.assertEqual(return_val.getvalue(), first_uploaded_file.getvalue())
 
     def test_max_upload_size_mb(self):
         """Test that the max upload size is the configuration value."""
@@ -173,7 +174,7 @@ class FileUploaderTest(DeltaGeneratorTestCase):
     def test_deleted_file_omitted(self, get_upload_files_patch):
         """We should omit DeletedFile objects for final user value ."""
 
-        uploaded_files = [DeletedFile()]
+        uploaded_files = [DeletedFile(file_id="A")]
         get_upload_files_patch.return_value = uploaded_files
 
         result_1: UploadedFile = st.file_uploader("a", accept_multiple_files=False)
@@ -190,15 +191,15 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         rec2 = UploadedFileRec("file2", "file2", "type", b"5678")
 
         uploaded_files = [
-            DeletedFile(),
+            DeletedFile(file_id="a"),
             UploadedFile(
                 rec1, FileURLsProto(file_id="file1", delete_url="d1", upload_url="u1")
             ),
-            DeletedFile(),
+            DeletedFile(file_id="b"),
             UploadedFile(
                 rec2, FileURLsProto(file_id="file2", delete_url="d1", upload_url="u1")
             ),
-            DeletedFile(),
+            DeletedFile(file_id="c"),
         ]
 
         get_upload_files_patch.return_value = uploaded_files

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -21,8 +21,8 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit import config
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
-from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -80,16 +80,23 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.file_uploader
         self.assertEqual(c.type, [".png", ".jpg", ".jpeg"])
 
-    @patch("streamlit.elements.file_uploader._get_file_recs")
-    def test_multiple_files(self, get_file_recs_patch):
+    @patch("streamlit.elements.file_uploader._get_upload_files")
+    def test_multiple_files(self, get_upload_files_patch):
         """Test the accept_multiple_files flag"""
         # Patch UploadFileManager to return two files
-        file_recs = [
-            UploadedFileRec(1, "file1", "type", b"123"),
-            UploadedFileRec(2, "file2", "type", b"456"),
+        rec1 = UploadedFileRec("file1", "file1", "type", b"123")
+        rec2 = UploadedFileRec("file2", "file2", "type", b"456")
+
+        uploaded_files = [
+            UploadedFile(
+                rec1, FileURLsProto(file_id="file1", delete_url="d1", upload_url="u1")
+            ),
+            UploadedFile(
+                rec2, FileURLsProto(file_id="file2", delete_url="d1", upload_url="u1")
+            ),
         ]
 
-        get_file_recs_patch.return_value = file_recs
+        get_upload_files_patch.return_value = uploaded_files
 
         for accept_multiple in [True, False]:
             return_val = st.file_uploader(
@@ -101,25 +108,20 @@ class FileUploaderTest(DeltaGeneratorTestCase):
             # If "accept_multiple_files" is True, then we should get a list of
             # values back. Otherwise, we should just get a single value.
 
-            # Because file_uploader returns unique UploadedFile instances
-            # each time it's called, we convert the return value back
-            # from UploadedFile -> UploadedFileRec (which implements
-            # equals()) to test equality.
-
             if accept_multiple:
-                results = [
-                    UploadedFileRec(file.id, file.name, file.type, file.getvalue())
-                    for file in return_val
-                ]
-                self.assertEqual(file_recs, results)
+                self.assertEqual(return_val, uploaded_files)
+
+                for actual, expected in zip(return_val, uploaded_files):
+                    self.assertEqual(actual.name, expected.name)
+                    self.assertEqual(actual.type, expected.type)
+                    self.assertEqual(actual.size, expected.size)
+                    self.assertEqual(actual.getvalue(), expected.getvalue())
             else:
-                results = UploadedFileRec(
-                    return_val.id,
-                    return_val.name,
-                    return_val.type,
-                    return_val.getvalue(),
-                )
-                self.assertEqual(file_recs[0], results)
+                self.assertEqual(return_val, uploaded_files[0])
+                self.assertEqual(return_val.name, uploaded_files[0].name)
+                self.assertEqual(return_val.type, uploaded_files[0].type)
+                self.assertEqual(return_val.size, uploaded_files[0].size)
+                self.assertEqual(return_val.getvalue(), uploaded_files[0].getvalue())
 
     def test_max_upload_size_mb(self):
         """Test that the max upload size is the configuration value."""
@@ -130,18 +132,25 @@ class FileUploaderTest(DeltaGeneratorTestCase):
             c.max_upload_size_mb, config.get_option("server.maxUploadSize")
         )
 
-    @patch("streamlit.elements.file_uploader._get_file_recs")
-    def test_unique_uploaded_file_instance(self, get_file_recs_patch):
+    @patch("streamlit.elements.file_uploader._get_upload_files")
+    def test_unique_uploaded_file_instance(self, get_upload_files_patch):
         """We should get a unique UploadedFile instance each time we access
         the file_uploader widget."""
 
         # Patch UploadFileManager to return two files
-        file_recs = [
-            UploadedFileRec(1, "file1", "type", b"123"),
-            UploadedFileRec(2, "file2", "type", b"456"),
+        rec1 = UploadedFileRec("file1", "file1", "type", b"123")
+        rec2 = UploadedFileRec("file2", "file2", "type", b"456")
+
+        uploaded_files = [
+            UploadedFile(
+                rec1, FileURLsProto(file_id="file1", delete_url="d1", upload_url="u1")
+            ),
+            UploadedFile(
+                rec2, FileURLsProto(file_id="file2", delete_url="d1", upload_url="u1")
+            ),
         ]
 
-        get_file_recs_patch.return_value = file_recs
+        get_upload_files_patch.return_value = uploaded_files
 
         # These file_uploaders have different labels so that we don't cause
         # a DuplicateKey error - but because we're patching the get_files
@@ -155,41 +164,6 @@ class FileUploaderTest(DeltaGeneratorTestCase):
         file1.seek(2)
         self.assertEqual(b"3", file1.read())
         self.assertEqual(b"123", file2.read())
-
-    @patch(
-        "streamlit.runtime.uploaded_file_manager.UploadedFileManager.remove_orphaned_files"
-    )
-    @patch("streamlit.elements.file_uploader._get_file_recs")
-    def test_remove_orphaned_files(
-        self, get_file_recs_patch, remove_orphaned_files_patch
-    ):
-        """When file_uploader is accessed, it should call
-        UploadedFileManager.remove_orphaned_files.
-        """
-        ctx = get_script_run_ctx()
-        ctx.uploaded_file_mgr._file_id_counter = 101
-
-        file_recs = [
-            UploadedFileRec(1, "file1", "type", b"123"),
-            UploadedFileRec(2, "file2", "type", b"456"),
-        ]
-        get_file_recs_patch.return_value = file_recs
-
-        st.file_uploader("foo", accept_multiple_files=True)
-
-        args, kwargs = remove_orphaned_files_patch.call_args
-        self.assertEqual(len(args), 0)
-        self.assertEqual(kwargs["session_id"], "test session id")
-        self.assertEqual(kwargs["newest_file_id"], 100)
-        self.assertEqual(kwargs["active_file_ids"], [1, 2])
-
-        # Patch _get_file_recs to return [] instead. remove_orphaned_files
-        # should not be called when file_uploader is accessed.
-        get_file_recs_patch.return_value = []
-        remove_orphaned_files_patch.reset_mock()
-
-        st.file_uploader("foo")
-        remove_orphaned_files_patch.assert_not_called()
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -26,6 +26,7 @@ from hypothesis import strategies as hst
 import streamlit as st
 import tests.streamlit.runtime.state.strategies as stst
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
 from streamlit.runtime.scriptrunner import get_script_run_ctx
@@ -37,7 +38,7 @@ from streamlit.runtime.state.session_state import (
     WidgetMetadata,
     WStates,
 )
-from streamlit.runtime.uploaded_file_manager import UploadedFileRec
+from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 from streamlit.testing.script_interactions import InteractiveScriptTests
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.testutil import patch_config_options
@@ -387,12 +388,16 @@ class SessionStateSerdeTest(DeltaGeneratorTestCase):
         )
         check_roundtrip("date_interval", date_interval)
 
-    @patch("streamlit.elements.file_uploader._get_file_recs")
-    def test_file_uploader_serde(self, get_file_recs_patch):
-        file_recs = [
-            UploadedFileRec(1, "file1", "type", b"123"),
+    @patch("streamlit.elements.file_uploader._get_upload_files")
+    def test_file_uploader_serde(self, get_upload_files_patch):
+        file_rec = UploadedFileRec("file1", "file1", "type", b"123")
+        uploaded_files = [
+            UploadedFile(
+                file_rec, FileURLsProto(file_id="1", delete_url="d1", upload_url="u1")
+            )
         ]
-        get_file_recs_patch.return_value = file_recs
+
+        get_upload_files_patch.return_value = uploaded_files
 
         uploaded_file = st.file_uploader("file_uploader", key="file_uploader")
         check_roundtrip("file_uploader", uploaded_file)

--- a/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
@@ -16,131 +16,78 @@
 
 import unittest
 
+from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.stats import CacheStat
-from streamlit.runtime.uploaded_file_manager import UploadedFileManager, UploadedFileRec
+from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from tests.exception_capturing_thread import call_on_threads
 
-FILE_1 = UploadedFileRec(file_url="url1", name="file1", type="type", data=b"file1")
-FILE_2 = UploadedFileRec(file_url="url2", name="file2", type="type", data=b"file222")
+FILE_1 = UploadedFileRec(file_id="url1", name="file1", type="type", data=b"file1")
+FILE_2 = UploadedFileRec(file_id="url2", name="file2", type="type", data=b"file222")
 
 
 class UploadedFileManagerTest(unittest.TestCase):
     def setUp(self):
-        self.mgr = UploadedFileManager()
-        self.filemgr_events = []
-        self.mgr.on_files_updated.connect(self._on_files_updated)
-
-    def _on_files_updated(self, file_list, **kwargs):
-        self.filemgr_events.append(file_list)
+        self.mgr = MemoryUploadedFileManager("/mock/upload")
 
     def test_added_file_id(self):
-        """An added file should have a unique ID."""
-        f1 = self.mgr.add_file("session", "widget", FILE_1)
-        f2 = self.mgr.add_file("session", "widget", FILE_1)
-        self.assertNotEqual(FILE_1.id, f1.id)
-        self.assertNotEqual(f1.id, f2.id)
-
-    def test_added_file_properties(self):
-        """An added file should maintain all its source properties
-        except its ID."""
-        added = self.mgr.add_file("session", "widget", FILE_1)
-        self.assertNotEqual(added.id, FILE_1.id)
-        self.assertEqual(added.name, FILE_1.name)
-        self.assertEqual(added.type, FILE_1.type)
-        self.assertEqual(added.data, FILE_1.data)
+        """Presigned file URL should have a unique ID."""
+        info1, info2 = self.mgr.get_upload_urls("session", ["name1", "name1"])
+        self.assertNotEqual(info1.file_id, info2.file_id)
 
     def test_retrieve_added_file(self):
-        """After adding a file to the mgr, we should be able to get it back."""
-        self.assertEqual([], self.mgr.get_all_files("non-report", "non-widget"))
+        """An added file should maintain all its source properties
+        except its ID."""
+        self.mgr.add_file("session", FILE_1)
+        self.mgr.add_file("session", FILE_2)
 
-        file_1 = self.mgr.add_file("session", "widget", FILE_1)
-        self.assertEqual([file_1], self.mgr.get_all_files("session", "widget"))
-        self.assertEqual([file_1], self.mgr.get_files("session", "widget", [file_1.id]))
-        self.assertEqual(len(self.filemgr_events), 1)
+        file1_from_storage, *rest_files = self.mgr.get_files("session", ["url1"])
+        self.assertEqual(len(rest_files), 0)
+        self.assertEqual(file1_from_storage.file_id, FILE_1.file_id)
+        self.assertEqual(file1_from_storage.name, FILE_1.name)
+        self.assertEqual(file1_from_storage.type, FILE_1.type)
+        self.assertEqual(file1_from_storage.data, FILE_1.data)
 
-        # Add another file
-        file_2 = self.mgr.add_file("session", "widget", FILE_2)
-        self.assertEqual([file_1, file_2], self.mgr.get_all_files("session", "widget"))
-        self.assertEqual([file_1], self.mgr.get_files("session", "widget", [file_1.id]))
-        self.assertEqual([file_2], self.mgr.get_files("session", "widget", [file_2.id]))
-        self.assertEqual(len(self.filemgr_events), 2)
+        file2_from_storage, *other_files = self.mgr.get_files("session", ["url2"])
+        self.assertEqual(len(other_files), 0)
+        self.assertEqual(file2_from_storage.file_id, FILE_2.file_id)
+        self.assertEqual(file2_from_storage.name, FILE_2.name)
+        self.assertEqual(file2_from_storage.type, FILE_2.type)
+        self.assertEqual(file2_from_storage.data, FILE_2.data)
 
     def test_remove_file(self):
         # This should not error.
-        self.mgr.remove_files("non-report", "non-widget")
+        self.mgr.remove_file("non-session", "non-file-id")
 
-        f1 = self.mgr.add_file("session", "widget", FILE_1)
-        self.mgr.remove_file("session", "widget", f1.id)
-        self.assertEqual([], self.mgr.get_all_files("session", "widget"))
+        self.mgr.add_file("session", FILE_1)
+        self.mgr.remove_file("session", FILE_1.file_id)
+        self.assertEqual([], self.mgr.get_files("session", [FILE_1.file_id]))
 
         # Remove the file again. It doesn't exist, but this isn't an error.
-        self.mgr.remove_file("session", "widget", f1.id)
-        self.assertEqual([], self.mgr.get_all_files("session", "widget"))
+        self.mgr.remove_file("session", FILE_1.file_id)
+        self.assertEqual([], self.mgr.get_files("session", [FILE_1.file_id]))
 
-        f1 = self.mgr.add_file("session", "widget", FILE_1)
-        f2 = self.mgr.add_file("session", "widget", FILE_2)
-        self.mgr.remove_file("session", "widget", f1.id)
-        self.assertEqual([f2], self.mgr.get_all_files("session", "widget"))
-
-    def test_remove_widget_files(self):
-        # This should not error.
-        self.mgr.remove_session_files("non-report")
-
-        # Add two files with different session IDs, but the same widget ID.
-        self.mgr.add_file("session1", "widget", FILE_1)
-        f2 = self.mgr.add_file("session2", "widget", FILE_1)
-
-        self.mgr.remove_files("session1", "widget")
-        self.assertEqual([], self.mgr.get_all_files("session1", "widget"))
-        self.assertEqual([f2], self.mgr.get_all_files("session2", "widget"))
+        self.mgr.add_file("session", FILE_1)
+        self.mgr.add_file("session", FILE_2)
+        self.mgr.remove_file("session", FILE_1.file_id)
+        self.assertEqual(
+            [FILE_2], self.mgr.get_files("session", [FILE_1.file_id, FILE_2.file_id])
+        )
 
     def test_remove_session_files(self):
         # This should not error.
         self.mgr.remove_session_files("non-report")
 
         # Add two files with different session IDs, but the same widget ID.
-        self.mgr.add_file("session1", "widget1", FILE_1)
-        self.mgr.add_file("session1", "widget2", FILE_1)
-        f3 = self.mgr.add_file("session2", "widget", FILE_1)
+        self.mgr.add_file("session1", FILE_1)
+        self.mgr.add_file("session1", FILE_2)
+
+        self.mgr.add_file("session2", FILE_1)
 
         self.mgr.remove_session_files("session1")
-        self.assertEqual([], self.mgr.get_all_files("session1", "widget1"))
-        self.assertEqual([], self.mgr.get_all_files("session1", "widget2"))
-        self.assertEqual([f3], self.mgr.get_all_files("session2", "widget"))
-
-    def test_remove_orphaned_files(self):
-        """Test the remove_orphaned_files behavior"""
-        f1 = self.mgr.add_file("session1", "widget1", FILE_1)
-        f2 = self.mgr.add_file("session1", "widget1", FILE_1)
-        f3 = self.mgr.add_file("session1", "widget1", FILE_1)
-        self.assertEqual([f1, f2, f3], self.mgr.get_all_files("session1", "widget1"))
-
-        # Nothing should be removed here (all files are active).
-        self.mgr.remove_orphaned_files(
-            "session1",
-            "widget1",
-            newest_file_id=f3.id,
-            active_file_ids=[f1.id, f2.id, f3.id],
+        self.assertEqual(
+            [], self.mgr.get_files("session1", [FILE_1.file_id, FILE_2.file_id])
         )
-        self.assertEqual([f1, f2, f3], self.mgr.get_all_files("session1", "widget1"))
-
-        # Nothing should be removed here (no files are active, but they're all
-        # "newer" than newest_file_id).
-        self.mgr.remove_orphaned_files(
-            "session1", "widget1", newest_file_id=f1.id - 1, active_file_ids=[]
-        )
-        self.assertEqual([f1, f2, f3], self.mgr.get_all_files("session1", "widget1"))
-
-        # f2 should be removed here (it's not in the active file list)
-        self.mgr.remove_orphaned_files(
-            "session1", "widget1", newest_file_id=f3.id, active_file_ids=[f1.id, f3.id]
-        )
-        self.assertEqual([f1, f3], self.mgr.get_all_files("session1", "widget1"))
-
-        # remove_orphaned_files on an untracked session/widget should not error
-        self.mgr.remove_orphaned_files(
-            "no_session", "no_widget", newest_file_id=0, active_file_ids=[]
-        )
+        self.assertEqual([FILE_1], self.mgr.get_files("session2", [FILE_1.file_id]))
 
     def test_cache_stats_provider(self):
         """Test CacheStatsProvider implementation."""
@@ -149,8 +96,8 @@ class UploadedFileManagerTest(unittest.TestCase):
         self.assertEqual([], self.mgr.get_stats())
 
         # Test manager with files
-        self.mgr.add_file("session1", "widget1", FILE_1)
-        self.mgr.add_file("session1", "widget2", FILE_2)
+        self.mgr.add_file("session1", FILE_1)
+        self.mgr.add_file("session1", FILE_2)
 
         expected = [
             CacheStat(
@@ -172,7 +119,7 @@ class UploadedFileManagerThreadingTest(unittest.TestCase):
     NUM_THREADS = 50
 
     def setUp(self) -> None:
-        self.mgr = UploadedFileManager()
+        self.mgr = MemoryUploadedFileManager("/mock/upload")
 
     def test_add_file(self):
         """`add_file` is thread-safe."""
@@ -181,22 +128,28 @@ class UploadedFileManagerThreadingTest(unittest.TestCase):
 
         def add_file(index: int) -> None:
             file = UploadedFileRec(
-                id=0, name=f"file_{index}", type="type", data=bytes(f"{index}", "utf-8")
+                file_id=f"id_{index}",
+                name=f"file_{index}",
+                type="type",
+                data=bytes(f"{index}", "utf-8"),
             )
-            added_files.append(self.mgr.add_file("session", f"widget_{index}", file))
+
+            self.mgr.add_file("session", file)
+            files_from_storage = self.mgr.get_files("session", [file.file_id])
+            added_files.extend(files_from_storage)
 
         call_on_threads(add_file, num_threads=self.NUM_THREADS)
 
         # Ensure all our files are present
         for ii in range(self.NUM_THREADS):
-            files = self.mgr.get_all_files("session", f"widget_{ii}")
+            files = self.mgr.get_files("session", [f"id_{ii}"])
             self.assertEqual(1, len(files))
             self.assertEqual(bytes(f"{ii}", "utf-8"), files[0].data)
 
         # Ensure all files have unique IDs
         file_ids = set()
-        for file_list in self.mgr._files_by_id.values():
-            file_ids.update(file.id for file in file_list)
+        for file_rec in self.mgr.file_storage["session"].values():
+            file_ids.add(file_rec.file_id)
         self.assertEqual(self.NUM_THREADS, len(file_ids))
 
     def test_remove_file(self):
@@ -204,79 +157,59 @@ class UploadedFileManagerThreadingTest(unittest.TestCase):
         # Add a bunch of files to a single widget
         file_ids = []
         for ii in range(self.NUM_THREADS):
-            file = UploadedFileRec(id=0, name=f"file_{ii}", type="type", data=b"123")
-            file_ids.append(self.mgr.add_file("session", "widget", file).id)
+            file = UploadedFileRec(
+                file_id=f"id_{ii}",
+                name=f"file_{ii}",
+                type="type",
+                data=b"123",
+            )
+            self.mgr.add_file("session", file)
+            file_ids.append(file.file_id)
 
         # Have each thread remove a single file
         def remove_file(index: int) -> None:
             file_id = file_ids[index]
 
             # Ensure our file exists
-            get_files_result = self.mgr.get_files("session", "widget", [file_id])
+            get_files_result = self.mgr.get_files("session", [file_id])
             self.assertEqual(1, len(get_files_result))
 
-            # Remove our file
-            was_removed = self.mgr.remove_file("session", "widget", file_id)
-            self.assertTrue(was_removed)
-
-            # Ensure our file no longer exists
-            get_files_result = self.mgr.get_files("session", "widget", [file_id])
+            # Remove our file and ensure our file no longer exists
+            self.mgr.remove_file("session", file_id)
+            get_files_result = self.mgr.get_files("session", [file_id])
             self.assertEqual(0, len(get_files_result))
 
         call_on_threads(remove_file, self.NUM_THREADS)
 
-        self.assertEqual(0, len(self.mgr.get_all_files("session", "widget")))
+        self.assertEqual(0, len(self.mgr.file_storage["session"]))
 
     def test_remove_session_files(self):
         """`remove_session_files` is thread-safe."""
         # Add a bunch of files, each to a different session
         file_ids = []
         for ii in range(self.NUM_THREADS):
-            file = UploadedFileRec(id=0, name=f"file_{ii}", type="type", data=b"123")
-            file_ids.append(self.mgr.add_file(f"session_{ii}", "widget", file).id)
+            file = UploadedFileRec(
+                file_id=f"id_{ii}",
+                name=f"file_{ii}",
+                type="type",
+                data=b"123",
+            )
+            self.mgr.add_file(f"session_{ii}", file)
+            file_ids.append(file.file_id)
 
         # Have each thread remove its session's file
         def remove_session_files(index: int) -> None:
             session_id = f"session_{index}"
             # Our file should exist
-            session_files = self.mgr.get_all_files(session_id, "widget")
+            session_files = self.mgr.get_files(session_id, [f"id_{index}"])
             self.assertEqual(1, len(session_files))
-            self.assertEqual(file_ids[index], session_files[0].id)
+            self.assertEqual(file_ids[index], session_files[0].file_id)
 
             # Remove session files
             self.mgr.remove_session_files(session_id)
 
             # Our file should no longer exist
-            session_files = self.mgr.get_all_files(session_id, "widget")
+            session_files = self.mgr.get_files(session_id, [f"id_{index}"])
             self.assertEqual(0, len(session_files))
 
         call_on_threads(remove_session_files, num_threads=self.NUM_THREADS)
-
-    def test_remove_orphaned_files(self):
-        """`remove_orphaned_files` is thread-safe."""
-        # Add a bunch of "active" files to a single widget
-        active_file_ids = []
-        for ii in range(self.NUM_THREADS):
-            file = UploadedFileRec(id=0, name=f"file_{ii}", type="type", data=b"123")
-            active_file_ids.append(self.mgr.add_file("session", "widget", file).id)
-
-        # Now add some "inactive" files to the same widget
-        inactive_file_ids = []
-        for ii in range(self.NUM_THREADS, self.NUM_THREADS + 50):
-            file = UploadedFileRec(id=0, name=f"file_{ii}", type="type", data=b"123")
-            inactive_file_ids.append(self.mgr.add_file("session", "widget", file).id)
-
-        newest_file_id = inactive_file_ids[len(inactive_file_ids) - 1] + 1
-
-        # Call `remove_orphaned_files` from each thread.
-        # Our active_files should remain intact, and our orphans should be removed!
-        def remove_orphans(_: int) -> None:
-            self.mgr.remove_orphaned_files(
-                "session", "widget", newest_file_id, active_file_ids
-            )
-            remaining_ids = [
-                file.id for file in self.mgr.get_all_files("session", "widget")
-            ]
-            self.assertEqual(sorted(active_file_ids), sorted(remaining_ids))
-
-        call_on_threads(remove_orphans, num_threads=self.NUM_THREADS)

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -87,12 +87,10 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(204, response.code, response.reason)
 
         self.assertEqual(
-            [(response.effective_url, file.name, file.data)],
+            [(file.name, file.name, file.data)],
             [
-                (rec.file_url, rec.name, rec.data)
-                for rec in self.file_mgr.get_files(
-                    "test_session_id", [response.effective_url]
-                )
+                (rec.file_id, rec.name, rec.data)
+                for rec in self.file_mgr.get_files("test_session_id", [file.name])
             ],
         )
 
@@ -188,6 +186,4 @@ class UploadFileRequestHandlerInvalidSessionTest(tornado.testing.AsyncHTTPTestCa
         response = self._upload_files(params, session_id="sessionId", file_id="fileId")
         self.assertEqual(400, response.code)
         self.assertIn("Invalid session_id: 'sessionId'", response.reason)
-        self.assertEqual(
-            self.file_mgr.get_files("sessionId", [response.effective_url]), []
-        )
+        self.assertEqual(self.file_mgr.get_files("sessionId", ["fileId"]), [])

--- a/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
+++ b/lib/tests/streamlit/web/server/upload_file_request_handler_test.py
@@ -131,9 +131,8 @@ class UploadFileRequestHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     def test_upload_missing_file_error(self):
         """Missing file should fail with 400 status."""
-        file_1 = MockFile("file1", b"123")
         file_body = {
-            file_1.name: None,
+            "file1": (None, b"123"),
         }
         response = self._upload_files(
             file_body, session_id="sessionId", file_id="fileId"


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

This PR mostly adds docstring and fix python unit tests that now work with new file_uploader logic.

Also, it introduces a concept of `DeletedFile` that we use as a placeholder in situations when we have info about a file from a frontend proto message, but the file is missing in file storage (because it was removed earlier).

This situation happens when we for example compare the old state and the new state after file deletion, to trigger the `on_change` callback. 

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
