### PR TITLE
Add tests to ensure we don't forget to update widget id computation

### DIFF
--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -365,6 +365,7 @@ class ButtonMixin:
             mime=mime,
             key=key,
             help=help,
+            type=type,
             use_container_width=use_container_width,
         )
 

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -281,6 +281,7 @@ class ChatMixin:
         id = compute_widget_id(
             "chat_input",
             user_key=key,
+            key=key,
             placeholder=placeholder,
             max_chars=max_chars,
         )

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -382,6 +382,7 @@ class SliderMixin:
             user_key=key,
             label=label,
             min_value=min_value,
+            max_value=max_value,
             value=value,
             step=step,
             format=format,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -602,6 +602,7 @@ class TimeWidgetsMixin:
             max_value=parsed_max_date,
             key=key,
             help=help,
+            format=format,
             form_id=current_form_id(self.dg),
         )
         if not bool(ALLOWED_DATE_FORMATS.match(format)):


### PR DESCRIPTION
In #7003, we made some fixes to a few widget ID instability bugs caused by how we used to
use a hash of the serialized widget proto to compute widget IDs rather than explicitly
hashing the args passed to a widget function. We now call the `compute_widget_id`
function at or near the very top of a widget function to ensure any nondeterminism in the
widget's behavior (for example, `st.date_input`'s default value being set to the current date when
unspecified) doesn't affect a widget's ID.

One potential maintenance/code health issue with this solution is that it's possible for a widget's
signature to get out of sync with its call to `compute_widget_id`. To help prevent this issue, this PR
adds some unit tests that verify that the kwargs that `compute_widget_id` is called with match those
in a widget's signature (with a few exceptions).