### PR TITLE
Prevent incompatible column config serialization

### DIFF
--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -530,10 +530,18 @@ def marshall_column_config(
         The column config to marshall.
     """
 
-    # Ignore all None values and prefix columns specified by numerical index:
-    proto.columns = json.dumps(
-        {
-            (f"{_NUMERICAL_POSITION_PREFIX}{str(k)}" if isinstance(k, int) else k): v
-            for (k, v) in remove_none_values(column_config_mapping).items()
-        }
-    )
+    try:
+        # Ignore all None values and prefix columns specified by numerical index:
+        proto.columns = json.dumps(
+            {
+                (
+                    f"{_NUMERICAL_POSITION_PREFIX}{str(k)}" if isinstance(k, int) else k
+                ): v
+                for (k, v) in remove_none_values(column_config_mapping).items()
+            },
+            allow_nan=False,
+        )
+    except ValueError as ex:
+        raise StreamlitAPIException(
+            f"The provided column config cannot be serialized into JSON: {ex}"
+        ) from ex

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -516,6 +516,24 @@ def apply_data_specific_configs(
         update_column_config(columns_config, INDEX_IDENTIFIER, {"required": True})
 
 
+def _convert_column_config_to_json(column_config_mapping: ColumnConfigMapping) -> str:
+    try:
+        # Ignore all None values and prefix columns specified by numerical index:
+        return json.dumps(
+            {
+                (
+                    f"{_NUMERICAL_POSITION_PREFIX}{str(k)}" if isinstance(k, int) else k
+                ): v
+                for (k, v) in remove_none_values(column_config_mapping).items()
+            },
+            allow_nan=False,
+        )
+    except ValueError as ex:
+        raise StreamlitAPIException(
+            f"The provided column config cannot be serialized into JSON: {ex}"
+        ) from ex
+
+
 def marshall_column_config(
     proto: ArrowProto, column_config_mapping: ColumnConfigMapping
 ) -> None:
@@ -530,18 +548,4 @@ def marshall_column_config(
         The column config to marshall.
     """
 
-    try:
-        # Ignore all None values and prefix columns specified by numerical index:
-        proto.columns = json.dumps(
-            {
-                (
-                    f"{_NUMERICAL_POSITION_PREFIX}{str(k)}" if isinstance(k, int) else k
-                ): v
-                for (k, v) in remove_none_values(column_config_mapping).items()
-            },
-            allow_nan=False,
-        )
-    except ValueError as ex:
-        raise StreamlitAPIException(
-            f"The provided column config cannot be serialized into JSON: {ex}"
-        ) from ex
+    proto.columns = _convert_column_config_to_json(column_config_mapping)

--- a/lib/tests/streamlit/elements/lib/column_config_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/column_config_utils_test.py
@@ -28,6 +28,7 @@ from streamlit.elements.lib.column_config_utils import (
     ColumnConfigMapping,
     ColumnConfigMappingInput,
     ColumnDataKind,
+    _convert_column_config_to_json,
     _determine_data_kind,
     _determine_data_kind_via_arrow,
     _determine_data_kind_via_inferred_type,
@@ -565,3 +566,17 @@ class ColumnConfigUtilsTest(unittest.TestCase):
         self.assertNotIn("b", columns_config)
         self.assertTrue(columns_config["c"]["disabled"])
         self.assertTrue(columns_config["d"]["disabled"])
+
+    def test_nan_as_value_raises_exception(self):
+        """Test that the usage of `nan` as value in column config raises an exception."""
+
+        with self.assertRaises(StreamlitAPIException):
+            _convert_column_config_to_json(
+                {
+                    "label": "Col1",
+                    "type_config": {
+                        "type": "selectbox",
+                        "options": ["a", "b", "c", np.nan],
+                    },
+                },
+            )


### PR DESCRIPTION
## Describe your changes

This PR sets `allow_nan` to False during column config serialization to raise an exception on Python site instead of a silent error on frontend side. 

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/7558

## Testing Plan

- Added python unit test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
