### PR TITLE
Improve st.connection caching behavior

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -204,6 +204,9 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             cur.execute(sql, params=params, **kwargs)
             return cur.fetch_pandas_all()
 
+        # We modify our helper function's `__qualname__` here to work around default
+        # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
+        # `ttl` values will reset the cache with each call.
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
             show_spinner=show_spinner,

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -206,7 +206,8 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
 
         # We modify our helper function's `__qualname__` here to work around default
         # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
-        # `ttl` values will reset the cache with each call.
+        # `ttl` values will reset the cache with each call, and the query caches won't
+        # be scoped by connection.
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
             show_spinner=show_spinner,

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -208,7 +208,10 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
         # `ttl` values will reset the cache with each call, and the query caches won't
         # be scoped by connection.
-        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
+        ttl_str = str(  # Avoid adding extra `.` characters to `__qualname__`
+            ttl
+        ).replace(".", "_")
+        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl_str}"
         _query = cache_data(
             show_spinner=show_spinner,
             ttl=ttl,

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -199,14 +199,16 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ),
             wait=wait_fixed(1),
         )
-        @cache_data(
-            show_spinner=show_spinner,
-            ttl=ttl,
-        )
         def _query(sql: str) -> pd.DataFrame:
             cur = self._instance.cursor()
             cur.execute(sql, params=params, **kwargs)
             return cur.fetch_pandas_all()
+
+        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
+        _query = cache_data(
+            show_spinner=show_spinner,
+            ttl=ttl,
+        )(_query)
 
         return _query(sql)
 

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -144,13 +144,15 @@ class SnowparkConnection(BaseConnection["Session"]):
             retry=retry_if_exception_type(SnowparkServerException),
             wait=wait_fixed(1),
         )
-        @cache_data(
-            show_spinner="Running `snowpark.query(...)`.",
-            ttl=ttl,
-        )
         def _query(sql: str) -> pd.DataFrame:
             with self._lock:
                 return self._instance.sql(sql).to_pandas()
+
+        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
+        _query = cache_data(
+            show_spinner="Running `snowpark.query(...)`.",
+            ttl=ttl,
+        )(_query)
 
         return _query(sql)
 

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -148,6 +148,9 @@ class SnowparkConnection(BaseConnection["Session"]):
             with self._lock:
                 return self._instance.sql(sql).to_pandas()
 
+        # We modify our helper function's `__qualname__` here to work around default
+        # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
+        # `ttl` values will reset the cache with each call.
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
             show_spinner="Running `snowpark.query(...)`.",

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -152,7 +152,10 @@ class SnowparkConnection(BaseConnection["Session"]):
         # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
         # `ttl` values will reset the cache with each call, and the query caches won't
         # be scoped by connection.
-        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
+        ttl_str = str(  # Avoid adding extra `.` characters to `__qualname__`
+            ttl
+        ).replace(".", "_")
+        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl_str}"
         _query = cache_data(
             show_spinner="Running `snowpark.query(...)`.",
             ttl=ttl,

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -150,7 +150,8 @@ class SnowparkConnection(BaseConnection["Session"]):
 
         # We modify our helper function's `__qualname__` here to work around default
         # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
-        # `ttl` values will reset the cache with each call.
+        # `ttl` values will reset the cache with each call, and the query caches won't
+        # be scoped by connection.
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
             show_spinner="Running `snowpark.query(...)`.",

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -221,7 +221,10 @@ class SQLConnection(BaseConnection["Engine"]):
         # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
         # `ttl` values will reset the cache with each call, and the query caches won't
         # be scoped by connection.
-        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
+        ttl_str = str(  # Avoid adding extra `.` characters to `__qualname__`
+            ttl
+        ).replace(".", "_")
+        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl_str}"
         _query = cache_data(
             show_spinner=show_spinner,
             ttl=ttl,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -217,6 +217,9 @@ class SQLConnection(BaseConnection["Engine"]):
                 **kwargs,
             )
 
+        # We modify our helper function's `__qualname__` here to work around default
+        # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
+        # `ttl` values will reset the cache with each call.
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
             show_spinner=show_spinner,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import hashlib
 from collections import ChainMap
 from copy import deepcopy
 from datetime import timedelta
@@ -218,16 +217,11 @@ class SQLConnection(BaseConnection["Engine"]):
                 **kwargs,
             )
 
-        dsn_hash = hashlib.md5(
-            self._instance.url.render_as_string(hide_password=True).encode()
-        ).hexdigest()
-        _query.__qualname__ = f"{_query.__qualname__}_{ttl}_{dsn_hash}"
-
+        _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
-            _query,
             show_spinner=show_spinner,
             ttl=ttl,
