### PR TITLE
Show a warning when server port `3000` is used

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -51,7 +51,7 @@ from streamlit.web.server.routes import (
     MessageCacheHandler,
     StaticFileHandler,
 )
-from streamlit.web.server.server_util import make_url_path_regex
+from streamlit.web.server.server_util import DEVELOPMENT_PORT, make_url_path_regex
 from streamlit.web.server.stats_request_handler import StatsRequestHandler
 from streamlit.web.server.upload_file_request_handler import UploadFileRequestHandler
 
@@ -183,10 +183,12 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
         address = config.get_option("server.address")
         port = config.get_option("server.port")
 
-        if int(port) == 3000:
+        if int(port) == DEVELOPMENT_PORT:
             LOGGER.warning(
-                "Port 3000 is reserved for internal development. "
-                "It is strongly recommended to select an alternative port."
+                "Port %s is reserved for internal development. "
+                "It is strongly recommended to select an alternative port "
+                "for `server.port`.",
+                DEVELOPMENT_PORT,
             )
 
         try:
@@ -203,9 +205,8 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
                         "Port %s already in use, trying to use the next one.", port
                     )
                     port += 1
-                    # Save port 3000 because it is used for the development
-                    # server in the front end.
-                    if port == 3000:
+                    # Don't use the development port here:
+                    if port == DEVELOPMENT_PORT:
                         port += 1
 
                     config.set_option(

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -183,6 +183,12 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
         address = config.get_option("server.address")
         port = config.get_option("server.port")
 
+        if int(port) == 3000:
+            LOGGER.warning(
+                "Port 3000 is reserved for internal development. "
+                "It is strongly recommended to select an alternative port."
+            )
+
         try:
             http_server.listen(port, address)
             break  # It worked! So let's break out of the loop.

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -14,12 +14,15 @@
 
 """Server related utility functions"""
 
-from typing import Optional
+from typing import Final, Optional
 from urllib.parse import urljoin
 
 import tornado.web
 
 from streamlit import config, net_util, url_util
+
+# The port reserved for internal development.
+DEVELOPMENT_PORT: Final = 3000
 
 
 def is_url_from_allowed_origins(url: str) -> bool:
@@ -111,7 +114,7 @@ def _get_browser_address_bar_port() -> int:
 
     """
     if config.get_option("global.developmentMode"):
-        return 3000
+        return DEVELOPMENT_PORT
     return int(config.get_option("browser.serverPort"))
 
 


### PR DESCRIPTION
## Describe your changes

Port 3000 is reserved for internal development. This PR adds a warning to make it more obvious to users to use a different port.

Related to https://github.com/streamlit/streamlit/issues/8149

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
