### PR TITLE
Add SVG to safe static files

### DIFF
--- a/lib/streamlit/web/server/app_static_file_handler.py
+++ b/lib/streamlit/web/server/app_static_file_handler.py
@@ -30,7 +30,7 @@ _LOGGER = get_logger(__name__)
 MAX_APP_STATIC_FILE_SIZE = 200 * 1024 * 1024  # 200 MB
 # The list of file extensions that we serve with the corresponding Content-Type header.
 # All files with other extensions will be served with Content-Type: text/plain
-SAFE_APP_STATIC_FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".webp")
+SAFE_APP_STATIC_FILE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg")
 
 
 class AppStaticFileHandler(tornado.web.StaticFileHandler):


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Up to this point, it was possible to serve other image types as static files, but SVG was presented as plain text, thus making it impossible to use SVGs in Markdown blocks. A workaround was to export to raster images, but that's not the point of SVG files.

This change adds SVG format to safe static formats, enabling its use in resolving static local images in Markdown blocks.

## GitHub Issue Link (if applicable)

## Testing Plan

This change doesn't introduce any code, which wasn't previously covered by tests. I performed a manual local test, to see if an SVG file was rendered properly when referenced from a Markdown block.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
