### PR TITLE
Resolve flaky `websocket_reconnects` & `camera_input` e2e tests

### DIFF
--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -30,6 +30,10 @@ describe("st.camera_input", () => {
   });
 
   it("capture photo when 'Take photo' button clicked", () => {
+    // Be generous with some of the timeouts in this test as uploading and
+    // rendering images can be quite slow.
+    const timeout = 30000;
+
     cy.get("[data-testid='stCameraInput']")
       .contains("Learn how to allow access.")
       .should("not.exist");
@@ -44,7 +48,7 @@ describe("st.camera_input", () => {
 
     cy.get("img").should("have.length.at.least", 2);
 
-    cy.get("[data-testid='stImage']").should("have.length.at.least", 1);
+    cy.get("[data-testid='stImage']", { timeout }).should("have.length.at.least", 1);
   });
 
   it("Remove photo when 'Clear photo' button clicked", () => {

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -77,7 +77,7 @@ describe("websocket reconnects", () => {
         }
       );
 
-      cy.wait("@uploadFile");
+      cy.wait("@uploadFile", {timeout: 10000});
 
       // The script should have printed the contents of the first files
       // into an st.text. (This tests that the upload actually went
@@ -123,7 +123,7 @@ describe("websocket reconnects", () => {
       .contains("Take Photo")
       .click();
 
-    cy.wait("@uploadFile");
+    cy.wait("@uploadFile", {timeout: 10000});
 
     cy.get("img").should("have.length.at.least", 2);
 

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -77,7 +77,7 @@ describe("websocket reconnects", () => {
         }
       );
 
-      cy.wait("@uploadFile", {timeout: 10000});
+      cy.wait("@uploadFile");
 
       // The script should have printed the contents of the first files
       // into an st.text. (This tests that the upload actually went
@@ -123,7 +123,7 @@ describe("websocket reconnects", () => {
       .contains("Take Photo")
       .click();
 
-    cy.wait("@uploadFile", {timeout: 10000});
+    cy.wait("@uploadFile", { timeout });
 
     cy.get("img").should("have.length.at.least", 2);
 


### PR DESCRIPTION
Video from recent flaky run shows timeout error, and since re-running resolves, increase timeout for uploadFile `.wait` from current 5000ms should resolve most incidences. 

**Websocket:**
https://github.com/streamlit/streamlit/assets/63436329/116d95ee-5f7d-4645-985b-606cbca60c4e
**Camera Input:**
https://github.com/streamlit/streamlit/assets/63436329/7efb5b17-44c8-408a-ae50-9130ddf22dbd