### PR TITLE
Add support for converting `st.query_params` to string

### DIFF
--- a/e2e_playwright/st_query_params.py
+++ b/e2e_playwright/st_query_params.py
@@ -14,4 +14,4 @@
 
 import streamlit as st
 
-st.write(st.query_params)
+st.markdown(str(st.query_params))

--- a/e2e_playwright/st_query_params_test.py
+++ b/e2e_playwright/st_query_params_test.py
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
-test_dicts = [{"x": "y"}, {"x": "y", "a": "b"}, {"x": ("y", 1, 2.34)}, {"x": ""}]
+test_dicts = [{"x": "y"}, {"x": "y", "a": "b"}, {"x": ["y", "1", "2.34"]}, {"x": ""}]
 
 
 @pytest.mark.parametrize("app_with_query_params", test_dicts, indirect=True)
 def test_app_with_query_params(app_with_query_params: Page):
     page, test_dict = app_with_query_params
-    for key, value in test_dict.items():
-        assert page.get_by_text(key) is not None
-
-        if isinstance(value, (list, tuple)):
-            for item in value:
-                assert page.get_by_text(item) is not None
-        else:
-            assert page.get_by_text(value) is not None
+    expect(page.get_by_test_id("stMarkdownContainer")).to_have_text(str(test_dict))

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -99,6 +99,10 @@ class QueryParams(MutableMapping[str, str]):
             {key for key in self._query_params if key not in EMBED_QUERY_PARAMS_KEYS}
         )
 
+    def __str__(self) -> str:
+        self._ensure_single_query_api_used()
+        return str(self._query_params)
+
     def _send_query_param_msg(self) -> None:
         # Avoid circular imports
         from streamlit.runtime.scriptrunner import get_script_run_ctx

--- a/lib/streamlit/runtime/state/query_params_proxy.py
+++ b/lib/streamlit/runtime/state/query_params_proxy.py
@@ -33,6 +33,10 @@ class QueryParamsProxy(MutableMapping[str, str]):
         with get_session_state().query_params() as qp:
             return len(qp)
 
+    def __str__(self) -> str:
+        with get_session_state().query_params() as qp:
+            return str(qp)
+
     @gather_metrics("query_params.get_item")
     def __getitem__(self, key: str) -> str:
         with get_session_state().query_params() as qp:

--- a/lib/tests/streamlit/runtime/state/query_params_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_proxy_test.py
@@ -68,6 +68,9 @@ class TestQueryParamsProxy(unittest.TestCase):
     def test__len__returns_correct_len(self):
         assert len(self.query_params_proxy) == 1
 
+    def test__str__returns_correct_str(self):
+        assert str(self.query_params_proxy) == "{'test': 'value'}"
+
     def test__iter__returns_correct_iter(self):
         keys = list(iter(self.query_params_proxy))
         assert keys == ["test"]


### PR DESCRIPTION
## Describe your changes

Doing `str(st.query_params)` currently only prints out the default string description for a class. This PR changes this to print out the actual content of the query parameters.`st.session_state` already supports this.

Update tests.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
