### PR TITLE
Add overrideable default timeout for script tests

### DIFF
--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -1298,6 +1298,7 @@ class ElementTree(Block):
 
     script_path: str | None = field(repr=False, default=None)
     _session_state: SessionState | None = field(repr=False, default=None)
+    _default_timeout: float = field(repr=False, default=3)
 
     def __init__(self):
         # Expect script_path and session_state to be filled in afterwards
@@ -1339,7 +1340,9 @@ class ElementTree(Block):
         from streamlit.testing.local_script_runner import LocalScriptRunner
 
         widget_states = self.get_widget_states()
-        runner = LocalScriptRunner(self.script_path, self.session_state)
+        runner = LocalScriptRunner(
+            self.script_path, self.session_state, default_timeout=self._default_timeout
+        )
         return runner.run(widget_states, timeout=timeout)
 
 

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -110,7 +110,7 @@ class Element:
     def widget_state(self) -> WidgetState | None:
         return None
 
-    def run(self, timeout: float = 3) -> ElementTree:
+    def run(self, timeout: float | None = None) -> ElementTree:
         """Run the script with updated widget values.
         Timeout is a number of seconds, or None to use the default.
         """
@@ -1257,7 +1257,7 @@ class Block:
 
     def run(self, timeout: float | None = None) -> ElementTree:
         """Run the script with updated widget values.
-        Timeout is a number of seconds.
+        Timeout is a number of seconds, or None to use the default.
         """
         return self.root.run(timeout=timeout)
 

--- a/lib/streamlit/testing/element_tree.py
+++ b/lib/streamlit/testing/element_tree.py
@@ -112,7 +112,7 @@ class Element:
 
     def run(self, timeout: float = 3) -> ElementTree:
         """Run the script with updated widget values.
-        Timeout is a number of seconds.
+        Timeout is a number of seconds, or None to use the default.
         """
         return self.root.run(timeout=timeout)
 
@@ -1255,7 +1255,7 @@ class Block:
     def widget_state(self) -> WidgetState | None:
         return None
 
-    def run(self, timeout: float = 3) -> ElementTree:
+    def run(self, timeout: float | None = None) -> ElementTree:
         """Run the script with updated widget values.
         Timeout is a number of seconds.
         """
@@ -1331,9 +1331,9 @@ class ElementTree(Block):
 
         return ws
 
-    def run(self, timeout: float = 3) -> ElementTree:
+    def run(self, timeout: float | None = None) -> ElementTree:
         """Run the script with updated widget values.
-        Timeout is a number of seconds.
+        Timeout is a number of seconds, or None to use the default.
         """
         assert self.script_path is not None
         from streamlit.testing.local_script_runner import LocalScriptRunner

--- a/lib/streamlit/testing/local_script_runner.py
+++ b/lib/streamlit/testing/local_script_runner.py
@@ -36,11 +36,18 @@ class LocalScriptRunner(ScriptRunner):
         self,
         script_path: str,
         prev_session_state: SessionState | None = None,
+        default_timeout: float = 3,
     ):
-        """Initializes the ScriptRunner for the given script_name"""
+        """Initializes the ScriptRunner for the given script_path.
+
+        `default_timeout` sets the time in seconds before a script run is
+        timed out. It can be temporarily overridden by passing an argument to
+        `.run()`
+        """
 
         assert os.path.isfile(script_path), f"File not found at {script_path}"
 
+        self.default_timeout = default_timeout
         self.forward_msg_queue = ForwardMsgQueue()
         self.script_path = script_path
         if prev_session_state is not None:
