### PR TITLE
Fix: `st.tabs` content jitter

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -188,7 +188,12 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
       nonce={document.currentScript?.nonce || ""}
     >
       {({ width }) => {
-        const propsWithNewWidth = { ...props, ...{ width } }
+        const propsWithNewWidth = {
+          ...props,
+          // tabs are special case where width passed in props; autosizer causes jitter w/ width = 0 - issue #5820
+          // @ts-expect-error
+          ...{ width: props.width ? props.width : width },
+        }
 
         return (
           <StyledVerticalBlock width={width} data-testid="stVerticalBlock">


### PR DESCRIPTION
## Describe your changes
`st.tabs` calls `VerticalBlock` to render the contents of each tab - it passes a width that is then overridden by the AutoSizer in `VerticalBlock`, which sets width to 0 for initial mount of non-selected tabs, causing a jitter. More details in the issue.

## GitHub Issue Link (if applicable)
Closes #5820 

## Testing Plan
Don't really have the ability to write automated test for this one - manually tested ✅ 