### PR TITLE
exclude async funcs docstring from magic prints

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/magic.py
+++ b/lib/streamlit/runtime/scriptrunner/magic.py
@@ -157,7 +157,7 @@ def _get_st_write_from_expr(node, i, parent_type):
     if (
         i == 0
         and _is_docstring_node(node.value)
-        and parent_type in (ast.FunctionDef, ast.Module)
+        and parent_type in (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)
     ):
         return None
 

--- a/lib/tests/streamlit/runtime/scriptrunner/magic_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/magic_test.py
@@ -185,7 +185,7 @@ def myfunc(a):
         self._testCode(CODE, 0)
 
     def test_docstring_is_ignored_async_func(self):
-        """Test that docstrings don't print in the app"""
+        """Test that async function docstrings don't print in the app"""
         CODE = """
 async def myfunc(a):
     '''This is the docstring for async func'''

--- a/lib/tests/streamlit/runtime/scriptrunner/magic_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/magic_test.py
@@ -175,11 +175,20 @@ async def myfunc(a):
 """
         self._testCode(CODE_ASYNC_FOR, 1)
 
-    def test_docstring_is_ignored(self):
+    def test_docstring_is_ignored_func(self):
         """Test that docstrings don't print in the app"""
         CODE = """
 def myfunc(a):
     '''This is the docstring'''
     return 42
+"""
+        self._testCode(CODE, 0)
+
+    def test_docstring_is_ignored_async_func(self):
+        """Test that docstrings don't print in the app"""
+        CODE = """
+async def myfunc(a):
+    '''This is the docstring for async func'''
+    return 43
 """
         self._testCode(CODE, 0)


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Ignore async functions docstrings from magic prints, same way how we ignore it from sync functions docstrings.

## GitHub Issue Link #7137

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
