### PR TITLE
Fix chart exception where color-handling code expected DF index to start at 0

### DIFF
--- a/lib/streamlit/elements/arrow_altair.py
+++ b/lib/streamlit/elements/arrow_altair.py
@@ -1070,7 +1070,7 @@ def _maybe_convert_color_column_in_place(df: pd.DataFrame, color_column: str | N
     if color_column is None or len(df[color_column]) == 0:
         return
 
-    first_color_datum = df[color_column][0]
+    first_color_datum = df[color_column].iat[0]
 
     if is_hex_color_like(first_color_datum):
         # Hex is already CSS-valid.
@@ -1381,7 +1381,7 @@ def _get_color_encoding(
 
         # If the 0th element in the color column looks like a color, we'll use the color column's
         # values as the colors in our chart.
-        elif len(df[color_column]) and is_color_like(df[color_column][0]):
+        elif len(df[color_column]) and is_color_like(df[color_column].iat[0]):
             color_range = [to_css_color(c) for c in df[color_column].unique()]
             color_enc["scale"] = alt.Scale(range=color_range)
             # Don't show the color legend, because it will just show text with the color values,

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -420,9 +420,7 @@ def _convert_color_arg_or_column(
 
     if color_col_name is not None:
         # Convert color column to the right format.
-        if len(data[color_col_name]) > 0 and is_color_like(
-            data.iloc[0][color_col_name]
-        ):
+        if len(data[color_col_name]) > 0 and is_color_like(data[color_col_name].iat[0]):
             # Use .loc[] to avoid a SettingWithCopyWarning in some cases.
             data.loc[:, color_col_name] = data.loc[:, color_col_name].map(
                 to_int_color_tuple

--- a/lib/tests/streamlit/elements/arrow_altair_test.py
+++ b/lib/tests/streamlit/elements/arrow_altair_test.py
@@ -638,6 +638,23 @@ class ArrowChartsTest(DeltaGeneratorTestCase):
             orig_df=df, expected_df=EXPECTED_DATAFRAME, chart_proto=proto
         )
 
+    def test_line_chart_with_non_contiguous_index(self):
+        """Test st.line_chart with a non-zero-based, non-contiguous, non-sorted index."""
+        df = pd.DataFrame(
+            {
+                "a": [11, 2, 55],
+                "b": [100, 101, 102],
+                "c": [200, 201, 202],
+                "d": [300, 301, 302],
+            }
+        )
+        df.set_index("a", inplace=True)
+
+        # There used to be a bug where this line would throw an exception.
+        # (Because some color-handling code was dependent on the DF index starting at 0)
+        # So if there's no exception, then the test passes.
+        st.line_chart(df, x="b", y="c", color="d")
+
     @parameterized.expand(ST_CHART_ARGS)
     def test_unused_columns_are_dropped(
         self, chart_command: Callable, altair_type: str


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Fixes an exception in our native st.foo_chart commands, where color-handling code expected DF index to start at 0.

So, for example, the code below used to throw an exception:

```python
        df = pd.DataFrame(
            {
                "a": [11, 2, 55],
                "b": [100, 101, 102],
                "c": [200, 201, 202],
                "d": [300, 301, 302],
            }
        )
        df.set_index("a", inplace=True)

        st.line_chart(df, x="b", y="c", color="d")
```

## GitHub Issue Link (if applicable)

None.

## Testing Plan

- ~~Explanation of why no additional tests are needed~~
- [x] Unit Tests (JS and/or Python)
- ~~E2E Tests~~
- Any manual testing needed?
  - **No**

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
