### PR TITLE
Tweak "forgot config" SnowflakeConnection error message

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -109,8 +109,8 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
                     "Missing Snowflake connection configuration. "
                     "Did you forget to set this in `secrets.toml`, a Snowflake configuration file, "
                     "or as kwargs to `st.connection`? "
-                    "See the [Snowflake Python Connector documentation](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#connecting-using-the-connections-toml-file) "
-                    "for some options on how to set connection params."
+                    "See the [SnowflakeConnection configuration documentation](https://docs.streamlit.io/st.connections.snowflakeconnection-configuration) "
+                    "for more details and examples."
                 )
             raise e
 


### PR DESCRIPTION
We're adding a new docs page for more information on how to set up a `SnowflakeConnection` since
the existing ones are more general and don't contain any Streamlit-specific information. This PR just
changes the error message for the "forgot config" error slightly to point to this new page.