### PR TITLE
Add Enum coercion to options elements, if input Enum classes "identical" but redefined on script run

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -591,14 +591,14 @@ _create_option(
 _create_option(
     "runner.enumCoercion",
     description="""
-        Adjust how certain 'options' widgets like radio, seletbox, and
+        Adjust how certain 'options' widgets like radio, selectbox, and
         multiselect coerce Enum members when the Enum class gets
         re-defined during a script re-run.
 
         Allowed values:
         * "off": Disables Enum coercion.
         * "nameOnly": Enum classes can be coerced if their member names match.
-        * "nameAndValue": Enum classes can be coerced if their member names
+        * "nameAndValue": Enum classes can be coerced if their member names AND
           member values match.
     """,
     default_val="nameOnly",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -588,6 +588,23 @@ _create_option(
     type_=bool,
 )
 
+_create_option(
+    "runner.enumCoercion",
+    description="""
+        Adjust how certain 'options' widgets like radio, seletbox, and
+        multiselect coerce Enum members when the Enum class gets
+        re-defined during a script re-run.
+
+        Allowed values:
+        * "off": Disables Enum coercion.
+        * "nameOnly": Enum classes can be coerced if their member names match.
+        * "nameAndValue": Enum classes can be coerced if their member names
+          member values match.
+    """,
+    default_val="nameOnly",
+    type_=str,
+)
+
 # Config Section: Server #
 
 _create_section("server", "Settings for the Streamlit server")

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -146,7 +146,7 @@ def maybe_coerce_enum(register_widget_result, options, opt_sequence):
         coerce_class = options
     else:
         coerce_class = _extract_common_class_from_iter(opt_sequence)
-        if not isinstance(coerce_class, EnumMeta):
+        if coerce_class is None:
             return register_widget_result
 
     return RegisterWidgetResult(
@@ -190,7 +190,7 @@ def maybe_coerce_enum_sequence(register_widget_result, options, opt_sequence):
         coerce_class = options
     else:
         coerce_class = _extract_common_class_from_iter(opt_sequence)
-        if not isinstance(coerce_class, EnumMeta):
+        if coerce_class is None:
             return register_widget_result
 
     # Return a new RegisterWidgetResult with the coerced enum values sequence
@@ -205,12 +205,12 @@ def maybe_coerce_enum_sequence(register_widget_result, options, opt_sequence):
 
 def _extract_common_class_from_iter(iterable: Iterable[Any]) -> Any:
     """Return the common class of all elements in a iterable if they share one.
-    Otherwise, return the iterable itself."""
+    Otherwise, return None."""
     try:
         inner_iter = iter(iterable)
         first_class = type(next(inner_iter))
     except StopIteration:
-        return iterable
+        return None
     if all(type(item) is first_class for item in inner_iter):
         return first_class
-    return iterable
+    return None

--- a/lib/streamlit/elements/utils.py
+++ b/lib/streamlit/elements/utils.py
@@ -35,6 +35,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from streamlit.runtime.state import WidgetCallback, get_session_state
 from streamlit.runtime.state.common import RegisterWidgetResult
+from streamlit.type_util import T
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -124,10 +125,10 @@ def maybe_coerce_enum(
 
 @overload
 def maybe_coerce_enum(
-    register_widget_result: RegisterWidgetResult[type_util.T],
-    options: type_util.OptionSequence[type_util.T],
-    opt_sequence: Sequence[type_util.T],
-) -> RegisterWidgetResult[type_util.T]:
+    register_widget_result: RegisterWidgetResult[T],
+    options: type_util.OptionSequence[T],
+    opt_sequence: Sequence[T],
+) -> RegisterWidgetResult[T]:
     ...
 
 
@@ -158,19 +159,19 @@ def maybe_coerce_enum(register_widget_result, options, opt_sequence):
 # (https://github.com/python/typing/issues/548)
 @overload
 def maybe_coerce_enum_sequence(
-    register_widget_result: RegisterWidgetResult[List[type_util.T]],
-    options: type_util.OptionSequence[type_util.T],
-    opt_sequence: Sequence[type_util.T],
-) -> RegisterWidgetResult[List[type_util.T]]:
+    register_widget_result: RegisterWidgetResult[List[T]],
+    options: type_util.OptionSequence[T],
+    opt_sequence: Sequence[T],
+) -> RegisterWidgetResult[List[T]]:
     ...
 
 
 @overload
 def maybe_coerce_enum_sequence(
-    register_widget_result: RegisterWidgetResult[Tuple[type_util.T, type_util.T]],
-    options: type_util.OptionSequence[type_util.T],
-    opt_sequence: Sequence[type_util.T],
-) -> RegisterWidgetResult[Tuple[type_util.T, type_util.T]]:
+    register_widget_result: RegisterWidgetResult[Tuple[T, T]],
+    options: type_util.OptionSequence[T],
+    opt_sequence: Sequence[T],
+) -> RegisterWidgetResult[Tuple[T, T]]:
     ...
 
 

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -348,7 +348,7 @@ class MultiSelectMixin:
             raise StreamlitAPIException(
                 _get_over_max_options_message(default_count, max_selections)
             )
-        widget_state = maybe_coerce_enum_sequence(widget_state, options)
+        widget_state = maybe_coerce_enum_sequence(widget_state, options, opt)
 
         if widget_state.value_changed:
             multiselect_proto.value[:] = serde.serialize(widget_state.value)

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -32,6 +32,7 @@ from streamlit.elements.utils import (
     check_callback_rules,
     check_session_state_rules,
     get_label_visibility_proto_value,
+    maybe_coerce_enum_sequence,
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
@@ -347,6 +348,7 @@ class MultiSelectMixin:
             raise StreamlitAPIException(
                 _get_over_max_options_message(default_count, max_selections)
             )
+        widget_state = maybe_coerce_enum_sequence(widget_state, options)
 
         if widget_state.value_changed:
             multiselect_proto.value[:] = serde.serialize(widget_state.value)

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -23,6 +23,7 @@ from streamlit.elements.utils import (
     check_callback_rules,
     check_session_state_rules,
     get_label_visibility_proto_value,
+    maybe_coerce_enum,
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
@@ -318,6 +319,7 @@ class RadioMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
+        widget_state = maybe_coerce_enum(widget_state, options)
 
         if widget_state.value_changed:
             if widget_state.value is not None:

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -319,7 +319,7 @@ class RadioMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
-        widget_state = maybe_coerce_enum(widget_state, options)
+        widget_state = maybe_coerce_enum(widget_state, options, opt)
 
         if widget_state.value_changed:
             if widget_state.value is not None:

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -47,7 +47,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
-from streamlit.runtime.state.common import compute_widget_id
+from streamlit.runtime.state.common import RegisterWidgetResult, compute_widget_id
 from streamlit.type_util import (
     Key,
     LabelVisibility,
@@ -333,7 +333,9 @@ class SelectSliderMixin:
             ctx=ctx,
         )
         if isinstance(widget_state.value, tuple):
-            widget_state = maybe_coerce_enum_sequence(widget_state, options)
+            widget_state = maybe_coerce_enum_sequence(
+                cast(RegisterWidgetResult[Tuple[T, T]], widget_state), options
+            )
         else:
             widget_state = maybe_coerce_enum(widget_state, options)
 

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -334,10 +334,10 @@ class SelectSliderMixin:
         )
         if isinstance(widget_state.value, tuple):
             widget_state = maybe_coerce_enum_sequence(
-                cast(RegisterWidgetResult[Tuple[T, T]], widget_state), options
+                cast(RegisterWidgetResult[Tuple[T, T]], widget_state), options, opt
             )
         else:
-            widget_state = maybe_coerce_enum(widget_state, options)
+            widget_state = maybe_coerce_enum(widget_state, options, opt)
 
         if widget_state.value_changed:
             slider_proto.value[:] = serde.serialize(widget_state.value)

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -34,6 +34,8 @@ from streamlit.elements.utils import (
     check_callback_rules,
     check_session_state_rules,
     get_label_visibility_proto_value,
+    maybe_coerce_enum,
+    maybe_coerce_enum_sequence,
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
@@ -330,6 +332,10 @@ class SelectSliderMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
+        if isinstance(widget_state.value, tuple):
+            widget_state = maybe_coerce_enum_sequence(widget_state, options)
+        else:
+            widget_state = maybe_coerce_enum(widget_state, options)
 
         if widget_state.value_changed:
             slider_proto.value[:] = serde.serialize(widget_state.value)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -287,7 +287,7 @@ class SelectboxMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
-        widget_state = maybe_coerce_enum(widget_state, options)
+        widget_state = maybe_coerce_enum(widget_state, options, opt)
 
         if widget_state.value_changed:
             serialized_value = serde.serialize(widget_state.value)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -22,6 +22,7 @@ from streamlit.elements.utils import (
     check_callback_rules,
     check_session_state_rules,
     get_label_visibility_proto_value,
+    maybe_coerce_enum,
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
@@ -286,6 +287,7 @@ class SelectboxMixin:
             serializer=serde.serialize,
             ctx=ctx,
         )
+        widget_state = maybe_coerce_enum(widget_state, options)
 
         if widget_state.value_changed:
             serialized_value = serde.serialize(widget_state.value)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -1092,9 +1092,13 @@ def coerce_enum(from_enum_value: E1, to_enum_class: Type[E2]) -> E1 | E2:
     match as well. (This is configurable in streamlist configs)
     """
     if not isinstance(from_enum_value, Enum):
-        raise ValueError("Expected an Enum")
+        raise ValueError(
+            f"Expected an Enum in the first argument. Got {type(from_enum_value)}"
+        )
     if not isinstance(to_enum_class, EnumMeta):
-        raise ValueError("Expected an EnumMeta (i.e. the class of an Enum)")
+        raise ValueError(
+            f"Expected an EnumMeta/Type in the second argument. Got {type(to_enum_class)}"
+        )
     if isinstance(from_enum_value, to_enum_class):
         return from_enum_value  # Enum is already a member, no coersion necessary
 
@@ -1108,9 +1112,12 @@ def coerce_enum(from_enum_value: E1, to_enum_class: Type[E2]) -> E1 | E2:
     if coercion_type == "off":
         return from_enum_value  # do not attempt to coerce
 
+    # We now know this IS an Enum the user has configured coercion enabled.
+    # Check if we do NOT meet the required conditions and log a failure message
+    # if that is the case.
     from_enum_class = from_enum_value.__class__
     if (
-        not from_enum_class.__qualname__ == to_enum_class.__qualname__
+        from_enum_class.__qualname__ != to_enum_class.__qualname__
         or (
             coercion_type == "nameOnly"
             and set(to_enum_class._member_names_) != set(from_enum_class._member_names_)
@@ -1123,6 +1130,7 @@ def coerce_enum(from_enum_value: E1, to_enum_class: Type[E2]) -> E1 | E2:
     ):
         _LOGGER.debug("Failed to coerce %s to class %s", from_enum_value, to_enum_class)
         return from_enum_value  # do not attempt to coerce
+
     # At this point we think the Enum is coercable, and we know
     # E1 and E2 have the same member names. We convert from E1 to E2 using _name_
     # (since user Enum subclasses can override the .name property in 3.11)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -1112,7 +1112,7 @@ def coerce_enum(from_enum_value: E1, to_enum_class: Type[E2]) -> E1 | E2:
     if coercion_type == "off":
         return from_enum_value  # do not attempt to coerce
 
-    # We now know this IS an Enum the user has configured coercion enabled.
+    # We now know this is an Enum AND the user has configured coercion enabled.
     # Check if we do NOT meet the required conditions and log a failure message
     # if that is the case.
     from_enum_class = from_enum_value.__class__

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -20,7 +20,7 @@ import contextlib
 import copy
 import re
 import types
-from enum import Enum, auto
+from enum import Enum, EnumType, auto
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -32,6 +32,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -45,7 +46,7 @@ from pandas.api.types import infer_dtype, is_dict_like, is_list_like
 from typing_extensions import Final, Literal, Protocol, TypeAlias, TypeGuard, get_args
 
 import streamlit as st
-from streamlit import errors
+from streamlit import config, errors
 from streamlit import logger as _logger
 from streamlit import string_util
 
@@ -1075,3 +1076,55 @@ def infer_vegalite_type(data: Series[Any]) -> Union[str, Tuple[str, List[Any]]]:
         #     stacklevel=1,
         # )
         return "nominal"
+
+
+E1 = TypeVar("E1", bound=Enum)
+E2 = TypeVar("E2", bound=Enum)
+
+ALLOWED_ENUM_COERCION_CONFIG_SETTINGS = ("off", "nameOnly", "nameAndValue")
+
+
+def coerce_enum(from_enum_value: E1, to_enum_class: Type[E2]) -> E1 | E2:
+    """Attempt to coerce an Enum value to another EnumType.
+
+    An Enum value of EnumType E1 is considered coercable to EnumType E2
+    if the EnumType __qualname__ match and the names of their members
+    match as well. (This is configurable in streamlist configs)
+    """
+    if not isinstance(from_enum_value, Enum):
+        raise ValueError("Expected an Enum")
+    if not isinstance(to_enum_class, EnumType):
+        raise ValueError("Expected an EnumType (i.e. the class of an Enum)")
+    if isinstance(from_enum_value, to_enum_class):
+        return from_enum_value  # Enum is already a member, no coersion necessary
+
+    coercion_type = config.get_option("runner.enumCoercion")
+    if coercion_type not in ALLOWED_ENUM_COERCION_CONFIG_SETTINGS:
+        raise errors.StreamlitAPIException(
+            "Invalid value for config option runner.enumCoercion. "
+            f"Expected one of {ALLOWED_ENUM_COERCION_CONFIG_SETTINGS}, "
+            f"but got '{coercion_type}'."
+        )
+    if coercion_type == "off":
+        return from_enum_value  # do not attempt to coerce
+
+    from_enum_class = from_enum_value.__class__
+    if (
+        not from_enum_class.__qualname__ == to_enum_class.__qualname__
+        or (
+            coercion_type == "nameOnly"
+            and set(to_enum_class._member_names_) != set(from_enum_class._member_names_)
+        )
+        or (
+            coercion_type == "nameAndValue"
+            and set(to_enum_class._value2member_map_)
+            != set(from_enum_class._value2member_map_)
+        )
+    ):
+        _LOGGER.debug("Failed to coerce %s to class %s", from_enum_value, to_enum_class)
+        return from_enum_value  # do not attempt to coerce
+    # At this point we think the Enum is coercable, and we know
+    # E1 and E2 have the same member names. We convert from E1 to E2 using _name_
+    # (since user Enum subclasses can override the .name property in 3.11)
+    _LOGGER.debug("Coerced %s to class %s", from_enum_value, to_enum_class)
+    return to_enum_class[from_enum_value._name_]

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -20,7 +20,7 @@ import contextlib
 import copy
 import re
 import types
-from enum import Enum, EnumType, auto
+from enum import Enum, EnumMeta, auto
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1085,16 +1085,16 @@ ALLOWED_ENUM_COERCION_CONFIG_SETTINGS = ("off", "nameOnly", "nameAndValue")
 
 
 def coerce_enum(from_enum_value: E1, to_enum_class: Type[E2]) -> E1 | E2:
-    """Attempt to coerce an Enum value to another EnumType.
+    """Attempt to coerce an Enum value to another EnumMeta.
 
-    An Enum value of EnumType E1 is considered coercable to EnumType E2
-    if the EnumType __qualname__ match and the names of their members
+    An Enum value of EnumMeta E1 is considered coercable to EnumType E2
+    if the EnumMeta __qualname__ match and the names of their members
     match as well. (This is configurable in streamlist configs)
     """
     if not isinstance(from_enum_value, Enum):
         raise ValueError("Expected an Enum")
-    if not isinstance(to_enum_class, EnumType):
-        raise ValueError("Expected an EnumType (i.e. the class of an Enum)")
+    if not isinstance(to_enum_class, EnumMeta):
+        raise ValueError("Expected an EnumMeta (i.e. the class of an Enum)")
     if isinstance(from_enum_value, to_enum_class):
         return from_enum_value  # Enum is already a member, no coersion necessary
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -132,7 +132,7 @@ def _fix_tornado_crash() -> None:
     """
     if env_util.IS_WINDOWS:
         try:
-            from asyncio import (
+            from asyncio import (  # type: ignore[attr-defined]
                 WindowsProactorEventLoopPolicy,
                 WindowsSelectorEventLoopPolicy,
             )

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -132,7 +132,7 @@ def _fix_tornado_crash() -> None:
     """
     if env_util.IS_WINDOWS:
         try:
-            from asyncio import (  # type: ignore[attr-defined]
+            from asyncio import (
                 WindowsProactorEventLoopPolicy,
                 WindowsSelectorEventLoopPolicy,
             )

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -369,6 +369,7 @@ class ConfigTest(unittest.TestCase):
                 "runner.fixMatplotlib",
                 "runner.postScriptGC",
                 "runner.fastReruns",
+                "runner.enumCoercion",
                 "magic.displayRootDocString",
                 "magic.displayLastExprIfNoSemicolon",
                 "mapbox.token",

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -34,7 +34,7 @@ class TestCaseMetadata(NamedTuple):
     expected_cols: int
     expected_data_format: DataFormat
 
-    # Test pytest this is not a TestClass despite having "Test" in the name.
+    # Tell pytest this is not a TestClass despite having "Test" in the name.
     __test__ = False
 
 

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -33,7 +33,9 @@ class TestCaseMetadata(NamedTuple):
     expected_rows: int
     expected_cols: int
     expected_data_format: DataFormat
-    __test__ = False  # Tell pytest that this is not a test class
+
+
+TestCaseMetadata.__test__ = False  # type: ignore  # Tell pytest that this is not a test class
 
 
 SHARED_TEST_CASES = [

--- a/lib/tests/streamlit/data_mocks.py
+++ b/lib/tests/streamlit/data_mocks.py
@@ -34,8 +34,8 @@ class TestCaseMetadata(NamedTuple):
     expected_cols: int
     expected_data_format: DataFormat
 
-
-TestCaseMetadata.__test__ = False  # type: ignore  # Tell pytest that this is not a test class
+    # Test pytest this is not a TestClass despite having "Test" in the name.
+    __test__ = False
 
 
 SHARED_TEST_CASES = [

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -269,13 +269,13 @@ class DateInputTest(DeltaGeneratorTestCase):
 
 def test_date_input_interaction():
     """Test interactions with an empty date_input widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
 
-    st.date_input("the label", value=None)
-    """
-    ).run()
+    def script():
+        import streamlit as st
+
+        st.date_input("the label", value=None)
+
+    at = AppTest.from_function(script).run()
     date_input = at.date_input[0]
     assert date_input.value is None
 

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import enum
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -21,8 +22,14 @@ import pytest
 
 from streamlit import config
 from streamlit.elements import utils
-from streamlit.elements.utils import check_callback_rules, check_session_state_rules
+from streamlit.elements.utils import (
+    check_callback_rules,
+    check_session_state_rules,
+    maybe_coerce_enum,
+    maybe_coerce_enum_sequence,
+)
 from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.state.common import RegisterWidgetResult
 
 SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
@@ -147,3 +154,40 @@ class ElementUtilsTest(unittest.TestCase):
             check_session_state_rules(5, key="the key", writes_allowed=False)
 
         assert "cannot be set using st.session_state" in str(e.value)
+
+    def test_maybe_coerce_enum(self):
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+
+        EnumAOrig = EnumA
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+
+        EnumAEqual = EnumA
+
+        int_result = RegisterWidgetResult(1, False)
+        intlist_result = RegisterWidgetResult([1, 2, 3], False)
+
+        single_result = RegisterWidgetResult(EnumAOrig.A, False)
+        single_coerced = RegisterWidgetResult(EnumAEqual.A, False)
+
+        tuple_result = RegisterWidgetResult((EnumAOrig.A, EnumAOrig.C), True)
+        tuple_coerced = RegisterWidgetResult((EnumAEqual.A, EnumAEqual.C), True)
+
+        list_result = RegisterWidgetResult([EnumAOrig.A, EnumAOrig.C], True)
+        list_coerced = RegisterWidgetResult([EnumAEqual.A, EnumAEqual.C], True)
+
+        assert maybe_coerce_enum(single_result, EnumAEqual) == single_coerced
+        assert maybe_coerce_enum(single_result, [1, 2, 3]) is single_result
+        assert maybe_coerce_enum(int_result, EnumAEqual) is int_result
+
+        assert maybe_coerce_enum_sequence(tuple_result, EnumAEqual) == tuple_coerced
+        assert maybe_coerce_enum_sequence(list_result, EnumAEqual) == list_coerced
+        assert maybe_coerce_enum_sequence(list_result, [1, 2, 3]) is list_result
+        assert maybe_coerce_enum_sequence(tuple_result, [1, 2, 3]) is tuple_result
+        assert maybe_coerce_enum_sequence(intlist_result, EnumAEqual) is intlist_result

--- a/lib/tests/streamlit/elements/element_utils_test.py
+++ b/lib/tests/streamlit/elements/element_utils_test.py
@@ -169,6 +169,7 @@ class ElementUtilsTest(unittest.TestCase):
             C = enum.auto()
 
         EnumAEqual = EnumA
+        EnumAEqualList = [EnumAEqual.A, EnumAEqual.C, EnumAEqual.B]
 
         int_result = RegisterWidgetResult(1, False)
         intlist_result = RegisterWidgetResult([1, 2, 3], False)
@@ -182,12 +183,56 @@ class ElementUtilsTest(unittest.TestCase):
         list_result = RegisterWidgetResult([EnumAOrig.A, EnumAOrig.C], True)
         list_coerced = RegisterWidgetResult([EnumAEqual.A, EnumAEqual.C], True)
 
-        assert maybe_coerce_enum(single_result, EnumAEqual) == single_coerced
-        assert maybe_coerce_enum(single_result, [1, 2, 3]) is single_result
-        assert maybe_coerce_enum(int_result, EnumAEqual) is int_result
+        assert maybe_coerce_enum(single_result, EnumAEqual, []) == single_coerced
+        assert (
+            maybe_coerce_enum(single_result, EnumAEqualList, EnumAEqualList)
+            == single_coerced
+        )
+        assert (
+            maybe_coerce_enum(single_result, EnumAEqualList, [EnumAEqual.A])
+            == single_coerced
+        )
+        assert maybe_coerce_enum(single_result, [1, 2, 3], []) is single_result
+        assert maybe_coerce_enum(int_result, EnumAEqual, []) is int_result
+        assert (
+            maybe_coerce_enum(
+                single_result, EnumAEqualList, [EnumAEqual.A, EnumAOrig.B]
+            )
+            is single_result
+        )
 
-        assert maybe_coerce_enum_sequence(tuple_result, EnumAEqual) == tuple_coerced
-        assert maybe_coerce_enum_sequence(list_result, EnumAEqual) == list_coerced
-        assert maybe_coerce_enum_sequence(list_result, [1, 2, 3]) is list_result
-        assert maybe_coerce_enum_sequence(tuple_result, [1, 2, 3]) is tuple_result
-        assert maybe_coerce_enum_sequence(intlist_result, EnumAEqual) is intlist_result
+        assert maybe_coerce_enum_sequence(tuple_result, EnumAEqual, []) == tuple_coerced
+        assert (
+            maybe_coerce_enum_sequence(tuple_result, EnumAEqualList, EnumAEqualList)
+            == tuple_coerced
+        )
+        assert (
+            maybe_coerce_enum_sequence(tuple_result, EnumAEqualList, [EnumAEqual.A])
+            == tuple_coerced
+        )
+        assert maybe_coerce_enum_sequence(list_result, EnumAEqual, []) == list_coerced
+        assert (
+            maybe_coerce_enum_sequence(list_result, EnumAEqualList, EnumAEqualList)
+            == list_coerced
+        )
+        assert (
+            maybe_coerce_enum_sequence(list_result, EnumAEqualList, [EnumAEqual.A])
+            == list_coerced
+        )
+        assert maybe_coerce_enum_sequence(list_result, [1, 2, 3], []) is list_result
+        assert maybe_coerce_enum_sequence(tuple_result, [1, 2, 3], []) is tuple_result
+        assert (
+            maybe_coerce_enum_sequence(intlist_result, EnumAEqual, []) is intlist_result
+        )
+        assert (
+            maybe_coerce_enum_sequence(
+                list_result, EnumAEqualList, [EnumAEqual.A, EnumAOrig.B]
+            )
+            is list_result
+        )
+        assert (
+            maybe_coerce_enum_sequence(
+                tuple_result, EnumAEqualList, [EnumAEqual.A, EnumAOrig.B]
+            )
+            is tuple_result
+        )

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -382,22 +382,23 @@ Please select at most 2 options.
 
 def test_multiselect_enum_coercion():
     """Test E2E Enum Coercion on a selectbox."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    from enum import Enum
 
-    class EnumA(Enum):
-        A = 1
-        B = 2
-        C = 3
+    def script():
+        from enum import Enum
 
-    selected_list = st.multiselect("my_enum", EnumA, default=[EnumA.A, EnumA.C])
-    st.text(id(selected_list[0].__class__))
-    st.text(id(EnumA))
-    st.text(all(selected in EnumA for selected in selected_list))
-    """
-    ).run()
+        import streamlit as st
+
+        class EnumA(Enum):
+            A = 1
+            B = 2
+            C = 3
+
+        selected_list = st.multiselect("my_enum", EnumA, default=[EnumA.A, EnumA.C])
+        st.text(id(selected_list[0].__class__))
+        st.text(id(EnumA))
+        st.text(all(selected in EnumA for selected in selected_list))
+
+    at = AppTest.from_function(script).run()
 
     def test_enum():
         multiselect = at.multiselect[0]

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -373,13 +373,13 @@ class NumberInputTest(DeltaGeneratorTestCase):
 
 def test_number_input_interaction():
     """Test interactions with an empty number input widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
 
-    st.number_input("the label", value=None)
-    """
-    ).run()
+    def script():
+        import streamlit as st
+
+        st.number_input("the label", value=None)
+
+    at = AppTest.from_function(script).run()
     number_input = at.number_input[0]
     assert number_input.value is None
 

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -254,13 +254,13 @@ class RadioTest(DeltaGeneratorTestCase):
 
 def test_radio_interaction():
     """Test interactions with an empty radio widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
 
-    st.radio("the label", ("m", "f"), index=None)
-    """
-    ).run()
+    def script():
+        import streamlit as st
+
+        st.radio("the label", ("m", "f"), index=None)
+
+    at = AppTest.from_function(script).run()
     radio = at.radio[0]
     assert radio.value is None
 
@@ -277,22 +277,23 @@ def test_radio_interaction():
 
 def test_radio_enum_coercion():
     """Test E2E Enum Coercion on a radio."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    from enum import Enum
 
-    class EnumA(Enum):
-        A = 1
-        B = 2
-        C = 3
+    def script():
+        from enum import Enum
 
-    selected = st.radio("my_enum", EnumA, index=0)
-    st.text(id(selected.__class__))
-    st.text(id(EnumA))
-    st.text(selected in EnumA)
-    """
-    ).run()
+        import streamlit as st
+
+        class EnumA(Enum):
+            A = 1
+            B = 2
+            C = 3
+
+        selected = st.radio("my_enum", EnumA, index=0)
+        st.text(id(selected.__class__))
+        st.text(id(EnumA))
+        st.text(selected in EnumA)
+
+    at = AppTest.from_function(script).run()
 
     def test_enum():
         radio = at.radio[0]

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -18,12 +18,14 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
+import pytest
 from parameterized import parameterized
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from streamlit.testing.v1.app_test import AppTest
+from streamlit.testing.v1.util import patch_config_options
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -286,25 +288,21 @@ def test_radio_enum_coercion():
         C = 3
 
     selected = st.radio("my_enum", EnumA, index=0)
-    st.text(str(selected in EnumA))
     st.text(id(selected.__class__))
+    st.text(id(EnumA))
+    st.text(selected in EnumA)
     """
     ).run()
-    radio = at.radio[0]
-    original_class = radio.value.__class__
-    original_id = at.text[1].value
-    assert original_class.__qualname__ == "EnumA"
-    assert at.text[0].value == "True"
 
-    at = radio.set_value(original_class.C).run()
-    radio = at.radio[0]
-    new_class = radio.value.__class__
-    # Note: We CANNOT check that `radio.value.__class__ is not original_class`
-    # here because `radio.value` uses `st.session_state` which HAS NOT been
-    # coerced, and thus still contains the Enum of the old class.
-    # Instead, we check the ID value printed within the script to verify the
-    # coercion has happened.
-    new_id = at.text[1].value
-    assert new_id != original_id
-    assert new_class.__qualname__ == "EnumA"
-    assert at.text[0].value == "True"
+    def test_enum():
+        radio = at.radio[0]
+        original_class = radio.value.__class__
+        radio.set_value(original_class.C).run()
+        assert at.text[0].value == at.text[1].value, "Enum Class ID not the same"
+        assert at.text[2].value == "True", "Not all enums found in class"
+
+    with patch_config_options({"runner.enumCoercion": "nameOnly"}):
+        test_enum()
+    with patch_config_options({"runner.enumCoercion": "off"}):
+        with pytest.raises(AssertionError):
+            test_enum()  # expect a failure with the config value off.

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -268,22 +268,23 @@ class SliderTest(DeltaGeneratorTestCase):
 
 def test_select_slider_enum_coercion():
     """Test E2E Enum Coercion on a select_slider."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    from enum import Enum
 
-    class EnumA(Enum):
-        A = 1
-        B = 2
-        C = 3
+    def script():
+        from enum import Enum
 
-    selected = st.select_slider("my_enum", EnumA, value=EnumA.A)
-    st.text(id(selected.__class__))
-    st.text(id(EnumA))
-    st.text(selected in EnumA)
-    """
-    ).run()
+        import streamlit as st
+
+        class EnumA(Enum):
+            A = 1
+            B = 2
+            C = 3
+
+        selected = st.select_slider("my_enum", EnumA, value=EnumA.A)
+        st.text(id(selected.__class__))
+        st.text(id(EnumA))
+        st.text(selected in EnumA)
+
+    at = AppTest.from_function(script).run()
 
     def test_enum():
         select_slider = at.select_slider[0]
@@ -301,22 +302,23 @@ def test_select_slider_enum_coercion():
 
 def test_select_slider_enum_coercion_multivalue():
     """Test E2E Enum Coercion on a selectbox."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    from enum import Enum
 
-    class EnumA(Enum):
-        A = 1
-        B = 2
-        C = 3
+    def script():
+        from enum import Enum
 
-    selected_list = st.select_slider("my_enum", EnumA, value=[EnumA.A, EnumA.C])
-    st.text(id(selected_list[0].__class__))
-    st.text(id(EnumA))
-    st.text(all(selected in EnumA for selected in selected_list))
-    """
-    ).run()
+        import streamlit as st
+
+        class EnumA(Enum):
+            A = 1
+            B = 2
+            C = 3
+
+        selected_list = st.select_slider("my_enum", EnumA, value=[EnumA.A, EnumA.C])
+        st.text(id(selected_list[0].__class__))
+        st.text(id(EnumA))
+        st.text(all(selected in EnumA for selected in selected_list))
+
+    at = AppTest.from_function(script).run()
 
     def test_enum():
         select_slider = at.select_slider[0]

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -206,12 +206,13 @@ class SelectboxTest(DeltaGeneratorTestCase):
 
 def test_selectbox_interaction():
     """Test interactions with an empty selectbox widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    st.selectbox("the label", ("m", "f"), index=None)
-    """
-    ).run()
+
+    def script():
+        import streamlit as st
+
+        st.selectbox("the label", ("m", "f"), index=None)
+
+    at = AppTest.from_function(script).run()
     selectbox = at.selectbox[0]
     assert selectbox.value is None
 
@@ -228,22 +229,23 @@ def test_selectbox_interaction():
 
 def test_selectbox_enum_coercion():
     """Test E2E Enum Coercion on a selectbox."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    from enum import Enum
 
-    class EnumA(Enum):
-        A = 1
-        B = 2
-        C = 3
+    def script():
+        from enum import Enum
 
-    selected = st.selectbox("my_enum", EnumA, index=0)
-    st.text(id(selected.__class__))
-    st.text(id(EnumA))
-    st.text(selected in EnumA)
-    """
-    ).run()
+        import streamlit as st
+
+        class EnumA(Enum):
+            A = 1
+            B = 2
+            C = 3
+
+        selected = st.selectbox("my_enum", EnumA, index=0)
+        st.text(id(selected.__class__))
+        st.text(id(EnumA))
+        st.text(selected in EnumA)
+
+    at = AppTest.from_function(script).run()
 
     def test_enum():
         selectbox = at.selectbox[0]

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -223,3 +223,40 @@ def test_selectbox_interaction():
     at = selectbox.set_value(None).run()
     selectbox = at.selectbox[0]
     assert selectbox.value is None
