### PR TITLE
Make DeltaGenerators deepcopyable

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import sys
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -352,6 +353,16 @@ class DeltaGenerator(
             raise StreamlitAPIException(message)
 
         return wrapper
+
+    def __deepcopy__(self, _memo):
+        dg = DeltaGenerator(
+            root_container=self._root_container,
+            cursor=deepcopy(self._cursor),
+            parent=deepcopy(self._parent),
+            block_type=self._block_type,
+        )
+        dg._form_data = deepcopy(self._form_data)
+        return dg
 
     @property
     def _parent_block_types(self) -> ParentBlockTypes:


### PR DESCRIPTION
Note: this change is being made for work being done in the `feature/st.experimental_fragment`
branch, but we're merging this PR into `develop` since there's no downside of doing so and it
keeps the final diff size down.

In building the upcoming `st.experimental_fragment` feature, it'll be useful for us to be able to
`deepcopy` instances of the `DeltaGenerator` class. `DeltaGenerator` doesn't currently support
this, so we add the ability to do so in this PR.