### PR TITLE
Add allowed-message-origins to config

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -574,6 +574,16 @@ _create_option(
 
 _create_section("server", "Settings for the Streamlit server")
 
+
+_create_option(
+    "server.allowedMessageOrigins",
+    description="""This list is an allow-list of origins from which a deployed Streamlit app can receive cross-origin messages from.
+    If not specified, a default list of origins will be used, which are designed for Community Cloud deployments.
+    Example: ['https://*.streamlit.app, "https://*.demo.streamlit.app",]
+    """,
+    default_val=[],
+)
+
 _create_option(
     "server.folderWatchBlacklist",
     description="""List of folders that should not be watched for changes. This

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -168,7 +168,7 @@ class HealthHandler(_SpecialRequestHandler):
 # run, this list will most likely be replaced by a config option allowing us to more
 # granularly control what domains a Streamlit app should accept cross-origin iframe
 # messages from.
-ALLOWED_MESSAGE_ORIGINS = [
+DEFAULT_ALLOWED_MESSAGE_ORIGINS = [
     "https://devel.streamlit.test",
     "https://*.streamlit.apptest",
     "https://*.streamlitapp.test",
@@ -190,7 +190,11 @@ ALLOWED_MESSAGE_ORIGINS = [
 
 class AllowedMessageOriginsHandler(_SpecialRequestHandler):
     def initialize(self):
-        self.allowed_message_origins = [*ALLOWED_MESSAGE_ORIGINS]
+        user_defined_origins = config.get_option("server.allowedMessageOrigins")
+        if len(user_defined_origins) == 0:
+            self.allowed_message_origins = DEFAULT_ALLOWED_MESSAGE_ORIGINS
+        else:
+            self.allowed_message_origins = user_defined_origins
         if config.get_option("global.developmentMode"):
             # Allow messages from localhost in dev mode for testing of host <-> guest communication
             self.allowed_message_origins.append("http://localhost")
@@ -211,7 +215,11 @@ class AllowedMessageOriginsHandler(_SpecialRequestHandler):
 
 class HostConfigHandler(_SpecialRequestHandler):
     def initialize(self):
-        self.allowed_message_origins = [*ALLOWED_MESSAGE_ORIGINS]
+        user_defined_origins = config.get_option("server.allowedMessageOrigins")
+        if len(user_defined_origins) == 0:
+            self.allowed_message_origins = DEFAULT_ALLOWED_MESSAGE_ORIGINS
+        else:
+            self.allowed_message_origins = user_defined_origins
         if config.get_option("global.developmentMode"):
             # Allow messages from localhost in dev mode for testing of host <-> guest communication
             self.allowed_message_origins.append("http://localhost")

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -369,6 +369,7 @@ class ConfigTest(unittest.TestCase):
                 "runner.postScriptGC",
                 "runner.fastReruns",
                 "mapbox.token",
+                "server.allowedMessageOrigins",
                 "server.baseUrlPath",
                 "server.enableCORS",
                 "server.cookieSecret",


### PR DESCRIPTION
## Describe your changes

Allow users to set a list of hosts to override default allowed_message_origins

## GitHub Issue Link (if applicable)

Addressing #6389 
Replacing PR #7172 
