### PR TITLE
fix: component dev url typo

### DIFF
--- a/frontend/lib/src/urls.ts
+++ b/frontend/lib/src/urls.ts
@@ -22,7 +22,7 @@ export const COMMUNITY_URL = "https://discuss.streamlit.io"
 
 /** The URL customers are directed to for troubleshooting components. */
 export const COMPONENT_DEVELOPER_URL =
-  "https://docs.streamlit.iorary/components"
+  "https://docs.streamlit.io/library/components"
 
 /** The URL customers are directed to for troubleshooting camera permissions. */
 export const CAMERA_PERMISSION_URL =


### PR DESCRIPTION
**Describe your changes:**

This PR addresses a minor typo in the component development URL in the documentation. The incorrect URL "https://docs.streamlit.iorary/components" has been corrected to "https://docs.streamlit.io/library/components", ensuring that users are directed to the appropriate page.

**GitHub Issue Link (if applicable):**

N/A

**Testing Plan:**

- **Explanation of why no additional tests are needed:** This change is a simple URL fix in the documentation and does not impact the codebase's functionality, hence no additional tests are required.
- **Unit Tests (JS and/or Python):** Not applicable.
- **E2E Tests:** Not applicable.
- **Any manual testing needed?** Manual verification that the corrected URL leads to the intended webpage.