-        )
+        )(_query)
 
         return _query(
             sql,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -219,7 +219,8 @@ class SQLConnection(BaseConnection["Engine"]):
 
         # We modify our helper function's `__qualname__` here to work around default
         # `@st.cache_data` behavior. Otherwise, `.query()` being called with different
-        # `ttl` values will reset the cache with each call.
+        # `ttl` values will reset the cache with each call, and the query caches won't
+        # be scoped by connection.
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl}"
         _query = cache_data(
             show_spinner=show_spinner,

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -76,11 +76,6 @@ def _create_connection(
       * Allow the user to specify ttl and max_entries when calling st.connection.
     """
 
-    @cache_resource(
-        max_entries=max_entries,
-        show_spinner="Running `st.connection(...)`.",
-        ttl=ttl,
-    )
     def __create_connection(
         name: str, connection_class: Type[ConnectionClass], **kwargs
     ) -> ConnectionClass:
@@ -91,6 +86,15 @@ def _create_connection(
             f"{connection_class} is not a subclass of BaseConnection!"
         )
 
+    __create_connection.__qualname__ = (
+        f"{__create_connection.__qualname__}_{ttl}_{max_entries}"
+    )
+    __create_connection = cache_resource(
+        __create_connection,
+        max_entries=max_entries,
+        show_spinner="Running `st.connection(...)`.",
+        ttl=ttl,
+    )
     return __create_connection(name, connection_class, **kwargs)
 
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -86,6 +86,9 @@ def _create_connection(
             f"{connection_class} is not a subclass of BaseConnection!"
         )
 
+    # We modify our helper function's `__qualname__` here to work around default
+    # `@st.cache_resource` behavior. Otherwise, `st.connection` being called with
+    # different `ttl` or `max_entries` values will reset the cache with each call.
     __create_connection.__qualname__ = (
         f"{__create_connection.__qualname__}_{ttl}_{max_entries}"
     )

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -89,8 +89,11 @@ def _create_connection(
     # We modify our helper function's `__qualname__` here to work around default
     # `@st.cache_resource` behavior. Otherwise, `st.connection` being called with
     # different `ttl` or `max_entries` values will reset the cache with each call.
+    ttl_str = str(ttl).replace(  # Avoid adding extra `.` characters to `__qualname__`
+        ".", "_"
+    )
     __create_connection.__qualname__ = (
-        f"{__create_connection.__qualname__}_{ttl}_{max_entries}"
+        f"{__create_connection.__qualname__}_{ttl_str}_{max_entries}"
     )
     __create_connection = cache_resource(
         max_entries=max_entries,

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -90,11 +90,11 @@ def _create_connection(
         f"{__create_connection.__qualname__}_{ttl}_{max_entries}"
     )
     __create_connection = cache_resource(
-        __create_connection,
         max_entries=max_entries,
         show_spinner="Running `st.connection(...)`.",
         ttl=ttl,
-    )
+    )(__create_connection)
+
     return __create_connection(name, connection_class, **kwargs)
 
 

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -142,6 +142,39 @@ class SQLConnectionTest(unittest.TestCase):
         patched_read_sql.assert_called_once()
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
+
+        conn = SQLConnection("my_sql_connection")
+
+        conn.query("SELECT 1;", ttl=10)
+        conn.query("SELECT 2;", ttl=20)
+        conn.query("SELECT 1;", ttl=10)
+        conn.query("SELECT 2;", ttl=20)
+
+        assert patched_read_sql.call_count == 2
+
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
+    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    def test_scopes_caches_by_connection_name(self, patched_read_sql):
+        # Caching functions rely on an active script run ctx
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+        patched_read_sql.return_value = "i am a dataframe"
+
+        conn1 = SQLConnection("my_sql_connection1")
+        conn2 = SQLConnection("my_sql_connection2")
+
+        conn1.query("SELECT 1;")
+        conn1.query("SELECT 1;")
+        conn2.query("SELECT 1;")
+        conn2.query("SELECT 1;")
+
+        assert patched_read_sql.call_count == 2
+
+    @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     def test_repr_html_(self):
         conn = SQLConnection("my_sql_connection")
         with conn.session as s:

--- a/lib/tests/streamlit/runtime/connection_factory_test.py
+++ b/lib/tests/streamlit/runtime/connection_factory_test.py
@@ -184,6 +184,28 @@ type="snowpark"
         conn = connection_factory("my_connection", MockConnection)
         assert connection_factory("my_connection", MockConnection) is conn
 
+    def test_does_not_clear_cache_when_ttl_changes(self):
+        with patch.object(
+            MockConnection, "__init__", return_value=None
+        ) as patched_init:
+            connection_factory("my_connection1", MockConnection, ttl=10)
+            connection_factory("my_connection2", MockConnection, ttl=20)
+            connection_factory("my_connection1", MockConnection, ttl=10)
+            connection_factory("my_connection2", MockConnection, ttl=20)
+
+        assert patched_init.call_count == 2
+
+    def test_does_not_clear_cache_when_max_entries_changes(self):
+        with patch.object(
+            MockConnection, "__init__", return_value=None
+        ) as patched_init:
+            connection_factory("my_connection1", MockConnection, max_entries=10)
+            connection_factory("my_connection2", MockConnection, max_entries=20)
+            connection_factory("my_connection1", MockConnection, max_entries=10)
+            connection_factory("my_connection2", MockConnection, max_entries=20)
+
+        assert patched_init.call_count == 2
+
     @parameterized.expand(
         [
             ("MySQLdb", "mysqlclient"),


### PR DESCRIPTION
This PR fixes some rough edges around how we use `st.cache_data` and `st.cache_resource` within `st.connection`:
* Scope query results to the connection on which the query was run
* Fix a bug where creating multiple connections / running multiple queries with different `ttl` or `max_entries`
   parameters would clear the data/resource cache.

Closes #7709