### PR TITLE
De-experimentalize st.connection

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -47,6 +47,7 @@ For more detailed info, see https://docs.streamlit.io.
 # Must be at the top, to avoid circular dependency.
 from streamlit import logger as _logger
 from streamlit import config as _config
+from streamlit.deprecation_util import deprecate_func_name as _deprecate_func_name
 from streamlit.version import STREAMLIT_VERSION_STRING as _STREAMLIT_VERSION_STRING
 
 # Give the package a version.
@@ -61,7 +62,7 @@ from streamlit.runtime.caching import (
     experimental_memo as _experimental_memo,
 )
 from streamlit.runtime.connection_factory import (
-    connection_factory as _connection_factory,
+    connection_factory as connection,
 )
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
@@ -206,4 +207,6 @@ experimental_get_query_params = _get_query_params
 experimental_set_query_params = _set_query_params
 experimental_rerun = _experimental_rerun
 experimental_data_editor = _main.experimental_data_editor
-experimental_connection = _connection_factory
+experimental_connection = _deprecate_func_name(
+    connection, "experimental_connection", "2024-01-01", name_override="connection"
+)

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -208,5 +208,5 @@ experimental_set_query_params = _set_query_params
 experimental_rerun = _experimental_rerun
 experimental_data_editor = _main.experimental_data_editor
 experimental_connection = _deprecate_func_name(
-    connection, "experimental_connection", "2024-01-01", name_override="connection"
+    connection, "experimental_connection", "2024-04-01", name_override="connection"
 )

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # Explicitly re-export public symbols.
-from streamlit.connections.base_connection import (
-    ExperimentalBaseConnection as ExperimentalBaseConnection,
-)
+from streamlit.connections.base_connection import BaseConnection as BaseConnection
 from streamlit.connections.snowpark_connection import (
     SnowparkConnection as SnowparkConnection,
 )
 from streamlit.connections.sql_connection import SQLConnection as SQLConnection
+
+# TODO(vdonato): Maybe figure out a reasonable way to add a deprecation warning to this
+# constructor. In case this is infeasible, it'll probably be fine to just remove this
+# along with the `st.experimental_connection` function.
+ExperimentalBaseConnection = BaseConnection

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -14,6 +14,9 @@
 
 # Explicitly re-export public symbols.
 from streamlit.connections.base_connection import BaseConnection as BaseConnection
+from streamlit.connections.snowflake_connection import (
+    SnowflakeConnection as SnowflakeConnection,
+)
 from streamlit.connections.snowpark_connection import (
     SnowparkConnection as SnowparkConnection,
 )

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -22,12 +22,12 @@ from streamlit.util import calc_md5
 RawConnectionT = TypeVar("RawConnectionT")
 
 
-class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
+class BaseConnection(ABC, Generic[RawConnectionT]):
     """The abstract base class that all Streamlit Connections must inherit from.
 
     This base class provides connection authors with a standardized way to hook into the
-    ``st.experimental_connection()`` factory function: connection authors are required to
-    provide an implementation for the abstract method ``_connect`` in their subclasses.
+    ``st.connection()`` factory function: connection authors are required to provide an
+    implementation for the abstract method ``_connect`` in their subclasses.
 
     Additionally, it also provides a few methods/properties designed to make
     implementation of connections more convenient. See the docstrings for each of the
@@ -42,13 +42,13 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
     """
 
     def __init__(self, connection_name: str, **kwargs) -> None:
-        """Create an ExperimentalBaseConnection.
+        """Create a BaseConnection.
 
         This constructor is called by the connection factory machinery when a user
-        script calls ``st.experimental_connection()``.
+        script calls ``st.connection()``.
 
-        Subclasses of ExperimentalBaseConnection that want to overwrite this method
-        should take care to also call the base class' implementation.
+        Subclasses of BaseConnection that want to overwrite this method should take care
+        to also call the base class' implementation.
 
         Parameters
         ----------
@@ -87,8 +87,8 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         """Return a human-friendly markdown string describing this connection.
 
         This is the string that will be written to the app if a user calls
-        ``st.write(this_connection)``. Subclasses of ExperimentalBaseConnection can freely
-        overwrite this method if desired.
+        ``st.write(this_connection)``. Subclasses of BaseConnection can freely overwrite
+        this method if desired.
 
         Returns
         -------
@@ -156,7 +156,7 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("my_conn")
+        >>> conn = st.connection("my_conn")
         >>>
         >>> # Reset the connection before using it if it isn't healthy
         >>> # Note: is_healthy() isn't a real method and is just shown for example here.
@@ -175,14 +175,14 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
         return self._raw_instance
 
-    # Abstract fields/methods that subclasses of ExperimentalBaseConnection must implement
+    # Abstract fields/methods that subclasses of BaseConnection must implement
     @abstractmethod
     def _connect(self, **kwargs) -> RawConnectionT:
         """Create an instance of an underlying connection object.
 
         This abstract method is the one method that we require subclasses of
-        ExperimentalBaseConnection to provide an implementation for. It is called when
-        first creating a connection and when reconnecting after a connection is reset.
+        BaseConnection to provide an implementation for. It is called when first
+        creating a connection and when reconnecting after a connection is reset.
 
         Parameters
         ----------

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -14,7 +14,7 @@
 
 import json
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
 from streamlit.util import calc_md5
@@ -72,6 +72,16 @@ class ExperimentalBaseConnection(ABC, Generic[RawConnectionT]):
 
     def __del__(self) -> None:
         secrets_singleton.file_change_listener.disconnect(self._on_secrets_changed)
