### PR TITLE
hack fix css object type error

### DIFF
--- a/frontend/app/src/components/StatusWidget/styled-components.ts
+++ b/frontend/app/src/components/StatusWidget/styled-components.ts
@@ -68,7 +68,9 @@ export const StyledAppStatus = styled.div(({ theme }) => ({
   height: "1.6rem",
 }))
 
-const minimizedStyles = (theme: EmotionTheme): CSSObject => ({
+const minimizedStyles = (
+  theme: EmotionTheme
+): Omit<CSSObject, "accentColor"> => ({
   opacity: 0,
   padding: theme.spacing.none,
   margin: theme.spacing.none,

--- a/frontend/lib/src/components/elements/ArrowTable/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowTable/styled-components.ts
@@ -33,7 +33,9 @@ export const StyledTable = styled.table(({ theme }) => ({
   border: `1px solid ${theme.colors.fadedText05}`,
 }))
 
-const styleCellFunction = (theme: EmotionTheme): CSSObject => ({
+const styleCellFunction = (
+  theme: EmotionTheme
+): Omit<CSSObject, "accentColor"> => ({
   borderBottom: `1px solid ${theme.colors.fadedText05}`,
   borderRight: `1px solid ${theme.colors.fadedText05}`,
   verticalAlign: "middle",

--- a/frontend/lib/src/components/elements/LinkButton/styled-components.ts
+++ b/frontend/lib/src/components/elements/LinkButton/styled-components.ts
@@ -42,7 +42,10 @@ export interface BaseLinkButtonProps {
 
 type RequiredBaseLinkButtonProps = Required<BaseLinkButtonProps>
 
-function getSizeStyle(size: BaseButtonSize, theme: EmotionTheme): CSSObject {
+function getSizeStyle(
+  size: BaseButtonSize,
+  theme: EmotionTheme
+): Omit<CSSObject, "accentColor"> {
   switch (size) {
     case BaseButtonSize.XSMALL:
       return {

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -54,7 +54,10 @@ export interface BaseButtonProps {
 
 type RequiredBaseButtonProps = Required<BaseButtonProps>
 
-function getSizeStyle(size: BaseButtonSize, theme: EmotionTheme): CSSObject {
+function getSizeStyle(
+  size: BaseButtonSize,
+  theme: EmotionTheme
+): Omit<CSSObject, "accentColor"> {
   switch (size) {
     case BaseButtonSize.XSMALL:
       return {

--- a/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
@@ -37,7 +37,10 @@ enum Size {
   LARGE = "large",
 }
 
-function getSizeStyle(size: Size, theme: EmotionTheme): CSSObject {
+function getSizeStyle(
+  size: Size,
+  theme: EmotionTheme
+): Omit<CSSObject, "accentColor"> {
   switch (size) {
     case Size.XSMALL:
       return {

--- a/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
@@ -125,7 +125,9 @@ export const StyledFileError = styled.small(({ theme }) => ({
 
 export const StyledFileErrorIcon = styled.span({})
 
-const compactFileUploader = (theme: EmotionTheme): CSSObject => ({
+const compactFileUploader = (
+  theme: EmotionTheme
+): Omit<CSSObject, "accentColor"> => ({
   [StyledFileDropzoneSection as any]: {
     display: "flex",
     flexDirection: "column",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15790,16 +15790,7 @@ react-window@^1.8.5, react-window@^1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.12.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^17.0.2:
+react@^16.12.0, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Fixes these issues:

<img width="1640" alt="Screenshot 2023-12-11 at 10 30 23 AM" src="https://github.com/streamlit/streamlit/assets/120425922/043e0a5b-6699-46ec-b01d-932e50bd4f6c">

I'm not sure why the type for accentColor is problematic. I tried upgrading to the newest version of `@emotion/styled` but the type error was still present. Rather than dig into this further I think it's fine to hack around for now and to omit the typing on `accentColor`. We don't seem to use it anyway.


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
