### PR TITLE
Fix app testing repr bug for `st.container`

### DIFF
--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1366,9 +1366,11 @@ class Block:
         self.proto = proto
         if proto:
             ty = proto.WhichOneof("type")
-            # TODO does not work for `st.container` which has no block proto
-            assert ty is not None
-            self.type = ty
+            if ty is not None:
+                self.type = ty
+            else:
+                # `st.container` has no sub-message
+                self.type = "container"
         else:
             self.type = "unknown"
         self.root = root

--- a/lib/tests/streamlit/testing/test_runner_test.py
+++ b/lib/tests/streamlit/testing/test_runner_test.py
@@ -77,3 +77,14 @@ def test_secrets():
     at.run()
     assert at.markdown[0].value == "bar"
     assert at.secrets["foo"] == "bar"
+
+
+def test_7636_regression():
+    def repro():
+        import streamlit as st
+
+        st.container()
+
+    at = AppTest.from_function(repro).run()
+
+    repr(at)


### PR DESCRIPTION
## Describe your changes
Fix an assertion error when app testing a script that uses `st.container`

## GitHub Issue Link (if applicable)
#7636 

## Testing Plan

Regression test added

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
