### PR TITLE
Fix embed params being dropped in page swaps

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -191,5 +191,5 @@ def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port
 
     assert (
         page.url
-        == f"http://localhost:{app_port}/page3?embed=True&embed_options=disable_scrolling&embed_options=show_colored_line"
+        == f"http://localhost:{app_port}/page3?embed=true&embed_options=disable_scrolling&embed_options=show_colored_line"
     )

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -176,3 +176,20 @@ def test_removes_query_params_when_swapping_pages(page: Page, app_port: int):
     wait_for_app_run(page)
 
     assert page.url == f"http://localhost:{app_port}/page3"
+
+
+def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port: int):
+    """Test that query params are removed when swapping pages"""
+
+    page.goto(
+        f"http://localhost:{app_port}/page_7?foo=bar&embed=True&embed_options=disable_scrolling&embed_options=show_colored_line"
+    )
+    wait_for_app_loaded(page)
+
+    page.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
+    wait_for_app_run(page)
+
+    assert (
+        page.url
+        == f"http://localhost:{app_port}/page3?embed=True&embed_options=disable_scrolling&embed_options=show_colored_line"
+    )

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -182,7 +182,7 @@ def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port
     """Test that query params are removed when swapping pages"""
 
     page.goto(
-        f"http://localhost:{app_port}/page_7?foo=bar&embed=True&embed_options=disable_scrolling&embed_options=show_colored_line"
+        f"http://localhost:{app_port}/page_7?foo=bar&embed=True&embed_options=show_toolbar&embed_options=show_colored_line"
     )
     wait_for_app_loaded(page)
 
