### PR TITLE
Allow a service managing a Streamlit runtime to set its own session IDs

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -80,6 +80,7 @@ class AppSession:
         message_enqueued_callback: Optional[Callable[[], None]],
         local_sources_watcher: LocalSourcesWatcher,
         user_info: Dict[str, Optional[str]],
+        session_id_override: Optional[str] = None,
     ) -> None:
         """Initialize the AppSession.
 
@@ -113,9 +114,13 @@ class AppSession:
             Information about the current user is optionally provided when a
             websocket connection is initialized via the "X-Streamlit-User" header.
 
+        session_id_override
+            The ID to assign to this session. Setting this can be useful when the
+            service that a Streamlit Runtime is running in wants to tie the lifecycle of
+            a Streamlit session to some other session-like object that it manages.
         """
         # Each AppSession has a unique string ID.
-        self.id = str(uuid.uuid4())
+        self.id = session_id_override or str(uuid.uuid4())
 
         self._event_loop = asyncio.get_running_loop()
         self._script_data = script_data

--- a/lib/streamlit/runtime/session_manager.py
+++ b/lib/streamlit/runtime/session_manager.py
@@ -237,6 +237,7 @@ class SessionManager(Protocol):
         script_data: ScriptData,
         user_info: Dict[str, Optional[str]],
         existing_session_id: Optional[str] = None,
