### PR TITLE
Add backend changes for st.experimental_fragment aside from the decorator itself

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -64,6 +64,7 @@ from streamlit.runtime.caching import (
 from streamlit.runtime.connection_factory import (
     connection_factory as _connection,
 )
+from streamlit.runtime.fragment import fragment as _fragment
 from streamlit.runtime.metrics_util import gather_metrics as _gather_metrics
 from streamlit.runtime.secrets import secrets_singleton as _secrets_singleton
 from streamlit.runtime.state import (
@@ -212,9 +213,10 @@ column_config = _column_config
 connection = _connection
 
 # Experimental APIs
-experimental_user = _UserInfoProxy()
-experimental_singleton = _experimental_singleton
+experimental_fragment = _fragment
 experimental_memo = _experimental_memo
+experimental_singleton = _experimental_singleton
+experimental_user = _UserInfoProxy()
 
 _EXPERIMENTAL_QUERY_PARAMS_DEPRECATE_MSG = "Refer to our [docs page](https://docs.streamlit.io/library/api-reference/utilities/st.query_params) for more information."
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import asyncio
 import sys
 import uuid
@@ -528,7 +530,7 @@ class AppSession:
             run. Set only for the SCRIPT_STARTED event.
 
         fragment_id : str | None
-            The fragment ID if this script run corresponds to a fragment.
+            The fragment ID if this script run was triggered by a fragment.
         """
 
         assert (
@@ -649,7 +651,7 @@ class AppSession:
         return msg
 
     def _create_new_session_message(
-        self, page_script_hash: str, fragment_id: Optional[str] = None
+        self, page_script_hash: str, fragment_id: str | None = None
     ) -> ForwardMsg:
         """Create and return a new_session ForwardMsg."""
         msg = ForwardMsg()

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -95,6 +95,8 @@ def fragment(
     ...
 
 
+# Support being able to pass parameters to this decorator (that is, being able to write
+# `@fragment(run_every=5.0)`).
 @overload
 def fragment(
     func: None = None,

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -15,10 +15,15 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar, overload
 
 from typing_extensions import Protocol
 
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.runtime.scriptrunner.script_run_context import dg_stack
+
+F = TypeVar("F", bound=Callable[..., Any])
 Fragment = Callable[[], Any]
 
 
@@ -79,3 +84,30 @@ class MemoryFragmentStorage(FragmentStorage):
 
     def clear(self) -> None:
         self._fragments.clear()
+
+
+@overload
+def fragment(
+    func: F,
+    *,
+    run_every: float | None = None,
+) -> F:
+    ...
+
+
+@overload
+def fragment(
+    func: None = None,
+    *,
+    run_every: float | None = None,
+) -> Callable[[F], F]:
+    ...
+
+
+@gather_metrics("experimental_fragment")
+def fragment(  # type: ignore[empty-body]
+    func: F | None = None,
+    *,
+    run_every: float | None = None,
+) -> Callable[[F], F] | F:
+    pass

--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -44,6 +44,7 @@ class RerunData:
     widget_states: Optional[WidgetStates] = None
     page_script_hash: str = ""
     page_name: str = ""
+    fragment_id: Optional[str] = None
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -130,6 +131,7 @@ class ScriptRequests:
                         widget_states=coalesced_states,
                         page_script_hash=new_data.page_script_hash,
                         page_name=new_data.page_name,
+                        fragment_id=new_data.fragment_id,
                     )
                     return True
 

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -82,6 +82,7 @@ class ScriptRunContext:
     form_ids_this_run: Set[str] = field(default_factory=set)
     cursors: Dict[int, "streamlit.cursor.RunningCursor"] = field(default_factory=dict)
     script_requests: Optional[ScriptRequests] = None
+    current_fragment_id: Optional[str] = None
 
     # TODO(willhuang1997): Remove this variable when experimental query params are removed
     _experimental_query_params_used = False
@@ -100,6 +101,7 @@ class ScriptRunContext:
         self.command_tracking_deactivated: bool = False
         self.tracked_commands = []
         self.tracked_commands_counter = collections.Counter()
+        self.current_fragment_id = None
 
         parsed_query_params = parse.parse_qs(query_string, keep_blank_values=True)
         with self.session_state.query_params() as qp:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -594,6 +594,8 @@ class ScriptRunner:
 
         finally:
             if rerun_exception_data:
+                # The handling for when a full script run or a fragment is stopped early
+                # is the same, so we only have one ScriptRunnerEvent for this scenario.
                 finished_event = ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN
             elif fragment_run:
                 finished_event = ScriptRunnerEvent.FRAGMENT_STOPPED_WITH_SUCCESS

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -69,6 +69,10 @@ class ScriptRunnerEvent(Enum):
     # The script run stopped in order to start a script run with newer widget state.
     SCRIPT_STOPPED_FOR_RERUN = "SCRIPT_STOPPED_FOR_RERUN"
 
+    # The script run corresponding to a fragment ran to completion, or was interrupted
+    # by the user.
+    FRAGMENT_STOPPED_WITH_SUCCESS = "FRAGMENT_STOPPED_WITH_SUCCESS"
+
     # The ScriptRunner is done processing the ScriptEventQueue and
     # is shut down.
     SHUTDOWN = "SHUTDOWN"
@@ -461,6 +465,7 @@ class ScriptRunner:
             self,
             event=ScriptRunnerEvent.SCRIPT_STARTED,
             page_script_hash=page_script_hash,
+            fragment_id=rerun_data.fragment_id,
         )
 
         # Compile the script. Any errors thrown here will be surfaced
@@ -510,6 +515,7 @@ class ScriptRunner:
         # If the script stops early, we don't want to remove unseen widgets,
         # so we track this to potentially skip session state cleanup later.
         premature_stop: bool = False
+        fragment_run: bool = False
 
         try:
             # Create fake module. This gives us a name global namespace to
@@ -545,7 +551,26 @@ class ScriptRunner:
 
                 ctx.on_script_start()
                 prep_time = timer() - start_time
-                exec(code, module.__dict__)
+
+                if rerun_data.fragment_id:
+                    fragment_run = True
+
+                    try:
+                        wrapped_fragment = self._fragment_storage.get(
+                            rerun_data.fragment_id
+                        )
+                    except KeyError:
+                        raise RuntimeError(
+                            f"Could not find fragment with id {rerun_data.fragment_id}"
+                        )
+
+                    wrapped_fragment()
+                    # TODO(vdonato): Maybe implement reruns on non-None return values
+                    # depending on exactly what we decide on the product side.
+                else:
+                    self._fragment_storage.clear()
+                    exec(code, module.__dict__)
+
                 self._session_state.maybe_check_serializable()
                 self._session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY] = True
         except RerunException as e:
@@ -570,6 +595,8 @@ class ScriptRunner:
         finally:
             if rerun_exception_data:
                 finished_event = ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN
+            elif fragment_run:
+                finished_event = ScriptRunnerEvent.FRAGMENT_STOPPED_WITH_SUCCESS
             else:
                 finished_event = ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS
 

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -59,3 +59,7 @@ class MemoryFragmentStorageTest(unittest.TestCase):
 
         self._storage.clear()
         assert len(self._storage._fragments) == 0
+
+
+class FragmentTest(unittest.TestCase):
+    pass

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -291,6 +291,10 @@ class ScriptRunnerTest(AsyncTestCase):
             scriptrunner,
             [
                 ScriptRunnerEvent.SCRIPT_STARTED,
+                # The only error ScriptRunnerEvent occurs when a script fails to
+                # compile. Other error types are displayed to the user via
+                # st.exception and from the ScriptRunner's perspective are still
+                # successful script runs.
                 ScriptRunnerEvent.FRAGMENT_STOPPED_WITH_SUCCESS,
                 ScriptRunnerEvent.SHUTDOWN,
             ],

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -251,6 +251,8 @@ class ScriptRunnerTest(AsyncTestCase):
     def test_run_script(self, filename, text):
         """Tests that we can run a script to completion."""
         scriptrunner = TestScriptRunner(filename)
+        scriptrunner._fragment_storage = MagicMock()
+
         scriptrunner.request_rerun(RerunData())
         scriptrunner.start()
         scriptrunner.join()
@@ -266,6 +268,7 @@ class ScriptRunnerTest(AsyncTestCase):
             ],
         )
         self._assert_text_deltas(scriptrunner, [text])
+        scriptrunner._fragment_storage.clear.assert_called_once()
         # The following check is a requirement for the CodeHasher to
         # work correctly. The CodeHasher is scoped to
         # files contained in the directory of __main__.__file__, which we
@@ -275,6 +278,48 @@ class ScriptRunnerTest(AsyncTestCase):
             sys.modules["__main__"].__file__,
             (" ScriptRunner should set the __main__.__file__" "attribute correctly"),
         )
+
+    @patch("streamlit.exception")
+    def test_run_nonexistent_fragment(self, patched_st_exception):
+        """Tests that we raise an exception when trying to run a nonexistent fragment."""
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.request_rerun(RerunData(fragment_id="nonexistent_fragment"))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.FRAGMENT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+
+        self._assert_no_exceptions(scriptrunner)
+        patched_st_exception.assert_called_once()
+
+    def test_run_fragment(self):
+        """Tests that we can run a fragment."""
+        fragment = MagicMock()
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner._fragment_storage.set("my_fragment", fragment)
+
+        scriptrunner.request_rerun(RerunData(fragment_id="my_fragment"))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_events(
+            scriptrunner,
+            [
+                ScriptRunnerEvent.SCRIPT_STARTED,
+                ScriptRunnerEvent.FRAGMENT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SHUTDOWN,
+            ],
+        )
+
+        fragment.assert_called_once()
 
     def test_compile_error(self):
         """Tests that we get an exception event when a script can't compile."""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -154,6 +154,7 @@ class StreamlitTest(unittest.TestCase):
                 "experimental_rerun",
                 "experimental_data_editor",
                 "experimental_connection",
+                "experimental_fragment",
                 "get_option",
                 "set_option",
                 "connection",


### PR DESCRIPTION
This PR implements most of the necessary Python-side changes to get
`st.experimental_fragment` working with the exception of the decorator
itself, which we will add in its own PR to keep this diff from getting too large.