### PR TITLE
Fix period type support for Pandas 2.2.0

### DIFF
--- a/frontend/lib/src/dataframes/Quiver.ts
+++ b/frontend/lib/src/dataframes/Quiver.ts
@@ -123,68 +123,114 @@ type IntervalClosed = "left" | "right" | "both" | "neither"
 type IntervalType = `interval[${IntervalData}, ${IntervalClosed}]`
 
 // The frequency strings defined in pandas.
-// See: https://pandas.pydata.org/docs/user_guide/timeseries.html#dateoffset-objects
-type SupportedPandasOffsetType = "W" | "Q" | "D" | "H" | "T" | "S" | "L"
+// See: https://pandas.pydata.org/docs/user_guide/timeseries.html#period-aliases
+// Not supported: "N" (nanoseconds), "U" & "us" (microseconds), and "B" (business days).
+// Reason is that these types are not supported by moment.js, but also they are not
+// very commonly used in practice.
+type SupportedPandasOffsetType =
+  // yearly frequency:
+  | "A"
+  | "Y"
+  // quarterly frequency:
+  | "Q"
+  // monthly frequency
+  | "M"
+  // weekly frequency:
+  | "W"
+  // calendar day frequency:
+  | "D"
+  // hourly frequency:
+  | "H"
+  | "h"
+  // minutely frequency
+  | "T"
+  | "min"
+  // secondly frequency:
+  | "S"
+  | "s"
+  // milliseconds:
+  | "L"
+  | "ms"
+
 type PeriodFrequency =
   | SupportedPandasOffsetType
   | `${SupportedPandasOffsetType}-${string}`
 type PeriodType = `period[${PeriodFrequency}]`
 
 const WEEKDAY_SHORT = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+const formatMs = (duration: number): string =>
+  moment("19700101", "YYYYMMDD")
+    .add(duration, "ms")
+    .format("YYYY-MM-DD HH:mm:ss.SSS")
 
