### PR TITLE
Fluent asserts and type narrowing for widgets in tests

### DIFF
--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -155,7 +155,7 @@ class Widget(ABC, Element):
         return self
 
     @property
-    def is_multiselect(self) -> Multiselect:
+    def is_multiselect(self) -> Multiselect[Any]:
         assert isinstance(self, Multiselect)
         return self
 
@@ -165,22 +165,22 @@ class Widget(ABC, Element):
         return self
 
     @property
-    def is_radio(self) -> Radio:
+    def is_radio(self) -> Radio[Any]:
         assert isinstance(self, Radio)
         return self
 
     @property
-    def is_select_slider(self) -> SelectSlider:
+    def is_select_slider(self) -> SelectSlider[Any]:
         assert isinstance(self, SelectSlider)
         return self
 
     @property
-    def is_selectbox(self) -> Selectbox:
+    def is_selectbox(self) -> Selectbox[Any]:
         assert isinstance(self, Selectbox)
         return self
 
     @property
-    def is_slider(self) -> Slider:
+    def is_slider(self) -> Slider[Any]:
         assert isinstance(self, Slider)
         return self
 

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -135,67 +135,67 @@ class Widget(ABC, Element):
         return self
 
     @property
-    def is_button(self) -> Button:
+    def as_button(self) -> Button:
         assert isinstance(self, Button)
         return self
 
     @property
-    def is_checkbox(self) -> Checkbox:
+    def as_checkbox(self) -> Checkbox:
         assert isinstance(self, Checkbox)
         return self
 
     @property
-    def is_color_picker(self) -> ColorPicker:
+    def as_color_picker(self) -> ColorPicker:
         assert isinstance(self, ColorPicker)
         return self
 
     @property
-    def is_date_input(self) -> DateInput:
+    def as_date_input(self) -> DateInput:
         assert isinstance(self, DateInput)
         return self
 
     @property
-    def is_multiselect(self) -> Multiselect[Any]:
+    def as_multiselect(self) -> Multiselect[Any]:
         assert isinstance(self, Multiselect)
         return self
 
     @property
-    def is_number_input(self) -> NumberInput:
+    def as_number_input(self) -> NumberInput:
         assert isinstance(self, NumberInput)
         return self
 
     @property
-    def is_radio(self) -> Radio[Any]:
+    def as_radio(self) -> Radio[Any]:
         assert isinstance(self, Radio)
         return self
 
     @property
-    def is_select_slider(self) -> SelectSlider[Any]:
+    def as_select_slider(self) -> SelectSlider[Any]:
         assert isinstance(self, SelectSlider)
         return self
 
     @property
-    def is_selectbox(self) -> Selectbox[Any]:
+    def as_selectbox(self) -> Selectbox[Any]:
         assert isinstance(self, Selectbox)
         return self
 
     @property
-    def is_slider(self) -> Slider[Any]:
+    def as_slider(self) -> Slider[Any]:
         assert isinstance(self, Slider)
         return self
 
     @property
-    def is_text_area(self) -> TextArea:
+    def as_text_area(self) -> TextArea:
         assert isinstance(self, TextArea)
         return self
 
     @property
-    def is_text_input(self) -> TextInput:
+    def as_text_input(self) -> TextInput:
         assert isinstance(self, TextInput)
         return self
 
     @property
-    def is_time_input(self) -> TimeInput:
+    def as_time_input(self) -> TimeInput:
         assert isinstance(self, TimeInput)
         return self
 

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -134,6 +134,71 @@ class Widget(ABC, Element):
         self._value = v
         return self
 
