### PR TITLE
Remove keyword sentences from docstrings

### DIFF
--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -38,7 +38,7 @@ class AlertMixin:
         body : str
             The error text to display.
         icon : str or None
-            An optional, keyword-only argument that specifies an emoji to use as
+            An optional argument that specifies an emoji to use as
             the icon for the alert. Shortcodes are not allowed, please use a
             single character instead. E.g. "🚨", "🔥", "🤖", etc.
             Defaults to None, which means no icon is displayed.
@@ -70,7 +70,7 @@ class AlertMixin:
         body : str
             The warning text to display.
         icon : str or None
-            An optional, keyword-only argument that specifies an emoji to use as
+            An optional argument that specifies an emoji to use as
             the icon for the alert. Shortcodes are not allowed, please use a
             single character instead. E.g. "🚨", "🔥", "🤖", etc.
             Defaults to None, which means no icon is displayed.
@@ -102,7 +102,7 @@ class AlertMixin:
         body : str
             The info text to display.
         icon : str or None
-            An optional, keyword-only argument that specifies an emoji to use as
+            An optional argument that specifies an emoji to use as
             the icon for the alert. Shortcodes are not allowed, please use a
             single character instead. E.g. "🚨", "🔥", "🤖", etc.
             Defaults to None, which means no icon is displayed.
@@ -135,7 +135,7 @@ class AlertMixin:
         body : str
             The success text to display.
         icon : str or None
-            An optional, keyword-only argument that specifies an emoji to use as
+            An optional argument that specifies an emoji to use as
             the icon for the alert. Shortcodes are not allowed, please use a
             single character instead. E.g. "🚨", "🔥", "🤖", etc.
             Defaults to None, which means no icon is displayed.

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -92,7 +92,6 @@ class ArrowMixin:
         use_container_width : bool
             If True, set the dataframe width to the width of the parent container.
             This takes precedence over the width argument.
-            This argument can only be supplied by keyword.
 
         hide_index : bool or None
             Whether to hide the index column(s). If None (default), the visibility of

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -134,18 +134,15 @@ class ArrowAltairMixin:
 
         x : str or None
             Column name to use for the x-axis. If None, uses the data index for the x-axis.
-            This argument can only be supplied by keyword.
 
         y : str, Sequence of str, or None
             Column name(s) to use for the y-axis. If a Sequence of strings,
             draws several series on the same chart by melting your wide-format
             table into a long-format table behind the scenes. If None, draws
-            the data of all remaining columns as data series. This argument
-            can only be supplied by keyword.
+            the data of all remaining columns as data series.
 
         color : str, tuple, Sequence of str, Sequence of tuple, or None
-            The color to use for different lines in this chart. This argument
-            can only be supplied by keyword.
+            The color to use for different lines in this chart.
 
             For a line chart with just one line, this can be:
 
@@ -186,16 +183,13 @@ class ArrowAltairMixin:
 
         width : int
             The chart width in pixels. If 0, selects the width automatically.
-            This argument can only be supplied by keyword.
 
         height : int
             The chart height in pixels. If 0, selects the height automatically.
-            This argument can only be supplied by keyword.
 
         use_container_width : bool
             If True, set the chart width to the column width. This takes
             precedence over the width argument.
-            This argument can only be supplied by keyword.
 
         Examples
         --------
@@ -298,18 +292,15 @@ class ArrowAltairMixin:
 
         x : str or None
             Column name to use for the x-axis. If None, uses the data index for the x-axis.
-            This argument can only be supplied by keyword.
 
         y : str, Sequence of str, or None
             Column name(s) to use for the y-axis. If a Sequence of strings,
             draws several series on the same chart by melting your wide-format
             table into a long-format table behind the scenes. If None, draws
-            the data of all remaining columns as data series. This argument can
-            only be supplied by keyword.
+            the data of all remaining columns as data series.
 
         color : str, tuple, Sequence of str, Sequence of tuple, or None
-            The color to use for different series in this chart. This argument
-            can only be supplied by keyword.
+            The color to use for different series in this chart.
 
             For an area chart with just 1 series, this can be:
 
