### PR TITLE
Lazy-load pandas and pyarrow to improve performance

### DIFF
--- a/e2e_playwright/lazy_loaded_modules.py
+++ b/e2e_playwright/lazy_loaded_modules.py
@@ -24,19 +24,18 @@ lazy_loaded_modules = [
     "altair",
     "graphviz",
     "watchdog",
+    "pandas",
+    "pyarrow",
     "streamlit.emojis",
     "streamlit.external",
     "streamlit.watcher.event_based_path_watcher",
     # TODO(lukasmasuch): Lazy load more packages:
     # "streamlit.hello",
     # "streamlit.vendor.pympler",
-    # "pandas",
-    # "pyarrow",
     # "numpy",
     # "matplotlib",
     # "plotly",
     # "pillow",
-    # "watchdog",
 ]
 
 for module in lazy_loaded_modules:

--- a/e2e_playwright/lazy_loaded_modules_test.py
+++ b/e2e_playwright/lazy_loaded_modules_test.py
@@ -20,6 +20,6 @@ from playwright.sync_api import Page, expect
 def test_lazy_loaded_modules_are_not_imported(app: Page):
     """Test that lazy loaded modules are not imported when the page is loaded."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(10)
+    expect(markdown_elements).to_have_count(12)
     for element in markdown_elements.all():
         expect(element).to_have_text(re.compile(r".*not loaded.*"))

--- a/lib/streamlit/components/v1/component_arrow.py
+++ b/lib/streamlit/components/v1/component_arrow.py
@@ -18,13 +18,14 @@ CustomComponent for dataframe serialization.
 
 from __future__ import annotations
 
-from typing import Any
-
-import pandas as pd
+from typing import TYPE_CHECKING, Any
 
 from streamlit import type_util
 from streamlit.elements.lib import pandas_styler_utils
 from streamlit.proto.Components_pb2 import ArrowTable as ArrowTableProto
+
+if TYPE_CHECKING:
+    from pandas import DataFrame, Index, Series
 
 
 def marshall(
@@ -50,7 +51,7 @@ def marshall(
     _marshall_data(proto, df)
 
 
-def _marshall_index(proto: ArrowTableProto, index: pd.Index) -> None:
+def _marshall_index(proto: ArrowTableProto, index: Index) -> None:
     """Marshall pandas.DataFrame index into an ArrowTable proto.
 
     Parameters
@@ -63,12 +64,14 @@ def _marshall_index(proto: ArrowTableProto, index: pd.Index) -> None:
         Will default to RangeIndex (0, 1, 2, ..., n) if no index is provided.
 
     """
+    import pandas as pd
+
     index = map(type_util.maybe_tuple_to_list, index.values)
     index_df = pd.DataFrame(index)
     proto.index = type_util.data_frame_to_bytes(index_df)
 
 
-def _marshall_columns(proto: ArrowTableProto, columns: pd.Series) -> None:
+def _marshall_columns(proto: ArrowTableProto, columns: Series) -> None:
     """Marshall pandas.DataFrame columns into an ArrowTable proto.
 
     Parameters
@@ -81,12 +84,14 @@ def _marshall_columns(proto: ArrowTableProto, columns: pd.Series) -> None:
         Will default to RangeIndex (0, 1, 2, ..., n) if no column labels are provided.
 
     """
+    import pandas as pd
+
     columns = map(type_util.maybe_tuple_to_list, columns.values)
     columns_df = pd.DataFrame(columns)
     proto.columns = type_util.data_frame_to_bytes(columns_df)
 
 
-def _marshall_data(proto: ArrowTableProto, df: pd.DataFrame) -> None:
+def _marshall_data(proto: ArrowTableProto, df: DataFrame) -> None:
     """Marshall pandas.DataFrame data into an ArrowTable proto.
 
     Parameters
@@ -101,7 +106,7 @@ def _marshall_data(proto: ArrowTableProto, df: pd.DataFrame) -> None:
     proto.data = type_util.data_frame_to_bytes(df)
 
 
-def arrow_proto_to_dataframe(proto: ArrowTableProto) -> pd.DataFrame:
+def arrow_proto_to_dataframe(proto: ArrowTableProto) -> DataFrame:
     """Convert ArrowTable proto to pandas.DataFrame.
 
     Parameters
@@ -110,11 +115,14 @@ def arrow_proto_to_dataframe(proto: ArrowTableProto) -> pd.DataFrame:
         Output. pandas.DataFrame
 
     """
+
     if type_util.is_pyarrow_version_less_than("14.0.1"):
         raise RuntimeError(
             "The installed pyarrow version is not compatible with this component. "
             "Please upgrade to 14.0.1 or higher: pip install -U pyarrow"
         )
+
+    import pandas as pd
 
     data = type_util.bytes_to_data_frame(proto.data)
     index = type_util.bytes_to_data_frame(proto.index)

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -23,19 +23,19 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
-import pandas as pd
-
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import running_in_sis
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from pandas import DataFrame
+    from snowflake.connector.cursor import SnowflakeCursor  # type:ignore[import]
+    from snowflake.snowpark.session import Session  # type:ignore[import]
+
     from snowflake.connector import (  # type:ignore[import] # isort: skip
         SnowflakeConnection as InternalSnowflakeConnection,
     )
