### PR TITLE
Miscellaneous docstring edits and argument names

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -858,7 +858,14 @@ _create_option(
 )
 
 
-@_create_option("browser.serverPort", type_=int)
+@_create_option(
+    "browser.serverPort",
+    visibility="hidden",
+    deprecated=True,
+    deprecation_text="browser.serverPort has been deprecated. It will be removed in a future version.",
+    expiration_date="2024-04-01",
+    type_=int,
+)
 def _browser_server_port() -> int:
     """Port where users should point their browsers in order to connect to the
     app.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -721,7 +721,10 @@ def _server_address() -> Optional[str]:
 _create_option(
     "server.port",
     description="""
-        The port where the server will listen for browser connections.""",
+        The port where the server will listen for browser connections.
+
+        Don't use port 3000 which is reserved for internal development.
+        """,
     default_val=8501,
     type_=int,
 )
@@ -864,6 +867,8 @@ def _browser_server_port() -> int:
     - Set the correct URL for CORS and XSRF protection purposes.
     - Show the URL on the terminal
     - Open the browser
+
+    Don't use port 3000 which is reserved for internal development.
 
     Default: whatever value is set in server.port.
     """

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -53,14 +53,16 @@ class PydeckMixin:
         - DeckGL JSON docs: https://github.com/uber/deck.gl/tree/master/modules/json
 
         When using this command, Mapbox provides the map tiles to render map
-        content. Note that Mapbox is a third-party product, the use of which is
-        governed by Mapbox's Terms of Use.
+        content. Note that Mapbox is a third-party product and Streamlit accepts
+        no responsibility or liability of any kind for Mapbox or for any content
+        or information made available by Mapbox.
 
         Mapbox requires users to register and provide a token before users can
         request map tiles. Currently, Streamlit provides this token for you, but
         this could change at any time. We strongly recommend all users create and
         use their own personal Mapbox token to avoid any disruptions to their
-        experience. You can do this with the ``mapbox.token`` config option.
+        experience. You can do this with the ``mapbox.token`` config option. The
+        use of Mapbox is governed by Mapbox's Terms of Use.
 
         To get a token for yourself, create an account at https://mapbox.com.
         For more info on how to set config options, see

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -108,14 +108,16 @@ class MapMixin:
         scatterplot charts on top of a map, with auto-centering and auto-zoom.
 
         When using this command, Mapbox provides the map tiles to render map
-        content. Note that Mapbox is a third-party product, the use of which is
-        governed by Mapbox's Terms of Use.
+        content. Note that Mapbox is a third-party product and Streamlit accepts
+        no responsibility or liability of any kind for Mapbox or for any content
+        or information made available by Mapbox.
 
         Mapbox requires users to register and provide a token before users can
         request map tiles. Currently, Streamlit provides this token for you, but
         this could change at any time. We strongly recommend all users create and
         use their own personal Mapbox token to avoid any disruptions to their
-        experience. You can do this with the ``mapbox.token`` config option.
+        experience. You can do this with the ``mapbox.token`` config option. The
+        use of Mapbox is governed by Mapbox's Terms of Use.
 
         To get a token for yourself, create an account at https://mapbox.com.
         For more info on how to set config options, see

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -21,7 +21,7 @@ from streamlit.runtime.scriptrunner import add_script_run_ctx
 
 
 @contextlib.contextmanager
-def spinner(text: str = "In progress...", *, cache: bool = False) -> Iterator[None]:
+def spinner(text: str = "In progress...", *, _cache: bool = False) -> Iterator[None]:
     """Temporarily displays a message while executing a block of code.
 
     Parameters
@@ -70,7 +70,7 @@ def spinner(text: str = "In progress...", *, cache: bool = False) -> Iterator[No
                         with caching.suppress_cached_st_function_warning():
                             spinner_proto = SpinnerProto()
                             spinner_proto.text = clean_text(text)
-                            spinner_proto.cache = cache
+                            spinner_proto.cache = _cache
                             message._enqueue("spinner", spinner_proto)
 
         add_script_run_ctx(threading.Timer(DELAY_SECS, set_message)).start()

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -273,7 +273,7 @@ class ButtonMixin:
 
         >>> import streamlit as st
         >>>
-        >>> @st.cache
+        >>> @st.cache_data
         ... def convert_df(df):
         ...     # IMPORTANT: Cache the conversion to prevent computation on every rerun
         ...     return df.to_csv().encode('utf-8')

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -78,7 +78,7 @@ class WriteMixin:
 
         Parameters
         ----------
-        arg : Callable, Generator, Iterable, OpenAI Stream, or LangChain Stream
+        stream : Callable, Generator, Iterable, OpenAI Stream, or LangChain Stream
             The generator or iterable to stream.
 
         Returns

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -237,7 +237,7 @@ class CachedFunc:
             message = self._info.show_spinner
 
         if self._info.show_spinner or isinstance(self._info.show_spinner, str):
-            with spinner(message, cache=True):
+            with spinner(message, _cache=True):
                 return self._get_or_create_cached_value(args, kwargs)
         else:
             return self._get_or_create_cached_value(args, kwargs)

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -712,7 +712,7 @@ def cache(
             return return_value
 
         if show_spinner:
-            with spinner(message, cache=True):
+            with spinner(message, _cache=True):
                 return get_or_create_cached_value()
         else:
             return get_or_create_cached_value()

--- a/lib/tests/streamlit/spinner_test.py
+++ b/lib/tests/streamlit/spinner_test.py
@@ -54,7 +54,7 @@ class SpinnerTest(DeltaGeneratorTestCase):
 
     def test_spinner_for_caching(self):
         """Test st.spinner in cache functions."""
-        with spinner("some text", cache=True):
+        with spinner("some text", _cache=True):
             # Without the timeout, the spinner is sometimes not available
             time.sleep(0.7)
             el = self.get_delta_from_queue().new_element


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

This is a miscellaneous collection of docstring edits plus a renaming of the `cache` parameter to `_cache` for `st.spinner`. The docstring parser has been updated to automatically hide parameters with an underscore prefix from documentation. This reduces the visibility of any parameters that are used for internal purposes only.

## Testing Plan

None. This PR contains only docstring edits and a renaming of a local variable within a function. Existing tests for `st.spinner` have been updated to use renamed argument.

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
