### PR TITLE
Configure non-range indices as required for editing with `st.data_editor`

### DIFF
--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -508,6 +508,11 @@ def apply_data_specific_configs(
         # We rename it to "value" in selected cases to make it more descriptive
         data_df.rename(columns={0: "value"}, inplace=True)
 
+    if not isinstance(data_df.index, pd.RangeIndex):
+        # If the index is not a range index, we will configure it as required
+        # since the user is required to provide a (unique) value for editing.
+        update_column_config(columns_config, INDEX_IDENTIFIER, {"required": True})
+
 
 def marshall_column_config(
     proto: ArrowProto, column_config_mapping: ColumnConfigMapping

--- a/lib/tests/streamlit/elements/lib/column_config_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/column_config_utils_test.py
@@ -491,6 +491,19 @@ class ColumnConfigUtilsTest(unittest.TestCase):
         else:
             self.assertNotIn(INDEX_IDENTIFIER, columns_config)
 
+    def test_apply_data_specific_configs_makes_index_required(self):
+        """Test that a non-range index gets configured as required."""
+        columns_config: ColumnConfigMapping = {}
+        data_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=["a", "b", "c"])
+        apply_data_specific_configs(
+            columns_config, data_df, DataFormat.PANDAS_DATAFRAME
+        )
+        self.assertEqual(
+            columns_config[INDEX_IDENTIFIER]["required"],
+            True,
+            f"Index of type {type(data_df.index)} should be configured as required.",
+        )
+
     @parameterized.expand(
         [
             (DataFormat.SET_OF_VALUES, True),


### PR DESCRIPTION
## Describe your changes

This PR adds logic to configure non-range indices as `required` automatically. Non-range indices need a value from the user for a row to be added correctly. Therefore, we automatically apply the `required` configuration for these columns to make this more obvious.

## GitHub Issue Link (if applicable)

- Closes #6995

## Testing Plan

- Added test. Additional e2e tests will be added in a subsequent PR.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
