### PR TITLE
More st.experimental_fragment skeleton code

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -16,7 +16,7 @@ import collections
 import contextvars
 import threading
 from dataclasses import dataclass, field
-from typing import Callable, Counter, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Counter, Dict, List, Optional, Set, Tuple
 from urllib import parse
 
 from typing_extensions import Final, TypeAlias
@@ -29,6 +29,9 @@ from streamlit.proto.PageProfile_pb2 import Command
 from streamlit.runtime.scriptrunner.script_requests import ScriptRequests
 from streamlit.runtime.state import SafeSessionState
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
+
+if TYPE_CHECKING:
+    from streamlit.runtime.fragment import FragmentStorage
 
 LOGGER: Final = get_logger(__name__)
 
@@ -66,6 +69,7 @@ class ScriptRunContext:
     main_script_path: str
     page_script_hash: str
     user_info: UserInfo
+    fragment_storage: "FragmentStorage"
 
     gather_usage_stats: bool = False
     command_tracking_deactivated: bool = False

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -19,7 +19,7 @@ import types
 from contextlib import contextmanager
 from enum import Enum
 from timeit import default_timer as timer
-from typing import Callable, Dict, Optional
+from typing import TYPE_CHECKING, Callable, Dict, Optional
 
 from blinker import Signal
 
