### PR TITLE
Make Snowpark dependency truly optional for SnowflakeConnection

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -52,11 +52,14 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
     def _connect(self, **kwargs) -> "InternalSnowflakeConnection":
         import snowflake.connector  # type:ignore[import]
         from snowflake.connector import Error as SnowflakeError  # type:ignore[import]
-        from snowflake.snowpark.context import get_active_session  # type:ignore[import]
 
         # If we're running in SiS, just call get_active_session() and retrieve the
         # lower-level connection from it.
         if running_in_sis():
+            from snowflake.snowpark.context import (  # type:ignore[import]  # isort: skip
+                get_active_session,
+            )
+
             session = get_active_session()
 
             if hasattr(session, "connection"):

--- a/lib/streamlit/connections/util.py
+++ b/lib/streamlit/connections/util.py
@@ -81,8 +81,11 @@ def load_from_snowsql_config_file(connection_name: str) -> Dict[str, Any]:
 
 def running_in_sis() -> bool:
     """Return whether this app is running in SiS."""
-    from snowflake.snowpark._internal.utils import (  # type: ignore[import]  # isort: skip
-        is_in_stored_procedure,
-    )
+    try:
+        from snowflake.snowpark._internal.utils import (  # type: ignore[import]  # isort: skip
+            is_in_stored_procedure,
+        )
 
-    return cast(bool, is_in_stored_procedure())
+        return cast(bool, is_in_stored_procedure())
+    except ModuleNotFoundError:
+        return False

--- a/lib/tests/streamlit/connections/util_test.py
+++ b/lib/tests/streamlit/connections/util_test.py
@@ -36,7 +36,6 @@ class ConnectionUtilTest(unittest.TestCase):
         assert extracted == {"k1": "v1", "k2": "v2"}
         assert d == {"k3": "v3", "k4": "v4"}
 
-    @pytest.mark.require_snowflake
     def test_not_running_in_sis(self):
         assert not running_in_sis()
 
@@ -47,6 +46,14 @@ class ConnectionUtilTest(unittest.TestCase):
     )
     def test_running_in_sis(self):
         assert running_in_sis()
+
+    @pytest.mark.require_snowflake
+    @patch(
+        "snowflake.snowpark._internal.utils.is_in_stored_procedure",
+        MagicMock(side_effect=ModuleNotFoundError("oh no")),
+    )
+    def test_running_in_sis_module_not_found_error(self):
+        assert not running_in_sis()
 
     def test_load_from_snowsql_config_file_no_file(self):
         assert load_from_snowsql_config_file("my_snowpark_connection") == {}


### PR DESCRIPTION
There's currently a bug in `SnowflakeConnection` where we attempt to import `snowflake.snowpark` on
connect, which blows up when `snowflake-snowpark-python`, which should be optional for use of this
connection, isn't installed. This PR fixes this by moving some imports and handling `ModuleNotFoundError`s
in the `running_in_sis` helper function. 