@@ -350,16 +341,13 @@ class ArrowAltairMixin:
 
         width : int
             The chart width in pixels. If 0, selects the width automatically.
-            This argument can only be supplied by keyword.
 
         height : int
             The chart height in pixels. If 0, selects the height automatically.
-            This argument can only be supplied by keyword.
 
         use_container_width : bool
             If True, set the chart width to the column width. This takes
             precedence over the width argument.
-            This argument can only be supplied by keyword.
 
         Examples
         --------
@@ -463,18 +451,15 @@ class ArrowAltairMixin:
 
         x : str or None
             Column name to use for the x-axis. If None, uses the data index for the x-axis.
-            This argument can only be supplied by keyword.
 
         y : str, Sequence of str, or None
             Column name(s) to use for the y-axis. If a Sequence of strings,
             draws several series on the same chart by melting your wide-format
             table into a long-format table behind the scenes. If None, draws
-            the data of all remaining columns as data series. This argument
-            can only be supplied by keyword.
+            the data of all remaining columns as data series.
 
         color : str, tuple, Sequence of str, Sequence of tuple, or None
-            The color to use for different series in this chart. This argument
-            can only be supplied by keyword.
+            The color to use for different series in this chart.
 
             For a bar chart with just one series, this can be:
 
@@ -515,16 +500,13 @@ class ArrowAltairMixin:
 
         width : int
             The chart width in pixels. If 0, selects the width automatically.
-            This argument can only be supplied by keyword.
 
         height : int
             The chart height in pixels. If 0, selects the height automatically.
-            This argument can only be supplied by keyword.
 
         use_container_width : bool
             If True, set the chart width to the column width. This takes
             precedence over the width argument.
-            This argument can only be supplied by keyword.
 
         Examples
         --------
@@ -631,18 +613,15 @@ class ArrowAltairMixin:
 
         x : str or None
             Column name to use for the x-axis. If None, uses the data index for the x-axis.
-            This argument can only be supplied by keyword.
 
         y : str, Sequence of str, or None
             Column name(s) to use for the y-axis. If a Sequence of strings,
             draws several series on the same chart by melting your wide-format
             table into a long-format table behind the scenes. If None, draws
-            the data of all remaining columns as data series. This argument can
-            only be supplied by keyword.
+            the data of all remaining columns as data series.
 
         color : str, tuple, Sequence of str, Sequence of tuple, or None
-            The color of the circles representing each datapoint. This argument
-            can only be supplied by keyword.
+            The color of the circles representing each datapoint.
 
             This can be:
 
@@ -681,8 +660,7 @@ class ArrowAltairMixin:
               for three series).
 
         size : str, float, int, or None
-            The size of the circles representing each point. This argument can
-            only be supplied by keyword.
+            The size of the circles representing each point.
 
             This can be:
 
@@ -693,16 +671,13 @@ class ArrowAltairMixin:
 
         width : int
             The chart width in pixels. If 0, selects the width automatically.
-            This argument can only be supplied by keyword.
 
         height : int
             The chart height in pixels. If 0, selects the height automatically.
-            This argument can only be supplied by keyword.
 
         use_container_width : bool
             If True, set the chart width to the column width. This takes
             precedence over the width argument.
-            This argument can only be supplied by keyword.
 
         Examples
         --------
@@ -829,7 +804,7 @@ class ArrowAltairMixin:
         https://altair-viz.github.io/gallery/.
 
         """
-        if theme != "streamlit" and theme != None:
+        if theme != "streamlit" and theme is not None:
             raise StreamlitAPIException(
                 f'You set theme="{theme}" while Streamlit charts only support theme=”streamlit” or theme=None to fallback to the default library theme.'
             )

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -804,7 +804,7 @@ class ArrowAltairMixin:
         https://altair-viz.github.io/gallery/.
 
         """
