### PR TITLE
Fix vertical button regression in toolbar actions

### DIFF
--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
@@ -74,6 +74,11 @@ describe("ToolbarActions", () => {
     expect(screen.getByTestId("stToolbarActions")).toBeInTheDocument()
   })
 
+  it("renders toolbar actions and renders action buttons horizontally", () => {
+    render(<ToolbarActions {...getProps()} />)
+    expect(screen.getByTestId("stToolbarActions")).toHaveStyle("display: flex")
+  })
+
   it("calls sendMessageToHost with correct args when clicked", () => {
     const props = getProps()
     render(<ToolbarActions {...props} />)

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
@@ -25,6 +25,7 @@ import {
 import {
   StyledActionButtonContainer,
   StyledActionButtonIcon,
+  StyledToolbarActions,
 } from "./styled-components"
 
 export interface ActionButtonProps {
@@ -65,7 +66,7 @@ function ToolbarActions({
   hostToolbarItems,
 }: ToolbarActionsProps): ReactElement {
   return (
-    <div data-testid="stToolbarActions" style={{ display: "flex" }}>
+    <StyledToolbarActions data-testid="stToolbarActions">
       {hostToolbarItems.map(({ key, label, icon }) => (
         <ActionButton
           key={key}
@@ -79,7 +80,7 @@ function ToolbarActions({
           }
         />
       ))}
-    </div>
+    </StyledToolbarActions>
   )
 }
 

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
@@ -65,7 +65,7 @@ function ToolbarActions({
   hostToolbarItems,
 }: ToolbarActionsProps): ReactElement {
   return (
-    <div data-testid="stToolbarActions">
+    <div data-testid="stToolbarActions" style={{ display: "flex" }}>
       {hostToolbarItems.map(({ key, label, icon }) => (
         <ActionButton
           key={key}

--- a/frontend/app/src/components/ToolbarActions/styled-components.ts
+++ b/frontend/app/src/components/ToolbarActions/styled-components.ts
@@ -39,3 +39,9 @@ export const StyledActionButtonIcon = styled.div<StyledActionButtonIconProps>(
     height: "1rem",
   })
 )
+
+export const StyledToolbarActions = styled.div(({}) => ({
+  display: "flex",
+  alignItems: "center",
+  flexDirection: "row",
+}))


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- add display: flex in order to make the buttons appear horizontally
## GitHub Issue Link (if applicable)
Closes #7471 
## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - added a unit test to make sure the style is there
- E2E Tests
  - I'm not sure how to add e2e tests for this because there is no `st.toolbar_actions` as it needs to receive a hostCommunication message
- Any manual testing needed?
  - yes, screenshots attached
  - 
<img width="1728" alt="Screenshot 2023-10-02 at 10 06 51 AM" src="https://github.com/streamlit/streamlit/assets/16749069/dff2835c-362d-4eaa-8bb3-52c5c7e7a6a6">
<img width="1728" alt="Screenshot 2023-10-02 at 9 47 56 AM" src="https://github.com/streamlit/streamlit/assets/16749069/6d724818-3171-4bac-93a3-4dbedaf9b697">


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
