### PR TITLE
Replace deprecated `find_executable` from `distutils.spawn`

### DIFF
--- a/lib/streamlit/env_util.py
+++ b/lib/streamlit/env_util.py
@@ -54,6 +54,6 @@ def is_repl():
 
 def is_executable_in_path(name):
     """Check if executable is in OS path."""
-    from distutils.spawn import find_executable
+    from shutil import which
 
-    return find_executable(name) is not None
+    return which(name) is not None


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Replace deprecated `find_executable` from `distutils.spawn` with recommended `which` from `shutil`
PEP: https://peps.python.org/pep-0632/
## GitHub Issue Link (if applicable)

## Testing Plan

Should be smoke tested manually before release on Linux, MacOS, and Windows with Python 3.12. 
Check that `streamlit hello` works correctly, and opens the browser would be the minimal test. 

A minimalistic test should check that `streamlit hello` works correctly, and open a browser. 

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?
    - Yes
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
