### PR TITLE
Prevent pandas keyerror when checking color column format in st.map

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -416,7 +416,9 @@ def _convert_color_arg_or_column(
 
     if color_col_name is not None:
         # Convert color column to the right format.
-        if len(data[color_col_name]) > 0 and is_color_like(data[color_col_name][0]):
+        if len(data[color_col_name]) > 0 and is_color_like(
+            data.iloc[0][color_col_name]
+        ):
             # Use .loc[] to avoid a SettingWithCopyWarning in some cases.
             data.loc[:, color_col_name] = data.loc[:, color_col_name].map(
                 to_int_color_tuple


### PR DESCRIPTION
Use iloc instead of accessing by index label incase the input dataframe is not indexed from zero

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Quick change to fix an issue in running `st.map` on dataframes without 0-based indexes. 

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8077

## Testing Plan

No additional tests needed? Just a one line change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
