### PR TITLE
Pin playwright version to < 1.40

### DIFF
--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -25,6 +25,7 @@ pytest-cov
 requests>=2.27, <3
 requests-mock
 testfixtures
+playwright<1.40
 pytest-playwright>=0.1.2
 pixelmatch>=0.3.0
 pytest-xdist

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -25,6 +25,8 @@ pytest-cov
 requests>=2.27, <3
 requests-mock
 testfixtures
+# Playwright 1.40 installs a broken webkit version.
+# Eventually unpin once a fixed version is rolled out.
 playwright<1.40
 pytest-playwright>=0.1.2
 pixelmatch>=0.3.0


### PR DESCRIPTION
## Describe your changes

The latest version of playwright installs a broken webkit version. The issue is that `Array.from(<number>)` doesn't work correctly which got fixed [here](https://github.com/WebKit/WebKit/commit/c68cf48dd75cff6ed634b66127a0bbf13ef913bb). This PR (temporarily) pins down the used playwright version until the issue gets resolved from webkit / playwright side.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
