### PR TITLE
Fix AST walk in `st.echo`

### DIFF
--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -72,7 +72,7 @@ def echo(code_location="above"):
             if not hasattr(node, "body"):
                 return
             for child in ast.iter_child_nodes(node):
-                # If child doesn't have "lineno", it is not something we could print
+                # If child doesn't have "lineno", it is not something we could display
                 if hasattr(child, "lineno"):
                     line_to_node_map[child.lineno] = child
                     collect_body_statements(child)

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -17,7 +17,7 @@ import contextlib
 import re
 import textwrap
 import traceback
-from typing import Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from streamlit.runtime.metrics_util import gather_metrics
 
@@ -58,7 +58,7 @@ def echo(code_location="above"):
         # Get stack frame *before* running the echoed code. The frame's
         # line number will point to the `st.echo` statement we're running.
         frame = traceback.extract_stack()[-3]
-        filename, start_line = frame.filename, frame.lineno
+        filename, start_line = frame.filename, frame.lineno or 0
 
         # Read the file containing the source code of the echoed statement.
         with source_util.open_python_file(filename) as source_file:
@@ -66,9 +66,9 @@ def echo(code_location="above"):
 
         # Use ast to parse the Python file and find the code block to display
         root_node = ast.parse("".join(source_lines))
-        line_to_node_map = {}
+        line_to_node_map: Dict[int, Any] = {}
 
-        def collect_body_statements(node):
+        def collect_body_statements(node: ast.AST) -> None:
             if not hasattr(node, "body"):
                 return
             for child in ast.iter_child_nodes(node):

--- a/lib/streamlit/echo.py
+++ b/lib/streamlit/echo.py
@@ -71,9 +71,11 @@ def echo(code_location="above"):
         def collect_body_statements(node):
             if not hasattr(node, "body"):
                 return
-            for child in node.body:
-                line_to_node_map[child.lineno] = child
-                collect_body_statements(child)
+            for child in ast.iter_child_nodes(node):
+                # If child doesn't have "lineno", it is not something we could print
+                if hasattr(child, "lineno"):
+                    line_to_node_map[child.lineno] = child
+                    collect_body_statements(child)
 
         collect_body_statements(root_node)
 

--- a/lib/tests/streamlit/elements/echo_test.py
+++ b/lib/tests/streamlit/elements/echo_test.py
@@ -122,6 +122,28 @@ class MyClass(object):
         self.assertEqual("Hello", element.markdown.body)
         self.clear_queue()
 
+    def test_if_elif_else(self):
+        page = "Dual"
+
+        if page == "Single":
+            with st.echo():
+                st.write("Single")
+
+        elif page == "Dual":
+            with st.echo():
+                st.write("Dual")
+
+        else:
+            with st.echo():
+                st.write("ELSE")
+
+        echo_str = 'st.write("Dual")'
+        element = self.get_delta_from_queue(0).new_element
+        self.assertEqual(echo_str, element.code.code_text)
+        element = self.get_delta_from_queue(1).new_element
+        self.assertEqual("Dual", element.markdown.body)
+        self.clear_queue()
+
     def test_root_level_echo(self):
         import tests.streamlit.echo_test_data.root_level_echo
 

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-import langchain
 import pytest
 import semver
 from google.protobuf.json_format import MessageToDict
@@ -77,8 +76,10 @@ class StreamlitCallbackHandlerAPITest(unittest.TestCase):
 
 
 class StreamlitCallbackHandlerTest(DeltaGeneratorTestCase):
+    from langchain import __version__ as langchain_version
+
     @pytest.mark.skipif(
-        semver.VersionInfo.parse(langchain.__version__) >= "0.0.296",
+        semver.VersionInfo.parse(langchain_version) >= "0.0.296",
         reason="Skip version verification when `SKIP_VERSION_CHECK` env var is set",
     )
     def test_agent_run(self):


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Better ast walking, now we also walk not just through the body, but any descending child that has `lineno` attribute
For example `If` AST node contains `body`, but also `orelse` block:
https://docs.python.org/3/library/ast.html#ast.If

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
