### PR TITLE
Stop dropping file uploader state after websocket disconnect

### DIFF
--- a/e2e/scripts/websocket_reconnects.py
+++ b/e2e/scripts/websocket_reconnects.py
@@ -25,6 +25,8 @@ if runtime.exists():
 
     st.write(f"count: {st.session_state.counter}")
 
-    # TODO(vdonato): Add st.file_uploader and st.camera_input tests once we're able to
-    # teach those widgets how to retrieve previously uploaded files after a session
-    # disconnect/reconnect.
+    if f := st.file_uploader("Upload a file"):
+        st.text(f.read())
+
+    if img := st.camera_input("Take a picture"):
+        st.image(img)

--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -16,8 +16,11 @@
 
 describe("st.camera_input", () => {
   before(() => {
+    // Increasing timeout since uploading and rendering images can be slow.
+    Cypress.config("defaultCommandTimeout", 30000);
+
     Cypress.Cookies.defaults({
-      preserve: ["_xsrf"]
+      preserve: ["_xsrf"],
     });
     cy.loadApp("http://localhost:3000/");
   });

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -19,10 +19,16 @@ const NUM_DISCONNECTS = 20;
 
 describe("websocket reconnects", () => {
   beforeEach(() => {
+    Cypress.Cookies.defaults({
+      preserve: ["_xsrf"],
+    });
+    cy.server();
+    cy.route("PUT", "**/upload_file/**").as("uploadFile");
+
     cy.loadApp("http://localhost:3000/");
   });
 
-  it("persists session state when the websocket connection is dropped and reconnects", () => {
+  it("retains session state when the websocket connection is dropped and reconnects", () => {
     let expectedCount = 0;
 
     for (let i = 0; i < NUM_DISCONNECTS; i++) {
@@ -48,5 +54,96 @@ describe("websocket reconnects", () => {
 
       cy.get(".stMarkdown").contains(`count: ${expectedCount}`);
     }
+  });
+
+  it("retains uploaded files when the websocket connection is dropped and reconnects", () => {
+    const fileName1 = "file1.txt";
+    const uploaderIndex = 0;
+
+    cy.fixture(fileName1).then((file1) => {
+      cy.getIndexed(
+        "[data-testid='stFileUploadDropzone']",
+        uploaderIndex
+      ).attachFile(
+        {
+          fileContent: file1,
+          fileName: fileName1,
+          mimeType: "text/plain",
+        },
+        {
+          force: true,
+          subjectType: "drag-n-drop",
+          events: ["dragenter", "drop"],
+        }
+      );
+
+      cy.wait("@uploadFile");
+
+      // The script should have printed the contents of the first files
+      // into an st.text. (This tests that the upload actually went
+      // through.)
+      cy.get(".uploadedFileName").should("have.text", fileName1);
+      cy.getIndexed("[data-testid='stText']", uploaderIndex).should(
+        "contain.text",
+        file1
+      );
+
+      cy.window().then((win) => {
+        setTimeout(() => {
+          win.streamlitDebug.disconnectWebsocket();
+        }, 100);
+      });
+
+      // Wait until we've disconnected.
+      cy.get("[data-testid='stStatusWidget']").should(
+        "have.text",
+        "Connecting"
+      );
+      // Wait until we've reconnected and rerun the script.
+      cy.get("[data-testid='stStatusWidget']").should("not.exist");
+
+      // Confirm that our uploaded file is still there.
+      cy.getIndexed("[data-testid='stText']", uploaderIndex).should(
+        "contain.text",
+        file1
+      );
+    });
+  });
+
+  it("retains captured pictures when the websocket connection is dropped and reconnects", () => {
+    // Be generous with some of the timeouts in this test as uploading and
+    // rendering images can be quite slow.
+    const timeout = 30000;
+
+    cy.get("[data-testid='stCameraInputButton']", { timeout })
+      .should("have.length", 1)
+      .first()
+      .wait(1000)
+      .should("not.be.disabled")
+      .contains("Take Photo")
+      .click();
+
+    cy.wait("@uploadFile");
+
+    cy.get("img").should("have.length.at.least", 2);
+
+    cy.get("[data-testid='stImage']", { timeout }).should(
+      "have.length.at.least",
+      1
+    );
+
+    cy.window().then((win) => {
+      setTimeout(() => {
+        win.streamlitDebug.disconnectWebsocket();
+      }, 100);
+    });
+
+    // Wait until we've disconnected.
+    cy.get("[data-testid='stStatusWidget']").should("have.text", "Connecting");
+    // Wait until we've reconnected and rerun the script.
+    cy.get("[data-testid='stStatusWidget']").should("not.exist");
+
+    // Confirm that our picture is still there.
+    cy.get("[data-testid='stImage']").should("have.length.at.least", 1);
   });
 });

--- a/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Sidebar/SidebarNav.test.tsx
@@ -43,7 +43,7 @@ expect.extend(matchers)
 
 jest.mock("@streamlit/lib/src/util/Hooks", () => ({
   __esModule: true,
-  ...jest.requireActual("@streamlit/lib/dist/util/Hooks"),
+  ...jest.requireActual("@streamlit/lib/src/util/Hooks"),
   useIsOverflowing: jest.fn(),
 }))
 

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -251,7 +251,7 @@ class CameraInput extends React.PureComponent<Props, State> {
     return "ready"
   }
 
-  public componentDidUpdate = (prevProps: Props): void => {
+  public componentDidUpdate = (): void => {
     // If our status is not "ready", then we have uploads in progress.
     // We won't submit a new widgetValue until all uploads have resolved.
     if (this.status !== "ready") {

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -252,31 +252,6 @@ class CameraInput extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate = (prevProps: Props): void => {
-    const { element, widgetMgr } = this.props
-
-    // TODO(vdonato): Rework this now that there's a short window where the app
-    // may reconnect to the server without losing its uploaded files. Just
-    // removing the if statement below (to avoid resetting widget state on a
-    // disconnect) seemed to work, but I'm not entirely sure if it's a complete
-    // fix.
-    //
-    // Widgets are disabled if the app is not connected anymore.
-    // If the app disconnects from the server, a new session is created and users
-    // will lose access to the files they uploaded in their previous session.
-    // If we are reconnecting, reset the camera input so that the widget is
-    // in sync with the new session.
-    if (prevProps.disabled !== this.props.disabled && this.props.disabled) {
-      this.reset()
-      widgetMgr.setFileUploaderStateValue(
-        element,
-        new FileUploaderStateProto(),
-        { fromUi: false }
-      )
-      return
-    }
-
-    // Maybe send a widgetValue update to the widgetStateManager.
-
     // If our status is not "ready", then we have uploads in progress.
     // We won't submit a new widgetValue until all uploads have resolved.
     if (this.status !== "ready") {
@@ -290,6 +265,9 @@ class CameraInput extends React.PureComponent<Props, State> {
       return
     }
 
+    const { element, widgetMgr } = this.props
+
+    // Maybe send a widgetValue update to the widgetStateManager.
     const prevWidgetValue = widgetMgr.getFileUploaderStateValue(element)
     if (!_.isEqual(newWidgetValue, prevWidgetValue)) {
       widgetMgr.setFileUploaderStateValue(element, newWidgetValue, {

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -578,14 +578,14 @@ describe("FileUploader widget enzyme tests", () => {
     expect(instance.status).toBe("ready")
   })
 
-  it("resets on disconnect", () => {
+  it("does not reset on disconnect", () => {
     const props = getProps()
     const wrapper = shallow(<FileUploader {...props} />)
     const instance = wrapper.instance() as FileUploader
     // @ts-expect-error
     const resetSpy = jest.spyOn(instance, "reset")
     wrapper.setProps({ disabled: true })
-    expect(resetSpy).toHaveBeenCalled()
+    expect(resetSpy).not.toHaveBeenCalled()
   })
 
   it("resets its value when form is cleared", async () => {

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -143,31 +143,6 @@ class FileUploader extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate = (prevProps: Props): void => {
-    const { element, widgetMgr } = this.props
-
-    // TODO(vdonato): Rework this now that there's a short window where the app
-    // may reconnect to the server without losing its uploaded files. Just
-    // removing the if statement below (to avoid resetting widget state on a
-    // disconnect) seemed to work, but I'm not entirely sure if it's a complete
-    // fix.
-    //
-    // Widgets are disabled if the app is not connected anymore.
-    // If the app disconnects from the server, a new session is created and users
-    // will lose access to the files they uploaded in their previous session.
-    // If we are reconnecting, reset the file uploader so that the widget is
-    // in sync with the new session.
-    if (prevProps.disabled !== this.props.disabled && this.props.disabled) {
-      this.reset()
-      widgetMgr.setFileUploaderStateValue(
-        element,
-        new FileUploaderStateProto(),
-        { fromUi: false }
-      )
-      return
-    }
-
-    // Maybe send a widgetValue update to the widgetStateManager.
-
     // If our status is not "ready", then we have uploads in progress.
     // We won't submit a new widgetValue until all uploads have resolved.
     if (this.status !== "ready") {
@@ -181,6 +156,9 @@ class FileUploader extends React.PureComponent<Props, State> {
       return
     }
 
+    const { element, widgetMgr } = this.props
+
+    // Maybe send a widgetValue update to the widgetStateManager.
     const prevWidgetValue = widgetMgr.getFileUploaderStateValue(element)
     if (!_.isEqual(newWidgetValue, prevWidgetValue)) {
       widgetMgr.setFileUploaderStateValue(element, newWidgetValue, {

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -142,7 +142,7 @@ class FileUploader extends React.PureComponent<Props, State> {
     return "ready"
   }
 
-  public componentDidUpdate = (prevProps: Props): void => {
+  public componentDidUpdate = (): void => {
     // If our status is not "ready", then we have uploads in progress.
     // We won't submit a new widgetValue until all uploads have resolved.
     if (this.status !== "ready") {


### PR DESCRIPTION
Before we merged #5856, a websocket connection dropping would result in the all of the session
info for the corresponding browser tab to be lost. Because of this, we had some behavior in the file
uploader frontend code that had the file uploader reset itself on websocket disconnect as we'd be
guaranteed to lose the files anyway.

As this is no longer true (and also thanks to our file uploader rework in #7025), we can just drop
this check entirely now so that files uploaded to a file uploader are still accessible after a websocket
connection disconnects and reconnects.

Note that there is one remaining edge case involving when a browser tab is disconnected long
enough that we do clean up all of its session state and lose any uploaded files. In this case, the file
uploader UI may display uploaded files that no longer exist on the server. This is ok, though, as this
scenario most commonly happens when, for example, a laptop lid has been closed or the user's
internet connection has been offline for awhile for any other reason. In these scenarios, it's highly 
likely that tab a refresh is necessary anyway to get rid of weird behavior.