+    @property
+    def is_button(self) -> Button:
+        assert isinstance(self, Button)
+        return self
+
+    @property
+    def is_checkbox(self) -> Checkbox:
+        assert isinstance(self, Checkbox)
+        return self
+
+    @property
+    def is_color_picker(self) -> ColorPicker:
+        assert isinstance(self, ColorPicker)
+        return self
+
+    @property
+    def is_date_input(self) -> DateInput:
+        assert isinstance(self, DateInput)
+        return self
+
+    @property
+    def is_multiselect(self) -> Multiselect:
+        assert isinstance(self, Multiselect)
+        return self
+
+    @property
+    def is_number_input(self) -> NumberInput:
+        assert isinstance(self, NumberInput)
+        return self
+
+    @property
+    def is_radio(self) -> Radio:
+        assert isinstance(self, Radio)
+        return self
+
+    @property
+    def is_select_slider(self) -> SelectSlider:
+        assert isinstance(self, SelectSlider)
+        return self
+
+    @property
+    def is_selectbox(self) -> Selectbox:
+        assert isinstance(self, Selectbox)
+        return self
+
+    @property
+    def is_slider(self) -> Slider:
+        assert isinstance(self, Slider)
+        return self
+
+    @property
+    def is_text_area(self) -> TextArea:
+        assert isinstance(self, TextArea)
+        return self
+
+    @property
+    def is_text_input(self) -> TextInput:
+        assert isinstance(self, TextInput)
+        return self
+
+    @property
+    def is_time_input(self) -> TimeInput:
+        assert isinstance(self, TimeInput)
+        return self
+
 
 @dataclass(repr=False)
 class Button(Widget):

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -1245,12 +1245,13 @@ class Block:
     def get(self, element_type: str) -> Sequence[Node]:
         return [e for e in self if e.type == element_type]
 
-    def get_widget(self, key: str) -> Widget | None:
+    def get_widget(self, key: str) -> Widget:
         for e in self:
             if e.key == key:
                 assert isinstance(e, Widget)
                 return e
-        return None
+
+        raise KeyError(key)
 
     def widget_state(self) -> WidgetState | None:
         return None

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -200,6 +200,41 @@ class Widget(ABC, Element):
         return self
 
 
+El = TypeVar("El", bound=Element, covariant=True)
+
+
+class ElementList(Generic[El]):
+    def __init__(self, els: Sequence[El]):
+        self._list: Sequence[El] = els
+
+    def __len__(self) -> int:
+        return len(self._list)
+
+    def len(self) -> int:
+        return len(self)
+
+    def __getitem__(self, idx: int) -> El:
+        return self._list[idx]
+
+    def __iter__(self):
+        yield from self._list
+
+    def values(self) -> Sequence[Any]:
+        return [e.value for e in self]
+
+
+W = TypeVar("W", bound=Widget, covariant=True)
+
+
+class WidgetList(Generic[W], ElementList[W]):
+    def get_widget(self, key: str) -> W:
+        for e in self._list:
+            if e.key == key:
+                return e
+
+        raise KeyError(key)
+
+
 @dataclass(repr=False)
 class Button(Widget):
     _value: bool
@@ -1121,96 +1156,96 @@ class Block:
     # We could implement these using __getattr__ but that would have
     # much worse type information.
     @property
-    def button(self) -> Sequence[Button]:
-        return self.get("button")
+    def button(self) -> WidgetList[Button]:
+        return WidgetList(self.get("button"))
 
     @property
-    def caption(self) -> Sequence[Caption]:
-        return self.get("caption")
+    def caption(self) -> ElementList[Caption]:
+        return ElementList(self.get("caption"))
 
     @property
-    def checkbox(self) -> Sequence[Checkbox]:
-        return self.get("checkbox")
+    def checkbox(self) -> WidgetList[Checkbox]:
+        return WidgetList(self.get("checkbox"))
 
     @property
-    def code(self) -> Sequence[Code]:
-        return self.get("code")
+    def code(self) -> ElementList[Code]:
+        return ElementList(self.get("code"))
 
     @property
-    def color_picker(self) -> Sequence[ColorPicker]:
-        return self.get("color_picker")
+    def color_picker(self) -> WidgetList[ColorPicker]:
+        return WidgetList(self.get("color_picker"))
 
     @property
-    def date_input(self) -> Sequence[DateInput]:
-        return self.get("date_input")
+    def date_input(self) -> WidgetList[DateInput]:
+        return WidgetList(self.get("date_input"))
 
     @property
-    def divider(self) -> Sequence[Divider]:
-        return self.get("divider")
+    def divider(self) -> ElementList[Divider]:
+        return ElementList(self.get("divider"))
 
     @property
-    def exception(self) -> Sequence[Exception]:
-        return self.get("exception")
+    def exception(self) -> ElementList[Exception]:
+        return ElementList(self.get("exception"))
 
     @property
