### PR TITLE
Ignore Require Labels on Open and Synchronize events

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -2,7 +2,7 @@ name: Pull Request Labels
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [labeled, unlabeled]
 
 jobs:
   security-assessment:


### PR DESCRIPTION
## Describe your changes

I'm tired of getting notification emails on when the PR is opened that the build failed for the labels. I still need to label it.

This change essentially removes the trigger of PR opened and synchronize to avoid needlessly running it. It is still required for merge, so it shouldn't prevent people from forgetting about it.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
