### PR TITLE
Use filetype dependency instead of imghdr

### DIFF
--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -42,7 +42,7 @@ ignore_missing_imports = True
 [mypy-pympler.*]
 ignore_missing_imports = True
 
-[mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,graphviz,matplotlib.*,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,seaborn,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers]
+[mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,graphviz,matplotlib.*,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,seaborn,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers, filetype]
 ignore_missing_imports = true
 
 [mypy-semver.*]

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -42,8 +42,11 @@ ignore_missing_imports = True
 [mypy-pympler.*]
 ignore_missing_imports = True
 
-[mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,graphviz,matplotlib.*,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,seaborn,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers, filetype]
+[mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,graphviz,matplotlib.*,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,seaborn,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers]
 ignore_missing_imports = true
+
+[mypy-filetype.*]
+ignore_missing_imports = True
 
 [mypy-semver.*]
 ignore_missing_imports = True

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     # Lowest version with available wheel for 3.7 + amd64 + linux
     "pandas>=1.3.0, <3",
     "pillow>=7.1.0, <10",
-    "filetype>=1.0"
+    "filetype>=1.0",
     # Python protobuf 4.21 (the first 4.x version) is compatible with protobufs
     # generated from `protoc` >= 3.20. (`protoc` is installed separately from the Python
     # protobuf package, so this pin doesn't actually enforce a `protoc` minimum version.

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -42,6 +42,7 @@ INSTALL_REQUIRES = [
     # Lowest version with available wheel for 3.7 + amd64 + linux
     "pandas>=1.3.0, <3",
     "pillow>=7.1.0, <10",
+    "filetype>=1.0"
     # Python protobuf 4.21 (the first 4.x version) is compatible with protobufs
     # generated from `protoc` >= 3.20. (`protoc` is installed separately from the Python
     # protobuf package, so this pin doesn't actually enforce a `protoc` minimum version.

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     # Lowest version with available wheel for 3.7 + amd64 + linux
     "pandas>=1.3.0, <3",
     "pillow>=7.1.0, <10",
-    "filetype>=1.0",
+    "filetype>=0.1.0, <1.0.0",
     # Python protobuf 4.21 (the first 4.x version) is compatible with protobufs
     # generated from `protoc` >= 3.20. (`protoc` is installed separately from the Python
     # protobuf package, so this pin doesn't actually enforce a `protoc` minimum version.

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -300,11 +300,8 @@ def _ensure_image_size_and_format(
         image = image.resize((width, new_height), resample=Image.BILINEAR)
         return _PIL_to_bytes(image, format=image_format, quality=90)
 
-    pillow_detected_format = image.format
-    if (
-        pillow_detected_format != None
-        and pillow_detected_format != image_format.lower()
-    ):
+    ext = filetype.guess(image_data)
+    if ext != None and ext != image_format.lower():
         # We need to reformat the image.
         return _PIL_to_bytes(image, format=image_format, quality=90)
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -300,7 +300,11 @@ def _ensure_image_size_and_format(
         image = image.resize((width, new_height), resample=Image.BILINEAR)
         return _PIL_to_bytes(image, format=image_format, quality=90)
 
-    ext = filetype.guess(image_data)
+    ext = filetype.guess(image_data).extension
+
+    # We are forgiving on the spelling of JPEG
+    if ext == "jpg":
+        ext = "jpeg"
     if ext != None and ext != image_format.lower():
         # We need to reformat the image.
         return _PIL_to_bytes(image, format=image_format, quality=90)

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -19,7 +19,6 @@
 
 """Image marshalling."""
 
-import imghdr
 import io
 import mimetypes
 import re
@@ -27,6 +26,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 from urllib.parse import urlparse
 
+import filetype
 import numpy as np
 from PIL import GifImagePlugin, Image, ImageFile
 from typing_extensions import Final, Literal, TypeAlias
@@ -300,8 +300,11 @@ def _ensure_image_size_and_format(
         image = image.resize((width, new_height), resample=Image.BILINEAR)
         return _PIL_to_bytes(image, format=image_format, quality=90)
 
-    ext = imghdr.what(None, image_data)
-    if ext != image_format.lower():
+    pillow_detected_format = image.format
+    if (
+        pillow_detected_format != None
+        and pillow_detected_format != image_format.lower()
+    ):
         # We need to reformat the image.
         return _PIL_to_bytes(image, format=image_format, quality=90)
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Context
There are 3 libraries that should replace `imghdr`: 
<img width="798" alt="Screenshot 2023-07-26 at 2 31 21 PM" src="https://github.com/streamlit/streamlit/assets/16749069/fa41965c-da7d-412c-bf78-3f9276614c49">
https://peps.python.org/pep-0594/#deprecated-modules

1. puremagic
  a. it is smaller lib (365 KB) 
  b. **However, attempted to incorporate the library but it didn't end up working and api documentation is sparse.**
     1. branch attempt on: https://github.com/streamlit/streamlit/tree/fix/7027_puremagic
2. python-magic
  a. no go almost surely; needs a separate installation of libmagic which is a c library
3. filetype
  a. easy api with documentation (https://h2non.github.io/filetype.py/v1.0.0/filetype.m.html)
  b. it ends up working and seems like an easy change
## Describe your changes
- replace `imghdr` with `filetype`
## GitHub Issue Link (if applicable)
- https://github.com/streamlit/streamlit/issues/7027
## Testing Plan
I attempted to fix e2e tests and unit tests
- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?
  - none needed from my perspective

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
