### PR TITLE
Better input/output visibility in Langchain callback

### DIFF
--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -199,6 +199,7 @@ class LLMThought:
             label=self._labeler.get_tool_label(self._last_tool, is_complete=False),
             state="running",
         )
+        self._container.markdown(f"Input:\n\n{input_str}")
 
     def on_tool_end(
         self,
@@ -208,7 +209,7 @@ class LLMThought:
         llm_prefix: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
-        self._container.markdown(output)
+        self._container.markdown(f"\n\nOutput:{output}")
 
     def on_tool_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
         self._container.markdown("**Tool encountered an error...**")

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -200,6 +200,7 @@ class LLMThought:
             state="running",
         )
         if len(input_str) > MAX_TOOL_INPUT_STR_LENGTH:
+            # output is printed later in on_tool_end
             self._container.markdown(f"**Input:**\n\n{input_str}\n\n**Output:**")
 
     def on_tool_end(

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -31,12 +31,13 @@ the API *from LangChain itself*.
 
 from __future__ import annotations
 
-from enum import Enum
 import time
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AgentFinish, LLMResult
+
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -209,7 +209,7 @@ class LLMThought:
         llm_prefix: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
-        self._container.markdown(f"\n\nOutput:{output}")
+        self._container.markdown(f"Output:\n\n{output}")
 
     def on_tool_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
         self._container.markdown("**Tool encountered an error...**")

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -31,13 +31,12 @@ the API *from LangChain itself*.
 
 from __future__ import annotations
 
-import time
 from enum import Enum
+import time
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AgentFinish, LLMResult
-
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
@@ -199,7 +198,8 @@ class LLMThought:
             label=self._labeler.get_tool_label(self._last_tool, is_complete=False),
             state="running",
         )
-        self._container.markdown(f"Input:\n\n{input_str}")
+        if len(input_str) > MAX_TOOL_INPUT_STR_LENGTH:
+            self._container.markdown(f"**Input:**\n\n{input_str}\n\n**Output:**")
 
     def on_tool_end(
         self,
@@ -209,7 +209,7 @@ class LLMThought:
         llm_prefix: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
-        self._container.markdown(f"Output:\n\n{output}")
+        self._container.markdown(output)
 
     def on_tool_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
         self._container.markdown("**Tool encountered an error...**")


### PR DESCRIPTION
Show long inputs under the cut:
<img width="669" alt="image" src="https://github.com/streamlit/streamlit/assets/18504735/57f1fdbe-6d20-43ed-94e5-c2ca15273ec8">

