### PR TITLE
Remove the experimental prefix from `st.experimental_connection`

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -47,6 +47,7 @@ For more detailed info, see https://docs.streamlit.io.
 # Must be at the top, to avoid circular dependency.
 from streamlit import logger as _logger
 from streamlit import config as _config
+from streamlit.deprecation_util import deprecate_func_name as _deprecate_func_name
 from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STRING
 
 # Give the package a version.
@@ -61,7 +62,7 @@ from streamlit.runtime.caching import (
     experimental_memo as _experimental_memo,
 )
 from streamlit.runtime.connection_factory import (
-    connection_factory as _connection_factory,
+    connection_factory as connection,
 )
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
@@ -225,4 +226,6 @@ experimental_get_query_params = _get_query_params
 experimental_set_query_params = _set_query_params
 experimental_rerun = _experimental_rerun
 experimental_data_editor = _main.experimental_data_editor
-experimental_connection = _connection_factory
+experimental_connection = _deprecate_func_name(
+    connection, "experimental_connection", "connection", "2024-01-01"
+)

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -227,5 +227,5 @@ experimental_set_query_params = _set_query_params
 experimental_rerun = _experimental_rerun
 experimental_data_editor = _main.experimental_data_editor
 experimental_connection = _deprecate_func_name(
-    connection, "experimental_connection", "connection", "2024-01-01"
+    connection, "experimental_connection", "2024-01-01", name_override="connection"
 )

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -14,10 +14,13 @@
 
 
 # Explicitly re-export public symbols.
-from streamlit.connections.base_connection import (
-    ExperimentalBaseConnection as ExperimentalBaseConnection,
-)
+from streamlit.connections.base_connection import BaseConnection as BaseConnection
 from streamlit.connections.snowpark_connection import (
     SnowparkConnection as SnowparkConnection,
 )
 from streamlit.connections.sql_connection import SQLConnection as SQLConnection
