### PR TITLE
Option to disable step buttons on number_input

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -419,6 +419,7 @@ class NumberInput extends React.PureComponent<Props, State> {
                 className="step-down"
                 onClick={this.modifyValueUsingStep("decrement")}
                 disabled={disableDecrement}
+                tabIndex={-1}
               >
                 <Icon
                   content={Minus}
@@ -430,6 +431,7 @@ class NumberInput extends React.PureComponent<Props, State> {
                 className="step-up"
                 onClick={this.modifyValueUsingStep("increment")}
                 disabled={disableIncrement}
+                tabIndex={-1}
               >
                 <Icon
                   content={Plus}


### PR DESCRIPTION

## Describe your changes
Add optional kwarg to `st.number_input` called `disable_step_button` which controls visibility of the +/- buttons next to the input field. 

## Motivation

We are using Streamlit to annotate images and have many numerical input fields the users must interact with. Allowing them to keep hands on keyboard with consistent tabbing behavior combined with forms greatly increases their throughput and minimizes errors. 


For example, if you have this setup:
```python
st.number_input("X", min_value=0, max_value=5)
st.number_input("Y", min_value=0, max_value=5)
```
entering a value of X=0 pressing TAB twice will get you to the Y input field. But entering X=1 requires  pressing TAB 3x. By changing to :
```python
st.number_input("X", min_value=0, max_value=5, disable_step_button=True)
st.number_input("Y", min_value=0, max_value=5, disable_step_button=True)
```
a single TAB gets you to the next input field regardless of the field value. 

## GitHub Issue Link (if applicable)
This adds on top of #7050 which dynamically hides the buttons to prevent them hiding the input field. 

## Testing Plan
* Python tests have been updated to verify default and accept user input
* JS tests updated to verify default and user specified value

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
