### PR TITLE
Add the disableUserTheme flag to host config

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -437,7 +437,7 @@ describe("App.handleNewSession", () => {
   it("should not process theme and log a warning if disableUserTheme is true", async () => {
     let appInstance: any
     const log = await import("@streamlit/lib/src/util/log")
-    const logWarningSpy = jest.spyOn(log, "logWarning")
+    const logErrorSpy = jest.spyOn(log, "logError")
 
     render(
       <App
@@ -455,7 +455,7 @@ describe("App.handleNewSession", () => {
     appInstance.processTheme = mockProcessTheme
     expect(mockProcessTheme).not.toHaveBeenCalled()
 
-    expect(logWarningSpy).toHaveBeenLastCalledWith(
+    expect(logErrorSpy).toHaveBeenLastCalledWith(
       "Setting the theme through config.toml is disabled by security policy of the host."
     )
   })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -434,6 +434,26 @@ describe("App.handleNewSession", () => {
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
+  it("should not process theme if disableUserTheme is true", async () => {
+    let appInstance: any
+
+    render(
+      <App
+        ref={node => {
+          appInstance = node
+        }}
+        {...getProps()}
+      />
+    )
+
+    appInstance.setHostConfig({ disableUserTheme: true })
+    appInstance.handleNewSession(new NewSession(NEW_SESSION_JSON))
+
+    const mockProcessTheme = jest.fn()
+    appInstance.processTheme = mockProcessTheme
+    expect(mockProcessTheme).not.toHaveBeenCalled()
+  })
+
   it("performs one-time initialization", () => {
     const wrapper = shallow(<App {...getProps()} />)
     const app = wrapper.instance()

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -434,8 +434,10 @@ describe("App.handleNewSession", () => {
     expect(props.theme.setTheme).not.toHaveBeenCalled()
   })
 
-  it("should not process theme if disableUserTheme is true", async () => {
+  it("should not process theme and log a warning if disableUserTheme is true", async () => {
     let appInstance: any
+    const log = await import("@streamlit/lib/src/util/log")
+    const logWarningSpy = jest.spyOn(log, "logWarning")
 
     render(
       <App
@@ -452,6 +454,10 @@ describe("App.handleNewSession", () => {
     const mockProcessTheme = jest.fn()
     appInstance.processTheme = mockProcessTheme
     expect(mockProcessTheme).not.toHaveBeenCalled()
+
+    expect(logWarningSpy).toHaveBeenLastCalledWith(
+      "Setting the theme through config.toml is disabled by security policy of the host."
+    )
   })
 
   it("performs one-time initialization", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -860,8 +860,12 @@ export class App extends PureComponent<Props, State> {
         window.history.pushState({}, "", pageUrl)
       }
     }
-
-    this.processThemeInput(themeInput)
+    console.log(this.state.hostConfig)
+    if (!this.state.hostConfig.disableUserTheme) {
+      this.processThemeInput(themeInput)
+    } else {
+      console.log("do not process theme input!")
+    }
     this.setState(
       {
         allowRunOnSave: config.allowRunOnSave,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -860,11 +860,8 @@ export class App extends PureComponent<Props, State> {
         window.history.pushState({}, "", pageUrl)
       }
     }
-    console.log(this.state.hostConfig)
     if (!this.state.hostConfig.disableUserTheme) {
       this.processThemeInput(themeInput)
-    } else {
-      console.log("do not process theme input!")
     }
     this.setState(
       {
@@ -1619,6 +1616,7 @@ export class App extends PureComponent<Props, State> {
       this.state.toolbarMode
     )
 
+    const usingCustomTheme = !isPresetTheme(this.props.theme.activeTheme)
     const outerDivClass = classNames(
       "stApp",
       getEmbeddingIdClassName(this.embeddingId),
@@ -1663,9 +1661,14 @@ export class App extends PureComponent<Props, State> {
             addScriptFinishedHandler: this.addScriptFinishedHandler,
             removeScriptFinishedHandler: this.removeScriptFinishedHandler,
             activeTheme: this.props.theme.activeTheme,
-            setTheme: this.setAndSendTheme,
+            setTheme:
+              this.state.hostConfig.disableUserTheme && usingCustomTheme
+                ? noop
+                : this.setAndSendTheme,
             availableThemes: this.props.theme.availableThemes,
-            addThemes: this.props.theme.addThemes,
+            addThemes: this.state.hostConfig.disableUserTheme
+              ? noop
+              : this.props.theme.addThemes,
             hideFullScreenButtons: false,
             hostConfig,
             setHostConfig: this.setHostConfig,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1620,7 +1620,6 @@ export class App extends PureComponent<Props, State> {
       this.state.toolbarMode
     )
 
-    const usingCustomTheme = !isPresetTheme(this.props.theme.activeTheme)
     const outerDivClass = classNames(
       "stApp",
       getEmbeddingIdClassName(this.embeddingId),

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -863,7 +863,7 @@ export class App extends PureComponent<Props, State> {
     if (!this.state.hostConfig.disableUserTheme) {
       this.processThemeInput(themeInput)
     } else {
-      logWarning(
+      logError(
         "Setting the theme through config.toml is disabled by security policy of the host."
       )
     }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -862,6 +862,10 @@ export class App extends PureComponent<Props, State> {
     }
     if (!this.state.hostConfig.disableUserTheme) {
       this.processThemeInput(themeInput)
+    } else {
+      logWarning(
+        "Setting the theme through config.toml is disabled by security policy of the host."
+      )
     }
     this.setState(
       {
@@ -1661,14 +1665,9 @@ export class App extends PureComponent<Props, State> {
             addScriptFinishedHandler: this.addScriptFinishedHandler,
             removeScriptFinishedHandler: this.removeScriptFinishedHandler,
             activeTheme: this.props.theme.activeTheme,
-            setTheme:
-              this.state.hostConfig.disableUserTheme && usingCustomTheme
-                ? noop
-                : this.setAndSendTheme,
+            setTheme: this.setAndSendTheme,
             availableThemes: this.props.theme.availableThemes,
-            addThemes: this.state.hostConfig.disableUserTheme
-              ? noop
-              : this.props.theme.addThemes,
+            addThemes: this.props.theme.addThemes,
             hideFullScreenButtons: false,
             hostConfig,
             setHostConfig: this.setHostConfig,

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -26,7 +26,7 @@ export type HostConfig = {
   disableIframes?: boolean
   disableSvgImages?: boolean
   disableElements?: string[]
-  // TODO(lukasmasuch): To my understanding, disabling the theming is not anymore needed? disableTheming?: boolean
+  disableUserTheme?: boolean
   // TODO(lukasmasuch): move the hideFullScreenButtons setting to this config?: disableFullScreenMode?: false
 }
 

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -118,6 +118,7 @@ export const customRenderLibContext = (
     hideFullScreenButtons: false,
     hostConfig: {},
     setHostConfig: jest.fn(),
+    disableUserTheme: false,
   }
 
   return reactTestingLibraryRender(component, {

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -228,7 +228,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 "disableSvgImages": False,
                 "disableIframes": False,
                 "disableElements": [],
-                "disableUserTheme": True,
+                "disableUserTheme": False,
             }
         )
         self.set_status(200)

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -228,6 +228,7 @@ class HostConfigHandler(_SpecialRequestHandler):
                 "disableSvgImages": False,
                 "disableIframes": False,
                 "disableElements": [],
+                "disableUserTheme": True,
             }
         )
         self.set_status(200)


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- add the default `disableUserTheme` to routes.py
- add `disableUserTheme` to LibContext
- check `disableUserTheme` and only call `processThemeInput` if `disableUserTheme` is false
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- added unit test
- E2E Tests
- Any manual testing needed?
- tested it manually
<img width="1567" alt="Screenshot 2023-08-15 at 9 15 42 AM" src="https://github.com/streamlit/streamlit/assets/103006371/b48954a2-7498-4ac0-8488-d0e34992b2be">

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
