### PR TITLE
Fix: Preload custom fonts to reduce FOUT

### DIFF
--- a/e2e/specs/hostframe.spec.js
+++ b/e2e/specs/hostframe.spec.js
@@ -64,7 +64,7 @@ describe("Host communication", () => {
                 // Open the Main Menu
                 cy.get("#MainMenu > button").click()
                 // Open the Settings Modal
-                cy.getIndexed('[data-testid="main-menu-list"] > ul', 1).click()
+                cy.getIndexed('[data-testid="main-menu-list"] > ul', 1).click({ force: true })
                 cy.get("div[role='dialog']").should("exist")
             });
         // Close modal
@@ -77,7 +77,7 @@ describe("Host communication", () => {
 
     it("handles a host menu item message", () => {
         // Add Menu Item message
-        cy.get("#toolbar").contains("Add Menu Item").click();
+        cy.get("#toolbar").contains("Add Menu Item").click({ force: true });
         cy.get("iframe")
             .iframe(() => {
                 // Open the Main Menu

--- a/frontend/app/public/index.html
+++ b/frontend/app/public/index.html
@@ -23,9 +23,9 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png" />
-    <link rel="preload" href="../src/assets/fonts/SourceSansPro/SourceSansPro-Regular.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="../src/assets/fonts/SourceSansPro/SourceSansPro-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="../src/assets/fonts/SourceSansPro/SourceSansPro-Bold.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSansPro-Regular.0d69e5ff5e92ac64a0c9.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSerifPro-SemiBold.5c1d378dd5990ef334ca.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSansPro-Bold.118dea98980e20a81ced.woff2" as="font" type="font/woff2" crossorigin>
 
     <title>Streamlit</title>
 

--- a/frontend/app/public/index.html
+++ b/frontend/app/public/index.html
@@ -23,6 +23,9 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png" />
+    <link rel="preload" href="../src/assets/fonts/SourceSansPro/SourceSansPro-Regular.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../src/assets/fonts/SourceSansPro/SourceSansPro-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../src/assets/fonts/SourceSansPro/SourceSansPro-Bold.woff2" as="font" type="font/woff2" crossorigin>
 
     <title>Streamlit</title>
 

--- a/frontend/app/src/FontPreload.test.tsx
+++ b/frontend/app/src/FontPreload.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from "fs"
+import path from "path"
+
+// Current hashes for our preloaded font assets:
+const REGULAR_HASH = "0d69e5ff5e92ac64a0c9"
+const SEMI_BOLD_HASH = "5c1d378dd5990ef334ca"
+const BOLD_HASH = "118dea98980e20a81ced"
+
+// Render a copy of index.html file to test
+const HTML = fs.readFileSync(
+  path.resolve(__dirname, "../public/index.html"),
+  "utf8"
+)
+document.documentElement.innerHTML = HTML.toString()
+
+function getFontHref(index: number): string {
+  const fontPreloadElements: NodeList | null = document.querySelectorAll(
+    "link[rel='preload']"
+  )
+  const fontElement: HTMLLinkElement | null = fontPreloadElements.item(
+    index
+  ) as HTMLLinkElement
+  return fontElement ? fontElement.href : ""
+}
+
+test("index.html preloads 3 expected fonts with expected hashes", () => {
+  const expectedfontHashes = [REGULAR_HASH, SEMI_BOLD_HASH, BOLD_HASH]
+  const preloadedFontsCount = document.querySelectorAll(
+    "link[rel='preload']"
+  ).length
+  expect(preloadedFontsCount).toBe(3)
+
+  for (let i = 0; i < preloadedFontsCount; i++) {
+    const fontHref = getFontHref(i)
+    const fontFullName = fontHref.split("/").pop()
+    const fontHash = fontFullName ? fontFullName.split(".")[1] : ""
+    expect(fontHash).toBe(expectedfontHashes[i])
+  }
+})

--- a/frontend/app/src/FontPreload.test.tsx
+++ b/frontend/app/src/FontPreload.test.tsx
@@ -17,6 +17,8 @@
 import fs from "fs"
 import path from "path"
 
+jest.dontMock("fs")
+
 // Current hashes for our preloaded font assets:
 const REGULAR_HASH = "0d69e5ff5e92ac64a0c9"
 const SEMI_BOLD_HASH = "5c1d378dd5990ef334ca"


### PR DESCRIPTION
## Describe your changes
Preload selected fonts in `index.html` - see more details in issue

## GitHub Issue Link (if applicable)
Closes #7153

**Before:**
<img src=https://github.com/streamlit/streamlit/assets/63436329/a6b12b13-6aeb-4a76-96a1-7a8b0f295e80 width=500 />

**After:**
<img src=https://github.com/streamlit/streamlit/assets/63436329/6a5085b3-5126-46dd-9a63-b30963fba2b6 width=500 />

## Testing
- Manual testing - both on local and CC ✅  - see [demo app](https://font-preload.streamlit.app/)