-    from snowflake.connector.cursor import SnowflakeCursor  # type:ignore[import]
-    from snowflake.snowpark.session import Session  # type:ignore[import]
 
 
 class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
@@ -125,7 +125,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         show_spinner: bool | str = "Running `snowflake.query(...)`.",
         params=None,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> DataFrame:
         """Run a read-only SQL query.
 
         This method implements both query result caching (with caching behavior
@@ -202,7 +202,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ),
             wait=wait_fixed(1),
         )
-        def _query(sql: str) -> pd.DataFrame:
+        def _query(sql: str) -> DataFrame:
             cur = self._instance.cursor()
             cur.execute(sql, params=params, **kwargs)
             return cur.fetch_pandas_all()
@@ -224,7 +224,7 @@ class SnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
 
     def write_pandas(
         self,
-        df: pd.DataFrame,
+        df: DataFrame,
         table_name: str,
         database: str | None = None,
         schema: str | None = None,

--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -18,13 +18,13 @@
 # way to configure this at a per-line level :(
 # mypy: no-warn-unused-ignores
 
+from __future__ import annotations
+
 import threading
 from collections import ChainMap
 from contextlib import contextmanager
 from datetime import timedelta
-from typing import TYPE_CHECKING, Iterator, Optional, Union, cast
-
-import pandas as pd
+from typing import TYPE_CHECKING, Iterator, cast
 
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import (
@@ -36,6 +36,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from pandas import DataFrame
     from snowflake.snowpark.session import Session  # type:ignore[import]
 
 
@@ -96,8 +97,8 @@ class SnowparkConnection(BaseConnection["Session"]):
     def query(
         self,
         sql: str,
-        ttl: Optional[Union[float, int, timedelta]] = None,
-    ) -> pd.DataFrame:
+        ttl: float | int | timedelta | None = None,
+    ) -> DataFrame:
         """Run a read-only SQL query.
 
         This method implements both query result caching (with caching behavior
@@ -144,7 +145,7 @@ class SnowparkConnection(BaseConnection["Session"]):
             retry=retry_if_exception_type(SnowparkServerException),
             wait=wait_fixed(1),
         )
-        def _query(sql: str) -> pd.DataFrame:
+        def _query(sql: str) -> DataFrame:
             with self._lock:
                 return self._instance.sql(sql).to_pandas()
 

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
 
 from collections import ChainMap
 from copy import deepcopy
 from datetime import timedelta
-from typing import TYPE_CHECKING, List, Optional, Union, cast
-
-import pandas as pd
+from typing import TYPE_CHECKING, List, cast
 
 from streamlit.connections import BaseConnection
 from streamlit.connections.util import extract_from_dict
@@ -26,6 +25,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
+    from pandas import DataFrame
     from sqlalchemy.engine import Connection as SQLAlchemyConnection
     from sqlalchemy.engine.base import Engine
     from sqlalchemy.orm import Session
@@ -124,12 +124,12 @@ class SQLConnection(BaseConnection["Engine"]):
         sql: str,
         *,  # keyword-only arguments:
         show_spinner: bool | str = "Running `sql.query(...)`.",
-        ttl: Optional[Union[float, int, timedelta]] = None,
-        index_col: Optional[Union[str, List[str]]] = None,
-        chunksize: Optional[int] = None,
+        ttl: float | int | timedelta | None = None,
+        index_col: str | List[str] | None = None,
+        chunksize: int | None = None,
         params=None,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> DataFrame:
         """Run a read-only query.
 
         This method implements both query result caching (with caching behavior
@@ -211,7 +211,9 @@ class SQLConnection(BaseConnection["Engine"]):
             chunksize=None,
             params=None,
             **kwargs,
-        ) -> pd.DataFrame:
+        ) -> DataFrame:
+            import pandas as pd
+
             instance = self._instance.connect()
             return pd.read_sql(
                 text(sql),

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Union, cast
 
-import pyarrow as pa
 from typing_extensions import TypeAlias
 
 from streamlit import type_util
@@ -33,6 +32,7 @@ from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
+    import pyarrow as pa
     from numpy import ndarray
     from pandas import DataFrame, Index, Series
     from pandas.io.formats.style import Styler
@@ -44,7 +44,7 @@ Data: TypeAlias = Union[
     "Series",
     "Styler",
     "Index",
-    pa.Table,
+    "pa.Table",
     "ndarray",
     Iterable,
     Dict[str, List[Any]],
@@ -184,6 +184,7 @@ class ArrowMixin:
            height: 350px
 
         """
+        import pyarrow as pa
 
         # Convert the user provided column config into the frontend compatible format:
         column_config_mapping = process_config_mapping(column_config)
@@ -283,7 +284,7 @@ class ArrowMixin:
         return self.dg._enqueue("arrow_table", proto)
 
     @gather_metrics("add_rows")
-    def add_rows(self, data: "Data" = None, **kwargs) -> Optional["DeltaGenerator"]:
+    def add_rows(self, data: "Data" = None, **kwargs) -> "DeltaGenerator" | None:
         """Concatenate a dataframe to the bottom of the current one.
 
         Parameters
@@ -342,7 +343,7 @@ class ArrowMixin:
         return cast("DeltaGenerator", self)
 
 
-def marshall(proto: ArrowProto, data: Data, default_uuid: Optional[str] = None) -> None:
+def marshall(proto: ArrowProto, data: Data, default_uuid: str | None = None) -> None:
     """Marshall pandas.DataFrame into an Arrow proto.
 
     Parameters
