### PR TITLE
Fix: Exclude Altair v5.1.0

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -31,7 +31,7 @@ NAME = "streamlit"
 # - Always include the lower bound as >= VERSION, to keep testing min versions easy
 # - And include an upper bound that's < NEXT_MAJOR_VERSION
 INSTALL_REQUIRES = [
-    "altair>=4.0, <6",
+    "altair>=4.0, <6, !=5.1.0",
     "blinker>=1.0.0, <2",
     "cachetools>=4.0, <6",
     "click>=7.0, <9",


### PR DESCRIPTION
## Describe your changes
Altair `v5.1.0` includes a regression on inferring data types (see [issue filed here](https://github.com/altair-viz/altair/issues/3177) for more details). To unblock, excluding this version but will revisit based on whether patch released.