### PR TITLE
Allow conda build number to be set via envvar

### DIFF
--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -27,10 +27,7 @@ source:
   path: ..
 
 build:
-  # NOTE: The build number is set because it's required, but it's essentially
-  # unused since the GIT_HASH uniquely identifies this build.
   number: {{ environ.get('CONDA_BUILD_NUMBER', 0)|int }}
-  string: {{ environ.get('GIT_HASH') }}
   noarch: python
   script: python -m pip install . -vv
   entry_points:

--- a/lib/conda-recipe/meta.yaml
+++ b/lib/conda-recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
 build:
   # NOTE: The build number is set because it's required, but it's essentially
   # unused since the GIT_HASH uniquely identifies this build.
-  number: 0
+  number: {{ environ.get('CONDA_BUILD_NUMBER', 0)|int }}
   string: {{ environ.get('GIT_HASH') }}
   noarch: python
   script: python -m pip install . -vv


### PR DESCRIPTION
We may (very rarely) need to create Streamlit conda builds of a version tag that we've
already made a build for. To make these cases easier, we slightly modify our `meta.yaml`
file to read a `CONDA_BUILD_NUMBER` envvar that can be used to set a build number. If
no envvar is set, then the build number defaults to 0.