### PR TITLE
Remove unnecessary PIL dependency in st.image docstring

### DIFF
--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -144,11 +144,7 @@ class ImageMixin:
         Example
         -------
         >>> import streamlit as st
-        >>> from PIL import Image
-        >>>
-        >>> image = Image.open('sunrise.jpg')
-        >>>
-        >>> st.image(image, caption='Sunrise by the mountains')
+        >>> st.image('sunrise.jpg', caption='Sunrise by the mountains')
 
         .. output::
            https://doc-image.streamlit.app/


### PR DESCRIPTION
## Describe your changes

`st.image`  can read images from a local file path. There is no need to introduce a dependency to read the image before passing it to `st.image`. This PR updates the docstring to remove the PIL dependency.


## Testing Plan

- No tests are required since this change only affects the docstring.


## References

- [~2 year old ticket](https://www.notion.so/snowflake-corp/I-m-too-dumb-to-use-st-image-b2414d642a5a40659fe1abd15a0acd8d)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
