### PR TITLE
Fix issues with mixing short- and longhand props

### DIFF
--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -270,7 +270,11 @@ const SubMenu = (props: SubMenuProps): ReactElement => {
           },
           style: {
             backgroundColor: "inherit",
-            borderRadius: 0,
+
+            borderBottomRadius: 0,
+            borderTopRadius: 0,
+            borderLeftRadius: 0,
+            borderRightRadius: 0,
 
             ":focus": {
               outline: "none",

--- a/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployCard.tsx
+++ b/frontend/app/src/components/StreamlitDialog/DeployDialog/DeployCard.tsx
@@ -33,21 +33,42 @@ function DeployCard(
       overrides={{
         Root: {
           style: {
-            borderWidth: "1px",
-            borderStyle: "solid",
-            borderColor: colors.fadedText10,
-            borderRadius: radii.lg,
+            borderTopWidth: "1px",
+            borderBottomWidth: "1px",
+            borderLeftWidth: "1px",
+            borderRightWidth: "1px",
+
+            borderTopStyle: "solid",
+            borderBottomStyle: "solid",
+            borderLeftStyle: "solid",
+            borderRightStyle: "solid",
+
+            borderTopColor: colors.fadedText10,
+            borderBottomColor: colors.fadedText10,
+            borderLeftColor: colors.fadedText10,
+            borderRightColor: colors.fadedText10,
+
+            borderRadiusBottom: radii.lg,
+            borderRadiusTop: radii.lg,
+            borderRadiusLeft: radii.lg,
+            borderRadiusRight: radii.lg,
           },
         },
         Contents: {
           style: {
-            margin: 0,
+            marginBottom: 0,
+            marginTop: 0,
+            marginLeft: 0,
+            marginRight: 0,
           },
         },
         Body: {
           style: {
             padding: spacing.threeXL,
-            margin: 0,
+            marginBottom: 0,
+            marginTop: 0,
+            marginLeft: 0,
+            marginRight: 0,
 
             [`@media (max-width: ${breakpoints.md})`]: {
               padding: spacing.xl,

--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -141,7 +141,10 @@ function Modal(props: ModalProps): ReactElement {
     },
     Dialog: {
       style: {
-        borderRadius: radii.xl,
+        borderBottomRadius: radii.xl,
+        borderTopRadius: radii.xl,
+        borderLeftRadius: radii.xl,
+        borderRightRadius: radii.xl,
       },
     },
     Close: {


### PR DESCRIPTION
## Describe your changes

BaseWeb UI throws a warning if short- and longhand properties are mixed:

<img width="694" alt="Screenshot 2023-08-08 at 17 31 21" src="https://github.com/streamlit/streamlit/assets/2852129/4e571f04-5534-4f90-9351-7ca0ef078ce0">

This PR fixes a couple of those instances.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
