### PR TITLE
Fix how connection is declared for typing purposes

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -62,7 +62,7 @@ from streamlit.runtime.caching import (
     experimental_memo as _experimental_memo,
 )
 from streamlit.runtime.connection_factory import (
-    connection_factory as connection,
+    connection_factory as _connection,
 )
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
@@ -198,6 +198,9 @@ cache_resource = _cache_resource
 
 # Namespaces
 column_config = _column_config
+
+# Connection
+connection = _connection
 
 # Experimental APIs
 experimental_user = _UserInfoProxy()


### PR DESCRIPTION
## Describe your changes

Adjusts the import for `connection_factory` to be prefixed with an underscore since it's typed as a private import at this point; declare `connection` (no underscore prefix) down below along with the publicly exported api.

Fixes the following error when type checking is enabled and you try to call `st.connection()`:
> "connection" is not a known member of module "streamlit"

## GitHub Issue Link (if applicable)

Small change; didn't make an issue.

## Testing Plan

N / A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
