### PR TITLE
Use `NoReturn` annotation for stop and rerun

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -24,7 +24,7 @@ _LOGGER = get_logger(__name__)
 
 
 @gather_metrics("stop")
-def stop() -> NoReturn:  # type: ignore
+def stop() -> NoReturn:  # type: ignore[misc]
     """Stops execution immediately.
 
     Streamlit will not run any statements after `st.stop()`.
@@ -50,7 +50,7 @@ def stop() -> NoReturn:  # type: ignore
 
 
 @gather_metrics("rerun")
-def rerun() -> NoReturn:  # type: ignore
+def rerun() -> NoReturn:  # type: ignore[misc]
     """Rerun the script immediately.
 
     When `st.rerun()` is called, the script is halted - no more statements will
@@ -74,7 +74,7 @@ def rerun() -> NoReturn:  # type: ignore
 
 
 @gather_metrics("experimental_rerun")
-def experimental_rerun() -> NoReturn:  # type: ignore
+def experimental_rerun() -> NoReturn:
     """Rerun the script immediately.
 
     When `st.experimental_rerun()` is called, the script is halted - no

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -24,7 +24,7 @@ _LOGGER = get_logger(__name__)
 
 
 @gather_metrics("stop")
-def stop() -> NoReturn:
+def stop() -> NoReturn:  # type: ignore
     """Stops execution immediately.
 
     Streamlit will not run any statements after `st.stop()`.
@@ -50,7 +50,7 @@ def stop() -> NoReturn:
 
 
 @gather_metrics("rerun")
-def rerun() -> NoReturn:
+def rerun() -> NoReturn:  # type: ignore
     """Rerun the script immediately.
 
     When `st.rerun()` is called, the script is halted - no more statements will
@@ -74,7 +74,7 @@ def rerun() -> NoReturn:
 
 
 @gather_metrics("experimental_rerun")
-def experimental_rerun() -> NoReturn:
+def experimental_rerun() -> NoReturn:  # type: ignore
     """Rerun the script immediately.
 
     When `st.experimental_rerun()` is called, the script is halted - no

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import NoReturn
 
 import streamlit as st
 from streamlit.deprecation_util import make_deprecated_name_warning
@@ -23,7 +24,7 @@ _LOGGER = get_logger(__name__)
 
 
 @gather_metrics("stop")
-def stop() -> None:
+def stop() -> NoReturn:
     """Stops execution immediately.
 
     Streamlit will not run any statements after `st.stop()`.
@@ -49,7 +50,7 @@ def stop() -> None:
 
 
 @gather_metrics("rerun")
-def rerun() -> None:
+def rerun() -> NoReturn:
     """Rerun the script immediately.
 
     When `st.rerun()` is called, the script is halted - no more statements will
@@ -73,7 +74,7 @@ def rerun() -> None:
 
 
 @gather_metrics("experimental_rerun")
-def experimental_rerun() -> None:
+def experimental_rerun() -> NoReturn:
     """Rerun the script immediately.
 
     When `st.experimental_rerun()` is called, the script is halted - no


### PR DESCRIPTION
## Describe your changes

In previous versions, `stop` and `rerun` functions were annotated with `NoReturn`, which mypy and other type checkers understand. 

For example, consider the following code:

```
import random
import streamlit as st

x = 1 if random.random() < 0.5 else None

if x is None:
    st.stop()

x += 1
```

In previous versions, mypy knows that `x` is not None, because stop is NoReturn, but not anymore.

## Testing Plan

No additional tests are needed because it's only typing change.