### PR TITLE
Set both auth token and prev session ID on websocket connect

### DIFF
--- a/frontend/app/src/connection/WebsocketConnection.test.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.test.tsx
@@ -656,7 +656,7 @@ describe("WebsocketConnection auth token handling", () => {
 
     expect(websocketSpy).toHaveBeenCalledWith(
       "ws://localhost:1234/_stcore/stream",
-      ["streamlit"]
+      ["streamlit", "PLACEHOLDER_AUTH_TOKEN"]
     )
     expect(resetHostAuthToken).toHaveBeenCalledTimes(1)
   })
@@ -679,7 +679,7 @@ describe("WebsocketConnection auth token handling", () => {
     )
   })
 
-  it("sets second Sec-WebSocket-Protocol option to lastSessionId", async () => {
+  it("sets third Sec-WebSocket-Protocol option to lastSessionId if available", async () => {
     // Create a mock SessionInfo with sessionInfo.last.sessionId == "lastSessionId"
     const sessionInfo = new SessionInfo()
     sessionInfo.setCurrent(
@@ -696,11 +696,11 @@ describe("WebsocketConnection auth token handling", () => {
     // "lastSessionId" should be the WebSocket's session token
     expect(websocketSpy).toHaveBeenCalledWith(
       "ws://localhost:1234/_stcore/stream",
-      ["streamlit", "lastSessionId"]
+      ["streamlit", "PLACEHOLDER_AUTH_TOKEN", "lastSessionId"]
     )
   })
 
-  it("prioritizes host provided auth token over lastSessionId if both set", async () => {
+  it("sets both host provided auth token and lastSessionId if both set", async () => {
     // Create a mock SessionInfo with sessionInfo.last.sessionId == "lastSessionId"
     const sessionInfo = new SessionInfo()
     sessionInfo.setCurrent(
@@ -723,7 +723,7 @@ describe("WebsocketConnection auth token handling", () => {
 
     expect(websocketSpy).toHaveBeenCalledWith(
       "ws://localhost:1234/_stcore/stream",
-      ["streamlit", "iAmAnAuthToken"]
+      ["streamlit", "iAmAnAuthToken", "lastSessionId"]
     )
     expect(resetHostAuthToken).toHaveBeenCalledTimes(1)
   })

--- a/frontend/app/src/connection/WebsocketConnection.tsx
+++ b/frontend/app/src/connection/WebsocketConnection.tsx
@@ -381,25 +381,28 @@ export class WebsocketConnection {
   }
 
   /**
-   * Get the session token to use to initialize a WebSocket connection.
+   * Get the session tokens to use to initialize a WebSocket connection.
    *
-   * There are two scenarios that are considered here:
-   *   1. If this Streamlit is embedded in a page that will be passing an
-   *      external, opaque auth token to it, we get it using claimHostAuthToken
-   *      and return it. This only occurs in deployment environments where
-   *      we're not connecting to the usual Tornado server, so we don't have to
-   *      worry about what this token actually is/does.
-   *   2. Otherwise, claimHostAuthToken will resolve immediately to undefined,
-   *      in which case we return the sessionId of the last session this
-   *      browser tab connected to (or undefined if this is the first time this
-   *      tab has connected to the Streamlit server). This sessionId is used to
-   *      attempt to reconnect to an existing session to handle transient
-   *      disconnects.
+   * This method returns an array containing either one or two elements:
+   *   1. The first element contains an auth token to be used in environments
+   *      where the parent frame of this app needs to pass down an external
+   *      auth token. If no token is provided, a placeholder is used.
+   *   2. The second element is the session ID to attempt to reconnect to if
+   *      one is available (that is, if this websocket has disconnected and is
+   *      reconnecting). On the initial connection attempt, this is unset and
+   *      the return value of this method is a singleton array.
    */
-  private async getSessionToken(): Promise<string | undefined> {
+  private async getSessionTokens(): Promise<Array<string>> {
     const hostAuthToken = await this.args.claimHostAuthToken()
     this.args.resetHostAuthToken()
-    return hostAuthToken || this.args.sessionInfo.last?.sessionId
+    return [
+      // NOTE: We have to set the auth token to some arbitrary placeholder if
+      // not provided since the empty string is an invalid protocol option.
+      hostAuthToken ?? "PLACEHOLDER_AUTH_TOKEN",
+      ...(this.args.sessionInfo.last?.sessionId
+        ? [this.args.sessionInfo.last?.sessionId]
+        : []),
+    ]
   }
 
   private async connectToWebSocket(): Promise<void> {
@@ -420,18 +423,16 @@ export class WebsocketConnection {
     // parameter to the WebSocket constructor) here in a slightly unfortunate
     // but necessary way. The browser WebSocket API doesn't allow us to set
     // arbitrary HTTP headers, and this header is the only one where we have
-    // the ability to set it to arbitrary values. Thus, we use it to pass an
-    // auth token from client to server as the *second* value in the list.
+    // the ability to set it to arbitrary values. Thus, we use it to pass auth
+    // and session tokens from client to server as the second/third values in
+    // the list.
     //
-    // The reason why the auth token is set as the second value is that, when
-    // Sec-WebSocket-Protocol is set, many clients expect the server to respond
-    // with a selected subprotocol to use. We don't want that reply to be the
-    // auth token, so we just hard-code it to "streamlit".
-    const sessionToken = await this.getSessionToken()
-    this.websocket = new WebSocket(uri, [
-      "streamlit",
-      ...(sessionToken ? [sessionToken] : []),
-    ])
+    // The reason why these tokens are set as the second/third values is that,
+    // when Sec-WebSocket-Protocol is set, many clients expect the server to
+    // respond with a selected subprotocol to use. We don't want that reply to
+    // contain sensitive data, so we just hard-code it to "streamlit".
+    const sessionTokens = await this.getSessionTokens()
+    this.websocket = new WebSocket(uri, ["streamlit", ...sessionTokens])
     this.websocket.binaryType = "arraybuffer"
 
     this.setConnectionTimeout(uri)

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -72,13 +72,15 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
         set arbitrary HTTP headers, and this header is the only one where we have the
         ability to set it to arbitrary values, so we use it to pass tokens (in this
         case, the previous session ID to allow us to reconnect to it) from client to
-        server as the *second* value in the list.
+        server as the *third* value in the list.
 
-        The reason why the auth token is set as the second value is that, when
-        Sec-WebSocket-Protocol is set, many clients expect the server to respond with a
-        selected subprotocol to use. We don't want that reply to be the token, so we
-        by convention have the client always set the first protocol to "streamlit" and
-        select that.
+        The reason why the auth token is set as the third value is that:
+          * when Sec-WebSocket-Protocol is set, many clients expect the server to
+            respond with a selected subprotocol to use. We don't want that reply to be
+            the session token, so we by convention have the client always set the first
+            protocol to "streamlit" and select that.
+          * the second protocol in the list is reserved in some deployment environments
+            for an auth token that we currently don't use
         """
         if subprotocols:
             return subprotocols[0]
@@ -111,10 +113,10 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                 for p in self.request.headers["Sec-Websocket-Protocol"].split(",")
             ]
 
-            if len(ws_protocols) > 1:
-                # See the NOTE in the docstring of the select_subprotocol method above
+            if len(ws_protocols) >= 3:
+                # See the NOTE in the docstring of the `select_subprotocol` method above
                 # for a detailed explanation of why this is done.
-                existing_session_id = ws_protocols[1]
+                existing_session_id = ws_protocols[2]
         except KeyError:
             # Just let existing_session_id=None if we run into any error while trying to
             # extract it from the Sec-Websocket-Protocol header.

--- a/lib/tests/streamlit/web/server/server_test_case.py
+++ b/lib/tests/streamlit/web/server/server_test_case.py
@@ -74,9 +74,9 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
         # See the comment in WebsocketConnection.tsx about how we repurpose the
         # Sec-WebSocket-Protocol header for more information on how this works.
         if existing_session_id is None:
-            subprotocols = ["streamlit"]
+            subprotocols = ["streamlit", "PLACEHOLDER_AUTH_TOKEN"]
         else:
-            subprotocols = ["streamlit", existing_session_id]
+            subprotocols = ["streamlit", "PLACEHOLDER_AUTH_TOKEN", existing_session_id]
 
         return await tornado.websocket.websocket_connect(
             self.get_ws_url("/_stcore/stream"),


### PR DESCRIPTION
Currently, we repurpose the `Sec-WebSocket-Protocol` header to send _either_ an auth
token or the session ID to reconnect to as part of the headers of a websocket upgrade
request. Now that platforms hosting streamlit apps are also starting to want to implement
the websocket reconnect resiliency that we have in the OS world, it would be useful to send
back both an auth token as well as the ID of the session to reconnect to.

This PR allows this to happen by having the list sent back in the `Sec-WebSocket-Protocol`
have either 2 or 3 elements rather than 1 or 2. More info on how this works are described in detail
in the docstrings edited in the PR.