### PR TITLE
Fix memory leak in runtime coroutine loop

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -604,8 +604,8 @@ class Runtime:
                     # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
                     await asyncio.wait(  # type: ignore[unreachable]
                         (
-                            asyncio.create_task(async_objs.must_stop.wait()),
-                            asyncio.create_task(async_objs.has_connection.wait()),
+                            async_objs.must_stop.wait(),
+                            async_objs.has_connection.wait(),
                         ),
                         return_when=asyncio.FIRST_COMPLETED,
                     )
@@ -636,8 +636,8 @@ class Runtime:
 
                 await asyncio.wait(
                     (
-                        asyncio.create_task(async_objs.must_stop.wait()),
-                        asyncio.create_task(async_objs.need_send_data.wait()),
+                        async_objs.must_stop.wait(),
+                        async_objs.need_send_data.wait(),
                     ),
                     return_when=asyncio.FIRST_COMPLETED,
                 )

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -599,21 +599,7 @@ class Runtime:
             async_objs.started.set_result(None)
 
             while not async_objs.must_stop.is_set():
-                if self._state == RuntimeState.NO_SESSIONS_CONNECTED:  # type: ignore[comparison-overlap]
-                    # mypy 1.4 incorrectly thinks this if-clause is unreachable,
-                    # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
-                    _, pending_tasks = await asyncio.wait(  # type: ignore[unreachable]
-                        (
-                            asyncio.create_task(async_objs.must_stop.wait()),
-                            asyncio.create_task(async_objs.has_connection.wait()),
-                        ),
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                    # Clean up pending tasks to avoid memory leaks
-                    for task in pending_tasks:
-                        task.cancel()
-
-                elif self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
+                if self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
                     async_objs.need_send_data.clear()
 
                     for active_session_info in self._session_mgr.list_active_sessions():
@@ -632,7 +618,12 @@ class Runtime:
                     # Yield for a few milliseconds between session message
                     # flushing.
                     await asyncio.sleep(0.01)
+                elif self._state == RuntimeState.NO_SESSIONS_CONNECTED:  # type: ignore[comparison-overlap]
+                    # mypy 1.4 incorrectly thinks this if-clause is unreachable,
+                    # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
 
+                    # This will jump to the asyncio.wait below.
+                    pass
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -304,7 +304,7 @@ class Runtime:
             if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
                 return
 
-            LOGGER.debug("Runtime stopping...")
+            LOGGER.error("Runtime stopping...")
             self._set_state(RuntimeState.STOPPING)
             async_objs.must_stop.set()
 
@@ -604,8 +604,8 @@ class Runtime:
                     # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
                     await asyncio.wait(  # type: ignore[unreachable]
                         (
-                            async_objs.must_stop.wait(),
-                            async_objs.has_connection.wait(),
+                            asyncio.create_task(async_objs.must_stop.wait()),
+                            asyncio.create_task(async_objs.has_connection.wait()),
                         ),
                         return_when=asyncio.FIRST_COMPLETED,
                     )
@@ -636,8 +636,8 @@ class Runtime:
 
                 await asyncio.wait(
                     (
-                        async_objs.must_stop.wait(),
-                        async_objs.need_send_data.wait(),
+                        # asyncio.create_task(async_objs.must_stop.wait()),
+                        asyncio.create_task(async_objs.need_send_data.wait()),
                     ),
                     return_when=asyncio.FIRST_COMPLETED,
                 )

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -644,7 +644,7 @@ class Runtime:
                     ),
                     return_when=asyncio.FIRST_COMPLETED,
                 )
-                # We need to cancel the pending task (the `must_stop` one in most situations).
+                # We need to cancel the pending tasks (the `must_stop` one in most situations).
                 # Otherwise, this would stack up one waiting task per loop
                 # (e.g. per forward message). These tasks cannot be garbage collected
                 # causing an increase in memory (-> memory leak).

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -642,12 +642,13 @@ class Runtime:
 
                 _, pending = await asyncio.wait(
                     (
-                        # asyncio.create_task(async_objs.must_stop.wait()),
+                        asyncio.create_task(async_objs.must_stop.wait()),
                         asyncio.create_task(async_objs.need_send_data.wait()),
                     ),
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 for task in pending:
+                    print("Cancel task 2")
                     task.cancel()
                     try:
                         await task

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -305,7 +305,7 @@ class Runtime:
             if self._state in (RuntimeState.STOPPING, RuntimeState.STOPPED):
                 return
 
-            LOGGER.error("Runtime stopping...")
+            LOGGER.debug("Runtime stopping...")
             self._set_state(RuntimeState.STOPPING)
             async_objs.must_stop.set()
 

--- a/lib/tests/streamlit/runtime/runtime_test.py
+++ b/lib/tests/streamlit/runtime/runtime_test.py
@@ -449,6 +449,24 @@ class RuntimeTest(RuntimeTestCase):
         raise_disconnected_error.assert_called_once()
         self.assertFalse(self.runtime.is_active_session(session_id))
 
+    async def test_stable_number_of_async_tasks(self):
+        """Test that the number of async tasks remains stable.
+
+        This is a regression test for a memory leak issue where the number of
+        tasks would grow with every loop.
+        """
+        await self.runtime.start()
+
+        client = MockSessionClient()
+        session_id = self.runtime.connect_session(client=client, user_info=MagicMock())
+
+        for _ in range(100):
+            self.enqueue_forward_msg(session_id, create_dataframe_msg([1, 2, 3]))
+            await self.tick_runtime_loop()
+
+        # It is expected that there are a couple of tasks, but not one per loop:
+        self.assertLess(len(asyncio.all_tasks()), 10)
+
     async def test_forwardmsg_hashing(self):
         """Test that outgoing ForwardMsgs contain hashes."""
         await self.runtime.start()


### PR DESCRIPTION
## Describe your changes

The coroutine loop in runtime has a memory leak (aka "Coroutine Creep"). On every loop, it will create two new `asyncio.Tasks` for the `must_stop` and `need_send_data` events and wait for one to complete. If the app isn't being shut down, only the `need_send_data` will resolve leaving the `must_stop` tasks waiting. Since we are never canceling these tasks, one waiting task will accumulate per loop (~per forward message). This requires around 1kb of memory space per loop (e.g. forward message), which will never be garbage collected. 

This PR fixes this by simply canceling all the pending tasks (-> the `must_stop` one) after the waiting step. 

## GitHub Issue Link (if applicable)

- Might be related to this since the user mentioned that it is also happening without the `st.image`: https://github.com/streamlit/streamlit/issues/7989
- Potentially related to #6602
- Potentially related to #6510

## Testing Plan

- Added unit test. To check that the number of tasks do not accumulate.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
