### PR TITLE
[WIP] Add support for formatting the display value of `LinkColumn` via Pandas Styler

### DIFF
--- a/e2e_playwright/st_dataframe_styler_support.py
+++ b/e2e_playwright/st_dataframe_styler_support.py
@@ -36,7 +36,7 @@ def highlight_first(value):
 
 
 df = pd.DataFrame(np.arange(0, 100, 1).reshape(10, 10))
-st.dataframe(df.style.applymap(highlight_first))
+st.dataframe(df.style.map(highlight_first))
 
 st.header("Pandas Styler: Background and font styling")
 
@@ -52,7 +52,7 @@ def highlight_max(s, props=""):
 
 
 # Passing style values w/ all color formats to test css-style-string parsing robustness.
-styled_df = df.style.applymap(style_negative, props="color:#FF0000;").applymap(
+styled_df = df.style.map(style_negative, props="color:#FF0000;").map(
     lambda v: "opacity: 20%;" if (v < 0.3) and (v > -0.3) else None
 )
 
@@ -94,7 +94,7 @@ styled_df = weather_df.style.pipe(make_pretty)
 
 st.dataframe(styled_df)
 
-st.header("Styled link column")
+st.header("LinkColumn with display value:")
 st.dataframe(
     pd.DataFrame(
         {

--- a/e2e_playwright/st_dataframe_styler_support.py
+++ b/e2e_playwright/st_dataframe_styler_support.py
@@ -93,3 +93,18 @@ def make_pretty(styler):
 styled_df = weather_df.style.pipe(make_pretty)
 
 st.dataframe(styled_df)
+
+st.header("Styled link column")
+st.dataframe(
+    pd.DataFrame(
+        {
+            "col_0": [
+                "https://streamlit.io",
+                "https://docs.streamlit.io",
+                "https://streamlit.io/gallery",
+                None,
+            ]
+        }
+    ).style.format(lambda url: url.replace("https://", "") if url else ""),
+    column_config={"col_0": st.column_config.LinkColumn()},
+)

--- a/frontend/lib/src/components/widgets/DataFrame/arrowUtils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/arrowUtils.ts
@@ -20,6 +20,7 @@ import {
   TextCell,
   NumberCell,
   GridCellKind,
+  UriCell,
 } from "@glideapps/glide-data-grid"
 import { DatePickerType } from "@glideapps/glide-data-grid-cells"
 import moment from "moment"
@@ -411,6 +412,11 @@ export function getCellFromArrow(
           ...cellTemplate,
           displayData,
         } as NumberCell
+      } else if (cellTemplate.kind === GridCellKind.Uri) {
+        cellTemplate = {
+          ...cellTemplate,
+          displayData,
+        } as UriCell
       } else if (
         cellTemplate.kind === GridCellKind.Custom &&
         (cellTemplate as DatePickerType).data?.kind === "date-picker-cell"

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -60,6 +60,7 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
   const cellTemplate = {
     kind: GridCellKind.Uri,
     data: "",
+    displayData: undefined,
     readonly: !props.isEditable,
     allowOverlay: true,
     contentAlign: props.contentAlignment,


### PR DESCRIPTION
## Describe your changes

This PR adds support for formatting the display value of link columns via Pandas Styler. E.g.:

```python
st.dataframe(
    pd.DataFrame(
        {
            "col_0": [
                "https://streamlit.io",
                "https://docs.streamlit.io",
                "https://streamlit.io/gallery",
                None,
            ]
        }
    ).style.format(lambda url: url.replace("https://", "") if url else ""),
    column_config={"col_0": st.column_config.LinkColumn()},
)
```

## GitHub Issue Link (if applicable)

It could help in some scenarios that are discussed in #6787. But resolving this with proper column config features is preferred. 

## Testing Plan

- Added snapshot test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
