### PR TITLE
Enforce pyarrow version for arrow-based custom components 

### DIFF
--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -110,6 +110,12 @@ def arrow_proto_to_dataframe(proto: ArrowTableProto) -> pd.DataFrame:
         Output. pandas.DataFrame
 
     """
+    if type_util.is_pyarrow_version_less_than("14.0.1"):
+        raise RuntimeError(
+            "The installed pyarrow version is not compatible with this component. "
+            "Please upgrade to 14.0.1 or higher: pip install -U pyarrow"
+        )
+
     data = type_util.bytes_to_data_frame(proto.data)
     index = type_util.bytes_to_data_frame(proto.index)
     columns = type_util.bytes_to_data_frame(proto.columns)

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -673,6 +673,24 @@ def is_pandas_version_less_than(v: str) -> bool:
     return version.parse(pd.__version__) < version.parse(v)
 
 
+def is_pyarrow_version_less_than(v: str) -> bool:
+    """Return True if the current Pyarrow version is less than the input version.
+
+    Parameters
+    ----------
+    v : str
+        Version string, e.g. "0.25.0"
+
+    Returns
+    -------
+    bool
+
+    """
+    from packaging import version
+
+    return version.parse(pa.__version__) < version.parse(v)
+
+
 def pyarrow_table_to_bytes(table: pa.Table) -> bytes:
     """Serialize pyarrow.Table to bytes using Apache Arrow.
 
@@ -809,6 +827,9 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
 
 def bytes_to_data_frame(source: bytes) -> DataFrame:
     """Convert bytes to pandas.DataFrame.
+
+    Using this function in production needs to make sure that
+    the pyarrow version >= 14.0.1.
 
     Parameters
     ----------


### PR DESCRIPTION
## Describe your changes

This PR prevents the usage of a specific part of pyarrow code which is impacted by the [CVE-2023-47248](https://nvd.nist.gov/vuln/detail/CVE-2023-47248) vulnerability. Arrow-based custom components that use the arrow table deserialization will be required to update to pyarrow >= 14.0.1. 

## GitHub Issue Link (if applicable)

- Closes #7700

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
