### PR TITLE
Fix: AppNode compatible w/o Event in RootContainer

### DIFF
--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -16,7 +16,7 @@
 
 import { produce } from "immer"
 import { Map as ImmutableMap } from "immutable"
-import Protobuf, {
+import {
   Arrow as ArrowProto,
   ArrowNamedDataSet,
   ArrowVegaLiteChart as ArrowVegaLiteChartProto,
@@ -495,15 +495,21 @@ export class AppRoot {
   }
 
   public get main(): BlockNode {
-    return this.root.children[Protobuf.RootContainer.MAIN] as BlockNode
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [main, sidebar, event] = this.root.children
+    return main as BlockNode
   }
 
   public get sidebar(): BlockNode {
-    return this.root.children[Protobuf.RootContainer.SIDEBAR] as BlockNode
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [main, sidebar, event] = this.root.children
+    return sidebar as BlockNode
   }
 
   public get event(): BlockNode {
-    return this.root.children[Protobuf.RootContainer.EVENT] as BlockNode
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [main, sidebar, event] = this.root.children
+    return event as BlockNode
   }
 
   public applyDelta(

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -495,20 +495,17 @@ export class AppRoot {
   }
 
   public get main(): BlockNode {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [main, sidebar, event] = this.root.children
+    const [main, ,] = this.root.children
     return main as BlockNode
   }
 
   public get sidebar(): BlockNode {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [main, sidebar, event] = this.root.children
+    const [, sidebar] = this.root.children
     return sidebar as BlockNode
   }
 
   public get event(): BlockNode {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [main, sidebar, event] = this.root.children
+    const [, , event] = this.root.children
     return event as BlockNode
   }
 


### PR DESCRIPTION
## Describe your changes
Updated `AppNode.ts` not to rely on having an Event field in the RootContainer proto - don't use RootContainer proto values as index value.

## Testing Plan

- Tests already in place for Open Source purposes
- Manually tested by removing event from BE and field from RootContainer

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
