### PR TITLE
Fix custom dataframe scrollbars in Chrome

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -413,6 +413,7 @@ function DataFrame({
     <StyledResizableContainer
       data-testid="stDataFrame"
       className="stDataFrame"
+      hasCustomizedScrollbars={hasCustomizedScrollbars}
       ref={resizableContainerRef}
       onMouseDown={e => {
         if (resizableContainerRef.current && hasCustomizedScrollbars) {

--- a/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
@@ -36,6 +36,9 @@ export const StyledResizableContainer =
       },
 
       "& .dvn-scroller": {
+        // We only want to configure scrollbar aspects for browsers that
+        // don't support custom scrollbars (e.g. Firefox). Also, applying this
+        // in Chrome causes the scrollbar to change to the default scrollbar style.
         ...(!hasCustomizedScrollbars && { scrollbarWidth: "thin" }),
         ["overflowX" as any]: "auto !important",
         ["overflowY" as any]: "auto !important",

--- a/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
@@ -16,22 +16,29 @@
 
 import styled from "@emotion/styled"
 
+export interface StyledResizableContainerProps {
+  hasCustomizedScrollbars: boolean
+}
+
 /**
  * A resizable data grid container component.
  */
-export const StyledResizableContainer = styled.div(({ theme }) => ({
-  position: "relative",
-  display: "inline-block",
+export const StyledResizableContainer =
+  styled.div<StyledResizableContainerProps>(
+    ({ hasCustomizedScrollbars, theme }) => ({
+      position: "relative",
+      display: "inline-block",
 
-  "& .glideDataEditor": {
-    height: "100%",
-    minWidth: "100%",
-    borderRadius: theme.radii.lg,
-  },
+      "& .glideDataEditor": {
+        height: "100%",
+        minWidth: "100%",
+        borderRadius: theme.radii.lg,
+      },
 
-  "& .dvn-scroller": {
-    scrollbarWidth: "thin",
-    ["overflowX" as any]: "auto !important",
-    ["overflowY" as any]: "auto !important",
-  },
-}))
+      "& .dvn-scroller": {
+        ...(!hasCustomizedScrollbars && { scrollbarWidth: "thin" }),
+        ["overflowX" as any]: "auto !important",
+        ["overflowY" as any]: "auto !important",
+      },
+    })
+  )


### PR DESCRIPTION
## Describe your changes

The latest Chrome update messed up our dataframe scrollbars once again. Apparently, applying the `scrollbarWidth: "thin"` we applied in CSS properties will now cause our custom scrollbars to not be used:

<img width="449" alt="image" src="https://github.com/streamlit/streamlit/assets/2852129/51f037ff-79ab-4489-8e11-ba2fce0a3093">

This PR fixes this by only applying the CSS property for browsers that don't use our customized scrollbars (e.g. Firefox). 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
