### PR TITLE
Adjust style of how we're defining module reexports

### DIFF
--- a/lib/streamlit/components/v1/__init__.py
+++ b/lib/streamlit/components/v1/__init__.py
@@ -15,10 +15,13 @@
 # `html` and `iframe` are part of Custom Components, so they appear in this
 # `streamlit.components.v1` namespace.
 import streamlit
-
-# Modules that the user should have access to. These are imported with "as"
-# syntax pass mypy checking with implicit_reexport disabled.
-from streamlit.components.v1.components import declare_component as declare_component
+from streamlit.components.v1.components import declare_component
 
 html = streamlit._main._html
 iframe = streamlit._main._iframe
+
+__all__ = [
+    "declare_component",
+    "html",
+    "iframe",
+]

--- a/lib/streamlit/connections/__init__.py
+++ b/lib/streamlit/connections/__init__.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Explicitly re-export public symbols.
-from streamlit.connections.base_connection import BaseConnection as BaseConnection
-from streamlit.connections.snowflake_connection import (
-    SnowflakeConnection as SnowflakeConnection,
-)
-from streamlit.connections.snowpark_connection import (
-    SnowparkConnection as SnowparkConnection,
-)
-from streamlit.connections.sql_connection import SQLConnection as SQLConnection
+from streamlit.connections.base_connection import BaseConnection
+from streamlit.connections.snowflake_connection import SnowflakeConnection
+from streamlit.connections.snowpark_connection import SnowparkConnection
+from streamlit.connections.sql_connection import SQLConnection
 
 ExperimentalBaseConnection = BaseConnection
+
+__all__ = [
+    "BaseConnection",
+    "SnowflakeConnection",
+    "SnowparkConnection",
+    "SQLConnection",
+    "ExperimentalBaseConnection",
+]

--- a/lib/streamlit/external/langchain/__init__.py
+++ b/lib/streamlit/external/langchain/__init__.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 from streamlit.external.langchain.streamlit_callback_handler import (
-    LLMThoughtLabeler as LLMThoughtLabeler,
+    LLMThoughtLabeler,
+    StreamlitCallbackHandler,
 )
-from streamlit.external.langchain.streamlit_callback_handler import (
-    StreamlitCallbackHandler as StreamlitCallbackHandler,
-)
+
+__all__ = [
+    "LLMThoughtLabeler",
+    "StreamlitCallbackHandler",
+]

--- a/lib/streamlit/runtime/__init__.py
+++ b/lib/streamlit/runtime/__init__.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Explicitly re-export public symbols from runtime.py and session_manager.py
-from streamlit.runtime.runtime import Runtime as Runtime
-from streamlit.runtime.runtime import RuntimeConfig as RuntimeConfig
-from streamlit.runtime.runtime import RuntimeState as RuntimeState
-from streamlit.runtime.session_manager import SessionClient as SessionClient
+from streamlit.runtime.runtime import Runtime, RuntimeConfig, RuntimeState
 from streamlit.runtime.session_manager import (
-    SessionClientDisconnectedError as SessionClientDisconnectedError,
+    SessionClient,
+    SessionClientDisconnectedError,
 )
 
 
