### PR TITLE
Deactivate auto focus of script execution error

### DIFF
--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -315,7 +315,7 @@ function scriptCompileErrorDialog(
   props: ScriptCompileErrorProps
 ): ReactElement {
   return (
-    <Modal isOpen onClose={props.onClose} size="auto">
+    <Modal isOpen onClose={props.onClose} size="auto" autoFocus={false}>
       <ModalHeader>Script execution error</ModalHeader>
       <ModalBody>
         <div>


### PR DESCRIPTION
## Describe your changes

This PR prevents autofocus for the script execution error dialog to allow building edit-and-preview like editors.

## GitHub Issue Link (if applicable)

- Closes #7539

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