-    def header(self) -> Sequence[Header]:
-        return self.get("header")
+    def header(self) -> ElementList[Header]:
+        return ElementList(self.get("header"))
 
     @property
-    def latex(self) -> Sequence[Latex]:
-        return self.get("latex")
+    def latex(self) -> ElementList[Latex]:
+        return ElementList(self.get("latex"))
 
     @property
-    def markdown(self) -> Sequence[Markdown]:
-        return self.get("markdown")
+    def markdown(self) -> ElementList[Markdown]:
+        return ElementList(self.get("markdown"))
 
     @property
-    def multiselect(self) -> Sequence[Multiselect[Any]]:
-        return self.get("multiselect")
+    def multiselect(self) -> WidgetList[Multiselect[Any]]:
+        return WidgetList(self.get("multiselect"))
 
     @property
-    def number_input(self) -> Sequence[NumberInput]:
-        return self.get("number_input")
+    def number_input(self) -> WidgetList[NumberInput]:
+        return WidgetList(self.get("number_input"))
 
     @property
-    def radio(self) -> Sequence[Radio[Any]]:
-        return self.get("radio")
+    def radio(self) -> WidgetList[Radio[Any]]:
+        return WidgetList(self.get("radio"))
 
     @property
-    def select_slider(self) -> Sequence[SelectSlider[Any]]:
-        return self.get("select_slider")
+    def select_slider(self) -> WidgetList[SelectSlider[Any]]:
+        return WidgetList(self.get("select_slider"))
 
     @property
-    def selectbox(self) -> Sequence[Selectbox[Any]]:
-        return self.get("selectbox")
+    def selectbox(self) -> WidgetList[Selectbox[Any]]:
+        return WidgetList(self.get("selectbox"))
 
     @property
-    def slider(self) -> Sequence[Slider[Any]]:
-        return self.get("slider")
+    def slider(self) -> WidgetList[Slider[Any]]:
+        return WidgetList(self.get("slider"))
 
     @property
-    def subheader(self) -> Sequence[Subheader]:
-        return self.get("subheader")
+    def subheader(self) -> ElementList[Subheader]:
+        return ElementList(self.get("subheader"))
 
     @property
-    def text(self) -> Sequence[Text]:
-        return self.get("text")
+    def text(self) -> ElementList[Text]:
+        return ElementList(self.get("text"))
 
     @property
-    def text_area(self) -> Sequence[TextArea]:
-        return self.get("text_area")
+    def text_area(self) -> WidgetList[TextArea]:
+        return WidgetList(self.get("text_area"))
 
     @property
-    def text_input(self) -> Sequence[TextInput]:
-        return self.get("text_input")
+    def text_input(self) -> WidgetList[TextInput]:
+        return WidgetList(self.get("text_input"))
 
     @property
-    def time_input(self) -> Sequence[TimeInput]:
-        return self.get("time_input")
+    def time_input(self) -> WidgetList[TimeInput]:
+        return WidgetList(self.get("time_input"))
 
     @property
-    def title(self) -> Sequence[Title]:
-        return self.get("title")
+    def title(self) -> ElementList[Title]:
+        return ElementList(self.get("title"))
 
     # These overloads improve type information for code calling `get`
     @overload

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -134,7 +134,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """,
         )
         sr = script.run()
-        assert sr.get_widget("r")
+        assert sr.get_widget("r").is_radio
         assert sr.get_widget("r") == sr.radio[1]
         with pytest.raises(KeyError):
             sr.get_widget("s")
@@ -158,22 +158,22 @@ class InteractiveScriptTest(InteractiveScriptTests):
         with pytest.raises(KeyError):
             sr.get_widget("conditional")
 
-        sr2 = sr.get_widget("cb").set_value("on").run()
+        sr2 = sr.get_widget("cb").is_radio.set_value("on").run()
         assert len(sr2.radio) == 2
-        assert sr2.get_widget("conditional").value == "a"
+        assert sr2.get_widget("conditional").is_radio.value == "a"
 
-        sr3 = sr2.get_widget("conditional").set_value("c").run()
+        sr3 = sr2.get_widget("conditional").is_radio.set_value("c").run()
         assert len(sr3.radio) == 2
-        assert sr3.get_widget("conditional").value == "c"
+        assert sr3.get_widget("conditional").is_radio.value == "c"
 
-        sr4 = sr3.get_widget("cb").set_value("off").run()
+        sr4 = sr3.get_widget("cb").is_radio.set_value("off").run()
         assert len(sr4.radio) == 1
         with pytest.raises(KeyError):
             sr4.get_widget("conditional")
 
-        sr5 = sr4.get_widget("cb").set_value("on").run()
+        sr5 = sr4.get_widget("cb").is_radio.set_value("on").run()
         assert len(sr5.radio) == 2
-        assert sr5.get_widget("conditional").value == "a"
+        assert sr5.get_widget("conditional").is_radio.value == "a"
 
     def test_query_narrowing(self):
         script = self.script_from_string(

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -134,7 +134,7 @@ class InteractiveScriptTest(InteractiveScriptTests):
             """,
         )
         sr = script.run()