+        session_id_override: Optional[str] = None,
     ) -> str:
         """Create a new session or connect to an existing one.
 
@@ -256,10 +257,16 @@ class SessionManager(Protocol):
             }
         existing_session_id
             The ID of an existing session to reconnect to. If one is not provided, a new
-            session is created. Note that whether a SessionManager supports reconnection
+            session is created. Note that whether a SessionManager supports reconnecting
             to an existing session is left up to the concrete SessionManager
             implementation. Those that do not support reconnection should simply ignore
             this argument.
+        session_id_override
+            The ID to assign to a new session being created with this method. Setting
+            this can be useful when the service that a Streamlit Runtime is running in
+            wants to tie the lifecycle of a Streamlit session to some other session-like
+            object that it manages. Only one of existing_session_id and
+            session_id_override should be set.
 
         Returns
         -------

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -64,7 +64,12 @@ class WebsocketSessionManager(SessionManager):
         script_data: ScriptData,
         user_info: Dict[str, Optional[str]],
         existing_session_id: Optional[str] = None,
+        session_id_override: Optional[str] = None,
     ) -> str:
+        assert not (
+            existing_session_id and session_id_override
+        ), "Only one of existing_session_id and session_id_override should be truthy"
+
         if existing_session_id in self._active_session_info_by_id:
             LOGGER.warning(
                 "Session with id %s is already connected! Connecting to a new session.",
@@ -97,6 +102,7 @@ class WebsocketSessionManager(SessionManager):
             message_enqueued_callback=self._message_enqueued_callback,
             local_sources_watcher=LocalSourcesWatcher(script_data.main_script_path),
             user_info=user_info,
+            session_id_override=session_id_override,
         )
 
         LOGGER.debug(

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -137,6 +137,18 @@ class RuntimeTest(RuntimeTestCase):
         self.runtime.disconnect_session(session_id)
         self.assertEqual(RuntimeState.NO_SESSIONS_CONNECTED, self.runtime.state)
 
+    async def test_connect_session_error_if_both_session_id_args(self):
+        """Test that setting both existing_session_id and session_id_override is an error."""
+        await self.runtime.start()
+
+        with pytest.raises(AssertionError):
+            self.runtime.connect_session(
+                client=MockSessionClient(),
+                user_info=MagicMock(),
+                existing_session_id="existing_session_id",
+                session_id_override="session_id_override",
+            )
+
     async def test_connect_session_existing_session_id_plumbing(self):
         """The existing_session_id parameter is plumbed to _session_mgr.connect_session."""
         await self.runtime.start()
@@ -159,6 +171,32 @@ class RuntimeTest(RuntimeTestCase):
                 script_data=ANY,
                 user_info=user_info,
                 existing_session_id=existing_session_id,
+                session_id_override=None,
+            )
+
+    async def test_connect_session_session_id_override_plumbing(self):
+        """The session_id_override parameter is plumbed to _session_mgr.connect_session."""
+        await self.runtime.start()
+
+        with patch.object(
+            self.runtime._session_mgr, "connect_session", new=MagicMock()
+        ) as patched_connect_session:
+            client = MockSessionClient()
+            user_info = MagicMock()
+            session_id_override = "some_session_id"
+
+            session_id = self.runtime.connect_session(
+                client=client,
+                user_info=user_info,
+                session_id_override=session_id_override,
+            )
+
+            patched_connect_session.assert_called_with(
+                client=client,
+                script_data=ANY,
+                user_info=user_info,
+                existing_session_id=None,
+                session_id_override=session_id_override,
             )
 
     @patch("streamlit.runtime.runtime.LOGGER")
@@ -178,6 +216,7 @@ class RuntimeTest(RuntimeTestCase):
                 client=client,
                 user_info=user_info,
                 existing_session_id=None,
+                session_id_override=None,
             )
             patched_logger.warning.assert_called_with(
                 "create_session is deprecated! Use connect_session instead."

--- a/lib/tests/streamlit/runtime/runtime_test_case.py
+++ b/lib/tests/streamlit/runtime/runtime_test_case.py
@@ -62,6 +62,7 @@ class MockSessionManager(SessionManager):
         script_data: ScriptData,
         user_info: Dict[str, Optional[str]],
         existing_session_id: Optional[str] = None,
+        session_id_override: Optional[str] = None,
     ) -> str:
         with mock.patch(
             "streamlit.runtime.scriptrunner.ScriptRunner", new=mock.MagicMock()
@@ -73,6 +74,7 @@ class MockSessionManager(SessionManager):
                 message_enqueued_callback=self._message_enqueued_callback,
                 local_sources_watcher=mock.MagicMock(),
                 user_info=user_info,
+                session_id_override=session_id_override,
             )
 
         assert (

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -61,12 +61,13 @@ class WebsocketSessionManagerTests(unittest.TestCase):
             message_enqueued_callback=MagicMock(),
         )
 
-    def connect_session(self, existing_session_id=None):
+    def connect_session(self, existing_session_id=None, session_id_override=None):
         return self.session_mgr.connect_session(
             client=MagicMock(),
             script_data=ScriptData("/fake/script_path.py", "fake_command_line"),
             user_info={},
             existing_session_id=existing_session_id,
+            session_id_override=session_id_override,
         )
 
     def test_connect_session(self):
@@ -74,6 +75,19 @@ class WebsocketSessionManagerTests(unittest.TestCase):
         session_info = self.session_mgr._active_session_info_by_id[session_id]
 
         assert session_info.session.id == session_id
+
+    def test_connect_session_assert(self):
+        with pytest.raises(AssertionError):
+            session_id = self.connect_session(
+                existing_session_id="existing_session_id",
+                session_id_override="session_id_override",
+            )
+
+    def test_connect_session_with_session_id_override(self):
+        self.connect_session(session_id_override="my_session_id")
+        session_info = self.session_mgr._active_session_info_by_id["my_session_id"]
+
+        assert session_info.session.id == "my_session_id"
 
     def test_connect_session_on_invalid_session_id(self):
         """Test that connect_session gives us a new session if existing_session_id is invalid."""


### PR DESCRIPTION
Followup work related to the recent `st.file_uploader` abstractions we built in #7025 uncovered
that it'd be useful to allow the service that manages a Streamlit runtime to be able to set session
IDs itself rather than have them automatically generated by the runtime. This comes in handy when
the service already maintains some sort of session-like objects that it naturally wants to tie the
lifecycle of Streamlit sessions to.

To enable this, we add a new `session_id_override` parameter to `Runtime.connect_session`,
`SessionManager.connect_session`, and other related methods/constructors. Note that we
do **NOT** use this new parameter in "normal" Streamlit OS deployments where the Streamlit
runtime is run via a Tornado server.