@@ -191,5 +191,5 @@ def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port
 
     assert (
         page.url
-        == f"http://localhost:{app_port}/page3?embed=true&embed_options=disable_scrolling&embed_options=show_colored_line"
+        == f"http://localhost:{app_port}/page3?embed=true&embed_options=show_toolbar&embed_options=show_colored_line"
     )

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1195,16 +1195,17 @@ describe("App.sendRerunBackMsg", () => {
   })
 
   it("retains embed query params even if the page hash is different", () => {
-    const originalWindowLocation = window.location
     const embedParams =
       "embed=true&embed_options=disable_scrolling&embed_options=show_colored_line"
 
-    // Change window.location.href in order for query params to exist
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      enumerable: true,
-      value: new URL(`${window.location.href}?${embedParams}`),
-    })
+    const prevWindowLocation = window.location
+    // @ts-expect-error
+    delete window.location
+    // @ts-expect-error
+    window.location = {
+      assign: jest.fn(),
+      search: `foo=bar&${embedParams}`,
+    }
 
     wrapper.setState({
       currentPageScriptHash: "current_page_hash",
@@ -1232,12 +1233,7 @@ describe("App.sendRerunBackMsg", () => {
       queryParams: embedParams,
     })
 
-    // Reset window.location
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      enumerable: true,
-      value: originalWindowLocation,
-    })
+    window.location = prevWindowLocation
   })
 })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -124,6 +124,7 @@ import withScreencast, {
 
 // Used to import fonts + responsive reboot items
 import "@streamlit/app/src/assets/css/theme.scss"
+import { parseEmbedUrlString } from "@streamlit/lib/src/util/utils"
 
 export interface Props {
   screenCast: ScreenCastHOC
@@ -865,10 +866,13 @@ export class App extends PureComponent<Props, State> {
       // e.g. the case where the user clicks the back button.
       // See https://github.com/streamlit/streamlit/pull/6271#issuecomment-1465090690 for the discussion.
       if (prevPageName !== newPageName) {
+        const queryString = parseEmbedUrlString()
+        const qs = queryString ? `?${queryString}` : ""
+
         const basePathPrefix = basePath ? `/${basePath}` : ""
 
         const pagePath = viewingMainPage ? "" : newPageName
-        const pageUrl = `${basePathPrefix}/${pagePath}`
+        const pageUrl = `${basePathPrefix}/${pagePath}${qs}`
 
         window.history.pushState({}, "", pageUrl)
       }
@@ -1307,8 +1311,8 @@ export class App extends PureComponent<Props, State> {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
       if (pageScriptHash != currentPageScriptHash) {
-        // clear query parameters within a page change
-        queryString = ""
+        // clear non-embed query parameters within a page change
+        queryString = parseEmbedUrlString()
         this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_QUERY_PARAM",
           queryParams: queryString,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -866,7 +866,7 @@ export class App extends PureComponent<Props, State> {
       // e.g. the case where the user clicks the back button.
       // See https://github.com/streamlit/streamlit/pull/6271#issuecomment-1465090690 for the discussion.
       if (prevPageName !== newPageName) {
-        // If embed params need to be changed, make sure to change to other parts of the code that reference parseEmbedUrlString
+        // If embed params need to be changed, make sure to change to other parts of the code that reference preserveEmbedQueryParams
         const queryString = preserveEmbedQueryParams()
         const qs = queryString ? `?${queryString}` : ""
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -866,6 +866,7 @@ export class App extends PureComponent<Props, State> {
       // e.g. the case where the user clicks the back button.
       // See https://github.com/streamlit/streamlit/pull/6271#issuecomment-1465090690 for the discussion.
       if (prevPageName !== newPageName) {
+        // If embed params need to be changed, make sure to change to other parts of the code that reference parseEmbedUrlString
         const queryString = parseEmbedUrlString()
         const qs = queryString ? `?${queryString}` : ""
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -124,7 +124,7 @@ import withScreencast, {
 
 // Used to import fonts + responsive reboot items
 import "@streamlit/app/src/assets/css/theme.scss"
-import { parseEmbedUrlString } from "@streamlit/lib/src/util/utils"
+import { preserveEmbedQueryParams } from "@streamlit/lib/src/util/utils"
 
 export interface Props {
   screenCast: ScreenCastHOC
@@ -867,7 +867,7 @@ export class App extends PureComponent<Props, State> {
       // See https://github.com/streamlit/streamlit/pull/6271#issuecomment-1465090690 for the discussion.
       if (prevPageName !== newPageName) {
         // If embed params need to be changed, make sure to change to other parts of the code that reference parseEmbedUrlString
-        const queryString = parseEmbedUrlString()
+        const queryString = preserveEmbedQueryParams()
         const qs = queryString ? `?${queryString}` : ""
 
         const basePathPrefix = basePath ? `/${basePath}` : ""
@@ -1313,7 +1313,7 @@ export class App extends PureComponent<Props, State> {
       // value in the BackMsg we send to the server.
       if (pageScriptHash != currentPageScriptHash) {
         // clear non-embed query parameters within a page change
-        queryString = parseEmbedUrlString()
+        queryString = preserveEmbedQueryParams()
         this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_QUERY_PARAM",
           queryParams: queryString,

--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -23,6 +23,7 @@ import {
   getLoadingScreenType,
   isEmbed,
   setCookie,
+  preserveEmbedQueryParams,
 } from "./utils"
 
 describe("getCookie", () => {
@@ -330,5 +331,48 @@ describe("getLoadingScreenType", () => {
     }))
 
     expect(getLoadingScreenType()).toBe(LoadingScreenType.V2)
+  })
+
+  describe("preserveEmbedQueryParams", () => {
+    let prevWindowLocation: Location
+    afterEach(() => {
+      window.location = prevWindowLocation
+    })
+
+    it("should return an empty string if not in embed mode", () => {
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = {
+        assign: jest.fn(),
+        search: "foo=bar",
+      }
+      expect(preserveEmbedQueryParams()).toBe("")
+    })
+
+    it("should preserve embed query string even with no embed options and remove foo=bar", () => {
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = {
+        assign: jest.fn(),
+        search: "embed=true&foo=bar",
+      }
+      expect(preserveEmbedQueryParams()).toBe("embed=true")
+    })
+
+    it("should preserve embed query string with embed options and remove foo=bar", () => {
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = {
+        assign: jest.fn(),
+        search:
+          "embed=true&embed_options=option1&embed_options=option2&foo=bar",
+      }
+      expect(preserveEmbedQueryParams()).toBe(
+        "embed=true&embed_options=option1&embed_options=option2"
+      )
+    })
   })
 })

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -109,15 +109,15 @@ export function preserveEmbedQueryParams(): string {
     return ""
   }
 
-  const embedValues = new URLSearchParams(window.location.search).getAll(
-    EMBED_OPTIONS_QUERY_PARAM_KEY
-  )
+  const embedOptionsValues = new URLSearchParams(
+    window.location.search
+  ).getAll(EMBED_OPTIONS_QUERY_PARAM_KEY)
 
   // instantiate multiple key values with an array of string pairs
   // https://stackoverflow.com/questions/72571132/urlsearchparams-with-multiple-values
   const embedUrlMap: string[][] = []
-  embedUrlMap.push([EMBED_QUERY_PARAM_KEY, "true"])
-  embedValues.forEach((embedValue: string) => {
+  embedUrlMap.push([EMBED_QUERY_PARAM_KEY, EMBED_TRUE])
+  embedOptionsValues.forEach((embedValue: string) => {
     embedUrlMap.push([EMBED_OPTIONS_QUERY_PARAM_KEY, embedValue])
   })
   return new URLSearchParams(embedUrlMap).toString()

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -112,6 +112,9 @@ export function parseEmbedUrlString(): string {
   const embedValues = new URLSearchParams(window.location.search).getAll(
     EMBED_OPTIONS_QUERY_PARAM_KEY
   )
+
+  // instantiate multiple key values with an array of string pairs
+  // https://stackoverflow.com/questions/72571132/urlsearchparams-with-multiple-values
   const embedUrlMap: string[][] = []
   embedUrlMap.push([EMBED_QUERY_PARAM_KEY, "true"])
   embedValues.forEach((embedValue: string) => {

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -99,6 +99,28 @@ export function getEmbedUrlParams(embedKey: string): Set<string> {
 }
 
 /**
+ * Returns "embed" and "embed_options" query param options in the url. Returns empty string if not embedded.
+ * Example:
+ *  returns "embed=true&embed_options=show_loading_screen_v2" if the url is
+ *  http://localhost:3000/test?embed=true&embed_options=show_loading_screen_v2
+ */
+export function parseEmbedUrlString(): string {
+  if (!isEmbed()) {
+    return ""
+  }
+
+  const embedValues = new URLSearchParams(window.location.search).getAll(
+    EMBED_OPTIONS_QUERY_PARAM_KEY
+  )
+  const map: Record<string, string> = {}
+  map[EMBED_QUERY_PARAM_KEY] = "true"
+  embedValues.forEach((embedValue: string) => {
+    map[EMBED_OPTIONS_QUERY_PARAM_KEY] = embedValue
+  })
+  return new URLSearchParams(map).toString()
+}
+
+/**
  * Returns true if the URL parameters contain ?embed=true (case insensitive).
  */
 export function isEmbed(): boolean {

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -112,12 +112,12 @@ export function parseEmbedUrlString(): string {
   const embedValues = new URLSearchParams(window.location.search).getAll(
     EMBED_OPTIONS_QUERY_PARAM_KEY
   )
-  const map: Record<string, string> = {}
-  map[EMBED_QUERY_PARAM_KEY] = "true"
+  const embedUrlMap: string[][] = []
+  embedUrlMap.push([EMBED_QUERY_PARAM_KEY, "true"])
   embedValues.forEach((embedValue: string) => {
-    map[EMBED_OPTIONS_QUERY_PARAM_KEY] = embedValue
+    embedUrlMap.push([EMBED_OPTIONS_QUERY_PARAM_KEY, embedValue])
   })
-  return new URLSearchParams(map).toString()
+  return new URLSearchParams(embedUrlMap).toString()
 }
 
 /**

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -104,7 +104,7 @@ export function getEmbedUrlParams(embedKey: string): Set<string> {
  *  returns "embed=true&embed_options=show_loading_screen_v2" if the url is
  *  http://localhost:3000/test?embed=true&embed_options=show_loading_screen_v2
  */
-export function parseEmbedUrlString(): string {
+export function preserveEmbedQueryParams(): string {
   if (!isEmbed()) {
     return ""
   }

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -128,7 +128,7 @@ def switch_page(page: str) -> NoReturn:  # type: ignore[misc]
 
     ctx.script_requests.request_rerun(
         RerunData(
-            query_string="",
+            query_string=ctx.query_string,
             page_script_hash=matched_pages[0]["page_script_hash"],
         )
     )

--- a/lib/streamlit/commands/experimental_query_params.py
+++ b/lib/streamlit/commands/experimental_query_params.py
@@ -16,14 +16,15 @@ import urllib.parse as parse
 from typing import Any, Dict, List, Union
 
 from streamlit import util
+from streamlit.constants import (
+    EMBED_OPTIONS_QUERY_PARAM,
+    EMBED_QUERY_PARAM,
+    EMBED_QUERY_PARAMS_KEYS,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
-
-EMBED_QUERY_PARAM = "embed"
-EMBED_OPTIONS_QUERY_PARAM = "embed_options"
-EMBED_QUERY_PARAMS_KEYS = [EMBED_QUERY_PARAM, EMBED_OPTIONS_QUERY_PARAM]
 
 
 @gather_metrics("experimental_get_query_params")

--- a/lib/streamlit/constants.py
+++ b/lib/streamlit/constants.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EMBED_QUERY_PARAM = "embed"
+EMBED_OPTIONS_QUERY_PARAM = "embed_options"
+EMBED_QUERY_PARAMS_KEYS = [EMBED_QUERY_PARAM, EMBED_OPTIONS_QUERY_PARAM]

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -52,18 +52,17 @@ class QueryParams(MutableMapping[str, str]):
                 EMBED_QUERY_PARAMS_KEYS,
             )
 
-            if key not in EMBED_QUERY_PARAMS_KEYS:
-                value = self._query_params[key]
-                if isinstance(value, list):
-                    if len(value) == 0:
-                        return ""
-                    else:
-                        # Return the last value to mimic Tornado's behavior
-                        # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_query_argument
-                        return value[-1]
-                return value
-            else:
+            if key in EMBED_QUERY_PARAMS_KEYS:
                 raise KeyError(missing_key_error_message(key))
+            value = self._query_params[key]
+            if isinstance(value, list):
+                if len(value) == 0:
+                    return ""
+                else:
+                    # Return the last value to mimic Tornado's behavior
+                    # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_query_argument
+                    return value[-1]
+            return value
         except KeyError:
             raise KeyError(missing_key_error_message(key))
 
@@ -94,8 +93,9 @@ class QueryParams(MutableMapping[str, str]):
                 EMBED_QUERY_PARAMS_KEYS,
             )
 
-            if key not in EMBED_QUERY_PARAMS_KEYS:
-                del self._query_params[key]
+            if key in EMBED_QUERY_PARAMS_KEYS:
+                raise KeyError(missing_key_error_message(key))
+            del self._query_params[key]
             self._send_query_param_msg()
         except KeyError:
             raise KeyError(missing_key_error_message(key))

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -96,7 +96,6 @@ class QueryParams(MutableMapping[str, str]):
 
     def _send_query_param_msg(self) -> None:
         # Avoid circular imports
-        from streamlit.commands.experimental_query_params import _ensure_no_embed_params
         from streamlit.runtime.scriptrunner import get_script_run_ctx
 
         ctx = get_script_run_ctx()
@@ -112,6 +111,7 @@ class QueryParams(MutableMapping[str, str]):
         ctx.enqueue(msg)
 
     def clear(self) -> None:
+        # Avoid circular imports
         from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
 
         new_query_params = {}
@@ -127,7 +127,7 @@ class QueryParams(MutableMapping[str, str]):
         from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
 
         self._ensure_single_query_api_used()
-        # return the last query param if multiple keys are set
+        # return the last query param if multiple values are set
         return {
             key: self[key]
             for key in self._query_params

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Iterable, Iterator, List, MutableMapping, Union
 from urllib import parse
 
+from streamlit.constants import EMBED_QUERY_PARAMS_KEYS
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 
@@ -31,9 +32,6 @@ class QueryParams(MutableMapping[str, str]):
     def __iter__(self) -> Iterator[str]:
         self._ensure_single_query_api_used()
 
-        # Avoid circular imports
-        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
-
         return iter(
             key
             for key in self._query_params.keys()
@@ -47,11 +45,6 @@ class QueryParams(MutableMapping[str, str]):
         """
         self._ensure_single_query_api_used()
         try:
-            # Avoid circular imports
-            from streamlit.commands.experimental_query_params import (
-                EMBED_QUERY_PARAMS_KEYS,
-            )
-
             if key in EMBED_QUERY_PARAMS_KEYS:
                 raise KeyError(missing_key_error_message(key))
             value = self._query_params[key]
@@ -71,8 +64,6 @@ class QueryParams(MutableMapping[str, str]):
             raise StreamlitAPIException(
                 f"You cannot set a query params key `{key}` to a dictionary."
             )
-        # Avoid circular imports
-        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
 
         if key in EMBED_QUERY_PARAMS_KEYS:
             raise StreamlitAPIException(
@@ -88,11 +79,6 @@ class QueryParams(MutableMapping[str, str]):
 
     def __delitem__(self, key: str) -> None:
         try:
-            # Avoid circular imports
-            from streamlit.commands.experimental_query_params import (
-                EMBED_QUERY_PARAMS_KEYS,
-            )
-
             if key in EMBED_QUERY_PARAMS_KEYS:
                 raise KeyError(missing_key_error_message(key))
             del self._query_params[key]
@@ -101,9 +87,6 @@ class QueryParams(MutableMapping[str, str]):
             raise KeyError(missing_key_error_message(key))
 
     def get_all(self, key: str) -> List[str]:
-        # Avoid circular imports
-        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
-
         self._ensure_single_query_api_used()
         if key not in self._query_params or key in EMBED_QUERY_PARAMS_KEYS:
             return []
@@ -112,9 +95,6 @@ class QueryParams(MutableMapping[str, str]):
 
     def __len__(self) -> int:
         self._ensure_single_query_api_used()
-        # Avoid circular imports
-        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
-
         return len(
             {key for key in self._query_params if key not in EMBED_QUERY_PARAMS_KEYS}
         )
@@ -136,9 +116,6 @@ class QueryParams(MutableMapping[str, str]):
         ctx.enqueue(msg)
 
     def clear(self) -> None:
-        # Avoid circular imports
-        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
-
         new_query_params = {}
         for key, value in self._query_params.items():
             if key in EMBED_QUERY_PARAMS_KEYS:
@@ -148,9 +125,6 @@ class QueryParams(MutableMapping[str, str]):
         self._send_query_param_msg()
 
     def to_dict(self) -> Dict[str, str]:
-        # Avoid circular imports
-        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
-
         self._ensure_single_query_api_used()
         # return the last query param if multiple values are set
         return {

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, Iterator, List, MutableMapping, Union
+from urllib import parse
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
@@ -55,12 +56,23 @@ class QueryParams(MutableMapping[str, str]):
             raise StreamlitAPIException(
                 f"You cannot set a query params key `{key}` to a dictionary."
             )
+        # Avoid circular imports
+        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
 
         # Type checking users should handle the string serialization themselves
         # We will accept any type for the list and serialize to str just in case
         if isinstance(value, Iterable) and not isinstance(value, str):
+            for item in value:
+                if item in EMBED_QUERY_PARAMS_KEYS:
+                    raise StreamlitAPIException(
+                        "Query param embed and embed_options (case-insensitive) cannot be set programmatically."
+                    )
             self._query_params[key] = [str(item) for item in value]
         else:
+            if key in EMBED_QUERY_PARAMS_KEYS:
+                raise StreamlitAPIException(
+                    "Query param embed and embed_options (case-insensitive) cannot be set programmatically."
+                )
             self._query_params[key] = str(value)
         self._send_query_param_msg()
 
@@ -93,27 +105,36 @@ class QueryParams(MutableMapping[str, str]):
         self._ensure_single_query_api_used()
 
         msg = ForwardMsg()
-        msg.page_info_changed.query_string = _ensure_no_embed_params(
-            self._query_params, ctx.query_string
+        msg.page_info_changed.query_string = parse.urlencode(
+            self._query_params, doseq=True
         )
         ctx.query_string = msg.page_info_changed.query_string
         ctx.enqueue(msg)
 
     def clear(self) -> None:
-        self._query_params.clear()
+        from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
+
+        new_query_params = {}
+        for key, value in self._query_params.items():
+            if key in EMBED_QUERY_PARAMS_KEYS:
+                new_query_params[key] = value
+        self._query_params = new_query_params
+
         self._send_query_param_msg()
 
     def to_dict(self) -> Dict[str, str]:
-        self._ensure_single_query_api_used()
-        # return the last query param if multiple keys are set
-        return {key: self[key] for key in self._query_params}
-
-    def set_with_no_forward_msg(self, key: str, val: Union[List[str], str]) -> None:
         # Avoid circular imports
         from streamlit.commands.experimental_query_params import EMBED_QUERY_PARAMS_KEYS
 
-        if key.lower() in EMBED_QUERY_PARAMS_KEYS:
-            return
+        self._ensure_single_query_api_used()
+        # return the last query param if multiple keys are set
+        return {
+            key: self[key]
+            for key in self._query_params
+            if key not in EMBED_QUERY_PARAMS_KEYS
+        }
+
+    def set_with_no_forward_msg(self, key: str, val: Union[List[str], str]) -> None:
         self._query_params[key] = val
 
     def clear_with_no_forward_msg(self) -> None:

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -145,9 +145,10 @@ class QueryParamsMethodTests(DeltaGeneratorTestCase):
             del self.query_params["embed"]
         assert "embed" in self.query_params._query_params
 
-    def test__delitem__does_nothing_for_embed_options_key(self):
+    def test__delitem__throws_KeyErrorException_for_embed_options_key(self):
         self.query_params._query_params = self.query_params_dict_with_embed_key
-        del self.query_params["embed_options"]
+        with pytest.raises(KeyError):
+            del self.query_params["embed_options"]
         assert "embed_options" in self.query_params._query_params
 
     def test_get_all_returns_empty_list_for_nonexistent_key(self):

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -20,10 +20,33 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
 class QueryParamsMethodTests(DeltaGeneratorTestCase):
+    query_params_dict_with_embed_key = {
+        "foo": "bar",
+        "two": ["x", "y"],
+        "embed": "true",
+        "embed_options": "disable_scrolling",
+    }
+
     def setUp(self):
         super().setUp()
         self.query_params = QueryParams()
         self.query_params._query_params = {"foo": "bar", "two": ["x", "y"]}
+
+    def test__iter__doesnt_include_embed_keys(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        for key in self.query_params.__iter__():
+            if key == "embed" or key == "embed_options":
+                raise KeyError("Cannot iterate through embed or embed_options key")
+
+    def test__getitem__raises_KeyError_for_nonexistent_key_for_embed(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        with pytest.raises(KeyError):
+            self.query_params["embed"]
+
+    def test__getitem__raises_KeyError_for_nonexistent_key_for_embed_options(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        with pytest.raises(KeyError):
+            self.query_params["embed_options"]
 
     def test__getitem__raises_KeyError_for_nonexistent_key(self):
         with pytest.raises(KeyError):
@@ -97,6 +120,14 @@ class QueryParamsMethodTests(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             self.query_params["embed_options"] = "show_toolbar"
 
+    def test__setitem__raises_error_with_embed_key(self):
+        with pytest.raises(StreamlitAPIException):
+            self.query_params["embed"] = "true"
+
+    def test__setitem__raises_error_with_embed_options_key(self):
+        with pytest.raises(StreamlitAPIException):
+            self.query_params["embed_options"] = "disable_scrolling"
+
     def test__delitem__removes_existing_key(self):
         del self.query_params["foo"]
         assert "foo" not in self.query_params
@@ -107,6 +138,16 @@ class QueryParamsMethodTests(DeltaGeneratorTestCase):
     def test__delitem__raises_error_for_nonexistent_key(self):
         with pytest.raises(KeyError):
             del self.query_params["nonexistent"]
+
+    def test__delitem__does_nothing_for_embed_key(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        del self.query_params["embed"]
+        assert "embed" in self.query_params._query_params
+
+    def test__delitem__does_nothing_for_embed_options_key(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        del self.query_params["embed_options"]
+        assert "embed_options" in self.query_params._query_params
 
     def test_get_all_returns_empty_list_for_nonexistent_key(self):
         assert self.query_params.get_all("nonexistent") == []
@@ -120,6 +161,18 @@ class QueryParamsMethodTests(DeltaGeneratorTestCase):
     def test_get_all_handles_mixed_type_values(self):
         self.query_params["test"] = ["", "a", 1, 1.23]
         assert self.query_params.get_all("test") == ["", "a", "1", "1.23"]
+
+    def test_get_all_returns_empty_array_for_embed_key(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        assert self.query_params.get_all("embed") == []
+
+    def test_get_all_returns_empty_array_for_embed_options_key(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        assert self.query_params.get_all("embed_options") == []
+
+    def test__len__doesnt_include_embed_and_embed_options_key(self):
+        self.query_params._query_params = self.query_params_dict_with_embed_key
+        assert len(self.query_params) == 2
 
     def test_clear_removes_all_query_params(self):
         self.query_params.clear()

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -139,9 +139,10 @@ class QueryParamsMethodTests(DeltaGeneratorTestCase):
         with pytest.raises(KeyError):
             del self.query_params["nonexistent"]
 
-    def test__delitem__does_nothing_for_embed_key(self):
+    def test__delitem__throws_KeyErrorException_for_embed_key(self):
         self.query_params._query_params = self.query_params_dict_with_embed_key
-        del self.query_params["embed"]
+        with pytest.raises(KeyError):
+            del self.query_params["embed"]
         assert "embed" in self.query_params._query_params
 
     def test__delitem__does_nothing_for_embed_options_key(self):


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- Parse `embed` and `embed_options` query params and keep them within the rerun string
- Make sure that we don't mess with `embed` and `embed_options` keys within `st.query_params` in all of the query param functions

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
  - added python tests
  - added typescript tests
- E2E Tests
  - added e2e test that makes sure embed and embed_options persist
- Any manual testing needed?
  - https://new-query-params-api-demo.streamlit.app/ExperimentalQueryParams?show_map=True&selected=asia&selected=america

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
