### PR TITLE
Expire session storage cache on an async timer

### DIFF
--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -22,7 +22,6 @@ import types
 from datetime import timedelta
 from typing import Any, Callable, TypeVar, cast, overload
 
-from cachetools import TTLCache
 from typing_extensions import TypeAlias
 
 import streamlit as st
@@ -48,6 +47,7 @@ from streamlit.runtime.caching.hashing import HashFuncsDict
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
+from streamlit.util import TimedCleanupCache
 from streamlit.vendor.pympler.asizeof import asizeof
 
 _LOGGER = get_logger(__name__)
@@ -473,7 +473,7 @@ class ResourceCache(Cache):
         super().__init__()
         self.key = key
         self.display_name = display_name
-        self._mem_cache: TTLCache[str, MultiCacheResults] = TTLCache(
+        self._mem_cache: TimedCleanupCache[str, MultiCacheResults] = TimedCleanupCache(
             maxsize=max_entries, ttl=ttl_seconds, timer=cache_utils.TTLCACHE_TIMER
         )
         self._mem_cache_lock = threading.Lock()

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 import math
 import threading
 
-from cachetools import TTLCache
-
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
@@ -26,6 +24,7 @@ from streamlit.runtime.caching.storage.cache_storage_protocol import (
     CacheStorageKeyNotFoundError,
 )
 from streamlit.runtime.stats import CacheStat
+from streamlit.util import TimedCleanupCache
 
 _LOGGER = get_logger(__name__)
 
@@ -62,7 +61,7 @@ class InMemoryCacheStorageWrapper(CacheStorage):
         self.function_display_name = context.function_display_name
         self._ttl_seconds = context.ttl_seconds
         self._max_entries = context.max_entries
-        self._mem_cache: TTLCache[str, bytes] = TTLCache(
+        self._mem_cache: TimedCleanupCache[str, bytes] = TimedCleanupCache(
             maxsize=self.max_entries,
             ttl=self.ttl_seconds,
             timer=cache_utils.TTLCACHE_TIMER,

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from typing import List, MutableMapping, Optional
 
-from cachetools import TTLCache
-
 from streamlit.runtime.session_manager import SessionInfo, SessionStorage
+from streamlit.util import TimedCleanupCache
 
 
 class MemorySessionStorage(SessionStorage):
@@ -55,7 +55,7 @@ class MemorySessionStorage(SessionStorage):
             inaccessible and will be removed eventually.
         """
 
-        self._cache: MutableMapping[str, SessionInfo] = TTLCache(
+        self._cache: MutableMapping[str, SessionInfo] = TimedCleanupCache(
             maxsize=maxsize, ttl=ttl_seconds
         )
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -207,14 +207,18 @@ def extract_key_query_params(
     )
 
 
-class TimedCleanupCache(TTLCache):
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class TimedCleanupCache(TTLCache[K, V]):
     """A TTLCache that asynchronously expires its entries."""
 
     def __init__(self, *args, **kwargs):
         self._task: Optional[asyncio.Task[Any]] = None
         super().__init__(*args, **kwargs)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: K, value: V) -> None:
         # Set an expiration task to run periodically
         # Can't be created in init because that only runs once and
         # the event loop might not exist yet.
@@ -231,7 +235,7 @@ class TimedCleanupCache(TTLCache):
             self._task.cancel()
 
 
-async def expire_cache(cache):
+async def expire_cache(cache: TTLCache) -> None:
     while True:
         await asyncio.sleep(30)
         cache.expire()

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -23,7 +23,6 @@ import hashlib
 import os
 import subprocess
 import sys
-import weakref
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, TypeVar, Union
 
 from cachetools import TTLCache
@@ -221,8 +220,7 @@ class TimedCleanupCache(TTLCache):
         # the event loop might not exist yet.
         if self._task is None:
             try:
-                ref = weakref.ref(self)
-                self._task = asyncio.create_task(expire_cache(ref))
+                self._task = asyncio.create_task(expire_cache(self))
             except RuntimeError:
                 # Just continue if the event loop isn't started yet.
                 pass
@@ -236,6 +234,4 @@ class TimedCleanupCache(TTLCache):
 async def expire_cache(cache):
     while True:
         await asyncio.sleep(30)
-        c = cache()
-        if c is not None:
-            c.expire()
+        cache.expire()

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -211,7 +211,7 @@ class TimedCleanupCache(TTLCache):
     """A TTLCache that asynchronously expires its entries."""
 
     def __init__(self, *args, **kwargs):
-        self._task: Optional[asyncio.Task] = None
+        self._task: Optional[asyncio.Task[Any]] = None
         super().__init__(*args, **kwargs)
 
     def __setitem__(self, key, value):

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -16,14 +16,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import functools
 import hashlib
 import os
 import subprocess
 import sys
-from typing import Any, Dict, Iterable, List, Mapping, Set, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, TypeVar, Union
 
+from cachetools import TTLCache
 from typing_extensions import Final
 
 from streamlit import env_util
@@ -203,3 +205,22 @@ def extract_key_query_params(
             for item in sublist
         ]
     )
+
+
+class TimedCleanupCache(TTLCache):
+    """A TTLCache that asynchronously expires its entries."""
+
+    def __init__(self, *args, **kwargs):
+        self._task: Optional[asyncio.Task] = None
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key, value):
+        if self._task is None:
+            self._task = asyncio.create_task(expire_cache(self))
+        super().__setitem__(key, value)
+
+
+async def expire_cache(cache):
+    while True:
+        await asyncio.sleep(30)
+        cache.expire()

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -215,6 +215,9 @@ class TimedCleanupCache(TTLCache):
         super().__init__(*args, **kwargs)
 
     def __setitem__(self, key, value):
+        # Set an expiration task to run periodically
+        # Can't be created in init because that only runs once and
+        # the event loop might not exist yet.
         if self._task is None:
             try:
                 self._task = asyncio.create_task(expire_cache(self))

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -23,7 +23,18 @@ import hashlib
 import os
 import subprocess
 import sys
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    TypeVar,
+    Union,
+)
 
 from cachetools import TTLCache
 from typing_extensions import Final
@@ -211,7 +222,7 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
-class TimedCleanupCache(TTLCache[K, V]):
+class TimedCleanupCache(TTLCache, Generic[K, V]):
     """A TTLCache that asynchronously expires its entries."""
 
     def __init__(self, *args, **kwargs):

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -222,6 +222,7 @@ class TimedCleanupCache(TTLCache):
             try:
                 self._task = asyncio.create_task(expire_cache(self))
             except RuntimeError:
+                # Just continue if the event loop isn't started yet.
                 pass
         super().__setitem__(key, value)
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -216,7 +216,10 @@ class TimedCleanupCache(TTLCache):
 
     def __setitem__(self, key, value):
         if self._task is None:
-            self._task = asyncio.create_task(expire_cache(self))
+            try:
+                self._task = asyncio.create_task(expire_cache(self))
+            except RuntimeError:
+                pass
         super().__setitem__(key, value)
 
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -226,8 +226,8 @@ class TimedCleanupCache(TTLCache, Generic[K, V]):
     """A TTLCache that asynchronously expires its entries."""
 
     def __init__(self, *args, **kwargs):
-        self._task: Optional[asyncio.Task[Any]] = None
         super().__init__(*args, **kwargs)
+        self._task: Optional[asyncio.Task[Any]] = None
 
     def __setitem__(self, key: K, value: V) -> None:
         # Set an expiration task to run periodically


### PR DESCRIPTION

## Describe your changes
To reduce the tendency of expired sessions to stick around for a long time for lower traffic apps, and potentially consume lots of memory, add an async task to periodically expire the TTLCache used in the default session storage implementation. 

## GitHub Issue Link (if applicable)

## Testing Plan

Was manually tested, and a unit test for tasks not sticking around was included.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
