### PR TITLE
Only ignore hiding required columns in dynamic mode

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -381,6 +381,28 @@ describe("useColumnLoader hook", () => {
     expect(result.current.columns[1].isHidden).toBe(false)
   })
 
+  it("respects hiding required columns for fixed editing", () => {
+    const element = ArrowProto.create({
+      data: UNICODE,
+      editingMode: ArrowProto.EditingMode.FIXED,
+      columns: JSON.stringify({
+        c1: {
+          required: true,
+          hidden: true,
+        },
+      }),
+    })
+
+    const data = new Quiver(element)
+
+    const { result } = renderHook(() => {
+      return useColumnLoader(element, data, false)
+    })
+
+    expect(result.current.columns[1].isRequired).toBe(true)
+    expect(result.current.columns[1].isHidden).toBe(true)
+  })
+
   it("doesn't configure any icon for non-editable columns", () => {
     const element = ArrowProto.create({
       data: UNICODE,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -399,8 +399,9 @@ describe("useColumnLoader hook", () => {
       return useColumnLoader(element, data, false)
     })
 
-    expect(result.current.columns[1].isRequired).toBe(true)
-    expect(result.current.columns[1].isHidden).toBe(true)
+    // Test that the column is hidden (not part of columns).
+    // Column with index 1 should be c2:
+    expect(result.current.columns[1].name).toBe("c2")
   })
 
   it("doesn't configure any icon for non-editable columns", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -359,7 +359,7 @@ describe("useColumnLoader hook", () => {
     }
   })
 
-  it("disallows hidden for editable columns that are required", () => {
+  it("disallows hidden for editable columns that are required for dynamic editing", () => {
     const element = ArrowProto.create({
       data: UNICODE,
       editingMode: ArrowProto.EditingMode.DYNAMIC,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -263,8 +263,11 @@ function useColumnLoader(
             icon: "editable",
           }
 
-          // Make sure that required columns are not hidden:
-          if (updatedColumn.isRequired) {
+          // Make sure that required columns are not hidden when editing mode is dynamic:
+          if (
+            updatedColumn.isRequired &&
+            element.editingMode === ArrowProto.EditingMode.DYNAMIC
+          ) {
             updatedColumn = {
               ...updatedColumn,
               isHidden: false,


### PR DESCRIPTION
## Describe your changes

In a previous PR (https://github.com/streamlit/streamlit/pull/7888) we enforce `required` columns to be shown if if configured as hidden. However, doing this is only useful for the dynamic editing mode where users have to fill in these cells when adding new rows. This PR only applies this logic to data editor usage with `num_rows=dynamic`

## GitHub Issue Link (if applicable)

Closes #7991

## Testing Plan

- Added unit tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
