### PR TITLE
Fix: Foreign language anchors

### DIFF
--- a/e2e/scripts/st_title.py
+++ b/e2e/scripts/st_title.py
@@ -16,3 +16,6 @@ import streamlit as st
 
 st.title("This title is awesome!")
 st.title("This title is awesome too!", anchor="awesome-title")
+
+st.title("日本語タイトル")
+st.title("その他の邦題", anchor="アンカー")

--- a/e2e/specs/st_title.spec.js
+++ b/e2e/specs/st_title.spec.js
@@ -19,14 +19,17 @@ describe("st.title", () => {
     cy.loadApp("http://localhost:3000/");
   });
 
-  it("displays correct number of elements", () => {
-    cy.get(".element-container .stMarkdown h1").should("have.length", 2);
+  it("displays correct number of elements & anchor links", () => {
+    cy.get(".element-container .stMarkdown h1").should("have.length", 4);
+    cy.get(".element-container .stMarkdown h1 a").should("have.length", 4);
   });
 
   it("displays a title", () => {
     cy.get(".element-container .stMarkdown h1").then(els => {
       expect(els[0].textContent).to.eq("This title is awesome!");
       expect(els[1].textContent).to.eq("This title is awesome too!");
+      expect(els[2].textContent).to.eq("日本語タイトル");
+      expect(els[3].textContent).to.eq("その他の邦題");
     });
   });
 
@@ -34,6 +37,8 @@ describe("st.title", () => {
     cy.get(".element-container .stMarkdown h1").then(els => {
       cy.wrap(els[0]).should("have.attr", "id", "this-title-is-awesome");
       cy.wrap(els[1]).should("have.attr", "id", "awesome-title");
+      cy.wrap(els[2]).should("have.attr", "id", "d3b04b7a");
+      cy.wrap(els[3]).should("have.attr", "id", "アンカー");
     });
   });
 });

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -103,7 +103,7 @@ export interface Props {
 export function createAnchorFromText(text: string | null): string {
   const newAnchor = text
     ?.toLowerCase()
-    .split(/[^A-Za-z0-9]/)
+    .split(/[^\p{L}\p{N}]+/gu) // split on non-alphanumeric characters across languages
     .filter(Boolean)
     .join("-")
   return newAnchor || ""

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -114,8 +114,7 @@ export function createAnchorFromText(text: string | null): string {
       .join("-")
   } else if (text) {
     // if the text is not valid ASCII, use a hash of the text
-    const firstWord = text.split(" ")[0]
-    newAnchor = xxhash.h32(firstWord, 0xabcd).toString(16)
+    newAnchor = xxhash.h32(text, 0xabcd).toString(16)
   }
   return newAnchor
 }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -110,7 +110,7 @@ export function createAnchorFromText(text: string | null): string {
     newAnchor = text
       ?.toLowerCase()
       .split(/[^\p{L}\p{N}]+/gu) // split on non-alphanumeric characters
-      .filter(Boolean)
+      .filter(Boolean) // filter out falsy values using Boolean constructor
       .join("-")
   } else if (text) {
     // if the text is not valid ASCII, use a hash of the text


### PR DESCRIPTION
## Describe your changes
Anchor Links for `st.title`, `st.header`, `st.subheader` are not generated for some foreign languages due to our current Regex matcher (A-Z, 0-9). Additionally, anchor functionality for non-ASCII characters in browsers is [limited](https://www.w3.org/TR/PR-html40-971107/struct/links.html#h-12.2.1), so added check - if anchor is valid ASCII characters, use that, otherwise hash the text into ASCII characters. 

Anchor will now work as follows:
- Anchor param provided? will use that (whether valid ASCII characters or not)
- No Anchor provided? will create anchor from the heading text (if valid ASCII characters), otherwise hash the text into ASCII characters to create the anchor.

## GitHub Issue Link (if applicable)
Closes #5291 

## Testing Plan
- E2E Tests ✅ 
- Manual Testing ✅ 