### PR TITLE
Remove unnecessary deb repository from init action

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -36,8 +36,6 @@ runs:
       shell: bash --login -eo pipefail {0}
     - name: Install system dependencies
       run: |
-        echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/protobuf.list
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
         sudo apt update
         # protobuf, pyodbc, dot, & graphviz dependencies
         sudo apt install -y gnupg \

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -86,9 +86,6 @@ jobs:
           make react-init
       - name: Install system dependencies
         run: |
-          echo "deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/protobuf.list
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4DEA8909DC6A13A3
-          sudo apt update
           # protobuf, pyodbc, dot, & graphviz dependencies
           sudo apt install -y gnupg \
               unixodbc-dev=2.3.9-5 \

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -86,7 +86,7 @@ jobs:
           make react-init
       - name: Install system dependencies
         run: |
-          sudo apt update \
+          sudo apt update
           # protobuf, pyodbc, dot, & graphviz dependencies
           sudo apt install -y gnupg \
               unixodbc-dev=2.3.9-5 \

--- a/.github/workflows/python-min-deps.yml
+++ b/.github/workflows/python-min-deps.yml
@@ -86,6 +86,7 @@ jobs:
           make react-init
       - name: Install system dependencies
         run: |
+          sudo apt update \
           # protobuf, pyodbc, dot, & graphviz dependencies
           sudo apt install -y gnupg \
               unixodbc-dev=2.3.9-5 \


### PR DESCRIPTION
## Describe your changes

This PR removes the usage of a deb repository that is most likely not required anymore since we will get the latest protobuf-compiler from the used ubuntu version.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
