### PR TITLE
Docs/toast - update of parameter description

### DIFF
--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -47,9 +47,8 @@ class ToastMixin:
         Parameters
         ----------
         body : str
-            Short message for the toast. The message can optionally contain
-            Markdown and supports the following elements: Bold, Italics,
-            Strikethroughs, Inline Code, Emojis, and Links.
+            The string to display as Github-flavored Markdown. Syntax
+            information can be found at: https://github.github.com/gfm.
 
             This also supports:
 
@@ -64,10 +63,6 @@ class ToastMixin:
             * Colored text, using the syntax ``:color[text to be colored]``,
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet.
-
-            Unsupported elements are unwrapped so only their children (text
-            contents) render. Display unsupported elements as literal characters
-            by backslash-escaping them. E.g. 1\. Not an ordered list.
         icon : str or None
             An optional, keyword-only argument that specifies an emoji to use as
             the icon for the toast. Shortcodes are not allowed, please use a


### PR DESCRIPTION
## Describe your changes
The description of the `body` parameter was updated to match the description of `body` used in `st.markdown`. Some restrictive language was removed that no longer applies.

## Testing Plan
No testing needed; docstring update only.

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.