### PR TITLE
Remove Altair exclusion v5.1.0

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -31,7 +31,7 @@ NAME = "streamlit"
 # - Always include the lower bound as >= VERSION, to keep testing min versions easy
 # - And include an upper bound that's < NEXT_MAJOR_VERSION
 INSTALL_REQUIRES = [
-    "altair>=4.0, <6, !=5.1.0",
+    "altair>=4.0, <6",
     "blinker>=1.0.0, <2",
     "cachetools>=4.0, <6",
     "click>=7.0, <9",


### PR DESCRIPTION
## Describe your changes
This PR reverses the excluded version specification for altair from PR [#7248](https://github.com/streamlit/streamlit/pull/7248) - a patch `v5.1.1` with fix was released. 
