### PR TITLE
Reuse style element for theme injection into custom components

### DIFF
--- a/component-lib/src/streamlit.test.ts
+++ b/component-lib/src/streamlit.test.ts
@@ -249,6 +249,23 @@ describe("Streamlit", () => {
         "--text-color"
       )
     ).toEqual(theme.textColor);
+    
+    expect(
+      document.getElementById(Streamlit.INJECTED_STYLE_ELEMENT_ID)
+    ).toBeInstanceOf(HTMLStyleElement)
+    expect(
+      document.querySelectorAll(`style#${Streamlit.INJECTED_STYLE_ELEMENT_ID}`)
+    ).toHaveLength(1);
+
+    window.postMessage(
+      { type: "streamlit:render", args: {}, theme: theme },
+      "*"
+    );
+    await tick();
+
+    expect(
+      document.querySelectorAll(`style#${Streamlit.INJECTED_STYLE_ELEMENT_ID}`)
+    ).toHaveLength(1);
   });
 
   test("The parent frame can sent plain arguments", async () => {

--- a/component-lib/src/streamlit.test.ts
+++ b/component-lib/src/streamlit.test.ts
@@ -249,7 +249,7 @@ describe("Streamlit", () => {
         "--text-color"
       )
     ).toEqual(theme.textColor);
-    
+
     expect(
       document.getElementById(Streamlit.INJECTED_STYLE_ELEMENT_ID)
     ).toBeInstanceOf(HTMLStyleElement)

--- a/component-lib/src/streamlit.ts
+++ b/component-lib/src/streamlit.ts
@@ -68,6 +68,8 @@ export class Streamlit {
   public static readonly API_VERSION = 1;
 
   public static readonly RENDER_EVENT = "streamlit:render";
+  
+  public static readonly INJECTED_STYLE_ELEMENT_ID = "__streamlit_injected_styles";
 
   /** Dispatches events received from Streamlit. */
   public static readonly events = new EventTarget();
@@ -228,11 +230,10 @@ export class Streamlit {
 }
 
 const _injectTheme = (theme: Theme) => {
-  const injectedStyleElementId = "__streamlit_injected_styles";
-  let style = document.getElementById(injectedStyleElementId);
+  let style = document.getElementById(Streamlit.INJECTED_STYLE_ELEMENT_ID);
   if (!style) {
     style = document.createElement("style");
-    style.id = injectedStyleElementId;
+    style.id = Streamlit.INJECTED_STYLE_ELEMENT_ID;
     document.head.appendChild(style);
   }
   style.innerHTML = `

--- a/component-lib/src/streamlit.ts
+++ b/component-lib/src/streamlit.ts
@@ -68,7 +68,7 @@ export class Streamlit {
   public static readonly API_VERSION = 1;
 
   public static readonly RENDER_EVENT = "streamlit:render";
-  
+
   public static readonly INJECTED_STYLE_ELEMENT_ID = "__streamlit_injected_styles";
 
   /** Dispatches events received from Streamlit. */

--- a/component-lib/src/streamlit.ts
+++ b/component-lib/src/streamlit.ts
@@ -228,8 +228,13 @@ export class Streamlit {
 }
 
 const _injectTheme = (theme: Theme) => {
-  const style = document.createElement("style");
-  document.head.appendChild(style);
+  const injectedStyleElementId = "__streamlit_injected_styles";
+  let style = document.getElementById(injectedStyleElementId);
+  if (!style) {
+    style = document.createElement("style");
+    style.id = injectedStyleElementId;
+    document.head.appendChild(style);
+  }
   style.innerHTML = `
     :root {
       --primary-color: ${theme.primaryColor};


### PR DESCRIPTION
## Describe your changes

In the current implementation, whenever a custom component receives a render event, the theme (which may have changed) is injected as a new style element, and this element is appended to the head of the iframe document.

This pull request introduces a modification to this behaviour. Instead of creating a new style element for each render event, a single style element is now created and reused for subsequent style updates.

The updated approach offers several advantages, primarily preventing the linear growth of the iframe document size with the increasing number of render events. This optimization enhances the efficiency and performance of the custom components, in particular for long lived custom components that receive a large number of or frequent render events. 

## Testing Plan

Since the injected css is constant in terms of its attributes and selectors, the current behaviour of appending new style elements is equal to the overwriting introduced in this PR. Thus no testing is required

---

**Contribution License Agreement**

By submitting this pull request I agree that all contributions to this project are made under the Apache 2.0 license.
