### PR TITLE
Fix embed query params flakiness e2e test

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -187,7 +187,7 @@ def test_removes_non_embed_query_params_when_swapping_pages(page: Page, app_port
     wait_for_app_loaded(page)
 
     page.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
-    wait_for_app_run(page)
+    wait_for_app_loaded(page)
 
     assert (
         page.url

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -173,7 +173,7 @@ def test_removes_query_params_when_swapping_pages(page: Page, app_port: int):
     wait_for_app_loaded(page)
 
     page.get_by_test_id("stSidebarNav").locator("a").nth(2).click()
-    wait_for_app_run(page)
+    wait_for_app_loaded(page)
 
     assert page.url == f"http://localhost:{app_port}/page3"
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
- I wait for app page run but it's better to wait for the app page to load since we are swapping pages
## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
