### PR TITLE
Remove importlib-metadata dependency

### DIFF
--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -3,7 +3,6 @@ blinker==1.0.0
 cachetools==4.0
 click==7.0
 gitpython==3.0.7
-importlib-metadata==1.4
 numpy==1.19.3
 packaging==16.8
 pandas==1.3.0

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -33,8 +33,6 @@ INSTALL_REQUIRES = [
     "blinker>=1.0.0, <2",
     "cachetools>=4.0, <6",
     "click>=7.0, <9",
-    # 1.4 introduced the functionality found in python 3.8's importlib.metadata module
-    "importlib-metadata>=1.4, <8",
     "numpy>=1.19.3, <2",
     "packaging>=16.8, <24",
     # Lowest version with available wheel for 3.7 + amd64 + linux

--- a/lib/streamlit/version.py
+++ b/lib/streamlit/version.py
@@ -14,9 +14,9 @@
 
 """Streamlit version utilities."""
 import random
+from importlib.metadata import version as _version
 
 import packaging.version
-from importlib_metadata import version as _version
 from typing_extensions import Final
 
 import streamlit.logger as logger


### PR DESCRIPTION
## Describe your changes

The `importlib-metadata` is a backport to bring some of the `importlib.metadata` functionality to pre Python 3.7. But we don't support Python 3.7 anymore, so we can just remove this dependency.

Related to #6066

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