+
+
+def test_selectbox_enum_coercion():
+    """Test E2E Enum Coercion on a selectbox."""
+    at = AppTest.from_string(
+        """
+    import streamlit as st
+    from enum import Enum
+
+    class EnumA(Enum):
+        A = 1
+        B = 2
+        C = 3
+
+    selected = st.selectbox("my_enum", EnumA, index=0)
+    st.text(str(selected in EnumA))
+    st.text(id(selected.__class__))
+    """
+    ).run()
+    selectbox = at.selectbox[0]
+    original_class = selectbox.value.__class__
+    original_id = at.text[1].value
+    assert original_class.__qualname__ == "EnumA"
+    assert at.text[0].value == "True"
+
+    at = selectbox.select_index(1).run()
+    selectbox = at.selectbox[0]
+    new_class = selectbox.value.__class__
+    # Note: We CANNOT check that `selectbox.value.__class__ is not original_class`
+    # here because `selectbox.value` uses `st.session_state` which HAS NOT been
+    # coerced, and thus still contains the Enum of the old class.
+    # Instead, we check the ID value printed within the script to verify the
+    # coercion has happened.
+    new_id = at.text[1].value
+    assert new_id != original_id
+    assert new_class.__qualname__ == "EnumA"
+    assert at.text[0].value == "True"

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -304,13 +304,12 @@ class SliderTest(DeltaGeneratorTestCase):
 
 
 def test_id_stability():
