### PR TITLE
Re-add homepage to package.json

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -3,6 +3,7 @@
   "version": "1.24.1",
   "license": "Apache-2.0",
   "private": true,
+  "homepage": "./",
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "env NODE_OPTIONS=--max_old_space_size=8192 ESLINT_NO_DEV_ERRORS=true craco start",


### PR DESCRIPTION
## Describe your changes

We removed the reference to the homepage as a part of the st-lib merge https://github.com/streamlit/streamlit/pull/6692 This part is unfortunately very important because it instructs how the JS assets are accessed in the HTML.

See [React Scripts testing the homepage](https://github.com/facebook/create-react-app/blob/main/packages/react-dev-utils/getPublicUrlOrPath.js#L47)

## Testing Plan

Let's deploy the core previews and check

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
