### PR TITLE
Remove `dateutil` and `tzlocal` dependencies

### DIFF
--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -18,7 +18,6 @@ wheel
 # mypy types
 types-click
 types-protobuf
-types-python-dateutil
 types-pytz
 types-requests
 types-setuptools

--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -11,7 +11,6 @@ pillow==7.1.0
 protobuf==3.20
 pyarrow==7.0
 pydeck==0.8.0b4
-python-dateutil==2.7.3
 requests==2.27
 rich==10.14.0
 tenacity==8.1.0

--- a/lib/min-constraints-gen.txt
+++ b/lib/min-constraints-gen.txt
@@ -17,6 +17,5 @@ tenacity==8.1.0
 toml==0.10.1
 tornado==6.0.3
 typing-extensions==4.3.0
-tzlocal==1.1
 validators==0.2
 watchdog==2.1.5

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -49,7 +49,6 @@ INSTALL_REQUIRES = [
     # doesn't tend to break the API on major version upgrades, so we don't put an
     # upper bound on it.
     "pyarrow>=7.0",
-    "python-dateutil>=2.7.3, <3",
     "requests>=2.27, <3",
     "rich>=10.14.0, <14",
     "tenacity>=8.1.0, <9",

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -54,7 +54,6 @@ INSTALL_REQUIRES = [
     "tenacity>=8.1.0, <9",
     "toml>=0.10.1, <2",
     "typing-extensions>=4.3.0, <5",
-    "tzlocal>=1.1, <6",
     "validators>=0.2, <1",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.
     # Without watchdog, we fallback to a polling file watcher to check for app changes.

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -29,7 +29,6 @@ from typing import (
     overload,
 )
 
-from dateutil import relativedelta
 from typing_extensions import TypeAlias
 
 from streamlit.elements.form import current_form_id
@@ -66,6 +65,23 @@ DEFAULT_STEP_MINUTES = 15
 ALLOWED_DATE_FORMATS = re.compile(
     r"^(YYYY[/.\-]MM[/.\-]DD|DD[/.\-]MM[/.\-]YYYY|MM[/.\-]DD[/.\-]YYYY)$"
 )
+
+
+def _adjust_years(input_date: date | datetime, years: int) -> date | datetime:
+    """Add or subtract years from a date or datetime."""
+    try:
+        # Attempt to directly add/subtract years
+        return input_date.replace(year=input_date.year + years)
+    except ValueError as err:
+        # Handle case for leap year date (February 29) that doesn't exist in the target year
+        # by moving the date to February 28
+        if input_date.month == 2 and input_date.day == 29:
+            return input_date.replace(year=input_date.year + years, month=2, day=28)
+
+        raise StreamlitAPIException(
+            f"Date {input_date} does not exist in the target year {input_date.year + years}. "
+            "This should never happen. Please report this bug."
+        ) from err
 
 
 def _parse_date_value(
@@ -112,9 +128,9 @@ def _parse_min_date(
         parsed_min_date = min_value
     elif min_value is None:
         if parsed_dates:
-            parsed_min_date = parsed_dates[0] - relativedelta.relativedelta(years=10)
+            parsed_min_date = _adjust_years(parsed_dates[0], years=-10)
         else:
-            parsed_min_date = date.today() - relativedelta.relativedelta(years=10)
+            parsed_min_date = _adjust_years(date.today(), years=-10)
     else:
         raise StreamlitAPIException(
             "DateInput min should either be a date/datetime or None"
@@ -133,9 +149,9 @@ def _parse_max_date(
         parsed_max_date = max_value
     elif max_value is None:
         if parsed_dates:
-            parsed_max_date = parsed_dates[-1] + relativedelta.relativedelta(years=10)
+            parsed_max_date = _adjust_years(parsed_dates[-1], years=10)
         else:
-            parsed_max_date = date.today() + relativedelta.relativedelta(years=10)
+            parsed_max_date = _adjust_years(date.today(), years=10)
     else:
         raise StreamlitAPIException(
             "DateInput max should either be a date/datetime or None"
@@ -651,9 +667,9 @@ class TimeWidgetsMixin:
     def _date_input(
         self,
         label: str,
-        value: DateValue
-        | Literal["today"]
-        | Literal["default_value_today"] = "default_value_today",
+        value: (
+            DateValue | Literal["today"] | Literal["default_value_today"]
+        ) = "default_value_today",
         min_value: SingleDateValue = None,
         max_value: SingleDateValue = None,
         key: Key | None = None,

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -67,8 +67,8 @@ ALLOWED_DATE_FORMATS = re.compile(
 )
 
 
-def _adjust_years(input_date: date | datetime, years: int) -> date | datetime:
-    """Add or subtract years from a date or datetime."""
+def _adjust_years(input_date: date, years: int) -> date:
+    """Add or subtract years from a date."""
     try:
         # Attempt to directly add/subtract years
         return input_date.replace(year=input_date.year + years)

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -57,3 +57,5 @@ semver<3
 langchain>=0.0.216; python_version < '3.12'
 # 8.0.0 causes test_sqlalchemy_engine_2_oracle to fail.
 cx-Oracle<8.0.0; python_version < '3.12'
+# Required for hashing test
+python-dateutil>=2.7.3, <3

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -59,3 +59,4 @@ langchain>=0.0.216; python_version < '3.12'
 cx-Oracle<8.0.0; python_version < '3.12'
 # Required for hashing test
 python-dateutil>=2.7.3, <3
+tzlocal>=1.1, <6

--- a/lib/test-requirements.txt
+++ b/lib/test-requirements.txt
@@ -58,5 +58,5 @@ langchain>=0.0.216; python_version < '3.12'
 # 8.0.0 causes test_sqlalchemy_engine_2_oracle to fail.
 cx-Oracle<8.0.0; python_version < '3.12'
 # Required for hashing test
-python-dateutil>=2.7.3, <3
-tzlocal>=1.1, <6
+python-dateutil>=2.7.3
+tzlocal>=1.1

--- a/lib/tests/streamlit/elements/time_widgets_test.py
+++ b/lib/tests/streamlit/elements/time_widgets_test.py
@@ -14,7 +14,10 @@
 
 import datetime
 
+from parameterized import parameterized
+
 import streamlit as st
+from streamlit.elements.widgets.time_widgets import _adjust_years
 from streamlit.errors import StreamlitAPIException
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -55,3 +58,30 @@ class StreamlitAPITest(DeltaGeneratorTestCase):
             st.time_input("Set an alarm for", value, step=datetime.timedelta(hours=24))
         with self.assertRaises(StreamlitAPIException):
             st.time_input("Set an alarm for", value, step=datetime.timedelta(days=1))
+
+
+@parameterized.expand(
+    [
+        # Test adding one year to a regular date:
+        (datetime.date(2021, 1, 1), 1, datetime.date(2022, 1, 1)),
+        # Test adding one year to a leap day, resulting in a non-leap year (Feb 28):
+        (datetime.date(2020, 2, 29), 1, datetime.date(2021, 2, 28)),
+        # Test subtracting one year from a leap day, adjusting to the previous year's Feb 28.
+        (datetime.date(2020, 2, 29), -1, datetime.date(2019, 2, 28)),
+        # Non-leap year, regular date
+        (datetime.date(2021, 3, 15), 1, datetime.date(2022, 3, 15)),
+        # Leap year to leap year:
+        (datetime.date(2020, 2, 29), 4, datetime.date(2024, 2, 29)),
+        # Subtracting years from a non-leap year date
+        (datetime.date(2019, 3, 15), -1, datetime.date(2018, 3, 15)),
+        # Adding 100 years, including a century leap year:
+        (datetime.date(1920, 4, 10), 100, datetime.date(2020, 4, 10)),
+        # End of year date
+        (datetime.date(2019, 12, 31), 1, datetime.date(2020, 12, 31)),
+    ]
+)
+def test_adjust_years(
+    input_date: datetime.date, years: int, expected_date: datetime.date
+):
+    """Test that `_adjust_years` correctly` adjusts the year of a date."""
+    assert _adjust_years(input_date, years) == expected_date


### PR DESCRIPTION
## Describe your changes

This PR removes `dateutil` dependency by replicating the required method. And removes the `tzlocal` dependency, which isn't used within Streamlit for anything. It's only used within one test. So its added as test-dependency instead.

Related to #6066

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