-    at = AppTest.from_string(
-        """
-    import streamlit as st
+    def script():
+        import streamlit as st
 
-    st.slider("slider", key="slider")
-    """
-    ).run()
+        st.slider("slider", key="slider")
+
+    at = AppTest.from_function(script).run()
     s1 = at.slider[0]
     at = s1.set_value(5).run()
     s2 = at.slider[0]

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -182,12 +182,13 @@ class SomeObj(object):
 
 def test_text_input_interaction():
     """Test interactions with an empty text_area widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    st.text_area("the label", value=None)
-    """
-    ).run()
+
+    def script():
+        import streamlit as st
+
+        st.text_area("the label", value=None)
+
+    at = AppTest.from_function(script).run()
     text_area = at.text_area[0]
     assert text_area.value is None
 

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -189,12 +189,13 @@ class SomeObj:
 
 def test_text_input_interaction():
     """Test interactions with an empty text_input widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    st.text_input("the label", value=None)
-    """
-    ).run()
+
+    def script():
+        import streamlit as st
+
+        st.text_input("the label", value=None)
+
+    at = AppTest.from_function(script).run()
     text_input = at.text_input[0]
     assert text_input.value is None
 

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -114,12 +114,13 @@ class TimeInputTest(DeltaGeneratorTestCase):
 
 def test_time_input_interaction():
     """Test interactions with an empty time_input widget."""
