### PR TITLE
ignore Enter on inputing with IME

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -62,8 +62,8 @@ const isEnterKeyPressed = (
 
   const { keyCode, key } = event
   return (
-      (key === "Enter" || keyCode === 13 || keyCode === 10) &&
-      !event.nativeEvent.isComposing
+    (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+    !event.nativeEvent.isComposing
   )
 }
 

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -63,6 +63,7 @@ const isEnterKeyPressed = (
   const { keyCode, key } = event
   return (
     (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+    // Do not send the sentence being composed when Enter is typed into the IME.
     !event.nativeEvent.isComposing
   )
 }

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -61,7 +61,10 @@ const isEnterKeyPressed = (
   // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
 
   const { keyCode, key } = event
-  return key === "Enter" || keyCode === 13 || keyCode === 10
+  return (
+      (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+      !event.nativeEvent.isComposing
+  )
 }
 
 function ChatInput({ width, element, widgetMgr }: Props): React.ReactElement {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -64,7 +64,7 @@ const isEnterKeyPressed = (
   return (
     (key === "Enter" || keyCode === 13 || keyCode === 10) &&
     // Do not send the sentence being composed when Enter is typed into the IME.
-    !event.nativeEvent.isComposing
+    !(event.nativeEvent?.isComposing === true)
   )
 }
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -165,7 +165,10 @@ class TextArea extends React.PureComponent<Props, State> {
 
     // Using keyCode as well due to some different behaviors on Windows
     // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
-    return key === "Enter" || keyCode === 13 || keyCode === 10
+    return (
+        (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+        !event.nativeEvent.isComposing
+    )
   }
 
   private onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -168,7 +168,7 @@ class TextArea extends React.PureComponent<Props, State> {
     return (
       (key === "Enter" || keyCode === 13 || keyCode === 10) &&
       // Do not send the sentence being composed when Enter is typed into the IME.
-      !event.nativeEvent.isComposing
+      !(event.nativeEvent?.isComposing === true)
     )
   }
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -167,6 +167,7 @@ class TextArea extends React.PureComponent<Props, State> {
     // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
     return (
       (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+      // Do not send the sentence being composed when Enter is typed into the IME.
       !event.nativeEvent.isComposing
     )
   }

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -166,8 +166,8 @@ class TextArea extends React.PureComponent<Props, State> {
     // Using keyCode as well due to some different behaviors on Windows
     // https://bugs.chromium.org/p/chromium/issues/detail?id=79407
     return (
-        (key === "Enter" || keyCode === 13 || keyCode === 10) &&
-        !event.nativeEvent.isComposing
+      (key === "Enter" || keyCode === 13 || keyCode === 10) &&
+      !event.nativeEvent.isComposing
     )
   }
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
When the user types Japanese or Chinese with IME, we use "Enter" not only to send but also to confirm the character conversion.
If the application captures the "composing Enter" event as send text, it's awkward, because it results in sending even though we're still inputing the words.
This seems to be a common problem. See the follow issue on React.
https://github.com/streamlit/streamlit/pull/6992

For example, when I want to input the sentence in Japanese "私(watashi)は(ha)人(hito)です(desu)" , I press the following keys.
"watashi<convert_key><enter>ha<enter>hito<convert_key><enter>desu<enter>"
As a result, the first <enter> is captured, and just "私(watashi)" is sent as a message.

To solve this problem, I found the `isComposing` field in nativeEvent, and I found that ignoring the `isComposing` event gave me comfortable input.
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
