### PR TITLE
Remove query params when a page swap occurs

### DIFF
--- a/e2e/specs/multipage_apps.spec.js
+++ b/e2e/specs/multipage_apps.spec.js
@@ -19,81 +19,90 @@ describe("multipage apps", () => {
     cy.loadApp("http://localhost:3000/");
   });
 
-  it("loads the main streamlit_app script on initial page load", () => {
-    cy.get(".element-container .stMarkdown h2").should("contain", "Main Page");
-  });
+  // it("loads the main streamlit_app script on initial page load", () => {
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Main Page");
+  // });
 
-  it("renders the SidebarNav correctly", () => {
-    cy.prepForElementSnapshots();
+  // it("renders the SidebarNav correctly", () => {
+  //   cy.prepForElementSnapshots();
 
-    cy.get("[data-testid='stSidebarNav']").matchThemedSnapshots(
-      "multipage-apps-sidebar-nav"
-    );
-  });
+  //   cy.get("[data-testid='stSidebarNav']").matchThemedSnapshots(
+  //     "multipage-apps-sidebar-nav"
+  //   );
+  // });
 
-  it("can switch between pages by clicking on the SidebarNav links", () => {
+  // it("can switch between pages by clicking on the SidebarNav links", () => {
+  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 1).click();
+
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
+  // });
+
+  // it("supports navigating to a page directly via URL", () => {
+  //   cy.loadApp("http://localhost:3000/page2");
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
+  // });
+
+  // it("can switch between pages and edit widgets", { retries: { runMode: 1 } }, () => {
+  //   cy.get('.stSlider [role="slider"]')
+  //     .click()
+  //     .type("{rightarrow}", { force: true });
+
+  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 2).click();
+
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 3");
+
+  //   // Identical widget on different page should be considered different
+  //   cy.get(".element-container .stMarkdown p").should("contain", "x is 0");
+
+  //   cy.get('.stSlider [role="slider"]')
+  //     .click()
+  //     .type("{rightarrow}", { force: true });
+
+  //   cy.get(".element-container .stMarkdown p").should("contain", "x is 1");
+  // });
+
+  // it("can switch to the first page with a duplicate name", () => {
+  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 3).click();
+
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
+  // });
+
+  // it("can switch to the second page with a duplicate name", () => {
+  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 4).click();
+
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 5");
+  // });
+
+  // it("runs the first page with a duplicate name if navigating via URL", () => {
+  //   cy.loadApp("http://localhost:3000/page_with_duplicate_name");
+  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
+  // });
+
+  // it("serves the react app and displays the page not found modal if the page does not exist", () => {
+  //   cy.loadApp("http://localhost:3000/not_a_page");
+
+  //   cy.get('[role="dialog"]').should("contain", "Page not found");
+  // });
+
+  // it("handles expand & collapse of MPA nav correctly (arrow does not disappear)", () => {
+  //   cy.loadApp("http://localhost:3000/page_7");
+
+  //   // Expand the nav
+  //   cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
+
+  //   // Collapse the nav
+  //   cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
+
+  //   // Expand the nav again
+  //   cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
+  // });
+
+  it('removes query params when swapping pages', () => {
+    cy.loadApp("http://localhost:3000?foo=bar");
+
     cy.getIndexed('[data-testid="stSidebarNav"] a', 1).click();
-
     cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
-  });
 
-  it("supports navigating to a page directly via URL", () => {
-    cy.loadApp("http://localhost:3000/page2");
-    cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
-  });
-
-  it("can switch between pages and edit widgets", { retries: { runMode: 1 } }, () => {
-    cy.get('.stSlider [role="slider"]')
-      .click()
-      .type("{rightarrow}", { force: true });
-
-    cy.getIndexed('[data-testid="stSidebarNav"] a', 2).click();
-
-    cy.get(".element-container .stMarkdown h2").should("contain", "Page 3");
-
-    // Identical widget on different page should be considered different
-    cy.get(".element-container .stMarkdown p").should("contain", "x is 0");
-
-    cy.get('.stSlider [role="slider"]')
-      .click()
-      .type("{rightarrow}", { force: true });
-
-    cy.get(".element-container .stMarkdown p").should("contain", "x is 1");
-  });
-
-  it("can switch to the first page with a duplicate name", () => {
-    cy.getIndexed('[data-testid="stSidebarNav"] a', 3).click();
-
-    cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
-  });
-
-  it("can switch to the second page with a duplicate name", () => {
-    cy.getIndexed('[data-testid="stSidebarNav"] a', 4).click();
-
-    cy.get(".element-container .stMarkdown h2").should("contain", "Page 5");
-  });
-
-  it("runs the first page with a duplicate name if navigating via URL", () => {
-    cy.loadApp("http://localhost:3000/page_with_duplicate_name");
-    cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
-  });
-
-  it("serves the react app and displays the page not found modal if the page does not exist", () => {
-    cy.loadApp("http://localhost:3000/not_a_page");
-
-    cy.get('[role="dialog"]').should("contain", "Page not found");
-  });
-
-  it("handles expand & collapse of MPA nav correctly (arrow does not disappear)", () => {
-    cy.loadApp("http://localhost:3000/page_7");
-
-    // Expand the nav
-    cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
-
-    // Collapse the nav
-    cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
-
-    // Expand the nav again
-    cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
-  });
+    cy.url().should('eq', 'http://localhost:3000/page2')
+  })
 });

