### PR TITLE
Fix tests related to deprecated config options

### DIFF
--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -441,15 +441,15 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(1234, config._maybe_read_env_variable("env:RANDOM_TEST"))
 
     def test_update_config_with_toml(self):
-        self.assertEqual(True, config.get_option("browser.gatherUsageStats"))
+        self.assertEqual(True, config.get_option("client.showErrorDetails"))
         toml = textwrap.dedent(
             """
-           [browser]
-           gatherUsageStats = false
+           [client]
+           showErrorDetails = false
         """
         )
         config._update_config_with_toml(toml, "test")
-        self.assertEqual(False, config.get_option("browser.gatherUsageStats"))
+        self.assertEqual(False, config.get_option("client.showErrorDetails"))
 
     def test_set_option(self):
         with self.assertLogs(logger="streamlit.config", level="WARNING") as cm:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -54,15 +54,15 @@ class ConfigTest(unittest.TestCase):
     def test_set_user_option_scriptable(self):
         """Test that scriptable options can be set from API."""
         # This is set in lib/tests/conftest.py to off
-        self.assertEqual(True, config.get_option("client.displayEnabled"))
+        self.assertEqual(True, config.get_option("client.showErrorDetails"))
 
         try:
-            # client.displayEnabled and client.caching can be set after run starts.
-            config.set_user_option("client.displayEnabled", False)
-            self.assertEqual(False, config.get_option("client.displayEnabled"))
+            # client.showErrorDetails can be set after run starts.
+            config.set_user_option("client.showErrorDetails", False)
+            self.assertEqual(False, config.get_option("client.showErrorDetails"))
         finally:
             # Restore original value
-            config.set_user_option("client.displayEnabled", True)
+            config.set_user_option("client.showErrorDetails", True)
 
     def test_set_user_option_unscriptable(self):
         """Test that unscriptable options cannot be set with st.set_option."""
@@ -441,15 +441,15 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(1234, config._maybe_read_env_variable("env:RANDOM_TEST"))
 
     def test_update_config_with_toml(self):
-        self.assertEqual(True, config.get_option("client.caching"))
+        self.assertEqual(True, config.get_option("browser.gatherUsageStats"))
         toml = textwrap.dedent(
             """
-           [client]
-           caching = false
+           [browser]
+           gatherUsageStats = false
         """
         )
         config._update_config_with_toml(toml, "test")
-        self.assertEqual(False, config.get_option("client.caching"))
+        self.assertEqual(False, config.get_option("browser.gatherUsageStats"))
 
     def test_set_option(self):
         with self.assertLogs(logger="streamlit.config", level="WARNING") as cm:
@@ -460,8 +460,8 @@ class ConfigTest(unittest.TestCase):
             cm.output[0],
         )
 
-        config._set_option("client.caching", "test", "test")
-        self.assertEqual("test", config.get_option("client.caching"))
+        config._set_option("browser.gatherUsageStats", "test", "test")
+        self.assertEqual("test", config.get_option("browser.gatherUsageStats"))
 
     def test_is_manually_set(self):
         config._set_option("browser.serverAddress", "some.bucket", "test")
@@ -607,7 +607,7 @@ class ConfigLoadingTest(unittest.TestCase):
             path_exists.return_value = False
             config.get_config_options()
 
-            self.assertEqual(True, config.get_option("client.caching"))
+            self.assertEqual(True, config.get_option("browser.gatherUsageStats"))
             self.assertIsNone(config.get_option("theme.font"))
 
     def test_load_global_config(self):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -37,29 +37,17 @@ class BootstrapTest(unittest.TestCase):
     @patch("streamlit.web.bootstrap._install_pages_watcher", Mock())
     def test_fix_matplotlib_crash(self):
         """Test that bootstrap.run sets the matplotlib backend to
-        "Agg" if config.runner.fixMatplotlib=True.
+        "Agg".
         """
         # TODO: Find a proper way to mock sys.platform
         ORIG_PLATFORM = sys.platform
 
-        for platform, do_fix in [("darwin", True), ("linux2", True)]:
+        for platform in ["darwin", "linux2"]:
             sys.platform = platform
 
             matplotlib.use("pdf", force=True)
-
-            config._set_option("runner.fixMatplotlib", True, "test")
             bootstrap.run("/not/a/script", "", [], {})
-            if do_fix:
-                self.assertEqual("agg", matplotlib.get_backend().lower())
-            else:
-                self.assertEqual("pdf", matplotlib.get_backend().lower())
-
-            # Reset
-            matplotlib.use("pdf", force=True)
-
-            config._set_option("runner.fixMatplotlib", False, "test")
-            bootstrap.run("/not/a/script", "", [], {})
-            self.assertEqual("pdf", matplotlib.get_backend().lower())
+            self.assertEqual("agg", matplotlib.get_backend().lower())
 
         sys.platform = ORIG_PLATFORM
 


### PR DESCRIPTION
## Describe your changes

This PR fixes python unit tests related to deprecated config options.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
