### PR TITLE
Fix issue using a local path with `st.image` on windows.

### DIFF
--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -19,5 +19,4 @@ toml==0.10.1
 tornado==6.0.3
 typing-extensions==4.3.0
 tzlocal==1.1
-validators==0.2
 watchdog==2.1.5

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -56,7 +56,6 @@ INSTALL_REQUIRES = [
     "toml>=0.10.1, <2",
     "typing-extensions>=4.3.0, <5",
     "tzlocal>=1.1, <6",
-    "validators>=0.2, <1",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.
     "watchdog>=2.1.5; platform_system != 'Darwin'",

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -15,7 +15,6 @@
 import random
 from textwrap import dedent
 from typing import TYPE_CHECKING, Mapping, Optional, Union, cast
-from urllib.parse import urlparse
 
 from typing_extensions import Final, Literal, TypeAlias
 

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -26,6 +26,7 @@ from streamlit.proto.PageConfig_pb2 import PageConfig as PageConfigProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.string_util import is_emoji
+from streamlit.url_util import is_url
 from streamlit.util import lower_clean_dict_keys
 
 if TYPE_CHECKING:
@@ -259,21 +260,11 @@ def validate_menu_items(menu_items: MenuItems) -> None:
                 '"Get help", "Report a bug", and "About" '
                 f'("{k}" is not a valid key.)'
             )
-        if v is not None:
-            if not valid_url(v) and k != ABOUT_KEY:
-                raise StreamlitAPIException(f'"{v}" is a not a valid URL!')
+        if v is not None and (
+            not is_url(v, ("http", "https", "mailto")) and k != ABOUT_KEY
+        ):
+            raise StreamlitAPIException(f'"{v}" is a not a valid URL!')
 
 
 def valid_menu_item_key(key: str) -> "TypeGuard[MenuKey]":
     return key in {GET_HELP_KEY, REPORT_A_BUG_KEY, ABOUT_KEY}
-
-
-def valid_url(url: str) -> bool:
-    # Function taken from https://stackoverflow.com/questions/7160737/how-to-validate-a-url-in-python-malformed-or-not
-    try:
-        result = urlparse(url)
-        if result.scheme == "mailto":
-            return all([result.scheme, result.path])
-        return all([result.scheme, result.netloc])
-    except Exception:
-        return False

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -25,13 +25,12 @@ import mimetypes
 import re
 from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
-from urllib.parse import urlparse
 
 import numpy as np
 from PIL import GifImagePlugin, Image, ImageFile
 from typing_extensions import Final, Literal, TypeAlias
 
