### PR TITLE
add: Supprt for HTTP <Head> method to /healthz endpoint

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -135,6 +135,12 @@ class HealthHandler(_SpecialRequestHandler):
         self._callback = callback
 
     async def get(self):
+        await self.handle_request()
+
+    async def head(self):
+        await self.handle_request()
+
+    async def handle_request(self):
         if self.request.uri and "_stcore/" not in self.request.uri:
             new_path = (
                 "/_stcore/script-health-check"

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -137,6 +137,8 @@ class HealthHandler(_SpecialRequestHandler):
     async def get(self):
         await self.handle_request()
 
+    # Some monitoring services only support the HTTP HEAD method for requests to
+    # healthcheck endpoints, so we support HEAD as well to play nicely with them.
     async def head(self):
         await self.handle_request()
 

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -62,6 +62,14 @@ class HealthHandlerTest(tornado.testing.AsyncHTTPTestCase):
         response = self.fetch("/_stcore/health")
         self.assertEqual(503, response.code)
 
+    def test_health_head(self):
+        response = self.fetch("/_stcore/health", method="HEAD")
+        self.assertEqual(200, response.code)
+
+        self._is_healthy = False
+        response = self.fetch("/_stcore/health", method="HEAD")
+        self.assertEqual(503, response.code)
+
     @patch_config_options({"server.enableXsrfProtection": False})
     def test_health_without_csrf(self):
         response = self.fetch("/_stcore/health")


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Implementing support for the HTTP HEAD method for the /healthz endpoint enhances efficiency and reduces bandwidth usage by allowing quick retrieval of metadata about the service's health without sending the entire response body.
This aligns with HTTP standards, improves monitoring capabilities.

## GitHub Issue Link (if applicable)
Closes #8144

## Testing Plan

- Since only the HEAD method is being added and the GET method remains unaltered, I believe there's no need for any extra tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
