### PR TITLE
Speed up plotly figures by 8x for users with "orjson"

### DIFF
--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -208,14 +208,14 @@ def marshall(
     proto.use_container_width = use_container_width
 
     if sharing == "streamlit":
-        import plotly.utils
+        import plotly.io
 
         config = dict(kwargs.get("config", {}))
         # Copy over some kwargs to config dict. Plotly does the same in plot().
         config.setdefault("showLink", kwargs.get("show_link", False))
         config.setdefault("linkText", kwargs.get("link_text", False))
 
-        proto.figure.spec = json.dumps(figure, cls=plotly.utils.PlotlyJSONEncoder)
+        proto.figure.spec = plotly.io.to_json(figure, validate=False)
         proto.figure.config = json.dumps(config)
 
     else:


### PR DESCRIPTION


<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Plotly provides a `plotly.io.to_json()` function that, among other things, provides an optimized implementation when the "orjson" package is installed. This PR switches plotly_chart's `marshall()` function to use this helper, rather than the lower-level `plotly.utils.PlotlyJSONEncoder`.

For one of our internal plots, this brought the runtime of st.plotly_chart(...) from 550ms to 64ms.

Pinging @AnOctopus 

Note that this PR does _not_ add a dependency of streamlit on `orjson`, because correct behavior does not depend on having it installed. This follows the pattern of plotly itself. It would probably be a good idea to document somewhere that having orjson will make plotly serialization faster.

## Testing Plan

This code should be well-exercised by existing tests that construct plotly graphs.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
