### PR TITLE
Fix potentially flaky playwright tests

### DIFF
--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -15,7 +15,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 
 
 def test_checkbox_widget_display(
@@ -57,6 +57,7 @@ def test_checkbox_values_on_click(app: Page):
 
     for checkbox_element in checkbox_elements.all():
         checkbox_element.click(delay=50)
+        wait_for_app_run(app)
 
     markdown_elements = app.locator(".stMarkdown")
     expected = [

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 
 
 def select_for_kth_multiselect(
@@ -39,6 +39,7 @@ def select_for_kth_multiselect(
     page.locator("li").filter(has_text=option_text).first.click()
     if close_after_selecting:
         page.keyboard.press("Escape")
+    wait_for_app_run(page)
 
 
 def del_from_kth_multiselect(page: Page, option_text: str, k: int):

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -15,7 +15,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 
 
 def test_number_input_widget_display(
@@ -96,6 +96,7 @@ def test_number_input_has_correct_value_on_increment_click(app: Page):
     for i, button in enumerate(number_input_up_buttons.all()):
         if i not in [5, 9]:
             button.click()
+            wait_for_app_run(app)
 
     markdown_elements = app.get_by_test_id("stMarkdown")
 

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -14,7 +14,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 
 
 def test_radio_widget_rendering(
@@ -70,6 +70,7 @@ def test_set_value_correctly_when_click(app: Page):
     for index, element in enumerate(app.get_by_test_id("stRadio").all()):
         if index not in [2, 3]:  # skip disabled and no-options widget
             element.locator('label[data-baseweb="radio"]').nth(1).click(force=True)
+            wait_for_app_run(app)
 
     expected = [
         "value 1: male",
@@ -99,6 +100,7 @@ def test_calls_callback_on_change(app: Page):
     radio_widget = app.get_by_test_id("stRadio").nth(11)
 
     radio_widget.locator('label[data-baseweb="radio"]').first.click(force=True)
+    wait_for_app_run(app)
 
     expect(app.get_by_test_id("stMarkdown").nth(11)).to_have_text(
         "value 12: female",
@@ -112,6 +114,7 @@ def test_calls_callback_on_change(app: Page):
     # Change different date input to trigger delta path change
     first_date_input_field = app.get_by_test_id("stRadio").first
     first_date_input_field.locator('label[data-baseweb="radio"]').last.click(force=True)
+    wait_for_app_run(app)
 
     expect(app.get_by_test_id("stMarkdown").first).to_have_text(
         "value 1: male", use_inner_text=True

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -15,7 +15,7 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 
 
 def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -55,6 +55,7 @@ def test_toggle_values_on_click(app: Page):
 
     for toggle_element in toggle_elements.all():
         toggle_element.click(delay=50)
+        wait_for_app_run(app)
 
     markdown_elements = app.locator(".stMarkdown")
     expected = [


### PR DESCRIPTION
## Describe your changes

Add wait for app runs to fix potentially flaky situations where a rerun cancels another rerun that hasn't been finished yet. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
