### PR TITLE
Fix Chrome-specific theme change issue during print dialog interaction

### DIFF
--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -359,6 +359,14 @@ describe("createTheme", () => {
 })
 
 describe("getSystemTheme", () => {
+  // Backup original matchMedia
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    // Reset matchMedia after each test
+    window.matchMedia = originalMatchMedia
+  })
+
   it("returns lightTheme when matchMedia does *not* match dark", () => {
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -383,6 +391,38 @@ describe("getSystemTheme", () => {
     })
 
     expect(getSystemTheme().name).toBe("Dark")
+  })
+
+  it("maintains the theme during printing process", () => {
+    // Simulate dark theme preference
+    window.matchMedia = jest.fn().mockImplementation(query => ({
+      matches: true,
+      media: query,
+      ...matchMediaFillers,
+    }))
+
+    // Check theme before printing
+    expect(getSystemTheme().name).toBe("Dark")
+
+    // Simulate opening print dialog
+    window.dispatchEvent(new Event("beforeprint"))
+    expect(getSystemTheme().name).toBe("Dark")
+
+    // Simulate closing print dialog
+    window.dispatchEvent(new Event("afterprint"))
+
+    // Check theme after printing, expecting it to still be Dark
+    expect(getSystemTheme().name).toBe("Dark")
+
+    // Change to light theme preference
+    window.matchMedia = jest.fn().mockImplementation(query => ({
+      matches: false, // Simulate light theme preference
+      media: query,
+      ...matchMediaFillers,
+    }))
+
+    // Check theme after changing preference post-printing
+    expect(getSystemTheme().name).toBe("Light")
   })
 })
 

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -50,11 +50,26 @@ import { createBaseUiTheme } from "./createThemeUtil"
 export const AUTO_THEME_NAME = "Use system setting"
 export const CUSTOM_THEME_NAME = "Custom Theme"
 
+let isPrinting = false
+let currentTheme: ThemeConfig = lightTheme // default
+
+window.addEventListener("beforeprint", () => {
+  isPrinting = true
+})
+
+window.addEventListener("afterprint", () => {
+  isPrinting = false
+})
+
 export const getSystemTheme = (): ThemeConfig => {
-  return window.matchMedia &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
+  if (isPrinting) {
+    return currentTheme
+  }
+
+  currentTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
     ? darkTheme
     : lightTheme
+  return currentTheme
 }
 
 export const createAutoTheme = (): ThemeConfig => ({

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -66,9 +66,11 @@ export const getSystemTheme = (): ThemeConfig => {
     return currentTheme
   }
 
-  currentTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? darkTheme
-    : lightTheme
+  currentTheme =
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? darkTheme
+      : lightTheme
   return currentTheme
 }
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Fixes a Chrome-specific theme change issue during print dialog interaction.

This PR addresses a Chrome-specific issue where the app's theme erroneously switches to light mode (as detected via `prefers-color-scheme`) when the print dialog is opened , despite the system preference being set to dark mode. The issue is fixed by preserving the current theme state during print operations:

- Introduced global variables `isPrinting` and `currentTheme` to track the printing state and the current theme, respectively
- Added event listeners for `beforeprint` and `afterprint` to set the `isPrinting` flag. This allows us to detect when the print dialog is open
- Modified `getSystemTheme` to return `currentTheme` when `isPrinting` is true, preventing the theme from switching in response to Chrome's temporary `prefers-color-scheme` change during print dialog interaction

## GitHub Issue Link (if applicable)

Closes #7879.

## Testing Plan

- [x] Unit Tests (JS)
- [ ] TODO: E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
