### PR TITLE
Fix pandas 2.1 deprecation warnings

### DIFF
--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -224,10 +224,10 @@ def _determine_data_kind_via_pandas_dtype(
     if pd.api.types.is_timedelta64_dtype(column_dtype):
         return ColumnDataKind.TIMEDELTA
 
-    if pd.api.types.is_period_dtype(column_dtype):
+    if isinstance(column_dtype, pd.PeriodDtype):
         return ColumnDataKind.PERIOD
 
-    if pd.api.types.is_interval_dtype(column_dtype):
+    if isinstance(column_dtype, pd.IntervalDtype):
         return ColumnDataKind.INTERVAL
 
     if pd.api.types.is_complex_dtype(column_dtype):


### PR DESCRIPTION
## Describe your changes

In addition to https://github.com/streamlit/streamlit/pull/7477, two other functions got we are using also deprecated in Pandas `2.1`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
