### PR TITLE
Fix flaky playwright test

### DIFF
--- a/e2e/playwright/conftest.py
+++ b/e2e/playwright/conftest.py
@@ -146,14 +146,15 @@ def wait_for_app_server_to_start(port: int, timeout: int = 5) -> bool:
     return True
 
 
-def wait_for_app_run(page: Page):
+def wait_for_app_run(page: Page, wait_delay: int = 100):
     """Wait for the given page to finish running."""
     page.wait_for_selector(
         "[data-testid='stStatusWidget']", timeout=20000, state="detached"
     )
-    # Give the app a little more time to render everything
-    # TODO(lukasmasuch): Do we need this to reduce flakiness?
-    # page.wait_for_timeout(500)
+
+    if wait_delay > 0:
+        # Give the app a little more time to render everything
+        page.wait_for_timeout(wait_delay)
 
 
 def wait_for_app_loaded(page: Page):

--- a/e2e/playwright/st_checkbox_test.py
+++ b/e2e/playwright/st_checkbox_test.py
@@ -59,7 +59,7 @@ def test_checkbox_values_on_click(app: Page):
     for checkbox_element in checkbox_elements.all():
         checkbox_element.click(delay=50)
     # The app run needs to finish before we can check the values.
-    wait_for_app_run(app)
+    wait_for_app_run(app, 500)
 
     markdown_elements = app.locator(".stMarkdown")
     texts = [text.strip() for text in markdown_elements.all_inner_texts()]


### PR DESCRIPTION
## Describe your changes

This PR adds back a small timeout to allow the app some additional time for rendering after the status icon has disappeared. Without this timeout, there is some flakiness in some tests. I previously had this timeout to lower the flakiness risk, but removed it since it seemed to work fine without it.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
