### PR TITLE
Convert Expander to Details/Summary Element

### DIFF
--- a/e2e/scripts/st_expander.py
+++ b/e2e/scripts/st_expander.py
@@ -24,3 +24,5 @@ collapsed.write("I am already collapsed")
 
 sidebar = st.sidebar.expander("Expand me!")
 sidebar.write("I am in the sidebar")
+
+st.expander("Expand me!")

--- a/e2e/specs/st_expander.spec.js
+++ b/e2e/specs/st_expander.spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const expanderHeaderIdentifier = ".streamlit-expanderHeader";
+const expanderHeaderIdentifier = "summary";
 
 describe("st.expander", () => {
   before(() => {

--- a/e2e/specs/st_select_slider.spec.js
+++ b/e2e/specs/st_select_slider.spec.js
@@ -169,13 +169,17 @@ describe("st.select_slider", () => {
 
   it("realigns label values when expander re-opened", () => {
     // Closes the expander
-    cy.get(".streamlit-expanderHeader").click();
+    cy.get('[data-testid="stExpander"] summary').click();
 
     // Reopens the expander
-    cy.get(".streamlit-expanderHeader").click();
+    cy.get('[data-testid="stExpander"] summary').click();
 
     // Positioning error occurs on overflow of expander container
     // which occurs when position left set to 0px
-    cy.getIndexed(".StyledThumbValue", 11).should("not.have.css", "left", "0px")
+    cy.getIndexed(".StyledThumbValue", 11).should(
+      "not.have.css",
+      "left",
+      "0px"
+    );
   });
 });

--- a/e2e/specs/st_slider.spec.js
+++ b/e2e/specs/st_slider.spec.js
@@ -49,17 +49,17 @@ describe("st.slider", () => {
     cy.get(".stSlider label").should(
       "have.text",
       "Label A" +
-      "Range A" +
-      "Label B" +
-      "Range B" +
-      "Label 1" +
-      "Label 2" +
-      "Label 3 - This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long label" +
-      "Label 4" +
-      "Label 5" +
-      "Label 6" +
-      "Label 7" +
-      "Label 8"
+        "Range A" +
+        "Label B" +
+        "Range B" +
+        "Label 1" +
+        "Label 2" +
+        "Label 3 - This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long label" +
+        "Label 4" +
+        "Label 5" +
+        "Label 6" +
+        "Label 7" +
+        "Label 8"
     );
   });
 
@@ -91,32 +91,36 @@ describe("st.slider", () => {
 
   it("realigns label values when expander re-opened", () => {
     // Closes the expander
-    cy.get(".streamlit-expanderHeader").click();
+    cy.get('[data-testid="stExpander"] summary').click();
 
     // Reopens the expander
-    cy.get(".streamlit-expanderHeader").click();
+    cy.get('[data-testid="stExpander"] summary').click();
 
     // Positioning error occurs on overflow of expander container
     // which occurs when position left set to 0px
-    cy.getIndexed(".StyledThumbValue", 5).should("not.have.css", "left", "0px")
+    cy.getIndexed(".StyledThumbValue", 5).should(
+      "not.have.css",
+      "left",
+      "0px"
+    );
   });
 
   it("has correct values", () => {
     cy.get(".stMarkdown").should(
       "have.text",
       "Value A: 12345678" +
-      "Range Value A: (10000, 25000)" +
-      "Value B: 10000" +
-      "Range Value B: (10000, 25000)" +
-      "Value 1: 25" +
-      "Value 2: (25.0, 75.0)" +
-      "Value 3: 1" +
-      "Value 4: 10000" +
-      "Value 5: 25" +
-      "Value 6: 36" +
-      "Value 7: 2019-08-01 2019-09-01" +
-      "Value 8: 25" +
-      "Slider changed: False"
+        "Range Value A: (10000, 25000)" +
+        "Value B: 10000" +
+        "Range Value B: (10000, 25000)" +
+        "Value 1: 25" +
+        "Value 2: (25.0, 75.0)" +
+        "Value 3: 1" +
+        "Value 4: 10000" +
+        "Value 5: 25" +
+        "Value 6: 36" +
+        "Value 7: 2019-08-01 2019-09-01" +
+        "Value 8: 25" +
+        "Slider changed: False"
     );
   });
 

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -16,7 +16,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
 
-EXPANDER_HEADER_IDENTIFIER = ".streamlit-expanderHeader"
+EXPANDER_HEADER_IDENTIFIER = '[data-testid="stExpander"] summary'
 
 
 def test_displays_expander_and_regular_containers_properly(app: Page):

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -74,7 +74,6 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
       <Expander
         empty={node.isEmpty}
         isStale={isStale}
-        widgetsDisabled={props.widgetsDisabled}
         element={node.deltaBlock.expandable as BlockProto.Expandable}
       >
         {child}

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -16,7 +16,7 @@
 
 import React from "react"
 
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 import { render } from "@streamlit/lib/src/test_util"
@@ -33,7 +33,6 @@ const getProps = (
     expanded: true,
     ...elementProps,
   }),
-  widgetsDisabled: false,
   isStale: false,
   empty: false,
   ...props,
@@ -49,6 +48,17 @@ describe("Expander container", () => {
     )
     const expanderContainer = screen.getByTestId("stExpander")
     expect(expanderContainer).toBeInTheDocument()
+  })
+
+  it("does not render a list", () => {
+    const props = getProps()
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+    const list = screen.queryByRole("list")
+    expect(list).not.toBeInTheDocument()
   })
 
   it("renders expander label as expected", () => {
@@ -116,6 +126,18 @@ describe("Expander container", () => {
         <div>test</div>
       </Expander>
     )
-    expect(screen.queryByText("test")).not.toBeInTheDocument()
+    expect(screen.getByText("test")).not.toBeVisible()
+  })
+
+  it("should render the text when expanded", () => {
+    const props = getProps({ expanded: false })
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    fireEvent.click(screen.getByText("hi"))
+    expect(screen.getByText("test")).toBeVisible()
   })
 })

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -14,21 +14,13 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useEffect, useState } from "react"
-import classNames from "classnames"
-import {
-  StatelessAccordion as Accordion,
-  Panel,
-  SharedStylePropsArg,
-} from "baseui/accordion"
-import { useTheme } from "@emotion/react"
+import React, { ReactElement, useEffect, useRef, useState } from "react"
 import {
   ExpandMore,
   ExpandLess,
   Check,
   ErrorOutline,
 } from "@emotion-icons/material-outlined"
-
 import { Block as BlockProto } from "@streamlit/lib/src/proto"
 import {
   StyledSpinnerIcon,
@@ -40,8 +32,13 @@ import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
 import { IconSize, isPresetTheme } from "@streamlit/lib/src/theme"
 
 import {
+  BORDER_SIZE,
   StyledExpandableContainer,
-  StyledIconContainer,
+  StyledSummary,
+  StyledSummaryHeading,
+  StyledDetailsPanel,
+  StyledEmptyDetailsPanel,
+  StyledDetails,
 } from "./styled-components"
 
 export interface ExpanderIconProps {
@@ -104,25 +101,34 @@ export const ExpanderIcon = (props: ExpanderIconProps): ReactElement => {
 
 export interface ExpanderProps {
   element: BlockProto.Expandable
-  widgetsDisabled: boolean
   isStale: boolean
   empty: boolean
 }
 
 const Expander: React.FC<ExpanderProps> = ({
   element,
-  widgetsDisabled,
   isStale,
   empty,
   children,
 }): ReactElement => {
   const { label, expanded: initialExpanded } = element
   const [expanded, setExpanded] = useState<boolean>(initialExpanded || false)
+  const detailsRef = useRef<HTMLDetailsElement>(null)
+  const summaryRef = useRef<HTMLElement>(null)
+  const animationRef = useRef<Animation | null>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
     // Only apply the expanded state if it was actually set in the proto.
     if (notNullOrUndefined(initialExpanded)) {
       setExpanded(initialExpanded)
+
+      // We manage the open attribute via the detailsRef and not with React state
+      if (detailsRef.current && initialExpanded) {
+        detailsRef.current.open = true
+      }
     }
+
     // Having `label` in the dependency array here is necessary because
     // sometimes two distinct expanders look so similar that even the react
     // diffing algorithm decides that they're the same element with updated
@@ -133,147 +139,102 @@ const Expander: React.FC<ExpanderProps> = ({
     // expander's `expanded` state in this edge case.
   }, [label, initialExpanded])
 
-  const toggle = (): void => {
-    if (!empty) {
-      setExpanded(!expanded)
+  const onAnimationFinish = (open: boolean): void => {
+    if (!detailsRef.current) {
+      return
+    }
+
+    detailsRef.current.open = open
+    animationRef.current = null
+    detailsRef.current.style.height = ""
+    detailsRef.current.style.overflow = ""
+  }
+
+  const toggleAnimation = (
+    detailsEl: HTMLDetailsElement,
+    startHeight: number,
+    endHeight: number
+  ): void => {
+    const isOpen = endHeight > startHeight
+
+    if (animationRef.current) {
+      animationRef.current.cancel()
+    }
+
+    const animation = detailsEl.animate(
+      {
+        height: [`${startHeight}px`, `${endHeight}px`],
+      },
+      {
+        duration: 500,
+        easing: "cubic-bezier(0.23, 1, 0.32, 1)",
+      }
+    )
+
+    animation.onfinish = () => onAnimationFinish(isOpen)
+    animationRef.current = animation
+  }
+
+  const toggle = (e: React.MouseEvent<HTMLDetailsElement>): void => {
+    e.preventDefault()
+
+    setExpanded(!expanded)
+    const detailsEl = detailsRef.current
+    if (!detailsEl || !summaryRef.current || !contentRef.current) {
+      return
+    }
+
+    detailsEl.style.overflow = "hidden"
+    const detailsHeight = detailsEl.getBoundingClientRect().height
+    const summaryHeight = summaryRef.current.getBoundingClientRect().height
+
+    if (!expanded) {
+      detailsEl.style.height = `${detailsHeight}px`
+      detailsEl.open = true
+      const contentHeight = contentRef.current.getBoundingClientRect().height
+
+      window.requestAnimationFrame(() => {
+        toggleAnimation(
+          detailsEl,
+          detailsHeight,
+          summaryHeight + contentHeight + 2 * BORDER_SIZE
+        )
+      })
+    } else {
+      toggleAnimation(
+        detailsEl,
+        detailsHeight,
+        summaryHeight + 2 * BORDER_SIZE
+      )
     }
   }
-  const { colors, radii, spacing, fontSizes } = useTheme()
 
   return (
-    <StyledExpandableContainer
-      data-testid="stExpander"
-      empty={empty}
-      disabled={widgetsDisabled}
-    >
-      <Accordion
-        onChange={toggle}
-        expanded={expanded && !empty ? ["panel"] : []}
-        disabled={widgetsDisabled}
-        overrides={{
-          Content: {
-            style: ({ $expanded }: SharedStylePropsArg) => ({
-              backgroundColor: colors.transparent,
-              marginLeft: spacing.none,
-              marginRight: spacing.none,
-              marginTop: spacing.none,
-              marginBottom: spacing.none,
-              overflow: "visible",
-              paddingLeft: spacing.lg,
-              paddingRight: spacing.lg,
-              paddingTop: 0,
-              paddingBottom: $expanded ? spacing.lg : 0,
-              borderTopStyle: "none",
-              borderBottomStyle: "none",
-              borderRightStyle: "none",
-              borderLeftStyle: "none",
-            }),
-            props: { className: "streamlit-expanderContent" },
-          },
-          // Allow fullscreen button to overflow the expander
-          ContentAnimationContainer: {
-            style: ({ $expanded }: SharedStylePropsArg) => ({
-              overflow: $expanded ? "visible" : "hidden",
-            }),
-          },
-          PanelContainer: {
-            style: () => ({
-              marginLeft: `${spacing.none} !important`,
-              marginRight: `${spacing.none} !important`,
-              marginTop: `${spacing.none} !important`,
-              marginBottom: `${spacing.none} !important`,
-              paddingLeft: `${spacing.none} !important`,
-              paddingRight: `${spacing.none} !important`,
-              paddingTop: `${spacing.none} !important`,
-              paddingBottom: `${spacing.none} !important`,
-              borderTopStyle: "none !important",
-              borderBottomStyle: "none !important",
-              borderRightStyle: "none !important",
-              borderLeftStyle: "none !important",
-            }),
-          },
-          Header: {
-            style: ({ $disabled }: SharedStylePropsArg) => ({
-              marginBottom: spacing.none,
-              marginLeft: spacing.none,
-              marginRight: spacing.none,
-              marginTop: spacing.none,
-              backgroundColor: colors.transparent,
-              color: $disabled ? colors.disabled : colors.bodyText,
-              fontSize: fontSizes.sm,
-              borderTopStyle: "none",
-              borderBottomStyle: "none",
-              borderRightStyle: "none",
-              borderLeftStyle: "none",
-              paddingBottom: spacing.md,
-              paddingTop: spacing.md,
-              paddingRight: spacing.lg,
-              paddingLeft: spacing.lg,
-              ...(isStale
-                ? {
-                    opacity: 0.33,
-                    transition: "opacity 1s ease-in 0.5s",
-                  }
-                : {}),
-            }),
-            props: {
-              className: "streamlit-expanderHeader",
-            },
-          },
-          ToggleIcon: {
-            style: ({ $disabled }: SharedStylePropsArg) => ({
-              color: $disabled ? colors.disabled : colors.bodyText,
-            }),
-            // eslint-disable-next-line react/display-name
-            component: () => {
-              if (empty) {
-                // Don't show then expand/collapse icon if there's no content.
-                return <></>
-              }
-              return (
-                <StyledIcon
-                  as={expanded ? ExpandLess : ExpandMore}
-                  color={"inherit"}
-                  aria-hidden="true"
-                  data-testid="stExpanderToggleIcon"
-                  size="lg"
-                  margin=""
-                  padding=""
-                />
-              )
-            },
-          },
-          Root: {
-            props: {
-              className: classNames("streamlit-expander"),
-            },
-            style: {
-              borderStyle: "solid",
-              borderWidth: "1px",
-              borderColor: colors.fadedText10,
-              borderRadius: radii.lg,
-              ...(isStale
-                ? {
-                    borderColor: colors.fadedText05,
-                    transition: "border 1s ease-in 0.5s",
-                  }
-                : {}),
-            },
-          },
-        }}
-      >
-        <Panel
-          title={
-            <StyledIconContainer>
-              {element.icon && <ExpanderIcon icon={element.icon} />}
-              <StreamlitMarkdown source={label} allowHTML={false} isLabel />
-            </StyledIconContainer>
-          }
-          key="panel"
-        >
-          {children}
-        </Panel>
-      </Accordion>
+    <StyledExpandableContainer data-testid="stExpander">
+      <StyledDetails isStale={isStale} ref={detailsRef}>
+        <StyledSummary onClick={toggle} ref={summaryRef}>
+          <StyledSummaryHeading>
+            {element.icon && <ExpanderIcon icon={element.icon} />}
+            <StreamlitMarkdown source={label} allowHTML={false} isLabel />
+          </StyledSummaryHeading>
+          <StyledIcon
+            as={expanded ? ExpandLess : ExpandMore}
+            color={"inherit"}
+            aria-hidden="true"
+            data-testid="stExpanderToggleIcon"
+            size="lg"
+            margin=""
+            padding=""
+          />
+        </StyledSummary>
+        {!empty ? (
+          <StyledDetailsPanel ref={contentRef}>{children}</StyledDetailsPanel>
+        ) : (
+          <StyledEmptyDetailsPanel ref={contentRef}>
+            empty
+          </StyledEmptyDetailsPanel>
+        )}
+      </StyledDetails>
     </StyledExpandableContainer>
   )
 }

--- a/frontend/lib/src/components/elements/Expander/styled-components.ts
+++ b/frontend/lib/src/components/elements/Expander/styled-components.ts
@@ -16,31 +16,77 @@
 
 import styled from "@emotion/styled"
 
-export const StyledIconContainer = styled.div(({ theme }) => ({
-  display: "flex",
-  gap: theme.spacing.sm,
-  alignItems: "center",
-}))
-
 export interface StyledExpandableContainerProps {
   empty: boolean
   disabled: boolean
 }
 
-export const StyledExpandableContainer =
-  styled.div<StyledExpandableContainerProps>(({ theme, empty, disabled }) => {
-    if (empty) {
-      // Don't apply hover styling if empty:
-      return {
-        ".streamlit-expanderHeader:hover": {
-          color: disabled ? theme.colors.disabled : theme.colors.bodyText,
-        },
-      }
-    }
+export const StyledExpandableContainer = styled.div({})
+interface StyledDetailsProps {
+  isStale: boolean
+}
 
-    return {
-      ".streamlit-expanderHeader:hover svg": {
-        fill: theme.colors.primary,
-      },
-    }
+export const BORDER_SIZE = 1 // px
+export const StyledDetails = styled.details<StyledDetailsProps>(
+  ({ isStale, theme }) => ({
+    marginBottom: 0,
+    marginTop: 0,
+    width: "100%",
+    borderStyle: "solid",
+    borderWidth: `${BORDER_SIZE}px`,
+    borderColor: theme.colors.fadedText10,
+    borderRadius: theme.radii.lg,
+    ...(isStale
+      ? {
+          borderColor: theme.colors.fadedText05,
+          transition: "border 1s ease-in 0.5s",
+        }
+      : {}),
   })
+)
+
+export const StyledSummaryHeading = styled.span(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing.sm,
+  alignItems: "center",
+  flexGrow: 1,
+}))
+
+export const StyledSummary = styled.summary(({ theme }) => ({
+  display: "flex",
+  width: "100%",
+  "&:focus": {
+    outline: "none",
+    color: theme.colors.primary,
+  },
+  "&:focus svg": {
+    fill: theme.colors.primary,
+  },
+  paddingLeft: theme.spacing.lg,
+  paddingRight: theme.spacing.lg,
+  paddingTop: theme.spacing.md,
+  paddingBottom: theme.spacing.md,
+  listStyleType: "none",
+  "&:hover": {
+    color: theme.colors.primary,
+  },
+  "&:hover svg": {
+    fill: theme.colors.primary,
+  },
+}))
+
+export const StyledDetailsPanel = styled.div(({ theme }) => ({
+  paddingBottom: theme.spacing.md,
+  paddingLeft: theme.spacing.lg,
+  paddingRight: theme.spacing.lg,
+}))
+
+export const StyledEmptyDetailsPanel = styled.div(({ theme }) => ({
+  color: theme.colors.darkGray,
+  fontStyle: "italic",
+  fontSize: theme.fontSizes.sm,
+  textAlign: "center",
+  paddingBottom: theme.spacing.lg,
+  paddingLeft: theme.spacing.lg,
+  paddingRight: theme.spacing.lg,
+}))


### PR DESCRIPTION
## Describe your changes

A follow up from https://github.com/streamlit/streamlit/pull/6831 I was able to implement expanders utilizing the `details`/`summary` HTML elements (See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details))

Removing the BaseWeb component in favor essentially makes things easier to style. In addition, Accessibility is not at risk because we use semantic HTML. If anything, we made it better since the BaseWeb component is exposed as a list, which is not the intended use case of expanders. This fixes the issue where the list styles were different inside expanders vs outside.

There's a couple other small changes:
- A change occurred that disabled expanders when widgets are disabled (due to the connection failing). It doesn't seem worthwhile to keep this so I removed it.
- There's UI for when an expander is empty, which we disallowed, but I reintroduced it back with the empty implementation.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/4111

## Testing Plan

- Unit Tests (JS and/or Python) to check that no lists are generated
- E2E Tests
- Any manual testing needed? I think a good smoke check to ensure it's parity with the original component

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
