### PR TITLE
another attempt to fix flaky camera_input

### DIFF
--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -43,12 +43,14 @@ describe("st.camera_input", () => {
     cy.get("[data-testid='stCameraInputButton']")
       .should("have.length.at.least", 2)
       .first()
-      .wait(1000)
+      .should("not.be.disabled")
+
+    cy.wait(2000)
+
+    cy.getIndexed("[data-testid='stCameraInputButton']", 0)
       .should("not.be.disabled")
       .contains("Take Photo")
       .click({force: true});
-
-    cy.get("img", {timeout}).should("have.length.at.least", 2);
 
     cy.get("[data-testid='stImage']", {timeout}).should("have.length.at.least", 1);
   });

--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -45,6 +45,8 @@ describe("st.camera_input", () => {
       .first()
       .should("not.be.disabled")
 
+    // Wait until the camera is ready, there some delay even between
+    // `onUserMedia` event and camera is ready.
     cy.wait(2000)
 
     cy.getIndexed("[data-testid='stCameraInputButton']", 0)


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Remove unnecessary img  selector (it anyway selects additional elements), use `getIndexed`, and wait for active `Take Photo` for two seconds instead of one second.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