@@ -96,10 +103,16 @@ class LocalScriptRunner(ScriptRunner):
     def run(
         self,
         widget_state: WidgetStates | None = None,
-        timeout: float = 3,
+        timeout: float | None = None,
     ) -> ElementTree:
         """Run the script, and parse the output messages for querying
-        and interaction."""
+        and interaction.
+
+        Timeout is in seconds, or None to use the default.
+        """
+        if timeout is None:
+            timeout = self.default_timeout
+
         rerun_data = RerunData(widget_states=widget_state)
         self.request_rerun(rerun_data)
         if not self._script_thread:

--- a/lib/streamlit/testing/local_script_runner.py
+++ b/lib/streamlit/testing/local_script_runner.py
@@ -118,9 +118,11 @@ class LocalScriptRunner(ScriptRunner):
         if not self._script_thread:
             self.start()
         require_widgets_deltas(self, timeout)
+
         tree = parse_tree_from_messages(self.forward_msgs())
         tree.script_path = self.script_path
         tree._session_state = self.session_state
+        tree._default_timeout = self.default_timeout
         return tree
 
     def script_stopped(self) -> bool:

--- a/lib/streamlit/testing/local_script_runner.py
+++ b/lib/streamlit/testing/local_script_runner.py
@@ -108,7 +108,7 @@ class LocalScriptRunner(ScriptRunner):
         """Run the script, and parse the output messages for querying
         and interaction.
 
-        Timeout is in seconds, or None to use the default.
+        Timeout is in seconds, or None to use the default timeout of the runner.
         """
         if timeout is None:
             timeout = self.default_timeout

--- a/lib/streamlit/testing/script_interactions.py
+++ b/lib/streamlit/testing/script_interactions.py
@@ -74,12 +74,17 @@ class InteractiveScriptTests(unittest.TestCase):
         # set unconditionally for whole process, since we are just running tests
         config.set_option("runner.postScriptGC", False)
 
-    def script_from_string(self, script: str) -> LocalScriptRunner:
+    def script_from_string(
+        self, script: str, default_timeout: float = 3
+    ) -> LocalScriptRunner:
         """Create a runner for a script with the contents from a string.
 
         Useful for testing short scripts that fit comfortably as an inline
         string in the test itself, without having to create a separate file
         for it.
+
+        `default_timeout` is the default time in seconds before a script is
+        timed out, if not overridden for an individual `.run()` call.
         """
         hasher = hashlib.md5(bytes(script, "utf-8"))
         script_name = hasher.hexdigest()
@@ -87,8 +92,16 @@ class InteractiveScriptTests(unittest.TestCase):
         path = pathlib.Path(self.tmp_script_dir.name, script_name)
         aligned_script = textwrap.dedent(script)
         path.write_text(aligned_script)
-        return LocalScriptRunner(str(path))
+        return LocalScriptRunner(str(path), default_timeout=default_timeout)
 
-    def script_from_filename(self, script_path: str) -> LocalScriptRunner:
-        """Create a runner for the script with the given name, for testing."""
-        return LocalScriptRunner(str(self.dir_path / script_path))
+    def script_from_filename(
+        self, script_path: str, default_timeout: float = 3
+    ) -> LocalScriptRunner:
+        """Create a runner for the script with the given name, for testing.
+
+        `default_timeout` is the default time in seconds before a script is
+        timed out, if not overridden for an individual `.run()` call.
+        """
+        return LocalScriptRunner(
+            str(self.dir_path / script_path), default_timeout=default_timeout
+        )

--- a/lib/tests/streamlit/script_interactions_test.py
+++ b/lib/tests/streamlit/script_interactions_test.py
@@ -239,3 +239,17 @@ class InteractiveScriptTest(InteractiveScriptTests):
     def test_script_not_found(self):
         with pytest.raises(AssertionError):
             self.script_from_filename("doesntexist.py")
+
+    def test_timeout(self):
+        script = self.script_from_string(
+            """
+            import time
+            time.sleep(0.5)
+            """,
+            default_timeout=0.2,
+        )
+        with pytest.raises(RuntimeError, match=r".*timed out.*"):
+            script.run()
+
+        # Overrides the default, doesn't raise
+        script.run(timeout=1)


### PR DESCRIPTION

## Describe your changes
LocalScriptRunner can now be given a default timeout via the `get_script` methods, which is used if a timeout is not passed to a `.run()` call. Useful for testing pages that will consistently take longer than the default default timeout of 3 sec.

## Testing Plan

Unit test added

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
