### PR TITLE
Upgrade pillow to 10.0.1 to fix SNYK-PYTHON-PILLOW-5918878.

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = [
     "packaging>=16.8, <24",
     # Lowest version with available wheel for 3.7 + amd64 + linux
     "pandas>=1.3.0, <3",
-    "pillow>=7.1.0, <10",
+    "pillow>=10.0.1",
     # Python protobuf 4.21 (the first 4.x version) is compatible with protobufs
     # generated from `protoc` >= 3.20. (`protoc` is installed separately from the Python
     # protobuf package, so this pin doesn't actually enforce a `protoc` minimum version.


### PR DESCRIPTION
⚠️ Dependent on #7437.

This is my first PR against this repository, I hope I have done everything properly. I'm not sure how to deal with the upgrade to the constraints files vs the upgrade to `setup.py` in this repository. Guidance would be appreciated!

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Upgrade pillow to [10.0.1](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html) to fix SNYK-PYTHON-PILLOW-5918878. More context is available in #7434 which failed. I'm hoping that a combination of #7437 and this PR will fix things because `make pytest` passes on my local machine when using 10.0.1

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
