### PR TITLE
Don't use hash on floats in hashing.py

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -228,7 +228,7 @@ def _int_to_bytes(i: int) -> bytes:
 def _float_to_bytes(f: float) -> bytes:
     # Floats are 64bit in Python, so we need to use the "d" format.
     return struct.pack("<d", f)
-    
+
 
 def _key(obj: Optional[Any]) -> Any:
     """Return key for memoization."""

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -22,6 +22,7 @@ import inspect
 import io
 import os
 import pickle
+import struct
 import sys
 import tempfile
 import threading
@@ -224,6 +225,11 @@ def _int_to_bytes(i: int) -> bytes:
     return i.to_bytes(num_bytes, "little", signed=True)
 
 
+def _float_to_bytes(f: float) -> bytes:
+    # Floats are 64bit in Python, so we need to use the "d" format.
+    return struct.pack("<d", f)
+    
+
 def _key(obj: Optional[Any]) -> Any:
     """Return key for memoization."""
 
@@ -361,7 +367,7 @@ class _CacheFuncHasher:
             return obj.encode()
 
         elif isinstance(obj, float):
-            return self.to_bytes(hash(obj))
+            return _float_to_bytes(obj)
 
         elif isinstance(obj, int):
             return _int_to_bytes(obj)


### PR DESCRIPTION
## Describe your changes

The current code uses `hash(obj)` when obj is of type float. Python's hash is salted with a random number. This will not work across restarts. Instead, use struct.pack to get the bytes of a float.

## Testing Plan

Manually tested the change. If there are existing tests that serialize primitive types, this change is already covered.

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
