### PR TITLE
Convert ThemedApp to React Testing Library

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -66,6 +66,7 @@
     "@testing-library/dom": "^8.19.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.4",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/enzyme": "^3.10.12",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^27.4.3",

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -82,7 +82,6 @@ import {
   ForwardMsgMetadata,
   GitInfo,
   IAppPage,
-  ICustomThemeConfig,
   IGitInfo,
   Initialize,
   NewSession,
@@ -125,16 +124,11 @@ import withScreencast, {
 // Used to import fonts + responsive reboot items
 import "@streamlit/app/src/assets/css/theme.scss"
 import { preserveEmbedQueryParams } from "@streamlit/lib/src/util/utils"
+import { ThemeManager } from "./util/useThemeManager"
 
 export interface Props {
   screenCast: ScreenCastHOC
-  theme: {
-    activeTheme: ThemeConfig
-    availableThemes: ThemeConfig[]
-    setTheme: (theme: ThemeConfig) => void
-    addThemes: (themes: ThemeConfig[]) => void
-    setImportedTheme: (themeInfo: ICustomThemeConfig) => void
-  }
+  theme: ThemeManager
 }
 
 interface State {

--- a/frontend/app/src/ThemedApp.test.tsx
+++ b/frontend/app/src/ThemedApp.test.tsx
@@ -15,41 +15,9 @@
  */
 
 import React from "react"
-
-import {
-  LocalStore,
-  shallow,
-  mount,
-  AUTO_THEME_NAME,
-  CUSTOM_THEME_NAME,
-  createPresetThemes,
-  darkTheme,
-  setCachedTheme,
-  ThemeConfig,
-} from "@streamlit/lib"
-import { ThemeProvider as BaseUIThemeProvider } from "baseui"
-
-import AppWithScreencast from "./App"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
 import ThemedApp from "./ThemedApp"
-import { act } from "react-dom/test-utils"
-import FontFaceDeclaration from "@streamlit/app/src/components/FontFaceDeclaration"
-
-const mockCustomThemeConfig = {
-  primaryColor: "#1A6CE7",
-  backgroundColor: "#FFFFFF",
-  secondaryBackgroundColor: "#F5F5F5",
-  textColor: "#1A1D21",
-  widgetBackgroundColor: "#FFFFFF",
-  widgetBorderColor: "#D3DAE8",
-  skeletonBackgroundColor: "#CCDDEE",
-  fontFaces: [
-    {
-      family: "Inter",
-      url: "https://rsms.me/inter/font-files/Inter-Regular.woff2?v=3.19",
-      weight: 400,
-    },
-  ],
-}
 
 jest.mock("@streamlit/app/src/connection/ConnectionManager")
 
@@ -82,120 +50,16 @@ describe("ThemedApp", () => {
     })
   })
 
-  afterEach(() => {
-    window.localStorage.clear()
-  })
-
   it("renders without crashing", () => {
-    const wrapper = mount(<ThemedApp />)
+    render(<ThemedApp />)
 
-    expect(wrapper.html()).not.toBeNull()
-  })
-
-  it("only renders a single instance of BaseWeb <ThemeProvider>", () => {
-    const wrapper = mount(<ThemedApp />)
-    expect(wrapper.find(BaseUIThemeProvider)).toHaveLength(1)
-  })
-
-  it("updates the theme", () => {
-    const wrapper = shallow(<ThemedApp />)
-    wrapper.find(AppWithScreencast).props().theme.setTheme(darkTheme)
-    const updatedTheme: ThemeConfig = wrapper.find(AppWithScreencast).props()
-      .theme.activeTheme
-    expect(updatedTheme.name).toBe("Dark")
-    const updatedLocalStorage = JSON.parse(
-      window.localStorage.getItem(LocalStore.ACTIVE_THEME) || ""
-    )
-    expect(updatedLocalStorage.name).toBe("Dark")
-  })
-
-  it("does not save Auto theme", () => {
-    const wrapper = shallow(<ThemedApp />)
-    wrapper.find(AppWithScreencast).props().theme.setTheme(darkTheme)
-
-    wrapper
-      .find(AppWithScreencast)
-      .props()
-      .theme.setTheme({
-        ...darkTheme,
-        name: AUTO_THEME_NAME,
-      })
-    const updatedLocalStorage = window.localStorage.getItem(
-      LocalStore.ACTIVE_THEME
-    )
-    expect(updatedLocalStorage).toBe(null)
-  })
-
-  it("updates availableThemes", () => {
-    const wrapper = shallow(<ThemedApp />)
-    const app = wrapper.find(AppWithScreencast)
-    const initialThemes = app.props().theme.availableThemes
-
-    app.props().theme.addThemes([darkTheme])
-    app.props().theme.addThemes([darkTheme])
-
-    wrapper.update()
-    const newThemes = wrapper.find(AppWithScreencast).props()
-      .theme.availableThemes
-
-    // Should only have added one theme despite multiple calls adding themes.
-    expect(newThemes.length).toBe(initialThemes.length + 1)
-  })
-
-  it("sets the cached theme as the default theme if one is set", () => {
-    setCachedTheme(darkTheme)
-
-    const wrapper = shallow(<ThemedApp />)
-    const app = wrapper.find(AppWithScreencast)
-    const { activeTheme, availableThemes } = app.props().theme
-
-    expect(activeTheme.name).toBe(darkTheme.name)
-    expect(availableThemes.length).toBe(createPresetThemes().length)
-  })
-
-  it("includes a custom theme as an available theme if one is cached", () => {
-    setCachedTheme({
-      ...darkTheme,
-      name: CUSTOM_THEME_NAME,
-    })
-
-    const wrapper = shallow(<ThemedApp />)
-    const app = wrapper.find(AppWithScreencast)
-    const { activeTheme, availableThemes } = app.props().theme
-
-    expect(activeTheme.name).toBe(CUSTOM_THEME_NAME)
-    expect(availableThemes.length).toBe(createPresetThemes().length + 1)
+    expect(screen.getByTestId("stApp")).toBeInTheDocument()
   })
 
   it("contains the overlay portal required by the interactive table", () => {
-    const wrapper = mount(<ThemedApp />)
-    expect(wrapper.find("div#portal")).toHaveLength(1)
-  })
+    render(<ThemedApp />)
 
-  it("handles custom theme sent from Host", () => {
-    const wrapper = mount(<ThemedApp />)
-
-    let fontFaceComponent = wrapper.find(FontFaceDeclaration)
-    expect(fontFaceComponent.exists()).toBe(false)
-
-    const props = wrapper.find(AppWithScreencast).props()
-    act(() => {
-      props.theme.setImportedTheme(mockCustomThemeConfig)
-    })
-
-    wrapper.update()
-
-    const updatedTheme: ThemeConfig = wrapper.find(AppWithScreencast).props()
-      .theme.activeTheme
-    expect(updatedTheme.name).toBe(CUSTOM_THEME_NAME)
-    expect(updatedTheme.emotion.genericColors.primary).toBe(
-      mockCustomThemeConfig.primaryColor
-    )
-
-    fontFaceComponent = wrapper.find(FontFaceDeclaration)
-    expect(fontFaceComponent.exists()).toBe(true)
-    expect(fontFaceComponent.props().fontFaces).toEqual(
-      mockCustomThemeConfig.fontFaces
-    )
+    expect(screen.getByTestId("portal")).toBeInTheDocument()
+    expect(screen.getByTestId("portal")).toBeInTheDocument()
   })
 })

