### PR TITLE
add app_heartbeat BackMsg type and send it when receiving SEND_APP_HEARTBEAT window message

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1505,14 +1505,15 @@ describe("handles HostCommunication messaging", () => {
     )
   })
 
-  it("fires clearCache function when cacheClearRequested message has been received", () => {
+  it("fires clearCache BackMsg when CLEAR_CACHE window message has been received", () => {
     instance.isServerConnected = jest.fn().mockReturnValue(true)
 
-    const clearCacheFunc = jest.spyOn(
+    const sendMessageFunc = jest.spyOn(
       // @ts-expect-error
-      instance.hostCommunicationMgr.props,
-      "clearCache"
+      instance.connectionManager,
+      "sendMessage"
     )
+
     // the clearCache function in App.tsx calls closeDialog
     const closeDialogFunc = jest.spyOn(instance, "closeDialog")
 
@@ -1527,8 +1528,31 @@ describe("handles HostCommunication messaging", () => {
       })
     )
 
-    expect(clearCacheFunc).toHaveBeenCalledWith()
+    expect(sendMessageFunc).toHaveBeenCalledWith({ clearCache: true })
     expect(closeDialogFunc).toHaveBeenCalledWith()
+  })
+
+  it("fires appHeartbeat BackMsg when SEND_APP_HEARTBEAT window message has been received", () => {
+    instance.isServerConnected = jest.fn().mockReturnValue(true)
+
+    const sendMessageFunc = jest.spyOn(
+      // @ts-expect-error
+      instance.connectionManager,
+      "sendMessage"
+    )
+
+    dispatchEvent(
+      "message",
+      new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SEND_APP_HEARTBEAT",
+        },
+        origin: "https://devel.streamlit.test",
+      })
+    )
+
+    expect(sendMessageFunc).toHaveBeenCalledWith({ appHeartbeat: true })
   })
 
   it("does not prevent a modal from opening when closure message is set", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -297,6 +297,7 @@ export class App extends PureComponent<Props, State> {
       stopScript: this.stopScript,
       rerunScript: this.rerunScript,
       clearCache: this.clearCache,
+      sendAppHeartbeat: this.sendAppHeartbeat,
       themeChanged: this.props.theme.setImportedTheme,
       pageChanged: this.onPageChange,
       isOwnerChanged: isOwner => this.setState({ isOwner }),
@@ -1411,6 +1412,19 @@ export class App extends PureComponent<Props, State> {
       this.sendBackMsg(backMsg)
     } else {
       logError("Cannot clear cache: disconnected from server")
+    }
+  }
+
+  /**
+   * Sends an app heartbeat message through the websocket
+   */
+  sendAppHeartbeat = (): void => {
+    if (this.isServerConnected()) {
+      const backMsg = new BackMsg({ appHeartbeat: true })
+      backMsg.type = "appHeartbeat"
+      this.sendBackMsg(backMsg)
+    } else {
+      logError("Cannot send app heartbeat: disconnected from server")
     }
   }
 

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -51,6 +51,7 @@ describe("HostCommunicationManager messaging", () => {
       stopScript: jest.fn(),
       rerunScript: jest.fn(),
       clearCache: jest.fn(),
+      sendAppHeartbeat: jest.fn(),
       isOwnerChanged: jest.fn(),
       hostMenuItemsChanged: jest.fn(),
       hostToolbarItemsChanged: jest.fn(),
@@ -177,6 +178,22 @@ describe("HostCommunicationManager messaging", () => {
     expect(hostCommunicationMgr.props.pageChanged).toHaveBeenCalledWith(
       "hash1"
     )
+  })
+
+  it("can process a received SEND_APP_HEARTBEAT message", () => {
+    dispatchEvent(
+      "message",
+      new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SEND_APP_HEARTBEAT",
+        },
+        origin: "https://devel.streamlit.test",
+      })
+    )
+
+    // @ts-expect-error - props are private
+    expect(hostCommunicationMgr.props.sendAppHeartbeat).toHaveBeenCalledWith()
   })
 
   it("should respond to SET_IS_OWNER message", () => {
@@ -409,6 +426,7 @@ describe("Test different origins", () => {
       stopScript: jest.fn(),
       rerunScript: jest.fn(),
       clearCache: jest.fn(),
+      sendAppHeartbeat: jest.fn(),
       isOwnerChanged: jest.fn(),
       hostMenuItemsChanged: jest.fn(),
       hostToolbarItemsChanged: jest.fn(),
@@ -502,6 +520,7 @@ describe("HostCommunicationManager external auth token handling", () => {
       stopScript: jest.fn(),
       rerunScript: jest.fn(),
       clearCache: jest.fn(),
+      sendAppHeartbeat: jest.fn(),
       isOwnerChanged: jest.fn(),
       hostMenuItemsChanged: jest.fn(),
       hostToolbarItemsChanged: jest.fn(),

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -41,6 +41,7 @@ export interface HostCommunicationProps {
   readonly stopScript: () => void
   readonly rerunScript: () => void
   readonly clearCache: () => void
+  readonly sendAppHeartbeat: () => void
   readonly themeChanged: (themeInfo: ICustomThemeConfig) => void
   readonly pageChanged: (pageScriptHash: string) => void
   readonly isOwnerChanged: (isOwner: boolean) => void
@@ -178,6 +179,10 @@ export default class HostCommunicationManager {
 
     if (message.type === "REQUEST_PAGE_CHANGE") {
       this.props.pageChanged(message.pageScriptHash)
+    }
+
+    if (message.type === "SEND_APP_HEARTBEAT") {
+      this.props.sendAppHeartbeat()
     }
 
     if (message.type === "SET_AUTH_TOKEN") {

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -284,6 +284,8 @@ class AppSession:
                 self._handle_git_information_request()
             elif msg_type == "clear_cache":
                 self._handle_clear_cache_request()
+            elif msg_type == "app_heartbeat":
+                self._handle_app_heartbeat_request()
             elif msg_type == "set_run_on_save":
                 self._handle_set_run_on_save_request(msg.set_run_on_save)
             elif msg_type == "stop_script":
@@ -731,6 +733,17 @@ class AppSession:
         caching.cache_data.clear()
         caching.cache_resource.clear()
         self._session_state.clear()
+
+    def _handle_app_heartbeat_request(self) -> None:
+        """Handle an incoming app heartbeat.
+
+        The heartbeat indicates the frontend is active and keeps the
+        websocket from going idle and disconnecting.
+
+        The actual handler here is a noop
+
+        """
+        pass
 
     def _handle_set_run_on_save_request(self, new_value: bool) -> None:
         """Change our run_on_save flag to the given value.

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -784,6 +784,22 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         session.handle_backmsg(msg)
         self.assertEqual(session._debug_last_backmsg_id, "some backmsg")
 
+    @patch("streamlit.runtime.app_session.LOGGER")
+    async def test_handles_app_heartbeat_backmsg(self, patched_logger):
+        session = _create_test_session(asyncio.get_running_loop())
+        with patch.object(
+            session, "handle_backmsg_exception"
+        ) as handle_backmsg_exception, patch.object(
+            session, "_handle_app_heartbeat_request"
+        ) as handle_app_heartbeat_request:
+            msg = BackMsg()
+            msg.app_heartbeat = True
+            session.handle_backmsg(msg)
+
+            handle_app_heartbeat_request.assert_called_once()
+            handle_backmsg_exception.assert_not_called()
+            patched_logger.warning.assert_not_called()
+
 
 class PopulateCustomThemeMsgTest(unittest.TestCase):
     @patch("streamlit.runtime.app_session.config")

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -67,6 +67,9 @@ message BackMsg {
     // Requests that the server generate URLs for getting/uploading/deleting
     // files for the `st.file_uploader` widget
     FileURLsRequest file_urls_request = 16;
+
+    // Sends an app heartbeat message through the websocket
+    bool app_heartbeat = 17;
   }
 
   // An ID used to associate this BackMsg with the corresponding ForwardMsgs
@@ -76,5 +79,5 @@ message BackMsg {
 
   reserved 1, 2, 3, 4, 8, 9, 10;
 
-  // Next: 17
+  // Next: 18
 }


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- Adds the ability to send a no-op "app heartbeat" message through the websocket. If an app user is active (sending input, waiting for script execution) but not regularly triggering websocket communication the websocket connection can go idle and disconnect.
- The heartbeat is triggered by sending a SEND_APP_HEARTBEAT window message. The host can implement its own detection of user activity and determine on what cadence to send the app heartbeat.

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)

Added JS and python unit tests.

- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
