### PR TITLE
Implement SnowflakeConnection

### DIFF
--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -14,6 +14,9 @@
 
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.snowflake_connection import (
+    SnowflakeConnection as SnowflakeConnection,
+)
 from streamlit.connections.snowpark_connection import (
     SnowparkConnection as SnowparkConnection,
 )

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -12,14 +12,177 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import pandas as pd
 
 from streamlit.connections import BaseConnection
+from streamlit.connections.util import load_from_snowsql_config_file, running_in_sis
+from streamlit.errors import StreamlitAPIException
+
+if TYPE_CHECKING:
+    from snowflake.connector import DictCursor as Cursor
+    from snowflake.connector import SnowflakeConnection as InternalSnowflakeConnection
+    from snowflake.snowpark.session import Session
 
 
-# TODO(vdonato): Correct type bound for BaseConnection.
-class SnowflakeConnection(BaseConnection[Any]):
-    """TODO(vdonato): docstring"""
+_REQUIRED_CONNECTION_PARAMS = {"account"}
 
-    def _connect(self, **kwargs) -> Any:
-        ...
+
+class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
+    """A connection to Snowflake using the Snowflake Python Connector. Initialize using
+    ``st.connection("<name>", type="snowflake")``.
+
+    TODO(vdonato): Finish this docstring.
+    """
+
+    def _connect(self, **kwargs) -> "InternalSnowflakeConnection":
+        import snowflake.connector
+        from snowflake.snowpark.context import get_active_session  # type: ignore
+
+        # If we're running in SiS, just call get_active_session() and retrieve the
+        # lower-level connection from it.
+        if running_in_sis():
+            session = get_active_session()
+
+            if hasattr(session, "connection"):
+                return session.connection
+            return session._conn._conn
+
+        # Otherwise, attempt to create a new connection from whatever credentials we
+        # have available.
+
+        st_secrets = self._secrets.to_dict()
+        if len(st_secrets):
+            # TODO(vdonato): Double-check that we want to merge any secrets we find with
+            # the kwargs passed to `st.connection`.
+            conn_kwargs = {**st_secrets, **kwargs}
+            return snowflake.connector.connect(**conn_kwargs)
+
+        if hasattr(snowflake.connector.connection, "CONFIG_MANAGER"):
+            # TODO(vdonato): Double-check that we want to map the "snowflake" connection
+            # name in a call to `st.connection` to the "default" connection in the
+            # Snowflake config file. This is aligned with the default behavior for the
+            # underlying python connector and seems more sane than having a "snowflake"
+            # connection in a snowflake-specific config file.
+            connection_name = (
+                "default"
+                if self._connection_name == "snowflake"
+                else self._connection_name
+            )
+            return snowflake.connector.connect(
+                connection_name=connection_name,
+                **kwargs,
+            )
+
+        # If we have a version of the Snowflake Python Connector installed that predates
+        # the ConfigManager, look for credentials in  ~/.snowsql/config as a last
+        # resort.
+        snowsql_config = load_from_snowsql_config_file()
+        conn_kwargs = {**snowsql_config, **kwargs}
+
+        for p in _REQUIRED_CONNECTION_PARAMS:
+            if p not in conn_params:
+                raise StreamlitAPIException(f"Missing Snowflake connection param: {p}")
+
+        return snowflake.connector.connect(**conn_kwargs)
+
+    def query(
+        self,
+        sql: str,
+        *,  # keyword-only arguments:
+        ttl: float | int | timedelta | None = None,
+        show_spinner: bool | str = "Running `snowflake.query(...)`.",
+        params=None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        """Run a read-only SQL query.
+
+        TODO(vdonato): Finish this docstring.
+        """
+        # TODO(vdonato): Make our error handling more specific if possible. This may be
+        # difficult to do given the limited documentation on the different connector
+        # error subclasses + how many there are.
+        from snowflake.connector import Error as SnowflakeError
+        from tenacity import (
+            retry,
+            retry_if_exception_type,
+            stop_after_attempt,
+            wait_fixed,
+        )
+
+        @retry(
+            after=lambda _: self.reset(),
+            stop=stop_after_attempt(3),
+            reraise=True,
+            retry=retry_if_exception_type(SnowflakeError),
+            wait=wait_fixed(1),
+        )
+        @cache_data(
+            show_spinner=show_spinner,
+            ttl=ttl,
+        )
+        def _query(sql: str) -> pd.DataFrame:
+            cur = self._instance.cursor()
+            cur.execute(sql)
+            return cur.fetch_pandas_all()
+
+        return _query(sql)
+
+    def write_pandas(
+        self,
+        df: pd.DataFrame,
+        table_name: str,
+        database: str = None,
+        schema: str = None,
+        chunk_size: int = None,
+        **kwargs,
+    ) -> (bool, int, int, str):
+        """Call snowflake.connector.pandas_tools.write_pandas with this connection.
+
+        This convenience method is simply a thin wrapper around the ``write_pandas``
+        function of the same name from ``snowflake.connector.pandas_tools``. For more
+        information, see the `Snowflake Python Connector documentation
+        <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#write_pandas>`_.
+        """
+        from snowflake.connector.pandas_tools import write_pandas
+
+        return write_pandas(
+            conn=self._instance,
+            df=df,
+            table_name=table_name,
+            database=database,
+            schema=schema,
+            chunk_size=chunk_size,
+            **kwargs,
+        )
+
+    def cursor(self) -> "Cursor":
+        """Return a PEP 249-compliant cursor object.
+
+        For more information, see the `Snowflake Python Connector documentation
+        <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#object-cursor>`_.
+        """
+        return conn._instance.cursor()
+
+    @property
+    def raw_connection(self) -> "InternalSnowflakeConnection":
+        """Access the underlying Snowflake Python connector object.
+
+        Information on how to use the Snowflake Python Connector can be found in the
+        `Snowflake Python Connector documentation<https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example>`_.
+        """
+        return self._instance
+
+    def session(self) -> "Session":
+        """Create a new Snowpark Session from this connection.
+
+        Information on how to use Snowpark sessions can be found in the `Snowpark documentation
+        <https://docs.snowflake.com/en/developer-guide/snowpark/python/working-with-dataframes>`_.
+        """
+        from snowflake.snowpark.session import Session
+
+        return Session.builder.configs({"connection": self._instance}).create()

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -1,0 +1,25 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from streamlit.connections import BaseConnection
+
+
+# TODO(vdonato): Correct type bound for BaseConnection.
+class SnowflakeConnection(BaseConnection[Any]):
+    """TODO(vdonato): docstring"""
+
+    def _connect(self, **kwargs) -> Any:
+        ...

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -12,21 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: We won't always be able to import from snowflake.{connector, snowpark}.* so need
+# the `type: ignore` comment below, but that comment will explode if `warn-unused-ignores`
+# is turned on when the package is available. Unfortunately, mypy doesn't provide a good
+# way to configure this at a per-line level :(
+# mypy: no-warn-unused-ignores
+
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence, cast
 
 import pandas as pd
 
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import load_from_snowsql_config_file, running_in_sis
 from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
-    from snowflake.connector import DictCursor as Cursor
-    from snowflake.connector import SnowflakeConnection as InternalSnowflakeConnection
-    from snowflake.snowpark.session import Session
+    from snowflake.connector import (  # type: ignore # isort: skip
+        SnowflakeConnection as InternalSnowflakeConnection,
+    )
+    from snowflake.connector.cursor import SnowflakeCursor  # type: ignore
+    from snowflake.snowpark.session import Session  # type: ignore
 
 
 _REQUIRED_CONNECTION_PARAMS = {"account"}
@@ -40,7 +49,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     """
 
     def _connect(self, **kwargs) -> "InternalSnowflakeConnection":
-        import snowflake.connector
+        import snowflake.connector  # type: ignore
         from snowflake.snowpark.context import get_active_session  # type: ignore
 
         # If we're running in SiS, just call get_active_session() and retrieve the
@@ -81,11 +90,11 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         # If we have a version of the Snowflake Python Connector installed that predates
         # the ConfigManager, look for credentials in  ~/.snowsql/config as a last
         # resort.
-        snowsql_config = load_from_snowsql_config_file()
+        snowsql_config = load_from_snowsql_config_file(self._connection_name)
         conn_kwargs = {**snowsql_config, **kwargs}
 
         for p in _REQUIRED_CONNECTION_PARAMS:
-            if p not in conn_params:
+            if p not in conn_kwargs:
                 raise StreamlitAPIException(f"Missing Snowflake connection param: {p}")
 
         return snowflake.connector.connect(**conn_kwargs)
@@ -136,11 +145,29 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         self,
         df: pd.DataFrame,
         table_name: str,
-        database: str = None,
-        schema: str = None,
-        chunk_size: int = None,
+        database: str | None = None,
+        schema: str | None = None,
+        chunk_size: int | None = None,
         **kwargs,
-    ) -> (bool, int, int, str):
+    ) -> tuple[  # This return type is somewhat horrifying but is the return type of pandas_tools.write_pandas, so we keep it consistent here.
+        bool,
+        int,
+        int,
+        Sequence[
+            tuple[
+                str,
+                str,
+                int,
+                int,
+                int,
+                int,
+                str | None,
+                int | None,
+                int | None,
+                str | None,
+            ]
+        ],
+    ]:
         """Call snowflake.connector.pandas_tools.write_pandas with this connection.
 
         This convenience method is simply a thin wrapper around the ``write_pandas``
@@ -148,9 +175,9 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         information, see the `Snowflake Python Connector documentation
         <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#write_pandas>`_.
         """
-        from snowflake.connector.pandas_tools import write_pandas
+        from snowflake.connector.pandas_tools import write_pandas  # type: ignore
 
-        return write_pandas(
+        return write_pandas(  # type: ignore
             conn=self._instance,
             df=df,
             table_name=table_name,
@@ -160,13 +187,13 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             **kwargs,
         )
 
-    def cursor(self) -> "Cursor":
+    def cursor(self) -> "SnowflakeCursor":
         """Return a PEP 249-compliant cursor object.
 
         For more information, see the `Snowflake Python Connector documentation
         <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#object-cursor>`_.
         """
-        return conn._instance.cursor()
+        return self._instance.cursor()
 
     @property
     def raw_connection(self) -> "InternalSnowflakeConnection":
@@ -185,4 +212,6 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         """
         from snowflake.snowpark.session import Session
 
-        return Session.builder.configs({"connection": self._instance}).create()
+        return cast(
+            Session, Session.builder.configs({"connection": self._instance}).create()
+        )

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -36,7 +36,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
-    from snowflake.snowpark.session import Session  # type: ignore
+    from snowflake.snowpark.session import Session  # type:ignore[import]
 
 
 _REQUIRED_CONNECTION_PARAMS = {"account"}
@@ -63,8 +63,8 @@ class SnowparkConnection(BaseConnection["Session"]):
         super().__init__(connection_name, **kwargs)
 
     def _connect(self, **kwargs) -> "Session":
-        from snowflake.snowpark.context import get_active_session  # type: ignore
-        from snowflake.snowpark.exceptions import (  # type: ignore
+        from snowflake.snowpark.context import get_active_session  # type:ignore[import]
+        from snowflake.snowpark.exceptions import (  # type:ignore[import]
             SnowparkSessionException,
         )
         from snowflake.snowpark.session import Session
@@ -127,7 +127,7 @@ class SnowparkConnection(BaseConnection["Session"]):
         >>> df = conn.query("select * from pet_owners")
         >>> st.dataframe(df)
         """
-        from snowflake.snowpark.exceptions import (  # type: ignore
+        from snowflake.snowpark.exceptions import (  # type:ignore[import]
             SnowparkServerException,
         )
         from tenacity import (

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -46,10 +46,11 @@ class SnowparkConnection(BaseConnection["Session"]):
     """A connection to Snowpark using snowflake.snowpark.session.Session. Initialize using
     ``st.connection("<name>", type="snowpark")``.
 
-    In addition to accessing the Snowpark Session, SnowparkConnection supports direct SQL querying using
-    ``query("...")`` and thread safe access using ``with conn.safe_session():``. See methods
-    below for more information. SnowparkConnections should always be created using
-    ``st.connection()``, **not** initialized directly.
+    In addition to providing access to the Snowpark Session, SnowparkConnection supports
+    direct SQL querying using ``query("...")`` and thread safe access using
+    ``with conn.safe_session():``. See methods below for more information.
+    SnowparkConnections should always be created using ``st.connection()``, **not**
+    initialized directly.
 
     .. note::
         We don't expect this iteration of SnowparkConnection to be able to scale

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -21,7 +21,7 @@
 
 import configparser
 import os
-from typing import Any, Collection, Dict
+from typing import Any, Collection, Dict, cast
 
 SNOWSQL_CONNECTION_FILE = "~/.snowsql/config"
 
@@ -80,10 +80,9 @@ def load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
 
 
 def running_in_sis() -> bool:
-    """Return whether this app seems to be running in SiS."""
-    import snowflake.connector.connection  # type: ignore
+    """Return whether this app is running in SiS."""
+    from snowflake.snowpark._internal.utils import (  # type: ignore[import]  # isort: skip
+        is_in_stored_procedure,
+    )
 
-    # snowflake.connector.connection.SnowflakeConnection does not exist inside a Stored
-    # Proc or Streamlit. It is only part of the external package. So this returns true
-    # only in SiS.
-    return not hasattr(snowflake.connector.connection, "SnowflakeConnection")
+    return cast(bool, is_in_stored_procedure())

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -22,7 +22,12 @@ from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
+from streamlit.connections import (
+    BaseConnection,
+    SnowflakeConnection,
+    SnowparkConnection,
+    SQLConnection,
+)
 from streamlit.deprecation_util import deprecate_obj_name
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
@@ -35,6 +40,7 @@ from streamlit.runtime.secrets import secrets_singleton
 #      only the connection name is specified and another when both name and type are).
 #   3. Updating test_get_first_party_connection_helper in connection_factory_test.py.
 FIRST_PARTY_CONNECTIONS = {
+    "snowflake": SnowflakeConnection,
     "snowpark": SnowparkConnection,
     "sql": SQLConnection,
 }
@@ -118,6 +124,29 @@ def connection_factory(
     autocommit: bool = False,
     **kwargs,
 ) -> SQLConnection:
+    pass
+
+
+@overload
+def connection_factory(
+    name: Literal["snowflake"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
+) -> SnowflakeConnection:
+    pass
+
+
+@overload
+def connection_factory(
+    name: str,
+    type: Literal["snowflake"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
+) -> SnowflakeConnection:
     pass
 
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -43,7 +43,8 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "MySQLdb": "mysqlclient",
     "psycopg2": "psycopg2-binary",
     "sqlalchemy": "sqlalchemy",
-    "snowflake": "snowflake-snowpark-python",
+    "snowflake": "snowflake-connector-python",
+    "snowflake.connector": "snowflake-connector-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -118,7 +118,7 @@ class SnowflakeConnectionTest(unittest.TestCase):
         assert conn.query("SELECT 1;") == "i am a dataframe"
 
         conn._instance.cursor.assert_called_once()
-        mock_cursor.execute.assert_called_once_with("SELECT 1;")
+        mock_cursor.execute.assert_called_once_with("SELECT 1;", params=None)
 
     @patch(
         "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -1,0 +1,162 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+import streamlit as st
+from streamlit.connections import SnowflakeConnection
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import AttrDict
+from tests.testutil import create_mock_script_run_ctx
+
+
+@pytest.mark.require_snowflake
+class SnowflakeConnectionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        st.cache_data.clear()
+
+    @patch(
+        "snowflake.snowpark.context.get_active_session",
+    )
+    @patch(
+        "streamlit.connections.snowflake_connection.running_in_sis",
+        MagicMock(return_value=True),
+    )
+    def test_uses_active_session_if_in_sis(self, patched_get_active_session):
+        active_session_mock = MagicMock()
+        active_session_mock.connection = "some active session"
+        patched_get_active_session.return_value = active_session_mock
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        assert conn._instance == "some active session"
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+        PropertyMock(
+            return_value=AttrDict({"account": "some_val_1", "some_key": "some_val_2"})
+        ),
+    )
+    @patch("snowflake.connector.connect")
+    def test_uses_streamlit_secrets_if_available(self, patched_connect):
+        SnowflakeConnection("my_snowflake_connection")
+        patched_connect.assert_called_once_with(
+            account="some_val_1", some_key="some_val_2"
+        )
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+        PropertyMock(return_value=AttrDict({"some_key": "some_val_2"})),
+    )
+    def test_uses_streamlit_secrets_error(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            SnowflakeConnection("my_snowflake_connection")
+        assert "Missing Snowflake connection param: account" in str(e.value)
+
+    @patch("streamlit.connections.snowflake_connection.load_from_snowsql_config_file")
+    @patch("snowflake.connector.connect")
+    def test_uses_config_manager_if_available(
+        self, patched_connect, patched_load_config
+    ):
+        SnowflakeConnection("snowflake", some_kwarg="some_value")
+
+        patched_load_config.assert_not_called()
+        patched_connect.assert_called_once_with(
+            connection_name="default", some_kwarg="some_value"
+        )
+
+    @patch("streamlit.connections.snowflake_connection.load_from_snowsql_config_file")
+    @patch("snowflake.connector.connection")
+    @patch("snowflake.connector.connect")
+    def test_falls_back_to_reading_from_snowsql_last(
+        self, patched_connect, patched_connection, patched_load_config
+    ):
+        delattr(patched_connection, "CONFIG_MANAGER")
+
+        SnowflakeConnection("snowflake", account="account", some_kwarg="some_value")
+
+        patched_load_config.assert_called_once_with("snowflake")
+        patched_connect.assert_called_once_with(
+            account="account", some_kwarg="some_value"
+        )
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_query_caches_value(self):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(return_value="i am a dataframe")
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+
+        conn._instance.cursor.assert_called_once()
+        mock_cursor.execute.assert_called_once_with("SELECT 1;")
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_retry_behavior(self):
+        from snowflake.connector import Error as SnowflakeError
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(
+            side_effect=SnowflakeError("oh noes :()")
+        )
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+            with pytest.raises(SnowflakeError):
+                conn.query("SELECT 1;")
+
+            # Our connection should have been reset after each failed attempt to call
+            # query.
+            assert wrapped_reset.call_count == 3
+
+        # conn._connect should have been called three times: once in the initial
+        # connection, then once each after the second and third attempts to call
+        # query.
+        assert conn._connect.call_count == 3
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_retry_fails_fast_for_most_errors(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(side_effect=Exception("oh noes :()"))
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        with pytest.raises(Exception):
+            conn.query("SELECT 1;")
+
+        # conn._connect should have just been called once when first creating the
+        # connection.
+        assert conn._connect.call_count == 1

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -133,8 +133,6 @@ class SnowparkConnectionTest(unittest.TestCase):
         MagicMock(),
     )
     def test_retry_fails_fast_for_most_errors(self):
-        from snowflake.snowpark.exceptions import SnowparkServerException
-
         mock_sql_return = MagicMock()
         mock_sql_return.to_pandas = MagicMock(side_effect=Exception("oh noes :("))
 

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -37,16 +37,15 @@ class ConnectionUtilTest(unittest.TestCase):
         assert d == {"k3": "v3", "k4": "v4"}
 
     @pytest.mark.require_snowflake
-    @patch("snowflake.connector.connection", MagicMock())
     def test_not_running_in_sis(self):
         assert not running_in_sis()
 
     @pytest.mark.require_snowflake
     @patch(
-        "snowflake.connector.connection",
+        "snowflake.snowpark._internal.utils.is_in_stored_procedure",
+        MagicMock(return_value=True),
     )
-    def test_running_in_sis(self, patched_connection):
-        delattr(patched_connection, "SnowflakeConnection")
+    def test_running_in_sis(self):
         assert running_in_sis()
 
     def test_load_from_snowsql_config_file_no_file(self):

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,7 +21,12 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
+from streamlit.connections import (
+    BaseConnection,
+    SnowflakeConnection,
+    SnowparkConnection,
+    SQLConnection,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
@@ -72,6 +77,7 @@ class ConnectionFactoryTest(unittest.TestCase):
 
     @parameterized.expand(
         [
+            ("snowflake", SnowflakeConnection),
             ("snowpark", SnowparkConnection),
             ("sql", SQLConnection),
         ]

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -183,7 +183,8 @@ type="snowpark"
             ("MySQLdb", "mysqlclient"),
             ("psycopg2", "psycopg2-binary"),
             ("sqlalchemy", "sqlalchemy"),
-            ("snowflake", "snowflake-snowpark-python"),
+            ("snowflake", "snowflake-connector-python"),
+            ("snowflake.connector", "snowflake-connector-python"),
             ("snowflake.snowpark", "snowflake-snowpark-python"),
         ]
     )


### PR DESCRIPTION
This PR implements `SnowflakeConnection`, which is intended to replace the existing `SnowparkConnection`
class that we ship as a default connection. This new class is a more general connection, but it also retains all
of the functionality that the existing `SnowparkConnection` class does as it allows users to create Snowpark
sessions from the underlying connection object using the `.session()` helper method.