### PR TITLE
Update docstrings for release 1.29

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -151,7 +151,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
 
         Returns
         -------
-        pd.DataFrame
+        pandas.DataFrame
             The result of running the query, formatted as a pandas DataFrame.
 
         Example

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -116,7 +116,7 @@ class SnowparkConnection(BaseConnection["Session"]):
 
         Returns
         -------
-        pd.DataFrame
+        pandas.DataFrame
             The result of running the query, formatted as a pandas DataFrame.
 
         Example

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -168,8 +168,10 @@ class SQLConnection(BaseConnection["Engine"]):
             paramstyle <https://peps.python.org/pep-0249/#paramstyle>`_, is supported.
             Default is None.
         **kwargs: dict
-            Additional keyword arguments are passed to `pandas.read_sql
-            <https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html>`_.
+            Additional keyword arguments are passed to |pandas.read_sql|_.
+
+            .. |pandas.read_sql| replace:: ``pandas.read_sql``
+            .. _pandas.read_sql: https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html
 
         Returns
         -------

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -133,14 +133,17 @@ class SQLConnection(BaseConnection["Engine"]):
         """Run a read-only query.
 
         This method implements both query result caching (with caching behavior
-        identical to that of using @st.cache_data) as well as simple error handling/retries.
+        identical to that of using ``@st.cache_data``) as well as simple error handling/retries.
 
         .. note::
             Queries that are run without a specified ttl are cached indefinitely.
 
         Aside from the ``ttl`` kwarg, all kwargs passed to this function are passed down
-        to `pd.read_sql <https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html>`_
+        to |pandas.read_sql|_
         and have the behavior described in the pandas documentation.
+
+        .. |pandas.read_sql| replace:: ``pandas.read_sql``
+        .. _pandas.read_sql: https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html
 
         Parameters
         ----------
@@ -165,12 +168,12 @@ class SQLConnection(BaseConnection["Engine"]):
             paramstyle <https://peps.python.org/pep-0249/#paramstyle>`_, is supported.
             Default is None.
         **kwargs: dict
-            Additional keyword arguments are passed to `pd.read_sql
+            Additional keyword arguments are passed to `pandas.read_sql
             <https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html>`_.
 
         Returns
         -------
-        pd.DataFrame
+        pandas.DataFrame
             The result of running the query, formatted as a pandas DataFrame.
 
         Example
@@ -239,12 +242,12 @@ class SQLConnection(BaseConnection["Engine"]):
         )
 
     def connect(self) -> "SQLAlchemyConnection":
-        """Call ``.connect()`` on the underlying SQLAlchemy Engine, returning a new
-        sqlalchemy.engine.Connection object.
+        """Call ``.connect()`` on the underlying SQLAlchemy Engine, returning a new\
+        ``sqlalchemy.engine.Connection`` object.
 
         Calling this method is equivalent to calling ``self._instance.connect()``.
 
-        NOTE: This method should not be confused with the internal _connect method used
+        NOTE: This method should not be confused with the internal ``_connect`` method used
         to implement a Streamlit Connection.
         """
         return self._instance.connect()

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -68,7 +68,7 @@ class LayoutsMixin:
 
         >>> import streamlit as st
         >>>
-        >>> container = st.container()
+        >>> container = st.container(border=True)
         >>> container.write("This is inside the container")
         >>> st.write("This is outside the container")
         >>>

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -607,9 +607,9 @@ class DataEditorMixin:
                 - Additionally, the following data types are not yet supported for editing:
                   complex, list, tuple, bytes, bytearray, memoryview, dict, set, frozenset,
                   fractions.Fraction, pandas.Interval, and pandas.Period.
-                - To prevent overflow in JavaScript, datetime.timedelta and pandas.Timedelta
-                  columns will default to uneditable but this can be changed through column
-                  configuration.
+                - To prevent overflow in JavaScript, columns containing datetime.timedelta
+                  and pandas.Timedelta values will default to uneditable but this can be
+                  changed through column configuration.
 
         width : int or None
             Desired width of the data editor expressed in pixels. If None, the width will
@@ -682,7 +682,7 @@ class DataEditorMixin:
         pandas.DataFrame, pandas.Series, pyarrow.Table, numpy.ndarray, list, set, tuple, or dict.
             The edited data. The edited data is returned in its original data type if
             it corresponds to any of the supported return types. All other data types
-            are returned as a ``pd.DataFrame``.
+            are returned as a ``pandas.DataFrame``.
 
         Examples
         --------

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -606,8 +606,10 @@ class DataEditorMixin:
                 - Mixing data types within a column can make the column uneditable.
                 - Additionally, the following data types are not yet supported for editing:
                   complex, list, tuple, bytes, bytearray, memoryview, dict, set, frozenset,
-                  datetime.timedelta, decimal.Decimal, fractions.Fraction, pandas.Interval,
-                  pandas.Period, pandas.Timedelta.
+                  fractions.Fraction, pandas.Interval, and pandas.Period.
+                - To prevent overflow in JavaScript, datetime.timedelta and pandas.Timedelta
+                  columns will default to uneditable but this can be changed through column
+                  configuration.
 
         width : int or None
             Desired width of the data editor expressed in pixels. If None, the width will


### PR DESCRIPTION
## Describe your changes
- Updated `st.container` example to show border
- Updated `st.data_editor` limitations regarding timedelta
- Corrected formatting for various `st.connections` docstrings

## Testing Plan
None. Docstrings only.

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
