### PR TITLE
Deprecate the `deprecation.showPyplotGlobalUse` config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1004,6 +1004,9 @@ _create_option(
     description="Set to false to disable the deprecation warning for using the global pyplot instance.",
     default_val=True,
     scriptable=True,
+    deprecated=True,
+    deprecation_text="The support for global pyplot instances is planned to be removed soon.",
+    expiration_date="2024-04-15",
     type_=bool,
 )
 


### PR DESCRIPTION
## Describe your changes

This PR deprecates the `deprecation.showPyplotGlobalUse` config options as preparation to fully remove the support for global matplotlib instances.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
