### PR TITLE
Only use get_active_session when running in SiS

### DIFF
--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -67,6 +67,15 @@ def _load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
     return conn_params
 
 
+def _running_in_sis() -> bool:
+    import snowflake.connector.connection  # type: ignore
+
+    # snowflake.connector.connection.SnowflakeConnection does not exist inside a Stored
+    # Proc or Streamlit. It is only part of the external package. So this returns true
+    # only in SiS.
+    return not hasattr(snowflake.connector.connection, "SnowflakeConnection")
+
+
 class SnowparkConnection(ExperimentalBaseConnection["Session"]):
     """A connection to Snowpark using snowflake.snowpark.session.Session. Initialize using
     ``st.experimental_connection("<name>", type="snowpark")``.
@@ -93,13 +102,10 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
         )
         from snowflake.snowpark.session import Session
 
-        # If we're in a runtime environment where there's already an active session
-        # available, we just use that one. Otherwise, we fall back to attempting to
-        # create a new one from whatever credentials we have available.
-        try:
+        # If we're running in SiS, just call get_active_session(). Otherwise, attempt to
+        # create a new session from whatever credentials we have available.
+        if _running_in_sis():
             return get_active_session()
-        except SnowparkSessionException:
-            pass
 
         conn_params = ChainMap(
             kwargs,

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -83,7 +83,11 @@ schemaname = public
         "snowflake.snowpark.context.get_active_session",
         MagicMock(return_value="some active session"),
     )
-    def test_just_uses_current_active_session_if_available(self):
+    @patch(
+        "streamlit.connections.snowpark_connection._running_in_sis",
+        MagicMock(return_value=True),
+    )
+    def test_uses_active_session_if_in_sis(self):
         conn = SnowparkConnection("my_snowpark_connection")
         assert conn._instance == "some active session"
 


### PR DESCRIPTION
NOTE: This work is related to `feature/st.connection_GA` but can be merged straight into `develop`.