### PR TITLE
Lower number of cypress workers

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,7 @@ jobs:
         # Be aware that specs should be sequential integers starting from 1 without gaps
         # based on logic in "Cypress Tests" step.
         # prettier-ignore
-        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
+        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
 
     steps:
       - name: Checkout Streamlit code
@@ -75,7 +75,7 @@ jobs:
         env:
           CURRENT_RUN: ${{matrix.specs}}
           CYPRESS_VERIFY_TIMEOUT: 90000
-          TOTAL_WORKERS: 16
+          TOTAL_WORKERS: 12
         run: |
           js_specs=(e2e/specs/*)
 


### PR DESCRIPTION
## Describe your changes

We have migrated a bunch of cypress e2e tests to Playwright in the last weeks. Therefore, we can also lower the number of workers a bit.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