--- a/frontend/app/src/ThemedApp.tsx
+++ b/frontend/app/src/ThemedApp.tsx
@@ -17,103 +17,24 @@
 import React from "react"
 
 import FontFaceDeclaration from "@streamlit/app/src/components/FontFaceDeclaration"
-import {
-  AUTO_THEME_NAME,
-  CUSTOM_THEME_NAME,
-  createAutoTheme,
-  createPresetThemes,
-  getDefaultTheme,
-  isPresetTheme,
-  removeCachedTheme,
-  setCachedTheme,
-  ThemeConfig,
-  createTheme,
-  CustomThemeConfig,
-  ICustomThemeConfig,
-  RootStyleProvider,
-} from "@streamlit/lib"
+import { CUSTOM_THEME_NAME, RootStyleProvider } from "@streamlit/lib"
 
 import AppWithScreencast from "./App"
 import { StyledDataFrameOverlay } from "@streamlit/app/src/styled-components"
+import { useThemeManager } from "./util/useThemeManager"
 
 const ThemedApp = (): JSX.Element => {
-  const defaultTheme = getDefaultTheme()
-
-  const [theme, setTheme] = React.useState<ThemeConfig>(defaultTheme)
-  const [fontFaces, setFontFaces] = React.useState<object[] | undefined>()
-  const [availableThemes, setAvailableThemes] = React.useState<ThemeConfig[]>([
-    ...createPresetThemes(),
-    ...(isPresetTheme(defaultTheme) ? [] : [defaultTheme]),
-  ])
-
-  const addThemes = (themeConfigs: ThemeConfig[]): void => {
-    setAvailableThemes([...createPresetThemes(), ...themeConfigs])
-  }
-
-  const updateTheme = React.useCallback(
-    (newTheme: ThemeConfig): void => {
-      if (newTheme !== theme) {
-        setTheme(newTheme)
-
-        // Only save to localStorage if it is not Auto since auto is the default.
-        // Important to not save since it can change depending on time of day.
-        if (newTheme.name === AUTO_THEME_NAME) {
-          removeCachedTheme()
-        } else {
-          setCachedTheme(newTheme)
-        }
-      }
-    },
-    [setTheme, theme]
-  )
-
-  const updateAutoTheme = React.useCallback((): void => {
-    if (theme.name === AUTO_THEME_NAME) {
-      updateTheme(createAutoTheme())
-    }
-    const constantThemes = availableThemes.filter(
-      theme => theme.name !== AUTO_THEME_NAME
-    )
-    setAvailableThemes([createAutoTheme(), ...constantThemes])
-  }, [theme.name, availableThemes, updateTheme])
-
-  const setImportedTheme = React.useCallback(
-    (themeInfo: ICustomThemeConfig): void => {
-      // If fonts are coming from a URL, they need to be imported through the FontFaceDeclaration
-      // component. So let's store them in state so we can pass them as props.
-      if (themeInfo.fontFaces) {
-        setFontFaces(themeInfo.fontFaces as object[] | undefined)
-      }
-
-      const themeConfigProto = new CustomThemeConfig(themeInfo)
-      const customTheme = createTheme(CUSTOM_THEME_NAME, themeConfigProto)
-      updateTheme(customTheme)
-    },
-    [setFontFaces, updateTheme]
-  )
-
-  React.useEffect(() => {
-    const mediaMatch = window.matchMedia("(prefers-color-scheme: dark)")
-    mediaMatch.addEventListener("change", updateAutoTheme)
-    return () => mediaMatch.removeEventListener("change", updateAutoTheme)
-  }, [theme, availableThemes, updateAutoTheme])
+  const [themeManager, fontFaces] = useThemeManager()
+  const { activeTheme } = themeManager
+  const hasCustomFonts =
+    activeTheme.name === CUSTOM_THEME_NAME && fontFaces.length > 0
 
   return (
-    <RootStyleProvider theme={theme}>
-      {theme.name === CUSTOM_THEME_NAME && fontFaces && (
-        <FontFaceDeclaration fontFaces={fontFaces} />
-      )}
-      <AppWithScreencast
-        theme={{
-          setTheme: updateTheme,
-          activeTheme: theme,
-          addThemes,
-          availableThemes,
-          setImportedTheme,
-        }}
-      />
+    <RootStyleProvider theme={activeTheme}>
+      {hasCustomFonts && <FontFaceDeclaration fontFaces={fontFaces} />}
+      <AppWithScreencast theme={themeManager} />
       {/* The data grid requires one root level portal element for rendering cell overlays */}
-      <StyledDataFrameOverlay id="portal" />
+      <StyledDataFrameOverlay id="portal" data-testid="portal" />
     </RootStyleProvider>
   )
 }

