### PR TITLE
Resolve python dep min version test

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -28,7 +28,7 @@ pytest-playwright>=0.1.2
 pixelmatch>=0.3.0
 pytest-xdist
 
-mypy-protobuf>=3.2
+mypy-protobuf>=3.2, <3.4
 
 # These requirements exist only for `@st.cache` tests. st.cache is deprecated, and
 # we're not going to update its associated tests anymore. Please don't modify


### PR DESCRIPTION
## Describe your changes
Specify `mypy-protobuf` version in test requirements to `<3.4.0` resolve failing python dep min version test

![Screenshot 2023-08-24 at 11 18 29 AM](https://github.com/streamlit/streamlit/assets/63436329/7c4a7b62-0a45-4127-8782-0213d376c848)