-// TODO: For now, we only support the most commonly used offset types.
-//  In the future, it is worth adding support for other types as needed.
+const formatSec = (duration: number): string =>
+  moment("19700101", "YYYYMMDD")
+    .add(duration, "s")
+    .format("YYYY-MM-DD HH:mm:ss")
+
+const formatMin = (duration: number): string =>
+  moment("19700101", "YYYYMMDD").add(duration, "m").format("YYYY-MM-DD HH:mm")
+
+const formatHours = (duration: number): string =>
+  moment("19700101", "YYYYMMDD").add(duration, "h").format("YYYY-MM-DD HH:mm")
+
+const formatDay = (duration: number): string =>
+  moment("19700101", "YYYYMMDD").add(duration, "d").format("YYYY-MM-DD")
+
+const formatMonth = (duration: number): string =>
+  moment("19700101", "YYYYMMDD").add(duration, "M").format("YYYY-MM")
+
+const formatYear = (duration: number): string =>
+  moment("19700101", "YYYYMMDD").add(duration, "y").format("YYYY")
+
+const formatWeeks = (duration: number, freqParam?: string): string => {
+  if (!freqParam) {
+    throw new Error('Frequency "W" requires parameter')
+  }
+  const dayIndex = WEEKDAY_SHORT.indexOf(freqParam)
+  if (dayIndex < 0) {
+    throw new Error(
+      `Invalid value: ${freqParam}. Supported values: ${JSON.stringify(
+        WEEKDAY_SHORT
+      )}`
+    )
+  }
+  const startDate = moment("19700101", "YYYYMMDD")
+    .add(duration, "w")
+    .day(dayIndex - 6)
+    .format("YYYY-MM-DD")
+  const endDate = moment("19700101", "YYYYMMDD")
+    .add(duration, "w")
+    .day(dayIndex)
+    .format("YYYY-MM-DD")
+
+  return `${startDate}/${endDate}`
+}
+
+const formatQuarter = (duration: number): string =>
+  moment("19700101", "YYYYMMDD")
+    .add(duration, "Q")
+    .endOf("quarter")
+    .format("YYYY[Q]Q")
+
 const PERIOD_TYPE_FORMATTERS: Record<
   SupportedPandasOffsetType,
   (duration: number, freqParam?: string) => string
 > = {
-  L: duration =>
-    moment("19700101", "YYYYMMDD")
-      .add(duration, "ms")
-      .format("YYYY-MM-DD HH:mm:ss.SSS"),
-  S: duration =>
-    moment("19700101", "YYYYMMDD")
-      .add(duration, "s")
-      .format("YYYY-MM-DD HH:mm:ss"),
-  T: duration =>
-    moment("19700101", "YYYYMMDD")
-      .add(duration, "m")
-      .format("YYYY-MM-DD HH:mm"),
-  H: duration =>
-    moment("19700101", "YYYYMMDD")
-      .add(duration, "h")
-      .format("YYYY-MM-DD HH:mm"),
-  D: duration =>
-    moment("19700101", "YYYYMMDD").add(duration, "d").format("YYYY-MM-DD"),
-  W: (duration, freqParam) => {
-    if (!freqParam) {
-      throw new Error('Frequency "W" requires parameter')
-    }
-    const dayIndex = WEEKDAY_SHORT.indexOf(freqParam)
-    if (dayIndex < 0) {
-      throw new Error(
-        `Invalid value: ${freqParam}. Supported values: ${JSON.stringify(
-          WEEKDAY_SHORT
-        )}`
-      )
-    }
-    const startDate = moment("19700101", "YYYYMMDD")
-      .add(duration, "w")
-      .day(dayIndex - 6)
-      .format("YYYY-MM-DD")
-    const endDate = moment("19700101", "YYYYMMDD")
-      .add(duration, "w")
-      .day(dayIndex)
-      .format("YYYY-MM-DD")
-
-    return `${startDate}/${endDate}`
-  },
-  Q: duration => {
-    return moment("19700101", "YYYYMMDD")
-      .add(duration, "Q")
-      .endOf("quarter")
-      .format("YYYY[Q]Q")
-  },
+  L: formatMs,
+  ms: formatMs,
+  S: formatSec,
+  s: formatSec,
+  T: formatMin,
+  min: formatMin,
+  H: formatHours,
+  h: formatHours,
+  D: formatDay,
+  M: formatMonth,
+  W: formatWeeks,
+  Q: formatQuarter,
+  Y: formatYear,
+  A: formatYear,
 }
 
 /** Interval data type. */

--- a/frontend/lib/src/dataframes/Quiver.ts
+++ b/frontend/lib/src/dataframes/Quiver.ts
@@ -129,27 +129,27 @@ type IntervalType = `interval[${IntervalData}, ${IntervalClosed}]`
 // very commonly used in practice.
 type SupportedPandasOffsetType =
   // yearly frequency:
-  | "A"
+  | "A" // deprecated alias
   | "Y"
   // quarterly frequency:
   | "Q"
-  // monthly frequency
+  // monthly frequency:
   | "M"
   // weekly frequency:
   | "W"
   // calendar day frequency:
   | "D"
   // hourly frequency:
-  | "H"
+  | "H" // deprecated alias
   | "h"
   // minutely frequency
-  | "T"
+  | "T" // deprecated alias
   | "min"
   // secondly frequency:
-  | "S"
+  | "S" // deprecated alias
   | "s"
-  // milliseconds:
-  | "L"
+  // milliseconds frequency:
+  | "L" // deprecated alias
   | "ms"
 
 type PeriodFrequency =


### PR DESCRIPTION
## Describe your changes

In Pandas 2.2.0, the "A, H, T, S, L, U, and N are deprecated in favour of the aliases Y, h, min, s, ms, us, and ns."

<img width="742" alt="image" src="https://github.com/streamlit/streamlit/assets/2852129/ffe01a96-6797-4e9b-9cbe-4bc23dabf17f">

This PR adds support for the new aliases.

## Testing Plan

The old e2e tests will cover these cases. But I started a bigger improvement / refactoring related to the period type here: https://github.com/streamlit/streamlit/pull/7987 which will also contain refactored tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