-        if theme != "streamlit" and theme is not None:
+        if theme != "streamlit" and theme != None:
             raise StreamlitAPIException(
                 f'You set theme="{theme}" while Streamlit charts only support theme=”streamlit” or theme=None to fallback to the default library theme.'
             )

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -255,11 +255,11 @@ class FormMixin:
             An optional dict of kwargs to pass to the callback.
         type : "secondary" or "primary"
             An optional string that specifies the button type. Can be "primary" for a
-            button with additional emphasis or "secondary" for a normal button. This
-            argument can only be supplied by keyword. Defaults to "secondary".
+            button with additional emphasis or "secondary" for a normal button. Defaults
+            to "secondary".
         disabled : bool
             An optional boolean, which disables the button if set to True. The
-            default is False. This argument can only be supplied by keyword.
+            default is False.
         use_container_width: bool
             An optional boolean, which makes the button stretch its width to match the parent container.
 

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -51,7 +51,6 @@ class JsonMixin:
         expanded : bool
             An optional boolean that allows the user to set whether the initial
             state of this json element should be expanded. Defaults to True.
-            This argument can only be supplied by keyword.
 
         Example
         -------

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -108,8 +108,7 @@ class LayoutsMixin:
               the width of the first one, and the third one is three times that width.
 
         gap : "small", "medium", or "large"
-            The size of the gap between the columns. Defaults to "small". This
-            argument can only be supplied by keyword.
+            The size of the gap between the columns. Defaults to "small".
 
         Returns
         -------

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -129,23 +129,20 @@ class MapMixin:
 
         latitude : str or None
             The name of the column containing the latitude coordinates of
-            the datapoints in the chart. This argument can only be supplied
-            by keyword.
+            the datapoints in the chart.
 
             If None, the latitude data will come from any column named 'lat',
             'latitude', 'LAT', or 'LATITUDE'.
 
         longitude : str or None
             The name of the column containing the longitude coordinates of
-            the datapoints in the chart. This argument can only be supplied
-            by keyword.
+            the datapoints in the chart.
 
             If None, the longitude data will come from any column named 'lon',
             'longitude', 'LON', or 'LONGITUDE'.
 
         color : str or tuple or None
-            The color of the circles representing each datapoint. This argument
-            can only be supplied by keyword.
+            The color of the circles representing each datapoint.
 
             Can be:
 
@@ -159,8 +156,7 @@ class MapMixin:
               as described above.
 
         size : str or float or None
-            The size of the circles representing each point, in meters. This
-            argument can only be supplied by keyword.
+            The size of the circles representing each point, in meters.
 
             This can be:
 
@@ -173,12 +169,10 @@ class MapMixin:
         zoom : int
             Zoom level as specified in
             https://wiki.openstreetmap.org/wiki/Zoom_levels.
-            This argument can only be supplied by keyword.
 
         use_container_width: bool
             If True, set the chart width to the column width. This takes
             precedence over the width argument.
-            This argument can only be supplied by keyword.
 
         Examples
         --------

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -104,7 +104,7 @@ class MetricMixin:
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Example
         -------

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -69,7 +69,7 @@ class ToastMixin:
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet, gray/grey, rainbow.
         icon : str or None
-            An optional, keyword-only argument that specifies an emoji to use as
+            An optional argument that specifies an emoji to use as
             the icon for the toast. Shortcodes are not allowed, please use a
             single character instead. E.g. "🚨", "🔥", "🤖", etc.
             Defaults to None, which means no icon is displayed.

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -115,11 +115,11 @@ class ButtonMixin:
             An optional dict of kwargs to pass to the callback.
         type : "secondary" or "primary"
             An optional string that specifies the button type. Can be "primary" for a
-            button with additional emphasis or "secondary" for a normal button. This
-            argument can only be supplied by keyword. Defaults to "secondary".
+            button with additional emphasis or "secondary" for a normal button. Defaults
+            to "secondary".
         disabled : bool
             An optional boolean, which disables the button if set to True. The
-            default is False. This argument can only be supplied by keyword.
+            default is False.
         use_container_width: bool
             An optional boolean, which makes the button stretch its width to match the parent container.
 
