### PR TITLE
Make the Streamlit frontend play nicely with CSPs

### DIFF
--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -31,6 +31,7 @@
     "@emotion-icons/material-outlined": "^3.14.0",
     "@emotion-icons/material-rounded": "^3.14.0",
     "@emotion-icons/open-iconic": "^3.14.0",
+    "@emotion/cache": "^11.10.5",
     "@emotion/is-prop-valid": "^1.2.0",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/frontend/lib/src/RootStyleProvider.tsx
+++ b/frontend/lib/src/RootStyleProvider.tsx
@@ -31,7 +31,9 @@ export interface RootStyleProviderProps {
 
 const nonce = document.currentScript?.nonce || ""
 const cache = createCache({
-  // The key field only matters if a single app
+  // The key field is required but only matters if there's more than one
+  // emotion cache in use. This will probably never be true for us, so we just
+  // set it arbitrarily.
   key: "st-emotion-cache",
   ...(nonce && { nonce }),
 })

--- a/frontend/lib/src/RootStyleProvider.tsx
+++ b/frontend/lib/src/RootStyleProvider.tsx
@@ -16,13 +16,25 @@
 
 import React, { ReactElement } from "react"
 import { BaseProvider } from "baseui"
-import { Global, ThemeProvider as EmotionThemeProvider } from "@emotion/react"
+import createCache from "@emotion/cache"
+import {
+  CacheProvider,
+  Global,
+  ThemeProvider as EmotionThemeProvider,
+} from "@emotion/react"
 import { globalStyles, ThemeConfig } from "./theme"
 
 export interface RootStyleProviderProps {
   theme: ThemeConfig
   children: React.ReactNode
 }
+
+const nonce = document.currentScript?.nonce || ""
+const cache = createCache({
+  // The key field only matters if a single app
+  key: "st-emotion-cache",
+  ...(nonce && { nonce }),
+})
 
 export function RootStyleProvider(
   props: RootStyleProviderProps
@@ -33,10 +45,12 @@ export function RootStyleProvider(
       theme={theme.basewebTheme}
       zIndex={theme.emotion.zIndices.popupMenu}
     >
-      <EmotionThemeProvider theme={theme.emotion}>
-        <Global styles={globalStyles} />
-        {children}
-      </EmotionThemeProvider>
+      <CacheProvider value={cache}>
+        <EmotionThemeProvider theme={theme.emotion}>
+          <Global styles={globalStyles} />
+          {children}
+        </EmotionThemeProvider>
+      </CacheProvider>
     </BaseProvider>
   )
 }

--- a/frontend/lib/src/assets/css/vega-embed.css
+++ b/frontend/lib/src/assets/css/vega-embed.css
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.vega-embed {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+}
+.vega-embed.has-actions {
+  padding-right: 38px;
+}
+.vega-embed details:not([open]) > :not(summary) {
+  display: none !important;
+}
+.vega-embed summary {
+  list-style: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 6px;
+  z-index: 1000;
+  background: white;
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+  color: #1b1e23;
+  border: 1px solid #aaa;
+  border-radius: 999px;
+  opacity: 0.2;
+  transition: opacity 0.4s ease-in;
+  cursor: pointer;
+  line-height: 0px;
+}
+.vega-embed summary::-webkit-details-marker {
+  display: none;
+}
+.vega-embed summary:active {
+  box-shadow: #aaa 0px 0px 0px 1px inset;
+}
+.vega-embed summary svg {
+  width: 14px;
+  height: 14px;
+}
+.vega-embed details[open] summary {
+  opacity: 0.7;
+}
+.vega-embed:hover summary,
+.vega-embed:focus-within summary {
+  opacity: 1 !important;
+  transition: opacity 0.2s ease;
+}
+.vega-embed .vega-actions {
+  position: absolute;
+  z-index: 1001;
+  top: 35px;
+  right: -9px;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.2);
+  border: 1px solid #d9d9d9;
+  background: white;
+  animation-duration: 0.15s;
+  animation-name: scale-in;
+  animation-timing-function: cubic-bezier(0.2, 0, 0.13, 1.5);
+  text-align: left;
+}
+.vega-embed .vega-actions a {
+  padding: 8px 16px;
+  font-family: sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  color: #434a56;
+  text-decoration: none;
+}
+.vega-embed .vega-actions a:hover,
+.vega-embed .vega-actions a:focus {
+  background-color: #f7f7f9;
+  color: black;
+}
+.vega-embed .vega-actions::before,
+.vega-embed .vega-actions::after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+}
+.vega-embed .vega-actions::before {
+  left: auto;
+  right: 14px;
+  top: -16px;
+  border: 8px solid rgba(0, 0, 0, 0);
+  border-bottom-color: #d9d9d9;
+}
+.vega-embed .vega-actions::after {
+  left: auto;
+  right: 15px;
+  top: -14px;
+  border: 7px solid rgba(0, 0, 0, 0);
+  border-bottom-color: #fff;
+}
+.vega-embed .chart-wrapper.fit-x {
+  width: 100%;
+}
+.vega-embed .chart-wrapper.fit-y {
+  height: 100%;
+}
+
+.vega-embed-wrapper {
+  max-width: 100%;
+  overflow: auto;
+  padding-right: 14px;
+}
+
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/frontend/lib/src/assets/css/vega-embed.scss
+++ b/frontend/lib/src/assets/css/vega-embed.scss
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// NOTE: These styles are copied here from https://github.com/vega/vega-embed/blob/main/vega-embed.scss
+// so that vega doesn't need to inject inline <style /> tags into the DOM at
+// runtime, which doesn't play nicely with CSPs. We keep the styles more or
+// less the same as the vega defaults for now but may choose to tweak them
+// later so that vega charts are more consistent with Streamlit's overall look
+// and feel.
+//
+// When modifying these styles, the compiled .css also needs to be updated by
+// running `yarn -s sass lib/src/assets/css/vega-embed.scss lib/src/assets/css/vega-embed.css`
+// from the `frontend` directory.
+
+.vega-embed {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+
+  &.has-actions {
+    padding-right: 38px;
+  }
+
+  details:not([open]) > :not(summary) {
+    display: none !important;
+  }
+
+  summary {
+    list-style: none;
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 6px;
+    z-index: 1000;
+    background: white;
+    box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+    color: #1b1e23;
+    border: 1px solid #aaa;
+    border-radius: 999px;
+    opacity: 0.2;
+    transition: opacity 0.4s ease-in;
+    cursor: pointer;
+    line-height: 0px; // For Safari
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:active {
+      box-shadow: #aaa 0px 0px 0px 1px inset;
+    }
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  details[open] summary {
+    opacity: 0.7;
+  }
+
+  &:hover summary,
+  &:focus-within summary {
+    opacity: 1 !important;
+    transition: opacity 0.2s ease;
+  }
+
+  .vega-actions {
+    position: absolute;
+    z-index: 1001;
+    top: 35px;
+    right: -9px;
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 8px;
+    padding-top: 8px;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.2);
+    border: 1px solid #d9d9d9;
+    background: white;
+    animation-duration: 0.15s;
+    animation-name: scale-in;
+    animation-timing-function: cubic-bezier(0.2, 0, 0.13, 1.5);
+    text-align: left; // only to make sure this is not a a different value
+
+    a {
+      padding: 8px 16px;
+      font-family: sans-serif;
+      font-size: 14px;
+      font-weight: 600;
+      white-space: nowrap;
+      color: #434a56;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        background-color: #f7f7f9;
+        color: black;
+      }
+    }
+
+    &::before,
+    &::after {
+      content: "";
+      display: inline-block;
+      position: absolute;
+    }
+
+    &::before {
+      left: auto;
+      right: 14px;
+      top: -16px;
+      border: 8px solid #0000;
+      border-bottom-color: #d9d9d9;
+    }
+
+    &::after {
+      left: auto;
+      right: 15px;
+      top: -14px;
+      border: 7px solid #0000;
+      border-bottom-color: #fff;
+    }
+  }
+
+  .chart-wrapper {
+    &.fit-x {
+      width: 100%;
+    }
+    &.fit-y {
+      height: 100%;
+    }
+  }
+}
+
+.vega-embed-wrapper {
+  max-width: 100%;
+  overflow: auto;
+  padding-right: 14px;
+}
+
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/frontend/lib/src/assets/css/vega-tooltip.css
+++ b/frontend/lib/src/assets/css/vega-tooltip.css
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#vg-tooltip-element {
+  visibility: hidden;
+  padding: 8px;
+  position: fixed;
+  z-index: 1000;
+  font-family: sans-serif;
+  font-size: 11px;
+  border-radius: 3px;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+}
+#vg-tooltip-element.visible {
+  visibility: visible;
+}
+#vg-tooltip-element h2 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+#vg-tooltip-element table {
+  border-spacing: 0;
+}
+#vg-tooltip-element table tr {
+  border: none;
+}
+#vg-tooltip-element table tr td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+#vg-tooltip-element table tr td.key {
+  color: #808080;
+  max-width: 150px;
+  text-align: right;
+  padding-right: 4px;
+}
+#vg-tooltip-element table tr td.value {
+  display: block;
+  max-width: 300px;
+  max-height: 7em;
+  text-align: left;
+}