--- a/frontend/app/src/util/useThemeManager.test.ts
+++ b/frontend/app/src/util/useThemeManager.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import React from "react"
 import { renderHook, act } from "@testing-library/react-hooks"
 import {
   LocalStore,

--- a/frontend/app/src/util/useThemeManager.test.ts
+++ b/frontend/app/src/util/useThemeManager.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { renderHook, act } from "@testing-library/react-hooks"
+import {
+  LocalStore,
+  AUTO_THEME_NAME,
+  CUSTOM_THEME_NAME,
+  createPresetThemes,
+  darkTheme,
+  setCachedTheme,
+  ThemeConfig,
+} from "@streamlit/lib"
+import { useThemeManager } from "./useThemeManager"
+
+const mockCustomThemeConfig = {
+  primaryColor: "#1A6CE7",
+  backgroundColor: "#FFFFFF",
+  secondaryBackgroundColor: "#F5F5F5",
+  textColor: "#1A1D21",
+  widgetBackgroundColor: "#FFFFFF",
+  widgetBorderColor: "#D3DAE8",
+  skeletonBackgroundColor: "#CCDDEE",
+  fontFaces: [
+    {
+      family: "Inter",
+      url: "https://rsms.me/inter/font-files/Inter-Regular.woff2?v=3.19",
+      weight: 400,
+    },
+  ],
+}
+
+describe("useThemeManager", () => {
+  beforeEach(() => {
+    // sourced from:
+    // https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    })
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("updates the theme", () => {
+    const { result } = renderHook(() => useThemeManager())
+    const [themeManager] = result.current
+
+    act(() => {
+      themeManager.setTheme(darkTheme)
+    })
+
+    const [themeManager2] = result.current
+    const updatedTheme: ThemeConfig = themeManager2.activeTheme
+
+    expect(updatedTheme.name).toBe("Dark")
+
+    const updatedLocalStorage = JSON.parse(
+      window.localStorage.getItem(LocalStore.ACTIVE_THEME) || ""
+    )
+
+    expect(updatedLocalStorage.name).toBe("Dark")
+  })
+
+  it("does not save Auto theme", () => {
+    const { result } = renderHook(() => useThemeManager())
+    const [themeManager] = result.current
+
+    act(() => {
+      themeManager.setTheme(darkTheme)
+    })
+
+    const [themeManager2] = result.current
+
+    act(() => {
+      themeManager2.setTheme({
+        ...darkTheme,
+        name: AUTO_THEME_NAME,
+      })
+    })
+
+    const updatedLocalStorage = window.localStorage.getItem(
+      LocalStore.ACTIVE_THEME
+    )
+
+    expect(updatedLocalStorage).toBe(null)
+  })
+
+  it("updates availableThemes", () => {
+    const { result } = renderHook(() => useThemeManager())
+    const [themeManager] = result.current
+
+    const initialThemes = themeManager.availableThemes
+
+    act(() => {
+      themeManager.addThemes([darkTheme])
+      themeManager.addThemes([darkTheme])
+    })
+
+    const [themeManager2] = result.current
+    const newThemes = themeManager2.availableThemes
+
+    // Should only have added one theme despite multiple calls adding themes.
+    expect(newThemes.length).toBe(initialThemes.length + 1)
+  })
+
+  it("sets the cached theme as the default theme if one is set", () => {
+    setCachedTheme(darkTheme)
+
+    const { result } = renderHook(() => useThemeManager())
+    const [themeManager] = result.current
+    const { activeTheme, availableThemes } = themeManager
+
+    expect(activeTheme.name).toBe(darkTheme.name)
+    expect(availableThemes.length).toBe(createPresetThemes().length)
+  })
+
+  it("includes a custom theme as an available theme if one is cached", () => {
+    setCachedTheme({
+      ...darkTheme,
+      name: CUSTOM_THEME_NAME,
+    })
+
+    const { result } = renderHook(() => useThemeManager())
+    const [themeManager] = result.current
+    const { activeTheme, availableThemes } = themeManager
+
+    expect(activeTheme.name).toBe(CUSTOM_THEME_NAME)
+    expect(availableThemes.length).toBe(createPresetThemes().length + 1)
+  })
+
+  it("handles custom theme sent from Host", () => {
+    const { result } = renderHook(() => useThemeManager())
+    const [themeManager, fontFaces] = result.current
+
+    expect(fontFaces).toHaveLength(0)
+
+    act(() => {
+      themeManager.setImportedTheme(mockCustomThemeConfig)
+    })
+
+    const [themeManager2, fontFaces2] = result.current
+
+    const updatedTheme: ThemeConfig = themeManager2.activeTheme
+
+    expect(updatedTheme.name).toBe(CUSTOM_THEME_NAME)
+    expect(updatedTheme.emotion.genericColors.primary).toBe(
+      mockCustomThemeConfig.primaryColor
+    )
+
+    expect(fontFaces2).toHaveLength(1)
+    expect(fontFaces2).toEqual(mockCustomThemeConfig.fontFaces)
+  })
+})

--- a/frontend/app/src/util/useThemeManager.ts
+++ b/frontend/app/src/util/useThemeManager.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useState } from "react"
+import {
+  AUTO_THEME_NAME,
+  CUSTOM_THEME_NAME,
+  createAutoTheme,
+  createPresetThemes,
+  getDefaultTheme,
+  isPresetTheme,
+  removeCachedTheme,
+  setCachedTheme,
+  ThemeConfig,
+  createTheme,
+  CustomThemeConfig,
+  ICustomThemeConfig,
+} from "@streamlit/lib"
+
+export interface ThemeManager {
+  activeTheme: ThemeConfig
+  availableThemes: ThemeConfig[]
+  setTheme: (theme: ThemeConfig) => void
+  addThemes: (themes: ThemeConfig[]) => void
+  setImportedTheme: (themeInfo: ICustomThemeConfig) => void
+}
+
+export function useThemeManager(): [ThemeManager, object[]] {
+  const defaultTheme = getDefaultTheme()
+  const [theme, setTheme] = useState<ThemeConfig>(defaultTheme)
+  const [fontFaces, setFontFaces] = useState<object[]>([])
+  const [availableThemes, setAvailableThemes] = useState<ThemeConfig[]>([
+    ...createPresetThemes(),
+    ...(isPresetTheme(defaultTheme) ? [] : [defaultTheme]),
+  ])
+
+  const addThemes = (themeConfigs: ThemeConfig[]): void => {
+    setAvailableThemes([...createPresetThemes(), ...themeConfigs])
+  }
+
+  const updateTheme = useCallback(
+    (newTheme: ThemeConfig): void => {
+      if (newTheme !== theme) {
+        setTheme(newTheme)
+
+        // Only save to localStorage if it is not Auto since auto is the default.
+        // Important to not save since it can change depending on time of day.
+        if (newTheme.name === AUTO_THEME_NAME) {
+          removeCachedTheme()
+        } else {
+          setCachedTheme(newTheme)
+        }
+      }
+    },
+    [setTheme, theme]
+  )
+
+  const updateAutoTheme = useCallback((): void => {
+    if (theme.name === AUTO_THEME_NAME) {
+      updateTheme(createAutoTheme())
+    }
+    const constantThemes = availableThemes.filter(
+      theme => theme.name !== AUTO_THEME_NAME
+    )
+    setAvailableThemes([createAutoTheme(), ...constantThemes])
+  }, [theme.name, availableThemes, updateTheme])
+
+  const setImportedTheme = useCallback(
+    (themeInfo: ICustomThemeConfig): void => {
+      // If fonts are coming from a URL, they need to be imported through the FontFaceDeclaration
+      // component. So let's store them in state so we can pass them as props.
+      if (themeInfo.fontFaces) {
+        setFontFaces(themeInfo.fontFaces as object[])
+      }
+
+      const themeConfigProto = new CustomThemeConfig(themeInfo)
+      const customTheme = createTheme(CUSTOM_THEME_NAME, themeConfigProto)
+      updateTheme(customTheme)
+    },
+    [setFontFaces, updateTheme]
+  )
+
+  useEffect(() => {
+    const mediaMatch = window.matchMedia("(prefers-color-scheme: dark)")
+    mediaMatch.addEventListener("change", updateAutoTheme)
+    return () => mediaMatch.removeEventListener("change", updateAutoTheme)
+  }, [theme, availableThemes, updateAutoTheme])
+
+  return [
+    {
+      setTheme: updateTheme,
+      activeTheme: theme,
+      addThemes,
+      availableThemes,
+      setImportedTheme,
+    },
+    fontFaces,
+  ]
+}


### PR DESCRIPTION
## Describe your changes

Testing ThemedApp is difficult cause the calls occur directly on the internal functions. Convert the theme work to be a full hook and test the React hook

## Testing Plan

Tests are copied over and should pass. E2E will ensure most theming. If necessary, we can perform some manual testing to make sure the theme works as expected.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