+
+# TODO(vdonato): Maybe figure out a reasonable way to add a deprecation warning to this
+# constructor. In case this is infeasible, it'll probably be fine to just remove this
+# along with the `st.experimental_connection` function.
+ExperimentalBaseConnection = BaseConnection

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
 from streamlit.connections.snowpark_connection import (

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -26,8 +26,8 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
     """The abstract base class that all Streamlit Connections must inherit from.
 
     This base class provides connection authors with a standardized way to hook into the
-    ``st.experimental_connection()`` factory function: connection authors are required to
-    provide an implementation for the abstract method ``_connect`` in their subclasses.
+    ``st.connection()`` factory function: connection authors are required to provide an
+    implementation for the abstract method ``_connect`` in their subclasses.
 
     Additionally, it also provides a few methods/properties designed to make
     implementation of connections more convenient. See the docstrings for each of the
@@ -45,7 +45,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         """Create a BaseConnection.
 
         This constructor is called by the connection factory machinery when a user
-        script calls ``st.experimental_connection()``.
+        script calls ``st.connection()``.
 
         Subclasses of BaseConnection that want to overwrite this method should take care
         to also call the base class' implementation.
@@ -156,7 +156,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("my_conn")
+        >>> conn = st.connection("my_conn")
         >>>
         >>> # Reset the connection before using it if it isn't healthy
         >>> # Note: is_healthy() isn't a real method and is just shown for example here.

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -22,7 +22,7 @@ from streamlit.util import calc_md5
 RawConnectionT = TypeVar("RawConnectionT")
 
 
-class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
+class BaseConnection(ABC, Generic[RawConnectionT]):
     """The abstract base class that all Streamlit Connections must inherit from.
 
     This base class provides connection authors with a standardized way to hook into the
@@ -42,13 +42,13 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     """
 
     def __init__(self, connection_name: str, **kwargs) -> None:
-        """Create an ExperimentalBaseConnection.
+        """Create a BaseConnection.
 
         This constructor is called by the connection factory machinery when a user
         script calls ``st.experimental_connection()``.
 
-        Subclasses of ExperimentalBaseConnection that want to overwrite this method
-        should take care to also call the base class' implementation.
+        Subclasses of BaseConnection that want to overwrite this method should take care
+        to also call the base class' implementation.
 
         Parameters
         ----------
@@ -87,8 +87,8 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         """Return a human-friendly markdown string describing this connection.
 
         This is the string that will be written to the app if a user calls
-        ``st.write(this_connection)``. Subclasses of ExperimentalBaseConnection can freely
-        overwrite this method if desired.
+        ``st.write(this_connection)``. Subclasses of BaseConnection can freely overwrite
+        this method if desired.
 
         Returns
         -------
@@ -175,14 +175,14 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
         return self._raw_instance
 
-    # Abstract fields/methods that subclasses of ExperimentalBaseConnection must implement
+    # Abstract fields/methods that subclasses of BaseConnection must implement
     @abstractmethod
     def _connect(self, **kwargs) -> RawConnectionT:
         """Create an instance of an underlying connection object.
 
         This abstract method is the one method that we require subclasses of
-        ExperimentalBaseConnection to provide an implementation for. It is called when
-        first creating a connection and when reconnecting after a connection is reset.
+        BaseConnection to provide an implementation for. It is called when first
+        creating a connection and when reconnecting after a connection is reset.
 
         Parameters
         ----------

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -69,12 +69,12 @@ def _load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
 
 class SnowparkConnection(BaseConnection["Session"]):
     """A connection to Snowpark using snowflake.snowpark.session.Session. Initialize using
-    ``st.experimental_connection("<name>", type="snowpark")``.
+    ``st.connection("<name>", type="snowpark")``.
 
     In addition to accessing the Snowpark Session, SnowparkConnection supports direct SQL querying using
     ``query("...")`` and thread safe access using ``with conn.safe_session():``. See methods
     below for more information. SnowparkConnections should always be created using
-    ``st.experimental_connection()``, **not** initialized directly.
+    ``st.connection()``, **not** initialized directly.
 
     .. note::
         We don't expect this iteration of SnowparkConnection to be able to scale
@@ -111,7 +111,7 @@ class SnowparkConnection(BaseConnection["Session"]):
             raise StreamlitAPIException(
                 "Missing Snowpark connection configuration. "
                 f"Did you forget to set this in `secrets.toml`, `{_DEFAULT_CONNECTION_FILE}`, "
-                "or as kwargs to `st.experimental_connection`?"
+                "or as kwargs to `st.connection`?"
             )
 
         for p in _REQUIRED_CONNECTION_PARAMS:
@@ -150,7 +150,7 @@ class SnowparkConnection(BaseConnection["Session"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("snowpark")
+        >>> conn = st.connection("snowpark")
         >>> df = conn.query("select * from pet_owners")
         >>> st.dataframe(df)
         """
@@ -198,7 +198,7 @@ class SnowparkConnection(BaseConnection["Session"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> session = st.experimental_connection("snowpark").session
+        >>> session = st.connection("snowpark").session
         >>> df = session.table("mytable").limit(10).to_pandas()
         >>> st.dataframe(df)
         """
@@ -221,7 +221,7 @@ class SnowparkConnection(BaseConnection["Session"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("snowpark")
+        >>> conn = st.connection("snowpark")
         >>> with conn.safe_session() as session:
         ...     df = session.table("mytable").limit(10).to_pandas()
         ...

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -67,7 +67,7 @@ def _load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
     return conn_params
 
 
-class SnowparkConnection(ExperimentalBaseConnection["Session"]):
+class SnowparkConnection(BaseConnection["Session"]):
     """A connection to Snowpark using snowflake.snowpark.session.Session. Initialize using
     ``st.experimental_connection("<name>", type="snowpark")``.
 

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, List, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.connections.util import extract_from_dict
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
@@ -42,7 +42,7 @@ _ALL_CONNECTION_PARAMS = {
 _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
-class SQLConnection(ExperimentalBaseConnection["Engine"]):
+class SQLConnection(BaseConnection["Engine"]):
     """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.experimental_connection("<name>", type="sql")``.
 
     SQLConnection provides the ``query()`` convenience method, which can be used to
@@ -250,7 +250,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
         return Session(self._instance)
 
     # NOTE: This more or less duplicates the default implementation in
-    # ExperimentalBaseConnection so that we can add another bullet point between the
+    # BaseConnection so that we can add another bullet point between the
     # "Configured from" and "Learn more" items :/
     def _repr_html_(self) -> str:
         module_name = getattr(self, "__module__", None)

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -43,17 +43,16 @@ _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
 class SQLConnection(BaseConnection["Engine"]):
-    """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.experimental_connection("<name>", type="sql")``.
+    """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.connection("<name>", type="sql")``.
 
     SQLConnection provides the ``query()`` convenience method, which can be used to
     run simple read-only queries with both caching and simple error handling/retries.
     More complex DB interactions can be performed by using the ``.session`` property
     to receive a regular SQLAlchemy Session.
 
-    SQLConnections should always be created using ``st.experimental_connection()``,
-    **not** initialized directly. Connection parameters for a SQLConnection can be
-    specified using either ``st.secrets`` or ``**kwargs``. Some frequently used
-    parameters include:
+    SQLConnections should always be created using ``st.connection()``, **not**
+    initialized directly. Connection parameters for a SQLConnection can be specified
+    using either ``st.secrets`` or ``**kwargs``. Some frequently used parameters include:
 
     - **url** or arguments for `sqlalchemy.engine.URL.create()
       <https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create>`_.
@@ -62,7 +61,7 @@ class SQLConnection(BaseConnection["Engine"]):
     - **create_engine_kwargs** can be passed via ``st.secrets``, such as for
       `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy#key-pair-authentication-support>`_
       or `Google BigQuery <https://github.com/googleapis/python-bigquery-sqlalchemy#authentication>`_.
-      These can also be passed directly as ``**kwargs`` to experimental_connection().
+      These can also be passed directly as ``**kwargs`` to connection().
 
     - **autocommit=True** to run with isolation level ``AUTOCOMMIT``. Default is False.
 
@@ -70,7 +69,7 @@ class SQLConnection(BaseConnection["Engine"]):
     -------
     >>> import streamlit as st
     >>>
-    >>> conn = st.experimental_connection("sql")
+    >>> conn = st.connection("sql")
     >>> df = conn.query("select * from pet_owners")
     >>> st.dataframe(df)
     """
@@ -85,7 +84,7 @@ class SQLConnection(BaseConnection["Engine"]):
         if not len(conn_params):
             raise StreamlitAPIException(
                 "Missing SQL DB connection configuration. "
-                "Did you forget to set this in `secrets.toml` or as kwargs to `st.experimental_connection`?"
+                "Did you forget to set this in `secrets.toml` or as kwargs to `st.connection`?"
             )
 
         if "url" in conn_params:
@@ -171,7 +170,7 @@ class SQLConnection(BaseConnection["Engine"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("sql")
+        >>> conn = st.connection("sql")
         >>> df = conn.query("select * from pet_owners where owner = :owner", ttl=3600, params={"owner":"barbara"})
         >>> st.dataframe(df)
         """
@@ -238,7 +237,7 @@ class SQLConnection(BaseConnection["Engine"]):
         Example
         -------
         >>> import streamlit as st
-        >>> conn = st.experimental_connection("sql")
+        >>> conn = st.connection("sql")
         >>> n = st.slider("Pick a number")
         >>> if st.button("Add the number!"):
         ...     with conn.session as session:

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -51,7 +51,11 @@ def make_deprecated_name_warning(
 
 
 def deprecate_func_name(
-    func: TFunc, old_name: str, removal_date: str, extra_message: str | None = None
+    func: TFunc,
+    old_name: str,
+    removal_date: str,
+    extra_message: str | None = None,
+    name_override: str | None = None,
 ) -> TFunc:
     """Wrap an `st` function whose name has changed.
 
@@ -81,7 +85,7 @@ def deprecate_func_name(
         result = func(*args, **kwargs)
         show_deprecation_warning(
             make_deprecated_name_warning(
-                old_name, func.__name__, removal_date, extra_message
+                old_name, name_override or func.__name__, removal_date, extra_message
             )
         )
         return result

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -52,7 +52,7 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
 ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
 
 
-@gather_metrics("experimental_connection")
+@gather_metrics("connection")
 def _create_connection(
     name: str,
     connection_class: Type[ConnectionClass],
@@ -65,12 +65,12 @@ def _create_connection(
     The weird implementation of this function with the @cache_resource annotated
     function defined internally is done to:
       * Always @gather_metrics on the call even if the return value is a cached one.
-      * Allow the user to specify ttl and max_entries when calling st.experimental_connection.
+      * Allow the user to specify ttl and max_entries when calling st.connection.
     """
 
     @cache_resource(
         max_entries=max_entries,
-        show_spinner="Running `st.experimental_connection(...)`.",
+        show_spinner="Running `st.connection(...)`.",
         ttl=ttl,
     )
     def __create_connection(
@@ -211,29 +211,29 @@ def connection_factory(
     default names and define corresponding sections in your ``secrets.toml`` file.
 
     >>> import streamlit as st
-    >>> conn = st.experimental_connection("sql") # Config section defined in [connections.sql] in secrets.toml.
+    >>> conn = st.connection("sql") # Config section defined in [connections.sql] in secrets.toml.
 
     Creating a SQLConnection with a custom name requires you to explicitly specify the
     type. If type is not passed as a kwarg, it must be set in the appropriate section of
     ``secrets.toml``.
 
     >>> import streamlit as st
-    >>> conn1 = st.experimental_connection("my_sql_connection", type="sql") # Config section defined in [connections.my_sql_connection].
-    >>> conn2 = st.experimental_connection("my_other_sql_connection") # type must be set in [connections.my_other_sql_connection].
+    >>> conn1 = st.connection("my_sql_connection", type="sql") # Config section defined in [connections.my_sql_connection].
+    >>> conn2 = st.connection("my_other_sql_connection") # type must be set in [connections.my_other_sql_connection].
 
     Passing the full module path to the connection class that you want to use can be
     useful, especially when working with a custom connection:
 
     >>> import streamlit as st
-    >>> conn = st.experimental_connection("my_sql_connection", type="streamlit.connections.SQLConnection")
+    >>> conn = st.connection("my_sql_connection", type="streamlit.connections.SQLConnection")
 
     Finally, you can pass the connection class to use directly to this function. Doing
     so allows static type checking tools such as ``mypy`` to infer the exact return
-    type of ``st.experimental_connection``.
+    type of ``st.connection``.
 
     >>> import streamlit as st
     >>> from streamlit.connections import SQLConnection
-    >>> conn = st.experimental_connection("my_sql_connection", type=SQLConnection)
+    >>> conn = st.connection("my_sql_connection", type=SQLConnection)
     """
     USE_ENV_PREFIX = "env:"
 
@@ -245,8 +245,8 @@ def connection_factory(
 
     if type is None:
         if name in FIRST_PARTY_CONNECTIONS:
-            # We allow users to simply write `st.experimental_connection("sql")`
-            # instead of `st.experimental_connection("sql", type="sql")`.
+            # We allow users to simply write `st.connection("sql")` instead of
+            # `st.connection("sql", type="sql")`.
             type = _get_first_party_connection(name)
         else:
             # The user didn't specify a type, so we try to pull it out from their
@@ -257,9 +257,9 @@ def connection_factory(
             secrets_singleton.load_if_toml_exists()
             type = secrets_singleton["connections"][name]["type"]
 
-    # type is a nice kwarg name for the st.experimental_connection user but is annoying
-    # to work with since it conflicts with the builtin function name and thus gets
-    # syntax highlighted.
+    # type is a nice kwarg name for the st.connection user but is annoying to work with
+    # since it conflicts with the builtin function name and thus gets syntax
+    # highlighted.
     connection_class = type
 
     if isinstance(connection_class, str):

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -22,11 +22,7 @@ from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import (
-    ExperimentalBaseConnection,
-    SnowparkConnection,
-    SQLConnection,
-)
+from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
@@ -50,11 +46,10 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 
-# The ExperimentalBaseConnection bound is parameterized to `Any` below as subclasses of
-# ExperimentalBaseConnection are responsible for binding the type parameter of
-# ExperimentalBaseConnection to a concrete type, but the type it gets bound to isn't
-# important to us here.
-ConnectionClass = TypeVar("ConnectionClass", bound=ExperimentalBaseConnection[Any])
+# The BaseConnection bound is parameterized to `Any` below as subclasses of
+# BaseConnection are responsible for binding the type parameter of BaseConnection to a
+# concrete type, but the type it gets bound to isn't important to us here.
+ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
 
 
 @gather_metrics("experimental_connection")
@@ -83,9 +78,9 @@ def _create_connection(
     ) -> ConnectionClass:
         return connection_class(connection_name=name, **kwargs)
 
-    if not issubclass(connection_class, ExperimentalBaseConnection):
+    if not issubclass(connection_class, BaseConnection):
         raise StreamlitAPIException(
-            f"{connection_class} is not a subclass of ExperimentalBaseConnection!"
+            f"{connection_class} is not a subclass of BaseConnection!"
         )
 
     return __create_connection(name, connection_class, **kwargs)
@@ -163,7 +158,7 @@ def connection_factory(
     max_entries: int | None = None,
     ttl: float | timedelta | None = None,
     **kwargs,
-) -> ExperimentalBaseConnection[Any]:
+) -> BaseConnection[Any]:
     pass
 
 
@@ -191,9 +186,9 @@ def connection_factory(
     type : str, connection class, or None
         The type of connection to create. It can be a keyword (``"sql"`` or ``"snowpark"``),
         a path to an importable class, or an imported class reference. All classes
-        must extend ``st.connections.ExperimentalBaseConnection`` and implement the
-        ``_connect()`` method. If the type kwarg is None, a ``type`` field must be set
-        in the connection's section in ``secrets.toml``.
+        must extend ``st.connections.BaseConnection`` and implement the ``_connect()``
+        method. If the type kwarg is None, a ``type`` field must be set in the
+        connection's section in ``secrets.toml``.
     max_entries : int or None
         The maximum number of connections to keep in the cache, or None
         for an unbounded cache. (When a new entry is added to a full cache,

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -19,7 +19,7 @@ from unittest.mock import PropertyMock, mock_open, patch
 import pytest
 
 import streamlit as st
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.runtime.secrets import AttrDict
 
 MOCK_TOML = """
@@ -33,7 +33,7 @@ class MockRawConnection:
         return "some raw connection method"
 
 
-class MockConnection(ExperimentalBaseConnection[str]):
+class MockConnection(BaseConnection[str]):
     def _connect(self, **kwargs) -> str:
         return MockRawConnection()
 
@@ -41,7 +41,7 @@ class MockConnection(ExperimentalBaseConnection[str]):
         return "some method"
 
 
-class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
+class BaseConnectionDefaultMethodTests(unittest.TestCase):
     def setUp(self) -> None:
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
@@ -114,7 +114,7 @@ class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
         # conn.reset() shouldn't be called because secrets haven't changed since conn
         # was constructed.
         with patch(
-            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
+            "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset:
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_not_called()
@@ -123,9 +123,9 @@ class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
         conn = MockConnection("my_mock_connection")
 
         with patch(
-            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
+            "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.ExperimentalBaseConnection._secrets",
+            "streamlit.connections.base_connection.BaseConnection._secrets",
             PropertyMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")

--- a/lib/tests/streamlit/deprecation_util_test.py
+++ b/lib/tests/streamlit/deprecation_util_test.py
@@ -66,6 +66,23 @@ class DeprecationUtilTest(unittest.TestCase):
         mock_show_warning.assert_called_once_with(expected_warning)
 
     @patch("streamlit.deprecation_util.show_deprecation_warning")
+    def test_deprecate_func_name_with_override(self, mock_show_warning: Mock):
+        def multiply(a, b):
+            return a * b
+
+        beta_multiply = deprecate_func_name(
+            multiply, "beta_multiply", "1980-01-01", name_override="mul"
+        )
+
+        self.assertEqual(beta_multiply(3, 2), 6)
+
+        expected_warning = (
+            "Please replace `st.beta_multiply` with `st.mul`.\n\n"
+            "`st.beta_multiply` will be removed after 1980-01-01."
+        )
+        mock_show_warning.assert_called_once_with(expected_warning)
+
+    @patch("streamlit.deprecation_util.show_deprecation_warning")
     def test_deprecate_obj_name(self, mock_show_warning: Mock):
         """Test that we override dunder methods."""
 

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,11 +21,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import (
-    ExperimentalBaseConnection,
-    SnowparkConnection,
-    SQLConnection,
-)
+from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
@@ -38,7 +34,7 @@ from streamlit.runtime.secrets import secrets_singleton
 from tests.testutil import create_mock_script_run_ctx
 
 
-class MockConnection(ExperimentalBaseConnection[None]):
+class MockConnection(BaseConnection[None]):
     def _connect(self, **kwargs):
         pass
 
@@ -63,7 +59,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self._prev_environ)
 
-    def test_create_connection_helper_explodes_if_not_ExperimentalBaseConnection_subclass(
+    def test_create_connection_helper_explodes_if_not_BaseConnection_subclass(
         self,
     ):
         class NotABaseConnection:
@@ -72,7 +68,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         with pytest.raises(StreamlitAPIException) as e:
             _create_connection("my_connection", NotABaseConnection)
 
-        assert "is not a subclass of ExperimentalBaseConnection" in str(e.value)
+        assert "is not a subclass of BaseConnection" in str(e.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -257,10 +257,11 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         """All commands of the public API should be tracked with the correct name."""
         # Some commands are currently not tracked for various reasons:
         ignored_commands = {
-            # We need to ignore `experimental_connection` because the `@gather_metrics`
-            # decorator is attached to a helper function rather than the
-            # publicly-exported function, which causes it not to be executed before an
-            # Exception is raised due to a lack of required arguments.
+            # We need to ignore `connection` because the `@gather_metrics` decorator is
+            # attached to a helper function rather than the publicly-exported function,
+            # which causes it not to be executed before an Exception is raised due to a
+            # lack of required arguments.
+            "connection",
             "experimental_connection",
             "spinner",
             "empty",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -153,6 +153,7 @@ class StreamlitTest(unittest.TestCase):
                 "experimental_connection",
                 "get_option",
                 "set_option",
+                "connection",
             },
         )
 


### PR DESCRIPTION
Note: this PR targets `feature/st.connection_GA`.

This PR removes the experimental prefix from both `st.experimental_connection` and the
`ExperimentalBaseConnection` ABC. We also add a deprecation warning for usage of the
`st.experimental_connection` function. We keep `ExperimentalBaseConnection` as an alias
for `BaseConnection`, but there's no associated deprecation warning for it since we don't
have existing machinery for deprecating a class. We might add this later if we have the time,
but it doesn't seem terribly necessary since it'll probably be nontrivial to write this, and it's
somewhat unlikely we'll use it in the future if we do.