### PR TITLE
Replace imghdr with pillow

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -372,7 +372,6 @@ def image_to_url(
 
     # PIL Images
     elif isinstance(image, (ImageFile.ImageFile, Image.Image)):
-        print("Getting a pil image")
         format = _validate_image_format_string(image, output_format)
         image_data = _PIL_to_bytes(image, format)
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -287,8 +287,8 @@ def _ensure_image_size_and_format(
     MAXIMUM_CONTENT_WIDTH. Ensure the image's format corresponds to the given
     ImageFormat. Return the (possibly resized and reformatted) image bytes.
     """
-    pillow_image = Image.open(io.BytesIO(image_data))
-    actual_width, actual_height = pillow_image.size
+    pil_image = Image.open(io.BytesIO(image_data))
+    actual_width, actual_height = pil_image.size
 
     if width < 0 and actual_width > MAXIMUM_CONTENT_WIDTH:
         width = MAXIMUM_CONTENT_WIDTH
@@ -296,13 +296,12 @@ def _ensure_image_size_and_format(
     if width > 0 and actual_width > width:
         # We need to resize the image.
         new_height = int(1.0 * actual_height * width / actual_width)
-        pillow_image = pillow_image.resize((width, new_height), resample=Image.BILINEAR)
-        return _PIL_to_bytes(pillow_image, format=image_format, quality=90)
+        pil_image = pil_image.resize((width, new_height), resample=Image.BILINEAR)
+        return _PIL_to_bytes(pil_image, format=image_format, quality=90)
 
-    pillow_detected_format = pillow_image.format
-    if pillow_detected_format != image_format:
+    if pil_image.format != image_format:
         # We need to reformat the image.
-        return _PIL_to_bytes(pillow_image, format=image_format, quality=90)
+        return _PIL_to_bytes(pil_image, format=image_format, quality=90)
 
     # No resizing or reformatting necessary - return the original bytes.
     return image_data

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -19,7 +19,6 @@
 
 """Image marshalling."""
 
-import imghdr
 import io
 import mimetypes
 import re
@@ -27,6 +26,7 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 from urllib.parse import urlparse
 
+import filetype
 import numpy as np
 from PIL import GifImagePlugin, Image, ImageFile
 from typing_extensions import Final, Literal, TypeAlias
@@ -300,8 +300,11 @@ def _ensure_image_size_and_format(
         image = image.resize((width, new_height), resample=Image.BILINEAR)
         return _PIL_to_bytes(image, format=image_format, quality=90)
 
-    ext = imghdr.what(None, image_data)
-    if ext != image_format.lower():
+    pillow_detected_format = image.format
+    if (
+        pillow_detected_format != None
+        and pillow_detected_format != image_format.lower()
+    ):
         # We need to reformat the image.
         return _PIL_to_bytes(image, format=image_format, quality=90)
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -299,7 +299,6 @@ def _ensure_image_size_and_format(
         pil_image = pil_image.resize((width, new_height), resample=Image.BILINEAR)
         return _PIL_to_bytes(pil_image, format=image_format, quality=90)
 
-    # pil_image.format should be defined since we call Image.open()
     if pil_image.format != image_format:
         # We need to reformat the image.
         return _PIL_to_bytes(pil_image, format=image_format, quality=90)
@@ -373,6 +372,7 @@ def image_to_url(
 
     # PIL Images
     elif isinstance(image, (ImageFile.ImageFile, Image.Image)):
+        print("Getting a pil image")
         format = _validate_image_format_string(image, output_format)
         image_data = _PIL_to_bytes(image, format)
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -287,8 +287,8 @@ def _ensure_image_size_and_format(
     MAXIMUM_CONTENT_WIDTH. Ensure the image's format corresponds to the given
     ImageFormat. Return the (possibly resized and reformatted) image bytes.
     """
-    image = Image.open(io.BytesIO(image_data))
-    actual_width, actual_height = image.size
+    pillow_image = Image.open(io.BytesIO(image_data))
+    actual_width, actual_height = pillow_image.size
 
     if width < 0 and actual_width > MAXIMUM_CONTENT_WIDTH:
         width = MAXIMUM_CONTENT_WIDTH
@@ -296,15 +296,13 @@ def _ensure_image_size_and_format(
     if width > 0 and actual_width > width:
         # We need to resize the image.
         new_height = int(1.0 * actual_height * width / actual_width)
-        image = image.resize((width, new_height), resample=Image.BILINEAR)
-        return _PIL_to_bytes(image, format=image_format, quality=90)
+        pillow_image = pillow_image.resize((width, new_height), resample=Image.BILINEAR)
+        return _PIL_to_bytes(pillow_image, format=image_format, quality=90)
 
-    pillow_detected_format = image.format
-    print(f"pillow_detected_format: {pillow_detected_format}")
-    print(f"image_format: {image_format}")
+    pillow_detected_format = pillow_image.format
     if pillow_detected_format != image_format:
         # We need to reformat the image.
-        return _PIL_to_bytes(image, format=image_format, quality=90)
+        return _PIL_to_bytes(pillow_image, format=image_format, quality=90)
 
     # No resizing or reformatting necessary - return the original bytes.
     return image_data

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -299,6 +299,7 @@ def _ensure_image_size_and_format(
         pil_image = pil_image.resize((width, new_height), resample=Image.BILINEAR)
         return _PIL_to_bytes(pil_image, format=image_format, quality=90)
 
+    # pil_image.format should be defined since we call Image.open()
     if pil_image.format != image_format:
         # We need to reformat the image.
         return _PIL_to_bytes(pil_image, format=image_format, quality=90)

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -26,7 +26,6 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 from urllib.parse import urlparse
 
-import filetype
 import numpy as np
 from PIL import GifImagePlugin, Image, ImageFile
 from typing_extensions import Final, Literal, TypeAlias

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -300,10 +300,9 @@ def _ensure_image_size_and_format(
         return _PIL_to_bytes(image, format=image_format, quality=90)
 
     pillow_detected_format = image.format
-    if (
-        pillow_detected_format != None
-        and pillow_detected_format != image_format.lower()
-    ):
+    print(f"pillow_detected_format: {pillow_detected_format}")
+    print(f"image_format: {image_format}")
+    if pillow_detected_format != image_format:
         # We need to reformat the image.
         return _PIL_to_bytes(image, format=image_format, quality=90)
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Context
There are 3 libraries that should supposedly replace `imghdr`: 
<img width="798" alt="Screenshot 2023-07-26 at 2 31 21 PM" src="https://github.com/streamlit/streamlit/assets/16749069/fa41965c-da7d-412c-bf78-3f9276614c49">
https://peps.python.org/pep-0594/#deprecated-modules

1. puremagic
  a. it is smaller lib (365 KB) 
  b. **However, attempted to incorporate the library but it didn't end up working and api documentation is sparse.**
     1. branch attempt on: https://github.com/streamlit/streamlit/tree/fix/7027_puremagic
2. python-magic
  a. no go almost surely; needs a separate installation of libmagic which is a c library
3. filetype
  a. easy api with documentation (https://h2non.github.io/filetype.py/v1.0.0/filetype.m.html)
  b. it ends up working and seems like an easy change
  c. looks like the filetype package isn’t in conda defaults, so we'd either need to find an equivalent package that is (since it looks like there are a few options) or contact the anaconda team requesting it be added

However, these are actually not needed because we can just use pillow to get the format. Technically, `For images created by the [pillow library itself (via a factory function, or by running a method on an existing image), [format] attribute is set to None.` However, since we actually save the image with `Pillow` in `_PIL_to_bytes`, then the format should always be specified.

This was sanity tested with the following code:
```
import streamlit as st
from PIL import Image

image = Image.open('google.png')
resized_image = image.resize([100,200])
st.write(resized_image.format)
st.image(resized_image, caption='GOOGLE')
```
which shows the format being `none` in the first line: 
<img width="1101" alt="Screenshot 2023-07-27 at 12 01 25 AM" src="https://github.com/streamlit/streamlit/assets/16749069/bfc50a38-4670-4515-984c-2a11340915ac">

and a print statement:
<img width="1168" alt="Screenshot 2023-07-27 at 12 03 29 AM" src="https://github.com/streamlit/streamlit/assets/16749069/2681ff44-ebff-42d2-9b4a-5a37a47902ea">



## Describe your changes
- replace `imghdr` with `pillow`
## GitHub Issue Link (if applicable)
- https://github.com/streamlit/streamlit/issues/7027
## Testing Plan
- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?
  - none needed from my perspective

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
