### PR TITLE
Add __getattribute__ to BaseConnection to provide helpful errors

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -14,7 +14,7 @@
 
 import json
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
 from streamlit.util import calc_md5
@@ -72,6 +72,16 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
     def __del__(self) -> None:
         secrets_singleton.file_change_listener.disconnect(self._on_secrets_changed)
+
+    def __getattribute__(self, name: str) -> Any:
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError as e:
+            if hasattr(self._instance, name):
+                raise AttributeError(
+                    f"`{name}` doesn't exist here, but you can call `._instance.{name}` instead"
+                )
+            raise e
 
     def _repr_html_(self) -> str:
         """Return a human-friendly markdown string describing this connection.


### PR DESCRIPTION
Note: this PR targets `feature/st.connection_GA`.


One thing that often confuses users with `st.connection` is that they try to use the wrapper
connection object as if it's the underlying connection. While we probably can't return the
underlying connection directly (the user has to be able to use the wrapper object to manage
the connection lifecycle in some cases), we can give users a friendly error message in cases
where it seems like they're accessing the wrong object.