### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/scripts/build_info.py
+++ b/.github/scripts/build_info.py
@@ -75,7 +75,7 @@ FILES_WITH_PYTHON_DEPENDENCIES = [
     "lib/setup.py",
 ]
 # +1 to make range inclusive.
-ALL_PYTHON_VERSIONS = [f"3.{d}" for d in range(8, 11 + 1)]
+ALL_PYTHON_VERSIONS = [f"3.{d}" for d in range(8, 12 + 1)]
 PYTHON_MIN_VERSION = ALL_PYTHON_VERSIONS[0]
 PYTHON_MAX_VERSION = ALL_PYTHON_VERSIONS[-1]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,87 +109,82 @@ repos:
         entry: "^\\s*from\\s+\\."
         pass_filenames: true
         files: \.py$
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.2.0
-    hooks:
-      - id: insert-license
-        name: Add license for all (S)CSS/JS(X)/TS(X) files
-        language_version: python3.8
-        files: \.(s?css|jsx?|tsx?)$
-        args:
-          - --comment-style
-          - "/**| *| */"
-          - --license-filepath
-          - scripts/license-template.txt
-          - --fuzzy-match-generates-todo
-        exclude: |
-          (?x)
-          /vendor/
-          |^vendor/
-          |^component-lib/declarations/apache-arrow
-          |^frontend/app/src/assets/css/variables\.scss
-      - id: insert-license
-        name: Add license for all Proto files
-        language_version: python3.8
-        files: \.proto$
-        args:
-          - --comment-style
-          - "/**!| *| */"
-          - --license-filepath
-          - scripts/license-template.txt
-          - --fuzzy-match-generates-todo
-        exclude: |
-          (?x)
-          /vendor/
-          |^vendor/
-          |^component-lib/declarations/apache-arrow
-          |^proto/streamlit/proto/openmetrics_data_model\.proto
-      - id: insert-license
-        name: Add license for all shell files
-        language_version: python3.8
-        files: \.sh$
-        args:
-          - --comment-style
-          - "|#|"
-          - --license-filepath
-          - scripts/license-template.txt
-          - --fuzzy-match-generates-todo
-        exclude: |
-          (?x)
-          /vendor/
-          |^vendor/
-          |^component-lib/declarations/apache-arrow
-      - id: insert-license
-        name: Add license for all Python files
-        language_version: python3.8
-        files: \.py$|\.pyi$
-        args:
-          - --comment-style
-          - "|#|"
-          - --license-filepath
-          - scripts/license-template.txt
-          - --fuzzy-match-generates-todo
-        exclude: |
-          (?x)
-          /vendor/
-          |^vendor/
-          |^component-lib/declarations/apache-arrow
-          |^lib/tests/isolated_asyncio_test_case\.py$
-      - id: insert-license
-        name: Add license for all HTML files
-        language_version: python3.8
-        files: \.html$
-        args:
-          - --comment-style
-          - "<!--||-->"
-          - --license-filepath
-          - scripts/license-template.txt
-          - --fuzzy-match-generates-todo
-        exclude: |
-          (?x)
-          /vendor/
-          |^vendor/
-          |^component-lib/declarations/apache-arrow
+#  - repo: https://github.com/Lucas-C/pre-commit-hooks
+#    rev: v1.2.0
+#    hooks:
+#      - id: insert-license
+#        name: Add license for all (S)CSS/JS(X)/TS(X) files
+#        files: \.(s?css|jsx?|tsx?)$
+#        args:
+#          - --comment-style
+#          - "/**| *| */"
+#          - --license-filepath
+#          - scripts/license-template.txt
+#          - --fuzzy-match-generates-todo
+#        exclude: |
+#          (?x)
+#          /vendor/
+#          |^vendor/
+#          |^component-lib/declarations/apache-arrow
+#          |^frontend/app/src/assets/css/variables\.scss
+#      - id: insert-license
+#        name: Add license for all Proto files
+#        files: \.proto$
+#        args:
+#          - --comment-style
+#          - "/**!| *| */"
+#          - --license-filepath
+#          - scripts/license-template.txt
+#          - --fuzzy-match-generates-todo
+#        exclude: |
+#          (?x)
+#          /vendor/
+#          |^vendor/
+#          |^component-lib/declarations/apache-arrow
+#          |^proto/streamlit/proto/openmetrics_data_model\.proto
+#      - id: insert-license
+#        name: Add license for all shell files
+#        files: \.sh$
+#        args:
+#          - --comment-style
+#          - "|#|"
+#          - --license-filepath
+#          - scripts/license-template.txt
+#          - --fuzzy-match-generates-todo
+#        exclude: |
+#          (?x)
+#          /vendor/
+#          |^vendor/
+#          |^component-lib/declarations/apache-arrow
+#      - id: insert-license
+#        name: Add license for all Python files
+#        files: \.py$|\.pyi$
+#        args:
+#          - --comment-style
+#          - "|#|"
+#          - --license-filepath
+#          - scripts/license-template.txt
+#          - --fuzzy-match-generates-todo
+#        exclude: |
+#          (?x)
+#          /vendor/
+#          |^vendor/
+#          |^component-lib/declarations/apache-arrow
+#          |^lib/tests/isolated_asyncio_test_case\.py$
+#      - id: insert-license
+#        name: Add license for all HTML files
+#        files: \.html$
+#        args:
+#          - --comment-style
+#          - "<!--||-->"
+#          - --license-filepath
+#          - scripts/license-template.txt
+#          - --fuzzy-match-generates-todo
+#        exclude: |
+#          (?x)
+#          /vendor/
+#          |^vendor/
+#          |^component-lib/declarations/apache-arrow
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,7 @@ repos:
     hooks:
       - id: insert-license
         name: Add license for all (S)CSS/JS(X)/TS(X) files