+
+    def __getattribute__(self, name: str) -> Any:
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError as e:
+            if hasattr(self._instance, name):
+                raise AttributeError(
+                    f"`{name}` doesn't exist here, but you can call `._instance.{name}` instead"
+                )
+            raise e
 
     def _repr_html_(self) -> str:
         """Return a human-friendly markdown string describing this connection.

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -1,0 +1,252 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We won't always be able to import from snowflake.{connector, snowpark}.* so need
+# the `type: ignore` comment below, but that comment will explode if `warn-unused-ignores`
+# is turned on when the package is available. Unfortunately, mypy doesn't provide a good
+# way to configure this at a per-line level :(
+# mypy: no-warn-unused-ignores
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, cast
+
+import pandas as pd
+
+from streamlit.connections import BaseConnection
+from streamlit.connections.util import running_in_sis
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_data
+
+if TYPE_CHECKING:
+    from snowflake.connector import (  # type:ignore[import] # isort: skip
+        SnowflakeConnection as InternalSnowflakeConnection,
+    )
+    from snowflake.connector.cursor import SnowflakeCursor  # type:ignore[import]
+    from snowflake.snowpark.session import Session  # type:ignore[import]
+
+
+_REQUIRED_CONNECTION_PARAMS = {"account"}
+
+
+def _validate_connection_params(required: set[str], params: dict[str, Any]) -> None:
+    missing = required - set(params)
+    if len(missing) > 0:
+        raise StreamlitAPIException(
+            f"Missing Snowflake connection params: {', '.join(missing)}"
+        )
+
+
+class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
+    """A connection to Snowflake using the Snowflake Python Connector. Initialize using
+    ``st.connection("<name>", type="snowflake")``.
+
+    SnowflakeConnection supports direct SQL querying using ``.query("...")``, access to
+    the underlying Snowflake Python Connector object with ``.raw_connection``, and other
+    convenience functions. See the methods below for more information.
+    SnowflakeConnections should always be created using ``st.connection()``, **not**
+    initialized directly.
+    """
+
+    def _connect(self, **kwargs) -> "InternalSnowflakeConnection":
+        import snowflake.connector  # type:ignore[import]
+        from snowflake.snowpark.context import get_active_session  # type:ignore[import]
+
+        # If we're running in SiS, just call get_active_session() and retrieve the
+        # lower-level connection from it.
+        if running_in_sis():
+            session = get_active_session()
+
+            if hasattr(session, "connection"):
+                return session.connection
+            return session._conn._conn
+
+        # We require qmark-style parameters everywhere for consistency across different
+        # environments where SnowflakeConnections may be used.
+        snowflake.connector.paramstyle = "qmark"
+
+        # Otherwise, attempt to create a new connection from whatever credentials we
+        # have available.
+        st_secrets = self._secrets.to_dict()
+        if len(st_secrets):
+            conn_kwargs = {**st_secrets, **kwargs}
+            _validate_connection_params(_REQUIRED_CONNECTION_PARAMS, conn_kwargs)
+            return snowflake.connector.connect(**conn_kwargs)
+
+        if hasattr(snowflake.connector.connection, "CONFIG_MANAGER"):
+            config_mgr = snowflake.connector.connection.CONFIG_MANAGER
+
+            default_connection_name = "default"
+            try:
+                default_connection_name = config_mgr["default_connection_name"]
+            except snowflake.connector.errors.ConfigSourceError:
+                pass
+
+            connection_name = (
+                default_connection_name
+                if self._connection_name == "snowflake"
+                else self._connection_name
+            )
+            return snowflake.connector.connect(
+                connection_name=connection_name,
+                **kwargs,
+            )
+
+        # If nothing else works, try using the kwargs passed to st.connection as our
+        # connection params.
+        conn_kwargs = {**kwargs}
+        _validate_connection_params(_REQUIRED_CONNECTION_PARAMS, conn_kwargs)
+
+        return snowflake.connector.connect(**conn_kwargs)
+
+    def query(
+        self,
+        sql: str,
+        *,  # keyword-only arguments:
+        ttl: float | int | timedelta | None = None,
+        show_spinner: bool | str = "Running `snowflake.query(...)`.",
+        params=None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        """Run a read-only SQL query.
+
+        This method implements both query result caching (with caching behavior
+        identical to that of using ``@st.cache_data``) as well as simple error handling/retries.
+
+        .. note::
+            Queries that are run without a specified ttl are cached indefinitely.
+
+        Parameters
+        ----------
+        sql : str
+            The read-only SQL query to execute.
+        ttl : float, int, timedelta or None
+            The maximum number of seconds to keep results in the cache, or
+            None if cached results should not expire. The default is None.
+        show_spinner : boolean or string
+            Enable the spinner. The default is to show a spinner when there is a
+            "cache miss" and the cached resource is being created. If a string, the value
+            of the show_spinner param will be used for the spinner text.
+        params : list, tuple, dict or None
+            List of parameters to pass to the execute method. The syntax used to pass
+            parameters is database driver dependent. Check your database driver
+            documentation for which of the five syntax styles, described in `PEP 249
+            paramstyle <https://peps.python.org/pep-0249/#paramstyle>`_, is supported.
+            Default is None.
+
+        Returns
+        -------
+        pd.DataFrame
+            The result of running the query, formatted as a pandas DataFrame.
+
+        Example
+        -------
+        >>> import streamlit as st
+        >>>
+        >>> conn = st.connection("snowflake")
+        >>> df = conn.query("select * from pet_owners")
+        >>> st.dataframe(df)
+        """
+        # TODO(vdonato): Make our error handling more specific if possible. This may be
+        # difficult to do given the limited documentation on the different connector
+        # error subclasses + how many there are.
+        from snowflake.connector import Error as SnowflakeError
+        from tenacity import (
+            retry,
+            retry_if_exception_type,
+            stop_after_attempt,
+            wait_fixed,
+        )
+
+        @retry(
+            after=lambda _: self.reset(),
+            stop=stop_after_attempt(3),
+            reraise=True,
+            retry=retry_if_exception_type(SnowflakeError),
+            wait=wait_fixed(1),
+        )
+        @cache_data(
+            show_spinner=show_spinner,
+            ttl=ttl,
+        )
+        def _query(sql: str) -> pd.DataFrame:
+            cur = self._instance.cursor()
+            cur.execute(sql, params=params, **kwargs)
+            return cur.fetch_pandas_all()
+
+        return _query(sql)
+
+    def write_pandas(
+        self,
+        df: pd.DataFrame,
+        table_name: str,
+        database: str | None = None,
+        schema: str | None = None,
+        chunk_size: int | None = None,
+        **kwargs,
+    ) -> tuple[bool, int, int]:
+        """Call snowflake.connector.pandas_tools.write_pandas with this connection.
+
+        This convenience method is simply a thin wrapper around the ``write_pandas``
+        function of the same name from ``snowflake.connector.pandas_tools``. For more
+        information, see the `Snowflake Python Connector documentation
+        <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#write_pandas>`_.
+        """
+        from snowflake.connector.pandas_tools import write_pandas  # type:ignore[import]
+
+        success, nchunks, nrows, _ = write_pandas(
+            conn=self._instance,
+            df=df,
+            table_name=table_name,
+            database=database,
+            schema=schema,
+            chunk_size=chunk_size,
+            **kwargs,
+        )
+
+        return (success, nchunks, nrows)
+
+    def cursor(self) -> "SnowflakeCursor":
+        """Return a PEP 249-compliant cursor object.
+
+        For more information, see the `Snowflake Python Connector documentation
+        <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#object-cursor>`_.
+        """
+        return self._instance.cursor()
+
+    @property
+    def raw_connection(self) -> "InternalSnowflakeConnection":
+        """Access the underlying Snowflake Python connector object.
+
+        Information on how to use the Snowflake Python Connector can be found in the
+        `Snowflake Python Connector documentation<https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example>`_.
+        """
+        return self._instance
+
+    def session(self) -> "Session":
+        """Create a new Snowpark Session from this connection.
+
+        Information on how to use Snowpark sessions can be found in the `Snowpark documentation
+        <https://docs.snowflake.com/en/developer-guide/snowpark/python/working-with-dataframes>`_.
+        """
+        from snowflake.snowpark.context import get_active_session  # type:ignore[import]
+        from snowflake.snowpark.session import Session  # type:ignore[import]
+
+        if running_in_sis():
+            return get_active_session()
+
+        return cast(
+            Session, Session.builder.configs({"connection": self._instance}).create()
+        )

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -36,7 +36,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
-    from snowflake.snowpark.session import Session  # type: ignore
+    from snowflake.snowpark.session import Session  # type:ignore[import]
 
 
 _REQUIRED_CONNECTION_PARAMS = {"account"}
@@ -46,10 +46,11 @@ class SnowparkConnection(BaseConnection["Session"]):
     """A connection to Snowpark using snowflake.snowpark.session.Session. Initialize using
     ``st.connection("<name>", type="snowpark")``.
 
