### PR TITLE
Remove unused logger in hello

### DIFF
--- a/lib/streamlit/hello/Hello.py
+++ b/lib/streamlit/hello/Hello.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import streamlit as st
-from streamlit.logger import get_logger
-
-LOGGER = get_logger(__name__)
 
 
 def run():


### PR DESCRIPTION
This PR removes the unnecessary import and creation of a logger in the hello app. It's been in the hello code since 2019 and to my knowledge doesn't serve any purpose nor is used in the app.