### PR TITLE
Add "ai" and "human" presets for `st.chat_message`

### DIFF
--- a/e2e/scripts/st_chat_message.py
+++ b/e2e/scripts/st_chat_message.py
@@ -66,4 +66,4 @@ with st.chat_message("Bot"):
     with st.expander("See more", expanded=True):
         st.write("Lorem ipsum dolor sit amet")
 
-st.chat_message("user")
+st.chat_message("human")

--- a/frontend/lib/src/components/elements/ChatMessage/ChatMessage.tsx
+++ b/frontend/lib/src/components/elements/ChatMessage/ChatMessage.tsx
@@ -91,7 +91,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
     <StyledChatMessageContainer
       className="stChatMessage"
       data-testid="stChatMessage"
-      background={["name", "human"].includes(name.toLowerCase())}
+      background={["user", "human"].includes(name.toLowerCase())}
     >
       <ChatMessageAvatar name={name} avatar={avatar} avatarType={avatarType} />
       <StyledMessageContent

--- a/frontend/lib/src/components/elements/ChatMessage/ChatMessage.tsx
+++ b/frontend/lib/src/components/elements/ChatMessage/ChatMessage.tsx
@@ -91,7 +91,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
     <StyledChatMessageContainer
       className="stChatMessage"
       data-testid="stChatMessage"
-      background={name.toLowerCase() === "user"}
+      background={["name", "human"].includes(name.toLowerCase())}
     >
       <ChatMessageAvatar name={name} avatar={avatar} avatarType={avatarType} />
       <StyledMessageContent

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
 class PresetNames(str, Enum):
     USER = "user"
     ASSISTANT = "assistant"
+    AI = "ai"  # Equivalent to assistant
+    HUMAN = "human"  # Equivalent to user
 
 
 def _process_avatar_input(
@@ -67,11 +69,14 @@ def _process_avatar_input(
 
     if avatar is None:
         return AvatarType.ICON, ""
-    elif isinstance(avatar, str) and avatar in [
-        PresetNames.USER,
-        PresetNames.ASSISTANT,
-    ]:
-        return AvatarType.ICON, avatar
+    elif isinstance(avatar, str) and avatar in set(item.value for item in PresetNames):
+        # On the frontend, we only support "assistant" and "user" as preset names.
+        return (
+            AvatarType.ICON,
+            "assistant"
+            if avatar in [PresetNames.AI, PresetNames.ASSISTANT]
+            else "user",
+        )
     elif isinstance(avatar, str) and is_emoji(avatar):
         return AvatarType.EMOJI, avatar
     else:
@@ -113,7 +118,7 @@ class ChatMixin:
     @gather_metrics("chat_message")
     def chat_message(
         self,
-        name: Literal["user", "assistant"] | str,
+        name: Literal["user", "assistant", "ai", "human"] | str,
         *,
         avatar: Literal["user", "assistant"] | str | AtomicImage | None = None,
     ) -> "DeltaGenerator":
@@ -125,9 +130,9 @@ class ChatMixin:
 
         Parameters
         ----------
-        name : "user", "assistant", or str
-            The name of the message author. Can be “user” or “assistant” to
-            enable preset styling and avatars.
+        name : "user", "assistant", "ai", "human", or str
+            The name of the message author. Can be “user”, “assistant”, “ai”, or “human”
+            to enable preset styling and avatars.
 
             Currently, the name is not shown in the UI but is only set as an
             accessibility label. For accessibility reasons, you should not use
@@ -142,8 +147,8 @@ class ChatMixin:
                 image file; URL to fetch the image from; array of shape (w,h) or (w,h,1)
                 for a monochrome image, (w,h,3) for a color image, or (w,h,4) for an RGBA image.
 
-            If None (default), uses default icons if ``name`` is "user" or
-            "assistant", or the first letter of the ``name`` value.
+            If None (default), uses default icons if ``name`` is "user",
+            "assistant", "ai", "human" or the first letter of the ``name`` value.
 
         Returns
         -------
@@ -185,12 +190,7 @@ class ChatMixin:
             )
 
         if avatar is None and (
-            name.lower()
-            in [
-                PresetNames.USER,
-                PresetNames.ASSISTANT,
-            ]
-            or is_emoji(name)
+            name.lower() in {item.value for item in PresetNames} or is_emoji(name)
         ):
             # For selected labels, we are mapping the label to an avatar
             avatar = name.lower()

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -70,7 +70,7 @@ def _process_avatar_input(
     if avatar is None:
         return AvatarType.ICON, ""
     elif isinstance(avatar, str) and avatar in set(item.value for item in PresetNames):
-        # On the frontend, we only support "assistant" and "user" as preset names.
+        # On the frontend, we only support "assistant" and "user" for the avatar.
         return (
             AvatarType.ICON,
             "assistant"

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -69,7 +69,7 @@ def _process_avatar_input(
 
     if avatar is None:
         return AvatarType.ICON, ""
-    elif isinstance(avatar, str) and avatar in set(item.value for item in PresetNames):
+    elif isinstance(avatar, str) and avatar in {item.value for item in PresetNames}:
         # On the frontend, we only support "assistant" and "user" for the avatar.
         return (
             AvatarType.ICON,

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -73,6 +73,38 @@ class ChatTest(DeltaGeneratorTestCase):
             BlockProto.ChatMessage.AvatarType.ICON,
         )
 
+    def test_ai_message(self):
+        """Test that the ai preset is mapped to assistant avatar."""
+        message = st.chat_message("ai")
+
+        with message:
+            pass
+
+        message_block = self.get_delta_from_queue()
+
+        self.assertEqual(message_block.add_block.chat_message.name, "ai")
+        self.assertEqual(message_block.add_block.chat_message.avatar, "assistant")
+        self.assertEqual(
+            message_block.add_block.chat_message.avatar_type,
+            BlockProto.ChatMessage.AvatarType.ICON,
+        )
+
+    def test_human_message(self):
+        """Test that the human preset is mapped to user avatar."""
+        message = st.chat_message("human")
+
+        with message:
+            pass
+
+        message_block = self.get_delta_from_queue()
+
+        self.assertEqual(message_block.add_block.chat_message.name, "human")
+        self.assertEqual(message_block.add_block.chat_message.avatar, "user")
+        self.assertEqual(
+            message_block.add_block.chat_message.avatar_type,
+            BlockProto.ChatMessage.AvatarType.ICON,
+        )
+
     def test_emoji_avatar(self):
         """Test that it is possible to set an emoji as avatar."""
 


### PR DESCRIPTION
## Describe your changes

This PR adds additional chat message presets when using `ai` or `human` as the author's name. Thereby, `ai` is equivalent to `assistant`, and `human` is equivalent to `user`. 

## Testing Plan

- Added unit tests to test mapping.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
