### PR TITLE
Don't pass query parameters from parent page into iframes

### DIFF
--- a/e2e_playwright/st_components_v1.py
+++ b/e2e_playwright/st_components_v1.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import streamlit as st
 import streamlit.components.v1 as components
 
 html = r"<h1>Hello, Streamlit!</h1>"
@@ -19,6 +20,10 @@ components.html(html, width=200, height=500, scrolling=False)
 
 src = "http://not.a.real.url"
 components.iframe(src, width=200, height=500, scrolling=True)
+
+# Set a query parameter to ensure that it doesn't affect the path of the custom component,
+# since that would trigger a reload if the query param changes
+st.query_params["hello"] = "world"
 
 url = "http://not.a.real.url"
 test_component = components.declare_component("test_component", url=url)

--- a/e2e_playwright/st_components_v1_test.py
+++ b/e2e_playwright/st_components_v1_test.py
@@ -63,5 +63,7 @@ def test_declare_component_correctly_sets_attr(app: Page):
     )
     expect(declare_component).to_have_attribute(
         "src",
-        re.compile(r"http://not.a.real.url\?streamlitUrl=http%3A%2F%2Flocalhost.*"),
+        re.compile(
+            r"http://not.a.real.url\?streamlitUrl=http%3A%2F%2Flocalhost%3A\d*%2F$"
+        ),
     )

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -374,10 +374,13 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
         src = this.props.registry.getComponentURL(componentName, "index.html")
       }
 
+      // Create a URL object from window.location
+      const currentUrl = new URL(window.location.href)
+
       // Add streamlitUrl query parameter to src.
       src = queryString.stringifyUrl({
         url: src,
-        query: { streamlitUrl: window.location.href },
+        query: { streamlitUrl: currentUrl.origin + currentUrl.pathname },
       })
 
       // Parse arguments. Our JSON arguments are just stored in a JSON string.


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Streamlit passes the URL of the current app into custom components using the `streamlitUrl` query parameter. This is used by several custom components. Unfortunately, it _also_ means that any change to st.query_params will cause the component to reload.

This change resolves that by passing only the origin and pathname in `streamlitUrl`, and excluding the query parameters or fragment identifier.

## GitHub Issue Link (if applicable)

Resolves #7503

## Testing Plan

Existing E2E test updated

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
