### PR TITLE
Enforce pyarrow version - patch

### DIFF
--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -340,6 +340,12 @@ def arrow_proto_to_dataframe(proto):
         Output. pandas.DataFrame
 
     """
+    if _is_pyarrow_version_less_than("14.0.1"):
+        raise RuntimeError(
+            "The installed pyarrow version is not compatible with this component. "
+            "Please upgrade to 14.0.1 or higher: pip install -U pyarrow"
+        )
+
     data = _pybytes_to_dataframe(proto.data)
     index = _pybytes_to_dataframe(proto.index)
     columns = _pybytes_to_dataframe(proto.columns)
@@ -360,3 +366,18 @@ def _pybytes_to_dataframe(source):
     """
     reader = pa.RecordBatchStreamReader(source)
     return reader.read_pandas()
+
+
+def _is_pyarrow_version_less_than(v: str) -> bool:
+    """Return True if the current Pyarrow version is less than the input version.
+    Parameters
+    ----------
+    v : str
+        Version string, e.g. "0.25.0"
+    Returns
+    -------
+    bool
+    """
+    from packaging import version
+
+    return version.parse(pa.__version__) < version.parse(v)


### PR DESCRIPTION
## Describe your changes

This PR prevents the usage of a specific part of pyarrow code which is impacted by the [CVE-2023-47248](https://nvd.nist.gov/vuln/detail/CVE-2023-47248) vulnerability. Arrow-based custom components that use the arrow table deserialization will be required to update to pyarrow >= 14.0.1. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