@@ -215,8 +215,8 @@ class ButtonMixin:
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet, gray/grey, rainbow.
 
-            Unsupported elements are unwrapped so only their children (text contents) render.
-            Display unsupported elements as literal characters by
+            Unsupported elements are unwrapped so only their children (text contents)
+            render. Display unsupported elements as literal characters by
             backslash-escaping them. E.g. ``1\. Not an ordered list``.
         data : str or bytes or file
             The contents of the file to be downloaded. See example below for
@@ -246,14 +246,14 @@ class ButtonMixin:
             An optional dict of kwargs to pass to the callback.
         type : "secondary" or "primary"
             An optional string that specifies the button type. Can be "primary" for a
-            button with additional emphasis or "secondary" for a normal button. This
-            argument can only be supplied by keyword. Defaults to "secondary".
+            button with additional emphasis or "secondary" for a normal button. Defaults
+            to "secondary".
         disabled : bool
             An optional boolean, which disables the download button if set to
-            True. The default is False. This argument can only be supplied by
-            keyword.
+            True. The default is False.
         use_container_width: bool
-            An optional boolean, which makes the button stretch its width to match the parent container.
+            An optional boolean, which makes the button stretch its width to match the
+            parent container.
 
 
         Returns
@@ -375,8 +375,8 @@ class ButtonMixin:
               where ``color`` needs to be replaced with any of the following
               supported colors: blue, green, orange, red, violet, gray/grey, rainbow.
 
-            Unsupported elements are unwrapped so only their children (text contents) render.
-            Display unsupported elements as literal characters by
+            Unsupported elements are unwrapped so only their children (text contents)
+            render. Display unsupported elements as literal characters by
             backslash-escaping them. E.g. ``1\. Not an ordered list``.
         url : str
             The url to be opened on user click
@@ -385,13 +385,14 @@ class ButtonMixin:
             hovered over.
         type : "secondary" or "primary"
             An optional string that specifies the button type. Can be "primary" for a
-            button with additional emphasis or "secondary" for a normal button. This
-            argument can only be supplied by keyword. Defaults to "secondary".
+            button with additional emphasis or "secondary" for a normal button. Defaults
+            to "secondary".
         disabled : bool
             An optional boolean, which disables the link button if set to
             True. The default is False.
         use_container_width: bool
-            An optional boolean, which makes the button stretch its width to match the parent container.
+            An optional boolean, which makes the button stretch its width to match the
+            parent container.
 
         Example
         -------

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -140,13 +140,12 @@ class CameraInputMixin:
 
         disabled : bool
             An optional boolean, which disables the camera input if set to
-            True. The default is False. This argument can only be supplied by
-            keyword.
+            True. Default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -112,12 +112,12 @@ class CheckboxMixin:
             An optional dict of kwargs to pass to the callback.
         disabled : bool
             An optional boolean, which disables the checkbox if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------
@@ -215,12 +215,12 @@ class CheckboxMixin:
             An optional dict of kwargs to pass to the callback.
         disabled : bool
             An optional boolean, which disables the toggle if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -116,10 +116,10 @@ class ColorPickerMixin:
             True. The default is False. This argument can only be supplied by
             keyword.
         label_visibility : "visible", "hidden", or "collapsed"
-            The visibility of the label. If "hidden", the label doesn’t show but there
+            The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -305,7 +305,7 @@ class FileUploaderMixin:
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -219,7 +219,6 @@ class MultiSelectMixin:
             An optional dict of kwargs to pass to the callback.
         max_selections : int
             The max selections that can be selected at a time.
-            This argument can only be supplied by keyword.
         placeholder : str
             A string to display when no options are selected. Defaults to 'Choose an option'.
         disabled : bool
@@ -230,7 +229,7 @@ class MultiSelectMixin:
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -197,13 +197,12 @@ class NumberInputMixin:
             If None, no placeholder is displayed.
         disabled : bool
             An optional boolean, which disables the number input if set to
