### PR TITLE
Exclude broken jsonschema version

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -60,6 +60,9 @@ INSTALL_REQUIRES = [
     "typing-extensions>=4.1.0, <5",
     "tzlocal>=1.1, <5",
     "validators>=0.2, <1",
+    # jsonschema is a dependency of altair. The patch version 4.18.1 seems to be broken
+    # resulting in the error mentioned here: https://github.com/python-jsonschema/jsonschema/issues/1124
+    "jsonschema!=4.18.1",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
     "watchdog>=2.1.5; platform_system != 'Darwin'",


### PR DESCRIPTION
## Describe your changes

The latest jsonschema version breaks Streamlit:

<img width="728" alt="image" src="https://github.com/streamlit/streamlit/assets/2852129/8c3ad288-ef75-4799-a14c-576aea1d7d87">

This seems to be a regression in the `4.18.1` version which is tracked here:

https://github.com/python-jsonschema/jsonschema/issues/1124

This PR excludes this specific version in the `setup.py` dependencies.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
