### PR TITLE
Fixes Secrets File Path Escape Behavior on Windows ( #6147)

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -210,7 +210,7 @@ class Secrets(Mapping[str, Any]):
             if not found_secrets_file:
                 err_msg = f"No secrets files found. Valid paths for a secrets.toml file are: {', '.join(self._file_paths)}"
                 if print_exceptions:
-                    st.error(err_msg)
+                    st.error(err_msg.replace("\\.","\\\\."))
                 raise FileNotFoundError(err_msg)
 
             if len([p for p in self._file_paths if os.path.exists(p)]) > 1:


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Changed escape behaviour for "\" for Secrets file path on Windows.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/6147

## Testing Plan

- Explanation of why no additional tests are needed
Just edits the err_msg being set to st.error(), and doesn't modify the original err_msg variable, so shouldn't cause any other conflicts. 
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