+        language_version: python3.8
         files: \.(s?css|jsx?|tsx?)$
         args:
           - --comment-style
@@ -129,6 +130,7 @@ repos:
           |^frontend/app/src/assets/css/variables\.scss
       - id: insert-license
         name: Add license for all Proto files
+        language_version: python3.8
         files: \.proto$
         args:
           - --comment-style
@@ -144,6 +146,7 @@ repos:
           |^proto/streamlit/proto/openmetrics_data_model\.proto
       - id: insert-license
         name: Add license for all shell files
+        language_version: python3.8
         files: \.sh$
         args:
           - --comment-style
@@ -158,6 +161,7 @@ repos:
           |^component-lib/declarations/apache-arrow
       - id: insert-license
         name: Add license for all Python files
+        language_version: python3.8
         files: \.py$|\.pyi$
         args:
           - --comment-style
@@ -173,6 +177,7 @@ repos:
           |^lib/tests/isolated_asyncio_test_case\.py$
       - id: insert-license
         name: Add license for all HTML files
+        language_version: python3.8
         files: \.html$
         args:
           - --comment-style

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,82 +109,82 @@ repos:
         entry: "^\\s*from\\s+\\."
         pass_filenames: true
         files: \.py$
-#  - repo: https://github.com/Lucas-C/pre-commit-hooks
-#    rev: v1.2.0
-#    hooks:
-#      - id: insert-license
-#        name: Add license for all (S)CSS/JS(X)/TS(X) files
-#        files: \.(s?css|jsx?|tsx?)$
-#        args:
-#          - --comment-style
-#          - "/**| *| */"
-#          - --license-filepath
-#          - scripts/license-template.txt
-#          - --fuzzy-match-generates-todo
-#        exclude: |
-#          (?x)
-#          /vendor/
-#          |^vendor/
-#          |^component-lib/declarations/apache-arrow
-#          |^frontend/app/src/assets/css/variables\.scss
-#      - id: insert-license
-#        name: Add license for all Proto files
-#        files: \.proto$
-#        args:
-#          - --comment-style
-#          - "/**!| *| */"
-#          - --license-filepath
-#          - scripts/license-template.txt
-#          - --fuzzy-match-generates-todo
-#        exclude: |
-#          (?x)
-#          /vendor/
-#          |^vendor/
-#          |^component-lib/declarations/apache-arrow
-#          |^proto/streamlit/proto/openmetrics_data_model\.proto
-#      - id: insert-license
-#        name: Add license for all shell files
-#        files: \.sh$
-#        args:
-#          - --comment-style
-#          - "|#|"
-#          - --license-filepath
-#          - scripts/license-template.txt
-#          - --fuzzy-match-generates-todo
-#        exclude: |
-#          (?x)
-#          /vendor/
-#          |^vendor/
-#          |^component-lib/declarations/apache-arrow
-#      - id: insert-license
-#        name: Add license for all Python files
-#        files: \.py$|\.pyi$
-#        args:
-#          - --comment-style
-#          - "|#|"
-#          - --license-filepath
-#          - scripts/license-template.txt
-#          - --fuzzy-match-generates-todo
-#        exclude: |
-#          (?x)
-#          /vendor/
-#          |^vendor/
-#          |^component-lib/declarations/apache-arrow
-#          |^lib/tests/isolated_asyncio_test_case\.py$
-#      - id: insert-license
-#        name: Add license for all HTML files
-#        files: \.html$
-#        args:
-#          - --comment-style
-#          - "<!--||-->"
-#          - --license-filepath
-#          - scripts/license-template.txt
-#          - --fuzzy-match-generates-todo
-#        exclude: |
-#          (?x)
-#          /vendor/
-#          |^vendor/
-#          |^component-lib/declarations/apache-arrow
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: insert-license
+        name: Add license for all (S)CSS/JS(X)/TS(X) files
+        files: \.(s?css|jsx?|tsx?)$
+        args:
+          - --comment-style
+          - "/**| *| */"
+          - --license-filepath
+          - scripts/license-template.txt
+          - --fuzzy-match-generates-todo
+        exclude: |
+          (?x)
+          /vendor/
+          |^vendor/
+          |^component-lib/declarations/apache-arrow
+          |^frontend/app/src/assets/css/variables\.scss
+      - id: insert-license
+        name: Add license for all Proto files
+        files: \.proto$
+        args:
+          - --comment-style
+          - "/**!| *| */"
+          - --license-filepath
+          - scripts/license-template.txt
+          - --fuzzy-match-generates-todo
+        exclude: |
+          (?x)
+          /vendor/
+          |^vendor/
+          |^component-lib/declarations/apache-arrow
+          |^proto/streamlit/proto/openmetrics_data_model\.proto
+      - id: insert-license
+        name: Add license for all shell files
+        files: \.sh$
+        args:
+          - --comment-style
+          - "|#|"
+          - --license-filepath
+          - scripts/license-template.txt
+          - --fuzzy-match-generates-todo
+        exclude: |
+          (?x)
+          /vendor/
+          |^vendor/
+          |^component-lib/declarations/apache-arrow
+      - id: insert-license
+        name: Add license for all Python files
+        files: \.py$|\.pyi$
+        args:
+          - --comment-style
+          - "|#|"
+          - --license-filepath
+          - scripts/license-template.txt
+          - --fuzzy-match-generates-todo
+        exclude: |
+          (?x)
+          /vendor/
+          |^vendor/
+          |^component-lib/declarations/apache-arrow
+          |^lib/tests/isolated_asyncio_test_case\.py$
+      - id: insert-license
+        name: Add license for all HTML files
+        files: \.html$
+        args:
+          - --comment-style
+          - "<!--||-->"
+          - --license-filepath
+          - scripts/license-template.txt
+          - --fuzzy-match-generates-todo
+        exclude: |
+          (?x)
+          /vendor/
+          |^vendor/
+          |^component-lib/declarations/apache-arrow
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -141,6 +141,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Database :: Front-Ends",
         "Topic :: Office/Business :: Financial :: Spreadsheet",
         "Topic :: Scientific/Engineering :: Information Analysis",

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -35,10 +35,10 @@ import time
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
 
