### PR TITLE
Make shallow copies of options returned from ensure_indexable

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -653,7 +653,12 @@ def ensure_indexable(obj: OptionSequence[V_co]) -> Sequence[V_co]:
     # function actually does the thing we want.
     index_fn = getattr(it, "index", None)
     if callable(index_fn):
-        return it  # type: ignore[return-value]
+        # We return a shallow copy of the Sequence here because the return value of
+        # this function is saved in a widget serde class instance to be used in later
+        # script runs, and we don't want mutations to the options object passed to a
+        # widget affect the widget.
+        # (See https://github.com/streamlit/streamlit/issues/7534)
+        return copy.copy(cast(Sequence[V_co], it))
     else:
         return list(it)
 

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -714,6 +714,20 @@ class TypeUtilTest(unittest.TestCase):
             {0: None, 1: None, 2: None, 3: None},
         )
 
+    def test_ensure_indexable_object_is_indexable(self):
+        l1 = ["a", "b", "c"]
+        l2 = type_util.ensure_indexable(l1)
+
+        # Assert that l1 was shallow copied into l2.
+        self.assertFalse(l1 is l2)
+        self.assertEqual(l1, l2)
+
+    def test_ensure_indexable_object_not_indexable(self):
+        l = type_util.ensure_indexable({"a", "b", "c"})
+        self.assertIn("a", l)
+        self.assertIn("b", l)
+        self.assertIn("c", l)
+
 
 class TestArrowTruncation(DeltaGeneratorTestCase):
     """Test class for the automatic arrow truncation feature."""


### PR DESCRIPTION
The strange behavior in #7534 is caused by us saving a reference to the `options` object into the
`*Serde` class of an options widget. This causes any mutations to that object to cause weird side
effects in the next script run.

To avoid this, we return a shallow copy of every object passed into `ensure_indexable` either
by calling `copy.copy` (for already indexable objects) or by converting the object into a `list`
(for non-indexable objects).

There's some chance that making this change may have unintended side effects in some apps
that somehow rely on the current behavior, so we should probably do some testing to see if we
can catch any of these cases before this PR lands in a release. Most likely, though, we'll be willing
to bend SemVer conventions and break any existing apps to make this fix because the current
behavior is quite strange/unintuitive.

Closes #7534