### PR TITLE
Fix bug where we should actually be defaulting to test@example.com instead of test@localhost.com

### DIFF
--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -96,7 +96,7 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             email = user_obj["email"]
             is_public_cloud_app = user_obj["isPublicCloudApp"]
         except (KeyError, binascii.Error, json.decoder.JSONDecodeError):
-            email = "test@localhost.com"
+            email = "test@example.com"
 
         user_info: Dict[str, Optional[str]] = dict()
         if is_public_cloud_app:


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- change default for st.experimental_user as `test@example.com` is a reserved domain
## GitHub Issue Link (if applicable)
Closes #7215 
## Testing Plan

- Explanation of why no additional tests are needed
- just a default in username. I don't think this really matters. just wanna close the issue.
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
