### PR TITLE
Disable watchdog suggestion for `none` or `poll` watcher type

### DIFF
--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -68,7 +68,9 @@ PathWatcherType = Union[
 
 def report_watchdog_availability():
     if not watchdog_available:
-        if not config.get_option("global.disableWatchdogWarning"):
+        if not config.get_option("global.disableWatchdogWarning") and config.get_option(
+            "server.fileWatcherType"
+        ) not in ["poll", "none"]:
             msg = "\n  $ xcode-select --install" if env_util.IS_DARWIN else ""
 
             click.secho(

--- a/lib/tests/streamlit/watcher/path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/path_watcher_test.py
@@ -52,6 +52,26 @@ class FileWatcherTest(unittest.TestCase):
         ]
         mock_echo.assert_has_calls(calls)
 
+    @patch_config_options({"server.fileWatcherType": "poll"})
+    def test_no_watchdog_suggestion_for_poll_type(self):
+        with patch(
+            "streamlit.watcher.path_watcher.watchdog_available", new=False
+        ), patch("streamlit.env_util.IS_DARWIN", new=False), patch(
+            "click.secho"
+        ) as mock_echo:
+            streamlit.watcher.path_watcher.report_watchdog_availability()
+        mock_echo.assert_not_called()
+
+    @patch_config_options({"server.fileWatcherType": "none"})
+    def test_no_watchdog_suggestion_for_none_type(self):
+        with patch(
+            "streamlit.watcher.path_watcher.watchdog_available", new=False
+        ), patch("streamlit.env_util.IS_DARWIN", new=False), patch(
+            "click.secho"
+        ) as mock_echo:
+            streamlit.watcher.path_watcher.report_watchdog_availability()
+        mock_echo.assert_not_called()
+
     def test_report_watchdog_availability_nonmac(self):
         with patch(
             "streamlit.watcher.path_watcher.watchdog_available", new=False


### PR DESCRIPTION
## Describe your changes

If the user has configured `server.fileWatcherType` to `none` or `poll`, we should not show the watchdog suggestion.

## GitHub Issue Link (if applicable)

- Closes #7999

## Testing Plan

Added test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