-            True. The default is False. This argument can only be supplied by
-            keyword.
+            True. The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -157,12 +157,10 @@ class RadioMixin:
             An optional dict of kwargs to pass to the callback.
         disabled : bool
             An optional boolean, which disables the radio button if set to
-            True. The default is False. This argument can only be supplied by
-            keyword.
+            True. The default is False.
         horizontal : bool
             An optional boolean, which orients the radio group horizontally.
-            The default is false (vertical buttons). This argument can only
-            be supplied by keyword.
+            The default is false (vertical buttons).
         captions : iterable of str or None
             A list of captions to show below each radio button. If None (default),
             no captions are shown.
@@ -170,7 +168,7 @@ class RadioMixin:
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -189,12 +189,12 @@ class SelectSliderMixin:
             An optional dict of kwargs to pass to the callback.
         disabled : bool
             An optional boolean, which disables the select slider if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -148,12 +148,12 @@ class SelectboxMixin:
             Defaults to 'Choose an option'.
         disabled : bool
             An optional boolean, which disables the selectbox if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -279,12 +279,12 @@ class SliderMixin:
             An optional dict of kwargs to pass to the callback.
         disabled : bool
             An optional boolean, which disables the slider if set to True. The
-            default is False. This argument can only be supplied by keyword.
+            default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
 
         Returns

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -189,15 +189,15 @@ class TextWidgetsMixin:
             An optional dict of kwargs to pass to the callback.
         placeholder : str or None
             An optional string displayed when the text input is empty. If None,
-            no text is displayed. This argument can only be supplied by keyword.
+            no text is displayed.
         disabled : bool
             An optional boolean, which disables the text input if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------
@@ -444,15 +444,15 @@ class TextWidgetsMixin:
             An optional dict of kwargs to pass to the callback.
         placeholder : str or None
             An optional string displayed when the text area is empty. If None,
-            no text is displayed. This argument can only be supplied by keyword.
+            no text is displayed.
         disabled : bool
             An optional boolean, which disables the text area if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -82,7 +82,7 @@ def _parse_date_value(
     elif isinstance(value, date):
         parsed_dates = [value]
     elif isinstance(value, (list, tuple)):
-        if not len(value) in (0, 1, 2):
+        if len(value) not in (0, 1, 2):
             raise StreamlitAPIException(
                 "DateInput value should either be an date/datetime or a list/tuple of "
                 "0 - 2 date/datetime values"
@@ -338,12 +338,12 @@ class TimeWidgetsMixin:
             An optional dict of kwargs to pass to the callback.
         disabled : bool
             An optional boolean, which disables the time input if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
         step : int or timedelta
             The stepping interval in seconds. Defaults to 900, i.e. 15 minutes.
             You can also pass a datetime.timedelta object.
@@ -568,12 +568,12 @@ class TimeWidgetsMixin:
             You may also use a period (.) or hyphen (-) as separators.
         disabled : bool
             An optional boolean, which disables the date input if set to True.
-            The default is False. This argument can only be supplied by keyword.
+            The default is False.
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. If "hidden", the label doesn't show but there
             is still empty space for it above the widget (equivalent to label="").
             If "collapsed", both the label and the space are removed. Default is
-            "visible". This argument can only be supplied by keyword.
+            "visible".
 
 
         Returns

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -82,7 +82,7 @@ def _parse_date_value(
     elif isinstance(value, date):
         parsed_dates = [value]
     elif isinstance(value, (list, tuple)):
-        if len(value) not in (0, 1, 2):
+        if not len(value) in (0, 1, 2):
             raise StreamlitAPIException(
                 "DateInput value should either be an date/datetime or a list/tuple of "
                 "0 - 2 date/datetime values"


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

We sometimes use the sentence "This argument can only be supplied by keyword" in our docstrings. However, we do this very inconsistently and in most situations, it doesn't have a lot of advantages (because these arguments are mostly used by keyword anyway). After discussing with Debbie, we agreed these can be removed. Later on, we might add a small header on the docs page to better mark keyword-only args. 

## GitHub Issue Link (if applicable)

## Testing Plan

Only docstring change. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
