### PR TITLE
Remove stale checks on sys.version_info

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 import time
 import traceback
 from dataclasses import dataclass, field
@@ -281,14 +280,9 @@ class Runtime:
         )
         self._async_objs = async_objs
 
-        if sys.version_info >= (3, 8, 0):
-            # Python 3.8+ supports a create_task `name` parameter, which can
-            # make debugging a bit easier.
-            self._loop_coroutine_task = asyncio.create_task(
-                self._loop_coroutine(), name="Runtime.loop_coroutine"
-            )
-        else:
-            self._loop_coroutine_task = asyncio.create_task(self._loop_coroutine())
+        self._loop_coroutine_task = asyncio.create_task(
+            self._loop_coroutine(), name="Runtime.loop_coroutine"
+        )
 
         await async_objs.started
 

--- a/lib/streamlit/runtime/scriptrunner/magic.py
+++ b/lib/streamlit/runtime/scriptrunner/magic.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import ast
-import sys
 
 from typing_extensions import Final
 
@@ -196,7 +195,4 @@ def _get_st_write_from_expr(node, i, parent_type):
 
 
 def _is_docstring_node(node):
-    if sys.version_info >= (3, 8, 0):
-        return type(node) is ast.Constant and type(node.value) is str
-    else:
-        return type(node) is ast.Str
+    return type(node) is ast.Constant and type(node.value) is str

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -130,7 +130,7 @@ def _fix_tornado_crash() -> None:
     FIXME: if/when tornado supports the defaults in asyncio,
     remove and bump tornado requirement for py38
     """
-    if env_util.IS_WINDOWS and sys.version_info >= (3, 8):
+    if env_util.IS_WINDOWS:
         try:
             from asyncio import (  # type: ignore[attr-defined]
                 WindowsProactorEventLoopPolicy,

--- a/lib/tests/streamlit/dataframe_selector_test.py
+++ b/lib/tests/streamlit/dataframe_selector_test.py
@@ -26,7 +26,7 @@ from streamlit.delta_generator import DeltaGenerator
 from tests.streamlit import pyspark_mocks
 from tests.streamlit.snowpark_mocks import DataFrame as MockSnowparkDataFrame
 from tests.streamlit.snowpark_mocks import Table as MockSnowparkTable
-from tests.testutil import patch_config_options, should_skip_pyspark_tests
+from tests.testutil import patch_config_options
 
 DATAFRAME = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
 ALTAIR_CHART = alt.Chart(DATAFRAME).mark_bar().encode(x="a", y="b")
@@ -80,9 +80,6 @@ class DataFrameSelectorTest(unittest.TestCase):
             column_config=None,
         )
 
-    @pytest.mark.skipif(
-        should_skip_pyspark_tests(), reason="pyspark is incompatible with Python3.11"
-    )
     @patch.object(DeltaGenerator, "_legacy_dataframe")
     @patch.object(DeltaGenerator, "_arrow_dataframe")
     @patch_config_options({"global.dataFrameSerialization": "arrow"})

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -394,9 +394,6 @@ class GetVariableNameFromCodeStrTest(unittest.TestCase):
                 actual = _get_variable_name_from_code_str(code)
                 self.assertEqual(actual, None)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="Walrus was introduced in Python 3.8"
-    )
     def test_walrus_should_return_var_name(self):
         for st_call in st_calls:
             # Wrap test in an st call.

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -28,11 +28,7 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit import pyspark_mocks
 from tests.streamlit.snowpark_mocks import DataFrame as MockedSnowparkDataFrame
 from tests.streamlit.snowpark_mocks import Table as MockedSnowparkTable
-from tests.testutil import (
-    create_snowpark_session,
-    patch_config_options,
-    should_skip_pyspark_tests,
-)
+from tests.testutil import create_snowpark_session, patch_config_options
 
 df1 = pd.DataFrame({"lat": [1, 2, 3, 4], "lon": [10, 20, 30, 40]})
 
@@ -368,9 +364,6 @@ class StMapTest(DeltaGeneratorTestCase):
         """Check if map data have 4 rows"""
         self.assertEqual(len(c["layers"][0]["data"]), 4)
 
-    @pytest.mark.skipif(
-        should_skip_pyspark_tests(), reason="pyspark is incompatible with Python3.11"
-    )
     def test_pyspark_dataframe(self):
         """Test st.map with pyspark.sql.DataFrame"""
         pyspark_map_dataframe = (

--- a/lib/tests/streamlit/runtime/caching/cache_errors_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_errors_test.py
@@ -29,7 +29,6 @@ from streamlit.runtime.caching.cache_utils import UNEVALUATED_DATAFRAME_TYPES
 from tests import testutil
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit import pyspark_mocks, snowpark_mocks
-from tests.testutil import should_skip_pyspark_tests
 
 
 class CacheErrorsTest(DeltaGeneratorTestCase):
@@ -112,10 +111,6 @@ def unhashable_type_func(_lock, ...):
         elif "snowpark.dataframe.DataFrame" in type_name:
             to_return = snowpark_mocks.DataFrame()
         else:
-            if should_skip_pyspark_tests():
-                # Python 3.11 is incompatible with Pyspark
-                return
-
             to_return = (
                 pyspark_mocks.create_pyspark_dataframe_with_mocked_personal_data()
             )

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -30,7 +30,6 @@ from streamlit.elements import write
 from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state import SessionStateProxy
-from tests.testutil import should_skip_pyspark_tests
 
 
 class StreamlitWriteTest(unittest.TestCase):
@@ -198,9 +197,6 @@ class StreamlitWriteTest(unittest.TestCase):
             )
             p.assert_called_once()
 
-    @pytest.mark.skipif(
-        should_skip_pyspark_tests(), reason="pyspark is incompatible with Python3.11"
-    )
     def test_pyspark_dataframe_write(self):
         """Test st.write with pyspark.sql.DataFrame."""
         # Import package inside the test so the test suite still runs even if you don't

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -14,7 +14,6 @@
 
 """Utility functions to use in our tests."""
 import json
-import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict
 from unittest.mock import patch
@@ -27,16 +26,6 @@ from tests.constants import SNOWFLAKE_CREDENTIAL_FILE
 
 if TYPE_CHECKING:
     from snowflake.snowpark import Session
-
-
-def should_skip_pyspark_tests() -> bool:
-    """Disable pyspark unit tests in Python 3.11.
-    Pyspark is not compatible with Python 3.11 as of 2023.01.12, and results in test failures.
-    (Please remove this when pyspark is compatible!)
-    """
-    # See: https://pyreadiness.org/3.11/
-    # See: https://stackoverflow.com/questions/74579273/indexerror-tuple-index-out-of-range-when-creating-pyspark-dataframe
-    return sys.version_info >= (3, 11, 0)
 
 
 def should_skip_pydantic_tests() -> bool:


### PR DESCRIPTION
Reviewing #7122 prompted me to look through a lot of the behavior forking we do based on the Python
version, and I noticed that we no longer need to do a decent amount of it now that our minimum supported
Python version is 3.8.

This PR removes the checks that are now stale.