### PR TITLE
Fix flickering effect when changing tabs

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -223,7 +223,10 @@ const VerticalBlock = (props: BlockPropsWithoutWidth): ReactElement => {
         window.requestAnimationFrame(() => {
           // We need to determine the available width here to be able to set
           // an explicit width for the `StyledVerticalBlock`.
-          setWidth(entry.target.getBoundingClientRect().width)
+
+          // The width should never be set to 0 since it can cause
+          // flickering effects.
+          setWidth(entry.target.getBoundingClientRect().width || -1)
         })
       }),
     [setWidth]

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -136,7 +136,7 @@ export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
   ({ width, theme }) => ({
     width,
     position: "relative", // Required for the automatic width computation.
-    display: width === 0 ? "none" : "flex",
+    display: "flex",
     flex: 1,
     flexDirection: "column",
     gap: theme.spacing.lg,

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -136,8 +136,7 @@ export const StyledVerticalBlock = styled.div<StyledVerticalBlockProps>(
   ({ width, theme }) => ({
     width,
     position: "relative", // Required for the automatic width computation.
-
-    display: "flex",
+    display: width === 0 ? "none" : "flex",
     flex: 1,
     flexDirection: "column",
     gap: theme.spacing.lg,


### PR DESCRIPTION
## Describe your changes

I don't know when and why the width == 0 flicker problem returned (could be related to [this](https://github.com/streamlit/streamlit/pull/7835) or [this](https://github.com/streamlit/streamlit/pull/7697) change or some browser changes). It seems to happen a bit more randomly:

https://github.com/streamlit/streamlit/assets/2852129/033623d7-0b61-4baa-ad18-6cddfce80209

The fixes in this PR seem to prevent this flickering fully. 

## Testing Plan

- Not really easy to test since it is just some flickering. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
