### PR TITLE
Identical widgets on different pages are distinct

### DIFF
--- a/e2e/scripts/multipage_apps/streamlit_app.py
+++ b/e2e/scripts/multipage_apps/streamlit_app.py
@@ -15,3 +15,4 @@
 import streamlit as st
 
 st.header("Main Page")
+st.slider("x")

--- a/e2e/specs/multipage_apps.spec.js
+++ b/e2e/specs/multipage_apps.spec.js
@@ -43,10 +43,15 @@ describe("multipage apps", () => {
   });
 
   it("can switch between pages and edit widgets", () => {
+    cy.get('.stSlider [role="slider"]')
+      .click()
+      .type("{rightarrow}", { force: true });
+
     cy.getIndexed('[data-testid="stSidebarNav"] a', 2).click();
 
     cy.get(".element-container .stMarkdown h2").should("contain", "Page 3");
 
+    // Identical widget on different page should be considered different
     cy.get(".element-container .stMarkdown p").should("contain", "x is 0");
 
     cy.get('.stSlider [role="slider"]')

--- a/lib/streamlit/components/v1/components.py
+++ b/lib/streamlit/components/v1/components.py
@@ -178,6 +178,8 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                 element.component_instance.json_args = serialized_json_args
                 element.component_instance.special_args.extend(special_args)
 
+            ctx = get_script_run_ctx()
+
             if key is None:
                 marshall_element_args()
                 id = compute_widget_id(
@@ -189,6 +191,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                     key=key,
                     json_args=serialized_json_args,
                     special_args=special_args,
+                    page=ctx.page_script_hash if ctx else None,
                 )
             else:
                 id = compute_widget_id(
@@ -198,6 +201,7 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                     form_id=current_form_id(dg),
                     url=self.url,
                     key=key,
+                    page=ctx.page_script_hash if ctx else None,
                 )
             element.component_instance.id = id
 
@@ -205,7 +209,6 @@ And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
                 # ui_value is an object from json, an ArrowTable proto, or a bytearray
                 return ui_value
 
-            ctx = get_script_run_ctx()
             component_state = register_widget(
                 element_type="component_instance",
                 element_proto=element.component_instance,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -437,6 +437,7 @@ class ButtonMixin:
             help=help,
             type=type,
             use_container_width=use_container_width,
+            page=ctx.page_script_hash if ctx else None,
         )
 
         if is_in_form(self.dg):
@@ -525,6 +526,7 @@ class ButtonMixin:
             is_form_submitter=is_form_submitter,
             type=type,
             use_container_width=use_container_width,
+            page=ctx.page_script_hash if ctx else None,
         )
 
         # It doesn't make sense to create a button inside a form (except

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -203,6 +203,7 @@ class CameraInputMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         camera_input_proto = CameraInputProto()

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -283,12 +283,14 @@ class ChatMixin:
         check_callback_rules(self.dg, on_submit)
         check_session_state_rules(default_value=default, key=key, writes_allowed=False)
 
+        ctx = get_script_run_ctx()
         id = compute_widget_id(
             "chat_input",
             user_key=key,
             key=key,
             placeholder=placeholder,
             max_chars=max_chars,
+            page=ctx.page_script_hash if ctx else None,
         )
 
         # We omit this check for scripts running outside streamlit, because
@@ -315,8 +317,6 @@ class ChatMixin:
 
         chat_input_proto.default = default
         chat_input_proto.position = ChatInputProto.Position.BOTTOM
-
-        ctx = get_script_run_ctx()
 
         serde = ChatInputSerde()
         widget_state = register_widget(

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -287,6 +287,7 @@ class CheckboxMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         checkbox_proto = CheckboxProto()

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -179,6 +179,7 @@ class ColorPickerMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         # set value default

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -797,6 +797,7 @@ class DataEditorMixin:
         # but it isn't clear how much processing is needed to have the data in a
         # format that will hash consistently, so we do it late here to have it
         # as close as possible to how it used to be.
+        ctx = get_script_run_ctx()
         id = compute_widget_id(
             "data_editor",
             user_key=key,
@@ -809,6 +810,7 @@ class DataEditorMixin:
             num_rows=num_rows,
             key=key,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         proto = ArrowProto()
@@ -865,7 +867,7 @@ class DataEditorMixin:
             kwargs=kwargs,
             deserializer=serde.deserialize,
             serializer=serde.serialize,
-            ctx=get_script_run_ctx(),
+            ctx=ctx,
         )
 
         _apply_dataframe_edits(data_df, widget_state.value, dataframe_schema)

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -405,6 +405,7 @@ class FileUploaderMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         if type:

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -307,6 +307,7 @@ class MultiSelectMixin:
             max_selections=max_selections,
             placeholder=placeholder,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         default_value: List[int] = [] if indices is None else indices

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -231,6 +231,7 @@ class NumberInputMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         # Ensure that all arguments are of the same type.

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -240,6 +240,7 @@ class RadioMixin:
             horizontal=horizontal,
             captions=captions,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         if not isinstance(index, int):

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -294,6 +294,7 @@ class SelectSliderMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         slider_proto = SliderProto()

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -224,6 +224,7 @@ class SelectboxMixin:
             help=help,
             placeholder=placeholder,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         if not isinstance(index, int):

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -389,6 +389,7 @@ class SliderMixin:
             key=key,
             help=help,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         SUPPORTED_TYPES = {

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -227,6 +227,7 @@ class TextWidgetsMixin:
             autocomplete=autocomplete,
             placeholder=str(placeholder),
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         text_input_proto = TextInputProto()
@@ -435,6 +436,7 @@ class TextWidgetsMixin:
             help=help,
             placeholder=str(placeholder),
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
 
         text_area_proto = TextAreaProto()

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -365,6 +365,7 @@ class TimeWidgetsMixin:
             help=help,
             step=step,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
         del value
 
@@ -604,6 +605,7 @@ class TimeWidgetsMixin:
             help=help,
             format=format,
             form_id=current_form_id(self.dg),
+            page=ctx.page_script_hash if ctx else None,
         )
         if not bool(ALLOWED_DATE_FORMATS.match(format)):
             raise StreamlitAPIException(

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -336,7 +336,7 @@ class ComputeWidgetIdTests(DeltaGeneratorTestCase):
 
         # Add some kwargs that are passed to compute_widget_id but don't appear in widget
         # signatures.
-        for kwarg in ["form_id", "user_key"]:
+        for kwarg in ["form_id", "user_key", "page"]:
             kwargs[kwarg] = ANY
 
         return kwargs


### PR DESCRIPTION
## Describe your changes
Use the active page (via `ctx.page_script_hash`) to distinguish otherwise identical widgets.

## GitHub Issue Link (if applicable)
#6146 

## Testing Plan

- Unit Tests (JS and/or Python)
Updated to account for new argument to id calc
- E2E Tests
Updated MPA cypress test to do basic check that a widget is reset when page switching

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
