### PR TITLE
Deprecate allowed-message-origins endpoint

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1517,7 +1517,7 @@ describe("handles HostCommunication messaging", () => {
     instance = wrapper.instance() as App
 
     // @ts-expect-error - hostCommunicationMgr is private
-    instance.hostCommunicationMgr.setAllowedOriginsResp({
+    instance.hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1517,7 +1517,7 @@ describe("handles HostCommunication messaging", () => {
     instance = wrapper.instance() as App
 
     // @ts-expect-error - hostCommunicationMgr is private
-    instance.hostCommunicationMgr.setHostConfigResp({
+    instance.hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1517,10 +1517,10 @@ describe("handles HostCommunication messaging", () => {
     instance = wrapper.instance() as App
 
     // @ts-expect-error - hostCommunicationMgr is private
-    instance.hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["https://devel.streamlit.test"],
-      useExternalAuthToken: false,
-    })
+    instance.hostCommunicationMgr.setAllowedOrigins(
+      ["https://devel.streamlit.test"],
+      false
+    )
 
     sendMessageFunc = jest.spyOn(
       // @ts-expect-error

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1151,7 +1151,7 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Update pendingElementsBuffer with the given Delta and set up a timer to
-   * update state.elements. This buffers us to process Deltas quickly
+   * update state.elements. This buffer allows us to process Deltas quickly
    * without spamming React with too many of render() calls.
    */
   handleDeltaMsg = (

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -383,10 +383,10 @@ export class App extends PureComponent<Props, State> {
       claimHostAuthToken: this.hostCommunicationMgr.claimAuthToken,
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
       setAllowedOrigins: (response: IHostConfigResponse) => {
-        this.hostCommunicationMgr.setAllowedOrigins({
-          allowedOrigins: response.allowedOrigins || [],
-          useExternalAuthToken: response.useExternalAuthToken || false,
-        })
+        this.hostCommunicationMgr.setAllowedOrigins(
+          response.allowedOrigins || [],
+          response.useExternalAuthToken || false
+        )
         this.setHostConfig(response)
       },
     })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -382,8 +382,11 @@ export class App extends PureComponent<Props, State> {
       connectionStateChanged: this.handleConnectionStateChanged,
       claimHostAuthToken: this.hostCommunicationMgr.claimAuthToken,
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
-      setHostConfigResp: (response: IHostConfigResponse) => {
-        this.hostCommunicationMgr.setHostConfigResp(response)
+      setAllowedOrigins: (response: IHostConfigResponse) => {
+        this.hostCommunicationMgr.setAllowedOrigins({
+          allowedOrigins: response.allowedOrigins || [],
+          useExternalAuthToken: response.useExternalAuthToken || false,
+        })
         this.setHostConfig(response)
       },
     })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -384,7 +384,6 @@ export class App extends PureComponent<Props, State> {
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
       setAllowedOriginsResp: this.hostCommunicationMgr.setAllowedOriginsResp,
       setHostConfigResp: (response: IHostConfigResponse) => {
-        // TODO(lukasmasuch): Also configure the allowed origins based on the host config response.
         this.setHostConfig(response)
       },
     })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -383,6 +383,7 @@ export class App extends PureComponent<Props, State> {
       claimHostAuthToken: this.hostCommunicationMgr.claimAuthToken,
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
       setHostConfigResp: (response: IHostConfigResponse) => {
+        this.hostCommunicationMgr.setHostConfigResp(response)
         this.setHostConfig(response)
       },
     })
@@ -1150,7 +1151,7 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Update pendingElementsBuffer with the given Delta and set up a timer to
-   * update state.elements. This buffer allows us to process Deltas quickly
+   * update state.elements. This buffers us to process Deltas quickly
    * without spamming React with too many of render() calls.
    */
   handleDeltaMsg = (

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -382,7 +382,6 @@ export class App extends PureComponent<Props, State> {
       connectionStateChanged: this.handleConnectionStateChanged,
       claimHostAuthToken: this.hostCommunicationMgr.claimAuthToken,
       resetHostAuthToken: this.hostCommunicationMgr.resetAuthToken,
-      setAllowedOriginsResp: this.hostCommunicationMgr.setAllowedOriginsResp,
       setHostConfigResp: (response: IHostConfigResponse) => {
         this.setHostConfig(response)
       },

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -78,7 +78,7 @@ interface Props {
    * Function to set the host config for this app (if in a relevant deployment
    * scenario).
    */
-  setHostConfigResp: (resp: IHostConfigResponse) => void
+  setAllowedOrigins: (resp: IHostConfigResponse) => void
 }
 
 /**
@@ -192,7 +192,7 @@ export class ConnectionManager {
       onRetry: this.showRetryError,
       claimHostAuthToken: this.props.claimHostAuthToken,
       resetHostAuthToken: this.props.resetHostAuthToken,
-      setHostConfigResp: this.props.setHostConfigResp,
+      setAllowedOrigins: this.props.setAllowedOrigins,
     })
   }
 }

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -16,7 +16,6 @@
 import { ReactNode } from "react"
 
 import {
-  IAllowedMessageOriginsResponse,
   IHostConfigResponse,
   BaseUriParts,
   getPossibleBaseUris,
@@ -74,12 +73,6 @@ interface Props {
    * resolves.
    */
   resetHostAuthToken: () => void
-
-  /**
-   * Function to set the list of origins that this app should accept
-   * cross-origin messages from (if in a relevant deployment scenario).
-   */
-  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void
 
   /**
    * Function to set the host config for this app (if in a relevant deployment

--- a/frontend/app/src/connection/ConnectionManager.ts
+++ b/frontend/app/src/connection/ConnectionManager.ts
@@ -192,7 +192,6 @@ export class ConnectionManager {
       onRetry: this.showRetryError,
       claimHostAuthToken: this.props.claimHostAuthToken,
       resetHostAuthToken: this.props.resetHostAuthToken,
-      setAllowedOriginsResp: this.props.setAllowedOriginsResp,
       setHostConfigResp: this.props.setHostConfigResp,
     })
   }

--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -34,13 +34,6 @@ import {
   Args,
 } from "@streamlit/app/src/connection/WebsocketConnection"
 
-const MOCK_ALLOWED_ORIGINS_RESPONSE = {
-  data: {
-    allowedOrigins: ["list", "of", "allowed", "origins"],
-    useExternalAuthToken: false,
-  },
-}
-
 const MOCK_ALLOWED_HOST_CONFIG_RESPONSE = {
   data: {
     allowedOrigins: ["list", "of", "allowed", "origins"],
@@ -67,7 +60,6 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     onRetry: jest.fn(),
     claimHostAuthToken: () => Promise.resolve(undefined),
     resetHostAuthToken: jest.fn(),
-    setAllowedOriginsResp: jest.fn(),
     setHostConfigResp: jest.fn(),
     ...overrides,
   }
@@ -82,7 +74,6 @@ describe("doInitPings", () => {
     timeoutMs: 10,
     maxTimeoutMs: 100,
     retryCallback: jest.fn(),
-    setAllowedOriginsResp: jest.fn(),
     setHostConfigResp: jest.fn(),
     userCommandLine: "streamlit run not-a-real-script.py",
   }
@@ -94,7 +85,6 @@ describe("doInitPings", () => {
     originalAxiosGet = axios.get
     axios.get = jest.fn()
     MOCK_PING_DATA.retryCallback = jest.fn()
-    MOCK_PING_DATA.setAllowedOriginsResp = jest.fn()
     MOCK_PING_DATA.setHostConfigResp = jest.fn()
     originalPromiseAll = Promise.all
   })
@@ -109,10 +99,7 @@ describe("doInitPings", () => {
       if (url.endsWith("_stcore/health")) {
         return MOCK_HEALTH_RESPONSE
       }
-      if (url.endsWith("_stcore/allowed-message-origins")) {
-        return MOCK_ALLOWED_ORIGINS_RESPONSE
-      }
-      if (url.endsWith("./_stcore/host-config")) {
+      if (url.endsWith("_stcore/host-config")) {
         return MOCK_ALLOWED_HOST_CONFIG_RESPONSE
       }
       return {}
@@ -123,62 +110,52 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
-    expect(MOCK_PING_DATA.setAllowedOriginsResp).toHaveBeenCalledWith(
-      MOCK_ALLOWED_ORIGINS_RESPONSE.data
+    expect(MOCK_PING_DATA.setHostConfigResp).toHaveBeenCalledWith(
+      MOCK_ALLOWED_HOST_CONFIG_RESPONSE.data
     )
   })
 
-  it("returns the uri index and sets allowedOrigins for the first successful ping (0)", async () => {
+  it("returns the uri index and sets hostConfig for the first successful ping (0)", async () => {
     Promise.all = jest
       .fn()
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     const uriIndex = await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
-    expect(MOCK_PING_DATA.setAllowedOriginsResp).toHaveBeenCalledWith(
-      MOCK_ALLOWED_ORIGINS_RESPONSE.data
+    expect(MOCK_PING_DATA.setHostConfigResp).toHaveBeenCalledWith(
+      MOCK_ALLOWED_HOST_CONFIG_RESPONSE.data
     )
   })
 
-  it("returns the uri index and sets allowedOrigins for the first successful ping (1)", async () => {
+  it("returns the uri index and sets hostConfig for the first successful ping (1)", async () => {
     Promise.all = jest
       .fn()
       .mockRejectedValueOnce(new Error(""))
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     const uriIndex = await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(1)
-    expect(MOCK_PING_DATA.setAllowedOriginsResp).toHaveBeenCalledWith(
-      MOCK_ALLOWED_ORIGINS_RESPONSE.data
+    expect(MOCK_PING_DATA.setHostConfigResp).toHaveBeenCalledWith(
+      MOCK_ALLOWED_HOST_CONFIG_RESPONSE.data
     )
   })
 
@@ -189,18 +166,14 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(new Error(TEST_ERROR_MESSAGE))
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -219,18 +192,13 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -253,18 +221,13 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -285,18 +248,13 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -341,18 +299,13 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA_LOCALHOST.uri,
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA_LOCALHOST.retryCallback,
-      MOCK_PING_DATA_LOCALHOST.setAllowedOriginsResp,
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA_LOCALHOST.userCommandLine
     )
@@ -386,18 +339,14 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -421,18 +370,14 @@ describe("doInitPings", () => {
       .fn()
       .mockRejectedValueOnce(TEST_ERROR)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -455,18 +400,14 @@ describe("doInitPings", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     await doInitPings(
       MOCK_PING_DATA.uri,
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -485,11 +426,7 @@ describe("doInitPings", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     const timeouts: number[] = []
     const callback = (
@@ -505,7 +442,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -533,11 +470,7 @@ describe("doInitPings", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     const timeouts: number[] = []
     const callback = (
@@ -553,7 +486,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -573,19 +506,11 @@ describe("doInitPings", () => {
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // Reset after second doInitPings call
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       .mockRejectedValueOnce(TEST_ERROR_MESSAGE)
       // The promise should be resolved to avoid an infinite loop.
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     const timeouts: number[] = []
     const callback = (
@@ -601,7 +526,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -620,7 +545,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
-      MOCK_PING_DATA.setAllowedOriginsResp,
+
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -647,11 +572,7 @@ describe("WebsocketConnection", () => {
     originalPromiseAll = Promise.all
     Promise.all = jest
       .fn()
-      .mockResolvedValueOnce([
-        "",
-        MOCK_ALLOWED_ORIGINS_RESPONSE,
-        MOCK_ALLOWED_HOST_CONFIG_RESPONSE,
-      ])
+      .mockResolvedValueOnce(["", MOCK_ALLOWED_HOST_CONFIG_RESPONSE])
 
     client = new WebsocketConnection(createMockArgs())
   })

--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -173,7 +173,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -346,7 +345,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -377,7 +375,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -407,7 +404,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -442,7 +438,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -486,7 +481,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -526,7 +520,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )
@@ -545,7 +538,6 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
-
       MOCK_PING_DATA.setHostConfigResp,
       MOCK_PING_DATA.userCommandLine
     )

--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -60,7 +60,7 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     onRetry: jest.fn(),
     claimHostAuthToken: () => Promise.resolve(undefined),
     resetHostAuthToken: jest.fn(),
-    setHostConfigResp: jest.fn(),
+    setAllowedOrigins: jest.fn(),
     ...overrides,
   }
 }
@@ -74,7 +74,7 @@ describe("doInitPings", () => {
     timeoutMs: 10,
     maxTimeoutMs: 100,
     retryCallback: jest.fn(),
-    setHostConfigResp: jest.fn(),
+    setAllowedOrigins: jest.fn(),
     userCommandLine: "streamlit run not-a-real-script.py",
   }
 
@@ -85,7 +85,7 @@ describe("doInitPings", () => {
     originalAxiosGet = axios.get
     axios.get = jest.fn()
     MOCK_PING_DATA.retryCallback = jest.fn()
-    MOCK_PING_DATA.setHostConfigResp = jest.fn()
+    MOCK_PING_DATA.setAllowedOrigins = jest.fn()
     originalPromiseAll = Promise.all
   })
 
@@ -110,11 +110,11 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
-    expect(MOCK_PING_DATA.setHostConfigResp).toHaveBeenCalledWith(
+    expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
       MOCK_ALLOWED_HOST_CONFIG_RESPONSE.data
     )
   })
@@ -130,11 +130,11 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
 
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(0)
-    expect(MOCK_PING_DATA.setHostConfigResp).toHaveBeenCalledWith(
+    expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
       MOCK_ALLOWED_HOST_CONFIG_RESPONSE.data
     )
   })
@@ -150,11 +150,11 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
     expect(uriIndex).toEqual(1)
-    expect(MOCK_PING_DATA.setHostConfigResp).toHaveBeenCalledWith(
+    expect(MOCK_PING_DATA.setAllowedOrigins).toHaveBeenCalledWith(
       MOCK_ALLOWED_HOST_CONFIG_RESPONSE.data
     )
   })
@@ -173,7 +173,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -198,7 +198,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -227,7 +227,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -254,7 +254,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -305,7 +305,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA_LOCALHOST.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA_LOCALHOST.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA_LOCALHOST.userCommandLine
     )
 
@@ -345,7 +345,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -375,7 +375,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -404,7 +404,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       MOCK_PING_DATA.retryCallback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -438,7 +438,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -481,7 +481,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -520,7 +520,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 
@@ -538,7 +538,7 @@ describe("doInitPings", () => {
       MOCK_PING_DATA.timeoutMs,
       MOCK_PING_DATA.maxTimeoutMs,
       callback2,
-      MOCK_PING_DATA.setHostConfigResp,
+      MOCK_PING_DATA.setAllowedOrigins,
       MOCK_PING_DATA.userCommandLine
     )
 

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -49,12 +49,7 @@ const LOG = "WebsocketConnection"
 const SERVER_PING_PATH = "_stcore/health"
 
 /**
- * The path to fetch the whitelist for accepting cross-origin messages.
- */
-const ALLOWED_ORIGINS_PATH = "_stcore/allowed-message-origins"
-
-/**
- * The path to fetch the host configuration.
+ * The path to fetch the host configuration and allowed-message-origins.
  */
 const HOST_CONFIG_PATH = "_stcore/host-config"
 
@@ -138,12 +133,6 @@ export interface Args {
    * resolves.
    */
   resetHostAuthToken: () => void
-
-  /**
-   * Function to set the list of origins that this app should accept
-   * cross-origin messages from (if in a relevant deployment scenario).
-   */
-  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void
 
   /**
    * Function to set the host config for this app (if in a relevant deployment
@@ -385,7 +374,6 @@ export class WebsocketConnection {
       PING_MINIMUM_RETRY_PERIOD_MS,
       PING_MAXIMUM_RETRY_PERIOD_MS,
       this.args.onRetry,
-      this.args.setAllowedOriginsResp,
       this.args.setHostConfigResp,
       userCommandLine
     )
@@ -624,7 +612,6 @@ export function doInitPings(
   minimumTimeoutMs: number,
   maximumTimeoutMs: number,
   retryCallback: OnRetry,
-  setAllowedOriginsResp: (resp: IAllowedMessageOriginsResponse) => void,
   setHostConfigResp: (resp: IHostConfigResponse) => void,
   userCommandLine?: string
 ): Promise<number> {
@@ -698,7 +685,6 @@ export function doInitPings(
   connect = () => {
     const uriParts = uriPartsList[uriNumber]
     const healthzUri = buildHttpUri(uriParts, SERVER_PING_PATH)
-    const allowedOriginsUri = buildHttpUri(uriParts, ALLOWED_ORIGINS_PATH)
     const hostConfigUri = buildHttpUri(uriParts, HOST_CONFIG_PATH)
 
     logMessage(LOG, `Attempting to connect to ${healthzUri}.`)
@@ -707,7 +693,7 @@ export function doInitPings(
       totalTries++
     }
 
-    // We fire off requests to the server's healthz and allowed message origins
+    // We fire off requests to the server's healthz and host-config
     // endpoints in parallel to avoid having to wait on too many sequential
     // round trip network requests before we can try to establish a WebSocket
     // connection. Technically, it would have been possible to implement a
@@ -716,11 +702,9 @@ export function doInitPings(
     // endpoint additional responsibilities.
     Promise.all([
       axios.get(healthzUri, { timeout: PING_TIMEOUT_MS }),
-      axios.get(allowedOriginsUri, { timeout: PING_TIMEOUT_MS }),
       axios.get(hostConfigUri, { timeout: PING_TIMEOUT_MS }),
     ])
-      .then(([_, originRequest, hostConfigRequest]) => {
-        setAllowedOriginsResp(originRequest.data)
+      .then(([_, hostConfigRequest]) => {
         setHostConfigResp(hostConfigRequest.data)
         resolver.resolve(uriNumber)
       })

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -137,7 +137,7 @@ export interface Args {
    * Function to set the host config and allowed-message-origins for this app (if in a relevant deployment
    * scenario).
    */
-  setHostConfigResp: (resp: IHostConfigResponse) => void
+  setAllowedOrigins: (resp: IHostConfigResponse) => void
 }
 
 interface MessageQueue {
@@ -373,7 +373,7 @@ export class WebsocketConnection {
       PING_MINIMUM_RETRY_PERIOD_MS,
       PING_MAXIMUM_RETRY_PERIOD_MS,
       this.args.onRetry,
-      this.args.setHostConfigResp,
+      this.args.setAllowedOrigins,
       userCommandLine
     )
 
@@ -611,7 +611,7 @@ export function doInitPings(
   minimumTimeoutMs: number,
   maximumTimeoutMs: number,
   retryCallback: OnRetry,
-  setHostConfigResp: (resp: IHostConfigResponse) => void,
+  setAllowedOrigins: (resp: IHostConfigResponse) => void,
   userCommandLine?: string
 ): Promise<number> {
   const resolver = new Resolver<number>()
@@ -705,7 +705,7 @@ export function doInitPings(
       axios.get(hostConfigUri, { timeout: PING_TIMEOUT_MS }),
     ])
       .then(([_, hostConfigResp]) => {
-        setHostConfigResp(hostConfigResp.data)
+        setAllowedOrigins(hostConfigResp.data)
         resolver.resolve(uriNumber)
       })
       .catch(error => {

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -18,7 +18,6 @@ import styled from "@emotion/styled"
 import axios from "axios"
 
 import {
-  IAllowedMessageOriginsResponse,
   IHostConfigResponse,
   ForwardMsgCache,
   logError,

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -704,8 +704,8 @@ export function doInitPings(
       axios.get(healthzUri, { timeout: PING_TIMEOUT_MS }),
       axios.get(hostConfigUri, { timeout: PING_TIMEOUT_MS }),
     ])
-      .then(([_, hostConfigRequest]) => {
-        setHostConfigResp(hostConfigRequest.data)
+      .then(([_, hostConfigResp]) => {
+        setHostConfigResp(hostConfigResp.data)
         resolver.resolve(uriNumber)
       })
       .catch(error => {

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -134,7 +134,7 @@ export interface Args {
   resetHostAuthToken: () => void
 
   /**
-   * Function to set the host config for this app (if in a relevant deployment
+   * Function to set the host config and allowed-message-origins for this app (if in a relevant deployment
    * scenario).
    */
   setHostConfigResp: (resp: IHostConfigResponse) => void
@@ -687,6 +687,7 @@ export function doInitPings(
     const hostConfigUri = buildHttpUri(uriParts, HOST_CONFIG_PATH)
 
     logMessage(LOG, `Attempting to connect to ${healthzUri}.`)
+    logMessage(LOG, `Attempting to connect to ${hostConfigUri}`)
 
     if (uriNumber === 0) {
       totalTries++

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -64,14 +64,14 @@ describe("HostCommunicationManager messaging", () => {
     originalHash = window.location.hash
     dispatchEvent = mockEventListeners()
 
-    setHostConfigFunc = jest.spyOn(hostCommunicationMgr, "setHostConfigResp")
+    setHostConfigFunc = jest.spyOn(hostCommunicationMgr, "setAllowedOrigins")
     openCommFunc = jest.spyOn(hostCommunicationMgr, "openHostCommunication")
     sendMessageToHostFunc = jest.spyOn(
       hostCommunicationMgr,
       "sendMessageToHost"
     )
 
-    hostCommunicationMgr.setHostConfigResp({
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
@@ -424,7 +424,7 @@ describe("Test different origins", () => {
   })
 
   it("exact pattern", () => {
-    hostCommunicationMgr.setHostConfigResp({
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://share.streamlit.io"],
       useExternalAuthToken: false,
     })
@@ -445,7 +445,7 @@ describe("Test different origins", () => {
   })
 
   it("wildcard pattern", () => {
-    hostCommunicationMgr.setHostConfigResp({
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://*.streamlitapp.com"],
       useExternalAuthToken: false,
     })
@@ -466,7 +466,7 @@ describe("Test different origins", () => {
   })
 
   it("ignores non-matching origins", () => {
-    hostCommunicationMgr.setHostConfigResp({
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://share.streamlit.io"],
       useExternalAuthToken: false,
     })
@@ -513,10 +513,10 @@ describe("HostCommunicationManager external auth token handling", () => {
   it("resolves promise to undefined immediately if useExternalAuthToken is false", async () => {
     const setAllowedOriginsFunc = jest.spyOn(
       hostCommunicationMgr,
-      "setHostConfigResp"
+      "setAllowedOrigins"
     )
 
-    hostCommunicationMgr.setHostConfigResp({
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
@@ -531,7 +531,7 @@ describe("HostCommunicationManager external auth token handling", () => {
   it("waits to receive SET_AUTH_TOKEN message before resolving promise if useExternalAuthToken is true", async () => {
     const dispatchEvent = mockEventListeners()
 
-    hostCommunicationMgr.setHostConfigResp({
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://devel.streamlit.test"],
       useExternalAuthToken: true,
     })
@@ -564,8 +564,8 @@ describe("HostCommunicationManager external auth token handling", () => {
 
     // Simulate the browser tab disconnecting and reconnecting, which from the
     // HostCommunication's perspective is only seen as a new call to
-    // setHostConfigResp.
-    hostCommunicationMgr.setHostConfigResp({
+    // setAllowedOrigins.
+    hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://devel.streamlit.test"],
       useExternalAuthToken: true,
     })

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -71,10 +71,10 @@ describe("HostCommunicationManager messaging", () => {
       "sendMessageToHost"
     )
 
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["https://devel.streamlit.test"],
-      useExternalAuthToken: false,
-    })
+    hostCommunicationMgr.setAllowedOrigins(
+      ["https://devel.streamlit.test"],
+      false
+    )
   })
 
   afterEach(() => {
@@ -82,10 +82,10 @@ describe("HostCommunicationManager messaging", () => {
   })
 
   it("sets allowedOrigins properly & opens HostCommunication", () => {
-    expect(setHostConfigFunc).toHaveBeenCalledWith({
-      allowedOrigins: ["https://devel.streamlit.test"],
-      useExternalAuthToken: false,
-    })
+    expect(setHostConfigFunc).toHaveBeenCalledWith(
+      ["https://devel.streamlit.test"],
+      false
+    )
     // @ts-expect-error
     expect(hostCommunicationMgr.allowedOrigins).toEqual([
       "https://devel.streamlit.test",
@@ -424,10 +424,10 @@ describe("Test different origins", () => {
   })
 
   it("exact pattern", () => {
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["http://share.streamlit.io"],
-      useExternalAuthToken: false,
-    })
+    hostCommunicationMgr.setAllowedOrigins(
+      ["http://share.streamlit.io"],
+      false
+    )
 
     dispatchEvent(
       "message",
@@ -445,10 +445,10 @@ describe("Test different origins", () => {
   })
 
   it("wildcard pattern", () => {
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["http://*.streamlitapp.com"],
-      useExternalAuthToken: false,
-    })
+    hostCommunicationMgr.setAllowedOrigins(
+      ["http://*.streamlitapp.com"],
+      false
+    )
 
     dispatchEvent(
       "message",
@@ -466,10 +466,10 @@ describe("Test different origins", () => {
   })
 
   it("ignores non-matching origins", () => {
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["http://share.streamlit.io"],
-      useExternalAuthToken: false,
-    })
+    hostCommunicationMgr.setAllowedOrigins(
+      ["http://share.streamlit.io"],
+      false
+    )
 
     dispatchEvent(
       "message",
@@ -516,10 +516,10 @@ describe("HostCommunicationManager external auth token handling", () => {
       "setAllowedOrigins"
     )
 
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["http://devel.streamlit.test"],
-      useExternalAuthToken: false,
-    })
+    hostCommunicationMgr.setAllowedOrigins(
+      ["http://share.streamlit.io"],
+      false
+    )
 
     expect(setAllowedOriginsFunc).toHaveBeenCalled()
     // @ts-expect-error - deferredAuthToken is private
@@ -531,11 +531,10 @@ describe("HostCommunicationManager external auth token handling", () => {
   it("waits to receive SET_AUTH_TOKEN message before resolving promise if useExternalAuthToken is true", async () => {
     const dispatchEvent = mockEventListeners()
 
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["http://devel.streamlit.test"],
-      useExternalAuthToken: true,
-    })
-
+    hostCommunicationMgr.setAllowedOrigins(
+      ["http://devel.streamlit.test"],
+      true
+    )
     // Asynchronously send a SET_AUTH_TOKEN message to the
     // HostCommunicationManager, which won't proceed past the `await`
     // statement below until the message is received and handled.
@@ -565,10 +564,10 @@ describe("HostCommunicationManager external auth token handling", () => {
     // Simulate the browser tab disconnecting and reconnecting, which from the
     // HostCommunication's perspective is only seen as a new call to
     // setAllowedOrigins.
-    hostCommunicationMgr.setAllowedOrigins({
-      allowedOrigins: ["http://devel.streamlit.test"],
-      useExternalAuthToken: true,
-    })
+    hostCommunicationMgr.setAllowedOrigins(
+      ["http://devel.streamlit.test"],
+      true
+    )
 
     setTimeout(() => {
       dispatchEvent(

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -38,7 +38,7 @@ describe("HostCommunicationManager messaging", () => {
   let dispatchEvent: (type: string, event: Event) => void
   let originalHash: string
 
-  let setAllowedOriginsFunc: jest.SpyInstance
+  let setHostConfigFunc: jest.SpyInstance
   let openCommFunc: jest.SpyInstance
   let sendMessageToHostFunc: jest.SpyInstance
 
@@ -64,17 +64,14 @@ describe("HostCommunicationManager messaging", () => {
     originalHash = window.location.hash
     dispatchEvent = mockEventListeners()
 
-    setAllowedOriginsFunc = jest.spyOn(
-      hostCommunicationMgr,
-      "setAllowedOriginsResp"
-    )
+    setHostConfigFunc = jest.spyOn(hostCommunicationMgr, "setHostConfigResp")
     openCommFunc = jest.spyOn(hostCommunicationMgr, "openHostCommunication")
     sendMessageToHostFunc = jest.spyOn(
       hostCommunicationMgr,
       "sendMessageToHost"
     )
 
-    hostCommunicationMgr.setAllowedOriginsResp({
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
@@ -85,7 +82,7 @@ describe("HostCommunicationManager messaging", () => {
   })
 
   it("sets allowedOrigins properly & opens HostCommunication", () => {
-    expect(setAllowedOriginsFunc).toHaveBeenCalledWith({
+    expect(setHostConfigFunc).toHaveBeenCalledWith({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
@@ -427,7 +424,7 @@ describe("Test different origins", () => {
   })
 
   it("exact pattern", () => {
-    hostCommunicationMgr.setAllowedOriginsResp({
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["http://share.streamlit.io"],
       useExternalAuthToken: false,
     })
@@ -448,7 +445,7 @@ describe("Test different origins", () => {
   })
 
   it("wildcard pattern", () => {
-    hostCommunicationMgr.setAllowedOriginsResp({
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["http://*.streamlitapp.com"],
       useExternalAuthToken: false,
     })
@@ -469,7 +466,7 @@ describe("Test different origins", () => {
   })
 
   it("ignores non-matching origins", () => {
-    hostCommunicationMgr.setAllowedOriginsResp({
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["http://share.streamlit.io"],
       useExternalAuthToken: false,
     })
@@ -516,10 +513,10 @@ describe("HostCommunicationManager external auth token handling", () => {
   it("resolves promise to undefined immediately if useExternalAuthToken is false", async () => {
     const setAllowedOriginsFunc = jest.spyOn(
       hostCommunicationMgr,
-      "setAllowedOriginsResp"
+      "setHostConfigResp"
     )
 
-    hostCommunicationMgr.setAllowedOriginsResp({
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["http://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
@@ -534,7 +531,7 @@ describe("HostCommunicationManager external auth token handling", () => {
   it("waits to receive SET_AUTH_TOKEN message before resolving promise if useExternalAuthToken is true", async () => {
     const dispatchEvent = mockEventListeners()
 
-    hostCommunicationMgr.setAllowedOriginsResp({
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["http://devel.streamlit.test"],
       useExternalAuthToken: true,
     })
@@ -567,8 +564,8 @@ describe("HostCommunicationManager external auth token handling", () => {
 
     // Simulate the browser tab disconnecting and reconnecting, which from the
     // HostCommunication's perspective is only seen as a new call to
-    // setAllowedOriginsResp.
-    hostCommunicationMgr.setAllowedOriginsResp({
+    // setHostConfigResp.
+    hostCommunicationMgr.setHostConfigResp({
       allowedOrigins: ["http://devel.streamlit.test"],
       useExternalAuthToken: true,
     })

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -23,7 +23,6 @@ import {
   IMenuItem,
   IToolbarItem,
   DeployedAppMetadata,
-  IHostConfigResponse,
 } from "./types"
 
 import { isValidOrigin } from "@streamlit/lib/src/util/UriUtil"
@@ -118,10 +117,10 @@ export default class HostCommunicationManager {
    *     WebsocketConnection class waits for this promise to resolve before
    *     attempting to establish a connection with the Streamlit server.
    */
-  public setAllowedOrigins = ({
-    allowedOrigins,
-    useExternalAuthToken,
-  }: IHostConfigResponse): void => {
+  public setAllowedOrigins = (
+    allowedOrigins: string[],
+    useExternalAuthToken: boolean
+  ): void => {
     if (!useExternalAuthToken) {
       this.deferredAuthToken.resolve(undefined)
     }

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -17,13 +17,13 @@
 import { ICustomThemeConfig, WidgetStates } from "@streamlit/lib/src/proto"
 
 import {
-  IAllowedMessageOriginsResponse,
   IGuestToHostMessage,
   IHostToGuestMessage,
   VersionedMessage,
   IMenuItem,
   IToolbarItem,
   DeployedAppMetadata,
+  IHostConfigResponse,
 } from "./types"
 
 import { isValidOrigin } from "@streamlit/lib/src/util/UriUtil"
@@ -121,7 +121,7 @@ export default class HostCommunicationManager {
   public setHostConfigResp = ({
     allowedOrigins,
     useExternalAuthToken,
-  }: IAllowedMessageOriginsResponse): void => {
+  }: IHostConfigResponse): void => {
     if (!useExternalAuthToken) {
       this.deferredAuthToken.resolve(undefined)
     }

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -110,7 +110,7 @@ export default class HostCommunicationManager {
 
   /**
    * Function to set the response body received from hitting the Streamlit
-   * server's /_stcore/allowed-message-origins endpoint. The response contains
+   * server's /_stcore/host-config endpoint. The response contains
    *   - allowedOrigins: A list of origins that we're allowed to receive
    *     cross-iframe messages from via the browser's window.postMessage API.
    *   - useExternalAuthToken: Whether to wait until we've received a
@@ -118,7 +118,7 @@ export default class HostCommunicationManager {
    *     WebsocketConnection class waits for this promise to resolve before
    *     attempting to establish a connection with the Streamlit server.
    */
-  public setAllowedOriginsResp = ({
+  public setHostConfigResp = ({
     allowedOrigins,
     useExternalAuthToken,
   }: IAllowedMessageOriginsResponse): void => {

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -118,7 +118,7 @@ export default class HostCommunicationManager {
    *     WebsocketConnection class waits for this promise to resolve before
    *     attempting to establish a connection with the Streamlit server.
    */
-  public setHostConfigResp = ({
+  public setAllowedOrigins = ({
     allowedOrigins,
     useExternalAuthToken,
   }: IHostConfigResponse): void => {

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -161,11 +161,6 @@ export type VersionedMessage<Message> = {
   stCommVersion: number
 } & Message
 
-export type IAllowedMessageOriginsResponse = {
-  allowedOrigins: string[]
-  useExternalAuthToken: boolean
-}
-
 export type IHostConfigResponse = HostConfig & {
   allowedOrigins?: string[]
   useExternalAuthToken?: boolean

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -162,7 +162,7 @@ export type VersionedMessage<Message> = {
 } & Message
 
 export type IHostConfigResponse = HostConfig & {
-  allowedOrigins: string[]
+  allowedOrigins?: string[]
   useExternalAuthToken?: boolean
 }
 

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -162,7 +162,7 @@ export type VersionedMessage<Message> = {
 } & Message
 
 export type IHostConfigResponse = HostConfig & {
-  allowedOrigins?: string[]
+  allowedOrigins: string[]
   useExternalAuthToken?: boolean
 }
 

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -38,7 +38,6 @@ export type {
   DeployedAppMetadata,
   IGuestToHostMessage,
   IMenuItem,
-  IAllowedMessageOriginsResponse,
   IHostConfigResponse,
   IToolbarItem,
   HostConfigViolation,

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -188,7 +188,7 @@ DEFAULT_ALLOWED_MESSAGE_ORIGINS = [
 ]
 
 
-class AllowedMessageOriginsHandler(_SpecialRequestHandler):
+class HostConfigHandler(_SpecialRequestHandler):
     def initialize(self):
         user_defined_origins = config.get_option("server.allowedMessageOrigins")
         if len(user_defined_origins) == 0:
@@ -204,27 +204,6 @@ class AllowedMessageOriginsHandler(_SpecialRequestHandler):
         # disallows writing lists directly into responses due to potential XSS
         # vulnerabilities.
         # See https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write
-        self.write(
-            {
-                "allowedOrigins": self.allowed_message_origins,
-                "useExternalAuthToken": False,
-            }
-        )
-        self.set_status(200)
-
-
-class HostConfigHandler(_SpecialRequestHandler):
-    def initialize(self):
-        user_defined_origins = config.get_option("server.allowedMessageOrigins")
-        if len(user_defined_origins) == 0:
-            self.allowed_message_origins = DEFAULT_ALLOWED_MESSAGE_ORIGINS
-        else:
-            self.allowed_message_origins = user_defined_origins
-        if config.get_option("global.developmentMode"):
-            # Allow messages from localhost in dev mode for testing of host <-> guest communication
-            self.allowed_message_origins.append("http://localhost")
-
-    async def get(self) -> None:
         self.write(
             {
                 "allowedOrigins": self.allowed_message_origins,

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -47,7 +47,6 @@ from streamlit.web.server.component_request_handler import ComponentRequestHandl
 from streamlit.web.server.media_file_handler import MediaFileHandler
 from streamlit.web.server.routes import (
     AddSlashHandler,
-    AllowedMessageOriginsHandler,
     HealthHandler,
     HostConfigHandler,
     MessageCacheHandler,
@@ -87,7 +86,6 @@ STREAM_ENDPOINT: Final = r"_stcore/stream"
 METRIC_ENDPOINT: Final = r"(?:st-metrics|_stcore/metrics)"
 MESSAGE_ENDPOINT: Final = r"_stcore/message"
 HEALTH_ENDPOINT: Final = r"(?:healthz|_stcore/health)"
-ALLOWED_MESSAGE_ORIGIN_ENDPOINT: Final = r"_stcore/allowed-message-origins"
 HOST_CONFIG_ENDPOINT: Final = r"_stcore/host-config"
 SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
     r"(?:script-health-check|_stcore/script-health-check)"
@@ -295,10 +293,6 @@ class Server:
                 make_url_path_regex(base, METRIC_ENDPOINT),
                 StatsRequestHandler,
                 dict(stats_manager=self._runtime.stats_mgr),
-            ),
-            (
-                make_url_path_regex(base, ALLOWED_MESSAGE_ORIGIN_ENDPOINT),
-                AllowedMessageOriginsHandler,
             ),
             (
                 make_url_path_regex(base, HOST_CONFIG_ENDPOINT),


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- remove `/_stcore/allowed-message-origins` endpoint
- put everything under `/_stcore/host-config` endpoint
- have app call `hostCommunicationManager`'s renamed method `setHostConfigResp`
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
  -  just modified current tests as that should be sufficient
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?
  - Tested on streamlit cloud through https://f-ajm7gcm0i8.streamlit.app/ to make sure it works.
![Screenshot 2023-08-17 at 4 36 07 PM](https://github.com/streamlit/streamlit/assets/103006371/e12cf283-732c-4ca5-a1a2-d8b14f2e06a3)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
