### PR TITLE
Group by stats for `_stcore/metrics` endpoint to avoid duplicate rows

### DIFF
--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 from abc import abstractmethod
 from typing import List, NamedTuple
 
@@ -81,8 +82,26 @@ class StatsManager:
         self._cache_stats_providers.append(provider)
 
     def get_stats(self) -> List[CacheStat]:
-        """Return a list containing all stats from each registered provider."""
+        """Return a list containing all stats from each registered provider.
+        Stats are grouped by category_name and cache_type."""
         all_stats: List[CacheStat] = []
         for provider in self._cache_stats_providers:
-            all_stats.extend(provider.get_stats())
+            provider_stats = provider.get_stats()
+            grouped_stats = itertools.groupby(
+                provider_stats,
+                lambda individual_stat: (
+                    individual_stat.category_name,
+                    individual_stat.cache_name,
+                ),
+            )
+
+            for (category_name, cache_name), stats in grouped_stats:
+                all_stats.append(
+                    CacheStat(
+                        category_name=category_name,
+                        cache_name=cache_name,
+                        byte_length=sum(map(lambda item: item.byte_length, stats)),
+                    )
+                )
+
         return all_stats

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -50,3 +50,36 @@ class StatsManagerTest(unittest.TestCase):
         ]
 
         self.assertEqual(provider1.stats + provider2.stats, manager.get_stats())
+
+    def test_get_stats_aggregated(self):
+        """StatsManager.get_stats should return all providers' stats aggregated."""
+        manager = StatsManager()
+        provider1 = MockStatsProvider()
+        provider2 = MockStatsProvider()
+        manager.register_provider(provider1)
+        manager.register_provider(provider2)
+
+        # No stats
+        self.assertEqual([], manager.get_stats())
+
+        # Some stats
+        provider1.stats = [
+            CacheStat("provider1", "foo", 1),
+            CacheStat("provider1", "foo", 8),
+            CacheStat("provider1", "bar", 2),
+        ]
+
+        provider2.stats = [
+            CacheStat("provider2", "baz", 4),
+            CacheStat("provider2", "qux", 5),
+            CacheStat("provider2", "qux", 6),
+        ]
+
+        expected_result = [
+            CacheStat("provider1", "foo", 9),
+            CacheStat("provider1", "bar", 2),
+            CacheStat("provider2", "baz", 4),
+            CacheStat("provider2", "qux", 11),
+        ]
+
+        self.assertEqual(expected_result, manager.get_stats())


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Aggregate stats with the same `cache_type` and `cache` (sum `byte_size`) in the `StatsManager` `get_stats` method, to not break [OpenMetrics standard](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md).

## GitHub Issue Link (if applicable)
Closes: #7891 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Added ✅ 
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
