### PR TITLE
Move dg_stack into a ContextVar to support with blocks in separate threads

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import contextvars
 import sys
 from typing import (
     TYPE_CHECKING,
@@ -26,7 +25,6 @@ from typing import (
     Iterable,
     NoReturn,
     Optional,
-    Tuple,
     Type,
     TypeVar,
     cast,
@@ -89,6 +87,7 @@ from streamlit.proto import Block_pb2, ForwardMsg_pb2
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime import caching, legacy_caching
 from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.runtime.scriptrunner.script_run_context import dg_stack
 from streamlit.runtime.state import NoValue
 
 if TYPE_CHECKING:
@@ -147,14 +146,6 @@ def _maybe_print_use_warning() -> None:
             logger.get_logger("root").warning(
                 f"\n  {warning} to view this Streamlit app on a browser, run it with the following\n  command:\n\n    streamlit run {script_name} [ARGUMENTS]"
             )
-
-
-# The dg_stack tracks the currently active DeltaGenerator, and is pushed to when
-# a DeltaGenerator is entered via a `with` block. This is implemented as a ContextVar
-# so that different threads or async tasks can have their own stacks.
-dg_stack: contextvars.ContextVar[Tuple[DeltaGenerator, ...]] = contextvars.ContextVar(
-    "dg_stack", default=tuple()
-)
 
 
 class DeltaGenerator(

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -14,17 +14,20 @@
 from __future__ import annotations
 
 import textwrap
-from typing import NamedTuple, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 from typing_extensions import Literal
 
 from streamlit import runtime
-from streamlit.delta_generator import DeltaGenerator, dg_stack
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
+from streamlit.runtime.scriptrunner.script_run_context import dg_stack
 from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
 
 
 class FormData(NamedTuple):

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -14,19 +14,17 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import NamedTuple, cast
 
 from typing_extensions import Literal
 
 from streamlit import runtime
+from streamlit.delta_generator import DeltaGenerator, dg_stack
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto import Block_pb2
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
-
-if TYPE_CHECKING:
-    from streamlit.delta_generator import DeltaGenerator
 
 
 class FormData(NamedTuple):
@@ -52,11 +50,7 @@ def _current_form(this_dg: DeltaGenerator) -> FormData | None:
     if this_dg == this_dg._main_dg:
         # We were created via an `st.foo` call.
         # Walk up the dg_stack to see if we're nested inside a `with st.form` statement.
-        ctx = get_script_run_ctx()
-        if ctx is None or len(ctx.dg_stack) == 0:
-            return None
-
-        for dg in reversed(ctx.dg_stack):
+        for dg in reversed(dg_stack.get()):
             if dg._form_data is not None:
                 return dg._form_data
     else:

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -40,7 +40,9 @@ class ScriptRunContext:
     scoped to a single connected "session").
 
     ScriptRunContext is used internally by virtually every `st.foo()` function.
-    It is accessed only from the script thread that's created by ScriptRunner.
+    It is accessed only from the script thread that's created by ScriptRunner,
+    or from app-created helper threads that have been "attached" to the
+    ScriptRunContext via `add_script_run_ctx`.
 
     Streamlit code typically retrieves the active ScriptRunContext via the
     `get_script_run_ctx` function.
@@ -64,9 +66,6 @@ class ScriptRunContext:
     widget_user_keys_this_run: Set[str] = field(default_factory=set)
     form_ids_this_run: Set[str] = field(default_factory=set)
     cursors: Dict[int, "streamlit.cursor.RunningCursor"] = field(default_factory=dict)
-    dg_stack: List["streamlit.delta_generator.DeltaGenerator"] = field(
-        default_factory=list
-    )
     script_requests: Optional[ScriptRequests] = None
 
     def reset(self, query_string: str = "", page_script_hash: str = "") -> None:

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import collections
+import contextvars
 import threading
 from dataclasses import dataclass, field
-from typing import Callable, Counter, Dict, List, Optional, Set
+from typing import Callable, Counter, Dict, List, Optional, Set, Tuple
 
 from typing_extensions import Final, TypeAlias
 
@@ -31,6 +32,14 @@ from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 LOGGER: Final = get_logger(__name__)
 
 UserInfo: TypeAlias = Dict[str, Optional[str]]
+
+
+# The dg_stack tracks the currently active DeltaGenerator, and is pushed to when
+# a DeltaGenerator is entered via a `with` block. This is implemented as a ContextVar
+# so that different threads or async tasks can have their own stacks.
+dg_stack: contextvars.ContextVar[
+    Tuple["streamlit.delta_generator.DeltaGenerator", ...]
+] = contextvars.ContextVar("dg_stack", default=tuple())
 
 
 @dataclass


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Previously, using a DeltaGenerator as a context manager appended to a dg_stack variable associated with the current ScriptRunContext. Unfortunately, if that ScriptRunContext is shared between multiple threads or async tasks, they would end up modifying each other's stacks, leading to broken behavior.

This PR instead uses the [contextvars](https://docs.python.org/3/library/contextvars.html) module to make dg_stack a context-local variable, which means it automatically does the "right thing" in those cases.

Note that this also requires making it immutable, so this PR switches from a list to a tuple. This does mean entering/exiting
contexts is now linear compute cost in the depth of the dg_stack, but it's really weird to have super deeply nested context managers, so I'm not too concerned.

Tagging @AnOctopus as the most recent person to touch this code.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/7668

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

It would be reasonable to have a unit test that verifies the correct behavior here, but I'm not sure where to put it.

There's some reproducing code in the linked issue, and I also have an internal test case that could be adapted. I'm definitely open to suggestions/guidance here.

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
