### PR TITLE
Update st.audio/st.video docstrings

### DIFF
--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -52,8 +52,7 @@ class MediaMixin:
 
         Parameters
         ----------
-        data : str, bytes, BytesIO, numpy.ndarray, or file opened with
-                io.open().
+        data : str, bytes, BytesIO, numpy.ndarray, or file
             Raw audio data, filename, or a URL pointing to the file to load.
             Raw data formats must include all necessary file headers to match the file
             format specified via ``format``.
@@ -124,8 +123,7 @@ class MediaMixin:
 
         Parameters
         ----------
-        data : str, bytes, BytesIO, numpy.ndarray, or file opened with
-                io.open().
+        data : str, bytes, BytesIO, numpy.ndarray, or file
             Raw video data, filename, or URL pointing to a video to load.
             Includes support for YouTube URLs.
             Numpy arrays and raw data formats must include all necessary file


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

The API reference for `st.audio` and `st.video` has a visual bug, where the last part of the type descriptor for `data` is added to the description: 

![CleanShot 2023-07-07 at 18 18 39](https://github.com/streamlit/streamlit/assets/5103165/ec43d64e-dc04-4b14-a166-6943132d6fe3)

While trying to fix this, I realized that we should probably just say "..., or file" instead of "..., or file opened with io.open()". `io.open()` is just a wrapper around Python's built-in `open()` method, and the return objects of this function are commonly described simply as "files" or "file objects", see [here](https://docs.python.org/3/glossary.html#term-file-object).

## GitHub Issue Link (if applicable)

## Testing Plan

Just docstring change, no test needed. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
