### PR TITLE
Set the correct color scheme in CSS

### DIFF
--- a/frontend/app/src/styled-components.ts
+++ b/frontend/app/src/styled-components.ts
@@ -16,22 +16,29 @@
 
 import styled from "@emotion/styled"
 
-export const StyledApp = styled.div(({ theme }) => ({
-  position: "absolute",
-  background: theme.colors.bgColor,
-  color: theme.colors.bodyText,
-  top: theme.spacing.none,
-  left: theme.spacing.none,
-  right: theme.spacing.none,
-  bottom: theme.spacing.none,
-  overflow: "hidden",
-  "@media print": {
-    float: "none",
-    height: theme.sizes.full,
-    position: "static",
-    overflow: "visible",
-  },
-}))
+import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
+
+export const StyledApp = styled.div(({ theme }) => {
+  const lightBackground = hasLightBackgroundColor(theme)
+
+  return {
+    position: "absolute",
+    background: theme.colors.bgColor,
+    color: theme.colors.bodyText,
+    top: theme.spacing.none,
+    left: theme.spacing.none,
+    right: theme.spacing.none,
+    bottom: theme.spacing.none,
+    colorScheme: lightBackground ? "light" : "dark",
+    overflow: "hidden",
+    "@media print": {
+      float: "none",
+      height: theme.sizes.full,
+      position: "static",
+      overflow: "visible",
+    },
+  }
+})
 
 /**
  * The glide-data-grid requires one root level portal element for rendering the cell overlays:

--- a/frontend/app/src/styled-components.ts
+++ b/frontend/app/src/styled-components.ts
@@ -16,7 +16,7 @@
 
 import styled from "@emotion/styled"
 
-import { hasLightBackgroundColor } from "@streamlit/lib/src/theme"
+import { hasLightBackgroundColor } from "@streamlit/lib"
 
 export const StyledApp = styled.div(({ theme }) => {
   const lightBackground = hasLightBackgroundColor(theme)


### PR DESCRIPTION
## Describe your changes

There is a property in CSS that allows an element to indicate which color schemes it can comfortably be rendered in (see [color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)). In the PR [here](https://github.com/streamlit/streamlit/pull/6889), I discovered that we are not using this property. Thereby, the browser thinks it is running in light mode and - for example - shows the wrong native scrollbars. The impact of not setting this in Streamlit is very minimal, but I don't really see any downsides to just setting this.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
