### PR TITLE
Remove outdated pandas version checks

### DIFF
--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -65,13 +65,7 @@ def _marshall_styler(proto, styler, default_uuid):
     # which is non-ideal and could break if Styler's interface changes.
     styler._compute()
 
-    # In Pandas 1.3.0, styler._translate() signature was changed.
-    # 2 arguments were added: sparse_index and sparse_columns.
-    # The functionality that they provide is not yet supported.
-    if type_util.is_pandas_version_less_than("1.3.0"):
-        pandas_styles = styler._translate()
-    else:
-        pandas_styles = styler._translate(False, False)
+    pandas_styles = styler._translate(False, False)
 
     _marshall_caption(proto, styler)
     _marshall_styles(proto, styler, pandas_styles)
@@ -190,16 +184,6 @@ def _pandas_style_to_css(style_type, style, uuid, separator=""):
 
     table_selector = "#T_" + str(uuid)
 
-    # In pandas < 1.1.0
-    # translated_style["cellstyle"] has the following shape:
-    # [
-    #   {
-    #       "props": [["color", " black"], ["background-color", "orange"], ["", ""]],
-    #       "selector": "row0_col0"
-    #   }
-    #   ...
-    # ]
-    #
     # In pandas >= 1.1.0
     # translated_style["cellstyle"] has the following shape:
     # [
@@ -209,9 +193,7 @@ def _pandas_style_to_css(style_type, style, uuid, separator=""):
     #   }
     #   ...
     # ]
-    if style_type == "table_styles" or (
-        style_type == "cell_style" and type_util.is_pandas_version_less_than("1.1.0")
-    ):
+    if style_type == "table_styles":
         cell_selectors = [style["selector"]]
     else:
         cell_selectors = style["selectors"]

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -45,13 +45,7 @@ def marshall_styler(proto: ArrowProto, styler: "Styler", default_uuid: str) -> N
     # which is not ideal and could break if the interface changes.
     styler._compute()
 
-    # In Pandas 1.3.0, styler._translate() signature was changed.
-    # 2 arguments were added: sparse_index and sparse_columns.
-    # The functionality that they provide is not yet supported.
-    if type_util.is_pandas_version_less_than("1.3.0"):
-        pandas_styles = styler._translate()
-    else:
-        pandas_styles = styler._translate(False, False)
+    pandas_styles = styler._translate(False, False)
 
     _marshall_caption(proto, styler)
     _marshall_styles(proto, styler, pandas_styles)
@@ -184,16 +178,6 @@ def _pandas_style_to_css(
 
     table_selector = f"#T_{uuid}"
 
-    # In pandas < 1.1.0
-    # translated_style["cellstyle"] has the following shape:
-    # [
-    #   {
-    #       "props": [["color", " black"], ["background-color", "orange"], ["", ""]],
-    #       "selector": "row0_col0"
-    #   }
-    #   ...
-    # ]
-    #
     # In pandas >= 1.1.0
     # translated_style["cellstyle"] has the following shape:
     # [
@@ -203,9 +187,7 @@ def _pandas_style_to_css(
     #   }
     #   ...
     # ]
-    if style_type == "table_styles" or (
-        style_type == "cell_style" and type_util.is_pandas_version_less_than("1.1.0")
-    ):
+    if style_type == "table_styles":
         cell_selectors = [style["selector"]]
     else:
         cell_selectors = style["selectors"]

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -21,22 +21,13 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest as pytest
+from pandas.io.formats.style_render import StylerRenderer as Styler
 
 import streamlit as st
 from streamlit.elements.lib.column_config_utils import INDEX_IDENTIFIER
-from streamlit.type_util import (
-    bytes_to_data_frame,
-    is_pandas_version_less_than,
-    pyarrow_table_to_bytes,
-)
+from streamlit.type_util import bytes_to_data_frame, pyarrow_table_to_bytes
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.testutil import create_snowpark_session
-
-# In Pandas 1.3.0, Styler functionality was moved under StylerRenderer.
-if is_pandas_version_less_than("1.3.0"):
-    from pandas.io.formats.style import Styler
-else:
-    from pandas.io.formats.style_render import StylerRenderer as Styler
 
 
 def mock_data_frame():

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -153,19 +153,6 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.type_util.is_pandas_version_less_than",
-        MagicMock(return_value=True),
-    )
-    @patch.object(Styler, "_translate")
-    def test_pandas_version_below_1_3_0(self, mock_styler_translate):
-        """Tests that `styler._translate` is called without arguments in Pandas < 1.3.0"""
-        df = mock_data_frame()
-        styler = df.style.set_uuid("FAKE_UUID")
-
-        st.dataframe(styler)
-        mock_styler_translate.assert_called_once_with()
-
-    @patch(
-        "streamlit.type_util.is_pandas_version_less_than",
         MagicMock(return_value=False),
     )
     @patch.object(Styler, "_translate")

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -116,19 +116,6 @@ class ArrowTest(DeltaGeneratorTestCase):
 
     @patch(
         "streamlit.type_util.is_pandas_version_less_than",
-        MagicMock(return_value=True),
-    )
-    @patch.object(Styler, "_translate")
-    def test_pandas_version_below_1_3_0(self, mock_styler_translate):
-        """Tests that `styler._translate` is called without arguments in Pandas < 1.3.0"""
-        df = mock_data_frame()
-        styler = df.style.set_uuid("FAKE_UUID")
-
-        st.table(styler)
-        mock_styler_translate.assert_called_once_with()
-
-    @patch(
-        "streamlit.type_util.is_pandas_version_less_than",
         MagicMock(return_value=False),
     )
     @patch.object(Styler, "_translate")

--- a/lib/tests/streamlit/elements/arrow_table_test.py
+++ b/lib/tests/streamlit/elements/arrow_table_test.py
@@ -19,20 +19,11 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+from pandas.io.formats.style_render import StylerRenderer as Styler
 
 import streamlit as st
-from streamlit.type_util import (
-    bytes_to_data_frame,
-    is_pandas_version_less_than,
-    pyarrow_table_to_bytes,
-)
+from streamlit.type_util import bytes_to_data_frame, pyarrow_table_to_bytes
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
-
-# In Pandas 1.3.0, Styler functionality was moved under StylerRenderer.
-if is_pandas_version_less_than("1.3.0"):
-    from pandas.io.formats.style import Styler
-else:
-    from pandas.io.formats.style_render import StylerRenderer as Styler
 
 
 def mock_data_frame():


### PR DESCRIPTION
## Describe your changes

This PR removes a couple of outdated pandas version checks, which are not required anymore since our minimum required version is `1.13`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
