### PR TITLE
Avoid confusion about file extensions: keep inner dots

### DIFF
--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
@@ -55,9 +55,9 @@ describe("FileDropzoneInstructions widget", () => {
 
   it("renders with extensions", () => {
     const props = getProps({
-      acceptedExtensions: ["jpg"],
+      acceptedExtensions: ["jpg", "csv.gz"],
     })
     render(<FileDropzoneInstructions {...props} />)
-    expect(screen.getByText(/• JPG/)).toBeInTheDocument()
+    expect(screen.getByText(/• JPG, CSV.GZ/)).toBeInTheDocument()
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
@@ -55,9 +55,9 @@ describe("FileDropzoneInstructions widget", () => {
 
   it("renders with extensions", () => {
     const props = getProps({
-      acceptedExtensions: ["jpg", "csv.gz"],
+      acceptedExtensions: ["jpg", "csv.gz", ".png", ".tar.gz"],
     })
     render(<FileDropzoneInstructions {...props} />)
-    expect(screen.getByText(/• JPG, CSV.GZ/)).toBeInTheDocument()
+    expect(screen.getByText(/• JPG, CSV.GZ, PNG, TAR.GZ/)).toBeInTheDocument()
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -50,9 +50,8 @@ const FileDropzoneInstructions = ({
         {`Limit ${getSizeDisplay(maxSizeBytes, FileSize.Byte, 0)} per file`}
         {acceptedExtensions.length
           ? ` • ${acceptedExtensions
-              .join(", ")
-              .replace(/\./g, "")
-              .toUpperCase()}`
+              .map(ext => ext.replace(/^\./, "").toUpperCase())
+              .join(", ")}`
           : null}
       </Small>
     </StyledFileDropzoneInstructionsColumn>


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Inner dots in file extensions are currently deleted
![before](https://github.com/streamlit/streamlit/assets/18382390/8be11fd1-8db4-4da2-82f7-c60e661f6ff8)

Some users might be confused of how the extension should look like.

After change:
![after](https://github.com/streamlit/streamlit/assets/18382390/370c127a-12d4-43f0-a8ba-2a46f307c668)

## GitHub Issue Link (if applicable)
No issue as one line change

## Testing Plan

- Unit test extended to also test for multiple extensions with inner dots (e.g., "csv.gz")

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
