### PR TITLE
Send Rerun message also for newly created pages

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -447,7 +447,9 @@ class AppSession:
         msg = ForwardMsg()
         _populate_app_pages(msg.pages_changed, self._script_data.main_script_path)
         self._enqueue_forward_msg(msg)
-        self._local_sources_watcher.update_watched_pages()
+
+        if self._local_sources_watcher is not None:
+            self._local_sources_watcher.update_watched_pages()
 
     def _clear_queue(self) -> None:
         self._browser_queue.clear()

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -447,6 +447,7 @@ class AppSession:
         msg = ForwardMsg()
         _populate_app_pages(msg.pages_changed, self._script_data.main_script_path)
         self._enqueue_forward_msg(msg)
+        self._local_sources_watcher.update_watched_pages()
 
     def _clear_queue(self) -> None:
         self._browser_queue.clear()

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -50,18 +50,13 @@ class LocalSourcesWatcher:
         )
 
         self._watched_modules: Dict[str, WatchedModule] = {}
-        self.watched_pages = set()
+        self._watched_pages: Set[str] = set()
 
-        for page_info in get_pages(self._main_script_path).values():
-            self.watched_pages.add(page_info["script_path"])
-            self._register_watcher(
-                page_info["script_path"],
-                module_name=None,  # Only root scripts have their modules set to None
-            )
+        self.update_watched_pages()
 
     def update_watched_pages(self) -> None:
-        old_watched_pages = self.watched_pages
-        new_pages_paths = set()
+        old_watched_pages = self._watched_pages
+        new_pages_paths: Set[str] = set()
 
         for page_info in get_pages(self._main_script_path).values():
             new_pages_paths.add(page_info["script_path"])
@@ -75,7 +70,7 @@ class LocalSourcesWatcher:
             if old_page_path not in new_pages_paths:
                 self._deregister_watcher(old_page_path)
 
-        self.watched_pages = new_pages_paths
+        self._watched_pages = new_pages_paths
 
     def register_file_change_callback(self, cb: Callable[[str], None]) -> None:
         self._on_file_changed.append(cb)
@@ -108,6 +103,7 @@ class LocalSourcesWatcher:
         for wm in self._watched_modules.values():
             wm.watcher.close()
         self._watched_modules = {}
+        self._watched_pages = set()
         self._is_closed = True
 
     def _register_watcher(self, filepath, module_name):

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict, List, Optional, Set
 from streamlit import config, file_util
 from streamlit.folder_black_list import FolderBlackList
 from streamlit.logger import get_logger
-from streamlit.source_util import get_pages, register_pages_changed_callback
+from streamlit.source_util import get_pages
 from streamlit.watcher.path_watcher import (
     NoOpPathWatcher,
     get_default_path_watcher_class,

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -384,6 +384,41 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         args3, _ = fob.call_args_list[2]
         assert args3[0] == "streamlit_app3.py"
 
+    @patch(
+        "streamlit.watcher.local_sources_watcher.get_pages",
+        MagicMock(
+            side_effect=[
+                {
+                    "someHash1": {
+                        "page_name": "page1",
+                        "script_path": "page1.py",
+                    },
+                    "someHash2": {
+                        "page_name": "page2",
+                        "script_path": "page2.py",
+                    },
+                },
+                {
+                    "someHash1": {
+                        "page_name": "page1",
+                        "script_path": "page1.py",
+                    },
+                    "someHash3": {
+                        "page_name": "page3",
+                        "script_path": "page3.py",
+                    },
+                },
+            ]
+        ),
+    )
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher", MagicMock())
+    def test_not_watches_removed_page_scripts(self):
+        lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
+        assert lsw._watched_pages == {"page1.py", "page2.py"}
+
+        lsw.update_watched_pages()
+        assert lsw._watched_pages == {"page1.py", "page3.py"}
+
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_passes_filepath_to_callback(self, fob):
         saved_filepath = None

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -342,6 +342,48 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         assert args1[0] == "streamlit_app.py"
         assert args2[0] == "streamlit_app2.py"
 
+    @patch(
+        "streamlit.watcher.local_sources_watcher.get_pages",
+        MagicMock(
+            side_effect=[
+                {
+                    "someHash1": {
+                        "page_name": "streamlit_app",
+                        "script_path": "streamlit_app.py",
+                    },
+                    "someHash2": {
+                        "page_name": "streamlit_app2",
+                        "script_path": "streamlit_app2.py",
+                    },
+                },
+                {
+                    "someHash1": {
+                        "page_name": "streamlit_app",
+                        "script_path": "streamlit_app.py",
+                    },
+                    "someHash3": {
+                        "page_name": "streamlit_app3",
+                        "script_path": "streamlit_app3.py",
+                    },
+                },
+            ]
+        ),
+    )
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_watches_new_page_scripts(self, fob):
+        lsw = local_sources_watcher.LocalSourcesWatcher(SCRIPT_PATH)
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        args1, _ = fob.call_args_list[0]
+        args2, _ = fob.call_args_list[1]
+
+        assert args1[0] == "streamlit_app.py"
+        assert args2[0] == "streamlit_app2.py"
+
+        lsw.update_watched_pages()
+        args3, _ = fob.call_args_list[2]
+        assert args3[0] == "streamlit_app3.py"
+
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_passes_filepath_to_callback(self, fob):
         saved_filepath = None


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Before this change, we registered page watchers one time during the `LocalSourcesWatcher` initialization (practically on session creation). 

With this PR we refresh the list of watched pages when the pages folder file list changes, this allow us to send a `Rerun` message to the app frontend for pages created during the session too. 

## GitHub Issue Link (if applicable)
Closes: #6341

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) DONE!
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
