### PR TITLE
Remove stale comments and group statements writing to protobufs

### DIFF
--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -368,6 +368,7 @@ class ButtonMixin:
         marshall_file(
             self.dg._get_delta_path_str(), data, download_button_proto, mime, file_name
         )
+        download_button_proto.disabled = disabled
 
         if help is not None:
             download_button_proto.help = dedent(help)
@@ -385,10 +386,6 @@ class ButtonMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        download_button_proto.disabled = disabled
 
         self.dg._enqueue("download_button", download_button_proto)
         return button_state.value
@@ -446,6 +443,8 @@ class ButtonMixin:
         button_proto.form_id = current_form_id(self.dg)
         button_proto.type = type
         button_proto.use_container_width = use_container_width
+        button_proto.disabled = disabled
+
         if help is not None:
             button_proto.help = dedent(help)
 
@@ -462,10 +461,6 @@ class ButtonMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        button_proto.disabled = disabled
 
         self.dg._enqueue("button", button_proto)
 

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -209,6 +209,10 @@ class CameraInputMixin:
         camera_input_proto.id = id
         camera_input_proto.label = label
         camera_input_proto.form_id = current_form_id(self.dg)
+        camera_input_proto.disabled = disabled
+        camera_input_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
 
         if help is not None:
             camera_input_proto.help = dedent(help)
@@ -225,13 +229,6 @@ class CameraInputMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-        )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        camera_input_proto.disabled = disabled
-        camera_input_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
         )
 
         self.dg._enqueue("camera_input", camera_input_proto)

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -185,6 +185,11 @@ class CheckboxMixin:
         checkbox_proto.label = label
         checkbox_proto.default = bool(value)
         checkbox_proto.form_id = current_form_id(self.dg)
+        checkbox_proto.disabled = disabled
+        checkbox_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             checkbox_proto.help = dedent(help)
 
@@ -200,13 +205,6 @@ class CheckboxMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-        )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        checkbox_proto.disabled = disabled
-        checkbox_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
         )
 
         if checkbox_state.value_changed:

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -212,6 +212,11 @@ class ColorPickerMixin:
         color_picker_proto.label = label
         color_picker_proto.default = str(value)
         color_picker_proto.form_id = current_form_id(self.dg)
+        color_picker_proto.disabled = disabled
+        color_picker_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             color_picker_proto.help = dedent(help)
 
@@ -229,12 +234,6 @@ class ColorPickerMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        color_picker_proto.disabled = disabled
-        color_picker_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             color_picker_proto.value = widget_state.value
             color_picker_proto.set_value = True

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -435,6 +435,11 @@ class FileUploaderMixin:
         )
         file_uploader_proto.multiple_files = accept_multiple_files
         file_uploader_proto.form_id = current_form_id(self.dg)
+        file_uploader_proto.disabled = disabled
+        file_uploader_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             file_uploader_proto.help = dedent(help)
 
@@ -453,13 +458,6 @@ class FileUploaderMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-        )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        file_uploader_proto.disabled = disabled
-        file_uploader_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
         )
 
         self.dg._enqueue("file_uploader", file_uploader_proto)

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -319,6 +319,11 @@ class MultiSelectMixin:
         multiselect_proto.form_id = current_form_id(self.dg)
         multiselect_proto.max_selections = max_selections or 0
         multiselect_proto.placeholder = placeholder
+        multiselect_proto.disabled = disabled
+        multiselect_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             multiselect_proto.help = dedent(help)
 
@@ -341,12 +346,6 @@ class MultiSelectMixin:
                 _get_over_max_options_message(default_count, max_selections)
             )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        multiselect_proto.disabled = disabled
-        multiselect_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             multiselect_proto.value[:] = serde.serialize(widget_state.value)
             multiselect_proto.set_value = True

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -349,6 +349,11 @@ class NumberInputMixin:
         number_input_proto.label = label
         number_input_proto.default = value
         number_input_proto.form_id = current_form_id(self.dg)
+        number_input_proto.disabled = disabled
+        number_input_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             number_input_proto.help = dedent(help)
 
@@ -377,13 +382,6 @@ class NumberInputMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-        )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        number_input_proto.disabled = disabled
-        number_input_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -250,6 +250,11 @@ class RadioMixin:
         radio_proto.options[:] = [str(format_func(option)) for option in opt]
         radio_proto.form_id = current_form_id(self.dg)
         radio_proto.horizontal = horizontal
+        radio_proto.disabled = disabled
+        radio_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             radio_proto.help = dedent(help)
 
@@ -265,13 +270,6 @@ class RadioMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-        )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        radio_proto.disabled = disabled
-        radio_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -308,6 +308,10 @@ class SelectSliderMixin:
         slider_proto.data_type = SliderProto.INT
         slider_proto.options[:] = [str(format_func(option)) for option in opt]
         slider_proto.form_id = current_form_id(self.dg)