-    at = AppTest.from_string(
-        """
-    import streamlit as st
-    st.time_input("the label", value=None)
-    """
-    ).run()
+
+    def script():
+        import streamlit as st
+
+        st.time_input("the label", value=None)
+
+    at = AppTest.from_function(script).run()
     time_input = at.time_input[0]
     assert time_input.value is None
 

--- a/lib/tests/streamlit/pyspark_mocks.py
+++ b/lib/tests/streamlit/pyspark_mocks.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from typing import Union
+
 import numpy as np
 import pandas as pd
 from pyspark.sql.dataframe import DataFrame as PySparkDataFrame
@@ -46,7 +49,7 @@ class DataFrame:
     def __init__(
         self, is_map: bool = False, is_numpy_arr: bool = False, num_of_rows: int = 50000
     ):
-        self._data = None
+        self._data: Union[pd.DataFrame, None] = None
         self._is_map: bool = is_map
         self._num_of_rows: int = num_of_rows
         self._is_numpy_arr: bool = is_numpy_arr
@@ -73,6 +76,7 @@ class DataFrame:
 
     def toPandas(self):
         self._lazy_evaluation()
+        assert self._data is not None
         if self._limit > 0:
             return self._data.head(self._limit)
         return self._data

--- a/lib/tests/streamlit/pyspark_mocks.py
+++ b/lib/tests/streamlit/pyspark_mocks.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import Union
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
@@ -49,7 +48,7 @@ class DataFrame:
     def __init__(
         self, is_map: bool = False, is_numpy_arr: bool = False, num_of_rows: int = 50000
     ):
