### PR TITLE
Make background color transparent for tabs

### DIFF
--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -146,6 +146,7 @@ function Tabs(props: TabProps): ReactElement {
                     paddingTop: theme.spacing.none,
                     paddingBottom: theme.spacing.none,
                     fontSize: theme.fontSizes.sm,
+                    background: "transparent",
                     color: widgetsDisabled
                       ? theme.colors.fadedText40
                       : theme.colors.bodyText,


### PR DESCRIPTION
## Describe your changes

This PR fixes https://github.com/streamlit/streamlit/issues/5707 by making the tabs `background-color` transparent by default.

**Before:**

<img width="213" alt="202043415-bfb4db98-cc5e-4390-b3b6-8e307994416e" src="https://github.com/streamlit/streamlit/assets/103376966/5a59b7e9-7450-4d12-969e-452e2966cb5e">

**After:**

<img width="1728" alt="Screenshot 2023-07-25 at 11 22 33 AM" src="https://github.com/streamlit/streamlit/assets/103376966/27d7d050-99e2-4405-8257-58a5ea1e318a">

## GitHub Issue Link (if applicable)

- https://github.com/streamlit/streamlit/issues/5707

## Testing Plan

- Explanation of why no additional tests are needed: Bugfix, all tests are in place already
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
