### PR TITLE
Add sensible Java options to proto files.

### DIFF
--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "AlertProto";
+
 // NOTE: This proto type is used by some external services so needs to remain
 // relatively stable. While it isn't entirely set in stone, changing it
 // may require a good amount of effort so should be avoided if possible.

--- a/proto/streamlit/proto/AppPage.proto
+++ b/proto/streamlit/proto/AppPage.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "AppPageProto";
+
 // A page in the app. Includes both the name of the page as well as the full
 // path to the corresponding script file.
 //

--- a/proto/streamlit/proto/Arrow.proto
+++ b/proto/streamlit/proto/Arrow.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ArrowProto";
+
 message Arrow {
   // The serialized arrow dataframe
   bytes data = 1;

--- a/proto/streamlit/proto/ArrowNamedDataSet.proto
+++ b/proto/streamlit/proto/ArrowNamedDataSet.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ArrowNamedDataSetProto";
+
 import "streamlit/proto/Arrow.proto";
 
 // A dataset that can be referenced by name.

--- a/proto/streamlit/proto/ArrowVegaLiteChart.proto
+++ b/proto/streamlit/proto/ArrowVegaLiteChart.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ArrowVegaLiteChartProto";
+
 import "streamlit/proto/Arrow.proto";
 import "streamlit/proto/ArrowNamedDataSet.proto";
 

--- a/proto/streamlit/proto/Audio.proto
+++ b/proto/streamlit/proto/Audio.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "AudioProto";
+
 message Audio {
   string url = 5;
 

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "BackMsgProto";
+
 import "streamlit/proto/ClientState.proto";
 import "streamlit/proto/Common.proto";
 

--- a/proto/streamlit/proto/Balloons.proto
+++ b/proto/streamlit/proto/Balloons.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "BalloonsProto";
+
 // A python empty.
 message Balloons {
   bool show = 3;  // Dummy boolean because protos need to have something.

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "BlockProto";
+
 message Block {
   oneof type {
     Vertical vertical = 1;

--- a/proto/streamlit/proto/BokehChart.proto
+++ b/proto/streamlit/proto/BokehChart.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "BokehChartProto";
+
 message BokehChart {
   // A JSON-formatted string from the Bokeh chart figure.
   string figure = 1;

--- a/proto/streamlit/proto/Button.proto
+++ b/proto/streamlit/proto/Button.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ButtonProto";
+
 message Button {
   string id = 1;
   string label = 2;

--- a/proto/streamlit/proto/CameraInput.proto
+++ b/proto/streamlit/proto/CameraInput.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "CameraInputProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message CameraInput {

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ChatInputProto";
+
 message ChatInput {
   enum Position {
     BOTTOM = 0;

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "CheckboxProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message Checkbox {

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ClientStateProto";
+
 import "streamlit/proto/WidgetStates.proto";
 
 

--- a/proto/streamlit/proto/Code.proto
+++ b/proto/streamlit/proto/Code.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "CodeProto";
+
 // st.code
 message Code {
   // Content to display.

--- a/proto/streamlit/proto/ColorPicker.proto
+++ b/proto/streamlit/proto/ColorPicker.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ColorPickerProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message ColorPicker {

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "CommonProto";
+
 // Message types that are common to multiple protobufs.
 
 message StringArray {

--- a/proto/streamlit/proto/Components.proto
+++ b/proto/streamlit/proto/Components.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ComponentsProto";
+
 message ComponentInstance {
   // The instance's "widget ID", used to uniquely identify it.
   string id = 1;

--- a/proto/streamlit/proto/DataFrame.proto
+++ b/proto/streamlit/proto/DataFrame.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DataFrameProto";
+
 import "streamlit/proto/Common.proto";
 
 // DEPRECATED: This proto message is deprecated and unsused. Use Arrow.proto instead.

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DateInputProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message DateInput {

--- a/proto/streamlit/proto/DeckGlJsonChart.proto
+++ b/proto/streamlit/proto/DeckGlJsonChart.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DeckGlJsonChartProto";
+
 message DeckGlJsonChart {
   // The json of the pydeck object (https://deckgl.readthedocs.io/en/latest/deck.html)
   string json = 1;

--- a/proto/streamlit/proto/Delta.proto
+++ b/proto/streamlit/proto/Delta.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DeltaProto";
+
 import "streamlit/proto/Block.proto";
 import "streamlit/proto/Element.proto";
 import "streamlit/proto/NamedDataSet.proto";

--- a/proto/streamlit/proto/DocString.proto
+++ b/proto/streamlit/proto/DocString.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DocStringProto";
+
 // Formatted text
 message DocString {
 

--- a/proto/streamlit/proto/DownloadButton.proto
+++ b/proto/streamlit/proto/DownloadButton.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "DownloadButtonProto";
+
 message DownloadButton {
   string id = 1;
   string label = 2;

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ElementProto";
+
 import "streamlit/proto/Alert.proto";
 import "streamlit/proto/Arrow.proto";
 import "streamlit/proto/Audio.proto";

--- a/proto/streamlit/proto/Empty.proto
+++ b/proto/streamlit/proto/Empty.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "EmptyProto";
+
 // A python empty.
 message Empty {
 }

--- a/proto/streamlit/proto/Exception.proto
+++ b/proto/streamlit/proto/Exception.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ExceptionProto";
+
 // A python exception.
 //
 // NOTE: This proto type is used by some external services so needs to remain

--- a/proto/streamlit/proto/Favicon.proto
+++ b/proto/streamlit/proto/Favicon.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "FaviconProto";
+
 message Favicon {
   string url = 1;
 }

--- a/proto/streamlit/proto/FileUploader.proto
+++ b/proto/streamlit/proto/FileUploader.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "FileUploaderProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 // file_uploader widget

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ForwardMsgProto";
+
 import "streamlit/proto/Common.proto";
 import "streamlit/proto/Delta.proto";
 import "streamlit/proto/GitInfo.proto";

--- a/proto/streamlit/proto/GitInfo.proto
+++ b/proto/streamlit/proto/GitInfo.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "GitInfoProto";
+
 // Message used to update page metadata.
 message GitInfo {
   string repository = 1;

--- a/proto/streamlit/proto/GraphVizChart.proto
+++ b/proto/streamlit/proto/GraphVizChart.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "GraphVizChartProto";
+
 message GraphVizChart {
   // A specification of the GraphViz graph in the "Dot" language.
   string spec = 1;

--- a/proto/streamlit/proto/Heading.proto
+++ b/proto/streamlit/proto/Heading.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "HeadingProto";
+
 message Heading {
     // h1, h2, h3, div, etc
     string tag = 1;

--- a/proto/streamlit/proto/IFrame.proto
+++ b/proto/streamlit/proto/IFrame.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "IFrameProto";
+
 message IFrame {
   oneof type {
     // A URL to load

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ImageProto";
+
 // An image which can be displayed on the screen.
 message Image {
   string url = 3;

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "JsonProto";
+
 message Json {
   // Content to display.
   string body = 1;

--- a/proto/streamlit/proto/LabelVisibilityMessage.proto
+++ b/proto/streamlit/proto/LabelVisibilityMessage.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "LabelVisibilityMessageProto";
+
 message LabelVisibilityMessage {
   // We use separate LabelVisibilityMessage instead of just defining Enum and
   // use it in other widgets proto files due to protobuf js error, when just

--- a/proto/streamlit/proto/LinkButton.proto
+++ b/proto/streamlit/proto/LinkButton.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "LinkButtonProto";
+
 message LinkButton {
   string label = 2;
   string help = 4;

--- a/proto/streamlit/proto/Markdown.proto
+++ b/proto/streamlit/proto/Markdown.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "MarkdownProto";
+
 // Formatted text
 message Markdown {
   // Content to display.

--- a/proto/streamlit/proto/Metric.proto
+++ b/proto/streamlit/proto/Metric.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "MetricProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message Metric {

--- a/proto/streamlit/proto/MultiSelect.proto
+++ b/proto/streamlit/proto/MultiSelect.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "MultiSelectProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message MultiSelect {

--- a/proto/streamlit/proto/NamedDataSet.proto
+++ b/proto/streamlit/proto/NamedDataSet.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "NamedDataSetProto";
+
 import "streamlit/proto/DataFrame.proto";
 
 // DEPRECATED: This proto message is deprecated and unsused.

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "NewSessionProto";
+
 import "streamlit/proto/AppPage.proto";
 import "streamlit/proto/SessionStatus.proto";
 

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "NumberInputProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message NumberInput {

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "PageConfigProto";
+
 // Properties of the page that the app creator may configure.
 message PageConfig {
   string title = 1;

--- a/proto/streamlit/proto/PageInfo.proto
+++ b/proto/streamlit/proto/PageInfo.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "PageInfoProto";
+
 // Message used to update page metadata.
 message PageInfo {
   // The page's query string, if the user decided to set it.

--- a/proto/streamlit/proto/PageNotFound.proto
+++ b/proto/streamlit/proto/PageNotFound.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "PageNotFoundProto";
+
 // Message used to tell the client that the requested page does not exist.
 message PageNotFound {
   string page_name = 1;

--- a/proto/streamlit/proto/PageProfile.proto
+++ b/proto/streamlit/proto/PageProfile.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "PageProfileProto";
+
 
 message PageProfile {
   repeated Command commands = 1;

--- a/proto/streamlit/proto/PagesChanged.proto
+++ b/proto/streamlit/proto/PagesChanged.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "PagesChangedProto";
+
 import "streamlit/proto/AppPage.proto";
 
 // Message used to tell the client that the app's pages have changed.

--- a/proto/streamlit/proto/ParentMessage.proto
+++ b/proto/streamlit/proto/ParentMessage.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ParentMessageProto";
+
 // NOTE: This proto type is used by some external services so needs to remain
 // relatively stable. While it isn't entirely set in stone, changing it
 // may require a good amount of effort so should be avoided if possible.

--- a/proto/streamlit/proto/PlotlyChart.proto
+++ b/proto/streamlit/proto/PlotlyChart.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "PlotlyChartProto";
+
 message PlotlyChart {
   oneof chart {
     // If the user chose to send the plot to Plotly's server, then this is the

--- a/proto/streamlit/proto/Progress.proto
+++ b/proto/streamlit/proto/Progress.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ProgressProto";
+
 message Progress {
   uint32 value = 1;
   string text = 2;

--- a/proto/streamlit/proto/Radio.proto
+++ b/proto/streamlit/proto/Radio.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "RadioProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message Radio {

--- a/proto/streamlit/proto/RootContainer.proto
+++ b/proto/streamlit/proto/RootContainer.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "RootContainerProto";
+
 // Constants for our three "RootContainers" - the top-level containers
 // that `st.foo` and `st.sidebar.foo` write to. Each value corresponds
 // to the first index in any `delta_path` that uses these containers.

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SelectboxProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message Selectbox {

--- a/proto/streamlit/proto/SessionEvent.proto
+++ b/proto/streamlit/proto/SessionEvent.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SessionEventProto";
+
 import "streamlit/proto/Exception.proto";
 
 // A transient event sent to all browsers connected to an associated app.

--- a/proto/streamlit/proto/SessionStatus.proto
+++ b/proto/streamlit/proto/SessionStatus.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SessionStatusProto";
+
 // Status for a session. Sent as part of the Initialize message, and also
 // on AppSession status change events.
 //

--- a/proto/streamlit/proto/Skeleton.proto
+++ b/proto/streamlit/proto/Skeleton.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SkeletonProto";
+
 // An internal-only element that displays an app skeleton.
 message Skeleton {
 }

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SliderProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message Slider {

--- a/proto/streamlit/proto/Snow.proto
+++ b/proto/streamlit/proto/Snow.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SnowProto";
+
 // A python empty.
 message Snow {
   bool show = 1;  // Dummy boolean because protos need to have something.

--- a/proto/streamlit/proto/Spinner.proto
+++ b/proto/streamlit/proto/Spinner.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "SpinnerProto";
+
 message Spinner {
   // A message to display while executing that block.
   string text = 1;

--- a/proto/streamlit/proto/Text.proto
+++ b/proto/streamlit/proto/Text.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "TextProto";
+
 // Preformatted text
 message Text {
   // Content to display.

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "TextAreaProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message TextArea {

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "TextInputProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message TextInput {

--- a/proto/streamlit/proto/TimeInput.proto
+++ b/proto/streamlit/proto/TimeInput.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "TimeInputProto";
+
 import "streamlit/proto/LabelVisibilityMessage.proto";
 
 message TimeInput {

--- a/proto/streamlit/proto/Toast.proto
+++ b/proto/streamlit/proto/Toast.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "ToastProto";
+
 message Toast {
     // Display message
     string body = 1;

--- a/proto/streamlit/proto/VegaLiteChart.proto
+++ b/proto/streamlit/proto/VegaLiteChart.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "VegaLiteChartProto";
+
 import "streamlit/proto/DataFrame.proto";
 import "streamlit/proto/NamedDataSet.proto";
 

--- a/proto/streamlit/proto/Video.proto
+++ b/proto/streamlit/proto/Video.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "VideoProto";
+
 message Video {
   // A url pointing to a video file
   string url = 6;

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -16,6 +16,9 @@
 
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "WidgetStatesProto";
+
 import "streamlit/proto/Common.proto";
 import "streamlit/proto/Components.proto";
 

--- a/proto/streamlit/proto/openmetrics_data_model.proto
+++ b/proto/streamlit/proto/openmetrics_data_model.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 
+option java_package = "com.snowflake.apps.streamlit";
+option java_outer_classname = "OpenmetricsDataModelProto";
+
 // The OpenMetrics protobuf schema which defines the protobuf wire format. 
 // Ensure to interpret "required" as semantically required for a valid message.
 // All string fields MUST be UTF-8 encoded strings.


### PR DESCRIPTION
## Describe your changes

Add a constant java_package to all proto files.

Add a sensible java_outer_classname to all proto files.

## Testing Plan

- Explanation of why no additional tests are needed

This only changes output of the `protoc` command when building Java files - so as long as these still compile with `make protobuf`, they are safe.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