-        self._data: Union[pd.DataFrame, None] = None
+        self._data: pd.DataFrame | None = None
         self._is_map: bool = is_map
         self._num_of_rows: int = num_of_rows
         self._is_numpy_arr: bool = is_numpy_arr

--- a/lib/tests/streamlit/snowpark_mocks.py
+++ b/lib/tests/streamlit/snowpark_mocks.py
@@ -14,7 +14,7 @@
 
 
 import random
-from typing import List
+from typing import List, Union
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,7 @@ class _SnowparkDataLikeBaseClass:
     def __init__(
         self, is_map: bool = False, num_of_rows: int = 50000, num_of_cols: int = 4
     ):
-        self._data = None
+        self._data: Union[pd.DataFrame, List[List[int]], None] = None
         self._is_map = is_map
         self._num_of_rows = num_of_rows
         self._num_of_cols = num_of_cols
@@ -37,11 +37,13 @@ class _SnowparkDataLikeBaseClass:
         self._lazy_evaluation()
         if n > self._num_of_rows:
             n = self._num_of_rows
+        assert self._data is not None
         return self._data[:n]
 
     def collect(self) -> List[List[int]]:
         """Returns fake Data like, which imitates collection of snowflake.snowpark.dataframe.DataFrame"""
         self._lazy_evaluation()
+        assert self._data is not None
         return self._data
 
     def _lazy_evaluation(self):

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -47,14 +47,13 @@ def test_alert():
 
 
 def test_button():
