### PR TITLE
Skip langchain `test_agent_run` failing test

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -46,3 +46,6 @@ sqlalchemy[mypy]>=1.4.25, <2.0
 # Pydantic 1.* fails to initialize validators, we add it to requirements
 # to test the fix. Pydantic 2 should not have that issue.
 pydantic>=1.0, <2.0
+
+# semver 3 renames VersionInfo so temporarily pin until we deal with it
+semver<3

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
+import langchain
+import pytest
+import semver
 from google.protobuf.json_format import MessageToDict
 
 import streamlit as st
@@ -74,6 +77,10 @@ class StreamlitCallbackHandlerAPITest(unittest.TestCase):
 
 
 class StreamlitCallbackHandlerTest(DeltaGeneratorTestCase):
+    @pytest.mark.skipif(
+        semver.VersionInfo.parse(langchain.__version__) >= "0.0.296",
+        reason="Skip version verification when `SKIP_VERSION_CHECK` env var is set",
+    )
     def test_agent_run(self):
         """Test a complete LangChain Agent run using StreamlitCallbackHandler."""
         from streamlit.external.langchain import StreamlitCallbackHandler


### PR DESCRIPTION
skip langchain `test_agent_run` test, if langchain version is newer than 0.0.295 (after https://github.com/langchain-ai/langchain/pull/10797/ PR old pickle file we use could not be marshaled into new  `AgentAction` class instance)

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
