### PR TITLE
fixes pandas is_categorical_dtype deprecation warning

### DIFF
--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -330,7 +330,7 @@ def _determine_data_kind(
         The data kind of the column.
     """
 
-    if pd.api.types.is_categorical_dtype(column.dtype):
+    if isinstance(column.dtype, pd.CategoricalDtype):
         # Categorical columns can have different underlying data kinds
         # depending on the categories.
         return _determine_data_kind_via_inferred_type(column.dtype.categories)


### PR DESCRIPTION
## Describe your changes
Fixes this warning from pandas
```sh
streamlit/elements/lib/column_config_utils.py:333: 
FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version.
Use isinstance(dtype, CategoricalDtype) instead
```
## GitHub Issue Link (if applicable)
N/A
Haven't created one since it was just an one liner fix. Please let me know if that is absolutely necessary here.

## Testing Plan

N/A
Since this fixes an warning to a dependent library, I feel no streamlit specific testing is required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