@@ -353,12 +354,14 @@ def marshall(proto: ArrowProto, data: Data, default_uuid: Optional[str] = None) 
     data : pandas.DataFrame, pandas.Styler, pyarrow.Table, numpy.ndarray, pyspark.sql.DataFrame, snowflake.snowpark.DataFrame, Iterable, dict, or None
         Something that is or can be converted to a dataframe.
 
-    default_uuid : Optional[str]
+    default_uuid : str | None
         If pandas.Styler UUID is not provided, this value will be used.
         This attribute is optional and only used for pandas.Styler, other elements
         (e.g. charts) can ignore it.
 
     """
+    import pyarrow as pa
+
     if type_util.is_pandas_styler(data):
         # default_uuid is a string only if the data is a `Styler`,
         # and `None` otherwise.

--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -21,11 +21,17 @@ from __future__ import annotations
 from contextlib import nullcontext
 from datetime import date
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Collection, Dict, List, Sequence, Tuple, cast
-
-import pandas as pd
-from pandas.api.types import infer_dtype, is_integer_dtype
-from typing_extensions import Literal
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    List,
+    Literal,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 import streamlit.elements.arrow_vega_lite as arrow_vega_lite
 from streamlit import type_util
@@ -47,6 +53,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     import altair as alt
+    import pandas as pd
 
     from streamlit.delta_generator import DeltaGenerator
 
@@ -848,6 +855,8 @@ def _melt_data(
     new_color_column_name: str,
 ) -> pd.DataFrame:
     """Converts a wide-format dataframe to a long-format dataframe."""
+    import pandas as pd
+    from pandas.api.types import infer_dtype
 
     melted_df = pd.melt(
         df,
@@ -1083,6 +1092,8 @@ def _convert_col_names_to_str_in_place(
     size_column: str | None,
 ) -> Tuple[str | None, List[str], str | None, str | None]:
     """Converts column names to strings, since Vega-Lite does not accept ints, etc."""
+    import pandas as pd
+
     column_names = list(df.columns)  # list() converts RangeIndex, etc, to regular list.
     str_column_names = [str(c) for c in column_names]
     df.columns = pd.Index(str_column_names)
@@ -1186,6 +1197,7 @@ def _get_scale(df: pd.DataFrame, column_name: str | None) -> alt.Scale:
 
 def _get_axis_config(df: pd.DataFrame, column_name: str | None, grid: bool) -> alt.Axis:
     import altair as alt
+    from pandas.api.types import is_integer_dtype
 
     if column_name is not None and is_integer_dtype(df[column_name]):
         # Use a max tick size of 1 for integer columns (prevents zoom into float numbers)

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -16,17 +16,20 @@ from __future__ import annotations
 
 import json
 from enum import Enum
-from typing import Dict, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Dict, Final, List, Literal, Mapping, Union
 
-import pandas as pd
-import pyarrow as pa
-from typing_extensions import Final, Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 from streamlit.elements.lib.column_types import ColumnConfig, ColumnType
 from streamlit.elements.lib.dicttools import remove_none_values
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 from streamlit.type_util import DataFormat, is_colum_type_arrow_incompatible
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+    from pandas import DataFrame, Index, Series
+
 
 # The index identifier can be used to apply configuration options
 IndexIdentifierType = Literal["_index"]
@@ -145,6 +148,8 @@ def _determine_data_kind_via_arrow(field: pa.Field) -> ColumnDataKind:
     ColumnDataKind
         The data kind of the field.
     """
+    import pyarrow as pa
+
     field_type = field.type
     if pa.types.is_integer(field_type):
         return ColumnDataKind.INTEGER
@@ -193,7 +198,7 @@ def _determine_data_kind_via_arrow(field: pa.Field) -> ColumnDataKind:
 
 
 def _determine_data_kind_via_pandas_dtype(
-    column: pd.Series | pd.Index,
+    column: Series | Index,
 ) -> ColumnDataKind:
     """Determine the data kind by using the pandas dtype.
 
@@ -210,6 +215,8 @@ def _determine_data_kind_via_pandas_dtype(
     ColumnDataKind
         The data kind of the column.
     """
+    import pandas as pd
+
     column_dtype = column.dtype
     if pd.api.types.is_bool_dtype(column_dtype):
         return ColumnDataKind.BOOLEAN
