### PR TITLE
Allow metrics gathering even if interrupted by rerun, and track `st.rerun`

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -44,7 +44,7 @@ def stop() -> NoReturn:
     raise StopException()
 
 
-@gather_metrics("rerun")
+@gather_metrics("experimental_rerun")
 def rerun() -> NoReturn:
     """Rerun the script immediately.
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -14,6 +14,7 @@
 
 from typing import NoReturn
 
+from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import (
     RerunData,
     RerunException,
@@ -43,6 +44,7 @@ def stop() -> NoReturn:
     raise StopException()
 
 
+@gather_metrics("rerun")
 def rerun() -> NoReturn:
     """Rerun the script immediately.
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -319,8 +319,9 @@ def gather_metrics(name: str, func: Optional[F] = None) -> Union[Callable[[F], F
     @wraps(non_optional_func)
     def wrapped_func(*args, **kwargs):
         exec_start = timer()
-        # get_script_run_ctx gets imported here to prevent circular dependencies
+        # Local imports to prevent circular dependencies
         from streamlit.runtime.scriptrunner import get_script_run_ctx
+        from streamlit.runtime.scriptrunner.script_runner import RerunException
 
         ctx = get_script_run_ctx(suppress_warning=True)
 
@@ -331,7 +332,6 @@ def gather_metrics(name: str, func: Optional[F] = None) -> Union[Callable[[F], F
             and len(ctx.tracked_commands)
             < _MAX_TRACKED_COMMANDS  # Prevent too much memory usage
         )
-        from streamlit.runtime.scriptrunner.script_runner import RerunException
 
         deferred_exception: Optional[RerunException] = None
         command_telemetry: Optional[Command] = None


### PR DESCRIPTION
## Describe your changes
A fix for `gather_metrics` when the command is interrupted by a `RerunException`, which is most relevant for `st.rerun` but will sometimes affect all functions.
Relatedly enabling metrics for `st.rerun`

