### PR TITLE
Disable the ability to submit form if a submit button is disabled

### DIFF
--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -411,6 +411,22 @@ describe("Widget State Manager", () => {
         widgets: [{ id: "firstSubmitButton", triggerValue: true }],
       })
     })
+
+    it("does not submit the form if the first submitButton is disabled", () => {
+      const formId = "mockFormId"
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "firstSubmitButton", disabled: true })
+      )
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "secondSubmitButton" })
+      )
+      // Submit the form
+      widgetMgr.submitForm(formId)
+
+      expect(sendBackMsg).not.toHaveBeenCalled()
+    })
   })
 
   describe("Forms don't interfere with each other", () => {

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -371,7 +371,6 @@ describe("Widget State Manager", () => {
       // We have a single pending form.
       expect(formsData.formsWithPendingChanges).toEqual(new Set([formId]))
 
-      // Submit the form
       widgetMgr.submitForm(formId)
 
       // Our backMsg should be populated with our two widget values,
@@ -404,7 +403,6 @@ describe("Widget State Manager", () => {
         formId,
         new ButtonProto({ id: "secondSubmitButton" })
       )
-      // Submit the form
       widgetMgr.submitForm(formId)
 
       expect(sendBackMsg).toHaveBeenCalledWith({
@@ -422,7 +420,6 @@ describe("Widget State Manager", () => {
         formId,
         new ButtonProto({ id: "secondSubmitButton" })
       )
-      // Submit the form
       widgetMgr.submitForm(formId)
 
       expect(sendBackMsg).not.toHaveBeenCalled()

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -424,6 +424,21 @@ describe("Widget State Manager", () => {
 
       expect(sendBackMsg).not.toHaveBeenCalled()
     })
+
+    it("does not submit the form if the second submitButton is disabled", () => {
+      const formId = "mockFormId"
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "firstSubmitButton" })
+      )
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "secondSubmitButton", disabled: true })
+      )
+      widgetMgr.submitForm(formId)
+
+      expect(sendBackMsg).not.toHaveBeenCalled()
+    })
   })
 
   describe("Forms don't interfere with each other", () => {

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -216,6 +216,12 @@ export class WidgetStateManager {
     const form = this.getOrCreateFormState(formId)
 
     const submitButtons = this.formsData.submitButtons.get(formId)
+    const disableForm = submitButtons?.some(
+      submitButton => submitButton.disabled
+    )
+    if (disableForm) {
+      return
+    }
 
     let selectedSubmitButton
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -217,7 +217,6 @@ export class WidgetStateManager {
 
     const submitButtons = this.formsData.submitButtons.get(formId)
     const disableForm = submitButtons?.at(0)?.disabled
-    console.log(disableForm)
     if (disableForm) {
       return
     }

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -216,7 +216,9 @@ export class WidgetStateManager {
     const form = this.getOrCreateFormState(formId)
 
     const submitButtons = this.formsData.submitButtons.get(formId)
-    const disableForm = submitButtons?.at(0)?.disabled
+    const disableForm = submitButtons?.some(
+      submitButton => submitButton.disabled
+    )
     if (disableForm) {
       return
     }

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -216,9 +216,8 @@ export class WidgetStateManager {
     const form = this.getOrCreateFormState(formId)
 
     const submitButtons = this.formsData.submitButtons.get(formId)
-    const disableForm = submitButtons?.some(
-      submitButton => submitButton.disabled
-    )
+    const disableForm = submitButtons?.at(0)?.disabled
+    console.log(disableForm)
     if (disableForm) {
       return
     }


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- disable the whole form if the first submit button is disabled within the form
  - this behavior might need to be adjusted based off of product say
## GitHub Issue Link (if applicable)
#7822 
## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - added unit tests
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
