### PR TITLE
Ignore iframe resizer anchor for apps with `st.chat_input`

### DIFF
--- a/e2e/specs/embedded_chat_input_app.js
+++ b/e2e/specs/embedded_chat_input_app.js
@@ -36,4 +36,8 @@ describe("embedded app with chat input", () => {
       "16px" // == 1rem
     );
   });
+
+  it("not have an iframe resizer anchor", () => {
+    cy.get(`[data-testid="IframeResizerAnchor"]`).should("not.exist");
+  });
 });

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -195,11 +195,15 @@ function AppView(props: AppViewProps): ReactElement {
       >
         {renderBlock(elements.main)}
         {/* Anchor indicates to the iframe resizer that this is the lowest
-        possible point to determine height */}
-        <StyledIFrameResizerAnchor
-          hasFooter={!embedded || showFooter}
-          data-iframe-height
-        />
+        possible point to determine height. But we don't add an anchor if there is a
+        bottom pinned chat_input in the app, since those two aspects don't work well together.
+        */}
+        {!containsChatInput && (
+          <StyledIFrameResizerAnchor
+            hasFooter={!embedded || showFooter}
+            data-iframe-height
+          />
+        )}
         {/* Spacer fills up dead space to ensure the footer remains at the
         bottom of the page in larger views */}
         {(!embedded || showFooter) && (

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -195,9 +195,9 @@ function AppView(props: AppViewProps): ReactElement {
       >
         {renderBlock(elements.main)}
         {/* Anchor indicates to the iframe resizer that this is the lowest
-        possible point to determine height. But we don't add an anchor if there is a
-        bottom pinned chat_input in the app, since those two aspects don't work well together.
-        */}
+        possible point to determine height. But we don't add an anchor if there is
+        a bottom pinned chat_input in the app, since those two aspects don't work
+        well together. */}
         {!containsChatInput && (
           <StyledIFrameResizerAnchor
             hasFooter={!embedded || showFooter}

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -201,6 +201,7 @@ function AppView(props: AppViewProps): ReactElement {
         {!containsChatInput && (
           <StyledIFrameResizerAnchor
             hasFooter={!embedded || showFooter}
+            data-testid="IframeResizerAnchor"
             data-iframe-height
           />
         )}


### PR DESCRIPTION
## Describe your changes

The iframe resizer feature does not work well with apps with a bottom pinned `st.chat_input`. As a quick fix, we don't add the iframe resizer if the app contains a `chat_input`.

> **Note**
> This is likely more of a temporary quick fix. I'm planning to eventually do a refactoring of some of these aspects as part of the chat follow-up work (tracked [here](https://www.notion.so/snowflake-corp/Refactor-bottom-pinned-chat-input-06a7028265a242c895539e48bea8a188)) to 1) handle those special cases better 2) support chat input usage in the sidebar and inline in app. 3) potentially moving it to it's own bottom root container.

## Testing Plan

- Added e2e test to check that iframe resizer anchor does not exist on page.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
