### PR TITLE
Fix a bunch of FileUploader js unit tests

### DIFF
--- a/frontend/lib/src/FileUploadClient.test.ts
+++ b/frontend/lib/src/FileUploadClient.test.ts
@@ -141,6 +141,8 @@ describe("FileUploadClient Upload", () => {
   })
 
   it("onFileURLsResponse rejects promise on errorMsg", () => {
+    const fileURLsPromise = uploader.fetchFileURLs([])
+
     // @ts-expect-error
     const pendingReqs = uploader.pendingFileURLsRequests
     const reqId = pendingReqs.keys().next().value
@@ -155,6 +157,8 @@ describe("FileUploadClient Upload", () => {
   })
 
   it("onFileURLsResponse resolves promise on success", () => {
+    const fileURLsPromise = uploader.fetchFileURLs([])
+
     // @ts-expect-error
     const pendingReqs = uploader.pendingFileURLsRequests
     const reqId = pendingReqs.keys().next().value

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -87,7 +87,6 @@ describe("CameraInput widget", () => {
     const wrapper = shallow(<CameraInput {...props} />)
     expect(wrapper.state()).toEqual({
       files: [],
-      newestServerFileId: 0,
       clearPhotoInProgress: false,
       facingMode: FacingMode.USER,
       imgSrc: null,
@@ -198,7 +197,6 @@ describe("CameraInput widget", () => {
     await wrapper.instance().removeCapture()
     expect(wrapper.state()).toEqual({
       files: [],
-      newestServerFileId: 1,
       clearPhotoInProgress: true,
       facingMode: FacingMode.USER,
       imgSrc: null,

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -250,14 +250,15 @@ class FileUploader extends React.PureComponent<Props, State> {
     this.props.uploadClient
       .fetchFileURLs(acceptedFiles)
       .then((fileURLsArray: IFileURLs[]) => {
-        // If this is a single-file uploader that already has a file,
+        // If this is a single-file uploader that already has an uploaded file,
         // remove that file so that it can be replaced with our new one.
-        if (
-          !multipleFiles &&
-          acceptedFiles.length > 0 &&
-          this.state.files.length > 0
-        ) {
-          this.deleteFile(this.state.files[0].id)
+        if (!multipleFiles && acceptedFiles.length > 0) {
+          const existingFile = this.state.files.find(
+            f => f.status.type !== "error"
+          )
+          if (existingFile) {
+            this.deleteFile(existingFile.id)
+          }
         }
 
         _.zip(fileURLsArray, acceptedFiles).forEach(

--- a/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/UploadedFile.test.tsx
@@ -34,8 +34,7 @@ describe("FileStatus widget", () => {
     const props = getProps({
       type: "uploaded",
       fileId: "fileId",
-      uploadFileURL: "uploadUrl",
-      deleteFileURL: "deleteUrl",
+      fileUrls: {},
     })
     const wrapper = shallow(<UploadedFileStatus {...props} />)
 
@@ -68,8 +67,7 @@ describe("FileStatus widget", () => {
     const props = getProps({
       type: "uploaded",
       fileId: "fileId",
-      uploadFileURL: "uploadUrl",
-      deleteFileURL: "deleteUrl",
+      fileUrls: {},
     })
 
     const wrapper = shallow(<UploadedFileStatus {...props} />)
@@ -83,21 +81,7 @@ describe("UploadedFile widget", () => {
     const props = getProps({
       type: "uploaded",
       fileId: "fileId",
-      uploadFileURL: "uploadUrl",
-      deleteFileURL: "deleteUrl",
-    })
-    const wrapper = shallow(<UploadedFile {...props} />)
-
-    expect(wrapper).toBeDefined()
-    expect(wrapper.text()).toContain("filename.txt")
-  })
-
-  it("calls delete callback", () => {
-    const props = getProps({
-      type: "uploaded",
-      fileId: "fileId",
-      uploadFileURL: "uploadUrl",
-      deleteFileURL: "deleteUrl",
+      fileUrls: {},
     })
     const wrapper = mount(<UploadedFile {...props} />)
     const deleteBtn = wrapper.find("button")


### PR DESCRIPTION
This PR fixes most of the `FileUploader` JS unit tests that the work on the feature branch
previously broke. Note that some of the `CameraInput` tests are still broken, but those can
be fixed in subsequent PRs.
