### PR TITLE
Allow to access external server IP via https.

### DIFF
--- a/lib/streamlit/net_util.py
+++ b/lib/streamlit/net_util.py
@@ -44,10 +44,8 @@ def get_external_ip() -> Optional[str]:
     if _external_ip is not None:
         return _external_ip
 
-    # try to get external IP from Amazon http url
     response = _make_blocking_http_get(_AWS_CHECK_IP, timeout=5)
 
-    # try to get external IP from Amazon https url
     if response is None:
         response = _make_blocking_http_get(_AWS_CHECK_IP_HTTPS, timeout=5)
 

--- a/lib/streamlit/net_util.py
+++ b/lib/streamlit/net_util.py
@@ -22,8 +22,9 @@ from streamlit.logger import get_logger
 
 LOGGER = get_logger(__name__)
 
-# URL for checking the current machine's external IP address.
+# URLs for checking the current machine's external IP address.
 _AWS_CHECK_IP: Final = "http://checkip.amazonaws.com"
+_AWS_CHECK_IP_HTTPS: Final = "https://checkip.amazonaws.com"
 
 _external_ip: Optional[str] = None
 _internal_ip: Optional[str] = None
@@ -43,7 +44,12 @@ def get_external_ip() -> Optional[str]:
     if _external_ip is not None:
         return _external_ip
 
+    # try to get external IP from Amazon http url
     response = _make_blocking_http_get(_AWS_CHECK_IP, timeout=5)
+
+    # try to get external IP from Amazon https url
+    if response is None:
+        response = _make_blocking_http_get(_AWS_CHECK_IP_HTTPS, timeout=5)
 
     if _looks_like_an_ip_adress(response):
         _external_ip = response

--- a/lib/tests/streamlit/net_util_test.py
+++ b/lib/tests/streamlit/net_util_test.py
@@ -37,6 +37,22 @@ class UtilTest(unittest.TestCase):
             m.get(net_util._AWS_CHECK_IP, exc=requests.exceptions.ConnectTimeout)
             self.assertEqual(None, net_util.get_external_ip())
 
+    def test_get_external_ip_use_http_by_default(self):
+        # Test that by default we do call http endpoint
+        with requests_mock.mock() as m:
+            m.get(net_util._AWS_CHECK_IP, text="1.2.3.4")
+            m.get(net_util._AWS_CHECK_IP_HTTPS, text="5.6.7.8")
+            self.assertEqual("1.2.3.4", net_util.get_external_ip())
+            # Test that we do only one http call
+            self.assertEqual(m.call_count, 1)
+
+    def test_get_external_ip_https(self):
+        # Test that if http fails, we try https
+        with requests_mock.mock() as m:
+            m.get(net_util._AWS_CHECK_IP, exc=requests.exceptions.ConnectTimeout)
+            m.get(net_util._AWS_CHECK_IP_HTTPS, text="5.6.7.8")
+            self.assertEqual("5.6.7.8", net_util.get_external_ip())
+
     def test_get_external_ip_html(self):
         # This tests the case where the external URL returns a web page.
         # https://github.com/streamlit/streamlit/issues/554#issuecomment-604847244

--- a/lib/tests/streamlit/net_util_test.py
+++ b/lib/tests/streamlit/net_util_test.py
@@ -38,20 +38,18 @@ class UtilTest(unittest.TestCase):
             self.assertEqual(None, net_util.get_external_ip())
 
     def test_get_external_ip_use_http_by_default(self):
-        # Test that by default we do call http endpoint
         with requests_mock.mock() as m:
             m.get(net_util._AWS_CHECK_IP, text="1.2.3.4")
             m.get(net_util._AWS_CHECK_IP_HTTPS, text="5.6.7.8")
             self.assertEqual("1.2.3.4", net_util.get_external_ip())
-            # Test that we do only one http call
             self.assertEqual(m.call_count, 1)
 
-    def test_get_external_ip_https(self):
-        # Test that if http fails, we try https
+    def test_get_external_ip_https_if_http_fails(self):
         with requests_mock.mock() as m:
             m.get(net_util._AWS_CHECK_IP, exc=requests.exceptions.ConnectTimeout)
             m.get(net_util._AWS_CHECK_IP_HTTPS, text="5.6.7.8")
             self.assertEqual("5.6.7.8", net_util.get_external_ip())
+            self.assertEqual(m.call_count, 2)
 
     def test_get_external_ip_html(self):
         # This tests the case where the external URL returns a web page.


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Fallback to HTTPS endpoint call to check external IP if HTTP call failed. 

This PR closes #7703 

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/7703

## Testing Plan

We just add a second https url to retrieve external IPs
If the http url returns None (e.g. only https requests are allowed) the https url is used as fallback to retrieve the server IP.

Python unit tests added. 
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
