### PR TITLE
Update st.selectbox description of placeholder

### DIFF
--- a/lib/streamlit/elements/selectbox.py
+++ b/lib/streamlit/elements/selectbox.py
@@ -138,6 +138,10 @@ class SelectboxMixin:
             An optional dict of kwargs to pass to the callback.
         placeholder : str
             A string to display when no options are selected. Defaults to 'Select...'.
+
+            A selectbox can't be empty, so a placeholder only displays while a
+            user's cursor is in a selectbox after manually deleting the current
+            selection. A future update will allow selectboxes to be empty.
         disabled : bool
             An optional boolean, which disables the selectbox if set to True.
             The default is False. This argument can only be supplied by keyword.


### PR DESCRIPTION
This commit updates the description of the `placeholder` parameter for `st.selectbox`. Since an empty selection is not yet possible, clarification was added about the limited application of this parameter to avoid confusion.

## Describe your changes
Docstring edit only.

## Testing Plan
None. Documentation only.

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
