### PR TITLE
Add tests enforcing that file_uploader-related protos are stable

### DIFF
--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -1,0 +1,48 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit.proto.Common_pb2 import FileURLs, FileURLsRequest, FileURLsResponse
+
+
+def test_file_urls_request_proto_stable():
+    d = FileURLsRequest.DESCRIPTOR
+    fd = d.fields[0]
+
+    assert {(f.name, f.label, f.type) for f in d.fields} == {
+        ("request_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("file_names", fd.LABEL_REPEATED, fd.TYPE_STRING),
+        ("session_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+    }
+
+
+def test_file_urls_proto_stable():
+    d = FileURLs.DESCRIPTOR
+    fd = d.fields[0]
+
+    assert {(f.name, f.label, f.type) for f in d.fields} == {
+        ("file_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("upload_url", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("delete_url", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+    }
+
+
+def test_file_urls_response_proto_stable():
+    d = FileURLsResponse.DESCRIPTOR
+    fd = d.fields[0]
+
+    assert {(f.name, f.label, f.type) for f in d.fields} == {
+        ("response_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("file_urls", fd.LABEL_REPEATED, fd.TYPE_MESSAGE),
+        ("error_msg", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+    }

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -46,10 +46,10 @@ message StringTriggerValue {
   optional string data = 1;
 }
 
-// TODO(vdonato / kajarenc): Finalize the next two proto types. We currently
-// have enough information here to support pure OS use cases, but we'll need to
-// coordinate with the SiS team to verify that we're passing enough file
-// metadata back for them.
+// NOTE: The FileURLsRequest, FileURLs, and FileURLsResponse message types
+// must remain stable as some external services rely on them to support
+// `st.file_uploader`. These types aren't completely set in stone, but changing
+// them requires a good amount of effort so should be avoided if possible.
 message FileURLsRequest {
   string request_id = 1;
   repeated string file_names = 2;


### PR DESCRIPTION
There are a few proto types used by other services that we need to ensure are stable (even once
we're otherwise able to not worry about backwards compatibility of our proto schemas).

This PR adds some unit tests for a few protos used by the `st.file_uploader` widget that fit into
this category.