-    In addition to accessing the Snowpark Session, SnowparkConnection supports direct SQL querying using
-    ``query("...")`` and thread safe access using ``with conn.safe_session():``. See methods
-    below for more information. SnowparkConnections should always be created using
-    ``st.connection()``, **not** initialized directly.
+    In addition to providing access to the Snowpark Session, SnowparkConnection supports
+    direct SQL querying using ``query("...")`` and thread safe access using
+    ``with conn.safe_session():``. See methods below for more information.
+    SnowparkConnections should always be created using ``st.connection()``, **not**
+    initialized directly.
 
     .. note::
         We don't expect this iteration of SnowparkConnection to be able to scale
@@ -62,8 +63,8 @@ class SnowparkConnection(BaseConnection["Session"]):
         super().__init__(connection_name, **kwargs)
 
     def _connect(self, **kwargs) -> "Session":
-        from snowflake.snowpark.context import get_active_session  # type: ignore
-        from snowflake.snowpark.exceptions import (  # type: ignore
+        from snowflake.snowpark.context import get_active_session  # type:ignore[import]
+        from snowflake.snowpark.exceptions import (  # type:ignore[import]
             SnowparkSessionException,
         )
         from snowflake.snowpark.session import Session
@@ -126,7 +127,7 @@ class SnowparkConnection(BaseConnection["Session"]):
         >>> df = conn.query("select * from pet_owners")
         >>> st.dataframe(df)
         """
-        from snowflake.snowpark.exceptions import (  # type: ignore
+        from snowflake.snowpark.exceptions import (  # type:ignore[import]
             SnowparkServerException,
         )
         from tenacity import (

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.connections.util import (
     SNOWSQL_CONNECTION_FILE,
     load_from_snowsql_config_file,
@@ -42,14 +42,14 @@ if TYPE_CHECKING:
 _REQUIRED_CONNECTION_PARAMS = {"account"}
 
 
-class SnowparkConnection(ExperimentalBaseConnection["Session"]):
+class SnowparkConnection(BaseConnection["Session"]):
     """A connection to Snowpark using snowflake.snowpark.session.Session. Initialize using
-    ``st.experimental_connection("<name>", type="snowpark")``.
+    ``st.connection("<name>", type="snowpark")``.
 
     In addition to accessing the Snowpark Session, SnowparkConnection supports direct SQL querying using
     ``query("...")`` and thread safe access using ``with conn.safe_session():``. See methods
     below for more information. SnowparkConnections should always be created using
-    ``st.experimental_connection()``, **not** initialized directly.
+    ``st.connection()``, **not** initialized directly.
 
     .. note::
         We don't expect this iteration of SnowparkConnection to be able to scale
@@ -83,7 +83,7 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
             raise StreamlitAPIException(
                 "Missing Snowpark connection configuration. "
                 f"Did you forget to set this in `secrets.toml`, `{SNOWSQL_CONNECTION_FILE}`, "
-                "or as kwargs to `st.experimental_connection`?"
+                "or as kwargs to `st.connection`?"
             )
 
         for p in _REQUIRED_CONNECTION_PARAMS:
@@ -122,7 +122,7 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("snowpark")
+        >>> conn = st.connection("snowpark")
         >>> df = conn.query("select * from pet_owners")
         >>> st.dataframe(df)
         """
@@ -170,7 +170,7 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> session = st.experimental_connection("snowpark").session
+        >>> session = st.connection("snowpark").session
         >>> df = session.table("mytable").limit(10).to_pandas()
         >>> st.dataframe(df)
         """
@@ -193,7 +193,7 @@ class SnowparkConnection(ExperimentalBaseConnection["Session"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("snowpark")
+        >>> conn = st.connection("snowpark")
         >>> with conn.safe_session() as session:
         ...     df = session.table("mytable").limit(10).to_pandas()
         ...

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, List, Optional, Union, cast
 
 import pandas as pd
 
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.connections.util import extract_from_dict
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
@@ -42,18 +42,17 @@ _ALL_CONNECTION_PARAMS = {
 _REQUIRED_CONNECTION_PARAMS = {"dialect", "username", "host"}
 
 
-class SQLConnection(ExperimentalBaseConnection["Engine"]):
-    """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.experimental_connection("<name>", type="sql")``.
+class SQLConnection(BaseConnection["Engine"]):
+    """A connection to a SQL database using a SQLAlchemy Engine. Initialize using ``st.connection("<name>", type="sql")``.
 
     SQLConnection provides the ``query()`` convenience method, which can be used to
     run simple read-only queries with both caching and simple error handling/retries.
     More complex DB interactions can be performed by using the ``.session`` property
     to receive a regular SQLAlchemy Session.
 
-    SQLConnections should always be created using ``st.experimental_connection()``,
-    **not** initialized directly. Connection parameters for a SQLConnection can be
-    specified using either ``st.secrets`` or ``**kwargs``. Some frequently used
-    parameters include:
+    SQLConnections should always be created using ``st.connection()``, **not**
+    initialized directly. Connection parameters for a SQLConnection can be specified
+    using either ``st.secrets`` or ``**kwargs``. Some frequently used parameters include:
 
     - **url** or arguments for `sqlalchemy.engine.URL.create()
       <https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create>`_.
@@ -62,7 +61,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
     - **create_engine_kwargs** can be passed via ``st.secrets``, such as for
       `snowflake-sqlalchemy <https://github.com/snowflakedb/snowflake-sqlalchemy#key-pair-authentication-support>`_
       or `Google BigQuery <https://github.com/googleapis/python-bigquery-sqlalchemy#authentication>`_.
-      These can also be passed directly as ``**kwargs`` to experimental_connection().
+      These can also be passed directly as ``**kwargs`` to connection().
 
     - **autocommit=True** to run with isolation level ``AUTOCOMMIT``. Default is False.
 
@@ -70,7 +69,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
     -------
     >>> import streamlit as st
     >>>
-    >>> conn = st.experimental_connection("sql")
+    >>> conn = st.connection("sql")
     >>> df = conn.query("select * from pet_owners")
     >>> st.dataframe(df)
     """
@@ -85,7 +84,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
         if not len(conn_params):
             raise StreamlitAPIException(
                 "Missing SQL DB connection configuration. "
-                "Did you forget to set this in `secrets.toml` or as kwargs to `st.experimental_connection`?"
+                "Did you forget to set this in `secrets.toml` or as kwargs to `st.connection`?"
             )
 
         if "url" in conn_params:
@@ -171,7 +170,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
         -------
         >>> import streamlit as st
         >>>
-        >>> conn = st.experimental_connection("sql")
+        >>> conn = st.connection("sql")
         >>> df = conn.query("select * from pet_owners where owner = :owner", ttl=3600, params={"owner":"barbara"})
         >>> st.dataframe(df)
         """
@@ -238,7 +237,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
         Example
         -------
         >>> import streamlit as st
-        >>> conn = st.experimental_connection("sql")
+        >>> conn = st.connection("sql")
         >>> n = st.slider("Pick a number")
         >>> if st.button("Add the number!"):
         ...     with conn.session as session:
@@ -250,7 +249,7 @@ class SQLConnection(ExperimentalBaseConnection["Engine"]):
         return Session(self._instance)
 
     # NOTE: This more or less duplicates the default implementation in
-    # ExperimentalBaseConnection so that we can add another bullet point between the
+    # BaseConnection so that we can add another bullet point between the
     # "Configured from" and "Learn more" items :/
     def _repr_html_(self) -> str:
         module_name = getattr(self, "__module__", None)

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -21,7 +21,7 @@
 
 import configparser
 import os
-from typing import Any, Collection, Dict
+from typing import Any, Collection, Dict, cast
 
 SNOWSQL_CONNECTION_FILE = "~/.snowsql/config"
 
@@ -80,10 +80,9 @@ def load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
 
 
 def running_in_sis() -> bool:
-    """Return whether this app seems to be running in SiS."""
-    import snowflake.connector.connection  # type: ignore
+    """Return whether this app is running in SiS."""
+    from snowflake.snowpark._internal.utils import (  # type: ignore[import]  # isort: skip
+        is_in_stored_procedure,
+    )
 
-    # snowflake.connector.connection.SnowflakeConnection does not exist inside a Stored
-    # Proc or Streamlit. It is only part of the external package. So this returns true
-    # only in SiS.
-    return not hasattr(snowflake.connector.connection, "SnowflakeConnection")
+    return cast(bool, is_in_stored_procedure())

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -51,7 +51,11 @@ def make_deprecated_name_warning(
 
 
 def deprecate_func_name(
-    func: TFunc, old_name: str, removal_date: str, extra_message: str | None = None
+    func: TFunc,
+    old_name: str,
+    removal_date: str,
+    extra_message: str | None = None,
+    name_override: str | None = None,
 ) -> TFunc:
     """Wrap an `st` function whose name has changed.
 
@@ -81,7 +85,7 @@ def deprecate_func_name(
         result = func(*args, **kwargs)
         show_deprecation_warning(
             make_deprecated_name_warning(
-                old_name, func.__name__, removal_date, extra_message
+                old_name, name_override or func.__name__, removal_date, extra_message
             )
         )
         return result

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -41,11 +41,19 @@ def show_deprecation_warning(message: str) -> None:
 
 
 def make_deprecated_name_warning(
-    old_name: str, new_name: str, removal_date: str, extra_message: str | None = None
+    old_name: str,
+    new_name: str,
+    removal_date: str,
+    extra_message: str | None = None,
+    include_st_prefix: bool = True,
 ) -> str:
+    if include_st_prefix:
+        old_name = f"st.{old_name}"
+        new_name = f"st.{new_name}"
+
     return (
-        f"Please replace `st.{old_name}` with `st.{new_name}`.\n\n"
-        f"`st.{old_name}` will be removed after {removal_date}."
+        f"Please replace `{old_name}` with `{new_name}`.\n\n"
+        f"`{old_name}` will be removed after {removal_date}."
         + (f"\n\n{extra_message}" if extra_message else "")
     )
 
@@ -78,6 +86,9 @@ def deprecate_func_name(
 
     extra_message
         An optional extra message to show in the deprecation warning.
+
+    name_override
+        An optional name to use in place of func.__name__.
     """
 
     @functools.wraps(func)
@@ -97,7 +108,11 @@ def deprecate_func_name(
 
 
 def deprecate_obj_name(
-    obj: TObj, old_name: str, new_name: str, removal_date: str
+    obj: TObj,
+    old_name: str,
+    new_name: str,
+    removal_date: str,
+    include_st_prefix: bool = True,
 ) -> TObj:
     """Wrap an `st` object whose name has changed.
 
@@ -120,12 +135,18 @@ def deprecate_obj_name(
     removal_date
         A date like "2020-01-01", indicating the last day we'll guarantee
         support for the deprecated name.
+
+    include_st_prefix
+        If False, does not prefix each of the object names in the deprecation
+        essage with `st.*`. Defaults to True.
     """
 
     return _create_deprecated_obj_wrapper(
         obj,
         lambda: show_deprecation_warning(
-            make_deprecated_name_warning(old_name, new_name, removal_date)
+            make_deprecated_name_warning(
+                old_name, new_name, removal_date, include_st_prefix=include_st_prefix
+            )
         ),
     )
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -22,7 +22,12 @@ from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
+from streamlit.connections import (
+    BaseConnection,
+    SnowflakeConnection,
+    SnowparkConnection,
+    SQLConnection,
+)
 from streamlit.deprecation_util import deprecate_obj_name
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
@@ -35,6 +40,7 @@ from streamlit.runtime.secrets import secrets_singleton
 #      only the connection name is specified and another when both name and type are).
 #   3. Updating test_get_first_party_connection_helper in connection_factory_test.py.
 FIRST_PARTY_CONNECTIONS = {
+    "snowflake": SnowflakeConnection,
     "snowpark": SnowparkConnection,
     "sql": SQLConnection,
 }
@@ -43,7 +49,8 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "MySQLdb": "mysqlclient",
     "psycopg2": "psycopg2-binary",
     "sqlalchemy": "sqlalchemy",
-    "snowflake": "snowflake-snowpark-python",
+    "snowflake": "snowflake-connector-python",
+    "snowflake.connector": "snowflake-connector-python",
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 
@@ -117,6 +124,29 @@ def connection_factory(
     autocommit: bool = False,
     **kwargs,
 ) -> SQLConnection:
+    pass
+
+
+@overload
+def connection_factory(
+    name: Literal["snowflake"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
+) -> SnowflakeConnection:
+    pass
+
+
+@overload
+def connection_factory(
+    name: str,
+    type: Literal["snowflake"],
+    max_entries: int | None = None,
+    ttl: float | timedelta | None = None,
+    autocommit: bool = False,
+    **kwargs,
+) -> SnowflakeConnection:
     pass
 
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -182,13 +182,13 @@ def connection_factory(
     ----------
     name : str
         The connection name used for secrets lookup in ``[connections.<name>]``.
-        Type will be inferred from passing ``"sql"`` or ``"snowpark"``.
+        Type will be inferred from passing ``"sql"``, ``"snowflake"``, or ``"snowpark"``.
     type : str, connection class, or None
-        The type of connection to create. It can be a keyword (``"sql"`` or ``"snowpark"``),
-        a path to an importable class, or an imported class reference. All classes
-        must extend ``st.connections.BaseConnection`` and implement the ``_connect()``
-        method. If the type kwarg is None, a ``type`` field must be set in the
-        connection's section in ``secrets.toml``.
+        The type of connection to create. It can be a keyword (``"sql"``, ``"snowflake"``,
+        or ``"snowpark"``), a path to an importable class, or an imported class reference.
+        All classes must extend ``st.connections.BaseConnection`` and implement the
+        ``_connect()`` method. If the type kwarg is None, a ``type`` field must be set in
+        the connection's section in ``secrets.toml``.
     max_entries : int or None
         The maximum number of connections to keep in the cache, or None
         for an unbounded cache. (When a new entry is added to a full cache,
@@ -207,8 +207,9 @@ def connection_factory(
 
     Examples
     --------
-    The easiest way to create a first-party (SQL or Snowpark) connection is to use their
-    default names and define corresponding sections in your ``secrets.toml`` file.
+    The easiest way to create a first-party (SQL, Snowflake, or Snowpark) connection is
+    to use their default names and define corresponding sections in your ``secrets.toml``
+    file.
 
     >>> import streamlit as st
     >>> conn = st.connection("sql") # Config section defined in [connections.sql] in secrets.toml.

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -22,11 +22,7 @@ from typing import Any, Dict, Type, TypeVar, overload
 
 from typing_extensions import Final, Literal
 
-from streamlit.connections import (
-    ExperimentalBaseConnection,
-    SnowparkConnection,
-    SQLConnection,
-)
+from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_resource
 from streamlit.runtime.metrics_util import gather_metrics
@@ -50,14 +46,13 @@ MODULES_TO_PYPI_PACKAGES: Final[Dict[str, str]] = {
     "snowflake.snowpark": "snowflake-snowpark-python",
 }
 
-# The ExperimentalBaseConnection bound is parameterized to `Any` below as subclasses of
-# ExperimentalBaseConnection are responsible for binding the type parameter of
-# ExperimentalBaseConnection to a concrete type, but the type it gets bound to isn't
-# important to us here.
-ConnectionClass = TypeVar("ConnectionClass", bound=ExperimentalBaseConnection[Any])
+# The BaseConnection bound is parameterized to `Any` below as subclasses of
+# BaseConnection are responsible for binding the type parameter of BaseConnection to a
+# concrete type, but the type it gets bound to isn't important to us here.
+ConnectionClass = TypeVar("ConnectionClass", bound=BaseConnection[Any])
 
 
-@gather_metrics("experimental_connection")
+@gather_metrics("connection")
 def _create_connection(
     name: str,
     connection_class: Type[ConnectionClass],
@@ -70,12 +65,12 @@ def _create_connection(
     The weird implementation of this function with the @cache_resource annotated
     function defined internally is done to:
       * Always @gather_metrics on the call even if the return value is a cached one.
-      * Allow the user to specify ttl and max_entries when calling st.experimental_connection.
+      * Allow the user to specify ttl and max_entries when calling st.connection.
     """
 
     @cache_resource(
         max_entries=max_entries,
-        show_spinner="Running `st.experimental_connection(...)`.",
+        show_spinner="Running `st.connection(...)`.",
         ttl=ttl,
     )
     def __create_connection(
@@ -83,9 +78,9 @@ def _create_connection(
     ) -> ConnectionClass:
         return connection_class(connection_name=name, **kwargs)
 
-    if not issubclass(connection_class, ExperimentalBaseConnection):
+    if not issubclass(connection_class, BaseConnection):
         raise StreamlitAPIException(
-            f"{connection_class} is not a subclass of ExperimentalBaseConnection!"
+            f"{connection_class} is not a subclass of BaseConnection!"
         )
 
     return __create_connection(name, connection_class, **kwargs)
@@ -163,7 +158,7 @@ def connection_factory(
     max_entries: int | None = None,
     ttl: float | timedelta | None = None,
     **kwargs,
-) -> ExperimentalBaseConnection[Any]:
+) -> BaseConnection[Any]:
     pass
 
 
@@ -191,9 +186,9 @@ def connection_factory(
     type : str, connection class, or None
         The type of connection to create. It can be a keyword (``"sql"`` or ``"snowpark"``),
         a path to an importable class, or an imported class reference. All classes
-        must extend ``st.connections.ExperimentalBaseConnection`` and implement the
-        ``_connect()`` method. If the type kwarg is None, a ``type`` field must be set
-        in the connection's section in ``secrets.toml``.
+        must extend ``st.connections.BaseConnection`` and implement the ``_connect()``
+        method. If the type kwarg is None, a ``type`` field must be set in the
+        connection's section in ``secrets.toml``.
     max_entries : int or None
         The maximum number of connections to keep in the cache, or None
         for an unbounded cache. (When a new entry is added to a full cache,
@@ -216,29 +211,29 @@ def connection_factory(
     default names and define corresponding sections in your ``secrets.toml`` file.
 
     >>> import streamlit as st
-    >>> conn = st.experimental_connection("sql") # Config section defined in [connections.sql] in secrets.toml.
+    >>> conn = st.connection("sql") # Config section defined in [connections.sql] in secrets.toml.
 
     Creating a SQLConnection with a custom name requires you to explicitly specify the
     type. If type is not passed as a kwarg, it must be set in the appropriate section of
     ``secrets.toml``.
 
     >>> import streamlit as st
-    >>> conn1 = st.experimental_connection("my_sql_connection", type="sql") # Config section defined in [connections.my_sql_connection].
-    >>> conn2 = st.experimental_connection("my_other_sql_connection") # type must be set in [connections.my_other_sql_connection].
+    >>> conn1 = st.connection("my_sql_connection", type="sql") # Config section defined in [connections.my_sql_connection].
+    >>> conn2 = st.connection("my_other_sql_connection") # type must be set in [connections.my_other_sql_connection].
 
     Passing the full module path to the connection class that you want to use can be
     useful, especially when working with a custom connection:
 
     >>> import streamlit as st
-    >>> conn = st.experimental_connection("my_sql_connection", type="streamlit.connections.SQLConnection")
+    >>> conn = st.connection("my_sql_connection", type="streamlit.connections.SQLConnection")
 
     Finally, you can pass the connection class to use directly to this function. Doing
     so allows static type checking tools such as ``mypy`` to infer the exact return
-    type of ``st.experimental_connection``.
+    type of ``st.connection``.
 
     >>> import streamlit as st
     >>> from streamlit.connections import SQLConnection
-    >>> conn = st.experimental_connection("my_sql_connection", type=SQLConnection)
+    >>> conn = st.connection("my_sql_connection", type=SQLConnection)
     """
     USE_ENV_PREFIX = "env:"
 
@@ -250,8 +245,8 @@ def connection_factory(
 
     if type is None:
         if name in FIRST_PARTY_CONNECTIONS:
-            # We allow users to simply write `st.experimental_connection("sql")`
-            # instead of `st.experimental_connection("sql", type="sql")`.
+            # We allow users to simply write `st.connection("sql")` instead of
+            # `st.connection("sql", type="sql")`.
             type = _get_first_party_connection(name)
         else:
             # The user didn't specify a type, so we try to pull it out from their
@@ -262,9 +257,9 @@ def connection_factory(
             secrets_singleton.load_if_toml_exists()
             type = secrets_singleton["connections"][name]["type"]
 
-    # type is a nice kwarg name for the st.experimental_connection user but is annoying
-    # to work with since it conflicts with the builtin function name and thus gets
-    # syntax highlighted.
+    # type is a nice kwarg name for the st.connection user but is annoying to work with
+    # since it conflicts with the builtin function name and thus gets syntax
+    # highlighted.
     connection_class = type
 
     if isinstance(connection_class, str):

--- a/lib/tests/streamlit/connections/base_connection_test.py
+++ b/lib/tests/streamlit/connections/base_connection_test.py
@@ -19,7 +19,7 @@ from unittest.mock import PropertyMock, mock_open, patch
 import pytest
 
 import streamlit as st
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.runtime.secrets import AttrDict
 
 MOCK_TOML = """
@@ -33,7 +33,7 @@ class MockRawConnection:
         return "some raw connection method"
 
 
-class MockConnection(ExperimentalBaseConnection[str]):
+class MockConnection(BaseConnection[str]):
     def _connect(self, **kwargs) -> str:
         return MockRawConnection()
 
@@ -41,7 +41,7 @@ class MockConnection(ExperimentalBaseConnection[str]):
         return "some method"
 
 
-class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
+class BaseConnectionDefaultMethodTests(unittest.TestCase):
     def setUp(self) -> None:
         # st.secrets modifies os.environ, so we save it here and
         # restore in tearDown.
@@ -114,7 +114,7 @@ class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
         # conn.reset() shouldn't be called because secrets haven't changed since conn
         # was constructed.
         with patch(
-            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
+            "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset:
             conn._on_secrets_changed("unused_arg")
             patched_reset.assert_not_called()
@@ -123,9 +123,9 @@ class ExperimentalBaseConnectionDefaultMethodTests(unittest.TestCase):
         conn = MockConnection("my_mock_connection")
 
         with patch(
-            "streamlit.connections.base_connection.ExperimentalBaseConnection.reset"
+            "streamlit.connections.base_connection.BaseConnection.reset"
         ) as patched_reset, patch(
-            "streamlit.connections.base_connection.ExperimentalBaseConnection._secrets",
+            "streamlit.connections.base_connection.BaseConnection._secrets",
             PropertyMock(return_value=AttrDict({"mock_connection": {"new": "secret"}})),
         ):
             conn._on_secrets_changed("unused_arg")

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -1,0 +1,167 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+import streamlit as st
+from streamlit.connections import SnowflakeConnection
+from streamlit.connections.snowflake_connection import _validate_connection_params
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.secrets import AttrDict
+from tests.testutil import create_mock_script_run_ctx
+
+
+@pytest.mark.require_snowflake
+class SnowflakeConnectionTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        st.cache_data.clear()
+
+    def test_validate_connection_params(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            _validate_connection_params(
+                {"required1", "required2", "required3"}, {"required1": "foo"}
+            )
+
+        for msg in [
+            "Missing Snowflake connection params",
+            "required2",
+            "required3",
+        ]:
+            assert msg in str(e.value)
+
+    @patch(
+        "snowflake.snowpark.context.get_active_session",
+    )
+    @patch(
+        "streamlit.connections.snowflake_connection.running_in_sis",
+        MagicMock(return_value=True),
+    )
+    def test_uses_active_session_if_in_sis(self, patched_get_active_session):
+        active_session_mock = MagicMock()
+        active_session_mock.connection = "some active session"
+        patched_get_active_session.return_value = active_session_mock
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        assert conn._instance == "some active session"
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+        PropertyMock(
+            return_value=AttrDict({"account": "some_val_1", "some_key": "some_val_2"})
+        ),
+    )
+    @patch("snowflake.connector.connect")
+    def test_uses_streamlit_secrets_if_available(self, patched_connect):
+        SnowflakeConnection("my_snowflake_connection")
+        patched_connect.assert_called_once_with(
+            account="some_val_1", some_key="some_val_2"
+        )
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+        PropertyMock(return_value=AttrDict({"some_key": "some_val_2"})),
+    )
+    def test_uses_streamlit_secrets_error(self):
+        with pytest.raises(StreamlitAPIException) as e:
+            SnowflakeConnection("my_snowflake_connection")
+        assert "Missing Snowflake connection params: account" in str(e.value)
+
+    @patch("snowflake.connector.connect")
+    def test_uses_config_manager_if_available(self, patched_connect):
+        SnowflakeConnection("snowflake", some_kwarg="some_value")
+
+        patched_connect.assert_called_once_with(
+            connection_name="default", some_kwarg="some_value"
+        )
+
+    @patch("snowflake.connector.connection")
+    @patch("snowflake.connector.connect")
+    def test_falls_back_to_using_kwargs_last(self, patched_connect, patched_connection):
+        delattr(patched_connection, "CONFIG_MANAGER")
+
+        SnowflakeConnection("snowflake", account="account", some_kwarg="some_value")
+        patched_connect.assert_called_once_with(
+            account="account", some_kwarg="some_value"
+        )
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_query_caches_value(self):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(return_value="i am a dataframe")
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+        assert conn.query("SELECT 1;") == "i am a dataframe"
+
+        conn._instance.cursor.assert_called_once()
+        mock_cursor.execute.assert_called_once_with("SELECT 1;", params=None)
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_retry_behavior(self):
+        from snowflake.connector import Error as SnowflakeError
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(
+            side_effect=SnowflakeError("oh noes :()")
+        )
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
+            with pytest.raises(SnowflakeError):
+                conn.query("SELECT 1;")
+
+            # Our connection should have been reset after each failed attempt to call
+            # query.
+            assert wrapped_reset.call_count == 3
+
+        # conn._connect should have been called three times: once in the initial
+        # connection, then once each after the second and third attempts to call
+        # query.
+        assert conn._connect.call_count == 3
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_retry_fails_fast_for_most_errors(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(side_effect=Exception("oh noes :()"))
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        with pytest.raises(Exception):
+            conn.query("SELECT 1;")
+
+        # conn._connect should have just been called once when first creating the
+        # connection.
+        assert conn._connect.call_count == 1

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -133,8 +133,6 @@ class SnowparkConnectionTest(unittest.TestCase):
         MagicMock(),
     )
     def test_retry_fails_fast_for_most_errors(self):
-        from snowflake.snowpark.exceptions import SnowparkServerException
-
         mock_sql_return = MagicMock()
         mock_sql_return.to_pandas = MagicMock(side_effect=Exception("oh noes :("))
 

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -37,16 +37,15 @@ class ConnectionUtilTest(unittest.TestCase):
         assert d == {"k3": "v3", "k4": "v4"}
 
     @pytest.mark.require_snowflake
-    @patch("snowflake.connector.connection", MagicMock())
     def test_not_running_in_sis(self):
         assert not running_in_sis()
 
     @pytest.mark.require_snowflake
     @patch(
-        "snowflake.connector.connection",
+        "snowflake.snowpark._internal.utils.is_in_stored_procedure",
+        MagicMock(return_value=True),
     )
-    def test_running_in_sis(self, patched_connection):
-        delattr(patched_connection, "SnowflakeConnection")
+    def test_running_in_sis(self):
         assert running_in_sis()
 
     def test_load_from_snowsql_config_file_no_file(self):

--- a/lib/tests/streamlit/deprecation_util_test.py
+++ b/lib/tests/streamlit/deprecation_util_test.py
@@ -105,3 +105,29 @@ class DeprecationUtilTest(unittest.TestCase):
 
         # We only show the warning a single time for a given object.
         mock_show_warning.assert_called_once_with(expected_warning)
+
+    @patch("streamlit.deprecation_util.show_deprecation_warning")
+    def test_deprecate_obj_name_no_st_prefix(self, mock_show_warning: Mock):
+        class DictClass(dict):
+            pass
+
+        beta_dict = deprecate_obj_name(
+            DictClass(),
+            "beta_dict",
+            "my_dict",
+            "1980-01-01",
+            include_st_prefix=False,
+        )
+
+        beta_dict["foo"] = "bar"
+        self.assertEqual(beta_dict["foo"], "bar")
+        self.assertEqual(len(beta_dict), 1)
+        self.assertEqual(list(beta_dict), ["foo"])
+
+        expected_warning = (
+            "Please replace `beta_dict` with `my_dict`.\n\n"
+            "`beta_dict` will be removed after 1980-01-01."
+        )
+
+        # We only show the warning a single time for a given object.
+        mock_show_warning.assert_called_once_with(expected_warning)

--- a/lib/tests/streamlit/deprecation_util_test.py
+++ b/lib/tests/streamlit/deprecation_util_test.py
@@ -66,6 +66,23 @@ class DeprecationUtilTest(unittest.TestCase):
         mock_show_warning.assert_called_once_with(expected_warning)
 
     @patch("streamlit.deprecation_util.show_deprecation_warning")
+    def test_deprecate_func_name_with_override(self, mock_show_warning: Mock):
+        def multiply(a, b):
+            return a * b
+
+        beta_multiply = deprecate_func_name(
+            multiply, "beta_multiply", "1980-01-01", name_override="mul"
+        )
+
+        self.assertEqual(beta_multiply(3, 2), 6)
+
+        expected_warning = (
+            "Please replace `st.beta_multiply` with `st.mul`.\n\n"
+            "`st.beta_multiply` will be removed after 1980-01-01."
+        )
+        mock_show_warning.assert_called_once_with(expected_warning)
+
+    @patch("streamlit.deprecation_util.show_deprecation_warning")
     def test_deprecate_obj_name(self, mock_show_warning: Mock):
         """Test that we override dunder methods."""
 

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,7 +21,12 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
+from streamlit.connections import (
+    BaseConnection,
+    SnowflakeConnection,
+    SnowparkConnection,
+    SQLConnection,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
@@ -72,6 +77,7 @@ class ConnectionFactoryTest(unittest.TestCase):
 
     @parameterized.expand(
         [
+            ("snowflake", SnowflakeConnection),
             ("snowpark", SnowparkConnection),
             ("sql", SQLConnection),
         ]
@@ -183,7 +189,8 @@ type="snowpark"
             ("MySQLdb", "mysqlclient"),
             ("psycopg2", "psycopg2-binary"),
             ("sqlalchemy", "sqlalchemy"),
-            ("snowflake", "snowflake-snowpark-python"),
+            ("snowflake", "snowflake-connector-python"),
+            ("snowflake.connector", "snowflake-connector-python"),
             ("snowflake.snowpark", "snowflake-snowpark-python"),
         ]
     )

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -21,11 +21,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from parameterized import parameterized
 
-from streamlit.connections import (
-    ExperimentalBaseConnection,
-    SnowparkConnection,
-    SQLConnection,
-)
+from streamlit.connections import BaseConnection, SnowparkConnection, SQLConnection
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_resource_api import _resource_caches
 from streamlit.runtime.connection_factory import (
@@ -38,7 +34,7 @@ from streamlit.runtime.secrets import secrets_singleton
 from tests.testutil import create_mock_script_run_ctx
 
 
-class MockConnection(ExperimentalBaseConnection[None]):
+class MockConnection(BaseConnection[None]):
     def _connect(self, **kwargs):
         pass
 
@@ -63,7 +59,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self._prev_environ)
 
-    def test_create_connection_helper_explodes_if_not_ExperimentalBaseConnection_subclass(
+    def test_create_connection_helper_explodes_if_not_BaseConnection_subclass(
         self,
     ):
         class NotABaseConnection:
@@ -72,7 +68,7 @@ class ConnectionFactoryTest(unittest.TestCase):
         with pytest.raises(StreamlitAPIException) as e:
             _create_connection("my_connection", NotABaseConnection)
 
-        assert "is not a subclass of ExperimentalBaseConnection" in str(e.value)
+        assert "is not a subclass of BaseConnection" in str(e.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -257,10 +257,11 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         """All commands of the public API should be tracked with the correct name."""
         # Some commands are currently not tracked for various reasons:
         ignored_commands = {
-            # We need to ignore `experimental_connection` because the `@gather_metrics`
-            # decorator is attached to a helper function rather than the
-            # publicly-exported function, which causes it not to be executed before an
-            # Exception is raised due to a lack of required arguments.
+            # We need to ignore `connection` because the `@gather_metrics` decorator is
+            # attached to a helper function rather than the publicly-exported function,
+            # which causes it not to be executed before an Exception is raised due to a
+            # lack of required arguments.
+            "connection",
             "experimental_connection",
             "spinner",
             "empty",

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -153,6 +153,7 @@ class StreamlitTest(unittest.TestCase):
                 "experimental_connection",
                 "get_option",
                 "set_option",
+                "connection",
             },
         )
 


### PR DESCRIPTION
This PR de-experimentalizes `st.experimental_connection` to just be `st.connection`.

As part of this work, we make several changes:
* Remove the `experimental` prefix from `st.experimental_connection` and `ExperimentalBaseConnection`
* Add a new `__getattribute__` method to `BaseConnection` that provides a friendly error message to the developer
   if they attempt to use a method that exists on the underlying connection but not the wrapper.
* Add a few new additional convenience methods to `SQLConnection`
* Implement a new `SnowflakeConnection` connection class. This new default connection class supersedes
  `SnowparkConnection` and provides the same functionality while also providing lower level access to the
   `snowflake-connector-python` library. 
* Add deprecation warnings for the usage of `st.experimental_connection` and `SnowparkConnection`