### PR TITLE
Catch KeyError exceptions within Compact Session State

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -566,7 +566,7 @@ _create_option(
         State, so it may be useful to detect incompatibility during development,
         or when the execution environment will stop supporting it in the future.
     """,
-    default_val=False,
+    default_val=True,
     type_=bool,
 )
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -566,7 +566,7 @@ _create_option(
         State, so it may be useful to detect incompatibility during development,
         or when the execution environment will stop supporting it in the future.
     """,
-    default_val=True,
+    default_val=False,
     type_=bool,
 )
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -308,7 +308,12 @@ class SessionState:
         widget_state.
         """
         for key_or_wid in self:
-            self._old_state[key_or_wid] = self[key_or_wid]
+            try:
+                self._old_state[key_or_wid] = self[key_or_wid]
+            # handle key errors from widget state not having metadata gracefully
+            # https://github.com/streamlit/streamlit/issues/7206
+            except KeyError:
+                pass
         self._new_session_state.clear()
         self._new_widget_state.clear()
 
@@ -398,7 +403,6 @@ class SessionState:
         At least one of the arguments must have a value.
         """
         assert user_key is not None or widget_id is not None
-
         if user_key is not None:
             try:
                 return self._new_session_state[user_key]

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -310,9 +310,9 @@ class SessionState:
         for key_or_wid in self:
             try:
                 self._old_state[key_or_wid] = self[key_or_wid]
-            # handle key errors from widget state not having metadata gracefully
-            # https://github.com/streamlit/streamlit/issues/7206
             except KeyError:
+                # handle key errors from widget state not having metadata gracefully
+                # https://github.com/streamlit/streamlit/issues/7206
                 pass
         self._new_session_state.clear()
         self._new_widget_state.clear()

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -403,6 +403,7 @@ class SessionState:
         At least one of the arguments must have a value.
         """
         assert user_key is not None or widget_id is not None
+
         if user_key is not None:
             try:
                 return self._new_session_state[user_key]

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -531,8 +531,8 @@ def _sorted_items(state: SessionState) -> List[Tuple[str, Any]]:
 
 class SessionStateMethodTests(unittest.TestCase):
     def setUp(self):
-        old_state = {"foo": "bar", "baz": "qux", "corge": "grault"}
-        new_session_state = {"foo": "bar2"}
+        self.old_state = {"foo": "bar", "baz": "qux", "corge": "grault"}
+        self.new_session_state = {"foo": "bar2"}
         new_widget_state = WStates(
             {
                 "baz": Value("qux2"),
@@ -540,7 +540,7 @@ class SessionStateMethodTests(unittest.TestCase):
             },
         )
         self.session_state = SessionState(
-            old_state, new_session_state, new_widget_state
+            self.old_state, self.new_session_state, new_widget_state
         )
 
     def test_compact(self):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -531,8 +531,8 @@ def _sorted_items(state: SessionState) -> List[Tuple[str, Any]]:
 
 class SessionStateMethodTests(unittest.TestCase):
     def setUp(self):
-        old_state = {"foo": "bar", "baz": "qux", "corge": "grault"}
-        new_session_state = {"foo": "bar2"}
+        self.old_state = {"foo": "bar", "baz": "qux", "corge": "grault"}
+        self.new_session_state = {"foo": "bar2"}
         new_widget_state = WStates(
             {
                 "baz": Value("qux2"),
@@ -540,7 +540,7 @@ class SessionStateMethodTests(unittest.TestCase):
             },
         )
         self.session_state = SessionState(
-            old_state, new_session_state, new_widget_state
+            self.old_state, self.new_session_state, new_widget_state
         )
 
     def test_compact(self):
@@ -556,18 +556,18 @@ class SessionStateMethodTests(unittest.TestCase):
 
     # https://github.com/streamlit/streamlit/issues/7206
     def test_ignore_key_error_within_compact_state(self):
-        # Arrange: Mock __getitem__ to throw a KeyError when it sees the key 'bad_key'
-        with patch.object(
-            WStates,
-            "__getitem__",
-            side_effect=lambda key: {"bad_key": KeyError("Key not found")}[key],
-        ):
-            try:
-                self.session_state._compact_state()
-            # KeyError should be thrown from grabbing a key with no metadata
-            # but we handle it so no KeyError should be thrown
-            except KeyError:
-                pytest.fail("_compact_state should not propagate KeyError")
+        wstates = WStates()
+
+        widget_state = WidgetStateProto()
+        widget_state.id = "widget_id_1"
+        widget_state.int_value = 5
+        wstates.set_widget_from_proto(widget_state)
+        session_state = SessionState(self.old_state, self.new_session_state, wstates)
+        # KeyError should be thrown from grabbing a key with no metadata
+        # but _compact_state catches it so no KeyError should be thrown
+        session_state._compact_state()
+        with pytest.raises(KeyError):
+            wstates["baz"]
 
     def test_clear_state(self):
         # Sanity test

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -531,8 +531,8 @@ def _sorted_items(state: SessionState) -> List[Tuple[str, Any]]:
 
 class SessionStateMethodTests(unittest.TestCase):
     def setUp(self):
-        self.old_state = {"foo": "bar", "baz": "qux", "corge": "grault"}
-        self.new_session_state = {"foo": "bar2"}
+        old_state = {"foo": "bar", "baz": "qux", "corge": "grault"}
+        new_session_state = {"foo": "bar2"}
         new_widget_state = WStates(
             {
                 "baz": Value("qux2"),
@@ -540,7 +540,7 @@ class SessionStateMethodTests(unittest.TestCase):
             },
         )
         self.session_state = SessionState(
-            self.old_state, self.new_session_state, new_widget_state
+            old_state, new_session_state, new_widget_state
         )
 
     def test_compact(self):


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- add a try and catch block within _compact_state within session state as keyErrors within widgetState propagate to compact_state and we should handle that
## GitHub Issue Link (if applicable)
- #7206 
## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- added a unit test for python
- E2E Tests
- Any manual testing needed?
- yes, manually reran the script several times.

https://github.com/streamlit/streamlit/assets/16749069/d5cf35a3-dc45-4c2c-969f-3f0caa95bd03


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
