### PR TITLE
Fix handling of ordinal columns for builtin-charts

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -1079,15 +1079,15 @@ def infer_vegalite_type(
         "complex",
     ]:
         return "quantitative"
-    # TODO(lukasmasuch): Our built-in chart implementation doesn't correctly support
-    # handling ordered categorical data yet so we just fall back to nominal for now.
-    # To support it, we would need to check if the return value from infer_vegalite_type
-    # is a tuple, and split it up into type and sort. But ordered categorical data
-    # are probably very rare, so we can just handling it as nominal might be fine.
-    # Related issue: https://github.com/streamlit/streamlit/issues/7776
 
-    # elif typ == "categorical" and data.cat.ordered:
-    #     return ("ordinal", data.cat.categories.tolist())
+    elif typ == "categorical" and data.cat.ordered:
+        # STREAMLIT MOD: The original code returns a tuple here:
+        # return ("ordinal", data.cat.categories.tolist())
+        # But returning the tuple here isn't compatible with our
+        # built-in chart implementation. And it also doesn't seem to be necessary.
+        # Altair already extracts the correct sort order somewhere else.
+        # More info about the issue here: https://github.com/streamlit/streamlit/issues/7776
+        return "ordinal"
     elif typ in ["string", "bytes", "categorical", "boolean", "mixed", "unicode"]:
         return "nominal"
     elif typ in [

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -1084,6 +1084,8 @@ def infer_vegalite_type(
     # To support it, we would need to check if the return value from infer_vegalite_type
     # is a tuple, and split it up into type and sort. But ordered categorical data
     # are probably very rare, so we can just handling it as nominal might be fine.
+    # Related issue: https://github.com/streamlit/streamlit/issues/7776
+
     # elif typ == "categorical" and data.cat.ordered:
     #     return ("ordinal", data.cat.categories.tolist())
     elif typ in ["string", "bytes", "categorical", "boolean", "mixed", "unicode"]:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -1079,10 +1079,13 @@ def infer_vegalite_type(
         "complex",
     ]:
         return "quantitative"
-    elif typ == "categorical" and data.cat.ordered:
-        # TODO(lukasmasuch): Is this correct, I cannot find any reference that
-        # altair supports a tuple here. It seems to be supported via sort instead?
-        return ("ordinal", data.cat.categories.tolist())  # type: ignore[return-value]
+    # TODO(lukasmasuch): Our built-in chart implementation doesn't correctly support
+    # handling ordered categorical data yet so we just fall back to nominal for now.
+    # To support it, we would need to check if the return value from infer_vegalite_type
+    # is a tuple, and split it up into type and sort. But ordered categorical data
+    # are probably very rare, so we can just handling it as nominal might be fine.
+    # elif typ == "categorical" and data.cat.ordered:
+    #     return ("ordinal", data.cat.categories.tolist())
     elif typ in ["string", "bytes", "categorical", "boolean", "mixed", "unicode"]:
         return "nominal"
     elif typ in [

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -606,7 +606,6 @@ class ArrowChartsTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
         chart_spec = json.loads(proto.spec)
 
-        print(chart_spec)
         self.assertIn(chart_spec["mark"], [altair_type, {"type": altair_type}])
         self.assertEqual(chart_spec["encoding"]["x"]["type"], "ordinal")
         self.assertEqual(chart_spec["encoding"]["x"]["sort"], ["c", "b", "a"])

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -609,6 +609,7 @@ class ArrowChartsTest(DeltaGeneratorTestCase):
         print(chart_spec)
         self.assertIn(chart_spec["mark"], [altair_type, {"type": altair_type}])
         self.assertEqual(chart_spec["encoding"]["x"]["type"], "ordinal")
+        self.assertEqual(chart_spec["encoding"]["x"]["sort"], ["c", "b", "a"])
         self.assertEqual(chart_spec["encoding"]["y"]["type"], "quantitative")
 
     def test_line_chart_with_named_index(self):

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -21,6 +21,7 @@ from typing import Any, Callable
 import altair as alt
 import pandas as pd
 import pytest
+from packaging import version
 from parameterized import parameterized
 
 import streamlit as st
@@ -586,11 +587,11 @@ class ArrowChartsTest(DeltaGeneratorTestCase):
             orig_df=df, expected_df=EXPECTED_DATAFRAME, chart_proto=proto
         )
 
-    @unittest.skipIf(
-        is_pandas_version_less_than("2.0.0") is True,
-        "This test only runs if Pandas is >= 2.0.0",
-    )
     @parameterized.expand(ST_CHART_ARGS)
+    @unittest.skipIf(
+        version.parse(alt.__version__) < version.parse("5.0.0"),
+        "This test only runs if Pandas is >= 5.0.0",
+    )
     def test_chart_with_ordered_categorical_data(
         self, chart_command: Callable, altair_type: str
     ):

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import unittest
 from datetime import date
 from functools import reduce
 from typing import Any, Callable
@@ -26,7 +27,7 @@ import streamlit as st
 from streamlit.elements import arrow_altair as altair
 from streamlit.elements.arrow_altair import ChartType
 from streamlit.errors import StreamlitAPIException
-from streamlit.type_util import bytes_to_data_frame
+from streamlit.type_util import bytes_to_data_frame, is_pandas_version_less_than
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit import pyspark_mocks, snowpark_mocks
 
@@ -585,6 +586,10 @@ class ArrowChartsTest(DeltaGeneratorTestCase):
             orig_df=df, expected_df=EXPECTED_DATAFRAME, chart_proto=proto
         )
 
+    @unittest.skipIf(
+        is_pandas_version_less_than("2.0.0") is True,
+        "This test only runs if Pandas is >= 2.0.0",
+    )
     @parameterized.expand(ST_CHART_ARGS)
     def test_chart_with_ordered_categorical_data(
         self, chart_command: Callable, altair_type: str

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -590,7 +590,7 @@ class ArrowChartsTest(DeltaGeneratorTestCase):
     @parameterized.expand(ST_CHART_ARGS)
     @unittest.skipIf(
         version.parse(alt.__version__) < version.parse("5.0.0"),
-        "This test only runs if Pandas is >= 5.0.0",
+        "This test only runs if Altair is >= 5.0.0",
     )
     def test_chart_with_ordered_categorical_data(
         self, chart_command: Callable, altair_type: str


### PR DESCRIPTION
## Describe your changes

Our built-in charts are not able to handle ordered categorical columns at the moment as described in this issue: https://github.com/streamlit/streamlit/issues/7776
This PR fixes this issue. Closes https://github.com/streamlit/streamlit/issues/7776.
## Testing Plan

- Added unit test to handle the situation 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
