### PR TITLE
Update `browser.serverPort` config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -858,22 +858,15 @@ _create_option(
 )
 
 
-@_create_option(
-    "browser.serverPort",
-    visibility="hidden",
-    deprecated=True,
-    deprecation_text="browser.serverPort has been deprecated. It will be removed in a future version.",
-    expiration_date="2024-04-01",
-    type_=int,
-)
+@_create_option("browser.serverPort", type_=int)
 def _browser_server_port() -> int:
     """Port where users should point their browsers in order to connect to the
     app.
 
     This is used to:
-    - Set the correct URL for CORS and XSRF protection purposes.
-    - Show the URL on the terminal
-    - Open the browser
+    - Set the correct URL for XSRF protection purposes.
+    - Show the URL on the terminal (part of `streamlit run`).
+    - Open the browser automatically (part of `streamlit run`).
 
     Don't use port 3000 which is reserved for internal development.
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -868,7 +868,9 @@ def _browser_server_port() -> int:
     - Show the URL on the terminal (part of `streamlit run`).
     - Open the browser automatically (part of `streamlit run`).
 
-    Don't use port 3000 which is reserved for internal development.
+    This option is for advanced use cases. To change the port of your app, use
+    `server.Port` instead. Don't use port 3000 which is reserved for internal
+    development.
 
     Default: whatever value is set in server.port.
     """


### PR DESCRIPTION
## Describe your changes
`browser.serverPort` was deprecated in PR #8118 but this PR reversed that since an isolated use case for the option was identified. It is used for the file upload endpoint if XSRF protection is activated.

## Testing Plan
None. This just reverts a deprecations.

---

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