-    sr = AppTest.from_string(
-        """
+    def script():
         import streamlit as st
 
         st.button("button")
         st.button("second button")
-        """,
-    ).run()
+
+    sr = AppTest.from_function(script).run()
     assert sr.button[0].value == False
     assert sr.button[1].value == False
 
@@ -117,15 +116,14 @@ def test_checkbox():
 
 
 def test_color_picker():
-    at = AppTest.from_string(
-        """
+    def script():
         import streamlit as st
 
         st.color_picker("what is your favorite color?")
         st.color_picker("short hex", value="#ABC")
         st.color_picker("invalid", value="blue")
-        """,
-    ).run()
+
+    at = AppTest.from_function(script).run()
     assert at.color_picker.len == 2
     assert at.color_picker.values == ["#000000", "#ABC"]
     assert "blue" in at.exception[0].value
@@ -182,16 +180,18 @@ def test_dataframe():
 
 
 def test_date_input():
-    at = AppTest.from_string(
-        """
-        import streamlit as st
+    def script():
         import datetime
+
+        import streamlit as st
 
         st.date_input("date", value=datetime.date(2023, 4, 17))
         st.date_input("datetime", value=datetime.datetime(2023, 4, 17, 11))
-        st.date_input("range", value=(datetime.date(2020, 1, 1), datetime.date(2030, 1, 1)))
-        """,
-    ).run()
+        st.date_input(
+            "range", value=(datetime.date(2020, 1, 1), datetime.date(2030, 1, 1))
+        )
+
+    at = AppTest.from_function(script).run()
     assert not at.exception
     assert at.date_input.values == [
         date(2023, 4, 17),

--- a/lib/tests/streamlit/testing/test_runner_test.py
+++ b/lib/tests/streamlit/testing/test_runner_test.py
@@ -16,14 +16,13 @@ from streamlit.testing.v1 import AppTest
 
 
 def test_smoke():
-    at = AppTest.from_string(
-        """
+    def script():
         import streamlit as st
 
         st.radio("radio", options=["a", "b", "c"], key="r")
         st.radio("default index", options=["a", "b", "c"], index=2)
-        """
-    ).run()
+
+    at = AppTest.from_function(script).run()
     assert at.radio
     assert at.radio[0].value == "a"
     assert at.radio(key="r").value == "a"

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -763,8 +763,7 @@ class TypeUtilTest(unittest.TestCase):
         with patch_config_options({"runner.enumCoercion": "nameAndValue"}):
             assert type_util.coerce_enum(EnumAOrig.A, EnumAEqual) is EnumAEqual.A
             assert type_util.coerce_enum(EnumAOrig.A, EnumADiffValues) is EnumAOrig.A
-        with (
-            pytest.raises(errors.StreamlitAPIException),
-            patch_config_options({"runner.enumCoercion": "badValue"}),
+        with pytest.raises(errors.StreamlitAPIException), patch_config_options(
+            {"runner.enumCoercion": "badValue"}
         ):
             type_util.coerce_enum(EnumAOrig.A, EnumAEqual)

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -752,7 +752,7 @@ class TypeUtilTest(unittest.TestCase):
         # Things that do not require coercion
         assert type_util.coerce_enum(EnumAOrig.A, EnumAOrig) is EnumAOrig.A
         # Things which cause errors
-        with pytest.raises(ValueError, match="Expected an EnumType"):
+        with pytest.raises(ValueError, match="Expected an EnumMeta"):
             type_util.coerce_enum(EnumAOrig.A, EnumAEqual.A)
         with pytest.raises(ValueError, match="Expected an Enum"):
             type_util.coerce_enum(EnumAOrig, EnumAEqual)

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import unittest
 from collections import namedtuple
 from datetime import date
@@ -26,16 +27,7 @@ import pytest
 from pandas.api.types import infer_dtype
 from parameterized import parameterized
 
-from streamlit import type_util
-from streamlit.type_util import (
-    DataFormat,
-    convert_anything_to_df,
-    data_frame_to_bytes,
-    fix_arrow_incompatible_column_types,
-    is_bytes_like,
-    is_snowpark_data_object,
-    to_bytes,
-)
+from streamlit import errors, type_util
 from tests.streamlit.data_mocks import (
     BASE_TYPES_DF,
     DATETIME_TYPES_DF,
@@ -51,7 +43,7 @@ from tests.streamlit.data_mocks import (
 )
 from tests.streamlit.snowpark_mocks import DataFrame as SnowparkDataFrame
 from tests.streamlit.snowpark_mocks import Row as SnowparkRow
-from tests.testutil import create_snowpark_session
+from tests.testutil import create_snowpark_session, patch_config_options
 
 
 class TypeUtilTest(unittest.TestCase):
@@ -109,24 +101,24 @@ class TypeUtilTest(unittest.TestCase):
 
     def test_to_bytes(self):
         bytes_obj = b"some bytes"
-        self.assertTrue(is_bytes_like(bytes_obj))
-        self.assertIsInstance(to_bytes(bytes_obj), bytes)
+        self.assertTrue(type_util.is_bytes_like(bytes_obj))
+        self.assertIsInstance(type_util.to_bytes(bytes_obj), bytes)
 
         bytearray_obj = bytearray("a bytearray string", "utf-8")
-        self.assertTrue(is_bytes_like(bytearray_obj))
-        self.assertIsInstance(to_bytes(bytearray_obj), bytes)
+        self.assertTrue(type_util.is_bytes_like(bytearray_obj))
+        self.assertIsInstance(type_util.to_bytes(bytearray_obj), bytes)
 
         string_obj = "a normal string"
-        self.assertFalse(is_bytes_like(string_obj))
+        self.assertFalse(type_util.is_bytes_like(string_obj))
         with self.assertRaises(RuntimeError):
-            to_bytes(string_obj)  # type: ignore
+            type_util.to_bytes(string_obj)  # type: ignore
 
     def test_data_frame_with_dtype_values_to_bytes(self):
         df1 = pd.DataFrame(["foo", "bar"])
         df2 = pd.DataFrame(df1.dtypes)
 
         try:
-            data_frame_to_bytes(df2)
+            type_util.data_frame_to_bytes(df2)
         except Exception as ex:
             self.fail(f"Converting dtype dataframes to Arrow should not fail: {ex}")
 
@@ -158,13 +150,13 @@ class TypeUtilTest(unittest.TestCase):
             index=[1.0, "foo", 3],
         )
 
-        converted_df = convert_anything_to_df(orginal_df, ensure_copy=True)
+        converted_df = type_util.convert_anything_to_df(orginal_df, ensure_copy=True)
         # Apply a change
         converted_df["integer"] = [4, 5, 6]
         # Ensure that the original dataframe is not changed
         self.assertEqual(orginal_df["integer"].to_list(), [1, 2, 3])
 
-        converted_df = convert_anything_to_df(orginal_df, ensure_copy=False)
+        converted_df = type_util.convert_anything_to_df(orginal_df, ensure_copy=False)
         # Apply a change
         converted_df["integer"] = [4, 5, 6]
         # The original dataframe should be changed here since ensure_copy is False
@@ -175,7 +167,7 @@ class TypeUtilTest(unittest.TestCase):
         key-value dicts to a dataframe.
         """
         data = {"a": 1, "b": 2}
-        df = convert_anything_to_df(data)
+        df = type_util.convert_anything_to_df(data)
         pd.testing.assert_frame_equal(df, pd.DataFrame.from_dict(data, orient="index"))
 
     def test_convert_anything_to_df_passes_styler_through(self):
@@ -191,7 +183,7 @@ class TypeUtilTest(unittest.TestCase):
 
         original_styler = original_df.style.highlight_max(axis=0)
 
-        out = convert_anything_to_df(original_styler, allow_styler=True)
+        out = type_util.convert_anything_to_df(original_styler, allow_styler=True)
         self.assertEqual(original_styler, out)
         self.assertEqual(id(original_df), id(out.data))
 
@@ -208,7 +200,7 @@ class TypeUtilTest(unittest.TestCase):
 
         original_styler = original_df.style.highlight_max(axis=0)
 
-        out = convert_anything_to_df(
+        out = type_util.convert_anything_to_df(
             original_styler, allow_styler=True, ensure_copy=True
         )
         self.assertNotEqual(original_styler, out)
@@ -230,7 +222,7 @@ class TypeUtilTest(unittest.TestCase):
 
         original_styler = original_df.style.highlight_max(axis=0)
 
-        out = convert_anything_to_df(original_styler, allow_styler=False)
+        out = type_util.convert_anything_to_df(original_styler, allow_styler=False)
         self.assertNotEqual(id(original_styler), id(out))
         self.assertEqual(id(original_df), id(out))
         pd.testing.assert_frame_equal(original_df, out)
@@ -248,7 +240,7 @@ class TypeUtilTest(unittest.TestCase):
 
         original_styler = original_df.style.highlight_max(axis=0)
 
-        out = convert_anything_to_df(
+        out = type_util.convert_anything_to_df(
             original_styler, allow_styler=False, ensure_copy=True
         )
         self.assertNotEqual(id(original_styler), id(out))
@@ -260,7 +252,7 @@ class TypeUtilTest(unittest.TestCase):
             def to_pandas(self):
                 return pd.DataFrame([])
 
-        converted = convert_anything_to_df(DataFrameIsh())
+        converted = type_util.convert_anything_to_df(DataFrameIsh())
         assert isinstance(converted, pd.DataFrame)
         assert converted.empty
 
@@ -342,7 +334,7 @@ class TypeUtilTest(unittest.TestCase):
         leaves supported columns unchanged.
         """
         df = pd.DataFrame({"c1": column})
-        fixed_df = fix_arrow_incompatible_column_types(df)
+        fixed_df = type_util.fix_arrow_incompatible_column_types(df)
         col_dtype = fixed_df["c1"].dtype
         inferred_type = infer_dtype(fixed_df["c1"])
 
@@ -369,7 +361,7 @@ class TypeUtilTest(unittest.TestCase):
             }
         )
 
