### PR TITLE
Upgrade playwright to use 16 cores

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-16-cores
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes

This PR upgrades the playwright workflow to use 16 cores to speed up the process and push the runtime under 20 minutes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