-        assert sr.get_widget("r").is_radio
+        assert sr.get_widget("r").as_radio
         assert sr.get_widget("r") == sr.radio[1]
         with pytest.raises(KeyError):
             sr.get_widget("s")
@@ -158,22 +158,22 @@ class InteractiveScriptTest(InteractiveScriptTests):
         with pytest.raises(KeyError):
             sr.get_widget("conditional")
 
-        sr2 = sr.get_widget("cb").is_radio.set_value("on").run()
+        sr2 = sr.get_widget("cb").as_radio.set_value("on").run()
         assert len(sr2.radio) == 2
-        assert sr2.get_widget("conditional").is_radio.value == "a"
+        assert sr2.get_widget("conditional").as_radio.value == "a"
 
-        sr3 = sr2.get_widget("conditional").is_radio.set_value("c").run()
+        sr3 = sr2.get_widget("conditional").as_radio.set_value("c").run()
         assert len(sr3.radio) == 2
-        assert sr3.get_widget("conditional").is_radio.value == "c"
+        assert sr3.get_widget("conditional").as_radio.value == "c"
 
-        sr4 = sr3.get_widget("cb").is_radio.set_value("off").run()
+        sr4 = sr3.get_widget("cb").as_radio.set_value("off").run()
         assert len(sr4.radio) == 1
         with pytest.raises(KeyError):
             sr4.get_widget("conditional")
 
-        sr5 = sr4.get_widget("cb").is_radio.set_value("on").run()
+        sr5 = sr4.get_widget("cb").as_radio.set_value("on").run()
         assert len(sr5.radio) == 2
-        assert sr5.get_widget("conditional").is_radio.value == "a"
+        assert sr5.get_widget("conditional").as_radio.value == "a"
 
     def test_query_narrowing(self):
         script = self.script_from_string(

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -136,7 +136,8 @@ class InteractiveScriptTest(InteractiveScriptTests):
         sr = script.run()
         assert sr.get_widget("r")
         assert sr.get_widget("r") == sr.radio[1]
-        assert sr.get_widget("s") is None
+        with pytest.raises(KeyError):
+            sr.get_widget("s")
 
     def test_widget_added_removed(self):
         """
@@ -154,7 +155,8 @@ class InteractiveScriptTest(InteractiveScriptTests):
         )
         sr = script.run()
         assert len(sr.radio) == 1
-        assert sr.get_widget("conditional") == None
+        with pytest.raises(KeyError):
+            sr.get_widget("conditional")
 
         sr2 = sr.get_widget("cb").set_value("on").run()
         assert len(sr2.radio) == 2
@@ -166,7 +168,8 @@ class InteractiveScriptTest(InteractiveScriptTests):
 
         sr4 = sr3.get_widget("cb").set_value("off").run()
         assert len(sr4.radio) == 1
-        assert sr4.get_widget("conditional") == None
+        with pytest.raises(KeyError):
+            sr4.get_widget("conditional")
 
         sr5 = sr4.get_widget("cb").set_value("on").run()
         assert len(sr5.radio) == 2


### PR DESCRIPTION

## Describe your changes
Ergonomics improvement to the script testing API. When widgets are accessed by key, you can now use the `.is_foo` properties to assert which type of widget it is, which refines the type information and improves autocomplete.

## Testing Plan

Integration tests updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
