### PR TITLE
Fix: `st.page_link` & `st.switch_page` handling / prefixed paths

### DIFF
--- a/e2e_playwright/multipage_apps/pages/02_page2.py
+++ b/e2e_playwright/multipage_apps/pages/02_page2.py
@@ -16,6 +16,6 @@ import streamlit as st
 
 st.header("Page 2")
 
-page_6 = st.button("`/pages/06_page_6.py`")
+page_6 = st.button("`pages/06_page_6.py`")
 if page_6:
-    st.switch_page("/pages/06_page_6.py")
+    st.switch_page("pages/06_page_6.py")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -141,8 +141,8 @@ def switch_page(page: str) -> NoReturn:  # type: ignore[misc]
     main_script_path = os.path.join(os.getcwd(), ctx.main_script_path)
     main_script_directory = os.path.dirname(main_script_path)
 
-    # Convenience for handling ./ notation and ensure leading / doesn't refer to root directory
-    page = os.path.normpath(page.strip("/"))
+    # Convenience for handling ./ notation
+    page = os.path.normpath(page)
 
     # Build full path
     requested_page = os.path.join(main_script_directory, page)

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -667,8 +667,8 @@ class ButtonMixin:
         main_script_path = os.path.join(os.getcwd(), ctx_main_script)
         main_script_directory = os.path.dirname(main_script_path)
 
-        # Convenience for handling ./ notation and ensure leading / doesn't refer to root directory
-        page = os.path.normpath(page.strip("/"))
+        # Convenience for handling ./ notation
+        page = os.path.normpath(page)
 
         # Build full path
         requested_page = os.path.join(main_script_directory, page)


### PR DESCRIPTION
## Describe your changes
Remove the convenience handling of preceding "/"

## GitHub Issue Link (if applicable)
Closes #8081 