### PR TITLE
Use cleaner test framework syntax in old tests

### DIFF
--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -994,19 +994,19 @@ class WidgetReplayInteractionTest(InteractiveScriptTests):
         script = self.script_from_filename("test_data/cached_widget_replay_dynamic.py")
 
         sr = script.run()
-        assert len(sr.get("checkbox")) == 1
-        assert sr.get("text")[0].value == "['foo']"
+        assert len(sr.checkbox) == 1
+        assert sr.text[0].value == "['foo']"
 
-        sr2 = sr.get("checkbox")[0].check().run()
-        assert len(sr2.get("multiselect")) == 1
-        assert sr2.get("text")[0].value == "[]"
+        sr2 = sr.checkbox[0].check().run()
+        assert len(sr2.multiselect) == 1
+        assert sr2.text[0].value == "[]"
 
-        sr3 = sr2.get("multiselect")[0].select("baz").run()
-        assert sr3.get("text")[0].value == "['baz']"
+        sr3 = sr2.multiselect[0].select("baz").run()
+        assert sr3.text[0].value == "['baz']"
 
-        sr4 = sr3.get("checkbox")[0].uncheck().run()
-        sr5 = sr4.get("button")[0].click().run()
-        assert sr5.get("text")[0].value == "['foo']"
+        sr4 = sr3.checkbox[0].uncheck().run()
+        sr5 = sr4.button[0].click().run()
+        assert sr5.text[0].value == "['foo']"
 
 
 class WidgetReplayTest(InteractiveScriptTests):
@@ -1015,4 +1015,4 @@ class WidgetReplayTest(InteractiveScriptTests):
         script = self.script_from_filename("test_data/arrow_replay.py")
 
         sr = script.run()
-        assert len(sr.get("exception")) == 0
+        assert len(sr.exception) == 0

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -286,32 +286,32 @@ class SessionStateInteractionTest(InteractiveScriptTests):
     def test_updates(self):
         script = self.script_from_filename("test_data/linked_sliders.py")
         sr = script.run()
-        assert sr.get("slider")[0].value == -100.0
-        assert sr.get("markdown")[0].value == "Celsius `-100.0`"
-        assert sr.get("slider")[1].value == -148.0
-        assert sr.get("markdown")[1].value == "Fahrenheit `-148.0`"
+        assert sr.slider[0].value == -100.0
+        assert sr.markdown[0].value == "Celsius `-100.0`"
+        assert sr.slider[1].value == -148.0
+        assert sr.markdown[1].value == "Fahrenheit `-148.0`"
 
         # Both sliders update when first is changed
-        sr2 = sr.get("slider")[0].set_value(0.0).run()
-        assert sr2.get("slider")[0].value == 0.0
-        assert sr2.get("markdown")[0].value == "Celsius `0.0`"
-        assert sr2.get("slider")[1].value == 32.0
-        assert sr2.get("markdown")[1].value == "Fahrenheit `32.0`"
+        sr2 = sr.slider[0].set_value(0.0).run()
+        assert sr2.slider[0].value == 0.0
+        assert sr2.markdown[0].value == "Celsius `0.0`"
+        assert sr2.slider[1].value == 32.0
+        assert sr2.markdown[1].value == "Fahrenheit `32.0`"
 
         # Both sliders update when second is changed
-        sr3 = sr2.get("slider")[1].set_value(212.0).run()
-        assert sr3.get("slider")[0].value == 100.0
-        assert sr3.get("markdown")[0].value == "Celsius `100.0`"
-        assert sr3.get("slider")[1].value == 212.0
-        assert sr3.get("markdown")[1].value == "Fahrenheit `212.0`"
+        sr3 = sr2.slider[1].set_value(212.0).run()
+        assert sr3.slider[0].value == 100.0
+        assert sr3.markdown[0].value == "Celsius `100.0`"
+        assert sr3.slider[1].value == 212.0
+        assert sr3.markdown[1].value == "Fahrenheit `212.0`"
 
         # Sliders update when one is changed repeatedly
-        sr4 = sr3.get("slider")[0].set_value(0.0).run()
-        assert sr4.get("slider")[0].value == 0.0
-        assert sr4.get("slider")[1].value == 32.0
-        sr5 = sr4.get("slider")[0].set_value(100.0).run()
-        assert sr5.get("slider")[0].value == 100.0
-        assert sr5.get("slider")[1].value == 212.0
+        sr4 = sr3.slider[0].set_value(0.0).run()
+        assert sr4.slider[0].value == 0.0
+        assert sr4.slider[1].value == 32.0
+        sr5 = sr4.slider[0].set_value(100.0).run()
+        assert sr5.slider[0].value == 100.0
+        assert sr5.slider[1].value == 212.0
 
     def test_serializable_check(self):
         """When the config option is on, adding unserializable data to session
@@ -329,8 +329,8 @@ class SessionStateInteractionTest(InteractiveScriptTests):
                 """,
             )
             sr = script.run()
-            assert sr.get("exception")
-            assert "pickle" in sr.get("exception")[0].value
+            assert sr.exception
+            assert "pickle" in sr.exception[0].value
 
     def test_serializable_check_off(self):
         """When the config option is off, adding unserializable data to session
@@ -348,7 +348,7 @@ class SessionStateInteractionTest(InteractiveScriptTests):
                 """,
             )
             sr = script.run()
-            assert not sr.get("exception")
+            assert not sr.exception
 
 
 def check_roundtrip(widget_id: str, value: Any) -> None:

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -34,7 +34,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
         # first column has 4 elements
         assert len(main[0][0]) == 4
 