--- a/frontend/lib/src/assets/css/vega-tooltip.scss
+++ b/frontend/lib/src/assets/css/vega-tooltip.scss
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// NOTE: These styles are copied from https://github.com/vega/vega-tooltip/blob/main/vega-tooltip.scss
+// so that vega doesn't need to inject inline <style /> tags into the DOM at
+// runtime, which doesn't play nicely with CSPs. We keep the styles more or
+// less the same as the vega defaults for now but may choose to tweak them
+// later so that vega charts are more consistent with Streamlit's overall look
+// and feel.
+//
+// When modifying these styles, the compiled .css also needs to be updated by
+// running `yarn -s sass lib/src/assets/css/vega-tooltip.scss lib/src/assets/css/vega-tooltip.css`
+// from the `frontend` directory.
+
+#vg-tooltip-element {
+  visibility: hidden;
+  padding: 8px;
+  position: fixed;
+  z-index: 1000;
+  font-family: sans-serif;
+  font-size: 11px;
+  border-radius: 3px;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+
+  &.visible {
+    visibility: visible;
+  }
+
+  h2 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 13px;
+  }
+
+  table {
+    border-spacing: 0;
+
+    tr {
+      border: none;
+
+      td {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        &.key {
+          color: #808080;
+          max-width: 150px;
+          text-align: right;
+          padding-right: 4px;
+        }
+        &.value {
+          display: block;
+          max-width: 300px;
+          max-height: 7em;
+          text-align: left;
+        }
+      }
+    }
+  }
+
+  // NOTE: We comment out the code below as it overwrites theming we do
+  // on the Streamlit side, which isn't always noticeable with the default
+  // light and dark themes but can obviously conflict with a custom
+  // theme.
+  // /* The default theme is the light theme. */
+  // background-color: rgba(255, 255, 255, 0.95);
+  // border: 1px solid #d9d9d9;
+  // color: black;
+  //
+  // &.dark-theme {
+  // background-color: rgba(32, 32, 32, 0.9);
+  // border: 1px solid #f5f5f5;
+  // color: white;
+  // td.key {
+  // color: #bfbfbf;
+  // }
+  // }
+}

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -182,7 +182,11 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
   // StyledVerticalBlocks are the only things that calculate their own widths. They should never use
   // the width value coming from the parent via props.
   return (
-    <AutoSizer disableHeight={true} style={styledVerticalBlockWrapperStyles}>
+    <AutoSizer
+      disableHeight={true}
+      style={styledVerticalBlockWrapperStyles}
+      nonce={document.currentScript?.nonce || ""}
+    >
       {({ width }) => {
         const propsWithNewWidth = { ...props, ...{ width } }
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -325,10 +325,14 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
     const el = this.props.element
     const spec = this.generateSpec()
     const options = {
-      defaultStyle: true,
       // Adds interpreter support for Vega expressions that is compliant with CSP
       ast: true,
       expr: expressionInterpreter,
+      // Disable default styles so that vega doesn't inject <style> tags in the
+      // DOM. We set these styles manually for finer control over them and to
+      // avoid inlining styles.
+      tooltip: { disableDefaultStyle: true },
+      defaultStyle: false,
     }
 
     const { vgSpec, view, finalize } = await embed(this.element, spec, options)

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -26,6 +26,9 @@ import { ensureError } from "@streamlit/lib/src/util/ErrorHandling"
 import { IndexTypeName, Quiver } from "@streamlit/lib/src/dataframes/Quiver"
 import { EmotionTheme } from "@streamlit/lib/src/theme"
 
+import "@streamlit/lib/src/assets/css/vega-embed.css"
+import "@streamlit/lib/src/assets/css/vega-tooltip.css"
+
 import { applyStreamlitTheme, applyThemeDefaults } from "./CustomTheme"
 import { StyledVegaLiteChartContainer } from "./styled-components"
 
@@ -328,11 +331,20 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
       // Adds interpreter support for Vega expressions that is compliant with CSP
       ast: true,
       expr: expressionInterpreter,
+
       // Disable default styles so that vega doesn't inject <style> tags in the
       // DOM. We set these styles manually for finer control over them and to
       // avoid inlining styles.
       tooltip: { disableDefaultStyle: true },
-      defaultStyle: false,
+      // NOTE: We pass the empty string to the `defaultStyle` field here
+      // because setting it to false causes vega-embed to omit menu options on
+      // the chart entirely, which we don't want. Setting `defaultStyle` to the
+      // empty string causes vega-embed to inject an empty <style /> tag into
+      // the DOM, which may be harmlessly blocked by a CSP. This is fine as
+      // we're providing our own styles for vega components. While this works
+      // for now, we'll be submitting an upstream PR to vega-embed to make
+      // things less hacky.
+      defaultStyle: "",
     }
 
     const { vgSpec, view, finalize } = await embed(this.element, spec, options)

--- a/frontend/lib/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -16,9 +16,13 @@
 
 import React, { PureComponent } from "react"
 import { withTheme } from "@emotion/react"
-import { logMessage } from "@streamlit/lib/src/util/log"
 import { Map as ImmutableMap } from "immutable"
 import merge from "lodash/merge"
+import * as vega from "vega"
+import embed from "vega-embed"
+import { expressionInterpreter } from "vega-interpreter"
+
+import { logMessage } from "@streamlit/lib/src/util/log"
 import withFullScreenWrapper from "@streamlit/lib/src/hocs/withFullScreenWrapper"
 import {
   tableGetRowsAndCols,
@@ -27,9 +31,10 @@ import {
 } from "@streamlit/lib/src/dataframes/dataFrameProto"
 import { ensureError } from "@streamlit/lib/src/util/ErrorHandling"
 import { EmotionTheme } from "@streamlit/lib/src/theme"
-import embed from "vega-embed"
-import * as vega from "vega"
-import { expressionInterpreter } from "vega-interpreter"
+
+import "@streamlit/lib/src/assets/css/vega-embed.css"
+import "@streamlit/lib/src/assets/css/vega-tooltip.css"
+
 import { StyledVegaLiteChartContainer } from "./styled-components"
 
 const MagicFields = {
@@ -288,11 +293,20 @@ export class VegaLiteChart extends PureComponent<PropsWithHeight, State> {
       // Adds interpreter support for Vega expressions that is compliant with CSP
       ast: true,
       expr: expressionInterpreter,
+
       // Disable default styles so that vega doesn't inject <style> tags in the
       // DOM. We set these styles manually for finer control over them and to
       // avoid inlining styles.
       tooltip: { disableDefaultStyle: true },
-      defaultStyle: false,
+      // NOTE: We pass the empty string to the `defaultStyle` field here
+      // because setting it to false causes vega-embed to omit menu options on
+      // the chart entirely, which we don't want. Setting `defaultStyle` to the
+      // empty string causes vega-embed to inject an empty <style /> tag into
+      // the DOM, which may be harmlessly blocked by a CSP. This is fine as
+      // we're providing our own styles for vega components. While this works
+      // for now, we'll be submitting an upstream PR to vega-embed to make
+      // things less hacky.
+      defaultStyle: "",
     }
 
     const { vgSpec, view, finalize } = await embed(this.element, spec, options)

--- a/frontend/lib/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -288,6 +288,11 @@ export class VegaLiteChart extends PureComponent<PropsWithHeight, State> {
       // Adds interpreter support for Vega expressions that is compliant with CSP
       ast: true,
       expr: expressionInterpreter,
+      // Disable default styles so that vega doesn't inject <style> tags in the
+      // DOM. We set these styles manually for finer control over them and to
+      // avoid inlining styles.
+      tooltip: { disableDefaultStyle: true },
+      defaultStyle: false,
     }
 
     const { vgSpec, view, finalize } = await embed(this.element, spec, options)


### PR DESCRIPTION
NOTE: When reviewing this PR, the `.scss` and `.css` files can be skimmed over or entirely
ignored as they're copied from the vega defaults.

---

This PR makes a few changes needed to make the Streamlit frontend compatible with a
nonce-based CSP. At a high level, the changes in this PR do this by either entirely removing the
need for third party dependencies to inline `<style />` tags into the DOM at runtime or by plumbing
the script's `nonce` to these dependencies so that it can be added to any styles that must be
inlined.

To give a more specific list of changes, we:
* plumb a nonce (if present) to `emotion` using emotion's `createCache` and `CacheProvider`
* plumb a nonce (if present) to `react-virtualized`'s `AutoSizer` component
* get rid of the need for `vega-embed` and `vega-tooltip` to inline `<style>` tags entirely by
   duplicating vega's default styles in our own codebase so that they're included in our CSS bundle
   * For now, we just check in both the original `.scss` files as well as the compiled `.css` with essentially
      no modifications (aside from deleting some styling that interacts weirdly with our custom themes. See
      the comments in the `.scss` files).
   * In the future, we may want to change these styles to make the tooltips on vega lite charts more
      consistent with the rest of the Streamlit UI. At that point, we may want to figure out a way to unify
      the way these styles are defined with the rest of our styles, but I don't think there's much to gain from
      doing this right now.
   * We don't have a total guarantee that these vega styles will never change, but according to
      https://github.com/vega/vega-embed/issues/1214, the classnames/IDs used in the styles should
      be mostly stable, and any major changes will likely correspond to a major version bump.