### PR TITLE
Define the FragmentStorage protocol and implement MemoryFragmentStorage

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -1,0 +1,78 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Callable
+
+from typing_extensions import Protocol
+
+Fragment = Callable[[], Any]
+
+
+class FragmentStorage(Protocol):
+    """A key-value store for Fragments. Used to implement the @st.experimental_fragment
+    decorator.
+
+    We intentionally define this as its own protocol despite how generic it appears to
+    be at first glance. The reason why is that, in any case where fragments aren't just
+    stored as Python closures in memory, storing and retrieving Fragments will generally
+    involve serializing and deserializing function bytecode, which is a tricky aspect
+    to implementing FragmentStorages that won't generally appear with our other *Storage
+    protocols.
+    """
+
+    @abstractmethod
+    def get(self, key: str) -> Fragment:
+        """Returns the stored fragment for the given key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def set(self, key: str, value: Fragment) -> None:
+        """Saves a fragment under the given key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Delete the fragment corresponding to the given key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all fragments saved in this FragmentStorage."""
+        raise NotImplementedError
+
+
+class MemoryFragmentStorage(FragmentStorage):
+    """A simple, memory-backed implementation of FragmentStorage.
+
+    MemoryFragmentStorage is just a wrapper around a plain Python dict that complies with
+    the FragmentStorage protocol.
+    """
+
+    def __init__(self):
+        self._fragments: dict[str, Fragment] = {}
+
+    def get(self, key: str) -> Fragment:
+        return self._fragments[key]
+
+    def set(self, key: str, value: Fragment) -> None:
+        self._fragments[key] = value
+
+    def delete(self, key: str) -> None:
+        del self._fragments[key]
+
+    def clear(self) -> None:
+        self._fragments.clear()

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -55,6 +55,9 @@ class FragmentStorage(Protocol):
         raise NotImplementedError
 
 
+# TODO(vdonato): Have this class implement a get_stats method, then add a new
+# MemoryFragmentStorageStatProvider class to register with the StatsManager in
+# runtime.py (see SessionState and SessionStateStatProvider for an example).
 class MemoryFragmentStorage(FragmentStorage):
     """A simple, memory-backed implementation of FragmentStorage.
 

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pytest
+
+from streamlit.runtime.fragment import MemoryFragmentStorage
+
+
+class MemoryFragmentStorageTest(unittest.TestCase):
+    """Sanity checks for MemoryFragmentStorage.
+
+    These tests may be a bit excessive given that MemoryFragmentStorage is currently
+    just a wrapper around a Python dict, but we include them for completeness.
+    """
+
+    def setUp(self):
+        self._storage = MemoryFragmentStorage()
+        self._storage._fragments["some_key"] = "some_fragment"
+
+    def test_get(self):
+        assert self._storage.get("some_key") == "some_fragment"
+
+    def test_get_KeyError(self):
+        with pytest.raises(KeyError):
+            self._storage.get("nonexistent_key")
+
+    def test_set(self):
+        self._storage.set("some_key", "new_fragment")
+        self._storage.set("some_other_key", "some_other_fragment")
+
+        assert self._storage.get("some_key") == "new_fragment"
+        assert self._storage.get("some_other_key") == "some_other_fragment"
+
+    def test_delete(self):
+        self._storage.delete("some_key")
+        with pytest.raises(KeyError):
+            self._storage.get("nonexistent_key")
+
+    def test_del_KeyError(self):
+        with pytest.raises(KeyError):
+            self._storage.delete("nonexistent_key")
+
+    def test_clear(self):
+        self._storage._fragments["some_other_key"] = "some_other_fragment"
+        assert len(self._storage._fragments) == 2
+
+        self._storage.clear()
+        assert len(self._storage._fragments) == 0


### PR DESCRIPTION
This PR kicks off work on the upcoming `st.experimental_fragment` (name TBD) feature by defining a new
`FragmentStorage` protocol along with a simple concrete class (`MemoryFragmentStorage`) implementing it.

None of this code is particularly interesting right now, but it'll eventually end up useful for allowing us to have
fragments work well with horizontally scaled Streamlit apps (in the eventual future when we finally release
better support for this).