### PR TITLE
Automatically attach fragmentIds to delta messages

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -879,4 +879,7 @@ def _enqueue_message(msg: ForwardMsg_pb2.ForwardMsg) -> None:
     if ctx is None:
         raise NoSessionContext()
 
+    if ctx.current_fragment_id and msg.WhichOneof("type") == "delta":
+        msg.delta.fragment_id = ctx.current_fragment_id
+
     ctx.enqueue(msg)

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -41,7 +41,7 @@ from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.proto.TextArea_pb2 import TextArea
 from streamlit.proto.TextInput_pb2 import TextInput
-from streamlit.runtime.scriptrunner import add_script_run_ctx
+from streamlit.runtime.scriptrunner import add_script_run_ctx, get_script_run_ctx
 from streamlit.runtime.state.common import compute_widget_id
 from streamlit.runtime.state.widgets import _build_duplicate_widget_message
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -346,7 +346,9 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
         self.assertEqual(1, dg._cursor.index)
         self.assertEqual(container, new_dg._root_container)
 
-        element = self.get_delta_from_queue().new_element
+        delta = self.get_delta_from_queue()
+        element = delta.new_element
+        self.assertEqual(delta.fragment_id, "")
         self.assertEqual(element.text.body, test_data)
 
     def test_enqueue_same_id(self):
@@ -367,6 +369,16 @@ class DeltaGeneratorClassTest(DeltaGeneratorTestCase):
             make_delta_path(RootContainer.MAIN, (), 123), msg.metadata.delta_path
         )
         self.assertEqual(msg.delta.new_element.text.body, test_data)
+
+    def test_enqueue_adds_fragment_id_to_delta_if_set(self):
+        ctx = get_script_run_ctx()
+        ctx.current_fragment_id = "my_fragment_id"
+
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+        dg._enqueue("text", TextProto())
+
+        delta = self.get_delta_from_queue()
+        self.assertEqual(delta.fragment_id, "my_fragment_id")
 
 
 class DeltaGeneratorContainerTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
This is a small change that I must have forgotten to make while focused on the backend side of
this feature. In this PR, we attach a `fragmentId` to each delta sent from server -> client while running
a fragment.

Note that this differs from the prototype (where each widget sets this manually) because we need to
attach a fragment ID to _all_ elements (and not just widgets) to ensure that we're able to mark elements
as stale correctly during fragment runs. Also, we're still using the `fragmentId` name everywhere as
we're still deciding on a different name for the internals of the implementation.