### PR TITLE
Add github token to fix community voting

### DIFF
--- a/.github/workflows/community-voting.yml
+++ b/.github/workflows/community-voting.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Add comment to issue
         run: gh issue comment ${{ github.event.issue.html_url }} --body "$ISSUE_BODY"
         env:
+          GH_TOKEN: ${{ github.token }}
           ISSUE_BODY: |
             **To help Streamlit prioritize this feature, react with a 👍 (thumbs up emoji) to the initial post.**
 
@@ -36,6 +37,7 @@ jobs:
       - name: Add comment to issue
         run: gh issue comment ${{ github.event.issue.html_url }} --body "$ISSUE_BODY"
         env:
+          GH_TOKEN: ${{ github.token }}
           ISSUE_BODY: |
             **If this issue affects you, please react with a 👍 (thumbs up emoji) to the initial post.**
 


### PR DESCRIPTION
## Describe your changes

I forgot to set the GH_TOKEN env variable which is required for the GitHub CLI. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
