### PR TITLE
Make the outline for expanders appear on focus-visible and not focus

### DIFF
--- a/frontend/lib/src/components/elements/Expander/styled-components.ts
+++ b/frontend/lib/src/components/elements/Expander/styled-components.ts
@@ -56,7 +56,7 @@ export const StyledSummary = styled.summary(({ theme }) => ({
   position: "relative",
   display: "flex",
   width: "100%",
-  "&:focus": {
+  "&:focus-visible": {
     outline: `${BORDER_SIZE}px solid ${theme.colors.primary}`,
     outlineOffset: `-${BORDER_SIZE}px`,
     borderRadius: theme.radii.lg,


### PR DESCRIPTION
## Describe your changes

We don't want the focus border to appear when the user interacts with a click. This can be resolved with just making the outline appear on focus-visible. For clarity:

> The :focus-visible pseudo-class applies while an element matches the [:focus](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus) pseudo-class and the UA ([User Agent](https://developer.mozilla.org/en-US/docs/Glossary/User_agent)) determines via heuristics that the focus should be made evident on the element.

## Testing Plan

No real new tests are needed outside of a visual verification, it's a CSS selector change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
