### PR TITLE
Fix autofill browser by making sure we commit the value in text inputs

### DIFF
--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -103,13 +103,13 @@ class TextArea extends React.PureComponent<Props, State> {
   }
 
   /** Commit state.value to the WidgetStateManager. */
-  private commitWidgetValue = (source: Source, dirty = false): void => {
+  private commitWidgetValue = (source: Source): void => {
     this.props.widgetMgr.setStringValue(
       this.props.element,
       this.state.value,
       source
     )
-    this.setState({ dirty })
+    this.setState({ dirty: false })
   }
 
   /**
@@ -140,22 +140,9 @@ class TextArea extends React.PureComponent<Props, State> {
       return
     }
 
-    // If the TextInput is *not* part of a form, we mark it dirty but don't
-    // update its value in the WidgetMgr. This means that individual keypresses
-    // won't trigger a script re-run.
-    if (!isInForm(this.props.element)) {
-      this.setState({ dirty: true, value })
-      return
-    }
-
-    // If TextArea *is* part of a form, we immediately update its widgetValue
-    // on text changes. The widgetValue won't be passed to the Python
-    // script until the form is submitted, so this won't cause the script
-    // to re-run.
-    this.setState({ dirty: true, value }, () =>
-      // make sure dirty is true so that enter to submit text shows
-      this.commitWidgetValue({ fromUi: false }, true)
-    )
+    // mark it dirty but don't update its value in the WidgetMgr
+    // This means that individual keypresses won't trigger a script re-run.
+    this.setState({ dirty: true, value })
   }
 
   isEnterKeyPressed = (

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -217,24 +217,6 @@ describe("TextInput widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledTimes(1)
   })
 
-  it("updates widget value on text changes when inside of a form", () => {
-    const props = getProps({ formId: "form" })
-    jest.spyOn(props.widgetMgr, "setStringValue")
-    render(<TextInput {...props} />)
-
-    const textInput = screen.getByRole("textbox")
-    fireEvent.change(textInput, { target: { value: "TEST" } })
-
-    // Check that the last call used the TEST value.
-    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
-      props.element,
-      "TEST",
-      {
-        fromUi: true,
-      }
-    )
-  })
-
   it("limits input length if max_chars is passed", () => {
     const props = getProps({ maxChars: 10 })
     render(<TextInput {...props} />)

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -229,7 +229,6 @@ describe("TextInput widget", () => {
     expect(textInput).toHaveValue("0123456789")
   })
 
-  // make sure we update the widget value inside of a form otherwise this bug can occur: https://github.com/streamlit/streamlit/issues/7101
   it("does update widget value on text changes when inside of a form", async () => {
     const props = getProps({ formId: "formId" })
     const setStringValueSpy = jest.spyOn(props.widgetMgr, "setStringValue")

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -106,8 +106,8 @@ class TextInput extends React.PureComponent<Props, State> {
    *
    * @param source - Whether or not from the UI
    * @param updateState - Optional flag to determine if the state should be updated
-   *                           to reflect that the value is no longer 'dirty' or modified.
-   *                           By default, this is true, meaning the state WILL be updated.
+   *                      to reflect that the value is no longer 'dirty' or modified.
+   *                      By default, this is true, meaning the state WILL be updated.
    */
   private commitWidgetValue = (source: Source, updateState = true): void => {
     this.props.widgetMgr.setStringValue(

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -155,6 +155,7 @@ class TextInput extends React.PureComponent<Props, State> {
     // to re-run.
     this.setState({ dirty: true, value }, () =>
       // make sure dirty is true so that enter to submit text shows
+      // make sure we commit the widget value or this bug can occur: https://github.com/streamlit/streamlit/issues/7101
       this.commitWidgetValue({ fromUi: true }, true)
     )
   }

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -155,7 +155,7 @@ class TextInput extends React.PureComponent<Props, State> {
     // to re-run.
     this.setState({ dirty: true, value }, () =>
       // make sure dirty is true so that enter to submit text shows
-      this.commitWidgetValue({ fromUi: false }, true)
+      this.commitWidgetValue({ fromUi: true }, true)
     )
   }
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -105,7 +105,7 @@ class TextInput extends React.PureComponent<Props, State> {
    * Commits the current state value to the WidgetStateManager.
    *
    * @param source - Whether or not from the UI
-   * @param updateDirtyState - Optional flag to determine if the state should be updated
+   * @param updateState - Optional flag to determine if the state should be updated
    *                           to reflect that the value is no longer 'dirty' or modified.
    *                           By default, this is true, meaning the state WILL be updated.
    */
@@ -166,7 +166,6 @@ class TextInput extends React.PureComponent<Props, State> {
     else {
       // make sure dirty is true so that enter to apply text shows
       this.setState({ dirty: true, value })
-      return
     }
   }
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -107,7 +107,7 @@ class TextInput extends React.PureComponent<Props, State> {
    * @param source - Whether or not from the UI
    * @param updateDirtyState - Optional flag to determine if the state should be updated
    *                           to reflect that the value is no longer 'dirty' or modified.
-   *                           By default, this is false, meaning the state will not be updated.
+   *                           By default, this is true, meaning the state WILL be updated.
    */
   private commitWidgetValue = (source: Source, updateState = true): void => {
     this.props.widgetMgr.setStringValue(

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -144,7 +144,14 @@ class TextInput extends React.PureComponent<Props, State> {
     // If the TextInput is *not* part of a form, we mark it dirty but don't
     // update its value in the WidgetMgr. This means that individual keypresses
     // won't trigger a script re-run.
-    this.setState({ dirty: true, value })
+    if (!isInForm(this.props.element)) {
+      this.setState({ dirty: true, value })
+      return
+    }
+
+    this.setState({ dirty: true, value }, () =>
+      this.commitWidgetValue({ fromUi: true })
+    )
   }
 
   private onKeyPress = (

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -102,13 +102,13 @@ class TextInput extends React.PureComponent<Props, State> {
   }
 
   /** Commit state.value to the WidgetStateManager. */
-  private commitWidgetValue = (source: Source): void => {
+  private commitWidgetValue = (source: Source, dirty = false): void => {
     this.props.widgetMgr.setStringValue(
       this.props.element,
       this.state.value,
       source
     )
-    this.setState({ dirty: false })
+    this.setState({ dirty })
   }
 
   /**
@@ -149,8 +149,13 @@ class TextInput extends React.PureComponent<Props, State> {
       return
     }
 
+    // If TextArea *is* part of a form, we immediately update its widgetValue
+    // on text changes. The widgetValue won't be passed to the Python
+    // script until the form is submitted, so this won't cause the script
+    // to re-run.
     this.setState({ dirty: true, value }, () =>
-      this.commitWidgetValue({ fromUi: true })
+      // make sure dirty is true so that enter to submit text shows
+      this.commitWidgetValue({ fromUi: false }, true)
     )
   }
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- Change commitWidgetValue to take in dirty parameter as we need to change dirty to true when committing the widget value
  -  we need to commit the widget value because when autofill is done, the widget value is not committed as thus username will show up to be an empty string without interaction
## GitHub Issue Link (if applicable)
 #7101 
#7084 
## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- readded tests I deleted before with some slight additions
- E2E Tests
- Any manual testing needed?
- yes
- it doesn't seem very doable to test autofill functionality. However, I can probably add some tests for commit value being called 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
