### PR TITLE
Directly use package name in setup.py

### DIFF
--- a/lib/setup.py
+++ b/lib/setup.py
@@ -23,8 +23,6 @@ THIS_DIRECTORY = Path(__file__).parent
 
 VERSION = "1.28.1"  # PEP-440
 
-NAME = "streamlit"
-
 # IMPORTANT: We should try very hard *not* to add dependencies to Streamlit.
 # And if you do add one, make the required version as general as possible:
 # - Include relevant lower bound for any features we use from our dependencies
@@ -113,7 +111,7 @@ else:
     long_description = ""
 
 setuptools.setup(
-    name=NAME,
+    name="streamlit",
     version=VERSION,
     description="A faster way to build and share data apps",
     long_description=long_description,

--- a/scripts/update_name.py
+++ b/scripts/update_name.py
@@ -34,7 +34,7 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # "<post_match>" named group. Text between these pre- and post-match
 # groups will be replaced with the specified project_name text.
 FILES_AND_REGEXES = {
-    "lib/setup.py": r"(?P<pre_match>.*NAME = \").*(?P<post_match>\")",
+    "lib/setup.py": r"(?P<pre_match>.*name=\").*(?P<post_match>\")",
     "lib/streamlit/version.py": r"(?P<pre_match>.*_version\(\").*(?P<post_match>\"\)$)",
 }
 


### PR DESCRIPTION
## Describe your changes

Github cannot detect `streamlit` as the main package in the repo. Therefore, the dependency graph feature doesn't work correctly. This is a try to fix this by moving the name directly to the setup section. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
