### PR TITLE
[DRAFT] Large message cache project, option 1

### DIFF
--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -135,13 +135,14 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     }).then(() => undefined) // If the request succeeds, we don't care about the response body
   }
 
-  public async fetchCachedForwardMsg(hash: string): Promise<Uint8Array> {
+  public async fetchCachedForwardMsg(refUrl: string): Promise<Uint8Array> {
     const serverURI = this.requireServerUri()
+
+    const messageUrl = refUrl.startsWith(FORWARD_MSG_CACHE_ENDPOINT)
+      ? buildHttpUri(serverURI, refUrl)
+      : refUrl
     const rsp = await axios.request({
-      url: buildHttpUri(
-        serverURI,
-        `${FORWARD_MSG_CACHE_ENDPOINT}?hash=${hash}`
-      ),
+      url: messageUrl,
       method: "GET",
       responseType: "arraybuffer",
     })

--- a/frontend/lib/src/ForwardMessageCache.ts
+++ b/frontend/lib/src/ForwardMessageCache.ts
@@ -92,24 +92,27 @@ export class ForwardMsgCache {
   ): Promise<ForwardMsg> {
     this.maybeCacheMessage(msg, encodedMsg)
 
-    if (msg.type !== "refHash") {
+    if (msg.type !== "forwardMsgRef") {
       return msg
     }
 
-    let newMsg = this.getCachedMessage(msg.refHash as string, true)
+    let newMsg = this.getCachedMessage(
+      msg.forwardMsgRef?.refHash as string,
+      true
+    )
     if (newMsg != null) {
-      logMessage(`Cached ForwardMsg HIT [hash=${msg.refHash}]`)
+      logMessage(`Cached ForwardMsg HIT [hash=${msg.forwardMsgRef?.refHash}]`)
     } else {
       // Cache miss: fetch from the server
-      logMessage(`Cached ForwardMsg MISS [hash=${msg.refHash}]`)
+      logMessage(`Cached ForwardMsg MISS [hash=${msg.forwardMsgRef?.refHash}]`)
       const encodedNewMsg = await this.endpoints.fetchCachedForwardMsg(
-        msg.refHash as string
+        msg.forwardMsgRef?.refUrl as string
       )
       try {
         newMsg = ForwardMsg.decode(encodedNewMsg)
       } catch (e) {
         throw new Error(
-          `Failed to decode ForwardMsg (hash=${msg.refHash}): ${
+          `Failed to decode ForwardMsg (hash=${msg.forwardMsgRef?.refHash}): ${
             ensureError(e).message
           }`
         )
@@ -130,7 +133,7 @@ export class ForwardMsgCache {
    * Add a new message to the cache if appropriate.
    */
   private maybeCacheMessage(msg: ForwardMsg, encodedMsg: Uint8Array): void {
-    if (msg.type === "refHash") {
+    if (msg.type === "forwardMsgRef") {
       // We never cache reference messages. These messages
       // may have `metadata.cacheable` set, but this is
       // only because they carry the metadata for the messages

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -81,7 +81,9 @@ def create_reference_msg(msg: ForwardMsg) -> ForwardMsg:
 
     """
     ref_msg = ForwardMsg()
-    ref_msg.ref_hash = populate_hash_if_needed(msg)
+    populate_hash_if_needed(msg)
+    ref_msg.forward_msg_ref.ref_url = f"/_stcore/message?hash={msg.hash}"
+    ref_msg.forward_msg_ref.ref_hash = msg.hash
     ref_msg.metadata.CopyFrom(msg.metadata)
     return ref_msg
 

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -54,7 +54,7 @@ of the client's browser and the Streamlit server._
 
 def is_cacheable_msg(msg: ForwardMsg) -> bool:
     """True if the given message qualifies for caching."""
-    if msg.WhichOneof("type") in {"ref_hash", "initialize"}:
+    if msg.WhichOneof("type") in {"forward_msg_ref", "initialize"}:
         # Some message types never get cached
         return False
     return msg.ByteSize() >= int(config.get_option("global.minCachedMessageSize"))

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -227,7 +227,6 @@ class MessageCacheHandler(tornado.web.RequestHandler):
             self.set_header("Access-Control-Allow-Origin", "*")
 
     def get(self):
-        print("IN GGGGGGGGGGGET!")
         msg_hash = self.get_argument("hash", None)
         if msg_hash is None:
             # Hash is missing! This is a malformed request.

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -227,6 +227,7 @@ class MessageCacheHandler(tornado.web.RequestHandler):
             self.set_header("Access-Control-Allow-Origin", "*")
 
     def get(self):
+        print("IN GGGGGGGGGGGET!")
         msg_hash = self.get_argument("hash", None)
         if msg_hash is None:
             # Hash is missing! This is a malformed request.

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -72,6 +72,14 @@ TORNADO_SETTINGS = {
     "websocket_ping_timeout": 30,
 }
 
+
+class LargeForwardMessageHandler(tornado.web.StaticFileHandler):
+    def set_default_headers(self):
+        # CORS protection is disabled because we need access to this endpoint
+        # from the inner iframe.
+        self.set_header("Access-Control-Allow-Origin", "*")
+
+
 # When server.port is not available it will look for the next available port
 # up to MAX_PORT_SEARCH_RETRIES.
 MAX_PORT_SEARCH_RETRIES = 100
@@ -85,6 +93,7 @@ UPLOAD_FILE_ENDPOINT: Final = "/_stcore/upload_file"
 STREAM_ENDPOINT: Final = r"_stcore/stream"
 METRIC_ENDPOINT: Final = r"(?:st-metrics|_stcore/metrics)"
 MESSAGE_ENDPOINT: Final = r"_stcore/message"
+LARGE_MESSAGE_ENDPOINT: Final = r"_stcore/s4/(.*)"
 HEALTH_ENDPOINT: Final = r"(?:healthz|_stcore/health)"
 HOST_CONFIG_ENDPOINT: Final = r"_stcore/host-config"
 SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
@@ -288,6 +297,11 @@ class Server:
                 make_url_path_regex(base, MESSAGE_ENDPOINT),
                 MessageCacheHandler,
                 dict(cache=self._runtime.message_cache),
+            ),
+            (
+                make_url_path_regex(base, LARGE_MESSAGE_ENDPOINT),
+                LargeForwardMessageHandler,
+                {"path": r"s4"},
             ),
             (
                 make_url_path_regex(base, METRIC_ENDPOINT),

--- a/lib/tests/streamlit/runtime/forward_msg_cache_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_cache_test.py
@@ -56,7 +56,7 @@ class ForwardMsgCacheTest(unittest.TestCase):
         """Test creation of 'reference' ForwardMsgs"""
         msg = create_dataframe_msg([1, 2, 3], 34)
         ref_msg = create_reference_msg(msg)
-        self.assertEqual(populate_hash_if_needed(msg), ref_msg.ref_hash)
+        self.assertEqual(populate_hash_if_needed(msg), ref_msg.forward_msg_ref.ref_hash)
         self.assertEqual(msg.metadata, ref_msg.metadata)
 
     def test_add_message(self):

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -479,10 +479,10 @@ class RuntimeTest(RuntimeTestCase):
             await self.tick_runtime_loop()
 
             cached = client.forward_msgs.pop()
-            self.assertEqual("ref_hash", cached.WhichOneof("type"))
+            self.assertEqual("forward_msg_ref", cached.WhichOneof("type"))
             # We should have the *hash* of msg1 and msg2:
-            self.assertEqual(msg1.hash, cached.ref_hash)
-            self.assertEqual(msg2.hash, cached.ref_hash)
+            self.assertEqual(msg1.hash, cached.forward_msg_ref.ref_hash)
+            self.assertEqual(msg2.hash, cached.forward_msg_ref.ref_hash)
             # And the same *metadata* as msg2:
             self.assertEqual(msg2.metadata, cached.metadata)
 

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -68,6 +68,11 @@ message FileURLsResponse {
   string error_msg = 3;
 }
 
+message ForwardMsgRef {
+  string ref_url = 1;
+  string ref_hash = 2;
+}
+
 // Information on a file uploaded via the file_uploader widget.
 message UploadedFileInfo {
   // DEPRECATED.

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -77,6 +77,7 @@ message ForwardMsg {
     // for this one. If the client does not have the referenced message
     // in its cache, it can retrieve it from the server.
     string ref_hash = 11;
+    ForwardMsgRef forward_msg_ref = 21;
   }
 
   // The ID of the last BackMsg that we received before sending this
@@ -85,7 +86,7 @@ message ForwardMsg {
   string debug_last_backmsg_id = 17;
 
   reserved 7, 8;
-  // Next: 21
+  // Next: 22
 }
 
 // ForwardMsgMetadata contains all data that does _not_ get hashed (or cached)

--- a/s4/.gitkeep
+++ b/s4/.gitkeep
@@ -1,0 +1,13 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Demo PR for Large Message delivery project, option 1. 

It is proof of concept for the idea that large messages could be stored in remote storage (e.g. S3) and delivered as reference messages to the frontend, and then the frontend could successfully process it.

As an example to prove it, I just modified the open source `SessionClient` implementation class, and used file storage as an alternative to S3 ( `_stcore/s4/` endpoint :) )

## GitHub Issue Link (if applicable)

## Testing Plan

I manually tested that this implementation works correctly for small messages, and large messages, in situations when the frontend message cache corrupted we were able to restore messages from the `_stcore/message` endpoint e.t.c

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
