### PR TITLE
Fix issue with duplicated widget ID for toggle

### DIFF
--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -272,7 +272,7 @@ class CheckboxMixin:
         maybe_raise_label_warnings(label, label_visibility)
 
         id = compute_widget_id(
-            "checkbox",
+            "toggle" if type == CheckboxProto.StyleType.TOGGLE else "checkbox",
             user_key=key,
             label=label,
             value=bool(value),


### PR DESCRIPTION
## Describe your changes

Use a different name for generating the widget ID if the checkbox type is toggle. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
