### PR TITLE
Call matplotlib crash fix for scripts run in tests

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -64,8 +64,11 @@ from streamlit.testing.v1.element_tree import (
 )
 from streamlit.testing.v1.local_script_runner import LocalScriptRunner
 from streamlit.testing.v1.util import patch_config_options
+from streamlit.web.bootstrap import _fix_matplotlib_crash
 
 TMP_DIR = tempfile.TemporaryDirectory()
+
+_fix_matplotlib_crash()
 
 
 class AppTest:


### PR DESCRIPTION

## Describe your changes
Apply the matplotlib crash fix when loading test module, so scripts that rely on it happening in the bootstrap process can be run in tests without crashing.

## Testing Plan

Verified manually by using this branch to run tests for a repo that had the crash happening.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
