### PR TITLE
Fix top padding when embedding an app with a sidebar

### DIFF
--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -142,6 +142,8 @@ function AppView(props: AppViewProps): ReactElement {
       addPaddingForHeader={showToolbar || showColoredLine}
       addPaddingForChatInput={containsChatInput}
       events={events}
+      isEmbedded={embedded}
+      hasSidebar={showSidebar}
     >
       <VerticalBlock
         node={node}

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -133,6 +133,12 @@ function AppView(props: AppViewProps): ReactElement {
     toastAdjustment,
   } = React.useContext(AppContext)
 
+  const layout = wideMode ? "wide" : "narrow"
+  const hasSidebarElements = !elements.sidebar.isEmpty
+  const showSidebar =
+    hasSidebarElements || (!hideSidebarNav && appPages.length > 1)
+  const hasEventElements = !elements.event.isEmpty
+
   const renderBlock = (node: BlockNode, events = false): ReactElement => (
     <StyledAppViewBlockContainer
       className="block-container"
@@ -159,12 +165,6 @@ function AppView(props: AppViewProps): ReactElement {
       />
     </StyledAppViewBlockContainer>
   )
-
-  const layout = wideMode ? "wide" : "narrow"
-  const hasSidebarElements = !elements.sidebar.isEmpty
-  const showSidebar =
-    hasSidebarElements || (!hideSidebarNav && appPages.length > 1)
-  const hasEventElements = !elements.event.isEmpty
 
   // The tabindex is required to support scrolling by arrow keys.
   return (

--- a/frontend/app/src/components/AppView/styled-components.ts
+++ b/frontend/app/src/components/AppView/styled-components.ts
@@ -72,6 +72,8 @@ export const StyledAppViewMain = styled.section<StyledAppViewMainProps>(
 )
 
 export interface StyledAppViewBlockContainerProps {
+  hasSidebar: boolean
+  isEmbedded: boolean
   isWideMode: boolean
   showPadding: boolean
   addPaddingForHeader: boolean
@@ -82,6 +84,8 @@ export interface StyledAppViewBlockContainerProps {
 export const StyledAppViewBlockContainer =
   styled.div<StyledAppViewBlockContainerProps>(
     ({
+      hasSidebar,
+      isEmbedded,
       isWideMode,
       showPadding,
       addPaddingForHeader,
@@ -90,7 +94,10 @@ export const StyledAppViewBlockContainer =
       theme,
     }) => {
       let topEmbedPadding: string = showPadding ? "6rem" : "2rem"
-      if (addPaddingForHeader && !showPadding) {
+      if (
+        (addPaddingForHeader && !showPadding) ||
+        (isEmbedded && hasSidebar)
+      ) {
         topEmbedPadding = "3rem"
       }
       const bottomEmbedPadding =


### PR DESCRIPTION
## Describe your changes

This PR fixes an issue reported by @jrieke where embedded apps with a sidebar would have little padding between the `>` icon and the content below it.

**Before:**

![localhost_3000__embed=True(iPhone SE)](https://github.com/streamlit/streamlit/assets/103376966/3d38a305-d1c4-451d-a89f-1b65c3ccf1a3)

**After:**

![localhost_3000__embed=True(iPhone SE) (1)](https://github.com/streamlit/streamlit/assets/103376966/13c2e5b2-39ce-4447-b0b1-b87a4ed5e018)

## GitHub Issue Link (if applicable)

* https://www.notion.so/snowflake-corp/Sidebar-icon-when-embedded-37fbd756b0444de28adfea8574829642?pvs=4

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
