### PR TITLE
Open up pydeck version to include the beta

### DIFF
--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -10,7 +10,7 @@ pandas==1.3.0
 pillow==7.1.0
 protobuf==3.20
 pyarrow==6.0
-pydeck==0.8
+pydeck==0.8.0b4
 pympler==0.9
 python-dateutil==2.7.3
 requests==2.18

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -71,7 +71,7 @@ INSTALL_REQUIRES = [
 # `pip install streamlit` or `conda install -c conda-forge streamlit`)
 SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
     "gitpython>=3.0.7, <4, !=3.1.19",
-    "pydeck>=0.8, <1",
+    "pydeck>=0.8.0b4, <1",
     # Tornado 6.0.3 was the current Tornado version when Python 3.8, our earliest supported Python version,
     # was released (Oct 14, 2019).
     "tornado>=6.0.3, <7",


### PR DESCRIPTION
## Describe your changes

From [this comment](https://github.com/conda-forge/streamlit-feedstock/pull/81#issuecomment-1673752065) The pydeck conda release provides the beta version vs the final 0.8.0 version. This broke our conda releases since we required >=0.8.0 which "didn't exist" in testing. Let's allow it for now.

## Testing Plan

- Minimum Version Testing should ensure it does not break anything.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
