### PR TITLE
Scale down cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "develop"
-      - "feature/**"
   pull_request:
     types: [opened, synchronize, reopened]
   # Allows workflow to be called from other workflows
@@ -34,7 +33,7 @@ jobs:
         # Be aware that specs should be sequential integers starting from 1 without gaps
         # based on logic in "Cypress Tests" step.
         # prettier-ignore
-        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
+        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ]
 
     steps:
       - name: Checkout Streamlit code
@@ -76,7 +75,7 @@ jobs:
         env:
           CURRENT_RUN: ${{matrix.specs}}
           CYPRESS_VERIFY_TIMEOUT: 90000
-          TOTAL_WORKERS: 22
+          TOTAL_WORKERS: 18
         run: |
           js_specs=(e2e/specs/*)
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,7 @@ jobs:
         # Be aware that specs should be sequential integers starting from 1 without gaps
         # based on logic in "Cypress Tests" step.
         # prettier-ignore
-        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ]
+        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
 
     steps:
       - name: Checkout Streamlit code
@@ -75,7 +75,7 @@ jobs:
         env:
           CURRENT_RUN: ${{matrix.specs}}
           CYPRESS_VERIFY_TIMEOUT: 90000
-          TOTAL_WORKERS: 18
+          TOTAL_WORKERS: 16
         run: |
           js_specs=(e2e/specs/*)
 


### PR DESCRIPTION
## Describe your changes

We have migrated around 25% of e2e tests to playwright. Therefore, we can scale down the workers a bit to save cost. I also removed it from automatically running for all `feature` branches since 1) this will lead to duplicated runs of a PRs which are also `feature` branchs 2) we are also not doing the same with playwright. From now on, triggering these tests in CI will always require a PR which I think should be fine,. or? 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
