### PR TITLE
Add `query_params` argument to `st.page_link`

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1287,8 +1287,8 @@ export class App extends PureComponent<Props, State> {
     )
   }
 
-  onPageChange = (pageScriptHash: string): void => {
-    this.sendRerunBackMsg(undefined, pageScriptHash)
+  onPageChange = (pageScriptHash: string, queryParams?: Map<string, string[]>): void => {
+    this.sendRerunBackMsg(undefined, pageScriptHash, queryParams)
   }
 
   isAppInReadyState = (prevState: Readonly<State>): boolean => {
@@ -1302,7 +1302,8 @@ export class App extends PureComponent<Props, State> {
 
   sendRerunBackMsg = (
     widgetStates?: WidgetStates,
-    pageScriptHash?: string
+    pageScriptHash?: string,
+    queryParams?: Map<string, string[]>,
   ): void => {
     const baseUriParts = this.getBaseUriParts()
     if (!baseUriParts) {
@@ -1316,7 +1317,12 @@ export class App extends PureComponent<Props, State> {
 
     const { currentPageScriptHash } = this.state
     const { basePath } = baseUriParts
-    let queryString = this.getQueryString()
+    let queryString: string;
+    if (queryParams !== undefined) {
+      queryString = this.queryParamsToString(queryParams)
+    } else {
+      queryString = this.getQueryString()
+    }
     let pageName = ""
 
     if (pageScriptHash) {
@@ -1596,6 +1602,13 @@ export class App extends PureComponent<Props, State> {
         : document.location.search
 
     return queryString.startsWith("?") ? queryString.substring(1) : queryString
+  }
+
+  queryParamsToString = (queryParams: Map<string, string[]>): string => {
+    return [...queryParams.entries()]
+      .flatMap(([k, vs]) => vs.map((v) => [k, v]))
+      .map(([k, v]) => encodeURIComponent(k) + "=" + encodeURIComponent(v))
+      .join("&")
   }
 
   isInCloudEnvironment = (): boolean => {

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -78,7 +78,7 @@ export interface AppViewProps {
 
   appPages: IAppPage[]
 
-  onPageChange: (pageName: string) => void
+  onPageChange: (pageName: string, queryParams?: Map<string, string[]>) => void
 
   currentPageScriptHash: string
 

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -51,7 +51,7 @@ export interface SidebarProps {
   theme: EmotionTheme
   hasElements: boolean
   appPages: IAppPage[]
-  onPageChange: (pageName: string) => void
+  onPageChange: (pageName: string, queryParams?: Map<string, string[]>) => void
   currentPageScriptHash: string
   hideSidebarNav: boolean
 }

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -74,7 +74,7 @@ export interface LibContextProps {
    * Change the page in a multi-page app.
    * @see PageLink
    */
-  onPageChange: (pageScriptHash: string) => void
+  onPageChange: (pageScriptHash: string, queryParams?: Map<string, string[]>) => void
 
   /**
    * The current page of a multi-page app.

--- a/frontend/lib/src/components/elements/PageLink/PageLink.tsx
+++ b/frontend/lib/src/components/elements/PageLink/PageLink.tsx
@@ -72,7 +72,7 @@ function PageLink(props: Props): ReactElement {
       // MPA Page Link
       e.preventDefault()
       if (!disabled) {
-        onPageChange(element.pageScriptHash as string)
+        onPageChange(element.pageScriptHash as string, element.queryParams)
       }
     }
   }

--- a/lib/streamlit/elements/lib/url_tools.py
+++ b/lib/streamlit/elements/lib/url_tools.py
@@ -1,10 +1,10 @@
-from typing import Dict, Iterable, Union
+from typing import Dict, Iterable, List, Mapping, Union
 from urllib.parse import urlsplit, urlencode, parse_qs, urlunsplit
 
 
 def merge_query_params(
     url: str,
-    query_params: Union[Dict[str, Union[str, Iterable[str]]], None],
+    query_params: Union[Mapping[str, Union[str, Iterable[str]]], None],
 ) -> str:
     if query_params is None:
         return url
@@ -24,3 +24,15 @@ def merge_query_params(
     split = split._replace(query=params_str)
 
     return urlunsplit(split)
+
+
+def normalize_query_params(
+    query_params: Union[Mapping[str, Union[str, Iterable[str]]], None],
+) -> Dict[str, List[str]]:
+    if query_params is None:
+        return {}
+
+    return {
+        key: [value] if isinstance(value, str) else list(value)
+        for key, value in query_params.items()
+    }

--- a/lib/streamlit/elements/lib/url_tools.py
+++ b/lib/streamlit/elements/lib/url_tools.py
@@ -1,0 +1,26 @@
+from typing import Dict, Iterable, Union
+from urllib.parse import urlsplit, urlencode, parse_qs, urlunsplit
+
+
+def merge_query_params(
+    url: str,
+    query_params: Union[Dict[str, Union[str, Iterable[str]]], None],
+) -> str:
+    if query_params is None:
+        return url
+
+    split = urlsplit(url=url)
+
+    params = parse_qs(split.query)
+    for key, value in query_params.items():
+        if isinstance(value, str):
+            params.setdefault(key, []).append(value)
+        else:
+            for item in value:
+                params.setdefault(key, []).append(item)
+
+    params_str = urlencode(params, doseq=True)
+
+    split = split._replace(query=params_str)
+
+    return urlunsplit(split)

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -18,11 +18,13 @@ import io
 import os
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Dict, Iterable, TYPE_CHECKING, BinaryIO, Optional, TextIO, Union, \
+from typing import Iterable, Mapping, TYPE_CHECKING, BinaryIO, Optional, TextIO, \
+    Union, \
     cast
 
 from typing_extensions import Final, Literal
 
+from elements.lib.url_tools import normalize_query_params
 from streamlit import runtime, source_util
 from streamlit.elements.form import current_form_id, is_in_form
 from streamlit.elements.lib.url_tools import merge_query_params
@@ -438,7 +440,7 @@ class ButtonMixin:
         help: str | None = None,
         disabled: bool = False,
         use_container_width: bool | None = None,
-        query_params: Union[Dict[str, Union[str, Iterable[str]]], None] = None,
+        query_params: Union[Mapping[str, Union[str, Iterable[str]]], None] = None,
     ) -> "DeltaGenerator":
         """Display a link to another page in a multipage app or to an external page.
 
@@ -493,8 +495,8 @@ class ButtonMixin:
             An optional boolean, which makes the link stretch its width to
             match the parent container. The default is ``True`` for page links
             in the sidebar, and ``False`` for those in the main app.
-        query_params: dict[str, str | Iterable[str]] | None
-            An optional dictionary of query params to include in the generated
+        query_params: Mapping[str, str | Iterable[str]] | None
+            An optional map of query params to include in the generated
             link. The default is ``None``.
 
         Example
@@ -639,7 +641,7 @@ class ButtonMixin:
         help: str | None = None,
         disabled: bool = False,
         use_container_width: bool | None = None,
-        query_params: Union[Dict[str, Union[str, Iterable[str]]], None] = None,
+        query_params: Union[Mapping[str, Union[str, Iterable[str]]], None] = None,
     ) -> "DeltaGenerator":
         page_link_proto = PageLinkProto()
         page_link_proto.disabled = disabled
@@ -694,6 +696,7 @@ class ButtonMixin:
                 page_link_proto.page_script_hash = page_data["page_script_hash"]
                 page_name_params = merge_query_params(page_name, query_params)
                 page_link_proto.page = page_name_params
+                page_link_proto.query_params = normalize_query_params(query_params)
                 break
 
         if page_link_proto.page_script_hash == "":

--- a/lib/tests/streamlit/elements/lib/url_tools_test.py
+++ b/lib/tests/streamlit/elements/lib/url_tools_test.py
@@ -1,0 +1,25 @@
+import unittest
+
+from streamlit.elements.lib.url_tools import merge_query_params
+
+
+class UrlToolsTest(unittest.TestCase):
+    def test_none(self):
+        actual = merge_query_params("https://streamlit.io", None)
+        self.assertEqual(actual, "https://streamlit.io")
+
+    def test_single(self):
+        actual = merge_query_params("https://streamlit.io", {"foo": "bar"})
+        self.assertEqual(actual, "https://streamlit.io/?foo=bar")
+
+    def test_multiple(self):
+        actual = merge_query_params("https://streamlit.io", {"foo": ("bar", "baz")})
+        self.assertEqual(actual, "https://streamlit.io/?foo=bar&foo=baz")
+
+    def test_merge(self):
+        actual = merge_query_params("https://streamlit.io/?foo=bar", {"foo": "baz"})
+        self.assertEqual(actual, "https://streamlit.io/?foo=bar&foo=baz")
+
+    def test_page_name(self):
+        actual = merge_query_params("foobar", {"foo": "bar"})
+        self.assertEqual(actual, "foobar?foo=bar")

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -106,3 +106,13 @@ class PageLinkTest(DeltaGeneratorTestCase):
         self.assertEqual(c.page, "https://streamlit.io")
         self.assertTrue(c.external)
         self.assertEqual(c.use_container_width, False)
+
+    def test_external_with_query_params(self):
+        st.page_link(
+            "https://streamlit.io", label="the label", query_params={"foo": "bar"}
+        )
+
+        c = self.get_delta_from_queue().new_element.page_link
+        self.assertEqual(c.label, "the label")
+        self.assertEqual(c.page, "https://streamlit.io/?foo=bar")
+        self.assertTrue(c.external)

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -35,6 +35,7 @@ class PageLinkTest(DeltaGeneratorTestCase):
         self.assertFalse(c.disabled)
         self.assertEqual(c.icon, "")
         self.assertEqual(c.help, "")
+        self.assertEqual(c.query_params, {})
 
     def test_external_https_page(self):
         """Test that it can be called with an external https page link."""

--- a/proto/streamlit/proto/PageLink.proto
+++ b/proto/streamlit/proto/PageLink.proto
@@ -19,6 +19,10 @@ syntax = "proto3";
 option java_package = "com.snowflake.apps.streamlit";
 option java_outer_classname = "PageLinkProto";
 
+message StringList {
+  repeated string values = 1;
+}
+
 message PageLink {
   string page = 1;
   string label = 2;
@@ -28,4 +32,5 @@ message PageLink {
   optional bool use_container_width = 6;
   bool disabled = 7;
   bool external = 8;
+  map<string, StringList> query_params = 9;
 }


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Adding `query_params` argument to `st.page_link`, so that internal links can have query params attached too. Useful for creating drill down page links.

```python
st.page_link("pages/foo.py", query_params={"input_value": "1337"})
```

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8112

## Testing Plan

- [ ] Explanation of why no additional tests are needed
- [x] Unit Tests (<s>JS and/or </s>Python)
- [ ] E2E Tests (WIP)
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
