### PR TITLE
Support multiple path characteristics for switch_page and page_link

### DIFF
--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -26,6 +26,7 @@ from streamlit import runtime, source_util
 from streamlit.elements.form import current_form_id, is_in_form
 from streamlit.elements.utils import check_callback_rules, check_session_state_rules
 from streamlit.errors import StreamlitAPIException
+from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.DownloadButton_pb2 import DownloadButton as DownloadButtonProto
 from streamlit.proto.LinkButton_pb2 import LinkButton as LinkButtonProto
@@ -664,15 +665,10 @@ class ButtonMixin:
         if ctx:
             ctx_main_script = ctx.main_script_path
 
-        normalized_ctx_main_script_path = os.path.normpath(ctx_main_script)
-        main_script_path = os.path.join(os.getcwd(), normalized_ctx_main_script_path)
-        main_script_directory = os.path.dirname(main_script_path)
-
-        # Convenience for handling ./ notation
-        page = os.path.normpath(page)
-
-        # Build full path
-        requested_page = os.path.join(main_script_directory, page)
+        main_script_directory = get_main_script_directory(ctx_main_script)
+        requested_page = os.path.realpath(
+            normalize_path_join(main_script_directory, page)
+        )
         all_app_pages = source_util.get_pages(ctx_main_script).values()
 
         # Handle retrieving the page_script_hash & page
@@ -688,7 +684,7 @@ class ButtonMixin:
 
         if page_link_proto.page_script_hash == "":
             raise StreamlitAPIException(
-                f"Could not find page: '{page}'. Must be the file path relative to the main script, from the directory: {os.path.basename(main_script_directory)}. Only the main app file and files in the `pages/` directory are supported."
+                f"Could not find page: `{page}`. Must be the file path relative to the main script, from the directory: `{os.path.basename(main_script_directory)}`. Only the main app file and files in the `pages/` directory are supported."
             )
 
         return self.dg._enqueue("page_link", page_link_proto)

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -207,3 +207,38 @@ def file_in_pythonpath(filepath) -> bool:
         file_is_in_folder_glob(os.path.normpath(filepath), path)
         for path in absolute_paths
     )
+
+
+def normalize_path_join(*args):
+    """Return the normalized path of the joined path.
+
+    Parameters
+    ----------
+    *args : str
+        The path components to join.
+
+    Returns
+    -------
+    str
+        The normalized path of the joined path.
+    """
+    return os.path.normpath(os.path.join(*args))
+
+
+def get_main_script_directory(main_script):
+    """Return the full path to the main script directory.
+
+    Parameters
+    ----------
+    main_script : str
+        The main script path. The path can be an absolute path or a relative
+        path.
+
+    Returns
+    -------
+    str
+        The full path to the main script directory.
+    """
+    main_script_path = normalize_path_join(os.getcwd(), main_script)
+
+    return os.path.dirname(main_script_path)

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -270,3 +270,66 @@ class FileInPythonPathTest(unittest.TestCase):
                     self._make_it_absolute("../something_else/module")
                 )
             )
+
+    def test_get_main_script_directory(self):
+        """Test file_util.get_main_script_directory."""
+        with patch("os.getcwd", return_value="/some/random"):
+            self.assertEqual(
+                file_util.get_main_script_directory("app.py"),
+                "/some/random",
+            )
+            self.assertEqual(
+                file_util.get_main_script_directory("./app.py"),
+                "/some/random",
+            )
+            self.assertEqual(
+                file_util.get_main_script_directory("../app.py"),
+                "/some",
+            )
+            self.assertEqual(
+                file_util.get_main_script_directory("/path/to/my/app.py"),
+                "/path/to/my",
+            )
+
+    def test_normalize_path_join(self):
+        """Test file_util.normalize_path_join."""
+        self.assertEqual(
+            file_util.normalize_path_join("/some", "random", "path"),
+            "/some/random/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("some", "random", "path"),
+            "some/random/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("/some", "random", "./path"),
+            "/some/random/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("some", "random", "./path"),
+            "some/random/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("/some", "random", "../path"),
+            "/some/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("some", "random", "../path"),
+            "some/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("/some", "random", "/path"),
+            "/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("some", "random", "/path"),
+            "/path",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("some", "random", "path", ".."),
+            "some/random",
+        )
+        self.assertEqual(
+            file_util.normalize_path_join("some", "random", "path", "../.."),
+            "some",
+        )


### PR DESCRIPTION
## Describe your changes

The changes made improve page path calculation, but don't support file path scenarios with `..`, etc. This change aims to clean up the logic and ensure it's consistent.

## Testing Plan

- Unit Tests - Tested the file path methods to cover all the use cases
- Manual Testing - Testing on Windows and Mac

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
