### PR TITLE
Add _xsrf cookie options

### DIFF
--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -55,6 +55,14 @@ describe("st.file_uploader", () => {
     );
   });
 
+  it("sets cookie options correctly", () => {
+    cy.getCookie("_xsrf").should("have.property", "secure", true);
+    // Cypress use a "no_restrictions" value for SameSite header when
+    // it is set to "None".
+    // https://docs.cypress.io/api/commands/setcookie#Arguments
+    cy.getCookie("_xsrf").should("have.property", "sameSite", "no_restriction");
+  });
+
   it("shows error message for disallowed files", () => {
     const fileName = "example.json";
     const uploaderIndex = 0;

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -70,6 +70,7 @@ TORNADO_SETTINGS = {
     # If we don't get a ping response within 30s, the connection
     # is timed out.
     "websocket_ping_timeout": 30,
+    "xsrf_cookie_kwargs": {"secure": True, "samesite": "None"},
 }
 
 # When server.port is not available it will look for the next available port


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Add `secure` and `samesite` options to `_xsrf` cookie set by Tornado.

The motivation for adding this change is described[ in the first issue of notion doc](https://www.notion.so/snowflake-corp/_xsrf-cookie-related-problems-in-Streamlit-OS-library-a3e7d481c74743a38824230877810226?pvs=4#6d08a3dd88614095acc1d63efbb757b9). 

This change uses Tornado library mechanism for setting cookie options, therefore this should not affect SiS if they do not rely on Tornado as a streamlit opensource server implementation.

## GitHub Issue Link (if applicable) Closes #5793 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
    -  Added
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