-        fixed_df = fix_arrow_incompatible_column_types(df)
+        fixed_df = type_util.fix_arrow_incompatible_column_types(df)
         pd.testing.assert_frame_equal(df, fixed_df)
 
     def test_fix_mixed_column_types(self):
@@ -387,7 +379,7 @@ class TypeUtilTest(unittest.TestCase):
             index=[1.0, "foo", 3],
         )
 
-        fixed_df = fix_arrow_incompatible_column_types(df)
+        fixed_df = type_util.fix_arrow_incompatible_column_types(df)
 
         # Check dtypes
         self.assertIsInstance(fixed_df["mixed-integer"].dtype, pd.StringDtype)
@@ -422,7 +414,7 @@ class TypeUtilTest(unittest.TestCase):
         )
 
         try:
-            data_frame_to_bytes(df)
+            type_util.data_frame_to_bytes(df)
         except Exception as ex:
             self.fail(
                 "No exception should have been thrown here. "
@@ -449,7 +441,7 @@ class TypeUtilTest(unittest.TestCase):
         DataFrames with a variety of types to Arrow.
         """
         try:
-            data_frame_to_bytes(input_df)
+            type_util.data_frame_to_bytes(input_df)
         except Exception as ex:
             self.fail(
                 "No exception should have been thrown here. "
@@ -470,47 +462,47 @@ class TypeUtilTest(unittest.TestCase):
         )
 
         # pandas dataframe should not be SnowparkDataFrame
-        self.assertFalse(is_snowpark_data_object(df))
+        self.assertFalse(type_util.is_snowpark_data_object(df))
 
         # if snowflake.snowpark.dataframe.DataFrame def is_snowpark_data_object should return true
-        self.assertTrue(is_snowpark_data_object(SnowparkDataFrame()))
+        self.assertTrue(type_util.is_snowpark_data_object(SnowparkDataFrame()))
 
         # any object should not be snowpark dataframe
-        self.assertFalse(is_snowpark_data_object("any text"))
-        self.assertFalse(is_snowpark_data_object(123))
+        self.assertFalse(type_util.is_snowpark_data_object("any text"))
+        self.assertFalse(type_util.is_snowpark_data_object(123))
 
         class DummyClass:
             """DummyClass for testing purposes"""
 
-        self.assertFalse(is_snowpark_data_object(DummyClass()))
+        self.assertFalse(type_util.is_snowpark_data_object(DummyClass()))
 
         # empty list should not be snowpark dataframe
-        self.assertFalse(is_snowpark_data_object(list()))
+        self.assertFalse(type_util.is_snowpark_data_object(list()))
 
         # list with items should not be snowpark dataframe
         self.assertFalse(
-            is_snowpark_data_object(
+            type_util.is_snowpark_data_object(
                 [
                     "any text",
                 ]
             )
         )
         self.assertFalse(
-            is_snowpark_data_object(
+            type_util.is_snowpark_data_object(
                 [
                     123,
                 ]
             )
         )
         self.assertFalse(
-            is_snowpark_data_object(
+            type_util.is_snowpark_data_object(
                 [
                     DummyClass(),
                 ]
             )
         )
         self.assertFalse(
-            is_snowpark_data_object(
+            type_util.is_snowpark_data_object(
                 [
                     df,
                 ]
@@ -519,7 +511,7 @@ class TypeUtilTest(unittest.TestCase):
 
         # list with SnowparkRow should be SnowparkDataframe
         self.assertTrue(
-            is_snowpark_data_object(
+            type_util.is_snowpark_data_object(
                 [
                     SnowparkRow(),
                 ]
@@ -530,15 +522,17 @@ class TypeUtilTest(unittest.TestCase):
     def test_is_snowpark_dataframe_integration(self):
         with create_snowpark_session() as snowpark_session:
             self.assertTrue(
-                is_snowpark_data_object(snowpark_session.sql("SELECT 40+2 as COL1"))
+                type_util.is_snowpark_data_object(
+                    snowpark_session.sql("SELECT 40+2 as COL1")
+                )
             )
             self.assertTrue(
-                is_snowpark_data_object(
+                type_util.is_snowpark_data_object(
                     snowpark_session.sql("SELECT 40+2 as COL1").collect()
                 )
             )
             self.assertTrue(
-                is_snowpark_data_object(
+                type_util.is_snowpark_data_object(
                     snowpark_session.sql("SELECT 40+2 as COL1").cache_result()
                 )
             )
@@ -576,7 +570,7 @@ class TypeUtilTest(unittest.TestCase):
         self.assertEqual(converted_df.shape[0], metadata.expected_rows)
         self.assertEqual(converted_df.shape[1], metadata.expected_cols)
 
-        if metadata.expected_data_format == DataFormat.UNKNOWN:
+        if metadata.expected_data_format == type_util.DataFormat.UNKNOWN:
             with self.assertRaises(ValueError):
                 type_util.convert_df_to_data_format(
                     converted_df, metadata.expected_data_format
@@ -590,11 +584,11 @@ class TypeUtilTest(unittest.TestCase):
             # Some data formats are converted to DataFrames instead of
             # the original data type/structure.
             if metadata.expected_data_format in [
-                DataFormat.SNOWPARK_OBJECT,
-                DataFormat.PYSPARK_OBJECT,
-                DataFormat.PANDAS_INDEX,
-                DataFormat.PANDAS_STYLER,
-                DataFormat.EMPTY,
+                type_util.DataFormat.SNOWPARK_OBJECT,
+                type_util.DataFormat.PYSPARK_OBJECT,
+                type_util.DataFormat.PANDAS_INDEX,
+                type_util.DataFormat.PANDAS_STYLER,
+                type_util.DataFormat.EMPTY,
             ]:
                 assert isinstance(converted_data, pd.DataFrame)
                 self.assertEqual(converted_data.shape[0], metadata.expected_rows)
@@ -602,7 +596,7 @@ class TypeUtilTest(unittest.TestCase):
             else:
                 self.assertEqual(type(converted_data), type(input_data))
                 # Sets in python are unordered, so we can't compare them this way.
-                if metadata.expected_data_format != DataFormat.SET_OF_VALUES:
+                if metadata.expected_data_format != type_util.DataFormat.SET_OF_VALUES:
                     self.assertEqual(str(converted_data), str(input_data))
                     pd.testing.assert_frame_equal(
                         converted_df, type_util.convert_anything_to_df(converted_data)
@@ -614,7 +608,7 @@ class TypeUtilTest(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             type_util.convert_df_to_data_format(
-                pd.DataFrame({"a": [1, 2, 3]}), DataFormat.UNKNOWN
+                pd.DataFrame({"a": [1, 2, 3]}), type_util.DataFormat.UNKNOWN
             )
 
     def test_convert_df_with_missing_values(self):
@@ -630,19 +624,23 @@ class TypeUtilTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.LIST_OF_VALUES),
+            type_util.convert_df_to_data_format(
+                df, type_util.DataFormat.LIST_OF_VALUES
+            ),
             [None, None, None, None],
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.TUPLE_OF_VALUES),
+            type_util.convert_df_to_data_format(
+                df, type_util.DataFormat.TUPLE_OF_VALUES
+            ),
             (None, None, None, None),
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.SET_OF_VALUES),
+            type_util.convert_df_to_data_format(df, type_util.DataFormat.SET_OF_VALUES),
             {None},
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.LIST_OF_ROWS),
+            type_util.convert_df_to_data_format(df, type_util.DataFormat.LIST_OF_ROWS),
             [
                 [None],
                 [None],
@@ -651,7 +649,9 @@ class TypeUtilTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.LIST_OF_RECORDS),
+            type_util.convert_df_to_data_format(
+                df, type_util.DataFormat.LIST_OF_RECORDS
+            ),
             [
                 {"missing": None},
                 {"missing": None},
@@ -660,16 +660,111 @@ class TypeUtilTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.COLUMN_VALUE_MAPPING),
+            type_util.convert_df_to_data_format(
+                df, type_util.DataFormat.COLUMN_VALUE_MAPPING
+            ),
             {
                 "missing": [None, None, None, None],
             },
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.COLUMN_INDEX_MAPPING),
+            type_util.convert_df_to_data_format(
+                df, type_util.DataFormat.COLUMN_INDEX_MAPPING
+            ),
             {"missing": {0: None, 1: None, 2: None, 3: None}},
         )
         self.assertEqual(
-            type_util.convert_df_to_data_format(df, DataFormat.KEY_VALUE_DICT),
+            type_util.convert_df_to_data_format(
+                df, type_util.DataFormat.KEY_VALUE_DICT
+            ),
             {0: None, 1: None, 2: None, 3: None},
         )
+
+    def test_coerce_enum(self):
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+
+        EnumAOrig = EnumA
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+
+        EnumAEqual = EnumA
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            D = enum.auto()
+
+        EnumADiffMembers = EnumA
+
+        class EnumA(enum.Enum):
+            A = "1"
+            B = "2"
+            C = "3"
+
+        EnumADiffValues = EnumA
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+            D = enum.auto()
+
+        EnumAExtraMembers = EnumA
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+
+        EnumADiffQualname = EnumA
+        EnumADiffQualname.__qualname__ = "foobar.EnumA"
+
+        class EnumB(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+            C = enum.auto()
+
+        assert all(
+            EnumAOrig.A not in enum
+            for enum in (
+                EnumAEqual,
+                EnumADiffMembers,
+                EnumADiffValues,
+                EnumADiffQualname,
+            )
+        )
+        assert EnumAOrig.A.value == EnumAEqual.A.value
+
+        # Things that are coercable
+        assert type_util.coerce_enum(EnumAOrig.A, EnumAEqual) is EnumAEqual.A
+        assert type_util.coerce_enum(EnumAOrig.A, EnumADiffValues) is EnumADiffValues.A
+        # Things that are not coercable
+        assert type_util.coerce_enum(EnumAOrig.A, EnumADiffMembers) is EnumAOrig.A
+        assert type_util.coerce_enum(EnumAOrig.A, EnumAExtraMembers) is EnumAOrig.A
+        assert type_util.coerce_enum(EnumAOrig.A, EnumB) is EnumAOrig.A
+        assert type_util.coerce_enum(EnumAOrig.A, EnumADiffQualname) is EnumAOrig.A
+        # Things that do not require coercion
+        assert type_util.coerce_enum(EnumAOrig.A, EnumAOrig) is EnumAOrig.A
+        # Things which cause errors
+        with pytest.raises(ValueError, match="Expected an EnumType"):
+            type_util.coerce_enum(EnumAOrig.A, EnumAEqual.A)
+        with pytest.raises(ValueError, match="Expected an Enum"):
+            type_util.coerce_enum(EnumAOrig, EnumAEqual)
+
+        # test with different config option
+        with patch_config_options({"runner.enumCoercion": "off"}):
+            assert type_util.coerce_enum(EnumAOrig.A, EnumAEqual) is EnumAOrig.A
+        with patch_config_options({"runner.enumCoercion": "nameAndValue"}):
+            assert type_util.coerce_enum(EnumAOrig.A, EnumAEqual) is EnumAEqual.A
+            assert type_util.coerce_enum(EnumAOrig.A, EnumADiffValues) is EnumAOrig.A
+        with (
+            pytest.raises(errors.StreamlitAPIException),
+            patch_config_options({"runner.enumCoercion": "badValue"}),
+        ):
+            type_util.coerce_enum(EnumAOrig.A, EnumAEqual)

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -56,7 +56,8 @@ IGNORE_PATTERN = re.compile(
     r"|/(fixtures|__snapshots__|test_data|data)/"
     # Exclude vendored files.
     r"|/vendor/|^vendor/|^component-lib/declarations/apache-arrow"
-    r"|proto/streamlit/proto/openmetrics_data_model\.proto",
+    r"|proto/streamlit/proto/openmetrics_data_model\.proto"
+    r"|^e2e_flaky/scripts/.*\.py",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
* Enum classes will be special-cased in all streamlit elements that accept an `option` sequence argument (radio, selectbox, multiselect, etc...). This will ONLY work if 
  * the entire Enum class is passed to `option` as the iterable;
  * an iterable consisting of Enum members all from the same class is passed to `option`.
* When returning a Enum value (which comes from `session_state` of the previous script execution), the value will first be maybe-coerced to the class of the Enum passed to the `options` argument.
* An Enum member `Enum1.A` of Enum1 is considered coercable into `Enum2` if `Enum1` and `Enum2` share
   * the same `__qualname__`
   * the same member names (but not necessarily the same values) in the same order
* The coercion happens by calling `Enum2[Enum1.A._name_]`
* If coercion fails these criteria, the original Enum1.A is returned.

While the unexpected class-redefinition behavior is possible for ANY class that gets re-defined on each page run (see https://github.com/streamlit/streamlit/issues/6985 and https://github.com/streamlit/streamlit/issues/2379), the Enum seems to be the most frequent case where users encounter problems (because testing an Enum member's class membership is a very common operation). We can pretty safely do the coercion between classes, too, because of how restricted the base Enum implementation in python is compared to `<insert some generic user class or dataclass here>`.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/4909

## Testing Plan
- Unit test core enum coersion function
- Unit tests of the widget util functions
- Integrated test of streamlit page code (TODO)
- Edge-case testing (TODO; are there any edge cases where a user injects some kind of run-time value into an ENUM class and we screw something up)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