-from streamlit import runtime
+from streamlit import runtime, url_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
@@ -361,14 +360,9 @@ def image_to_url(
             # Return SVG as data URI:
             return f"data:image/svg+xml;base64,{image_b64_encoded}"
 
-        # If it's a url, return it directly.
-        try:
-            p = urlparse(image)
-            if p.scheme:
-                return image
-        except UnicodeDecodeError:
-            # If the string runs into a UnicodeDecodeError, we assume it is not a valid URL.
-            pass
+        if url_util.is_url(image, allowed_schemas=("http", "https", "data")):
+            # If it's a url, return it directly.
+            return image
 
         # Otherwise, try to open it as a file.
         try:

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
 from typing_extensions import Final, TypeAlias
 
 import streamlit as st
-from streamlit import runtime, type_util
+from streamlit import runtime, type_util, url_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
@@ -280,16 +280,16 @@ def marshall_video(
     start_time : int
         The time from which this element should start playing. (default: 0)
     """
-    from validators import url
 
     proto.start_time = start_time
 
     # "type" distinguishes between YouTube and non-YouTube links
     proto.type = VideoProto.Type.NATIVE
 
-    if isinstance(data, str) and url(data):
-        youtube_url = _reshape_youtube_url(data)
-        if youtube_url:
+    if isinstance(data, str) and url_util.is_url(
+        data, allowed_schemas=("http", "https", "data")
+    ):
+        if youtube_url := _reshape_youtube_url(data):
             proto.url = youtube_url
             proto.type = VideoProto.Type.YOUTUBE_IFRAME
         else:
@@ -405,11 +405,12 @@ def marshall_audio(
     sample_rate: int or None
         Optional param to provide sample_rate in case of numpy array
     """
-    from validators import url
 
     proto.start_time = start_time
 
-    if isinstance(data, str) and url(data):
+    if isinstance(data, str) and url_util.is_url(
+        data, allowed_schemas=("http", "https", "data")
+    ):
         proto.url = data
 
     else:

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -101,7 +101,7 @@ def is_url(
 
         if result.scheme in ["http", "https"]:
             return bool(result.netloc)
-        if result.scheme in ["mailto", "data"]:
+        elif result.scheme in ["mailto", "data"]:
             return bool(result.path)
         # This should never happen, all schemas should be covered above
         return False

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from typing import Literal, Optional, Set
+from typing import Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 from typing_extensions import TypeAlias
@@ -76,30 +76,31 @@ def print_url(title, url):
 
 def is_url(
     url: str,
-    allowed_schemas: Set[UrlSchema] = ("http", "https"),
+    allowed_schemas: Tuple[UrlSchema] = ("http", "https"),
 ) -> bool:
-    """Check if a string is a valid URL.
+    """Check if a string looks like an URL.
+
+    This doesn't check if the URL is actually valid or reachable.
 
     Parameters
     ----------
     url : str
         The URL to check.
 
-    allowed_schemas : Set[str]
+    allowed_schemas : Tuple[str]
         The allowed URL schemas. Default is ("http", "https").
     """
     try:
         result = urlparse(url)
-        if result is None:
-            return False
 
         if result.scheme not in allowed_schemas:
             return False
 
         if result.scheme in ["http", "https"]:
-            return all([result.scheme, result.netloc])
+            return bool(result.netloc)
         if result.scheme in ["mailto", "data"]:
-            return all([result.scheme, result.path])
+            return bool(result.path)
+        # This should never happen, all schemas should be covered above
         return False
     except ValueError:
         return False

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -90,12 +90,8 @@ def is_url(
     allowed_schemas : Tuple[str]
         The allowed URL schemas. Default is ("http", "https").
     """
-    if not isinstance(url, str):
-        return False
-
     try:
-        result = urlparse(url)
-
+        result = urlparse(str(url))
         if result.scheme not in allowed_schemas:
             return False
 
@@ -103,5 +99,7 @@ def is_url(
             return bool(result.netloc)
         elif result.scheme in ["mailto", "data"]:
             return bool(result.path)
+
     except ValueError:
         return False
+    return False

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -76,7 +76,7 @@ def print_url(title, url):
 
 def is_url(
     url: str,
-    allowed_schemas: Tuple[UrlSchema] = ("http", "https"),
+    allowed_schemas: Tuple[UrlSchema, ...] = ("http", "https"),
 ) -> bool:
     """Check if a string looks like an URL.
 

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -90,6 +90,9 @@ def is_url(
     allowed_schemas : Tuple[str]
         The allowed URL schemas. Default is ("http", "https").
     """
+    if not isinstance(url, str):
+        return False
+
     try:
         result = urlparse(url)
 

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -103,7 +103,5 @@ def is_url(
             return bool(result.netloc)
         elif result.scheme in ["mailto", "data"]:
             return bool(result.path)
-        # This should never happen, all schemas should be covered above
-        return False
     except ValueError:
         return False

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -196,7 +196,7 @@ def main_run(target: str, args=None, **kwargs):
     will download the script to a temporary file and runs this file.
 
     """
-    from validators import url
+    from streamlit import url_util
 
     bootstrap.load_config_options(flag_options=kwargs)
 
@@ -211,13 +211,11 @@ def main_run(target: str, args=None, **kwargs):
                 f"Streamlit requires raw Python (.py) files, not {extension}.\nFor more information, please see https://docs.streamlit.io"
             )
 
-    if url(target):
+    if url_util.is_url(target):
         from streamlit.temporary_directory import TemporaryDirectory
 
         with TemporaryDirectory() as temp_dir:
             from urllib.parse import urlparse
-
-            from streamlit import url_util
 
             path = urlparse(target).path
             main_script_path = os.path.join(

--- a/lib/tests/streamlit/commands/page_config_test.py
+++ b/lib/tests/streamlit/commands/page_config_test.py
@@ -17,12 +17,7 @@ from unittest import mock
 from parameterized import param, parameterized
 
 import streamlit as st
-from streamlit.commands.page_config import (
-    ENG_EMOJIS,
-    RANDOM_EMOJIS,
-    PageIcon,
-    valid_url,
-)
+from streamlit.commands.page_config import ENG_EMOJIS, RANDOM_EMOJIS, PageIcon
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.PageConfig_pb2 import PageConfig as PageConfigProto
 from streamlit.string_util import is_emoji
@@ -154,20 +149,3 @@ class PageConfigTest(DeltaGeneratorTestCase):
         st.set_page_config(menu_items={})
         c = self.get_message_from_queue().page_config_changed.menu_items
         self.assertEqual(c.about_section_md, "")
-
-    @parameterized.expand(
-        [
-            ("http://www.cwi.nl:80/%7Eguido/Python.html", True),
-            ("/data/Python.html", False),
-            (532, False),
-            ("dkakasdkjdjakdjadjfalskdjfalk", False),
-            ("https://stackoverflow.com", True),
-            ("mailto:test@example.com", True),
-            ("mailto:", False),
-        ]
-    )
-    def test_valid_url(self, url, expected_value):
-        if expected_value:
-            self.assertTrue(valid_url(url))
-        else:
-            self.assertFalse(valid_url(url))

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -100,7 +100,6 @@ class UrlUtilTest(unittest.TestCase):
             ("mailto:", False),
             ("ftp://example.com/resource", False),  # Unsupported scheme
             ("https:///path/to/resource", False),  # Missing netloc
-            ("mailto:invalid_email", False),  # Invalid email format
         ]
     )
     def test_is_url(self, url: Any, expected_value: bool):

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import unittest
+from typing import Any, Set
+
+from parameterized import parameterized
 
 from streamlit import url_util
 
@@ -63,13 +66,35 @@ INVALID_URLS = [
 
 class GitHubUrlTest(unittest.TestCase):
     def test_github_url_is_replaced(self):
-        for (target, processed) in GITHUB_URLS:
+        for target, processed in GITHUB_URLS:
             assert url_util.process_gitblob_url(target) == processed
 
     def test_gist_url_is_replaced(self):
-        for (target, processed) in GIST_URLS:
+        for target, processed in GIST_URLS:
             assert url_util.process_gitblob_url(target) == processed
 
     def test_nonmatching_url_is_not_replaced(self):
         for url in INVALID_URLS:
             assert url == url_util.process_gitblob_url(url)
+
+
+class UrlUtilTest(unittest.TestCase):
+
+    @parameterized.expand(
+        [
+            ("http://www.cwi.nl:80/%7Eguido/Python.html", True),
+            ("/data/Python.html", False),
+            (532, False),
+            ("dkakasdkjdjakdjadjfalskdjfalk", False),
+            ("https://stackoverflow.com", True),
+            ("mailto:test@example.com", True),
+            ("mailto:", False),
+            ("data:image/svg+xml;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
+            ("data:application/pdf;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
+        ]
+    )
+    def test_is_url(self, url: Any, expected_value: bool):
+        """Test the is_url utility function."""
+        self.assertEqual(
+            url_util.is_url(url, ("http", "https", "data", "mailto")), expected_value
+        )

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -82,25 +82,24 @@ class UrlUtilTest(unittest.TestCase):
 
     @parameterized.expand(
         [
+            # Valid URLs:
             ("http://www.cwi.nl:80/%7Eguido/Python.html", True),
+            ("https://stackoverflow.com", True),
+            ("mailto:test@example.com", True),
+            ("data:image/svg+xml;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
+            ("data:application/pdf;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
+            ("http://127.0.0.1", True),  # IP as domain
+            ("https://[::1]", True),  # IPv6 address in URL
+            # Invalid URLs:
             ("/data/Python.html", False),
             (532, False),
             ("dkakasdkjdjakdjadjfalskdjfalk", False),
-            ("https://stackoverflow.com", True),
-            ("mailto:test@example.com", True),
             ("mailto:", False),
-            ("data:image/svg+xml;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
-            ("data:application/pdf;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
             ("ftp://example.com/resource", False),  # Unsupported scheme
             ("https:///path/to/resource", False),  # Missing netloc
             ("mailto:invalid_email", False),  # Invalid email format
             ("data:text/plain;base64,", False),  # Valid scheme but missing data
-            (
-                "http://example.com/illegal<characters",
-                False,
-            ),  # URL with illegal characters
-            ("http://127.0.0.1", True),  # IP as domain
-            ("https://[::1]", True),  # IPv6 address in URL
+            ("http://example.com/illegal<chars", False),  # URL with illegal characters
         ]
     )
     def test_is_url(self, url: Any, expected_value: bool):

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -81,7 +81,6 @@ class GitHubUrlTest(unittest.TestCase):
 
 
 class UrlUtilTest(unittest.TestCase):
-
     @parameterized.expand(
         [
             # Valid URLs:

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -91,6 +91,16 @@ class UrlUtilTest(unittest.TestCase):
             ("mailto:", False),
             ("data:image/svg+xml;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
             ("data:application/pdf;base64,PHN2ZyB4aHcvMjAwMC9zdmci", True),
+            ("ftp://example.com/resource", False),  # Unsupported scheme
+            ("https:///path/to/resource", False),  # Missing netloc
+            ("mailto:invalid_email", False),  # Invalid email format
+            ("data:text/plain;base64,", False),  # Valid scheme but missing data
+            (
+                "http://example.com/illegal<characters",
+                False,
+            ),  # URL with illegal characters
+            ("http://127.0.0.1", True),  # IP as domain
+            ("https://[::1]", True),  # IPv6 address in URL
         ]
     )
     def test_is_url(self, url: Any, expected_value: bool):

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from typing import Any, Set
+from typing import Any
 
 from parameterized import parameterized
 

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -124,7 +124,10 @@ class UrlUtilTest(unittest.TestCase):
         ]
     )
     def test_is_url_limits_schema(
-        self, url: str, allowed_schemas: Tuple[str] | None, expected_value: bool
+        self,
+        url: str,
+        allowed_schemas: Tuple[url_util.UrlSchema, ...] | None,
+        expected_value: bool,
     ):
         """Test that is_ur applies the allowed schema parameter."""
 

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -76,7 +76,7 @@ class CliTest(unittest.TestCase):
 
     def test_run_existing_file_argument(self):
         """streamlit run succeeds if an existing file is passed."""
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
             result = self.runner.invoke(cli, ["run", "file_name.py"])
@@ -85,7 +85,7 @@ class CliTest(unittest.TestCase):
     def test_run_non_existing_file_argument(self):
         """streamlit run should fail if a non existing file is passed."""
 
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=False):
             result = self.runner.invoke(cli, ["run", "file_name.py"])
@@ -106,7 +106,7 @@ class CliTest(unittest.TestCase):
     def test_run_valid_url(self, temp_dir):
         """streamlit run succeeds if an existing url is passed."""
 
-        with patch("validators.url", return_value=True), patch(
+        with patch("streamlit.url_util.is_url", return_value=True), patch(
             "streamlit.web.cli._main_run"
         ), requests_mock.mock() as m:
             file_content = b"content"
@@ -125,7 +125,7 @@ class CliTest(unittest.TestCase):
         url is passed.
         """
 
-        with patch("validators.url", return_value=True), patch(
+        with patch("streamlit.url_util.is_url", return_value=True), patch(
             "streamlit.web.cli._main_run"
         ), requests_mock.mock() as m:
             m.get("http://url/app.py", exc=requests.exceptions.RequestException)
@@ -138,7 +138,7 @@ class CliTest(unittest.TestCase):
 
     def test_run_arguments(self):
         """The correct command line should be passed downstream."""
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "os.path.exists", return_value=True
         ):
             with patch("streamlit.web.cli._main_run") as mock_main_run:
@@ -161,7 +161,7 @@ class CliTest(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     def test_run_command_with_flag_config_options(self):
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
             result = self.runner.invoke(
@@ -175,7 +175,7 @@ class CliTest(unittest.TestCase):
 
     @parameterized.expand(["mapbox.token", "server.cookieSecret"])
     def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
             result = self.runner.invoke(
@@ -248,7 +248,7 @@ class CliTest(unittest.TestCase):
         """If headless mode and no config is present,
         activation should be None."""
         with testutil.patch_config_options({"server.headless": True}):
-            with patch("validators.url", return_value=False), patch(
+            with patch("streamlit.url_util.is_url", return_value=False), patch(
                 "streamlit.web.bootstrap.run"
             ), patch("os.path.exists", return_value=True), patch(
                 "streamlit.runtime.credentials._check_credential_file_exists",
@@ -268,7 +268,7 @@ class CliTest(unittest.TestCase):
         So we call `_check_activated`.
         """
         with testutil.patch_config_options({"server.headless": headless_mode}):
-            with patch("validators.url", return_value=False), patch(
+            with patch("streamlit.url_util.is_url", return_value=False), patch(
                 "streamlit.web.bootstrap.run"
             ), patch("os.path.exists", return_value=True), mock.patch(
                 "streamlit.runtime.credentials.Credentials._check_activated"
@@ -285,7 +285,7 @@ class CliTest(unittest.TestCase):
         """If headless mode, show a message about usage metrics gathering."""
 
         with testutil.patch_config_options({"server.headless": headless_mode}):
-            with patch("validators.url", return_value=False), patch(
+            with patch("streamlit.url_util.is_url", return_value=False), patch(
                 "os.path.exists", return_value=True
             ), patch("streamlit.config.is_manually_set", return_value=False), patch(
                 "streamlit.runtime.credentials._check_credential_file_exists",
@@ -339,7 +339,7 @@ class CliTest(unittest.TestCase):
             mock_logger.warning.assert_called_once()
 
     def test_hello_command_with_flag_config_options(self):
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
             result = self.runner.invoke(cli, ["hello", "--server.port=8502"])
@@ -358,7 +358,7 @@ class CliTest(unittest.TestCase):
             mock_config.assert_called()
 
     def test_config_show_command_with_flag_config_options(self):
-        with patch("validators.url", return_value=False), patch(
+        with patch("streamlit.url_util.is_url", return_value=False), patch(
             "streamlit.web.cli._main_run"
         ), patch("os.path.exists", return_value=True):
             result = self.runner.invoke(cli, ["config", "show", "--server.port=8502"])


### PR DESCRIPTION
## Describe your changes

This PR fixes an issue with using image files via a local path on Windows (https://github.com/streamlit/streamlit/issues/7271). This also unifies all URL checks in the Streamlit server with a Python native implementation and cuts out the `validators` dependency. 

## GitHub Issue Link (if applicable)

- Closes #7271
- Related to #6066

## Testing Plan

- Updated tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
