### PR TITLE
Use Mapping instead of Dict in for column config mapping

### DIFF
--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -382,7 +382,7 @@ def determine_dataframe_schema(
 
 
 # A mapping of column names/IDs to column configs.
-ColumnConfigMapping: TypeAlias = Mapping[Union[IndexIdentifierType, str], ColumnConfig]
+ColumnConfigMapping: TypeAlias = Dict[Union[IndexIdentifierType, str], ColumnConfig]
 ColumnConfigMappingInput: TypeAlias = Mapping[
     Union[IndexIdentifierType, str],
     Union[ColumnConfig, None, str],

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Mapping, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -382,8 +382,8 @@ def determine_dataframe_schema(
 
 
 # A mapping of column names/IDs to column configs.
-ColumnConfigMapping: TypeAlias = Dict[Union[IndexIdentifierType, str], ColumnConfig]
-ColumnConfigMappingInput: TypeAlias = Dict[
+ColumnConfigMapping: TypeAlias = Mapping[Union[IndexIdentifierType, str], ColumnConfig]
+ColumnConfigMappingInput: TypeAlias = Mapping[
     Union[IndexIdentifierType, str],
     Union[ColumnConfig, None, str],
 ]


### PR DESCRIPTION
## Describe your changes

Used type `Mapping` for mapping in the column config.

This should fix the following mypy error when using a column config:

```
error: Argument "column_config" has incompatible type "Dict[str, Optional[ColumnConfig]]"; expected "Optional[Dict[Union[Literal['_index'], str], Union[ColumnConfig, None, str]]]"  [arg-type]
note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
note: Consider using "Mapping" instead, which is covariant in the value type
```

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
