### PR TITLE
[WIP] Lower number of playwright workers to 12

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,6 +50,8 @@ jobs:
         run: make frontend-fast
       - name: Run make playwright
         run: make playwright
+        env:
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 12
       - name: Check that all screenshot have been committed
         run: |
           set -x;


### PR DESCRIPTION
## Describe your changes

This PR lowers the number of playwright workers to 12 as a potential quick fix for the flakiness caused by randomly dying Streamlit servers.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
