### PR TITLE
Don't require new methods/args in StreamlitEndpoints and FileUploadClient

### DIFF
--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -40,7 +40,7 @@ export interface StreamlitEndpoints {
    * returned unchanged. Otherwise, the return value will be a URL for fetching
    * the media file from the connected Streamlit instance.
    */
-  buildFileUploadURL(url: string): string
+  buildFileUploadURL?(url: string): string
 
   /**
    * Construct a URL for an app page in a multi-page app.
@@ -79,7 +79,7 @@ export interface StreamlitEndpoints {
    * @param fileUrl: The URL of the file to delete.
    * @param sessionId the current sessionID.
    */
-  deleteFileAtURL(fileUrl: string, sessionId: string): Promise<void>
+  deleteFileAtURL?(fileUrl: string, sessionId: string): Promise<void>
 
   /**
    * Fetch a cached ForwardMsg from the server.


### PR DESCRIPTION
We want to avoid having the notebooks team have to make any code changes on their end due to the
interface / constructor changes we're making to `StreamlitEndpoints` and `FileUploadClient`. In order
to do this, we make the newly added methods/args optional.