### PR TITLE
Support direct editing for link column

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
@@ -21,7 +21,7 @@ import { screen } from "@testing-library/react"
 import { render } from "@streamlit/lib/src/test_util"
 import "@testing-library/jest-dom"
 
-const LINK_CELL_TEST_ID = "link-cell"
+const LINK_CELL_TEST_ID = "stLinkCell"
 
 describe("LinkCell", () => {
   function getMockLinkCell(

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
@@ -52,7 +52,9 @@ describe("LinkCell", () => {
   })
 
   it("renders into the dom with correct value", async () => {
-    const cell = getMockLinkCell("https://streamlit.io")
+    const cell = getMockLinkCell("https://streamlit.io", "", {
+      readonly: true,
+    })
     const Editor = linkCellRenderer.provideEditor?.(cell)
 
     render(

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
@@ -70,38 +70,10 @@ describe("LinkCell", () => {
     expect(linkCell).toHaveTextContent("https://streamlit.io")
   })
 
-  it("should render the pencil edit icon", async () => {
-    const cell = getMockLinkCell("https://streamlit.io")
-    const Editor = linkCellRenderer.provideEditor?.(cell)
-
-    render(
-      // @ts-expect-error
-      <Editor isHighlighted={false} value={cell} />
-    )
-
-    const element = await screen.findByTestId("gdg-edit-icon")
-
-    expect(element).toBeDefined()
-  })
-
-  it("should not render the pencil icon when cell is readonly", async () => {
-    const cell = getMockLinkCell("https://streamlit.io", undefined, {
+  it("should render the displayText", async () => {
+    const cell = getMockLinkCell("https://streamlit.io", "Click here", {
       readonly: true,
     })
-    const Editor = linkCellRenderer.provideEditor?.(cell)
-
-    render(
-      // @ts-expect-error
-      <Editor isHighlighted={false} value={cell} />
-    )
-
-    const element = screen.queryByTestId("gdg-edit-icon")
-
-    expect(element).toBeNull()
-  })
-
-  it("should render the displayText", async () => {
-    const cell = getMockLinkCell("https://streamlit.io", "Click here")
     const Editor = linkCellRenderer.provideEditor?.(cell)
 
     render(

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.tsx
@@ -40,7 +40,9 @@ function onClickSelect(
 ): string | null | undefined {
   const canvas = document.createElement("canvas")
   const ctx = canvas.getContext("2d", { alpha: false })
-  if (ctx === null) return
+  if (ctx === null) {
+    return
+  }
 
   const { posX: hoverX, bounds: rect, cell, theme } = e
   const font = `${theme.baseFontStyle} ${theme.fontFamily}`
@@ -67,7 +69,9 @@ export const linkCellRenderer: CustomRenderer<LinkCell> = {
   draw: (args, cell) => {
     const { ctx, rect, theme, hoverX = -100 } = args
     const { href, displayText } = cell.data
-    if (isNullOrUndefined(href)) return
+    if (isNullOrUndefined(href)) {
+      return
+    }
 
     const displayValue = displayText || href
 
@@ -109,7 +113,9 @@ export const linkCellRenderer: CustomRenderer<LinkCell> = {
   kind: GridCellKind.Custom,
   measure: (ctx, cell, theme) => {
     const { href, displayText } = cell.data
-    if (isNullOrUndefined(href)) return 0
+    if (isNullOrUndefined(href)) {
+      return 0
+    }
 
     return (
       ctx.measureText(displayText || href).width +
@@ -134,11 +140,10 @@ export const linkCellRenderer: CustomRenderer<LinkCell> = {
     },
   }),
   provideEditor: () => p => {
-    const { onChange, value, forceEditMode, validatedSelection } = p
+    const { onChange, value, validatedSelection } = p
     const { href, displayText } = value.data
     return (
       <UriOverlayEditor
-        forceEditMode={forceEditMode}
         uri={value.data.href}
         preview={(displayText || href) ?? ""}
         validatedSelection={validatedSelection}

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.tsx
@@ -40,9 +40,7 @@ function onClickSelect(
 ): string | null | undefined {
   const canvas = document.createElement("canvas")
   const ctx = canvas.getContext("2d", { alpha: false })
-  if (ctx === null) {
-    return
-  }
+  if (ctx === null) return
 
   const { posX: hoverX, bounds: rect, cell, theme } = e
   const font = `${theme.baseFontStyle} ${theme.fontFamily}`
@@ -69,9 +67,7 @@ export const linkCellRenderer: CustomRenderer<LinkCell> = {
   draw: (args, cell) => {
     const { ctx, rect, theme, hoverX = -100 } = args
     const { href, displayText } = cell.data
-    if (isNullOrUndefined(href)) {
-      return
-    }
+    if (isNullOrUndefined(href)) return
 
     const displayValue = displayText || href
 
@@ -113,9 +109,7 @@ export const linkCellRenderer: CustomRenderer<LinkCell> = {
   kind: GridCellKind.Custom,
   measure: (ctx, cell, theme) => {
     const { href, displayText } = cell.data
-    if (isNullOrUndefined(href)) {
-      return 0
-    }
+    if (isNullOrUndefined(href)) return 0
 
     return (
       ctx.measureText(displayText || href).width +

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/UriOverlayEditor.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/UriOverlayEditor.tsx
@@ -16,14 +16,11 @@
 
 import { SelectionRange, TextCellEntry } from "@glideapps/glide-data-grid"
 import React from "react"
-import { Edit } from "@emotion-icons/material-rounded"
-import Icon from "@streamlit/lib/src/components/shared/Icon"
 import { UriOverlayEditorStyle } from "@streamlit/lib/src/components/widgets/DataFrame/columns/cells/uri-overlay-editor-style"
 
 interface Props {
   readonly uri?: string | null
   readonly onChange: (ev: React.ChangeEvent<HTMLTextAreaElement>) => void
-  readonly forceEditMode: boolean
   readonly readonly: boolean
   readonly preview: string
   readonly validatedSelection?: SelectionRange
@@ -32,24 +29,9 @@ interface Props {
 // this is essentially just copying the UriOverlayEditor from glide's implementation: https://github.com/glideapps/glide-data-grid/blob/0ea52f371a5e2aaa8595aceefa40722d35410b1a/packages/core/src/data-grid-overlay-editor/private/uri-overlay-editor-style.tsx
 // we use it in LinkCell.tsx which is our custom version of the UriCell.
 const UriOverlayEditor: React.FunctionComponent<Props> = p => {
-  const {
-    uri,
-    onChange,
-    forceEditMode,
-    readonly,
-    validatedSelection,
-    preview,
-  } = p
+  const { uri, onChange, readonly, validatedSelection, preview } = p
 
-  const [editMode, setEditMode] = React.useState<boolean>(
-    !readonly && (!uri || forceEditMode)
-  )
-
-  const onEditClick = React.useCallback(() => {
-    setEditMode(true)
-  }, [])
-
-  if (editMode) {
+  if (!readonly) {
     return (
       <TextCellEntry
         validatedSelection={validatedSelection}
@@ -64,7 +46,7 @@ const UriOverlayEditor: React.FunctionComponent<Props> = p => {
   return (
     <UriOverlayEditorStyle>
       <a
-        data-testid={"link-cell"}
+        data-testid="link-cell"
         className="gdg-link-area"
         href={uri ?? ""}
         target="_blank"
@@ -72,16 +54,6 @@ const UriOverlayEditor: React.FunctionComponent<Props> = p => {
       >
         {preview}
       </a>
-      {!readonly && (
-        <div
-          className="gdg-edit-icon"
-          data-testid="gdg-edit-icon"
-          onClick={onEditClick}
-        >
-          <Icon content={Edit} size="lg" />
-        </div>
-      )}
-      <textarea className="gdg-input" autoFocus={true} />
     </UriOverlayEditorStyle>
   )
 }

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/UriOverlayEditor.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/UriOverlayEditor.tsx
@@ -46,7 +46,7 @@ const UriOverlayEditor: React.FunctionComponent<Props> = p => {
   return (
     <UriOverlayEditorStyle>
       <a
-        data-testid="link-cell"
+        data-testid="stLinkCell"
         className="gdg-link-area"
         href={uri ?? ""}
         target="_blank"

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/uri-overlay-editor-style.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/uri-overlay-editor-style.tsx
@@ -42,26 +42,4 @@ export const UriOverlayEditorStyle = styled.div`
     text-decoration: underline !important;
     padding-bottom: 3px;
   }
-
-  .gdg-edit-icon {
-    flex-shrink: 0;
-    width: 32px;
-    color: var(--gdg-accent-color);
-
-    cursor: pointer;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  textarea {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    width: 0px;
-    height: 0px;
-
-    opacity: 0;
-  }
 `


### PR DESCRIPTION
## Describe your changes

Changes the link column overlay to directly jump into editing mode instead of requiring the click on the edit pencil. 
 
Before:

Note: the current overlay editor also has some issues if the mouse goes out of the boundaries of the table. 

https://github.com/streamlit/streamlit/assets/103002573/66261280-fdde-4bfa-9357-e385919959c9

After:

https://github.com/streamlit/streamlit/assets/103002573/0fb52720-10d6-44b4-a0fc-d12b195e1058

There might be a bit of a risk that the current click behavior doesn't work in some environments (e.g. because of strict CSP), which would require us to use the current editor. But let's see if someone complains about this. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
