### PR TITLE
Bump protobufjs to 7.2.4

### DIFF
--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -66,7 +66,7 @@
         "node-emoji": "^1.11.0",
         "numbro": "^2.3.6",
         "plotly.js": "^2.18.1",
-        "protobufjs": "^7.2.0",
+        "protobufjs": "^7.2.4",
         "protobufjs-cli": "^1.1.0",
         "query-string": "^8.1.0",
         "re-resizable": "^6.9.9",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13938,7 +13938,7 @@ protobufjs-cli@^1.1.0:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@^7.2.0:
+protobufjs@^7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
   integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Context
https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-5756498

## Describe your changes
Bump protobuf js to 7.2.4 in the `package.json`
## GitHub Issue Link (if applicable)

## Testing Plan
N/A
- Explanation of why no additional tests are needed
- just a bump of version. if ci passes, that should be enough
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?
No
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
