### PR TITLE
Rename Tornado default `_xsrf` cookie name

### DIFF
--- a/e2e/specs/st_camera_input.spec.js
+++ b/e2e/specs/st_camera_input.spec.js
@@ -20,7 +20,7 @@ describe("st.camera_input", () => {
     Cypress.config("defaultCommandTimeout", 30000);
 
     Cypress.Cookies.defaults({
-      preserve: ["_xsrf"],
+      preserve: ["_streamlit_xsrf"],
     });
     cy.loadApp("http://localhost:3000/");
   });

--- a/e2e/specs/st_file_uploader.spec.js
+++ b/e2e/specs/st_file_uploader.spec.js
@@ -17,7 +17,7 @@
 describe("st.file_uploader", () => {
   beforeEach(() => {
     Cypress.Cookies.defaults({
-      preserve: ["_xsrf"],
+      preserve: ["_streamlit_xsrf"],
     });
     cy.server();
     cy.route("PUT", "**/upload_file/**").as("uploadFile");

--- a/e2e/specs/websocket_reconnects.spec.js
+++ b/e2e/specs/websocket_reconnects.spec.js
@@ -20,7 +20,7 @@ const NUM_DISCONNECTS = 20;
 describe("websocket reconnects", () => {
   beforeEach(() => {
     Cypress.Cookies.defaults({
-      preserve: ["_xsrf"],
+      preserve: ["_streamlit_xsrf"],
     });
     cy.server();
     cy.route("PUT", "**/upload_file/**").as("uploadFile");

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -550,7 +550,7 @@ export class App extends PureComponent<Props, State> {
       this.widgetMgr.sendUpdateWidgetsMessage()
       this.setState({ dialog: null })
     } else {
-      setCookie("_xsrf", "")
+      setCookie("_streamlit_xsrf", "")
 
       if (this.sessionInfo.isSet) {
         this.sessionInfo.clearCurrent()

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.test.ts
@@ -306,7 +306,7 @@ describe("DefaultStreamlitEndpoints", () => {
 
     beforeEach(() => {
       prevDocumentCookie = document.cookie
-      document.cookie = "_xsrf=mockXsrfCookie;"
+      document.cookie = "_streamlit_xsrf=mockXsrfCookie;"
     })
 
     afterEach(() => {

--- a/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
+++ b/frontend/app/src/connection/DefaultStreamlitEndpoints.ts
@@ -179,7 +179,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     params.url = url
 
     if (this.csrfEnabled) {
-      const xsrfCookie = getCookie("_xsrf")
+      const xsrfCookie = getCookie("_streamlit_xsrf")
       if (xsrfCookie != null) {
         params.headers = {
           "X-Xsrftoken": xsrfCookie,

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -148,13 +148,18 @@ class HealthHandler(_SpecialRequestHandler):
             self.write(msg)
             self.set_status(200)
 
-            # Tornado will set the _xsrf cookie automatically for the page on
+            # Tornado will set the _streamlit_xsrf cookie automatically for the page on
             # request for the document. However, if the server is reset and
             # server.enableXsrfProtection is updated, the browser does not reload the document.
             # Manually setting the cookie on /healthz since it is pinged when the
             # browser is disconnected from the server.
             if config.get_option("server.enableXsrfProtection"):
-                self.set_cookie("_xsrf", self.xsrf_token)
+                cookie_kwargs = self.settings.get("xsrf_cookie_kwargs", {})
+                self.set_cookie(
+                    self.settings.get("xsrf_cookie_name", "_streamlit_xsrf"),
+                    self.xsrf_token,
+                    **cookie_kwargs,
+                )
 
         else:
             # 503 = SERVICE_UNAVAILABLE

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -70,6 +70,7 @@ TORNADO_SETTINGS = {
     # If we don't get a ping response within 30s, the connection
     # is timed out.
     "websocket_ping_timeout": 30,
+    "xsrf_cookie_name": "_streamlit_xsrf",
 }
 
 # When server.port is not available it will look for the next available port


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Rename Tornado default `_xsrf` cookie name to `_streamlit_xsrf` to avoid collisions with other apps (e.g. Jupyter Notebook)

## GitHub Issue Link (if applicable)
Closes #2517 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
