### PR TITLE
Fix: Flaky tabs playwright test

### DIFF
--- a/e2e_playwright/st_tabs_selection_test.py
+++ b/e2e_playwright/st_tabs_selection_test.py
@@ -36,6 +36,7 @@ def test_maintains_selection_when_other_tab_added(
     control_buttons.nth(0).click()
     # Wait for tabs to properly load
     wait_for_app_run(app)
+    app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-selection-add-tab")
 
 
@@ -54,7 +55,8 @@ def test_maintains_selection_when_other_tab_removed(
     tab_buttons.nth(2).click()
     # Select Remove Tab 1 button
     control_buttons.nth(1).click()
-    # Test a little flaky - needs extra time to remove old tab content
+    # Wait for tabs to properly load
+    wait_for_app_run(app)
     app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-selection-remove-tab")
 
@@ -74,6 +76,7 @@ def test_resets_selection_when_selected_tab_removed(
     control_buttons.nth(2).click()
     # Wait for tabs to properly load
     wait_for_app_run(app)
+    app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-remove-selected")
 
 
@@ -94,6 +97,7 @@ def test_maintains_selection_when_same_name_exists(
     control_buttons.nth(3).click()
     # Wait for tabs to properly load
     wait_for_app_run(app)
+    app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-change-some-names")
 
 
@@ -112,4 +116,5 @@ def test_resets_selection_when_tab_names_change(
     control_buttons.nth(4).click()
     # Wait for tabs to properly load
     wait_for_app_run(app)
+    app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-change-all-names")

--- a/e2e_playwright/st_tabs_selection_test.py
+++ b/e2e_playwright/st_tabs_selection_test.py
@@ -36,6 +36,7 @@ def test_maintains_selection_when_other_tab_added(
     control_buttons.nth(0).click()
     # Wait for tabs to properly load
     wait_for_app_run(app)
+    # Tab add/remove/switch can still be in process despite app run finishing.
     app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-selection-add-tab")
 

--- a/e2e_playwright/st_tabs_selection_test.py
+++ b/e2e_playwright/st_tabs_selection_test.py
@@ -54,8 +54,8 @@ def test_maintains_selection_when_other_tab_removed(
     tab_buttons.nth(2).click()
     # Select Remove Tab 1 button
     control_buttons.nth(1).click()
-    # Wait for tabs to properly load
-    wait_for_app_run(app)
+    # Test a little flaky - needs extra time to remove old tab content
+    app.wait_for_timeout(1000)
     assert_snapshot(app.locator(".stTabs"), name="tabs-selection-remove-tab")
 
 


### PR DESCRIPTION
## Describe your changes
The new tab selection test I added seems a little flaky - adding a 1 sec wait so that tabs/content are situated before snapshot is taken.