### PR TITLE
Scale down cypress CI workflow and scale up others

### DIFF
--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v4

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,7 @@ jobs:
         # Be aware that specs should be sequential integers starting from 1 without gaps
         # based on logic in "Cypress Tests" step.
         # prettier-ignore
-        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        specs: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
 
     steps:
       - name: Checkout Streamlit code
@@ -75,7 +75,7 @@ jobs:
         env:
           CURRENT_RUN: ${{matrix.specs}}
           CYPRESS_VERIFY_TIMEOUT: 90000
-          TOTAL_WORKERS: 12
+          TOTAL_WORKERS: 10
         run: |
           js_specs=(e2e/specs/*)
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-32-cores
 
     defaults:
       run:


### PR DESCRIPTION
## Describe your changes

This PR removes two additional workers from cypress (since we have migrated additional tests). And scales up the playwright CI workflow to 32 cores, and the component templates to 8 cores which will get the runtime of both tasks down to ~10 minutes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
