### PR TITLE
Added permission to use Clipboard API in IFrame

### DIFF
--- a/frontend/lib/src/util/IFrameUtil.ts
+++ b/frontend/lib/src/util/IFrameUtil.ts
@@ -96,9 +96,6 @@ export const DEFAULT_IFRAME_FEATURE_POLICY = [
   // Controls whether the current document is allowed to use video input devices. When this policy is disabled, the Promise returned by getUserMedia() will reject with a NotAllowedError DOMException.
   "camera",
 
-  // Controls whether the current document is allowed to read from the clipboard. When this policy is disabled, attempts to read from the clipboard will be rejected.
-  "clipboard-read",
-
   // Controls whether the current document is allowed to write to the clipboard. When this policy is disabled, attempts to write to the clipboard will be rejected.
   "clipboard-write",
 

--- a/frontend/lib/src/util/IFrameUtil.ts
+++ b/frontend/lib/src/util/IFrameUtil.ts
@@ -96,6 +96,12 @@ export const DEFAULT_IFRAME_FEATURE_POLICY = [
   // Controls whether the current document is allowed to use video input devices. When this policy is disabled, the Promise returned by getUserMedia() will reject with a NotAllowedError DOMException.
   "camera",
 
+  // Controls whether the current document is allowed to read from the clipboard. When this policy is disabled, attempts to read from the clipboard will be rejected.
+  "clipboard-read",
+
+  // Controls whether the current document is allowed to write to the clipboard. When this policy is disabled, attempts to write to the clipboard will be rejected.
+  "clipboard-write",
+
   // Controls whether or not the current document is permitted to use the getDisplayMedia() method to capture screen contents. When this policy is disabled, the promise returned by getDisplayMedia() will reject with a NotAllowedError if permission is not obtained to capture the display's contents.
   // "display-capture",
 


### PR DESCRIPTION
## Added clipboard allow permissions to the IFrame properties.

## [Github Issue Link](https://github.com/streamlit/streamlit/issues/7347)

## Follow below steps to reproduce this issue and test after these changes.
- create a react component with a simple button element and call navigator.clipboard.writeText(text)
- render this react component within streamlit application.
- you will encounter following error on the browser, and copy function would be rejected.
`Uncaught (in promise) DOMException: The Clipboard API has been blocked because of a permissions policy applied to the current document. See https://goo.gl/EuHzyv for more details.`
- After adding permissions (we have added in this PR) issue will be resolved.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
