### PR TITLE
Simplify internal storage and use of client state

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -386,7 +386,6 @@ class AppSession:
         self._scriptrunner = ScriptRunner(
             session_id=self.id,
             main_script_path=self._script_data.main_script_path,
-            client_state=self._client_state,
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,
             script_cache=self._script_cache,

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -311,8 +311,6 @@ class ScriptRunner:
         client_state = ClientState()
         client_state.query_string = ctx.query_string
         client_state.page_script_hash = ctx.page_script_hash
-        widget_states = self._session_state.get_widget_states()
-        client_state.widget_states.widgets.extend(widget_states)
         self.on_event.send(
             self, event=ScriptRunnerEvent.SHUTDOWN, client_state=client_state
         )

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -145,9 +145,6 @@ class ScriptRunner:
         self._script_cache = script_cache
         self._user_info = user_info
 
-        # Initialize SessionState with the latest widget states
-        session_state.set_widgets_from_proto(client_state.widget_states)
-
         self._client_state = client_state
         self._session_state = SafeSessionState(session_state)
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -99,7 +99,6 @@ class ScriptRunner:
         self,
         session_id: str,
         main_script_path: str,
-        client_state: ClientState,
         session_state: SessionState,
         uploaded_file_mgr: UploadedFileManager,
         script_cache: ScriptCache,
@@ -117,9 +116,6 @@ class ScriptRunner:
 
         main_script_path
             Path to our main app script.
-
-        client_state
-            The current state from the client (widgets and query params).
 
         uploaded_file_mgr
             The File manager to store the data uploaded by the file_uploader widget.
@@ -145,7 +141,6 @@ class ScriptRunner:
         self._script_cache = script_cache
         self._user_info = user_info
 
-        self._client_state = client_state
         self._session_state = SafeSessionState(session_state)
 
         self._requests = ScriptRequests()
@@ -284,10 +279,10 @@ class ScriptRunner:
             session_id=self._session_id,
             _enqueue=self._enqueue_forward_msg,
             script_requests=self._requests,
-            query_string=self._client_state.query_string,
+            query_string="",
             session_state=self._session_state,
             uploaded_file_mgr=self._uploaded_file_mgr,
-            page_script_hash=self._client_state.page_script_hash,
+            page_script_hash="",
             user_info=self._user_info,
             gather_usage_stats=bool(config.get_option("browser.gatherUsageStats")),
         )

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -304,10 +304,8 @@ class ScriptRunner:
 
         assert request.type == ScriptRequestType.STOP
 
-        # Send a SHUTDOWN event before exiting. This includes the widget values
-        # as they existed after our last successful script run, which the
-        # AppSession will pass on to the next ScriptRunner that gets
-        # created.
+        # Send a SHUTDOWN event before exiting, so some state can be saved
+        # for use in a future script run when not triggered by the client.
         client_state = ClientState()
         client_state.query_string = ctx.query_string
         client_state.page_script_hash = ctx.page_script_hash

--- a/lib/streamlit/testing/local_script_runner.py
+++ b/lib/streamlit/testing/local_script_runner.py
@@ -51,7 +51,6 @@ class LocalScriptRunner(ScriptRunner):
         super().__init__(
             session_id="test session id",
             main_script_path=script_path,
-            client_state=ClientState(),
             session_state=self.session_state,
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             script_cache=ScriptCache(),

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -266,7 +266,6 @@ class AppSessionTest(unittest.TestCase):
         mock_scriptrunner.assert_called_once_with(
             session_id=session.id,
             main_script_path=session._script_data.main_script_path,
-            client_state=session._client_state,
             session_state=session._session_state,
             uploaded_file_mgr=session._uploaded_file_mgr,
             script_cache=session._script_cache,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -998,7 +998,6 @@ class TestScriptRunner(ScriptRunner):
         super().__init__(
             session_id="test session id",
             main_script_path=main_script_path,
-            client_state=ClientState(),
             session_state=SessionState(),
             uploaded_file_mgr=MemoryUploadedFileManager("/mock/upload"),
             script_cache=ScriptCache(),


### PR DESCRIPTION
While looking into fixing an issue with trigger values not resetting with fast reruns, I sketched out how both control and values flow between app session, session state, and script runner, while handling different kinds of reruns. It was apparent that there are several unnecessary transfers of widget state, either because it is already being set elsewhere, or because the widget state in session state is already there and more up to date, so I opted to remove those while I was adjusting our handling of session state.

I have some other related ideas that could also simplify things (maybe even remove the need for the session state disconnect alltogether?) and improve responsiveness of scripts that don't use fast reruns, but those can be considered separately.

## Testing Plan

It is just a refactor, which shouldn't change any visible behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
