### PR TITLE
Track st.stop usage

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -18,6 +18,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import RerunData, get_script_run_ctx
 
 
+@gather_metrics("stop")
 def stop() -> None:
     """Stops execution immediately.
 


### PR DESCRIPTION

## Describe your changes
The metrics decorator works for `st.stop` with the new implementation, so it would be nice to collect usage like everything else.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