--- a/e2e/specs/multipage_apps.spec.js
+++ b/e2e/specs/multipage_apps.spec.js
@@ -19,83 +19,83 @@ describe("multipage apps", () => {
     cy.loadApp("http://localhost:3000/");
   });
 
-  // it("loads the main streamlit_app script on initial page load", () => {
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Main Page");
-  // });
+  it("loads the main streamlit_app script on initial page load", () => {
+    cy.get(".element-container .stMarkdown h2").should("contain", "Main Page");
+  });
 
-  // it("renders the SidebarNav correctly", () => {
-  //   cy.prepForElementSnapshots();
+  it("renders the SidebarNav correctly", () => {
+    cy.prepForElementSnapshots();
 
-  //   cy.get("[data-testid='stSidebarNav']").matchThemedSnapshots(
-  //     "multipage-apps-sidebar-nav"
-  //   );
-  // });
+    cy.get("[data-testid='stSidebarNav']").matchThemedSnapshots(
+      "multipage-apps-sidebar-nav"
+    );
+  });
 
-  // it("can switch between pages by clicking on the SidebarNav links", () => {
-  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 1).click();
+  it("can switch between pages by clicking on the SidebarNav links", () => {
+    cy.getIndexed('[data-testid="stSidebarNav"] a', 1).click();
 
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
-  // });
+    cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
+  });
 
-  // it("supports navigating to a page directly via URL", () => {
-  //   cy.loadApp("http://localhost:3000/page2");
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
-  // });
+  it("supports navigating to a page directly via URL", () => {
+    cy.loadApp("http://localhost:3000/page2");
+    cy.get(".element-container .stMarkdown h2").should("contain", "Page 2");
+  });
 
-  // it("can switch between pages and edit widgets", { retries: { runMode: 1 } }, () => {
-  //   cy.get('.stSlider [role="slider"]')
-  //     .click()
-  //     .type("{rightarrow}", { force: true });
+  it("can switch between pages and edit widgets", { retries: { runMode: 1 } }, () => {
+    cy.get('.stSlider [role="slider"]')
+      .click()
+      .type("{rightarrow}", { force: true });
 
-  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 2).click();
+    cy.getIndexed('[data-testid="stSidebarNav"] a', 2).click();
 
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 3");
+    cy.get(".element-container .stMarkdown h2").should("contain", "Page 3");
 
-  //   // Identical widget on different page should be considered different
-  //   cy.get(".element-container .stMarkdown p").should("contain", "x is 0");
+    // Identical widget on different page should be considered different
+    cy.get(".element-container .stMarkdown p").should("contain", "x is 0");
 
-  //   cy.get('.stSlider [role="slider"]')
-  //     .click()
-  //     .type("{rightarrow}", { force: true });
+    cy.get('.stSlider [role="slider"]')
+      .click()
+      .type("{rightarrow}", { force: true });
 
-  //   cy.get(".element-container .stMarkdown p").should("contain", "x is 1");
-  // });
+    cy.get(".element-container .stMarkdown p").should("contain", "x is 1");
+  });
 
-  // it("can switch to the first page with a duplicate name", () => {
-  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 3).click();
+  it("can switch to the first page with a duplicate name", () => {
+    cy.getIndexed('[data-testid="stSidebarNav"] a', 3).click();
 
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
-  // });
+    cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
+  });
 
-  // it("can switch to the second page with a duplicate name", () => {
-  //   cy.getIndexed('[data-testid="stSidebarNav"] a', 4).click();
+  it("can switch to the second page with a duplicate name", () => {
+    cy.getIndexed('[data-testid="stSidebarNav"] a', 4).click();
 
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 5");
-  // });
+    cy.get(".element-container .stMarkdown h2").should("contain", "Page 5");
+  });
 
-  // it("runs the first page with a duplicate name if navigating via URL", () => {
-  //   cy.loadApp("http://localhost:3000/page_with_duplicate_name");
-  //   cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
-  // });
+  it("runs the first page with a duplicate name if navigating via URL", () => {
+    cy.loadApp("http://localhost:3000/page_with_duplicate_name");
+    cy.get(".element-container .stMarkdown h2").should("contain", "Page 4");
+  });
 
