### PR TITLE
`USE_CONSTRAINT_FILE` should be plural

### DIFF
--- a/.github/actions/build_info/action.yml
+++ b/.github/actions/build_info/action.yml
@@ -22,9 +22,9 @@ outputs:
   PYTHON_MAX_VERSION:
     description: Latest version of Python supported by Streamlit
     value: ${{ steps.build_info.outputs.PYTHON_MAX_VERSION }}
-  USE_CONSTRAINT_FILE:
+  USE_CONSTRAINTS_FILE:
     description: Whether to use a constraint file to install Python dependencies
-    value: ${{ steps.build_info.outputs.USE_CONSTRAINT_FILE }}
+    value: ${{ steps.build_info.outputs.USE_CONSTRAINTS_FILE }}
 
 runs:
   using: composite

--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -267,7 +267,7 @@ def get_output_variables() -> Dict[str, str]:
         )
         else [ALL_PYTHON_VERSIONS[0], ALL_PYTHON_VERSIONS[-1]]
     )
-    use_constraint_file = not (
+    use_constraints_file = not (
         canary_build
         or check_if_pr_has_label(
             LABEL_UPGRADE_DEPENDENCIES, "Latest dependencies will be used"
@@ -277,7 +277,7 @@ def get_output_variables() -> Dict[str, str]:
         "PYTHON_MIN_VERSION": PYTHON_MIN_VERSION,
         "PYTHON_MAX_VERSION": PYTHON_MAX_VERSION,
         "PYTHON_VERSIONS": json.dumps(python_versions),
-        "USE_CONSTRAINT_FILE": str(use_constraint_file).lower(),
+        "USE_CONSTRAINTS_FILE": str(use_constraints_file).lower(),
     }
     # Environment variables can be overridden at job level and we don't want
     # to change them then.

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -64,7 +64,7 @@ jobs:
       PYTHON_VERSIONS: ${{ steps.build_info.outputs.PYTHON_VERSIONS }}
       PYTHON_MIN_VERSION: ${{ steps.build_info.outputs.PYTHON_MIN_VERSION }}
       PYTHON_MAX_VERSION: ${{ steps.build_info.outputs.PYTHON_MAX_VERSION }}
-      USE_CONSTRAINT_FILE: ${{ steps.build_info.outputs.USE_CONSTRAINT_FILE }}
+      USE_CONSTRAINTS_FILE: ${{ steps.build_info.outputs.USE_CONSTRAINTS_FILE }}
 
   py_version:
     needs:
@@ -88,7 +88,7 @@ jobs:
             (matrix.python_version == 'max' && needs.build_info.outputs.PYTHON_MAX_VERSION || matrix.python_version)
           )
         }}
-      USE_CONSTRAINT_FILE: "${{ fromJson(needs.build_info.outputs.USE_CONSTRAINT_FILE )}}"
+      USE_CONSTRAINTS_FILE: "${{ fromJson(needs.build_info.outputs.USE_CONSTRAINTS_FILE )}}"
       CONSTRAINTS_BRANCH: ${{ inputs.constraints-branch || 'constraints-develop' }}
 
     steps:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -42,7 +42,7 @@ jobs:
 
     env:
       # We don't want to use constraints files because they might not exist yet.
-      USE_CONSTRAINT_FILE: "false"
+      USE_CONSTRAINTS_FILE: "false"
 
     steps:
       - name: Checkout Streamlit code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       # for the current release
       CONSTRAINTS_TAG: constraints/${{ github.ref_name }}
       # We don't want to use constraints files because they might not exist yet.
-      USE_CONSTRAINT_FILE: "false"
+      USE_CONSTRAINTS_FILE: "false"
 
     steps:
       - name: Checkout Streamlit code

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SHELL=/bin/bash
 
 INSTALL_DEV_REQS ?= true
 INSTALL_TEST_REQS ?= true
-USE_CONSTRAINT_FILE ?= true
+USE_CONSTRAINTS_FILE ?= true
 PYTHON_VERSION := $(shell python --version | cut -d " " -f 2 | cut -d "." -f 1-2)
 GITHUB_REPOSITORY ?= streamlit/streamlit
 CONSTRAINTS_BRANCH ?= constraints-develop
@@ -103,7 +103,7 @@ python-init-test-min-deps:
 .PHONY: python-init
 python-init:
 	pip_args=("--editable" "lib[snowflake]");\
-	if [ "${USE_CONSTRAINT_FILE}" = "true" ] ; then\
+	if [ "${USE_CONSTRAINTS_FILE}" = "true" ] ; then\
 		pip_args+=(--constraint "${CONSTRAINTS_URL}"); \
 	fi;\
 	if [ "${INSTALL_DEV_REQS}" = "true" ] ; then\


### PR DESCRIPTION
The min deps workflow is running incorrectly on canary builds because it sets `USE_CONSTRAINTS_FILE`, which is a typo. We fix the issue here by changing the envvar everywhere else, to be plural, which makes it consistent with other envvars.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
