### PR TITLE
Add user-friendly exception if dataframe exceeds max config of Pandas Styler

### DIFF
--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -252,7 +252,7 @@ def _use_display_values(df: pd.DataFrame, styles: Mapping[str, Any]) -> pd.DataF
     # If values in a column are not of the same type, Arrow
     # serialization would fail. Thus, we need to cast all values
     # of the dataframe to strings before assigning them display values.
-    new_df = df.astype("string").applymap(lambda x: None)
+    new_df = df.astype(str)
 
     cell_selector_regex = re.compile(r"row(\d+)_col(\d+)")
     if "body" in styles:

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -14,9 +14,10 @@
 
 from typing import TYPE_CHECKING, Any, List, Mapping, TypeVar
 
-from pandas import DataFrame
+import pandas as pd
 
 from streamlit import type_util
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 
 if TYPE_CHECKING:
@@ -38,6 +39,16 @@ def marshall_styler(proto: ArrowProto, styler: "Styler", default_uuid: str) -> N
         If pandas.Styler uuid is not provided, this value will be used.
 
     """
+    styler_data_df: pd.DataFrame = styler.data
+    if styler_data_df.size > int(pd.options.styler.render.max_elements):
+        raise StreamlitAPIException(
+            f"The dataframe has `{styler_data_df.size}` cells, but the maximum number "
+            "of cells allowed to be rendered by Pandas Styler is configured to "
+            f"`{pd.options.styler.render.max_elements}`. To allow more cells to be "
+            'styled, you can change the `"styler.render.max_elements"` config. For example: '
+            f'`pd.set_option("styler.render.max_elements", {styler_data_df.size})`'
+        )
+
     # pandas.Styler uuid should be set before _compute is called.
     _marshall_uuid(proto, styler, default_uuid)
 
@@ -49,7 +60,7 @@ def marshall_styler(proto: ArrowProto, styler: "Styler", default_uuid: str) -> N
 
     _marshall_caption(proto, styler)
     _marshall_styles(proto, styler, pandas_styles)
-    _marshall_display_values(proto, styler.data, pandas_styles)
+    _marshall_display_values(proto, styler_data_df, pandas_styles)
 
 
 def _marshall_uuid(proto: ArrowProto, styler: "Styler", default_uuid: str) -> None:
@@ -204,7 +215,7 @@ def _pandas_style_to_css(
 
 
 def _marshall_display_values(
-    proto: ArrowProto, df: DataFrame, styles: Mapping[str, Any]
+    proto: ArrowProto, df: pd.DataFrame, styles: Mapping[str, Any]
 ) -> None:
     """Marshall pandas.Styler display values into an Arrow proto.
 
@@ -224,7 +235,7 @@ def _marshall_display_values(
     proto.styler.display_values = type_util.data_frame_to_bytes(new_df)
 
 
-def _use_display_values(df: DataFrame, styles: Mapping[str, Any]) -> DataFrame:
+def _use_display_values(df: pd.DataFrame, styles: Mapping[str, Any]) -> pd.DataFrame:
     """Create a new pandas.DataFrame where display values are used instead of original ones.
 
     Parameters
@@ -241,16 +252,16 @@ def _use_display_values(df: DataFrame, styles: Mapping[str, Any]) -> DataFrame:
     # If values in a column are not of the same type, Arrow
     # serialization would fail. Thus, we need to cast all values
     # of the dataframe to strings before assigning them display values.
-    new_df = df.astype(str)
+    new_df = df.astype("string").applymap(lambda x: None)
 
     cell_selector_regex = re.compile(r"row(\d+)_col(\d+)")
     if "body" in styles:
         rows = styles["body"]
         for row in rows:
             for cell in row:
-                match = cell_selector_regex.match(cell["id"])
-                if match:
-                    r, c = map(int, match.groups())
-                    new_df.iat[r, c] = str(cell["display_value"])
+                if "id" in cell:
+                    if match := cell_selector_regex.match(cell["id"]):
+                        r, c = map(int, match.groups())
+                        new_df.iat[r, c] = str(cell["display_value"])
 
     return new_df


### PR DESCRIPTION
## Describe your changes

Pandas Styler has a global configuration that defines the maximum number of elements allowed to be rendered/processed. As described in #5953, if the underlying dataframe exceeds this configuration, an indescriptive `KeyError` will be thrown. This PR adds a more user-friendly error message if the dataframe exceeds the configured maximum with a workaround to resolve the issue:

<img width="692" alt="image" src="https://github.com/streamlit/streamlit/assets/2852129/e5f6263a-82ae-4e70-9418-9759658090f5">

## GitHub Issue Link (if applicable)

- Closes #5953

## Testing Plan

- Added unit test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
