### PR TITLE
Remove unwrapping single element lists method

### DIFF
--- a/e2e/specs/st_experimental_get_query_params.spec.js
+++ b/e2e/specs/st_experimental_get_query_params.spec.js
@@ -31,8 +31,8 @@ describe("st.experimental_get_query_string", () => {
     );
     cy.contains(
       "Current query string is: {" +
-        "'show_map': 'True', " +
-        "'number_of_countries': '2', " +
+        "'show_map': ['True'], " +
+        "'number_of_countries': ['2'], " +
         "'selected': ['asia', 'america']" +
         "}"
     );

--- a/lib/streamlit/commands/query_params.py
+++ b/lib/streamlit/commands/query_params.py
@@ -58,11 +58,9 @@ def get_query_params() -> Dict[str, List[str]]:
     if ctx is None:
         return {}
     # Return new query params dict, but without embed, embed_options query params
-    return util.unwrap_single_element_lists(
-        util.exclude_key_query_params(
-            parse.parse_qs(ctx.query_string, keep_blank_values=True),
-            keys_to_exclude=EMBED_QUERY_PARAMS_KEYS,
-        )
+    return util.exclude_key_query_params(
+        parse.parse_qs(ctx.query_string, keep_blank_values=True),
+        keys_to_exclude=EMBED_QUERY_PARAMS_KEYS,
     )
 
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -212,19 +212,3 @@ def extract_key_query_params(
             for item in sublist
         ]
     )
-
-
-def unwrap_single_element_lists(d: Dict[str, List[Any]]) -> Dict[str, Any]:
-    """Extracts the single element from lists in a dictionary if the list has a length of 1.
-
-    Parameters
-    ----------
-    d : dict
-        The dictionary containing lists.
-
-    Returns
-    -------
-    dict
-        The modified dictionary with single element lists extracted.
-    """
-    return {k: v[0] if isinstance(v, list) and len(v) == 1 else v for k, v in d.items()}

--- a/lib/tests/streamlit/commands/query_params_test.py
+++ b/lib/tests/streamlit/commands/query_params_test.py
@@ -42,7 +42,7 @@ class QueryParamsAPITest(DeltaGeneratorTestCase):
         p_set = {"x": ["a"]}
         st.experimental_set_query_params(**p_set)
         p_get = st.experimental_get_query_params()
-        self.assertEqual(p_get, {"x": "a"})
+        self.assertEqual(p_get, p_set)
 
     def test_get_query_params_after_set_query_params_list(self):
         """Test valid st.set_query_params sends protobuf message."""
@@ -56,7 +56,7 @@ class QueryParamsAPITest(DeltaGeneratorTestCase):
         empty_str_params = {"x": [""]}
         st.experimental_set_query_params(**empty_str_params)
         params_get = st.experimental_get_query_params()
-        self.assertEqual(params_get, {"x": ""})
+        self.assertEqual(params_get, empty_str_params)
 
 
 class QueryParamsMethodTests(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/testing/test_runner_test.py
+++ b/lib/tests/streamlit/testing/test_runner_test.py
@@ -53,7 +53,7 @@ def test_get_query_params():
     at.query_params["foo"] = 5
     at.query_params["bar"] = "baz"
     at.run()
-    assert at.json[0].value == '{"foo": "5", "bar": "baz"}'
+    assert at.json[0].value == '{"foo": ["5"], "bar": ["baz"]}'
 
 
 def test_set_query_params():

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -187,21 +187,3 @@ class UtilTest(unittest.TestCase):
             util.calc_md5("eventually bytes"),
             util.calc_md5("eventually bytes".encode("utf-8")),
         )
-
-    @parameterized.expand(
-        [
-            (
-                {"a": [1], "b": [2, 3], "c": 4, "d": ["hello"]},
-                {"a": 1, "b": [2, 3], "c": 4, "d": "hello"},
-            ),
-            (
-                {"a": [], "b": [2, 3], "c": 4, "d": ["hello"]},
-                {"a": [], "b": [2, 3], "c": 4, "d": "hello"},
-            ),
-            ({}, {}),
-            ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3}),
-            ({"a": [1], "b": ["b"], "c": [True]}, {"a": 1, "b": "b", "c": True}),
-        ]
-    )
-    def test_unwrap_single_element_lists(self, input_dict, expected_output):
-        self.assertEqual(util.unwrap_single_element_lists(input_dict), expected_output)


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- Remove unnecessary method as I realized we don't need to unwrap these lists with the new query_params api
- We don't need to include this as these would be breaking changes for `st.experimental_set_query_parameters`
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
