### PR TITLE
Add exhaustive proto stability tests

### DIFF
--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -12,37 +12,206 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+from google.protobuf.descriptor import FieldDescriptor
+from parameterized import parameterized
+
+from streamlit.proto.Alert_pb2 import Alert
+from streamlit.proto.AppPage_pb2 import AppPage
 from streamlit.proto.Common_pb2 import FileURLs, FileURLsRequest, FileURLsResponse
+from streamlit.proto.Exception_pb2 import Exception as Exception_
+from streamlit.proto.NewSession_pb2 import (
+    Config,
+    CustomThemeConfig,
+    EnvironmentInfo,
+    FontFace,
+    FontSizes,
+    Initialize,
+    NewSession,
+    Radii,
+    UserInfo,
+)
+from streamlit.proto.ParentMessage_pb2 import ParentMessage
+from streamlit.proto.SessionStatus_pb2 import SessionStatus
+
+FD = FieldDescriptor
 
 
-def test_file_urls_request_proto_stable():
-    d = FileURLsRequest.DESCRIPTOR
-    fd = d.fields[0]
+@parameterized.expand(
+    [
+        (
+            AppPage,
+            {
+                ("page_script_hash", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("page_name", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("icon", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            NewSession,
+            {
+                ("initialize", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("script_run_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("name", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("main_script_path", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("config", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("custom_theme", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("app_pages", FD.LABEL_REPEATED, FD.TYPE_MESSAGE),
+                ("page_script_hash", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            Initialize,
+            {
+                ("user_info", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("environment_info", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("session_status", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("command_line", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("session_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            Config,
+            {
+                ("gather_usage_stats", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+                ("max_cached_message_age", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+                ("mapbox_token", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("allow_run_on_save", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+                ("hide_top_bar", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+                ("hide_sidebar_nav", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+                ("toolbar_mode", FD.LABEL_OPTIONAL, FD.TYPE_ENUM),
+            },
+        ),
+        (
+            CustomThemeConfig,
+            {
+                ("primary_color", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("secondary_background_color", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("background_color", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("text_color", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("font", FD.LABEL_OPTIONAL, FD.TYPE_ENUM),
+                ("base", FD.LABEL_OPTIONAL, FD.TYPE_ENUM),
+                ("widget_background_color", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("widget_border_color", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("radii", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+                ("body_font", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("code_font", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("font_faces", FD.LABEL_REPEATED, FD.TYPE_MESSAGE),
+                ("font_sizes", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+            },
+        ),
+        (
+            FontFace,
+            {
+                ("url", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("family", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("weight", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+                ("style", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            Radii,
+            {
+                ("base_widget_radius", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+                ("checkbox_radius", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+            },
+        ),
+        (
+            FontSizes,
+            {
+                ("tiny_font_size", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+                ("small_font_size", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+                ("base_font_size", FD.LABEL_OPTIONAL, FD.TYPE_INT32),
+            },
+        ),
+        (
+            UserInfo,
+            {
+                ("installation_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("installation_id_v3", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            EnvironmentInfo,
+            {
+                ("streamlit_version", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("python_version", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            SessionStatus,
+            {
+                ("run_on_save", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+                ("script_is_running", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+            },
+        ),
+    ]
+)
+def test_new_session_protos_stable(proto_class, expected_fields):
+    d = proto_class.DESCRIPTOR
+
+    assert {(f.name, f.label, f.type) for f in d.fields} == expected_fields
+
+
+@parameterized.expand(
+    [
+        (
+            FileURLsRequest,
+            {
+                ("request_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("file_names", FD.LABEL_REPEATED, FD.TYPE_STRING),
+                ("session_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            FileURLs,
+            {
+                ("file_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("upload_url", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("delete_url", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+        (
+            FileURLsResponse,
+            {
+                ("response_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("file_urls", FD.LABEL_REPEATED, FD.TYPE_MESSAGE),
+                ("error_msg", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+            },
+        ),
+    ]
+)
+def test_file_uploader_protos_stable(proto_class, expected_fields):
+    d = proto_class.DESCRIPTOR
+
+    assert {(f.name, f.label, f.type) for f in d.fields} == expected_fields
+
+
+def test_alert_proto_stable():
+    d = Alert.DESCRIPTOR
 
     assert {(f.name, f.label, f.type) for f in d.fields} == {
-        ("request_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
-        ("file_names", fd.LABEL_REPEATED, fd.TYPE_STRING),
-        ("session_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("body", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+        ("format", FD.LABEL_OPTIONAL, FD.TYPE_ENUM),
+        ("icon", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
     }
 
 
-def test_file_urls_proto_stable():
-    d = FileURLs.DESCRIPTOR
-    fd = d.fields[0]
+def test_exception_proto_stable():
+    d = Exception_.DESCRIPTOR
 
     assert {(f.name, f.label, f.type) for f in d.fields} == {
-        ("file_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
-        ("upload_url", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
-        ("delete_url", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("type", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+        ("message", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+        ("message_is_markdown", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
+        ("stack_trace", FD.LABEL_REPEATED, FD.TYPE_STRING),
+        ("is_warning", FD.LABEL_OPTIONAL, FD.TYPE_BOOL),
     }
 
 
-def test_file_urls_response_proto_stable():
-    d = FileURLsResponse.DESCRIPTOR
-    fd = d.fields[0]
+def test_parent_message_proto_stable():
+    d = ParentMessage.DESCRIPTOR
 
     assert {(f.name, f.label, f.type) for f in d.fields} == {
-        ("response_id", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
-        ("file_urls", fd.LABEL_REPEATED, fd.TYPE_MESSAGE),
-        ("error_msg", fd.LABEL_OPTIONAL, fd.TYPE_STRING),
+        ("message", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
     }

--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+// NOTE: This proto type is used by some external services so needs to remain
+// relatively stable. While it isn't entirely set in stone, changing it
+// may require a good amount of effort so should be avoided if possible.
 message Alert {
   // Content to display.
   string body = 1;

--- a/proto/streamlit/proto/AppPage.proto
+++ b/proto/streamlit/proto/AppPage.proto
@@ -18,6 +18,10 @@ syntax = "proto3";
 
 // A page in the app. Includes both the name of the page as well as the full
 // path to the corresponding script file.
+//
+// NOTE: This proto type is used by some external services so needs to remain
+// relatively stable. While it isn't entirely set in stone, changing it
+// may require a good amount of effort so should be avoided if possible.
 message AppPage {
   string page_script_hash = 1;
   string page_name = 2;

--- a/proto/streamlit/proto/Exception.proto
+++ b/proto/streamlit/proto/Exception.proto
@@ -17,6 +17,10 @@
 syntax = "proto3";
 
 // A python exception.
+//
+// NOTE: This proto type is used by some external services so needs to remain
+// relatively stable. While it isn't entirely set in stone, changing it
+// may require a good amount of effort so should be avoided if possible.
 message Exception {
 
   // The type of the exception. This can be any string, but is usually a valid

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -19,6 +19,10 @@ syntax = "proto3";
 import "streamlit/proto/AppPage.proto";
 import "streamlit/proto/SessionStatus.proto";
 
+// NOTE: These proto types are used by some external services so need to
+// remain relatively stable. While they aren't entirely set in stone, changing
+// them may require a good amount of effort so should be avoided if possible.
+
 // This is the first message that is sent when a new session starts.
 message NewSession {
   // Initialization data. This data does *not* change from rerun to rerun,
@@ -151,15 +155,15 @@ message FontFace {
 
 message Radii {
   // In pixels.
-  int32 baseWidgetRadius = 1;
-  int32 checkboxRadius = 2;
+  int32 base_widget_radius = 1;
+  int32 checkbox_radius = 2;
 }
 
 message FontSizes {
   // In pixels.
-  int32 tinyFontSize = 1;
-  int32 smallFontSize = 2;
-  int32 baseFontSize = 3;
+  int32 tiny_font_size = 1;
+  int32 small_font_size = 2;
+  int32 base_font_size = 3;
 }
 
 // Data that identifies the Streamlit app creator.

--- a/proto/streamlit/proto/ParentMessage.proto
+++ b/proto/streamlit/proto/ParentMessage.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+// NOTE: This proto type is used by some external services so needs to remain
+// relatively stable. While it isn't entirely set in stone, changing it
+// may require a good amount of effort so should be avoided if possible.
 message ParentMessage {
   // Message to send to the host.
   string message = 1;

--- a/proto/streamlit/proto/SessionStatus.proto
+++ b/proto/streamlit/proto/SessionStatus.proto
@@ -18,6 +18,10 @@ syntax = "proto3";
 
 // Status for a session. Sent as part of the Initialize message, and also
 // on AppSession status change events.
+//
+// NOTE: This proto type is used by some external services so needs to remain
+// relatively stable. While it isn't entirely set in stone, changing it
+// may require a good amount of effort so should be avoided if possible.
 message SessionStatus {
   // If true, streamlit will re-run the script if it detects that the script
   // has been changed. This value comes from the server.runOnSave config.


### PR DESCRIPTION
This PR continues to add some tests around proto stability so that we cover all proto types
that we'll need to provide stronger compatibility guarantees around.

We do this by more or less just duplicating the proto config in `lib/tests/streamlit/proto_compatibility_test.py`
and enforcing that the proto types are what we expect them to be. This approach feels a bit
funny but should be effective in preventing us from making changes to these protos while forgetting
about the compatibility guarantees around them that we need to adhere to.

We also add comments to the corresponding protos / files that we're adding tests for.