### PR TITLE
Fixed typos in example documentation

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -116,8 +116,8 @@ def switch_page(page: str) -> NoReturn:  # type: ignore[misc]
 
     >>> your-repository/
     >>> ├── pages/
-    >>> │   ├── page_1.py.py
-    >>> │   └── page_2.py.py
+    >>> │   ├── page_1.py
+    >>> │   └── page_2.py
     >>> └── your_app.py
 
     >>> import streamlit as st

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -498,8 +498,8 @@ class ButtonMixin:
 
         >>> your-repository/
         >>> ├── pages/
-        >>> │   ├── page_1.py.py
-        >>> │   └── page_2.py.py
+        >>> │   ├── page_1.py
+        >>> │   └── page_2.py
         >>> └── your_app.py
 
         >>> import streamlit as st


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
Fixed a couple typos in the documentation: changed "page_1.py.py" to "page_1.py" and "page_2.py.py" to "page_2.py".

This issue affected two files: `execution_control.py` and `button.py`

![image](https://github.com/streamlit/streamlit/assets/19372035/c1904669-6ac2-489a-8c36-a30072a1870f)
Found at [https://docs.streamlit.io/library/api-reference/widgets/st.page_link](https://docs.streamlit.io/library/api-reference/widgets/st.page_link) and [https://docs.streamlit.io/library/api-reference/control-flow/st.switch_page](https://docs.streamlit.io/library/api-reference/control-flow/st.switch_page)

## Testing Plan

- Explanation of why no additional tests are needed
No code was modified
- Unit Tests (JS and/or Python): -
- E2E Tests: -
- Any manual testing needed?: -

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