+        slider_proto.disabled = disabled
+        slider_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
         if help is not None:
             slider_proto.help = dedent(help)
 
@@ -325,12 +329,6 @@ class SelectSliderMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        slider_proto.disabled = disabled
-        slider_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             slider_proto.value[:] = serde.serialize(widget_state.value)
             slider_proto.set_value = True

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -243,6 +243,11 @@ class SelectboxMixin:
         selectbox_proto.options[:] = [str(format_func(option)) for option in opt]
         selectbox_proto.form_id = current_form_id(self.dg)
         selectbox_proto.placeholder = placeholder
+        selectbox_proto.disabled = disabled
+        selectbox_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             selectbox_proto.help = dedent(help)
 
@@ -260,12 +265,6 @@ class SelectboxMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        selectbox_proto.disabled = disabled
-        selectbox_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             selectbox_proto.value = serde.serialize(widget_state.value)
             selectbox_proto.set_value = True

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -641,6 +641,11 @@ class SliderMixin:
         slider_proto.data_type = data_type
         slider_proto.options[:] = []
         slider_proto.form_id = current_form_id(self.dg)
+        slider_proto.disabled = disabled
+        slider_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             slider_proto.help = dedent(help)
 
@@ -656,13 +661,6 @@ class SliderMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-        )
-
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        slider_proto.disabled = disabled
-        slider_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -234,6 +234,10 @@ class TextWidgetsMixin:
         text_input_proto.label = label
         text_input_proto.default = str(value)
         text_input_proto.form_id = current_form_id(self.dg)
+        text_input_proto.disabled = disabled
+        text_input_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
 
         if help is not None:
             text_input_proto.help = dedent(help)
@@ -274,12 +278,6 @@ class TextWidgetsMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        text_input_proto.disabled = disabled
-        text_input_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             text_input_proto.value = widget_state.value
             text_input_proto.set_value = True
@@ -444,6 +442,10 @@ class TextWidgetsMixin:
         text_area_proto.label = label
         text_area_proto.default = str(value)
         text_area_proto.form_id = current_form_id(self.dg)
+        text_area_proto.disabled = disabled
+        text_area_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
 
         if help is not None:
             text_area_proto.help = dedent(help)
@@ -470,12 +472,6 @@ class TextWidgetsMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        text_area_proto.disabled = disabled
-        text_area_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             text_area_proto.value = widget_state.value
             text_area_proto.set_value = True

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -384,6 +384,11 @@ class TimeWidgetsMixin:
                 f"`step` must be between 60 seconds and 23 hours but is currently set to {step} seconds."
             )
         time_input_proto.step = step
+        time_input_proto.disabled = disabled
+        time_input_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
+
         if help is not None:
             time_input_proto.help = dedent(help)
 
@@ -400,12 +405,6 @@ class TimeWidgetsMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        time_input_proto.disabled = disabled
-        time_input_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             time_input_proto.value = serde.serialize(widget_state.value)
             time_input_proto.set_value = True
@@ -622,19 +621,21 @@ class TimeWidgetsMixin:
         date_input_proto = DateInputProto()
         date_input_proto.id = id
         date_input_proto.is_range = parsed_values.is_range
-        if help is not None:
-            date_input_proto.help = dedent(help)
-
+        date_input_proto.disabled = disabled
+        date_input_proto.label_visibility.value = get_label_visibility_proto_value(
+            label_visibility
+        )
         date_input_proto.format = format
         date_input_proto.label = label
         date_input_proto.default[:] = [
             date.strftime(v, "%Y/%m/%d") for v in parsed_values.value
         ]
-
         date_input_proto.min = date.strftime(parsed_values.min, "%Y/%m/%d")
         date_input_proto.max = date.strftime(parsed_values.max, "%Y/%m/%d")
-
         date_input_proto.form_id = current_form_id(self.dg)
+
+        if help is not None:
+            date_input_proto.help = dedent(help)
 
         serde = DateInputSerde(parsed_values)
 
@@ -650,12 +651,6 @@ class TimeWidgetsMixin:
             ctx=ctx,
         )
 
-        # This needs to be done after register_widget because we don't want
-        # the following proto fields to affect a widget's ID.
-        date_input_proto.disabled = disabled
-        date_input_proto.label_visibility.value = get_label_visibility_proto_value(
-            label_visibility
-        )
         if widget_state.value_changed:
             date_input_proto.value[:] = serde.serialize(widget_state.value)
             date_input_proto.set_value = True


### PR DESCRIPTION
Now that we've merged #7003, some of the comments we have about when certain
fields are written to widget protos are now stale. While removing these comments, we also
move a few lines around so that lines where we're writing to widget protobufs are grouped.