@@ -245,7 +252,7 @@ def _determine_data_kind_via_pandas_dtype(
 
 
 def _determine_data_kind_via_inferred_type(
-    column: pd.Series | pd.Index,
+    column: Series | Index,
 ) -> ColumnDataKind:
     """Determine the data kind by inferring it from the underlying data.
 
@@ -262,8 +269,9 @@ def _determine_data_kind_via_inferred_type(
     ColumnDataKind
         The data kind of the column.
     """
+    from pandas.api.types import infer_dtype
 
-    inferred_type = pd.api.types.infer_dtype(column)
+    inferred_type = infer_dtype(column)
 
     if inferred_type == "string":
         return ColumnDataKind.STRING
@@ -307,12 +315,13 @@ def _determine_data_kind_via_inferred_type(
     if inferred_type == "empty":
         return ColumnDataKind.EMPTY
 
-    # TODO(lukasmasuch): Unused types: mixed, unknown-array, categorical, mixed-integer
+    # Unused types: mixed, unknown-array, categorical, mixed-integer
+
     return ColumnDataKind.UNKNOWN
 
 
 def _determine_data_kind(
-    column: pd.Series | pd.Index, field: Optional[pa.Field] = None
+    column: Series | Index, field: pa.Field | None = None
 ) -> ColumnDataKind:
     """Determine the data kind of a column.
 
@@ -331,6 +340,7 @@ def _determine_data_kind(
     ColumnDataKind
         The data kind of the column.
     """
+    import pandas as pd
 
     if isinstance(column.dtype, pd.CategoricalDtype):
         # Categorical columns can have different underlying data kinds
@@ -349,7 +359,7 @@ def _determine_data_kind(
 
 
 def determine_dataframe_schema(
-    data_df: pd.DataFrame, arrow_schema: pa.Schema
+    data_df: DataFrame, arrow_schema: pa.Schema
 ) -> DataframeSchema:
     """Determine the schema of a dataframe.
 
@@ -452,7 +462,7 @@ def update_column_config(
 
 def apply_data_specific_configs(
     columns_config: ColumnConfigMapping,
-    data_df: pd.DataFrame,
+    data_df: DataFrame,
     data_format: DataFormat,
     check_arrow_compatibility: bool = False,
 ) -> None:
@@ -475,6 +485,8 @@ def apply_data_specific_configs(
     check_arrow_compatibility : bool
         Whether to check if the data is compatible with arrow.
     """
+    import pandas as pd
+
     # Deactivate editing for columns that are not compatible with arrow
     if check_arrow_compatibility:
         for column_name, column_data in data_df.items():

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, List, Mapping, TypeVar
+from __future__ import annotations
 
-import pandas as pd
+from typing import TYPE_CHECKING, Any, List, Mapping, TypeVar
 
 from streamlit import type_util
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Arrow_pb2 import Arrow as ArrowProto
 
 if TYPE_CHECKING:
+    from pandas import DataFrame
     from pandas.io.formats.style import Styler
 
 
@@ -39,6 +40,8 @@ def marshall_styler(proto: ArrowProto, styler: "Styler", default_uuid: str) -> N
         If pandas.Styler uuid is not provided, this value will be used.
 
     """
+    import pandas as pd
+
     styler_data_df: pd.DataFrame = styler.data
     if styler_data_df.size > int(pd.options.styler.render.max_elements):
         raise StreamlitAPIException(
@@ -215,7 +218,7 @@ def _pandas_style_to_css(
 
 
 def _marshall_display_values(
-    proto: ArrowProto, df: pd.DataFrame, styles: Mapping[str, Any]
+    proto: ArrowProto, df: DataFrame, styles: Mapping[str, Any]
 ) -> None:
     """Marshall pandas.Styler display values into an Arrow proto.
 
@@ -235,7 +238,7 @@ def _marshall_display_values(
     proto.styler.display_values = type_util.data_frame_to_bytes(new_df)
 
 
-def _use_display_values(df: pd.DataFrame, styles: Mapping[str, Any]) -> pd.DataFrame:
+def _use_display_values(df: DataFrame, styles: Mapping[str, Any]) -> DataFrame:
     """Create a new pandas.DataFrame where display values are used instead of original ones.
 
     Parameters

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -14,6 +14,8 @@
 
 """A wrapper for simple PyDeck scatter charts."""
 
+from __future__ import annotations
+
 import copy
 import hashlib
 import json
@@ -22,16 +24,15 @@ from typing import (
     Any,
     Collection,
     Dict,
+    Final,
     Iterable,
-    Optional,
     Set,
     Tuple,
     Union,
     cast,
 )
 
-import pandas as pd
-from typing_extensions import Final, TypeAlias
+from typing_extensions import TypeAlias
 
 import streamlit.elements.deck_gl_json_chart as deck_gl_json_chart
 from streamlit import config, type_util
@@ -42,13 +43,14 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.util import HASHLIB_KWARGS
 
 if TYPE_CHECKING:
+    from pandas import DataFrame
     from pandas.io.formats.style import Styler
 
     from streamlit.delta_generator import DeltaGenerator
 
 
 Data: TypeAlias = Union[
-    pd.DataFrame,
+    "DataFrame",
     "Styler",
     Iterable[Any],
     Dict[Any, Any],
@@ -95,11 +97,11 @@ class MapMixin:
         self,
         data: Data = None,
         *,
-        latitude: Optional[str] = None,
-        longitude: Optional[str] = None,
+        latitude: str | None = None,
+        longitude: str | None = None,
         color: Union[None, str, Color] = None,
         size: Union[None, str, float] = None,
-        zoom: Optional[int] = None,
+        zoom: int | None = None,
         use_container_width: bool = True,
     ) -> "DeltaGenerator":
         """Display a map with a scatterplot overlaid onto it.
@@ -250,12 +252,12 @@ class MapMixin:
 
 def to_deckgl_json(
     data: Data,
-    lat: Optional[str],
-    lon: Optional[str],
-    size: Union[None, str, float],
-    color: Union[None, str, Collection[float]],
-    map_style: Optional[str],
-    zoom: Optional[int],
+    lat: str | None,
+    lon: str | None,
+    size: None | str | float,
+    color: None | str | Collection[float],
+    map_style: str | None,
+    zoom: int | None,
 ) -> str:
     if data is None:
         return json.dumps(_DEFAULT_MAP)
@@ -320,9 +322,9 @@ def to_deckgl_json(
 
 
 def _get_lat_or_lon_col_name(
-    data: pd.DataFrame,
+    data: DataFrame,
     human_readable_name: str,
-    col_name_from_user: Optional[str],
+    col_name_from_user: str | None,
     default_col_names: Set[str],
 ) -> str:
     """Returns the column name to be used for latitude or longitude."""
@@ -366,10 +368,10 @@ def _get_lat_or_lon_col_name(
 
 
 def _get_value_and_col_name(
-    data: pd.DataFrame,
+    data: DataFrame,
     value_or_name: Any,
     default_value: Any,
-) -> Tuple[Any, Optional[str]]:
+) -> Tuple[Any, str | None]:
     """Take a value_or_name passed in by the Streamlit developer and return a PyDeck
     argument and column name for that property.
 
@@ -398,10 +400,10 @@ def _get_value_and_col_name(
 
 
 def _convert_color_arg_or_column(
-    data: pd.DataFrame,
-    color_arg: Union[str, Color],
-    color_col_name: Optional[str],
-) -> Union[None, str, IntColorTuple]:
+    data: DataFrame,
+    color_arg: str | Color,
+    color_col_name: str | None,
+) -> None | str | IntColorTuple:
     """Converts color to a format accepted by PyDeck.
 
     For example:
@@ -438,7 +440,9 @@ def _convert_color_arg_or_column(
     return color_arg_out
 
 
-def _get_viewport_details(data, lat_col_name, lon_col_name, zoom):
+def _get_viewport_details(
+    data: DataFrame, lat_col_name: str, lon_col_name: str, zoom: int | None
+) -> Tuple[int, float, float]:
     """Auto-set viewport when not fully specified by user."""
     min_lat = data[lat_col_name].min()
     max_lat = data[lat_col_name].max()

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -21,21 +21,21 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Final,
     Iterable,
     List,
+    Literal,
     Mapping,
-    Optional,
     Set,
     Tuple,
+    TypedDict,
     TypeVar,
     Union,
     cast,
     overload,
 )
 
-import pandas as pd
-import pyarrow as pa
-from typing_extensions import Literal, TypeAlias, TypedDict
+from typing_extensions import TypeAlias
 
 from streamlit import logger as _logger
 from streamlit import type_util
@@ -72,11 +72,13 @@ from streamlit.util import calc_md5
 
 if TYPE_CHECKING:
     import numpy as np
+    import pandas as pd
+    import pyarrow as pa
     from pandas.io.formats.style import Styler
 
     from streamlit.delta_generator import DeltaGenerator
 
-_LOGGER = _logger.get_logger("root")
+_LOGGER: Final = _logger.get_logger(__name__)
 
 # All formats that support direct editing, meaning that these
 # formats will be returned with the same type when used with data_editor.
@@ -99,11 +101,11 @@ EditableData = TypeVar(
 
 # All data types supported by the data editor.
 DataTypes: TypeAlias = Union[
-    pd.DataFrame,
-    pd.Series,
-    pd.Index,
+    "pd.DataFrame",
+    "pd.Series",
+    "pd.Index",
     "Styler",
-    pa.Table,
+    "pa.Table",
     "np.ndarray[Any, np.dtype[np.float64]]",
     Tuple[Any],
     List[Any],
@@ -137,7 +139,7 @@ class EditingState(TypedDict, total=False):
 class DataEditorSerde:
     """DataEditorSerde is used to serialize and deserialize the data editor state."""
 
-    def deserialize(self, ui_value: Optional[str], widget_id: str = "") -> EditingState:
+    def deserialize(self, ui_value: str | None, widget_id: str = "") -> EditingState:
         data_editor_state: EditingState = (
             {
                 "edited_rows": {},
@@ -190,6 +192,8 @@ def _parse_value(
     """
     if value is None:
         return None
+
+    import pandas as pd
 
     try:
         if column_data_kind == ColumnDataKind.STRING:
@@ -294,8 +298,11 @@ def _apply_row_additions(
     dataframe_schema: DataframeSchema
         The schema of the dataframe.
     """
+
     if not added_rows:
         return
+
+    import pandas as pd
 
     # This is only used if the dataframe has a range index:
     # There seems to be a bug in older pandas versions with RangeIndex in
@@ -392,6 +399,7 @@ def _is_supported_index(df_index: pd.Index) -> bool:
     bool
         True if the index is supported, False otherwise.
     """
+    import pandas as pd
 
     return (
         type(df_index)
@@ -418,6 +426,7 @@ def _is_supported_index(df_index: pd.Index) -> bool:
 def _fix_column_headers(data_df: pd.DataFrame) -> None:
     """Fix the column headers of the provided dataframe inplace to work
     correctly for data editing."""
+    import pandas as pd
 
     if isinstance(data_df.columns, pd.MultiIndex):
         # Flatten hierarchical column headers to a single level:
@@ -765,6 +774,8 @@ class DataEditorMixin:
            height: 350px
 
         """
+        import pandas as pd
+        import pyarrow as pa
 
         key = to_key(key)
         check_callback_rules(self.dg, on_change)

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -29,7 +29,6 @@ from typing import (
     overload,
 )
 
-from pandas import DataFrame
 from typing_extensions import TypeAlias
 
 from streamlit import type_util, util
@@ -78,6 +77,8 @@ from streamlit.runtime.state.common import user_key_from_widget_id
 from streamlit.runtime.state.safe_session_state import SafeSessionState
 
 if TYPE_CHECKING:
+    from pandas import DataFrame as PandasDataframe
+
     from streamlit.testing.v1.app_test import AppTest
 
 T = TypeVar("T")
@@ -507,7 +508,7 @@ class Dataframe(Element):
         self.type = "arrow_data_frame"
 
     @property
-    def value(self) -> DataFrame:
+    def value(self) -> PandasDataframe:
         return type_util.bytes_to_data_frame(self.proto.data)
 
 
@@ -1097,7 +1098,7 @@ class Table(Element):
         self.type = "arrow_table"
 
     @property
-    def value(self) -> DataFrame:
+    def value(self) -> PandasDataframe:
         return type_util.bytes_to_data_frame(self.proto.data)
 
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -26,10 +26,12 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Final,
     Iterable,
     List,
+    Literal,
     NamedTuple,
-    Optional,
+    Protocol,
     Sequence,
     Set,
     Tuple,
@@ -37,14 +39,11 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
     overload,
 )
 
-import numpy as np
-import pyarrow as pa
-from pandas import DataFrame, Index, MultiIndex, Series
-from pandas.api.types import infer_dtype, is_dict_like, is_list_like
-from typing_extensions import Final, Literal, Protocol, TypeAlias, TypeGuard, get_args
+from typing_extensions import TypeAlias, TypeGuard
 
 import streamlit as st
 from streamlit import config, errors
@@ -54,7 +53,10 @@ from streamlit.errors import StreamlitAPIException
 
 if TYPE_CHECKING:
     import graphviz
+    import numpy as np
+    import pyarrow as pa
     import sympy
+    from pandas import DataFrame, Index, Series
     from pandas.core.indexing import _iLocIndexer
     from pandas.io.formats.style import Styler
     from pandas.io.formats.style_renderer import StyleRenderer
@@ -65,7 +67,7 @@ if TYPE_CHECKING:
 # Maximum number of rows to request from an unevaluated (out-of-core) dataframe
 MAX_UNEVALUATED_DF_ROWS = 10000
 
-_LOGGER = _logger.get_logger("root")
+_LOGGER = _logger.get_logger(__name__)
 
 # The array value field names are part of the larger set of possible value
 # field names. See the explanation for said set below. The message types
@@ -368,6 +370,14 @@ def is_altair_chart(obj: object) -> bool:
     return is_type(obj, _ALTAIR_RE)
 
 
+_PILLOW_RE: Final = re.compile(r"^PIL\..*")
+
+
+def is_pillow_image(obj: object) -> bool:
+    """True if input looks like a pillow image."""
+    return is_type(obj, _PILLOW_RE)
+
+
 def is_keras_model(obj: object) -> bool:
     """True if input looks like a Keras model."""
     return (
@@ -380,6 +390,8 @@ def is_keras_model(obj: object) -> bool:
 
 def is_list_of_scalars(data: Iterable[Any]) -> bool:
     """Check if the list only contains scalar values."""
+    from pandas.api.types import infer_dtype
+
     # Overview on all value that are interpreted as scalar:
     # https://pandas.pydata.org/docs/reference/api/pandas.api.types.is_scalar.html
     return infer_dtype(data, skipna=True) not in ["mixed", "unknown-array"]
@@ -535,8 +547,10 @@ def convert_anything_to_df(
     pandas.DataFrame or pandas.Styler
 
     """
+    import pandas as pd
+
     if is_type(data, _PANDAS_DF_TYPE_STR):
-        return data.copy() if ensure_copy else cast(DataFrame, data)
+        return data.copy() if ensure_copy else cast(pd.DataFrame, data)
 
     if is_pandas_styler(data):
         # Every Styler is a StyleRenderer. I'm casting to StyleRenderer here rather than to the more
@@ -556,8 +570,8 @@ def convert_anything_to_df(
 
     if is_type(data, "numpy.ndarray"):
         if len(data.shape) == 0:
-            return DataFrame([])
-        return DataFrame(data)
+            return pd.DataFrame([])
+        return pd.DataFrame(data)
 
     if (
         is_type(data, _SNOWPARK_DF_TYPE_STR)
@@ -567,30 +581,30 @@ def convert_anything_to_df(
         if is_type(data, _PYSPARK_DF_TYPE_STR):
             data = data.limit(max_unevaluated_rows).toPandas()
         else:
-            data = DataFrame(data.take(max_unevaluated_rows))
+            data = pd.DataFrame(data.take(max_unevaluated_rows))
         if data.shape[0] == max_unevaluated_rows:
             st.caption(
                 f"⚠️ Showing only {string_util.simplify_number(max_unevaluated_rows)} rows. "
                 "Call `collect()` on the dataframe to show more."
             )
-        return cast(DataFrame, data)
+        return cast(pd.DataFrame, data)
 
     # This is inefficient when data is a pyarrow.Table as it will be converted
     # back to Arrow when marshalled to protobuf, but area/bar/line charts need
     # DataFrame magic to generate the correct output.
     if hasattr(data, "to_pandas"):
-        return cast(DataFrame, data.to_pandas())
+        return cast(pd.DataFrame, data.to_pandas())
 
     # Try to convert to pandas.DataFrame. This will raise an error is df is not
     # compatible with the pandas.DataFrame constructor.
     try:
-        return DataFrame(data)
+        return pd.DataFrame(data)
 
     except ValueError as ex:
         if isinstance(data, dict):
             with contextlib.suppress(ValueError):
                 # Try to use index orient as back-up to support key-value dicts
-                return DataFrame.from_dict(data, orient="index")
+                return pd.DataFrame.from_dict(data, orient="index")
         raise errors.StreamlitAPIException(
             f"""
 Unable to convert object of type `{type(data)}` to `pandas.DataFrame`.
@@ -713,6 +727,7 @@ def is_pyarrow_version_less_than(v: str) -> bool:
     bool
 
     """
+    import pyarrow as pa
     from packaging import version
 
     return version.parse(pa.__version__) < version.parse(v)
@@ -816,6 +831,8 @@ def pyarrow_table_to_bytes(table: pa.Table) -> bytes:
             exc_info=err,
         )
 
+    import pyarrow as pa
+
     # Convert table to bytes
     sink = pa.BufferOutputStream()
     writer = pa.RecordBatchStreamWriter(sink, table.schema)
@@ -826,6 +843,8 @@ def pyarrow_table_to_bytes(table: pa.Table) -> bytes:
 
 def is_colum_type_arrow_incompatible(column: Union[Series[Any], Index]) -> bool:
     """Return True if the column type is known to cause issues during Arrow conversion."""
+    from pandas.api.types import infer_dtype, is_dict_like, is_list_like
+
     if column.dtype.kind in [
         "c",  # complex64, complex128, complex256
     ]:
@@ -868,7 +887,7 @@ def is_colum_type_arrow_incompatible(column: Union[Series[Any], Index]) -> bool:
 
 
 def fix_arrow_incompatible_column_types(
-    df: DataFrame, selected_columns: Optional[List[str]] = None
+    df: DataFrame, selected_columns: List[str] | None = None
 ) -> DataFrame:
     """Fix column types that are not supported by Arrow table.
 
@@ -883,13 +902,15 @@ def fix_arrow_incompatible_column_types(
     df : pandas.DataFrame
         A dataframe to fix.
 
-    selected_columns: Optional[List[str]]
+    selected_columns: List[str] or None
         A list of columns to fix. If None, all columns are evaluated.
 
     Returns
     -------
     The fixed dataframe.
     """
+    import pandas as pd
+
     # Make a copy, but only initialize if necessary to preserve memory.
     df_copy: DataFrame | None = None
     for col in selected_columns or df.columns:
@@ -905,7 +926,7 @@ def fix_arrow_incompatible_column_types(
     if not selected_columns and (
         not isinstance(
             df.index,
-            MultiIndex,
+            pd.MultiIndex,
         )
         and is_colum_type_arrow_incompatible(df.index)
     ):
@@ -924,6 +945,8 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
         A dataframe to convert.
 
     """
+    import pyarrow as pa
+
     try:
         table = pa.Table.from_pandas(df)
     except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
@@ -949,8 +972,10 @@ def bytes_to_data_frame(source: bytes) -> DataFrame:
         A bytes object to convert.
 
     """
+    import pyarrow as pa
+
     reader = pa.RecordBatchStreamReader(source)
-    return cast(DataFrame, reader.read_pandas())
+    return reader.read_pandas()
 
 
 def determine_data_format(input_data: Any) -> DataFormat:
@@ -966,9 +991,13 @@ def determine_data_format(input_data: Any) -> DataFormat:
     DataFormat
         The data format of the input data.
     """
+    import numpy as np
+    import pandas as pd
+    import pyarrow as pa
+
     if input_data is None:
         return DataFormat.EMPTY
-    elif isinstance(input_data, DataFrame):
+    elif isinstance(input_data, pd.DataFrame):
         return DataFormat.PANDAS_DATAFRAME
     elif isinstance(input_data, np.ndarray):
         if len(input_data.shape) == 1:
@@ -978,9 +1007,9 @@ def determine_data_format(input_data: Any) -> DataFormat:
         return DataFormat.NUMPY_MATRIX
     elif isinstance(input_data, pa.Table):
         return DataFormat.PYARROW_TABLE
-    elif isinstance(input_data, Series):
+    elif isinstance(input_data, pd.Series):
         return DataFormat.PANDAS_SERIES
-    elif isinstance(input_data, Index):
+    elif isinstance(input_data, pd.Index):
         return DataFormat.PANDAS_INDEX
     elif is_pandas_styler(input_data):
         return DataFormat.PANDAS_STYLER
@@ -1014,7 +1043,7 @@ def determine_data_format(input_data: Any) -> DataFormat:
                 return DataFormat.COLUMN_INDEX_MAPPING
             if isinstance(first_value, (list, tuple)):
                 return DataFormat.COLUMN_VALUE_MAPPING
-            if isinstance(first_value, Series):
+            if isinstance(first_value, pd.Series):
                 return DataFormat.COLUMN_SERIES_MAPPING
             # In the future, we could potentially also support the tight & split formats here
             if is_list_of_scalars(input_data.values()):
@@ -1030,6 +1059,7 @@ def _unify_missing_values(df: DataFrame) -> DataFrame:
     NaT, None, and pd.NA. This function replaces all of these values with None,
     which is the only missing value type that is supported by all data
     """
+    import numpy as np
 
     return df.fillna(np.nan).replace([np.nan], [None])
 
@@ -1061,6 +1091,7 @@ def convert_df_to_data_format(
     pd.DataFrame, pd.Series, pyarrow.Table, np.ndarray, list, set, tuple, or dict.
         The converted dataframe.
     """
+
     if data_format in [
         DataFormat.EMPTY,
         DataFormat.PANDAS_DATAFRAME,
@@ -1071,14 +1102,20 @@ def convert_df_to_data_format(
     ]:
         return df
     elif data_format == DataFormat.NUMPY_LIST:
+        import numpy as np
+
         # It's a 1-dimensional array, so we only return
         # the first column as numpy array
         # Calling to_numpy() on the full DataFrame would result in:
         # [[1], [2]] instead of [1, 2]
         return np.ndarray(0) if df.empty else df.iloc[:, 0].to_numpy()
     elif data_format == DataFormat.NUMPY_MATRIX:
+        import numpy as np
+
         return np.ndarray(0) if df.empty else df.to_numpy()
     elif data_format == DataFormat.PYARROW_TABLE:
+        import pyarrow as pa
+
         return pa.Table.from_pandas(df)
     elif data_format == DataFormat.PANDAS_SERIES:
         # Select first column in dataframe and create a new series based on the values
@@ -1136,7 +1173,7 @@ def to_key(key: Key) -> str:
     ...
 
 
-def to_key(key: Optional[Key]) -> Optional[str]:
+def to_key(key: Key | None) -> str | None:
     if key is None:
         return None
     else:
@@ -1148,7 +1185,7 @@ def maybe_tuple_to_list(item: Any) -> Any:
     return list(item) if isinstance(item, tuple) else item
 
 
-def maybe_raise_label_warnings(label: Optional[str], label_visibility: Optional[str]):
+def maybe_raise_label_warnings(label: str | None, label_visibility: str | None):
     if not label:
         _LOGGER.warning(
             "`label` got an empty value. This is discouraged for accessibility "
@@ -1182,6 +1219,8 @@ def infer_vegalite_type(
     ----------
     data: Numpy array or Pandas Series
     """
+    from pandas.api.types import infer_dtype
+
     # STREAMLIT MOD: I'm using infer_dtype directly here, rather than using Altair's wrapper. Their
     # wrapper is only there to support Pandas < 0.20, but Streamlit requires Pandas 1.3.
     typ = infer_dtype(data)

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -129,7 +129,7 @@ class SQLConnectionTest(unittest.TestCase):
         assert kwargs == {"foo": "bar", "baz": "qux"}
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    @patch("pandas.read_sql")
     def test_query_caches_value(self, patched_read_sql):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
@@ -142,7 +142,7 @@ class SQLConnectionTest(unittest.TestCase):
         patched_read_sql.assert_called_once()
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    @patch("pandas.read_sql")
     def test_does_not_reset_cache_when_ttl_changes(self, patched_read_sql):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
@@ -158,7 +158,7 @@ class SQLConnectionTest(unittest.TestCase):
         assert patched_read_sql.call_count == 2
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    @patch("pandas.read_sql")
     def test_scopes_caches_by_connection_name(self, patched_read_sql):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
@@ -207,7 +207,7 @@ class SQLConnectionTest(unittest.TestCase):
 
     @parameterized.expand([(DatabaseError,), (InternalError,), (OperationalError,)])
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    @patch("pandas.read_sql")
     def test_retry_behavior(self, error_class, patched_read_sql):
         patched_read_sql.side_effect = error_class("kaboom", params=None, orig=None)
 
@@ -228,7 +228,7 @@ class SQLConnectionTest(unittest.TestCase):
         conn._connect.reset_mock()
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
-    @patch("streamlit.connections.sql_connection.pd.read_sql")
+    @patch("pandas.read_sql")
     def test_retry_behavior_fails_fast_for_most_errors(self, patched_read_sql):
         patched_read_sql.side_effect = Exception("kaboom")
 


### PR DESCRIPTION
## Describe your changes

Lazy-load `pandas` and `pyarrow` only when required (e.g. usage of `st.dataframe`).

This PR also includes a couple of other small refactorings related to typing and imports.

## GitHub Issue Link (if applicable)

Related to #6066

## Testing Plan

- Added e2e test to ensure that `pyarrow` and `pandas` are lazy-loaded. 
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
