### PR TITLE
Update script to auto generate the release notes correctly

### DIFF
--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -30,8 +30,26 @@ def create_release():
 
     url = "https://api.github.com/repos/streamlit/streamlit/releases"
     header = {"Authorization": f"token {access_token}"}
-    payload = {"tag_name": tag, "name": tag}
 
+    # Get the latest release tag to compare against
+    response = requests.get(f"{url}/latest", headers=header)
+    previous_tag_name = None
+    if response.status_code == 200:
+        previous_tag_name = response.json()["tag_name"]
+    else:
+        raise Exception(f"Unable get the latest release: {response.text}")
+
+    # Generate the automated release notes
+    payload = {"tag_name": tag, "previous_tag_name": previous_tag_name}
+    response = requests.post(f"{url}/generate-notes", json=payload, headers=header)
+    body = None
+    if response.status_code == 200:
+        body = response.json()["body"]
+    else:
+        raise Exception(f"Unable generate the latest release notes: {response.text}")
+
+    # Create the release with the generated release notes
+    payload = {"tag_name": tag, "name": tag, "body": body}
     response = requests.post(url, json=payload, headers=header)
 
     if response.status_code == 201:
@@ -41,7 +59,6 @@ def create_release():
 
 
 def main():
-
     create_release()
 
 


### PR DESCRIPTION
## Describe your changes

In between release and the documentation, we have the opportunity to generate release notes. However our create release script does not auto generate them. Furthermore, the ones autogenerated were incorrect because GitHub is incorrectly choosing the previous tag.

This change modifies the GitHub release generation to:

1. Get the latest release's tag
2. Generate the notes
3. Include those notes into the new release

**Positive Side Effect** We can now accurately share recognition to our contributors accurately and regularly 😊

## Testing Plan

This is performed post the release to PyPi. Failure at this stage is not a major issue. That being said, @MathCatsAnd I demonstrated this work with the 1.26.0 release

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
