### PR TITLE
Revert JS CI workflow from using 4 cores

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   js_test:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes


The Javascript workflow randomly cancels after the 4 core update. Reverting this for now. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
