### PR TITLE
Move `st.rerun` out of experimental

### DIFF
--- a/e2e/scripts/st_rerun.py
+++ b/e2e/scripts/st_rerun.py
@@ -24,7 +24,7 @@ count = rerun_record()
 count[0] += 1
 
 if count[0] < 4:
-    st.experimental_rerun()
+    st.rerun()
 
 if count[0] >= 4:
     st.text("Being able to rerun a session is awesome!")

--- a/e2e/specs/st_rerun.spec.js
+++ b/e2e/specs/st_rerun.spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-describe("st.experimental_rerun", () => {
+describe("st.rerun", () => {
   before(() => {
     cy.loadApp("http://localhost:3000/");
   });

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -82,7 +82,8 @@ from streamlit.elements.spinner import spinner as spinner
 from streamlit.commands.page_config import set_page_config as set_page_config
 from streamlit.commands.execution_control import (
     stop as stop,
-    rerun as _rerun,
+    rerun as rerun,
+    experimental_rerun as _experimental_rerun,
 )
 
 # We add the metrics tracking for caching here,
@@ -220,6 +221,6 @@ experimental_singleton = _experimental_singleton
 experimental_memo = _experimental_memo
 experimental_get_query_params = _get_query_params
 experimental_set_query_params = _set_query_params
-experimental_rerun = _rerun
+experimental_rerun = _experimental_rerun
 experimental_data_editor = _main.experimental_data_editor
 experimental_connection = _connection_factory

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -14,8 +14,12 @@
 
 
 import streamlit as st
+from streamlit.deprecation_util import make_deprecated_name_warning
+from streamlit.logger import get_logger
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import RerunData, get_script_run_ctx
+
+_LOGGER = get_logger(__name__)
 
 
 @gather_metrics("stop")
@@ -44,13 +48,12 @@ def stop() -> None:
         st.empty()
 
 
-@gather_metrics("experimental_rerun")
+@gather_metrics("rerun")
 def rerun() -> None:
     """Rerun the script immediately.
 
-    When `st.experimental_rerun()` is called, the script is halted - no
-    more statements will be run, and the script will be queued to re-run
-    from the top.
+    When `st.rerun()` is called, the script is halted - no more statements will
+    be run, and the script will be queued to re-run from the top.
     """
 
     ctx = get_script_run_ctx()
@@ -67,3 +70,19 @@ def rerun() -> None:
         )
         # Force a yield point so the runner can do the rerun
         st.empty()
+
+
+@gather_metrics("experimental_rerun")
+def experimental_rerun() -> None:
+    """Rerun the script immediately.
+
+    When `st.experimental_rerun()` is called, the script is halted - no
+    more statements will be run, and the script will be queued to re-run
+    from the top.
+    """
+    msg = make_deprecated_name_warning("experimental_rerun", "rerun", "2024-04-01")
+    # Log warning before the rerun, or else it would be interrupted
+    # by the rerun. We do not send a frontend warning because it wouldn't
+    # be seen.
+    _LOGGER.warning(msg)
+    rerun()

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -498,9 +498,7 @@ class SessionState:
             try:
                 self._new_widget_state.call_callback(wid)
             except RerunException:
-                st.warning(
-                    "Calling st.experimental_rerun() within a callback is a no-op."
-                )
+                st.warning("Calling st.rerun() within a callback is a no-op.")
 
     def _widget_changed(self, widget_id: str) -> bool:
         """True if the given widget's value changed between the previous

--- a/lib/tests/streamlit/rerun_test.py
+++ b/lib/tests/streamlit/rerun_test.py
@@ -1,0 +1,29 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import Mock, patch
+
+import streamlit as st
+
+
+@patch("streamlit.commands.execution_control._LOGGER.warning")
+def test_deprecation_warnings(logger_mock: Mock):
+
+    st.experimental_rerun()
+    logger_mock.assert_called_once()
+    msg = logger_mock.call_args.args[0]
+    assert "will be removed" in msg
+
+    logger_mock.reset_mock()
+    st.rerun()
+    logger_mock.assert_not_called()

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -262,8 +262,6 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
             # publicly-exported function, which causes it not to be executed before an
             # Exception is raised due to a lack of required arguments.
             "experimental_connection",
-            "experimental_rerun",
-            "stop",
             "spinner",
             "empty",
             "progress",

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -261,8 +261,8 @@ class SessionStateTest(DeltaGeneratorTestCase):
 
 
 class SessionStateCallbackTest(InteractiveScriptTests):
-    def test_callbacks_with_experimental_rerun(self):
-        """Calling 'experimental_rerun' from within a widget callback
+    def test_callbacks_with_rerun(self):
+        """Calling 'rerun' from within a widget callback
         is disallowed and results in a warning.
         """
         script = self.script_from_string(
@@ -271,7 +271,7 @@ class SessionStateCallbackTest(InteractiveScriptTests):
 
         def callback():
             st.session_state["message"] = "ran callback"
-            st.experimental_rerun()
+            st.rerun()
         st.checkbox("cb", on_change=callback)
         """
         )

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -135,6 +135,7 @@ class StreamlitTest(unittest.TestCase):
                 "spinner",
                 "set_page_config",
                 "stop",
+                "rerun",
                 "cache",
                 "secrets",
                 "session_state",


### PR DESCRIPTION
## Describe your changes
Rename function to reflect it no longer being experimental, and add a deprecation notice for the experimental alias.


## Testing Plan

- Unit Tests (JS and/or Python)
Short test added for logging the warning


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
