### PR TITLE
Added Client IP addresses to client_info dict

### DIFF
--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -105,6 +105,8 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
             user_info["email"] = None
         else:
             user_info["email"] = email
+        
+        user_info["ip_addr"] = self.request.remote_ip
 
         existing_session_id = None
         try:


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
added client ip addresses to user_info dict so that developers can leverage whitelisting/blacklisting from top-level app.py. Useful for intra-networks in medium to large sized companies.

Usage from app.py:        
```
from streamlit.runtime.scriptrunner import get_script_run_ctx

client_info = get_script_run_ctx
user_ip = client_info.user_info["ip_addr"]
```
## GitHub Issue Link (if applicable)
[#602](https://github.com/streamlit/streamlit/issues/602)

## Testing Plan

static change, no testing needed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