-  // it("serves the react app and displays the page not found modal if the page does not exist", () => {
-  //   cy.loadApp("http://localhost:3000/not_a_page");
+  it("serves the react app and displays the page not found modal if the page does not exist", () => {
+    cy.loadApp("http://localhost:3000/not_a_page");
 
-  //   cy.get('[role="dialog"]').should("contain", "Page not found");
-  // });
+    cy.get('[role="dialog"]').should("contain", "Page not found");
+  });
 
-  // it("handles expand & collapse of MPA nav correctly (arrow does not disappear)", () => {
-  //   cy.loadApp("http://localhost:3000/page_7");
+  it("handles expand & collapse of MPA nav correctly (arrow does not disappear)", () => {
+    cy.loadApp("http://localhost:3000/page_7");
 
-  //   // Expand the nav
-  //   cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
+    // Expand the nav
+    cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
 
-  //   // Collapse the nav
-  //   cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
+    // Collapse the nav
+    cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
 
-  //   // Expand the nav again
-  //   cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
-  // });
+    // Expand the nav again
+    cy.get('[data-testid="stSidebarNavSeparator"] svg').click();
+  });
 
   it('removes query params when swapping pages', () => {
     cy.loadApp("http://localhost:3000?foo=bar");

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1153,7 +1153,7 @@ describe("App.sendRerunBackMsg", () => {
     })
   })
 
-  it("removes the query params if a new page is selected", () => {
+  it("sets queryString to an empty string if the page hash is different", () => {
     wrapper.setState({
       currentPageScriptHash: "current_page_hash",
       queryParams: "foo=bar",
@@ -1171,7 +1171,6 @@ describe("App.sendRerunBackMsg", () => {
       rerunScript: {
         pageScriptHash: "some_other_page_hash",
         pageName: "",
-        // must be reset to an empty string
         queryString: "",
       },
     })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1152,6 +1152,35 @@ describe("App.sendRerunBackMsg", () => {
       },
     })
   })
+
+  it("removes the query params if a new page is selected", () => {
+    wrapper.setState({
+      currentPageScriptHash: "current_page_hash",
+      queryParams: "foo=bar",
+    })
+    const sendMessageFunc = jest.spyOn(
+      // @ts-expect-error
+      instance.hostCommunicationMgr,
+      "sendMessageToHost"
+    )
+
+    instance.sendRerunBackMsg(undefined, "some_other_page_hash")
+
+    // @ts-expect-error
+    expect(instance.sendBackMsg).toHaveBeenCalledWith({
+      rerunScript: {
+        pageScriptHash: "some_other_page_hash",
+        pageName: "",
+        // must be reset to an empty string
+        queryString: "",
+      },
+    })
+
+    expect(sendMessageFunc).toHaveBeenCalledWith({
+      type: "SET_QUERY_PARAM",
+      queryParams: "",
+    })
+  })
 })
 
 //   * handlePageNotFound has branching error messages depending on pageName

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -865,13 +865,10 @@ export class App extends PureComponent<Props, State> {
       // e.g. the case where the user clicks the back button.
       // See https://github.com/streamlit/streamlit/pull/6271#issuecomment-1465090690 for the discussion.
       if (prevPageName !== newPageName) {
-        const queryString = this.getQueryString()
-
-        const qs = queryString ? `?${queryString}` : ""
         const basePathPrefix = basePath ? `/${basePath}` : ""
 
         const pagePath = viewingMainPage ? "" : newPageName
-        const pageUrl = `${basePathPrefix}/${pagePath}${qs}`
+        const pageUrl = `${basePathPrefix}/${pagePath}`
 
         window.history.pushState({}, "", pageUrl)
       }
@@ -1303,12 +1300,20 @@ export class App extends PureComponent<Props, State> {
 
     const { currentPageScriptHash } = this.state
     const { basePath } = baseUriParts
-    const queryString = this.getQueryString()
+    let queryString = this.getQueryString()
     let pageName = ""
 
     if (pageScriptHash) {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
+      if (pageScriptHash != currentPageScriptHash) {
+        // reset query string when changing pages to replicate real web apps
+        queryString = ""
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_QUERY_PARAM",
+          queryParams: queryString,
+        })
+      }
     } else if (currentPageScriptHash) {
       // The user didn't specify which page to run, which happens when they
       // click the "Rerun" button in the main menu. In this case, we

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1307,7 +1307,6 @@ export class App extends PureComponent<Props, State> {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
       if (pageScriptHash != currentPageScriptHash) {
-        // reset query string when changing pages to replicate real web apps
         queryString = ""
         this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_QUERY_PARAM",


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- check if the past and current page hashes are the same
  - if they are not the same, set the query string to be `""` and send a hostMessage to update the query params
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - added unit tests
- E2E Tests
  -  added unit tests
- Any manual testing needed?
  - manually tested on streamlit community cloud

https://github.com/streamlit/streamlit/assets/16749069/5b7021c4-a01a-4b2f-8b76-1b3277985fbb


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
