### PR TITLE
Clearly state mapbox tokens can't currently be set inside Snowflake

### DIFF
--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -52,7 +52,10 @@ class PydeckMixin:
 
         When using this command, Mapbox provides the map tiles to render map
         content. Note that Mapbox is a third-party product, the use of which is
-        governed by Mapbox's Terms of Use.
+        governed by Mapbox's Terms of Use. Further, if you are running ``st.pydeck_chart``
+        inside of Snowflake, Mapbox constitutes an "External Offering" and is
+        subject to Snowflake's `External Offerings Terms
+        <https://www.snowflake.com/legal/third-party-terms/>`_.
 
         Mapbox requires users to register and provide a token before users can
         request map tiles. Currently, Streamlit provides this token for you, but
@@ -62,7 +65,9 @@ class PydeckMixin:
 
         To get a token for yourself, create an account at https://mapbox.com.
         For more info on how to set config options, see
-        https://docs.streamlit.io/library/advanced-features/configuration
+        https://docs.streamlit.io/library/advanced-features/configuration. Note
+        that the ability to set your config options is not yet available for
+        ``st.pydeck_chart`` inside of Snowflake.
 
         Parameters
         ----------

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -108,7 +108,10 @@ class MapMixin:
 
         When using this command, Mapbox provides the map tiles to render map
         content. Note that Mapbox is a third-party product, the use of which is
-        governed by Mapbox's Terms of Use.
+        governed by Mapbox's Terms of Use. Further, if you are running ``st.map``
+        inside of Snowflake, Mapbox constitutes an "External Offering" and is
+        subject to Snowflake's `External Offerings Terms
+        <https://www.snowflake.com/legal/third-party-terms/>`_.
 
         Mapbox requires users to register and provide a token before users can
         request map tiles. Currently, Streamlit provides this token for you, but
@@ -118,7 +121,9 @@ class MapMixin:
 
         To get a token for yourself, create an account at https://mapbox.com.
         For more info on how to set config options, see
-        https://docs.streamlit.io/library/advanced-features/configuration
+        https://docs.streamlit.io/library/advanced-features/configuration. Note
+        that the ability to set your config options is not yet available for
+        ``st.map`` inside of Snowflake.
 
         Parameters
         ----------


### PR DESCRIPTION
## Describe your changes

Following up on #6143, to support SiS PuPr, Docs has been requested by Legal to update the `st.map` and `st.pydeck_chart` documentation to link to Snowflake's [External Offering Terms](https://www.snowflake.com/legal/third-party-terms/) and callout that setting mapbox tokens via config options is currently not possible in SiS.

## Testing Plan

- No additional tests are needed as the changes are to the docstrings text
- This was already reviewed by Legal

<details open><summary><h3>View revised docs</h3></summary>

![image](https://github.com/streamlit/streamlit/assets/20672874/b4c48e54-75ac-46df-96f3-70905bf9410d)
![image](https://github.com/streamlit/streamlit/assets/20672874/1bd00f38-fa14-4746-8b92-c10d5f2e2d1b)

</details>

<details><summary><h3>View current docs</h3></summary>

![image](https://github.com/streamlit/streamlit/assets/20672874/5f46471a-3c74-432f-84a5-c1e80695f32d)
![image](https://github.com/streamlit/streamlit/assets/20672874/2359158c-c708-4eaf-951b-bd9b7fe47d72)

</details>


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
