### PR TITLE
Teach st.write how to not set unsafe_allow_html when possible

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -26,7 +26,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.state import SessionStateProxy
-from streamlit.string_util import is_mem_address_str
+from streamlit.string_util import is_mem_address_str, probably_contains_html_tags
 from streamlit.user_info import UserInfoProxy
 
 if TYPE_CHECKING:
@@ -249,10 +249,12 @@ class WriteMixin:
                 # https://github.com/python/mypy/issues/12933
                 self.dg.help(cast(type, arg))
             elif hasattr(arg, "_repr_html_"):
-                self.dg.markdown(
-                    arg._repr_html_(),
-                    unsafe_allow_html=True,
+                repr_html = arg._repr_html_()
+                unsafe_allow_html = unsafe_allow_html or probably_contains_html_tags(
+                    repr_html
                 )
+
+                self.dg.markdown(repr_html, unsafe_allow_html=unsafe_allow_html)
             else:
                 stringified_arg = str(arg)
 

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -126,3 +126,14 @@ def is_mem_address_str(string):
         return True
 
     return False
+
+
+_RE_CONTAINS_HTML = re.compile(r"(?:</[^<]+>)|(?:<[^<]+/>)")
+
+
+def probably_contains_html_tags(s: str) -> bool:
+    """Returns True if the given string contains what seem to be HTML tags.
+
+    Note that false positives/negatives are possible, so this function should not be
+    used in contexts where complete correctness is required."""
+    return bool(_RE_CONTAINS_HTML.search(s))

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -78,3 +78,19 @@ class StringUtilTest(unittest.TestCase):
         self.assertEqual(string_util.simplify_number(1000000000), "1b")
 
         self.assertEqual(string_util.simplify_number(1000000000000), "1t")
+
+    @parameterized.expand(
+        [
+            # Correctly identified as containing HTML tags.
+            ("<br/>", True),
+            ("<p>foo</p>", True),
+            ("bar <div>baz</div>", True),
+            # Correctly identified as not containing HTML tags.
+            ("Hello, World", False),  # No HTML tags
+            ("<a>", False),  # No closing tag
+            ("<<a>>", False),  # Malformatted tag
+            ("a < 3 && b > 3", False),  # Easily mistaken for a tag by more naive regex
+        ]
+    )
+    def test_probably_contains_html_tags(self, text, expected):
+        self.assertEqual(string_util.probably_contains_html_tags(text), expected)

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -56,6 +56,20 @@ class StreamlitWriteTest(unittest.TestCase):
                 "<strong>hello world</strong>", unsafe_allow_html=True
             )
 
+    def test_repr_html_no_html_tags_in_string(self):
+        """Test st.write with an object that defines _repr_html_ but does not have any
+        html tags in the returned string.
+        """
+
+        class FakeHTMLable(object):
+            def _repr_html_(self):
+                return "hello **world**"
+
+        with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:
+            st.write(FakeHTMLable())
+
+            p.assert_called_once_with("hello **world**", unsafe_allow_html=False)
+
     def test_string(self):
         """Test st.write with a string."""
         with patch("streamlit.delta_generator.DeltaGenerator.markdown") as p:


### PR DESCRIPTION
NOTE: This PR contains work mostly related to `feature/st.connection_GA`, but there's no reason not to
merge it straight into `develop`.

---

The default connections that we ship with the streamlit library define a `_repr_html_` method, but the
methods themselves return markdown instead of HTML both for conciseness and because avoiding
usage of `unsafe_allow_html` when possible is a good idea.

This PR teaches the `st.write` function to avoid using `unsafe_allow_html` when the return value of an object's
`_repr_html_` doesn't seem to contain any HTML tags.