### PR TITLE
Greatly narrow errors that we retry in SnowflakeConnection

### DIFF
--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -108,18 +108,21 @@ class SnowflakeConnectionTest(unittest.TestCase):
         MagicMock(),
     )
     def test_retry_behavior(self):
-        from snowflake.connector import Error as SnowflakeError
+        from snowflake.connector.errors import ProgrammingError
+        from snowflake.connector.network import MASTER_TOKEN_EXPIRED_GS_CODE
 
         mock_cursor = MagicMock()
         mock_cursor.fetch_pandas_all = MagicMock(
-            side_effect=SnowflakeError("oh noes :()")
+            side_effect=ProgrammingError(
+                "oh noes :(", errno=int(MASTER_TOKEN_EXPIRED_GS_CODE)
+            )
         )
 
         conn = SnowflakeConnection("my_snowflake_connection")
         conn._instance.cursor.return_value = mock_cursor
 
         with patch.object(conn, "reset", wraps=conn.reset) as wrapped_reset:
-            with pytest.raises(SnowflakeError):
+            with pytest.raises(ProgrammingError):
                 conn.query("SELECT 1;")
 
             # Our connection should have been reset after each failed attempt to call
@@ -135,9 +138,53 @@ class SnowflakeConnectionTest(unittest.TestCase):
         "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
         MagicMock(),
     )
-    def test_retry_fails_fast_for_most_errors(self):
+    def test_retry_fails_fast_for_programming_errors_with_wrong_code(self):
+        from snowflake.connector.errors import ProgrammingError
+
         mock_cursor = MagicMock()
-        mock_cursor.fetch_pandas_all = MagicMock(side_effect=Exception("oh noes :()"))
+        mock_cursor.fetch_pandas_all = MagicMock(
+            side_effect=ProgrammingError("oh noes :(", errno=42)
+        )
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        with pytest.raises(ProgrammingError):
+            conn.query("SELECT 1;")
+
+        # conn._connect should have just been called once when first creating the
+        # connection.
+        assert conn._connect.call_count == 1
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_retry_fails_fast_for_general_snowflake_errors(self):
+        from snowflake.connector.errors import Error as SnowflakeError
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(
+            side_effect=SnowflakeError("oh noes :(")
+        )
+
+        conn = SnowflakeConnection("my_snowflake_connection")
+        conn._instance.cursor.return_value = mock_cursor
+
+        with pytest.raises(SnowflakeError):
+            conn.query("SELECT 1;")
+
+        # conn._connect should have just been called once when first creating the
+        # connection.
+        assert conn._connect.call_count == 1
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",
+        MagicMock(),
+    )
+    def test_retry_fails_fast_for_other_errors(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetch_pandas_all = MagicMock(side_effect=Exception("oh noes :("))
 
         conn = SnowflakeConnection("my_snowflake_connection")
         conn._instance.cursor.return_value = mock_cursor


### PR DESCRIPTION
We were overly broad with the errors that we retry for in `SnowflakeConnection`, which results in
some silly retries for errors that there's no chance will ever succeed on another attempt (such as when
the user tries to execute SQL that contains a syntax error).

Looking at the `snowflake-connector-python` library, it turns out retries for retryable HTTP status codes
is already baked into the library, so we can drastically reduce the error types that we retry on.

Closes #7637