### PR TITLE
Fix baseweb warnings by using longhand properties

### DIFF
--- a/frontend/src/lib/components/shared/AlertContainer/AlertContainer.tsx
+++ b/frontend/src/lib/components/shared/AlertContainer/AlertContainer.tsx
@@ -81,7 +81,10 @@ export default function AlertContainer({
             marginRight: 0,
             width: width ? width.toString() : undefined,
             border: 0,
-            borderRadius: radii.lg,
+            borderTopRightRadius: radii.lg,
+            borderBottomRightRadius: radii.lg,
+            borderTopLeftRadius: radii.lg,
+            borderBottomLeftRadius: radii.lg,
           },
         },
         InnerContainer: {


### PR DESCRIPTION
## Describe your changes

[This PR](https://github.com/streamlit/streamlit/pull/6944) added some unwanted baseweb warnings:

<img width="651" alt="Screenshot 2023-07-10 at 19 45 40" src="https://github.com/streamlit/streamlit/assets/2852129/85e407bb-af8a-46ed-a60f-6dfae7464b46">

This PR fixes the warnings by using longhand props instead.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