-        radios = sr.get("radio")
+        radios = sr.radio
         assert radios[0].value == "1"
         assert radios[1].value == "a"
 
@@ -76,9 +76,9 @@ class InteractiveScriptTest(InteractiveScriptTests):
         )
         sr = script.run()
 
-        assert len(sr.get("radio")) == 1
+        assert len(sr.radio) == 1
         sr2 = sr.run()
-        assert len(sr2.get("radio")) == 1
+        assert len(sr2.radio) == 1
 
     def test_cached_widget_replay_interaction(self):
         script = self.script_from_string(
@@ -97,11 +97,11 @@ class InteractiveScriptTest(InteractiveScriptTests):
         )
         sr = script.run()
 
-        assert len(sr.get("radio")) == 1
-        assert sr.get("radio")[0].value == "bar"
+        assert len(sr.radio) == 1
+        assert sr.radio[0].value == "bar"
 
-        sr2 = sr.get("radio")[0].set_value("qux").run()
-        assert sr2.get("radio")[0].value == "qux"
+        sr2 = sr.radio[0].set_value("qux").run()
+        assert sr2.radio[0].value == "qux"
 
     def test_radio_interaction(self):
         script = self.script_from_string(
@@ -113,16 +113,16 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """,
         )
         sr = script.run()
-        assert sr.get("radio")
-        assert sr.get("radio")[0].value == "a"
-        assert sr.get("radio")[1].value == "c"
+        assert sr.radio
+        assert sr.radio[0].value == "a"
+        assert sr.radio[1].value == "c"
 
-        r = sr.get("radio")[0].set_value("b")
+        r = sr.radio[0].set_value("b")
         assert r.index == 1
         assert r.value == "b"
         sr2 = r.run()
-        assert sr2.get("radio")[0].value == "b"
-        assert [s.value for s in sr2.get("radio")] == ["b", "c"]
+        assert sr2.radio[0].value == "b"
+        assert [s.value for s in sr2.radio] == ["b", "c"]
 
     def test_widget_key_lookup(self):
         script = self.script_from_string(
@@ -135,7 +135,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
         )
         sr = script.run()
         assert sr.get_widget("r")
-        assert sr.get_widget("r") == sr.get("radio")[1]
+        assert sr.get_widget("r") == sr.radio[1]
         assert sr.get_widget("s") is None
 
     def test_widget_added_removed(self):
@@ -153,23 +153,23 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """,
         )
         sr = script.run()
-        assert len(sr.get("radio")) == 1
+        assert len(sr.radio) == 1
         assert sr.get_widget("conditional") == None
 
         sr2 = sr.get_widget("cb").set_value("on").run()
-        assert len(sr2.get("radio")) == 2
+        assert len(sr2.radio) == 2
         assert sr2.get_widget("conditional").value == "a"
 
         sr3 = sr2.get_widget("conditional").set_value("c").run()
-        assert len(sr3.get("radio")) == 2
+        assert len(sr3.radio) == 2
         assert sr3.get_widget("conditional").value == "c"
 
         sr4 = sr3.get_widget("cb").set_value("off").run()
-        assert len(sr4.get("radio")) == 1
+        assert len(sr4.radio) == 1
         assert sr4.get_widget("conditional") == None
 
         sr5 = sr4.get_widget("cb").set_value("on").run()
-        assert len(sr5.get("radio")) == 2
+        assert len(sr5.radio) == 2
         assert sr5.get_widget("conditional").value == "a"
 
     def test_query_narrowing(self):
@@ -185,9 +185,9 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """,
         )
         sr = script.run()
-        assert len(sr.get("text")) == 4
+        assert len(sr.text) == 4
         # querying elements via a block only returns the elements in that block
-        assert len(sr.get("expandable")[0].get("text")) == 2
+        assert len(sr.get("expandable")[0].text) == 2
 
     def test_session_state_immutable(self):
         script = self.script_from_string(
@@ -208,14 +208,14 @@ class InteractiveScriptTest(InteractiveScriptTests):
         assert state1["radio"] == "a"
         assert state1["other"] == 5
 
-        sr2 = sr.get("radio")[0].set_value("b").run()
+        sr2 = sr.radio[0].set_value("b").run()
         assert sr2.session_state["radio"] == "b"
         assert sr2.session_state["other"] == 10
         # unaffected by second script run
         assert state1["radio"] == "a"
         assert state1["other"] == 5
 
-        sr3 = sr2.get("radio")[0].set_value("c").run()
+        sr3 = sr2.radio[0].set_value("c").run()
         assert sr3.session_state["radio"] == "c"
         # has value from second script run despite being a different instance
         assert sr3.session_state["other"] == 10
@@ -230,11 +230,11 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """,
         )
         sr = script.run()
-        assert sr.get("radio")[0].value == "a"
-        assert sr.get("radio")[1].value == 1
+        assert sr.radio[0].value == "a"
+        assert sr.radio[1].value == 1
 
-        sr2 = sr.get("radio")[1].set_value(3).run()
-        assert sr2.get("radio")[1].value == 3
+        sr2 = sr.radio[1].set_value(3).run()
+        assert sr2.radio[1].value == 3
 
     def test_script_not_found(self):
         with pytest.raises(AssertionError):


### PR DESCRIPTION

## Describe your changes
Refactor interactive script tests to use the newer, cleaner syntax for getting collections of elements

