### PR TITLE
Cleaner `st.rerun` and `st.stop` implementations

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NoReturn
 
 import streamlit as st
 from streamlit.runtime.metrics_util import gather_metrics
@@ -24,12 +23,11 @@ from streamlit.runtime.scriptrunner import (
 )
 
 
-def stop() -> NoReturn:
+def stop() -> None:
     """Stops execution immediately.
 
     Streamlit will not run any statements after `st.stop()`.
     We recommend rendering a message to explain why the script has stopped.
-    When run outside of Streamlit, this will raise an Exception.
 
     Example
     -------
@@ -47,7 +45,6 @@ def stop() -> NoReturn:
     if ctx and ctx.script_requests:
         ctx.script_requests.request_stop()
         st.empty()
-    raise StopException()
 
 
 @gather_metrics("experimental_rerun")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -58,8 +58,6 @@ def rerun() -> None:
 
     ctx = get_script_run_ctx()
 
-    query_string = ""
-    page_script_hash = ""
     if ctx and ctx.script_requests:
         query_string = ctx.query_string
         page_script_hash = ctx.page_script_hash

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -15,12 +15,7 @@
 
 import streamlit as st
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner import (
-    RerunData,
-    RerunException,
-    StopException,
-    get_script_run_ctx,
-)
+from streamlit.runtime.scriptrunner import RerunData, get_script_run_ctx
 
 
 def stop() -> None:

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -57,9 +57,6 @@ def rerun() -> None:
     When `st.experimental_rerun()` is called, the script is halted - no
     more statements will be run, and the script will be queued to re-run
     from the top.
-
-    If this function is called outside of Streamlit, it will raise an
-    Exception.
     """
 
     ctx = get_script_run_ctx()
@@ -77,10 +74,3 @@ def rerun() -> None:
             )
         )
         st.empty()
-
-    raise RerunException(
-        RerunData(
-            query_string=query_string,
-            page_script_hash=page_script_hash,
-        )
-    )

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -44,6 +44,7 @@ def stop() -> None:
 
     if ctx and ctx.script_requests:
         ctx.script_requests.request_stop()
+        # Force a yield point so the runner can stop
         st.empty()
 
 
@@ -68,4 +69,5 @@ def rerun() -> None:
                 page_script_hash=page_script_hash,
             )
         )
+        # Force a yield point so the runner can do the rerun
         st.empty()

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -24,6 +24,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.PageProfile_pb2 import Command
+from streamlit.runtime.scriptrunner.script_requests import ScriptRequests
 from streamlit.runtime.state import SafeSessionState
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 
@@ -66,6 +67,7 @@ class ScriptRunContext:
     dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = field(
         default_factory=list
     )
+    script_requests: Optional[ScriptRequests] = None
 
     def reset(self, query_string: str = "", page_script_hash: str = "") -> None:
         self.cursors = {}

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -286,6 +286,7 @@ class ScriptRunner:
         ctx = ScriptRunContext(
             session_id=self._session_id,
             _enqueue=self._enqueue_forward_msg,
+            script_requests=self._requests,
             query_string=self._client_state.query_string,
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,

--- a/lib/tests/delta_generator_test_case.py
+++ b/lib/tests/delta_generator_test_case.py
@@ -34,6 +34,7 @@ from streamlit.runtime.scriptrunner import (
     add_script_run_ctx,
     get_script_run_ctx,
 )
+from streamlit.runtime.scriptrunner.script_requests import ScriptRequests
 from streamlit.runtime.state import SafeSessionState, SessionState
 from streamlit.web.server.server import MEDIA_ENDPOINT, UPLOAD_FILE_ENDPOINT
 
@@ -54,6 +55,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             uploaded_file_mgr=MemoryUploadedFileManager(UPLOAD_FILE_ENDPOINT),
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            script_requests=ScriptRequests(),
         )
         add_script_run_ctx(threading.current_thread(), self.script_run_ctx)
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -259,33 +259,27 @@ class SessionStateTest(DeltaGeneratorTestCase):
         ctx = get_script_run_ctx()
         assert ctx.session_state["color"] is not color
 
-    @patch("streamlit.warning")
-    def test_callbacks_with_experimental_rerun(self, patched_warning):
+
+class SessionStateCallbackTest(InteractiveScriptTests):
+    def test_callbacks_with_experimental_rerun(self):
         """Calling 'experimental_rerun' from within a widget callback
         is disallowed and results in a warning.
         """
+        script = self.script_from_string(
+            """
+        import streamlit as st
 
-        # A mock on_changed handler for our checkbox. It will call
-        # `st.experimental_rerun`, which should result in a warning
-        # being printed to the user's app.
-        mock_on_checkbox_changed = MagicMock(side_effect=st.experimental_rerun)
-
-        st.checkbox("the checkbox", on_change=mock_on_checkbox_changed)
-
-        session_state = _raw_session_state()
-
-        # Pretend that the checkbox has a new state value
-        checkbox_state = WidgetStateProto()
-        checkbox_state.id = list(session_state._new_widget_state.keys())[0]
-        checkbox_state.bool_value = True
-        widget_states = WidgetStatesProto()
-        widget_states.widgets.append(checkbox_state)
-
-        # Tell session_state to call our callbacks.
-        session_state.on_script_will_rerun(widget_states)
-
-        mock_on_checkbox_changed.assert_called_once()
-        patched_warning.assert_called_once()
+        def callback():
+            st.session_state["message"] = "ran callback"
+            st.experimental_rerun()
+        st.checkbox("cb", on_change=callback)
+        """
+        )
+        sr = script.run()
+        sr2 = sr.checkbox[0].check().run()
+        assert sr2.session_state["message"] == "ran callback"
+        warning = sr2.get("alert")[0]
+        assert "no-op" in warning.proto.alert.body
 
 
 class SessionStateInteractionTest(InteractiveScriptTests):

--- a/lib/tests/streamlit/stop_test.py
+++ b/lib/tests/streamlit/stop_test.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 
 import streamlit as st
-from streamlit.runtime.scriptrunner import StopException
+from streamlit.runtime.scriptrunner.script_requests import ScriptRequestType
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
 class StopTest(DeltaGeneratorTestCase):
     def test_stop(self):
-        with pytest.raises(StopException) as exc_message:
-            st.stop()
+        st.stop()
+        assert self.script_run_ctx.script_requests._state == ScriptRequestType.STOP


### PR DESCRIPTION
## Describe your changes
Access the runner's `ScriptRequests` via the context, rather than directly raising exceptions for control flow

## Testing Plan

- Unit Tests (JS and/or Python)
updated



---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
