### PR TITLE
Remove numpy.ndarray from list of supported types from docstring

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -124,8 +124,9 @@ class MapMixin:
         Parameters
         ----------
         data : pandas.DataFrame, pandas.Styler, pyarrow.Table, pyspark.sql.DataFrame,\
-             snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table,\
-             Iterable, dict, or None
+            snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table,\
+            Iterable, dict, or None
+
             The data to be plotted.
 
         latitude : str or None

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -123,9 +123,9 @@ class MapMixin:
 
         Parameters
         ----------
-        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray,\
-            pyspark.sql.DataFrame, snowflake.snowpark.dataframe.DataFrame,\
-            snowflake.snowpark.table.Table, Iterable, dict, or None
+        data : pandas.DataFrame, pandas.Styler, pyarrow.Table, pyspark.sql.DataFrame,\
+             snowflake.snowpark.dataframe.DataFrame, snowflake.snowpark.table.Table,\
+             Iterable, dict, or None
             The data to be plotted.
 
         latitude : str or None


### PR DESCRIPTION
Remove numpy.ndarray from list of supported types in documentation forr st.map data

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Remove `numpy.ndarray` from list of supported types in docstring for st.map data

## GitHub Issue Link (if applicable)
Closes: #5835 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