@@ -38,3 +35,14 @@ def exists() -> bool:
     to adapt.
     """
     return Runtime.exists()
+
+
+__all__ = [
+    "Runtime",
+    "RuntimeConfig",
+    "RuntimeState",
+    "SessionClient",
+    "SessionClientDisconnectedError",
+    "get_instance",
+    "exists",
+]

--- a/lib/streamlit/runtime/caching/__init__.py
+++ b/lib/streamlit/runtime/caching/__init__.py
@@ -23,7 +23,7 @@ from streamlit.runtime.caching.cache_data_api import (
     CacheDataAPI,
     _data_caches,
 )
-from streamlit.runtime.caching.cache_errors import CACHE_DOCS_URL as CACHE_DOCS_URL
+from streamlit.runtime.caching.cache_errors import CACHE_DOCS_URL
 from streamlit.runtime.caching.cache_resource_api import (
     CACHE_RESOURCE_MESSAGE_REPLAY_CTX,
     CacheResourceAPI,
@@ -100,11 +100,9 @@ def suppress_cached_st_function_warning() -> Iterator[None]:
 
 
 # Explicitly export public symbols
-from streamlit.runtime.caching.cache_data_api import (
-    get_data_cache_stats_provider as get_data_cache_stats_provider,
-)
+from streamlit.runtime.caching.cache_data_api import get_data_cache_stats_provider
 from streamlit.runtime.caching.cache_resource_api import (
-    get_resource_cache_stats_provider as get_resource_cache_stats_provider,
+    get_resource_cache_stats_provider,
 )
 
 # Create and export public API singletons.
@@ -130,3 +128,20 @@ experimental_singleton = CacheResourceAPI(
     decorator_metric_name="experimental_singleton",
     deprecation_warning=_SINGLETON_WARNING,
 )
+
+
+__all__ = [
+    "CACHE_DOCS_URL",
+    "save_element_message",
+    "save_block_message",
+    "save_widget_metadata",
+    "save_media_data",
+    "maybe_show_cached_st_function_warning",
+    "suppress_cached_st_function_warning",
+    "get_data_cache_stats_provider",
+    "get_resource_cache_stats_provider",
+    "cache_data",
+    "cache_resource",
+    "experimental_memo",
+    "experimental_singleton",
+]

--- a/lib/streamlit/runtime/caching/storage/__init__.py
+++ b/lib/streamlit/runtime/caching/storage/__init__.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    CacheStorage as CacheStorage,
+    CacheStorage,
+    CacheStorageContext,
+    CacheStorageError,
+    CacheStorageKeyNotFoundError,
+    CacheStorageManager,
 )
-from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    CacheStorageContext as CacheStorageContext,
-)
-from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    CacheStorageError as CacheStorageError,
-)
-from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    CacheStorageKeyNotFoundError as CacheStorageKeyNotFoundError,
-)
-from streamlit.runtime.caching.storage.cache_storage_protocol import (
-    CacheStorageManager as CacheStorageManager,
-)
+
+__all__ = [
+    "CacheStorage",
+    "CacheStorageContext",
+    "CacheStorageError",
+    "CacheStorageKeyNotFoundError",
+    "CacheStorageManager",
+]

--- a/lib/streamlit/runtime/legacy_caching/__init__.py
+++ b/lib/streamlit/runtime/legacy_caching/__init__.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit.runtime.legacy_caching.caching import cache as cache
-from streamlit.runtime.legacy_caching.caching import clear_cache as clear_cache
-from streamlit.runtime.legacy_caching.caching import get_cache_path as get_cache_path
 from streamlit.runtime.legacy_caching.caching import (
-    maybe_show_cached_st_function_warning as maybe_show_cached_st_function_warning,
+    cache,
+    clear_cache,
+    get_cache_path,
+    maybe_show_cached_st_function_warning,
 )
+
+__all__ = [
+    "cache",
+    "clear_cache",
+    "get_cache_path",
+    "maybe_show_cached_st_function_warning",
+]

--- a/lib/streamlit/runtime/scriptrunner/__init__.py
+++ b/lib/streamlit/runtime/scriptrunner/__init__.py
@@ -12,22 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Explicitly export public symbols
-from streamlit.runtime.scriptrunner.script_requests import RerunData as RerunData
+from streamlit.runtime.scriptrunner.script_requests import RerunData
 from streamlit.runtime.scriptrunner.script_run_context import (
-    ScriptRunContext as ScriptRunContext,
-)
-from streamlit.runtime.scriptrunner.script_run_context import (
-    add_script_run_ctx as add_script_run_ctx,
-)
-from streamlit.runtime.scriptrunner.script_run_context import (
-    get_script_run_ctx as get_script_run_ctx,
+    ScriptRunContext,
+    add_script_run_ctx,
+    get_script_run_ctx,
 )
 from streamlit.runtime.scriptrunner.script_runner import (
-    RerunException as RerunException,
+    RerunException,
+    ScriptRunner,
+    ScriptRunnerEvent,
+    StopException,
 )
-from streamlit.runtime.scriptrunner.script_runner import ScriptRunner as ScriptRunner
-from streamlit.runtime.scriptrunner.script_runner import (
-    ScriptRunnerEvent as ScriptRunnerEvent,
-)
-from streamlit.runtime.scriptrunner.script_runner import StopException as StopException
+
+__all__ = [
+    "RerunData",
+    "ScriptRunContext",
+    "add_script_run_ctx",
+    "get_script_run_ctx",
+    "RerunException",
+    "ScriptRunner",
+    "ScriptRunnerEvent",
+    "StopException",
+]

--- a/lib/streamlit/runtime/state/__init__.py
+++ b/lib/streamlit/runtime/state/__init__.py
@@ -12,29 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit.runtime.state.common import WidgetArgs as WidgetArgs
-from streamlit.runtime.state.common import WidgetCallback as WidgetCallback
-from streamlit.runtime.state.common import WidgetKwargs as WidgetKwargs
-
-# Explicitly re-export public symbols
-from streamlit.runtime.state.safe_session_state import (
-    SafeSessionState as SafeSessionState,
-)
+from streamlit.runtime.state.common import WidgetArgs, WidgetCallback, WidgetKwargs
+from streamlit.runtime.state.safe_session_state import SafeSessionState
 from streamlit.runtime.state.session_state import (
-    SCRIPT_RUN_WITHOUT_ERRORS_KEY as SCRIPT_RUN_WITHOUT_ERRORS_KEY,
-)
-from streamlit.runtime.state.session_state import SessionState as SessionState
-from streamlit.runtime.state.session_state import (
-    SessionStateStatProvider as SessionStateStatProvider,
+    SCRIPT_RUN_WITHOUT_ERRORS_KEY,
+    SessionState,
+    SessionStateStatProvider,
 )
 from streamlit.runtime.state.session_state_proxy import (
-    SessionStateProxy as SessionStateProxy,
+    SessionStateProxy,
+    get_session_state,
 )
-from streamlit.runtime.state.session_state_proxy import (
-    get_session_state as get_session_state,
-)
-from streamlit.runtime.state.widgets import NoValue as NoValue
 from streamlit.runtime.state.widgets import (
-    coalesce_widget_states as coalesce_widget_states,
+    NoValue,
+    coalesce_widget_states,
+    register_widget,
 )
-from streamlit.runtime.state.widgets import register_widget as register_widget
+
+__all__ = [
+    "WidgetArgs",
+    "WidgetCallback",
+    "WidgetKwargs",
+    "SafeSessionState",
+    "SCRIPT_RUN_WITHOUT_ERRORS_KEY",
+    "SessionState",
+    "SessionStateStatProvider",
+    "SessionStateProxy",
+    "get_session_state",
+    "NoValue",
+    "coalesce_widget_states",
+    "register_widget",
+]

--- a/lib/streamlit/testing/v1/__init__.py
+++ b/lib/streamlit/testing/v1/__init__.py
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit.testing.v1.app_test import AppTest as AppTest
+from streamlit.testing.v1.app_test import AppTest
+
+__all__ = ["AppTest"]

--- a/lib/streamlit/watcher/__init__.py
+++ b/lib/streamlit/watcher/__init__.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit.watcher.local_sources_watcher import (
-    LocalSourcesWatcher as LocalSourcesWatcher,
-)
+
+from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 from streamlit.watcher.path_watcher import (
-    report_watchdog_availability as report_watchdog_availability,
+    report_watchdog_availability,
+    watch_dir,
+    watch_file,
 )
-from streamlit.watcher.path_watcher import watch_dir as watch_dir
-from streamlit.watcher.path_watcher import watch_file as watch_file
+
+__all__ = [
+    "LocalSourcesWatcher",
+    "report_watchdog_availability",
+    "watch_dir",
+    "watch_file",
+]

--- a/lib/streamlit/web/server/__init__.py
+++ b/lib/streamlit/web/server/__init__.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 from streamlit.web.server.component_request_handler import ComponentRequestHandler
-from streamlit.web.server.routes import (
-    allow_cross_origin_requests as allow_cross_origin_requests,
-)
-from streamlit.web.server.server import Server as Server
-from streamlit.web.server.server import (
-    server_address_is_unix_socket as server_address_is_unix_socket,
-)
+from streamlit.web.server.routes import allow_cross_origin_requests
+from streamlit.web.server.server import Server, server_address_is_unix_socket
 from streamlit.web.server.stats_request_handler import StatsRequestHandler
+
+__all__ = [
+    "ComponentRequestHandler",
+    "allow_cross_origin_requests",
+    "Server",
+    "server_address_is_unix_socket",
+    "StatsRequestHandler",
+]


### PR DESCRIPTION
It was pointed out in #7523 that the way that we're reexporting symbols from our modules is awkward.
This PR changes things to reexport symbols via defining `__all__` rather than writing
`from some_module import X as X` for each thing we want to reexport.