### PR TITLE
Fix config option expiration behaviour

### DIFF
--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -259,7 +259,7 @@ class ConfigOption:
                 from streamlit.logger import get_logger
 
                 LOGGER = get_logger(__name__)
-                LOGGER.warning(
+                LOGGER.error(
                     textwrap.dedent(
                         """
                     ════════════════════════════════════════════════

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -247,7 +247,6 @@ class ConfigOption:
         self.is_default = value == self.default_val
 
         if self.deprecated and self.where_defined != ConfigOption.DEFAULT_DEFINITION:
-
             details = {
                 "key": self.key,
                 "file": self.where_defined,
@@ -256,7 +255,11 @@ class ConfigOption:
             }
 
             if self.is_expired():
-                raise DeprecationError(
+                # Import here to avoid circular imports
+                from streamlit.logger import get_logger
+
+                LOGGER = get_logger(__name__)
+                LOGGER.warning(
                     textwrap.dedent(
                         """
                     ════════════════════════════════════════════════

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -66,7 +66,7 @@ def show_config(
     def append_setting(text):
         out.append(click.style(text, fg="green"))
 
-    for section, section_description in section_descriptions.items():
+    for section, _ in section_descriptions.items():
         # We inject a fake config section used for unit tests that we exclude here as
         # its options are often missing required properties, which confuses the code
         # below.

--- a/lib/tests/streamlit/config_option_test.py
+++ b/lib/tests/streamlit/config_option_test.py
@@ -120,8 +120,9 @@ class ConfigOptionTest(unittest.TestCase):
             expiration_date="2000-01-01",
         )
 
-        with self.assertRaises(DeprecationError):
-            c.set_value(my_value, where_defined)
+        # Expired options behave like deprecated options
+        # just a slightly different text.
+        c.set_value(my_value, where_defined)
 
         self.assertTrue(c.is_expired())
 


### PR DESCRIPTION
## Describe your changes

Instead of throwing an error on expired config options and thereby preventing a script run, we will just keep showing an error message in the CLI but still allow you to use Streamlit. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
