### PR TITLE
Fix: Add built-in retries for flaky Cypress tests

### DIFF
--- a/e2e/specs/multipage_apps.spec.js
+++ b/e2e/specs/multipage_apps.spec.js
@@ -42,7 +42,7 @@ describe("multipage apps", () => {
     cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
   });
 
-  it("can switch between pages and edit widgets", () => {
+  it("can switch between pages and edit widgets", { retries: { runMode: 1 } }, () => {
     cy.get('.stSlider [role="slider"]')
       .click()
       .type("{rightarrow}", { force: true });

--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -59,7 +59,7 @@ describe("st.camera_input", () => {
     cy.get("[data-testid='stImage']").should("not.exist");
   });
 
-  it("shows disabled widget correctly", () => {
+  it("shows disabled widget correctly", { retries: { runMode: 1 } }, () => {
     cy.get("[data-testid='stCameraInput']").should("have.length.at.least", 2);
 
     cy.getIndexed("[data-testid='stCameraInput']", 1).matchThemedSnapshots(

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -177,7 +177,7 @@ describe("st.file_uploader", () => {
     });
   });
 
-  it("uploads and deletes multiple files quickly", () => {
+  it("uploads and deletes multiple files quickly", { retries: { runMode: 1 } }, () => {
     const fileName1 = "file1.txt";
     const fileName2 = "file2.txt";
     const uploaderIndex = 2;
@@ -396,7 +396,7 @@ describe("st.file_uploader", () => {
   });
 
   // regression test for https://github.com/streamlit/streamlit/issues/4256 bug
-  it("does not call a callback when not changed", () => {
+  it("does not call a callback when not changed", { retries: { runMode: 1 } }, () => {
     const fileName1 = "file1.txt";
     const uploaderIndex = 6;
 

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -110,7 +110,7 @@ describe("websocket reconnects", () => {
     });
   });
 
-  it("retains captured pictures when the websocket connection is dropped and reconnects", () => {
+  it("retains captured pictures when the websocket connection is dropped and reconnects", { retries: { runMode: 1 } }, () => {
     // Be generous with some of the timeouts in this test as uploading and
     // rendering images can be quite slow.
     const timeout = 30000;


### PR DESCRIPTION
## Describe your changes
Adding Cypress' built in [retries](https://docs.cypress.io/guides/guides/test-retries) to resolve tests I've seen flakiness on