### PR TITLE
Use more cores for `Javascript` and `Component-template` CI tests

### DIFF
--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v4

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "develop"
-      - "feature/**"
   pull_request:
     types: [opened, synchronize, reopened]
   # Allows workflow to be called from other workflows

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   js_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes

- The component template and js tests are the slowest CI tests we have, often taking more than 20 minutes. This PR upgrades these tests to use the 4 core image to - hopefully - get some speed-up.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
