### PR TITLE
Add ability to add empty query params

### DIFF
--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -58,7 +58,8 @@ def get_query_params() -> Dict[str, List[str]]:
         return {}
     # Return new query params dict, but without embed, embed_options query params
     return util.exclude_key_query_params(
-        parse.parse_qs(ctx.query_string, True), keys_to_exclude=EMBED_QUERY_PARAMS_KEYS
+        parse.parse_qs(ctx.query_string, keep_blank_values=True),
+        keys_to_exclude=EMBED_QUERY_PARAMS_KEYS,
     )
 
 
@@ -115,7 +116,7 @@ def _ensure_no_embed_params(
             "Query param embed and embed_options (case-insensitive) cannot be set using set_query_params method."
         )
 
-    all_current_params = parse.parse_qs(query_string, True)
+    all_current_params = parse.parse_qs(query_string, keep_blank_values=True)
     current_embed_params = parse.urlencode(
         {
             EMBED_QUERY_PARAM: [

--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -116,7 +116,6 @@ def _ensure_no_embed_params(
         )
 
     all_current_params = parse.parse_qs(query_string, True)
-    print(f"{all_current_params=}")
     current_embed_params = parse.urlencode(
         {
             EMBED_QUERY_PARAM: [
@@ -134,9 +133,7 @@ def _ensure_no_embed_params(
         },
         doseq=True,
     )
-    print(f"{current_embed_params=}")
     query_string = parse.urlencode(query_params, doseq=True)
-    print(f"{query_string=}")
 
     if query_string:
         separator = "&" if current_embed_params else ""

--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -58,7 +58,7 @@ def get_query_params() -> Dict[str, List[str]]:
         return {}
     # Return new query params dict, but without embed, embed_options query params
     return util.exclude_key_query_params(
-        parse.parse_qs(ctx.query_string), keys_to_exclude=EMBED_QUERY_PARAMS_KEYS
+        parse.parse_qs(ctx.query_string, True), keys_to_exclude=EMBED_QUERY_PARAMS_KEYS
     )
 
 
@@ -115,7 +115,8 @@ def _ensure_no_embed_params(
             "Query param embed and embed_options (case-insensitive) cannot be set using set_query_params method."
         )
 
-    all_current_params = parse.parse_qs(query_string)
+    all_current_params = parse.parse_qs(query_string, True)
+    print(f"{all_current_params=}")
     current_embed_params = parse.urlencode(
         {
             EMBED_QUERY_PARAM: [
@@ -133,7 +134,9 @@ def _ensure_no_embed_params(
         },
         doseq=True,
     )
+    print(f"{current_embed_params=}")
     query_string = parse.urlencode(query_params, doseq=True)
+    print(f"{query_string=}")
 
     if query_string:
         separator = "&" if current_embed_params else ""

--- a/lib/tests/streamlit/commands/query_params_test.py
+++ b/lib/tests/streamlit/commands/query_params_test.py
@@ -39,3 +39,9 @@ class QueryParamsAPITest(DeltaGeneratorTestCase):
         st.experimental_set_query_params(**p_set)
         p_get = st.experimental_get_query_params()
         self.assertEqual(p_get, p_set)
+
+    def test_set_query_params_empty(self):
+        p_set = dict(x=[""])
+        st.experimental_set_query_params(**p_set)
+        p_get = st.experimental_get_query_params()
+        self.assertEqual(p_get, p_set)

--- a/lib/tests/streamlit/commands/query_params_test.py
+++ b/lib/tests/streamlit/commands/query_params_test.py
@@ -40,8 +40,8 @@ class QueryParamsAPITest(DeltaGeneratorTestCase):
         p_get = st.experimental_get_query_params()
         self.assertEqual(p_get, p_set)
 
-    def test_set_query_params_empty(self):
-        p_set = dict(x=[""])
-        st.experimental_set_query_params(**p_set)
-        p_get = st.experimental_get_query_params()
-        self.assertEqual(p_get, p_set)
+    def test_set_query_params_empty_str(self):
+        empty_str_params = dict(x=[""])
+        st.experimental_set_query_params(**empty_str_params)
+        params_get = st.experimental_get_query_params()
+        self.assertEqual(params_get, empty_str_params)


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- add the parameter keep_blank_values within the parse.parse_qs method
## GitHub Issue Link (if applicable)
Closes #7416 
## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - added a unit test to make sure we get empty query params
- E2E Tests
- Any manual testing needed?
  - Manually tested 

https://github.com/streamlit/streamlit/assets/16749069/f104fd6f-2402-4ae1-a910-7e7496ac839e


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