-from langchain.callbacks.base import (  # type: ignore[import-not-found]
+from langchain.callbacks.base import (  # type: ignore[import-not-found, unused-ignore]
     BaseCallbackHandler,
 )
-from langchain.schema import (  # type: ignore[import-not-found]
+from langchain.schema import (  # type: ignore[import-not-found, unused-ignore]
     AgentAction,
     AgentFinish,
     LLMResult,

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -35,8 +35,14 @@ import time
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
 
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain.schema import AgentAction, AgentFinish, LLMResult
+from langchain.callbacks.base import (  # type: ignore[import-not-found]
+    BaseCallbackHandler,
+)
+from langchain.schema import (  # type: ignore[import-not-found]
+    AgentAction,
+    AgentFinish,
+    LLMResult,
+)
 
 from streamlit.runtime.metrics_util import gather_metrics
 

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -6,7 +6,7 @@ bokeh==2.4.3
 cffi>=1.14
 chart-studio>=1.1.0
 graphviz>=0.17
-langchain>=0.0.216
+langchain>=0.0.216; python_version < '3.12'
 matplotlib>=3.3.4
 opencv-python>=4.5.3
 plotly>=5.3.1
@@ -39,7 +39,7 @@ mypy-protobuf>=3.2, <3.4
 # these pinned versions!
 
 # 8.0.0 causes test_sqlalchemy_engine_2_oracle to fail.
-cx-Oracle<8.0.0
+cx-Oracle<8.0.0; python_version < '3.12'
 mysqlclient>=2.0.3
 psycopg2-binary>=2.9.1
 pyodbc>=4.0.32

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -6,7 +6,6 @@ bokeh==2.4.3
 cffi>=1.14
 chart-studio>=1.1.0
 graphviz>=0.17
-langchain>=0.0.216; python_version < '3.12'
 matplotlib>=3.3.4
 opencv-python>=4.5.3
 plotly>=5.3.1
@@ -38,8 +37,6 @@ mypy-protobuf>=3.2, <3.4
 # we're not going to update its associated tests anymore. Please don't modify
 # these pinned versions!
 
-# 8.0.0 causes test_sqlalchemy_engine_2_oracle to fail.
-cx-Oracle<8.0.0; python_version < '3.12'
 mysqlclient>=2.0.3
 psycopg2-binary>=2.9.1
 pyodbc>=4.0.32
@@ -53,3 +50,8 @@ pydantic>=1.0, <2.0
 
 # semver 3 renames VersionInfo so temporarily pin until we deal with it
 semver<3
+
+# Langchain and cx-Oracle are not supported on Python 3.12 yet.
+langchain>=0.0.216; python_version < '3.12'
+# 8.0.0 causes test_sqlalchemy_engine_2_oracle to fail.
+cx-Oracle<8.0.0; python_version < '3.12'

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -392,4 +392,4 @@ class StMapTest(DeltaGeneratorTestCase):
         df = pd.DataFrame({"lat": [1, 2, 3, 4], "lon": [10, 20, 30, 40]})
         st.map(df)
         new_id = self.get_delta_from_queue().new_element.deck_gl_json_chart.id
-        self.assertNotEquals(orig_id, new_id)
+        self.assertNotEqual(orig_id, new_id)

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -22,6 +22,9 @@ import pytest
 import semver
 from google.protobuf.json_format import MessageToDict
 
+import streamlit as st
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
 try:
     import langchain
 
@@ -29,13 +32,9 @@ try:
         playback_callbacks,
     )
 except ImportError:
-    langchain = MagicMock()
-    langchain.__version__ = "3.0.0"
+    langchain = MagicMock(__version__="0.0.0")
     playback_callbacks = None
-    pytestmark = pytest.mark.skip(reason="langchain not installed")
-
-import streamlit as st
-from tests.delta_generator_test_case import DeltaGeneratorTestCase
+    pytestmark = pytest.mark.skip(reason="Langchain doesn't support Python 3.12 yet.")
 
 
 class StreamlitCallbackHandlerAPITest(unittest.TestCase):

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -32,6 +32,9 @@ try:
         playback_callbacks,
     )
 except ImportError:
+    # If langchain isn't installed (it doesn't work with Python 3.12 yet),
+    # we'll skip this test.
+    # TODO[kajarenc] Remove this once langchain supports Python 3.12.
     langchain = MagicMock(__version__="0.0.0")
     playback_callbacks = None
     pytestmark = pytest.mark.skip(reason="Langchain doesn't support Python 3.12 yet.")

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -16,17 +16,26 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock
 
-import langchain
 import pytest
+
 import semver
 from google.protobuf.json_format import MessageToDict
 
+try:
+    import langchain
+    from tests.streamlit.external.langchain.capturing_callback_handler import (
+        playback_callbacks,
+    )
+except ImportError:
+    langchain = MagicMock()
+    langchain.__version__ = "3.0.0"
+    playback_callbacks = None
+    pytestmark = pytest.mark.skip(reason="langchain not installed")
+
 import streamlit as st
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
-from tests.streamlit.external.langchain.capturing_callback_handler import (
-    playback_callbacks,
-)
 
 
 class StreamlitCallbackHandlerAPITest(unittest.TestCase):

--- a/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
+++ b/lib/tests/streamlit/external/langchain/streamlit_callback_handler_test.py
@@ -19,12 +19,12 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
 import semver
 from google.protobuf.json_format import MessageToDict
 
 try:
     import langchain
+
     from tests.streamlit.external.langchain.capturing_callback_handler import (
         playback_callbacks,
     )

--- a/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
@@ -555,7 +555,9 @@ class HashTest(unittest.TestCase):
             ("mysql", "passwd"),
             ("oracle", "password"),
             ("mssql", "password"),
-        ] if sys.version_info < (3, 12) else [
+        ]
+        if sys.version_info < (3, 12)
+        else [
             ("postgresql", "password"),
             ("mysql", "passwd"),
             ("mssql", "password"),

--- a/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/legacy_caching/hashing_test.py
@@ -19,6 +19,7 @@ import hashlib
 import os
 import re
 import socket
+import sys
 import tempfile
 import time
 import types
@@ -553,6 +554,10 @@ class HashTest(unittest.TestCase):
             ("postgresql", "password"),
             ("mysql", "passwd"),
             ("oracle", "password"),
+            ("mssql", "password"),
+        ] if sys.version_info < (3, 12) else [
+            ("postgresql", "password"),
+            ("mysql", "passwd"),
             ("mssql", "password"),
         ]
     )

--- a/lib/tests/streamlit/runtime/scriptrunner/script_cache_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_cache_test.py
@@ -54,10 +54,10 @@ class ScriptCacheTest(unittest.TestCase):
         """`clear` removes cached entries."""
         cache = ScriptCache()
         cache.get_bytecode(_get_script_path("good_script.py"))
-        self.assertEquals(1, len(cache._cache))
+        self.assertEqual(1, len(cache._cache))
 
         cache.clear()
-        self.assertEquals(0, len(cache._cache))
+        self.assertEqual(0, len(cache._cache))
 
     def test_file_not_found_error(self):
         """An exception is thrown when a script file doesn't exist."""


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Updates Streamlit for Python 3.12 compatibility

- We have a test that checks interaction with langchain (callback handler), which is not yet 3.12-compatible. These are skipped when running on 3.12.
- ALL_PYTHON_VERSIONS are extended with 3.12 for our Github Actions runners
- Refactor a few tests to use `self.assertEqual` instead of deprecated ` self.assertEqualS`
- Bump revision of `insert-licence` pre-commit hook to work with Python 3.12


## GitHub Issue Link (if applicable)

Closes #7506 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
