### PR TITLE
Lazy-load vendored pympler asizeof module

### DIFF
--- a/e2e_playwright/lazy_loaded_modules.py
+++ b/e2e_playwright/lazy_loaded_modules.py
@@ -41,4 +41,9 @@ lazy_loaded_modules = [
 
 for module in lazy_loaded_modules:
     loaded = module in sys.modules
-    st.write(f"**{module}**:", ("loaded" if loaded else "not loaded"))
+    st.write(f"**{module}**:", ("imported" if loaded else "not loaded"))
+
+if st.button("Import lazy loaded modules"):
+    for module in lazy_loaded_modules:
+        __import__(module)
+    st.rerun()

--- a/e2e_playwright/lazy_loaded_modules.py
+++ b/e2e_playwright/lazy_loaded_modules.py
@@ -26,10 +26,10 @@ lazy_loaded_modules = [
     "watchdog",
     "streamlit.emojis",
     "streamlit.external",
+    "streamlit.vendor.pympler",
     "streamlit.watcher.event_based_path_watcher",
     # TODO(lukasmasuch): Lazy load more packages:
     # "streamlit.hello",
-    # "streamlit.vendor.pympler",
     # "pandas",
     # "pyarrow",
     # "numpy",

--- a/e2e_playwright/lazy_loaded_modules_test.py
+++ b/e2e_playwright/lazy_loaded_modules_test.py
@@ -20,6 +20,6 @@ from playwright.sync_api import Page, expect
 def test_lazy_loaded_modules_are_not_imported(app: Page):
     """Test that lazy loaded modules are not imported when the page is loaded."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(10)
+    expect(markdown_elements).to_have_count(11)
     for element in markdown_elements.all():
         expect(element).to_have_text(re.compile(r".*not loaded.*"))

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -20,7 +20,7 @@ import math
 import threading
 import types
 from datetime import timedelta
-from typing import Any, Callable, TypeVar, cast, overload
+from typing import Any, Callable, Final, List, TypeVar, cast, overload
 
 from typing_extensions import TypeAlias
 
@@ -48,9 +48,8 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 from streamlit.util import TimedCleanupCache
-from streamlit.vendor.pympler.asizeof import asizeof
 
-_LOGGER = get_logger(__name__)
+_LOGGER: Final = get_logger(__name__)
 
 
 CACHE_RESOURCE_MESSAGE_REPLAY_CTX = CachedMessageReplayContext(CacheType.RESOURCE)
@@ -520,7 +519,7 @@ class ResourceCache(Cache):
             return result
 
     @gather_metrics("_cache_resource_object")
-    def write_result(self, key: str, value: Any, messages: list[MsgData]) -> None:
+    def write_result(self, key: str, value: Any, messages: List[MsgData]) -> None:
         """Write a value and associated messages to the cache."""
         ctx = get_script_run_ctx()
         if ctx is None:
@@ -560,6 +559,9 @@ class ResourceCache(Cache):
         # the lock.
         with self._mem_cache_lock:
             cache_entries = list(self._mem_cache.values())
+
+        # Lazy-load vendored package to prevent import of numpy
+        from streamlit.vendor.pympler.asizeof import asizeof
 
         return [
             CacheStat(

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -20,7 +20,7 @@ import math
 import threading
 import types
 from datetime import timedelta
-from typing import Any, Callable, Final, List, TypeVar, cast, overload
+from typing import Any, Callable, Final, TypeVar, cast, overload
 
 from typing_extensions import TypeAlias
 

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -519,7 +519,7 @@ class ResourceCache(Cache):
             return result
 
     @gather_metrics("_cache_resource_object")
-    def write_result(self, key: str, value: Any, messages: List[MsgData]) -> None:
+    def write_result(self, key: str, value: Any, messages: list[MsgData]) -> None:
         """Write a value and associated messages to the cache."""
         ctx = get_script_run_ctx()
         if ctx is None:

--- a/lib/streamlit/runtime/legacy_caching/caching.py
+++ b/lib/streamlit/runtime/legacy_caching/caching.py
@@ -30,6 +30,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Final,
     Iterator,
     List,
     Optional,
@@ -58,9 +59,8 @@ from streamlit.runtime.legacy_caching.hashing import (
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider
 from streamlit.util import HASHLIB_KWARGS
-from streamlit.vendor.pympler.asizeof import asizeof
 
-_LOGGER = get_logger(__name__)
+_LOGGER: Final = get_logger(__name__)
 
 # The timer function we use with TTLCache. This is the default timer func, but
 # is exposed here as a constant so that it can be patched in unit tests.
@@ -225,6 +225,9 @@ class _MemCaches(CacheStatsProvider):
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.
             function_caches = self._function_caches.copy()
+
+        # Lazy-load vendored package to prevent import of numpy
+        from streamlit.vendor.pympler.asizeof import asizeof
 
         stats = [
             CacheStat("st_cache", cache.display_name, asizeof(c))

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
 
 import json
@@ -20,6 +21,7 @@ from dataclasses import dataclass, field, replace
 from typing import (
     TYPE_CHECKING,
     Any,
+    Final,
     Iterator,
     KeysView,
     List,
@@ -28,7 +30,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Final, TypeAlias
+from typing_extensions import TypeAlias
 
 import streamlit as st
 from streamlit import config, util
@@ -45,7 +47,6 @@ from streamlit.runtime.state.common import (
 from streamlit.runtime.state.query_params import QueryParams
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
 from streamlit.type_util import ValueFieldName, is_array_value_field_name
-from streamlit.vendor.pympler.asizeof import asizeof
 
 if TYPE_CHECKING:
     from streamlit.runtime.session_manager import SessionManager
@@ -637,6 +638,9 @@ class SessionState:
             return True
 
     def get_stats(self) -> list[CacheStat]:
+        # Lazy-load vendored package to prevent import of numpy
+        from streamlit.vendor.pympler.asizeof import asizeof
+
         stat = CacheStat("st_session_state", "", asizeof(self))
         return [stat]
 


### PR DESCRIPTION
## Describe your changes

The vendored pympler module is only used when someone explicitly requests the metrics via the metrics endpoint. This PR moves the module to lazyloading. 

## GitHub Issue Link (if applicable)

Related to #6066

## Testing Plan

- Added e2e test to ensure that vendored `pympler` module is lazy loaded.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
