### PR TITLE
Prevent CacheKeyNotFoundError printouts when exception raised

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -264,7 +264,8 @@ class CachedFunc:
             cached_result = cache.read_result(value_key)
             return self._handle_cache_hit(cached_result)
         except CacheKeyNotFoundError:
-            return self._handle_cache_miss(cache, value_key, func_args, func_kwargs)
+            pass
+        return self._handle_cache_miss(cache, value_key, func_args, func_kwargs)
 
     def _handle_cache_hit(self, result: CachedResult) -> Any:
         """Handle a cache hit: replay the result's cached messages, and return its value."""
@@ -314,35 +315,37 @@ class CachedFunc:
                 return self._handle_cache_hit(cached_result)
 
             except CacheKeyNotFoundError:
-                # We acquired the lock before any other thread. Compute the value!
-                with self._info.cached_message_replay_ctx.calling_cached_function(
-                    self._info.func, self._info.allow_widgets
-                ):
-                    computed_value = self._info.func(*func_args, **func_kwargs)
+                pass
 
-                # We've computed our value, and now we need to write it back to the cache
-                # along with any "replay messages" that were generated during value computation.
-                messages = self._info.cached_message_replay_ctx._most_recent_messages
-                try:
-                    cache.write_result(value_key, computed_value, messages)
-                    return computed_value
-                except (CacheError, RuntimeError):
-                    # An exception was thrown while we tried to write to the cache. Report it to the user.
-                    # (We catch `RuntimeError` here because it will be raised by Apache Spark if we do not
-                    # collect dataframe before using `st.cache_data`.)
-                    if True in [
-                        type_util.is_type(computed_value, type_name)
-                        for type_name in UNEVALUATED_DATAFRAME_TYPES
-                    ]:
-                        raise UnevaluatedDataFrameError(
-                            f"""
-                            The function {get_cached_func_name_md(self._info.func)} is decorated with `st.cache_data` but it returns an unevaluated dataframe
-                            of type `{type_util.get_fqn_type(computed_value)}`. Please call `collect()` or `to_pandas()` on the dataframe before returning it,
-                            so `st.cache_data` can serialize and cache it."""
-                        )
-                    raise UnserializableReturnValueError(
-                        return_value=computed_value, func=self._info.func
+            # We acquired the lock before any other thread. Compute the value!
+            with self._info.cached_message_replay_ctx.calling_cached_function(
+                self._info.func, self._info.allow_widgets
+            ):
+                computed_value = self._info.func(*func_args, **func_kwargs)
+
+            # We've computed our value, and now we need to write it back to the cache
+            # along with any "replay messages" that were generated during value computation.
+            messages = self._info.cached_message_replay_ctx._most_recent_messages
+            try:
+                cache.write_result(value_key, computed_value, messages)
+                return computed_value
+            except (CacheError, RuntimeError):
+                # An exception was thrown while we tried to write to the cache. Report it to the user.
+                # (We catch `RuntimeError` here because it will be raised by Apache Spark if we do not
+                # collect dataframe before using `st.cache_data`.)
+                if True in [
+                    type_util.is_type(computed_value, type_name)
+                    for type_name in UNEVALUATED_DATAFRAME_TYPES
+                ]:
+                    raise UnevaluatedDataFrameError(
+                        f"""
+                        The function {get_cached_func_name_md(self._info.func)} is decorated with `st.cache_data` but it returns an unevaluated dataframe
+                        of type `{type_util.get_fqn_type(computed_value)}`. Please call `collect()` or `to_pandas()` on the dataframe before returning it,
+                        so `st.cache_data` can serialize and cache it."""
                     )
+                raise UnserializableReturnValueError(
+                    return_value=computed_value, func=self._info.func
+                )
 
     def clear(self):
         """Clear the wrapped function's associated cache."""


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Previously, since the re-computation of cached values happened inside the except: block, any exception raised by the wrapped function would get printed by Python along with the CacheKeyNotFoundError message. This would get repeated several times in the case of nested cache functions.

This adds a lot of error noise and seems unnecessary, so this PR moves the re-computation outside the except block so that only the actual exception from user code is printed.

```
Traceback (most recent call last):
  File ".../site-packages/streamlit/runtime/caching/cache_utils.py", line 312, in _handle_cache_miss
    cached_result = cache.read_result(value_key)
  File ".../site-packages/streamlit/runtime/caching/cache_resource_api.py", line 500, in read_result
    raise CacheKeyNotFoundError()
streamlit.runtime.caching.cache_errors.CacheKeyNotFoundError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../site-packages/streamlit/runtime/caching/cache_utils.py", line 312, in _handle_cache_miss
    cached_result = cache.read_result(value_key)
  File ".../site-packages/streamlit/runtime/caching/cache_resource_api.py", line 500, in read_result
    raise CacheKeyNotFoundError()
streamlit.runtime.caching.cache_errors.CacheKeyNotFoundError

During handling of the above exception, another exception occurred:

...
```

This change won't actually change runtime behavior at all, since the relevant try: blocks end with return statements, so putting code in the except block is the same as putting "pass" there and placing the code after.

## GitHub Issue Link (if applicable)

## Testing Plan

Existing tests of cache decorators should suffice to make sure that this doesn't break existing users.

I'm not aware of an easy way to validate the actual behavior change here, since it's primarily observable by the printouts to stdout.

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
