### PR TITLE
Reduce e2e test flakiness by using waiting methods

### DIFF
--- a/e2e_playwright/st_both_query_params_error_test.py
+++ b/e2e_playwright/st_both_query_params_error_test.py
@@ -16,7 +16,7 @@ from playwright.sync_api import Page, expect
 
 
 def test_query_params_exception_msg(app: Page):
-    assert app.get_by_test_id("stException") is not None
+    expect(app.get_by_test_id("stException")).to_be_visible()
     expect(
         app.get_by_text(
             "Using st.query_params together with either st.experimental_get_query_params or st.experimental_set_query_params is not supported. Please convert your app to only use st.query_params"

--- a/e2e_playwright/st_graphviz_chart_test.py
+++ b/e2e_playwright/st_graphviz_chart_test.py
@@ -39,7 +39,7 @@ def test_shows_left_and_right_graph(app: Page):
         "Left"
     )
     expect(app.locator(".stGraphVizChart > svg > g > title").nth(4)).to_have_text(
-        "Left"
+        "Right"
     )
 
 

--- a/e2e_playwright/st_graphviz_chart_test.py
+++ b/e2e_playwright/st_graphviz_chart_test.py
@@ -29,26 +29,26 @@ def click_fullscreen(app: Page):
 
 def test_initial_setup(app: Page):
     """Initial setup: ensure charts are loaded."""
-
-    wait_for_app_run(app)
-    title_count = len(app.locator(".stGraphVizChart > svg > g > title").all())
-    assert title_count == 6
+    expect(app.locator(".stGraphVizChart > svg > g > title")).to_have_count(6)
 
 
 def test_shows_left_and_right_graph(app: Page):
     """Test if it shows left and right graph."""
 
-    left_text = app.locator(".stGraphVizChart > svg > g > title").nth(3).text_content()
-    right_text = app.locator(".stGraphVizChart > svg > g > title").nth(4).text_content()
-    assert "Left" in left_text and "Right" in right_text
+    expect(app.locator(".stGraphVizChart > svg > g > title").nth(3)).to_have_text(
+        "Left"
+    )
+    expect(app.locator(".stGraphVizChart > svg > g > title").nth(4)).to_have_text(
+        "Left"
+    )
 
 
 def test_first_graph_dimensions(app: Page):
     """Test the dimensions of the first graph."""
 
     first_graph_svg = get_first_graph_svg(app)
-    assert first_graph_svg.get_attribute("width") == "79pt"
-    assert first_graph_svg.get_attribute("height") == "116pt"
+    expect(first_graph_svg).to_have_attribute("width", "79pt")
+    expect(first_graph_svg).to_have_attribute("height", "116pt")
 
 
 def test_first_graph_fullscreen(app: Page, assert_snapshot: ImageCompareFunction):
@@ -84,8 +84,8 @@ def test_first_graph_after_exit_fullscreen(
     click_fullscreen(app)
 
     first_graph_svg = get_first_graph_svg(app)
-    assert first_graph_svg.get_attribute("width") == "79pt"
-    assert first_graph_svg.get_attribute("height") == "116pt"
+    expect(first_graph_svg).to_have_attribute("width", "79pt")
+    expect(first_graph_svg).to_have_attribute("height", "116pt")
     assert_snapshot(first_graph_svg, name="graphviz_after_exit_fullscreen")
 
 

--- a/scripts/audit_frontend_licenses.py
+++ b/scripts/audit_frontend_licenses.py
@@ -87,8 +87,17 @@ PACKAGE_EXCEPTIONS: Set[PackageInfo] = {
     ),
     (
         # Mapbox Web SDK license: https://github.com/mapbox/mapbox-gl-js/blob/main/LICENSE.txt
-        "mapbox-gl",
+        "@plotly/mapbox-gl",
         "1.13.4",
+        "SEE LICENSE IN LICENSE.txt",
+        "git://github.com/mapbox/mapbox-gl-js.git",
+        "Unknown",
+        "Unknown",
+    ),
+    (
+        # Mapbox Web SDK license: https://github.com/mapbox/mapbox-gl-js/blob/main/LICENSE.txt
+        "mapbox-gl",
+        "1.13.3",
         "SEE LICENSE IN LICENSE.txt",
         "git://github.com/mapbox/mapbox-gl-js.git",
         "Unknown",

--- a/scripts/audit_frontend_licenses.py
+++ b/scripts/audit_frontend_licenses.py
@@ -90,7 +90,7 @@ PACKAGE_EXCEPTIONS: Set[PackageInfo] = {
         "@plotly/mapbox-gl",
         "1.13.4",
         "SEE LICENSE IN LICENSE.txt",
-        "git://github.com/mapbox/mapbox-gl-js.git",
+        "git://github.com/plotly/mapbox-gl-js.git",
         "Unknown",
         "Unknown",
     ),

--- a/scripts/audit_frontend_licenses.py
+++ b/scripts/audit_frontend_licenses.py
@@ -88,16 +88,7 @@ PACKAGE_EXCEPTIONS: Set[PackageInfo] = {
     (
         # Mapbox Web SDK license: https://github.com/mapbox/mapbox-gl-js/blob/main/LICENSE.txt
         "mapbox-gl",
-        "1.13.3",
-        "SEE LICENSE IN LICENSE.txt",
-        "git://github.com/mapbox/mapbox-gl-js.git",
-        "Unknown",
-        "Unknown",
-    ),
-    (
-        # Mapbox Web SDK license: https://github.com/mapbox/mapbox-gl-js/blob/main/LICENSE.txt
-        "mapbox-gl",
-        "1.10.1",
+        "1.13.4",
         "SEE LICENSE IN LICENSE.txt",
         "git://github.com/mapbox/mapbox-gl-js.git",
         "Unknown",


### PR DESCRIPTION
## Describe your changes

Use waiting methods in some e2e playwright tests to reduce test flakiness. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
