### PR TITLE
Preload the correct font for semi bold

### DIFF
--- a/frontend/app/public/index.html
+++ b/frontend/app/public/index.html
@@ -24,7 +24,7 @@
     />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png" />
     <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSansPro-Regular.0d69e5ff5e92ac64a0c9.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSerifPro-SemiBold.5c1d378dd5990ef334ca.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSansPro-SemiBold.abed79cd0df1827e18cf.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="%PUBLIC_URL%/static/media/SourceSansPro-Bold.118dea98980e20a81ced.woff2" as="font" type="font/woff2" crossorigin>
 
     <title>Streamlit</title>

--- a/frontend/app/src/FontPreload.test.tsx
+++ b/frontend/app/src/FontPreload.test.tsx
@@ -21,7 +21,7 @@ jest.dontMock("fs")
 
 // Current hashes for our preloaded font assets:
 const REGULAR_HASH = "0d69e5ff5e92ac64a0c9"
-const SEMI_BOLD_HASH = "5c1d378dd5990ef334ca"
+const SEMI_BOLD_HASH = "abed79cd0df1827e18cf"
 const BOLD_HASH = "118dea98980e20a81ced"
 
 // Render a copy of index.html file to test


### PR DESCRIPTION
## Describe your changes

It seems that we have added the wrong font family for `SemiBold` to our preloaded fonts. `SourceSansPro-SemiBold` is the one that we actually use for our headings.

## Testing Plan

- Update unit test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
