### PR TITLE
Config - MPA Sidebar Page Navigation

### DIFF
--- a/e2e/scripts/multipage_apps/pages/02_page2.py
+++ b/e2e/scripts/multipage_apps/pages/02_page2.py
@@ -14,4 +14,6 @@
 
 import streamlit as st
 
+st.set_page_config(show_page_navigation=True)
+
 st.header("Page 2")

--- a/e2e/specs/multipage_apps_config.spec.js
+++ b/e2e/specs/multipage_apps_config.spec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("multipage apps - showSidebarNav", () => {
+  it("does not render the SidebarNav when client.showPageNavigation=false", () => {
+    cy.loadApp("http://localhost:3000/");
+    cy.get(".appview-container section").should("have.length", 1);
+  });
+
+  it("renders the SidebarNav when set_page_config sets to true", () => {
+    cy.loadApp("http://localhost:3000/page2");
+    cy.get(".appview-container section").should("have.length", 2);
+  });
+});

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -634,6 +634,23 @@ describe("App.handleNewSession", () => {
     expect(instance.clearAppState).not.toHaveBeenCalled()
   })
 
+  it("sets hideSidebarNav based on config.toml or set_page_config", () => {
+    const wrapper = shallow(<App {...getProps()} />)
+    const app = wrapper.instance() as App
+
+    // default in this.state is true
+    expect(app.state.hideSidebarNav).toBe(true)
+
+    // update the value based on new session message
+    // @ts-expect-error
+    wrapper.instance().handleNewSession(new NewSession(NEW_SESSION))
+    expect(app.state.hideSidebarNav).toBe(false)
+
+    // update the value based on set page config message
+    app.handlePageConfigChanged(new PageConfig({ showPageNavigation: false }))
+    expect(app.state.hideSidebarNav).toBe(true)
+  })
+
   describe("page change URL handling", () => {
     let wrapper: ShallowWrapper
     let instance: App

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -634,8 +634,14 @@ export class App extends PureComponent<Props, State> {
   }
 
   handlePageConfigChanged = (pageConfig: PageConfig): void => {
-    const { title, favicon, layout, initialSidebarState, menuItems } =
-      pageConfig
+    const {
+      title,
+      favicon,
+      layout,
+      initialSidebarState,
+      menuItems,
+      showPageNavigation,
+    } = pageConfig
 
     if (title) {
       this.hostCommunicationMgr.sendMessageToHost({
@@ -672,6 +678,12 @@ export class App extends PureComponent<Props, State> {
     }
 
     this.setState({ menuItems })
+
+    if (showPageNavigation === this.state.hideSidebarNav) {
+      this.setState(() => ({
+        hideSidebarNav: !showPageNavigation,
+      }))
+    }
   }
 
   handlePageInfoChanged = (pageInfo: PageInfo): void => {

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 
 from typing_extensions import Final, Literal, TypeAlias
 
+from streamlit import config
 from streamlit.elements import image
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg as ForwardProto
@@ -118,6 +119,8 @@ def set_page_config(
     layout: Layout = "centered",
     initial_sidebar_state: InitialSideBarState = "auto",
     menu_items: Optional[MenuItems] = None,
+    *,  # keyword-only args:
+    show_page_navigation: Optional[bool] = None,
 ) -> None:
     """
     Configures the default settings of the page.
@@ -162,6 +165,9 @@ def set_page_config(
             If None, only shows Streamlit's default About text.
 
         The URL may also refer to an email address e.g. ``mailto:john@example.com``.
+    show_page_navigation: bool
+        Controls display of the default sidebar page navigation in a multi-page app.
+        Defaults to True.
 
     Example
     -------
@@ -220,6 +226,14 @@ def set_page_config(
         validate_menu_items(lowercase_menu_items)
         menu_items_proto = msg.page_config_changed.menu_items
         set_menu_items_proto(lowercase_menu_items, menu_items_proto)
+
+    # Setting show_page_navigation in set_page_config takes precedence over config.toml setting
+    if show_page_navigation is not None:
+        msg.page_config_changed.show_page_navigation = show_page_navigation
+    else:
+        msg.page_config_changed.show_page_navigation = config.get_option(
+            "client.showPageNavigation"
+        )
 
     ctx = get_script_run_ctx()
     if ctx is None:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -509,6 +509,13 @@ _create_option(
     scriptable=True,
 )
 
+_create_option(
+    "client.showPageNavigation",
+    description="""Controls whether the default sidebar page navigation in a multi-page app is displayed.""",
+    default_val=True,
+    type_=bool,
+)
+
 # Config Section: Runner #
 
 _create_section("runner", "Settings for how Streamlit executes your script")

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -815,6 +815,8 @@ def _populate_config_msg(msg: Config) -> None:
     msg.allow_run_on_save = config.get_option("server.allowRunOnSave")
     msg.hide_top_bar = config.get_option("ui.hideTopBar")
     msg.hide_sidebar_nav = config.get_option("ui.hideSidebarNav")
+    if config.get_option("client.showPageNavigation") == False:
+        msg.hide_sidebar_nav = True
     msg.toolbar_mode = _get_toolbar_mode()
 
 

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -171,3 +171,18 @@ class PageConfigTest(DeltaGeneratorTestCase):
             self.assertTrue(valid_url(url))
         else:
             self.assertFalse(valid_url(url))
+
+    def test_set_page_config_sidebar_nav_default(self):
+        st.set_page_config()
+        c = self.get_message_from_queue().page_config_changed
+        self.assertEqual(c.show_page_navigation, True)
+
+    def test_set_page_config_sidebar_nav_true(self):
+        st.set_page_config(show_page_navigation=True)
+        c = self.get_message_from_queue().page_config_changed
+        self.assertEqual(c.show_page_navigation, True)
+
+    def test_set_page_config_sidebar_nav_false(self):
+        st.set_page_config(show_page_navigation=False)
+        c = self.get_message_from_queue().page_config_changed
+        self.assertEqual(c.show_page_navigation, False)

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -341,6 +341,7 @@ class ConfigTest(unittest.TestCase):
                 "client.displayEnabled",
                 "client.showErrorDetails",
                 "client.toolbarMode",
+                "client.showPageNavigation",
                 "theme.base",
                 "theme.primaryColor",
                 "theme.backgroundColor",

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -23,6 +23,7 @@ message PageConfig {
   Layout layout = 3;
   SidebarState initial_sidebar_state = 4;
   MenuItems menu_items = 5;
+  bool show_page_navigation = 6;
 
   message MenuItems {
     string get_help_url = 1;

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -437,6 +437,26 @@ def run_e2e_tests(
                         ["streamlit", "run", test_path],
                         show_output=verbose,
                     )
+
+            elif basename(spec_path) == "multipage_apps_config.spec.js":
+                test_name, _ = splitext(basename(spec_path))
+                test_name, _ = splitext(test_name)
+                test_path = join(
+                    ctx.tests_dir, "scripts", "multipage_apps", "streamlit_app.py"
+                )
+                if os.path.exists(test_path):
+                    run_test(
+                        ctx,
+                        str(spec_path),
+                        [
+                            "streamlit",
+                            "run",
+                            "--client.showPageNavigation=false",
+                            test_path,
+                        ],
+                        show_output=verbose,
+                    )
+
             elif basename(spec_path) == "staticfiles_app.spec.js":
                 test_name, _ = splitext(basename(spec_path))
                 test_name, _ = splitext(test_name)


### PR DESCRIPTION
## 🚧  Naming of config still TBD 🚧 ##

## Describe your changes
Add configuration option - ability to control whether default sidebar page navigation for a multi-page app is displayed.

**Usage Options:**
Pass setting in `config.toml`
  ```toml
  [client]
  showPageNavigation = false
  ```
Pass setting in command line:
  ```bash
  $ streamlit run --client.showPageNavigation False
  ```
Pass setting via `st.set_page_config()`
```
st.set_page_config(show_page_navigation=False)
```

## Testing Plan
- Unit Tests (JS and/or Python) - ✅ 
- E2E Tests - ✅ 
- Manually Tested - ✅ (see also demo [app](https://mpa-update.streamlit.app/) ⚡ )