### PR TITLE
Create a MemoryFragmentStorage in each AppSession

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -35,6 +35,7 @@ from streamlit.proto.NewSession_pb2 import (
 from streamlit.proto.PagesChanged_pb2 import PagesChanged
 from streamlit.runtime import caching, legacy_caching
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import FragmentStorage, MemoryFragmentStorage
 from streamlit.runtime.metrics_util import Installation
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.scriptrunner import RerunData, ScriptRunner, ScriptRunnerEvent
@@ -158,6 +159,8 @@ class AppSession:
         self._user_info = user_info
 
         self._debug_last_backmsg_id: Optional[str] = None
+
+        self._fragment_storage: FragmentStorage = MemoryFragmentStorage()
 
         LOGGER.debug("AppSession initialized (id=%s)", self.id)
 
@@ -398,6 +401,7 @@ class AppSession:
             script_cache=self._script_cache,
             initial_rerun_data=initial_rerun_data,
             user_info=self._user_info,
+            fragment_storage=self._fragment_storage,
         )
         self._scriptrunner.on_event.connect(self._on_scriptrunner_event)
         self._scriptrunner.start()

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -107,6 +107,12 @@ class RuntimeConfig:
     # True if the command used to start Streamlit was `streamlit hello`.
     is_hello: bool = False
 
+    # TODO(vdonato): Eventually add a new fragment_storage_class field enabling the code
+    # creating a new Streamlit Runtime to configure the FragmentStorage instances
+    # created by each new AppSession. We choose not to do this for now to avoid adding
+    # additional complexity to RuntimeConfig/SessionManager/etc when it's unlikely
+    # we'll have a custom implementation of this class anytime soon.
+
 
 class RuntimeState(Enum):
     INITIAL = "INITIAL"

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -22,6 +22,7 @@ from streamlit import runtime
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.WidgetStates_pb2 import WidgetStates
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import RerunData, ScriptRunner, ScriptRunnerEvent
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
@@ -54,6 +55,7 @@ class LocalScriptRunner(ScriptRunner):
             script_cache=ScriptCache(),
             initial_rerun_data=RerunData(),
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
 
         # Accumulates all ScriptRunnerEvents emitted by us.

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -35,6 +35,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import FragmentStorage
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.script_data import ScriptData
@@ -177,7 +178,15 @@ class AppSessionTest(unittest.TestCase):
 
     def test_creates_session_state_on_init(self):
         session = _create_test_session()
-        self.assertTrue(isinstance(session.session_state, SessionState))
+        self.assertIsInstance(session.session_state, SessionState)
+
+    def test_creates_fragment_storage_on_init(self):
+        session = _create_test_session()
+        # NOTE: We only call assertIsNotNone here because protocols can't be used with
+        # isinstance (there's no need to as the static type checker already ensures
+        # the field has the correct type), and we don't want to mark
+        # MemoryFragmentStorage as @runtime_checkable.
+        self.assertIsNotNone(session._fragment_storage)
 
     def test_clear_cache_resets_session_state(self):
         session = _create_test_session()
@@ -288,6 +297,7 @@ class AppSessionTest(unittest.TestCase):
             script_cache=session._script_cache,
             initial_rerun_data=RerunData(),
             user_info={"email": "test@test.com"},
+            fragment_storage=session._fragment_storage,
         )
 
         self.assertIsNotNone(session._scriptrunner)

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -33,6 +33,7 @@ from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.legacy_caching import caching
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
@@ -978,6 +979,7 @@ class TestScriptRunner(ScriptRunner):
             script_cache=ScriptCache(),
             initial_rerun_data=RerunData(),
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
 
         # Accumulates uncaught exceptions thrown by our run thread.


### PR DESCRIPTION
This PR continues work on the `st.experimental_fragment` feature in a pretty boring way: we simply create 
a new `MemoryFragmentStorage` in the `AppSession` constructor and pass it to each `ScriptRunner` that we
create.

Note that we intentionally don't allow the `FragmentStorage` used by `AppSession`s to be configurable from
`RuntimeConfig` for now as we're a ways away from needing to do this. We may choose to make this configurable
before merging the feature branch into `develop` if we have the free time, but there's little pressure to do this
right now so may also choose to punt on it until we have a concrete need for this.