### PR TITLE
Fix #5571

### DIFF
--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -737,7 +737,6 @@ class TimeWidgetsMixin:
             session_state = get_session_state().filtered_state
 
             if key is not None and key in session_state:
-                print("AAAAAAAAA MAMA JAN!")
                 state_value = session_state[key]
                 _session_state_parsed_values = _DateInputValues.from_raw_values(
                     value=state_value,
@@ -747,7 +746,6 @@ class TimeWidgetsMixin:
                 is_range = _session_state_parsed_values.is_range
                 value_for_proto = _session_state_parsed_values.value
                 serde_value = _session_state_parsed_values
-                print("MAMA JAN, PARSED VALUE: ", _session_state_parsed_values)
 
         del value, min_value, max_value
 

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -497,9 +497,7 @@ class TimeWidgetsMixin:
     def date_input(
         self,
         label: str,
-        value: DateValue
-        | Literal["today"]
-        | Literal["default_value_today"] = "default_value_today",
+        value: DateValue | Literal["today"] = "default_value_today",  # type: ignore[assignment]
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -738,10 +738,10 @@ class TimeWidgetsMixin:
             # the id to change.
 
             session_state = get_session_state().filtered_state
-            state_value = session_state[key]
 
             if key is not None and key in session_state:
                 print("AAAAAAAAA MAMA JAN!")
+                state_value = session_state[key]
                 _session_state_parsed_values = _DateInputValues.from_raw_values(
                     value=state_value,
                     min_value=min_value,

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -173,7 +173,7 @@ class DateInputTest(DeltaGeneratorTestCase):
 
     def test_range_session_state(self):
         """Test a range set by session state."""
-        date_range_input = [datetime.today(), datetime.today() + timedelta(2)]
+        date_range_input = [date(2024, 1, 15), date(2024, 1, 15) + timedelta(2)]
         state = st.session_state
         state["date_range"] = date_range_input[:]
 
@@ -182,10 +182,15 @@ class DateInputTest(DeltaGeneratorTestCase):
             key="date_range",
         )
 
+        c = self.get_delta_from_queue().new_element.date_input
+
         assert date_range == date_range_input
 
+        self.assertEqual(c.value, ["2024/01/15", "2024/01/17"])
+        self.assertEqual(c.is_range, True)
+
     def test_inside_column(self):
-        """Test that it works correctly inside of a column."""
+        """Test that it works correctly inside a column."""
         col1, col2 = st.columns(2)
 
         with col1:


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Make the behavior of `date_input` widget consistent with `st.slider` when the value is set from session_state.

We need to correctly determine that it is a range `date_input`. The main scenario we want to fix is a situation where we set range value via session_state. E.g.

```python
import streamlit as st
from datetime import date, timedelta


if "my_data_input" not in st.session_state:
    st.session_state.my_data_input = (date.today() - timedelta(days=10), date.today())

x = st.date_input(
    label="DATE INPUT LABEL",
    key="my_data_input",
)
```

This decision is not ideal, but it allows us to avoid unexpected behavior when the widget value is defined only via session_state. 

This code snippet reproduces the issue with a proposed solution. 
```python
if "my_slider" not in st.session_state:
    st.session_state.my_slider = (20, 30)

x = st.slider(
    label="SLIDER LABEL",
    value=42,
    key="my_slider",
)

st.write("VALUE:", x)
st.write(st.session_state.my_slider)
```

After the first interaction slider becomes a single slider, which is kind of expected, but confusing.
The good news is that we at least show `WidgetStateDuplicationWarning` in cases like that, so app developers should be notified about it.

I think for now we should make the behavior of `st.slider` and `st.date_input` consistent, and not buggy for most obvious cases, but as a long-term solution for the future, we should consider splitting them into pair of widgets for singe/range value. 

## GitHub Issue Link (if applicable) Closes #5571 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) ✅ 
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
