### PR TITLE
Don't disable tab on stale flag

### DIFF
--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -220,6 +220,14 @@ function Tabs(props: TabProps): ReactElement {
                           paddingRight: "0.6rem",
                         }
                       : {}),
+                    ...(!isStale && isStaleTab
+                      ? {
+                          // Apply stale effect if only this specific
+                          // tab is stale but not the entire tab container.
+                          opacity: 0.33,
+                          transition: "opacity 1s ease-in 0.5s",
+                        }
+                      : {}),
                   }),
                 },
               }}

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -144,13 +144,12 @@ function Tabs(props: TabProps): ReactElement {
             scriptRunState,
             scriptRunId
           )
-          const disabled = widgetsDisabled || isStaleTab
 
           // Ensure stale tab's elements are also marked stale/disabled
           const childProps = {
             ...props,
             isStale: isStale || isStaleTab,
-            widgetsDisabled: disabled,
+            widgetsDisabled,
             node: appNode as BlockNode,
           }
           let nodeLabel = index.toString()
@@ -159,8 +158,7 @@ function Tabs(props: TabProps): ReactElement {
           }
           allTabLabels[index] = nodeLabel
 
-          const isSelected =
-            activeTabKey.toString() === index.toString() && !isStaleTab
+          const isSelected = activeTabKey.toString() === index.toString()
           const isLast = index === node.children.length - 1
 
           return (
@@ -173,7 +171,7 @@ function Tabs(props: TabProps): ReactElement {
                 />
               }
               key={index}
-              disabled={disabled}
+              disabled={widgetsDisabled}
               overrides={{
                 TabPanel: {
                   style: () => ({
@@ -193,25 +191,25 @@ function Tabs(props: TabProps): ReactElement {
                     paddingBottom: theme.spacing.none,
                     fontSize: theme.fontSizes.sm,
                     background: "transparent",
-                    color: disabled
+                    color: widgetsDisabled
                       ? theme.colors.fadedText40
                       : theme.colors.bodyText,
                     ":focus": {
                       outline: "none",
-                      color: disabled
+                      color: widgetsDisabled
                         ? theme.colors.fadedText40
                         : theme.colors.primary,
                       background: "none",
                     },
                     ":hover": {
-                      color: disabled
+                      color: widgetsDisabled
                         ? theme.colors.fadedText40
                         : theme.colors.primary,
                       background: "none",
                     },
                     ...(isSelected
                       ? {
-                          color: disabled
+                          color: widgetsDisabled
                             ? theme.colors.fadedText40
                             : theme.colors.primary,
                         }


### PR DESCRIPTION
## Describe your changes

We time have a small visual regression causing tabs to flicker on every rerun since 1.27. I think its caused by the changes in [this PR](https://github.com/streamlit/streamlit/pull/7310). The problem is that i`sStale` flag is set for all elements instantly after rerun. Applying visual effects without delay as a reaction to `isStale` will lead to flickering effects:

https://github.com/streamlit/streamlit/assets/2852129/fe71bed0-bcee-4762-8644-70e7e222e5ac

This PR reverts the changes that disable the tab on stale and applies the opacity transition effect to indicate single stale tabs.

## GitHub Issue Link (if applicable)

- Closes: https://github.com/streamlit/streamlit/issues/7820

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