@@ -28,7 +28,6 @@ from streamlit.error_util import handle_uncaught_app_exception
 from streamlit.logger import get_logger
 from streamlit.proto.ClientState_pb2 import ClientState
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.fragment import FragmentStorage, MemoryFragmentStorage
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.scriptrunner.script_requests import (
     RerunData,
@@ -47,6 +46,9 @@ from streamlit.runtime.state import (
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFileManager
 from streamlit.vendor.ipython.modified_sys_path import modified_sys_path
+
+if TYPE_CHECKING:
+    from streamlit.runtime.fragment import FragmentStorage
 
 _LOGGER = get_logger(__name__)
 
@@ -105,7 +107,7 @@ class ScriptRunner:
         script_cache: ScriptCache,
         initial_rerun_data: RerunData,
         user_info: Dict[str, Optional[str]],
-        fragment_storage: FragmentStorage,
+        fragment_storage: "FragmentStorage",
     ):
         """Initialize the ScriptRunner.
 
@@ -285,6 +287,7 @@ class ScriptRunner:
             page_script_hash="",
             user_info=self._user_info,
             gather_usage_stats=bool(config.get_option("browser.gatherUsageStats")),
+            fragment_storage=self._fragment_storage,
         )
         add_script_run_ctx(threading.current_thread(), ctx)
 

--- a/lib/tests/delta_generator_test_case.py
+++ b/lib/tests/delta_generator_test_case.py
@@ -26,6 +26,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
@@ -57,6 +58,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
             page_script_hash="",
             user_info={"email": "test@test.com"},
             script_requests=ScriptRequests(),
+            fragment_storage=MemoryFragmentStorage(),
         )
         add_script_run_ctx(threading.current_thread(), self.script_run_ctx)
 

--- a/lib/tests/exception_capturing_thread.py
+++ b/lib/tests/exception_capturing_thread.py
@@ -16,6 +16,7 @@ import threading
 from typing import Any, Callable, Optional
 
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import ScriptRunContext, add_script_run_ctx
 from streamlit.runtime.state import SafeSessionState, SessionState
@@ -67,6 +68,7 @@ def call_on_threads(
                 main_script_path="",
                 page_script_hash="",
                 user_info={"email": "test@test.com"},
+                fragment_storage=MemoryFragmentStorage(),
             )
             thread = threads[ii]
             add_script_run_ctx(thread, ctx)

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -58,6 +58,7 @@ FD = FieldDescriptor
                 ("custom_theme", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
                 ("app_pages", FD.LABEL_REPEATED, FD.TYPE_MESSAGE),
                 ("page_script_hash", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("fragment_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
             },
         ),
         (

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -35,7 +35,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
-from streamlit.runtime.fragment import FragmentStorage
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.script_data import ScriptData
@@ -639,6 +639,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
         add_script_run_ctx(ctx=ctx)
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -42,6 +42,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import (
     ScriptRunContext,
@@ -260,6 +261,7 @@ class CommonCacheTest(DeltaGeneratorTestCase):
                 main_script_path="",
                 page_script_hash="",
                 user_info={"email": "test@test.com"},
+                fragment_storage=MemoryFragmentStorage(),
             ),
         )
         with patch.object(call_stack, "_show_cached_st_function_warning") as warning:

--- a/lib/tests/streamlit/script_run_context_test.py
+++ b/lib/tests/streamlit/script_run_context_test.py
@@ -18,6 +18,7 @@ from parameterized import parameterized
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import ScriptRunContext
 from streamlit.runtime.state import SafeSessionState, SessionState
@@ -37,6 +38,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
 
         msg = ForwardMsg()
@@ -60,6 +62,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
 
         ctx.on_script_start()
@@ -87,6 +90,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
 
         ctx.on_script_start()
@@ -113,6 +117,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
 
         ctx.on_script_start()
@@ -149,6 +154,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
         ctx._experimental_query_params_used = experimental_used
         ctx._production_query_params_used = production_used
@@ -170,6 +176,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
         ctx.mark_experimental_query_params_used()
         assert ctx._experimental_query_params_used == True
@@ -185,6 +192,7 @@ class ScriptRunContextTest(unittest.TestCase):
             main_script_path="",
             page_script_hash="",
             user_info={"email": "test@test.com"},
+            fragment_storage=MemoryFragmentStorage(),
         )
         ctx.mark_production_query_params_used()
         assert ctx._production_query_params_used == True

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -17,6 +17,7 @@ import threading
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.scriptrunner import (
     ScriptRunContext,
     add_script_run_ctx,
@@ -105,6 +106,7 @@ class UserInfoProxyTest(DeltaGeneratorTestCase):
                     main_script_path="",
                     page_script_hash="",
                     user_info={"email": "something@else.com"},
+                    fragment_storage=MemoryFragmentStorage(),
                 ),
             )
 

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from streamlit import config
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.scriptrunner import ScriptRunContext
 from streamlit.runtime.state import SafeSessionState, SessionState
@@ -54,6 +55,7 @@ def create_mock_script_run_ctx() -> ScriptRunContext:
         main_script_path="",
         page_script_hash="mock_page_script_hash",
         user_info={"email": "mock@test.com"},
+        fragment_storage=MemoryFragmentStorage(),
     )
 
 

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -27,4 +27,5 @@ message ClientState {
   WidgetStates widget_states = 2;
   string page_script_hash = 3;
   string page_name = 4;
+  string fragment_id = 5;
 }

--- a/proto/streamlit/proto/Delta.proto
+++ b/proto/streamlit/proto/Delta.proto
@@ -40,4 +40,6 @@ message Delta {
     NamedDataSet add_rows = 5;
     ArrowNamedDataSet arrow_add_rows = 7;
   }
+
+  string fragment_id = 8;
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -51,6 +51,9 @@ message ForwardMsg {
 
     // Script was interrupted by rerun
     FINISHED_EARLY_FOR_RERUN = 2;
+
+    // A fragment of the script ran successfully.
+    FINISHED_FRAGMENT_RUN_SUCCESSFULLY = 3;
   }
 
   oneof type {

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -62,6 +62,9 @@ message NewSession {
 
   // A hash of the script corresponding to the page currently being viewed.
   string page_script_hash = 9;
+
+  // The fragment ID if the new session corresponds to a fragment script run.
+  string fragment_id = 10;
 }
 
 // Contains the session status that existed at the time the user connected.


### PR DESCRIPTION
This PR builds on work done in #8088 to plumb `FragmentStorage` instances
to a session's `ScriptRunContext`. This probably could have been included in the
previous PR, but we somehow didn't realize that we would need to do this while
working on that one 🙈

We also add some new proto fields that we'll use in subsequent PRs. 