### PR TITLE
Pass around currentFragmentId and set element fragmentIds

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1283,6 +1283,27 @@ describe("App", () => {
       ).toBe("some_other_page_hash")
     })
 
+    it("sets fragmentId in BackMsg", () => {
+      renderApp(getProps())
+
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const connectionManager = getMockConnectionManager()
+
+      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage("myFragmentId")
+      expect(connectionManager.sendMessage).toBeCalledTimes(2)
+
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.fragmentId
+      ).toBe(undefined)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[1][0].rerunScript.fragmentId
+      ).toBe("myFragmentId")
+    })
+
     it("extracts the pageName as an empty string if we can't get a pageScriptHash (main page)", () => {
       renderApp(getProps())
       const widgetStateManager =

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -894,6 +894,7 @@ describe("AppRoot.applyDelta", () => {
 
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
+    expect(newRoot.main.fragmentId).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
@@ -914,11 +915,42 @@ describe("AppRoot.applyDelta", () => {
 
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
+    expect(newRoot.main.fragmentId).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1, 1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
+  })
+
+  it("can set fragmentId in 'newElement' deltas", () => {
+    const delta = makeProto(DeltaProto, {
+      newElement: { text: { body: "newElement!" } },
+      fragmentId: "myFragmentId",
+    })
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1])
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as ElementNode
+    expect(newNode.fragmentId).toBe("myFragmentId")
+  })
+
+  it("can set fragmentId in 'addBlock' deltas", () => {
+    const delta = makeProto(DeltaProto, {
+      addBlock: {},
+      fragmentId: "myFragmentId",
+    })
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1])
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+    expect(newNode.fragmentId).toBe("myFragmentId")
   })
 })
 

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -98,6 +98,10 @@ describe("Widget State Manager", () => {
       expect(sendBackMsg).not.toHaveBeenCalled()
     } else {
       expect(sendBackMsg).toHaveBeenCalledTimes(1)
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined // fragmentId
+      )
     }
   }
 
@@ -249,6 +253,112 @@ describe("Widget State Manager", () => {
     }
   )
 
+  it("setIntValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
+    widgetMgr.setIntValue(MOCK_WIDGET, Number.MAX_SAFE_INTEGER, {
+      fromUi: true,
+    })
+
+    expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MAX_SAFE_INTEGER)
+
+    widgetMgr.setIntValue(MOCK_WIDGET, Number.MIN_SAFE_INTEGER, {
+      fromUi: true,
+    })
+
+    expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MIN_SAFE_INTEGER)
+  })
+
+  it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
+    const values = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
+    widgetMgr.setIntArrayValue(MOCK_WIDGET, values, {
+      fromUi: true,
+    })
+
+    expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
+  })
+
+  describe("can set fragmentId in setter methods", () => {
+    it.each([
+      {
+        setterMethod: "setStringTriggerValue",
+        value: "Hello world",
+      },
+      {
+        setterMethod: "setBoolValue",
+        value: true,
+      },
+      {
+        setterMethod: "setIntValue",
+        value: 42,
+      },
+      {
+        setterMethod: "setDoubleValue",
+        value: 42.0,
+      },
+      {
+        setterMethod: "setStringValue",
+        value: "Hello world",
+      },
+      {
+        setterMethod: "setStringArrayValue",
+        value: ["Hello", "world"],
+      },
+      {
+        setterMethod: "setDoubleArrayValue",
+        value: [40.0, 2.0],
+      },
+      {
+        setterMethod: "setIntArrayValue",
+        value: [40, 2],
+      },
+      {
+        setterMethod: "setJsonValue",
+        value: MOCK_JSON,
+      },
+      {
+        setterMethod: "setArrowValue",
+        value: MOCK_ARROW_TABLE,
+      },
+      {
+        setterMethod: "setBytesValue",
+        value: MOCK_BYTES,
+      },
+      {
+        setterMethod: "setFileUploaderStateValue",
+        value: MOCK_FILE_UPLOADER_STATE,
+      },
+    ])("%p", ({ setterMethod, value }) => {
+      // @ts-expect-error
+      widgetMgr[setterMethod](
+        MOCK_WIDGET,
+        value,
+        {
+          fromUi: true,
+        },
+        "myFragmentId"
+      )
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        expect.anything(),
+        "myFragmentId"
+      )
+    })
+
+    // This test isn't parameterized like the ones above because setTriggerValue
+    // has a slightly different signature from the other setter methods.
+    it("can set fragmentId in setTriggerValue", () => {
+      widgetMgr.setTriggerValue(
+        MOCK_WIDGET,
+        {
+          fromUi: true,
+        },
+        "myFragmentId"
+      )
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        expect.anything(),
+        "myFragmentId"
+      )
+    })
+  })
+
   describe("Primitive types as JSON values", () => {
     it("sets string value as JSON correctly", () => {
       widgetMgr.setJsonValue(MOCK_WIDGET, "mockStringValue", { fromUi: true })
@@ -288,29 +398,6 @@ describe("Widget State Manager", () => {
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(
         JSON.stringify([1.1, 2.2, 3.3])
       )
-    })
-
-    it("setIntValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
-      widgetMgr.setIntValue(MOCK_WIDGET, Number.MAX_SAFE_INTEGER, {
-        fromUi: true,
-      })
-
-      expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MAX_SAFE_INTEGER)
-
-      widgetMgr.setIntValue(MOCK_WIDGET, Number.MIN_SAFE_INTEGER, {
-        fromUi: true,
-      })
-
-      expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MIN_SAFE_INTEGER)
-    })
-
-    it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
-      const values = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
-      widgetMgr.setIntArrayValue(MOCK_WIDGET, values, {
-        fromUi: true,
-      })
-
-      expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
     })
   })
 
@@ -375,13 +462,46 @@ describe("Widget State Manager", () => {
 
       // Our backMsg should be populated with our two widget values,
       // plus the submitButton's value.
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [
-          { id: "submitButton", triggerValue: true },
-          { id: "widget1", stringValue: "foo" },
-          { id: "widget2", stringValue: "bar" },
-        ],
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton", triggerValue: true },
+            { id: "widget1", stringValue: "foo" },
+            { id: "widget2", stringValue: "bar" },
+          ],
+        },
+        undefined // fragmentId
+      )
+
+      // We have no more pending form.
+      expect(formsData.formsWithPendingChanges).toEqual(new Set())
+    })
+
+    it("calls sendBackMsg with fragmentId", () => {
+      const formId = "mockFormId"
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "submitButton" })
+      )
+
+      // Populate a form
+      widgetMgr.setStringValue({ id: "widget1", formId }, "foo", {
+        fromUi: true,
       })
+
+      widgetMgr.submitForm(formId, undefined, "myFragmentId")
+
+      // Our backMsg should be populated with our two widget values,
+      // plus the submitButton's value.
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton", triggerValue: true },
+            { id: "widget1", stringValue: "foo" },
+          ],
+        },
+        "myFragmentId"
+      )
 
       // We have no more pending form.
       expect(formsData.formsWithPendingChanges).toEqual(new Set())
@@ -405,9 +525,12 @@ describe("Widget State Manager", () => {
       )
       widgetMgr.submitForm(formId)
 
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [{ id: "firstSubmitButton", triggerValue: true }],
-      })
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [{ id: "firstSubmitButton", triggerValue: true }],
+        },
+        undefined
+      )
     })
 
     it("does not submit the form if the first submitButton is disabled", () => {
@@ -480,12 +603,15 @@ describe("Widget State Manager", () => {
 
       // Our backMsg should be populated with the first form widget value,
       // plus the first submitButton's triggerValue.
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [
-          { id: "submitButton", triggerValue: true },
-          { id: FORM_1.id, stringValue: "foo" },
-        ],
-      })
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton", triggerValue: true },
+            { id: FORM_1.id, stringValue: "foo" },
+          ],
+        },
+        undefined
+      )
     })
 
     it("checks that only the second form is pending after the first is submitted", () => {
@@ -505,13 +631,16 @@ describe("Widget State Manager", () => {
 
       // Our most recent backMsg should be populated with the both forms' widget values,
       // plus the second submitButton's fromSubmitValue.
-      expect(sendBackMsg).toHaveBeenLastCalledWith({
-        widgets: [
-          { id: FORM_1.id, stringValue: "foo" },
-          { id: "submitButton2", triggerValue: true },
-          { id: FORM_2.id, stringValue: "bar" },
-        ],
-      })
+      expect(sendBackMsg).toHaveBeenLastCalledWith(
+        {
+          widgets: [
+            { id: FORM_1.id, stringValue: "foo" },
+            { id: "submitButton2", triggerValue: true },
+            { id: FORM_2.id, stringValue: "bar" },
+          ],
+        },
+        undefined
+      )
     })
 
     it("checks that no more pending forms exist after both are submitted", () => {
@@ -536,12 +665,15 @@ describe("Widget State Manager", () => {
         new ButtonProto({ id: "submitButton2" })
       )
 
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [
-          { id: "submitButton2", triggerValue: true },
-          { id: FORM_2.id, stringValue: "bar" },
-        ],
-      })
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton2", triggerValue: true },
+            { id: FORM_2.id, stringValue: "bar" },
+          ],
+        },
+        undefined
+      )
     })
   })
 })

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -154,7 +154,7 @@ class FormState {
 
 interface Props {
   /** Callback to deliver a message to the server */
-  sendRerunBackMsg: (widgetStates: WidgetStates) => void
+  sendRerunBackMsg: (widgetStates: WidgetStates, fragmentId?: string) => void
 
   /**
    * Callback invoked whenever our FormsData changed. (Because FormsData
@@ -206,7 +206,11 @@ export class WidgetStateManager {
    * Commit pending changes for widgets that belong to the given form,
    * and send a rerunBackMsg to the server.
    */
-  public submitForm(formId: string, actualSubmitButton?: WidgetInfo): void {
+  public submitForm(
+    formId: string,
+    actualSubmitButton?: WidgetInfo,
+    fragmentId?: string
+  ): void {
     if (!isValidFormId(formId)) {
       // This should never get thrown - only FormSubmitButton calls this
       // function.
@@ -245,7 +249,7 @@ export class WidgetStateManager {
     this.widgetStates.copyFrom(form.widgetStates)
     form.widgetStates.clear()
 
-    this.sendUpdateWidgetsMessage()
+    this.sendUpdateWidgetsMessage(fragmentId)
     this.syncFormsWithPendingChanges()
 
     if (selectedSubmitButton) {
@@ -270,11 +274,12 @@ export class WidgetStateManager {
   public setStringTriggerValue(
     widget: WidgetInfo,
     value: string,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).stringTriggerValue =
       new StringTriggerValue({ data: value })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
     this.deleteWidgetState(widget.id)
   }
 
@@ -282,9 +287,13 @@ export class WidgetStateManager {
    * Sets the trigger value for the given widget ID to true, sends a rerunScript message
    * to the server, and then immediately unsets the trigger value.
    */
-  public setTriggerValue(widget: WidgetInfo, source: Source): void {
+  public setTriggerValue(
+    widget: WidgetInfo,
+    source: Source,
+    fragmentId?: string
+  ): void {
     this.createWidgetState(widget, source).triggerValue = true
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
     this.deleteWidgetState(widget.id)
   }
 
@@ -300,10 +309,11 @@ export class WidgetStateManager {
   public setBoolValue(
     widget: WidgetInfo,
     value: boolean,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).boolValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getIntValue(widget: WidgetInfo): number | undefined {
@@ -318,10 +328,11 @@ export class WidgetStateManager {
   public setIntValue(
     widget: WidgetInfo,
     value: number | null,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).intValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getDoubleValue(widget: WidgetInfo): number | undefined {
@@ -336,10 +347,11 @@ export class WidgetStateManager {
   public setDoubleValue(
     widget: WidgetInfo,
     value: number | null,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).doubleValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getStringValue(widget: WidgetInfo): string | undefined {
@@ -354,21 +366,23 @@ export class WidgetStateManager {
   public setStringValue(
     widget: WidgetInfo,
     value: string | null,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).stringValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public setStringArrayValue(
     widget: WidgetInfo,
     value: string[],
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).stringArrayValue = new StringArray({
       data: value,
     })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getStringArrayValue(widget: WidgetInfo): string[] | undefined {
@@ -402,12 +416,13 @@ export class WidgetStateManager {
   public setDoubleArrayValue(
     widget: WidgetInfo,
     value: number[],
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({
       data: value,
     })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getIntArrayValue(widget: WidgetInfo): number[] | undefined {
@@ -427,12 +442,13 @@ export class WidgetStateManager {
   public setIntArrayValue(
     widget: WidgetInfo,
     value: number[],
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).intArrayValue = new SInt64Array({
       data: value,
     })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getJsonValue(widget: WidgetInfo): string | undefined {
@@ -444,18 +460,24 @@ export class WidgetStateManager {
     return undefined
   }
 
-  public setJsonValue(widget: WidgetInfo, value: any, source: Source): void {
+  public setJsonValue(
+    widget: WidgetInfo,
+    value: any,
+    source: Source,
+    fragmentId?: string
+  ): void {
     this.createWidgetState(widget, source).jsonValue = JSON.stringify(value)
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public setArrowValue(
     widget: WidgetInfo,
     value: IArrowTable,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).arrowValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getArrowValue(widget: WidgetInfo): IArrowTable | undefined {
@@ -474,10 +496,11 @@ export class WidgetStateManager {
   public setBytesValue(
     widget: WidgetInfo,
     value: Uint8Array,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).bytesValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getBytesValue(widget: WidgetInfo): Uint8Array | undefined {
@@ -492,10 +515,11 @@ export class WidgetStateManager {
   public setFileUploaderStateValue(
     widget: WidgetInfo,
     value: IFileUploaderState,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).fileUploaderStateValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getFileUploaderStateValue(
@@ -518,14 +542,16 @@ export class WidgetStateManager {
    *
    * Called by every "setValue" function.
    */
+  //
   private onWidgetValueChanged(
     formId: string | undefined,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     if (isValidFormId(formId)) {
       this.syncFormsWithPendingChanges()
     } else if (source.fromUi) {
-      this.sendUpdateWidgetsMessage()
+      this.sendUpdateWidgetsMessage(fragmentId)
     }
   }
 
@@ -546,8 +572,11 @@ export class WidgetStateManager {
     })
   }
 
-  public sendUpdateWidgetsMessage(): void {
-    this.props.sendRerunBackMsg(this.widgetStates.createWidgetStatesMsg())
+  public sendUpdateWidgetsMessage(fragmentId?: string): void {
+    this.props.sendRerunBackMsg(
+      this.widgetStates.createWidgetStatesMsg(),
+      fragmentId
+    )
   }
 
   /**

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -62,6 +62,7 @@ interface BlockPropsWithWidth extends BaseBlockProps {
 // Render BlockNodes (i.e. container nodes).
 const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const { node } = props
+  const { currentFragmentId } = useContext(LibContext)
 
   if (node.isEmpty && !node.deltaBlock.allowEmpty) {
     return <></>
@@ -72,7 +73,8 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
     enable,
     node,
     props.scriptRunState,
-    props.scriptRunId
+    props.scriptRunId,
+    currentFragmentId
   )
 
   const childProps = { ...props, ...{ node } }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -246,6 +246,7 @@ const RawElementNodeRenderer = (
     ...elementProps,
     widgetMgr: props.widgetMgr,
     disabled: props.widgetsDisabled,
+    fragmentId: node.fragmentId,
   }
 
   switch (node.element.type) {
@@ -260,6 +261,19 @@ const RawElementNodeRenderer = (
         />
       )
     }
+
+    case "arrowTable":
+      return (
+        <ArrowTable element={node.quiverElement as Quiver} {...elementProps} />
+      )
+
+    case "arrowVegaLiteChart":
+      return (
+        <ArrowVegaLiteChart
+          element={node.vegaLiteChartElement as VegaLiteChartElement}
+          {...elementProps}
+        />
+      )
 
     case "audio":
       return (
@@ -276,19 +290,6 @@ const RawElementNodeRenderer = (
         <Balloons scriptRunId={props.scriptRunId} />
       )
 
-    case "arrowTable":
-      return (
-        <ArrowTable element={node.quiverElement as Quiver} {...elementProps} />
-      )
-
-    case "arrowVegaLiteChart":
-      return (
-        <ArrowVegaLiteChart
-          element={node.vegaLiteChartElement as VegaLiteChartElement}
-          {...elementProps}
-        />
-      )
-
     case "bokehChart":
       return (
         <DebouncedBokehChart
@@ -296,6 +297,18 @@ const RawElementNodeRenderer = (
           {...elementProps}
         />
       )
+
+    case "code": {
+      const codeProto = node.element.code as CodeProto
+      return (
+        <StreamlitSyntaxHighlighter
+          language={codeProto.language}
+          showLineNumbers={codeProto.showLineNumbers}
+        >
+          {codeProto.codeText}
+        </StreamlitSyntaxHighlighter>
+      )
+    }
 
     case "deckGlJsonChart":
       return (
@@ -332,6 +345,14 @@ const RawElementNodeRenderer = (
         />
       )
 
+    case "heading":
+      return (
+        <Heading
+          element={node.element.heading as HeadingProto}
+          {...elementProps}
+        />
+      )
+
     case "iframe":
       return (
         <IFrame
@@ -362,13 +383,8 @@ const RawElementNodeRenderer = (
         />
       )
 
-    case "heading":
-      return (
-        <Heading
-          element={node.element.heading as HeadingProto}
-          {...elementProps}
-        />
-      )
+    case "metric":
+      return <Metric element={node.element.metric as MetricProto} />
 
     case "pageLink": {
       const pageLinkProto = node.element.pageLink as PageLinkProto
@@ -399,6 +415,16 @@ const RawElementNodeRenderer = (
         />
       )
 
+    case "skeleton": {
+      return <AppSkeleton />
+    }
+
+    case "snow":
+      return hideIfStale(
+        props.isStale,
+        <Snow scriptRunId={props.scriptRunId} />
+      )
+
     case "spinner":
       return (
         <Spinner
@@ -415,9 +441,6 @@ const RawElementNodeRenderer = (
         />
       )
 
-    case "metric":
-      return <Metric element={node.element.metric as MetricProto} />
-
     case "video":
       return (
         <Video
@@ -427,7 +450,21 @@ const RawElementNodeRenderer = (
         />
       )
 
-    // Widgets
+    // Events:
+    case "toast": {
+      const toastProto = node.element.toast as ToastProto
+      return (
+        <Toast
+          // React key needed so toasts triggered on re-run
+          key={node.scriptRunId}
+          body={toastProto.body}
+          icon={toastProto.icon}
+          {...elementProps}
+        />
+      )
+    }
+
+    // Widgets:
     case "arrowDataFrame": {
       const arrowProto = node.element.arrowDataFrame as ArrowProto
       widgetProps.disabled = widgetProps.disabled || arrowProto.disabled
@@ -479,11 +516,7 @@ const RawElementNodeRenderer = (
         />
       )
     }
-    case "linkButton": {
-      const linkButtonProto = node.element.linkButton as LinkButtonProto
-      widgetProps.disabled = widgetProps.disabled || linkButtonProto.disabled
-      return <LinkButton element={linkButtonProto} {...widgetProps} />
-    }
+
     case "cameraInput": {
       const cameraInputProto = node.element.cameraInput as CameraInputProto
       widgetProps.disabled = widgetProps.disabled || cameraInputProto.disabled
@@ -567,6 +600,12 @@ const RawElementNodeRenderer = (
       )
     }
 
+    case "linkButton": {
+      const linkButtonProto = node.element.linkButton as LinkButtonProto
+      widgetProps.disabled = widgetProps.disabled || linkButtonProto.disabled
+      return <LinkButton element={linkButtonProto} {...widgetProps} />
+    }
+
     case "multiselect": {
       const multiSelectProto = node.element.multiselect as MultiSelectProto
       widgetProps.disabled = widgetProps.disabled || multiSelectProto.disabled
@@ -611,10 +650,6 @@ const RawElementNodeRenderer = (
       )
     }
 
-    case "skeleton": {
-      return <AppSkeleton />
-    }
-
     case "slider": {
       const sliderProto = node.element.slider as SliderProto
       widgetProps.disabled = widgetProps.disabled || sliderProto.disabled
@@ -622,12 +657,6 @@ const RawElementNodeRenderer = (
         <Slider key={sliderProto.id} element={sliderProto} {...widgetProps} />
       )
     }
-
-    case "snow":
-      return hideIfStale(
-        props.isStale,
-        <Snow scriptRunId={props.scriptRunId} />
-      )
 
     case "textArea": {
       const textAreaProto = node.element.textArea as TextAreaProto
@@ -665,32 +694,6 @@ const RawElementNodeRenderer = (
       )
     }
 
-    case "code": {
-      const codeProto = node.element.code as CodeProto
-      return (
-        <StreamlitSyntaxHighlighter
-          language={codeProto.language}
-          showLineNumbers={codeProto.showLineNumbers}
-        >
-          {codeProto.codeText}
-        </StreamlitSyntaxHighlighter>
-      )
-    }
-
-    // Events:
-    case "toast": {
-      const toastProto = node.element.toast as ToastProto
-      return (
-        <Toast
-          // React key needed so toasts triggered on re-run
-          key={node.scriptRunId}
-          body={toastProto.body}
-          icon={toastProto.icon}
-          {...elementProps}
-        />
-      )
-    }
-
     default:
       throw new Error(`Unrecognized Element type ${node.element.type}`)
   }
@@ -701,7 +704,7 @@ const RawElementNodeRenderer = (
 const ElementNodeRenderer = (
   props: ElementNodeRendererProps
 ): ReactElement => {
-  const { isFullScreen } = React.useContext(LibContext)
+  const { isFullScreen, currentFragmentId } = React.useContext(LibContext)
   const { node, width } = props
 
   const elementType = node.element.type || ""
@@ -710,7 +713,8 @@ const ElementNodeRenderer = (
     enable,
     node,
     props.scriptRunState,
-    props.scriptRunId
+    props.scriptRunId,
+    currentFragmentId
   )
 
   // TODO: If would be great if we could return an empty fragment if isHidden is true, to keep the

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementNode } from "@streamlit/lib/src/AppNode"
+import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
+
+import { isElementStale } from "./utils"
+
+describe("isElementStale", () => {
+  // @ts-expect-error
+  const node = new ElementNode(null, null, "myScriptRunId", "myFragmentId")
+
+  it("returns true if scriptRunState is RERUN_REQUESTED", () => {
+    expect(
+      isElementStale(node, ScriptRunState.RERUN_REQUESTED, "someScriptRunId")
+    ).toBe(true)
+  })
+
+  // When running in a fragment, the only elements that should be set to stale
+  // are those belonging to the fragment that's currently running.
+  it("if running and currentFragmentId is set, compares with node's fragmentId", () => {
+    expect(
+      isElementStale(
+        node,
+        ScriptRunState.RUNNING,
+        "myScriptRunId",
+        "myFragmentId"
+      )
+    ).toBe(true)
+
+    expect(
+      isElementStale(
+        node,
+        ScriptRunState.RUNNING,
+        "myScriptRunId",
+        "someOtherFragmentId"
+      )
+    ).toBe(false)
+  })
+
+  // When not running in a fragment, all elements from script runs aside from
+  // the current one should be set to stale.
+  it("if running and currentFragmentId is not set, compares with node's scriptRunId", () => {
+    expect(
+      isElementStale(node, ScriptRunState.RUNNING, "someOtherScriptRunId")
+    ).toBe(true)
+
+    expect(isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId")).toBe(
+      false
+    )
+  })
+
+  it("returns false for all other script run states", () => {
+    const states = [
+      ScriptRunState.NOT_RUNNING,
+      ScriptRunState.STOP_REQUESTED,
+      ScriptRunState.COMPILATION_ERROR,
+    ]
+    states.forEach(s => {
+      expect(isElementStale(node, s, "someOtherScriptRunId")).toBe(false)
+    })
+  })
+})

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -36,16 +36,22 @@ export function shouldComponentBeEnabled(
 export function isElementStale(
   node: AppNode,
   scriptRunState: ScriptRunState,
-  scriptRunId: string
+  scriptRunId: string,
+  currentFragmentId?: string
 ): boolean {
   if (scriptRunState === ScriptRunState.RERUN_REQUESTED) {
     // If a rerun was just requested, all of our current elements
     // are about to become stale.
     return true
   }
+
   if (scriptRunState === ScriptRunState.RUNNING) {
+    if (currentFragmentId) {
+      return node.fragmentId === currentFragmentId
+    }
     return node.scriptRunId !== scriptRunId
   }
+
   return false
 }
 
@@ -53,9 +59,13 @@ export function isComponentStale(
   enable: boolean,
   node: AppNode,
   scriptRunState: ScriptRunState,
-  scriptRunId: string
+  scriptRunId: string,
+  currentFragmentId?: string
 ): boolean {
-  return !enable || isElementStale(node, scriptRunState, scriptRunId)
+  return (
+    !enable ||
+    isElementStale(node, scriptRunState, scriptRunId, currentFragmentId)
+  )
 }
 
 export function assignDividerColor(

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -82,10 +82,17 @@ export interface LibContextProps {
    */
   currentPageScriptHash: string
 
-  /** The lib-specific configuration from the apps host which is requested via the
+  /**
+   * The lib-specific configuration from the apps host which is requested via the
    * _stcore/host-config endpoint.
    */
   libConfig: LibConfig
+
+  /**
+   * The ID of the fragment that the current script run corresponds to. If the
+   * current script run isn't due to a fragment, this field is falsy.
+   */
+  currentFragmentId: string
 }
 
 export const LibContext = React.createContext<LibContextProps>({
@@ -100,4 +107,5 @@ export const LibContext = React.createContext<LibContextProps>({
   onPageChange: () => {},
   currentPageScriptHash: "",
   libConfig: {},
+  currentFragmentId: "",
 })

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useRef, useState, useEffect } from "react"
+import React, {
+  ReactElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { useTheme } from "@emotion/react"
 import { Tabs as UITabs, Tab as UITab } from "baseui/tabs-motion"
 
 import { BlockNode, AppNode } from "@streamlit/lib/src/AppNode"
 import { BlockPropsWithoutWidth } from "@streamlit/lib/src/components/core/Block"
 import { isElementStale } from "@streamlit/lib/src/components/core/Block/utils"
+import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
 import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
 
 import { StyledTabContainer } from "./styled-components"
@@ -34,6 +41,7 @@ export interface TabProps extends BlockPropsWithoutWidth {
 
 function Tabs(props: TabProps): ReactElement {
   const { widgetsDisabled, node, isStale, scriptRunState, scriptRunId } = props
+  const { currentFragmentId } = useContext(LibContext)
 
   let allTabLabels: string[] = []
   const [activeTabKey, setActiveTabKey] = useState<React.Key>(0)
@@ -143,7 +151,8 @@ function Tabs(props: TabProps): ReactElement {
           const isStaleTab = isElementStale(
             appNode,
             scriptRunState,
-            scriptRunId
+            scriptRunId,
+            currentFragmentId
           )
 
           // Ensure stale tab's elements are also marked stale/disabled

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -118,6 +118,7 @@ export const customRenderLibContext = (
     onPageChange: jest.fn(),
     currentPageScriptHash: "",
     libConfig: {},
+    currentFragmentId: "",
   }
 
   return reactTestingLibraryRender(component, {


### PR DESCRIPTION
This PR implements roughly half of the frontend implementation of the upcoming
`st.experimental_fragment` feature.

In this half, we add most things that have to do with sending and receiving
`fragmentId`s between the server and client.

* the `currentFragmentId` from the current script run is set in `App.tsx` and
   passed around via `LibContext` so that elements can be marked as stale
   during fragment runs
* `fragmentId`s set in `Delta` messages are plumbed to their corresponding
   `AppNode` instances
* `fragmentId`s are passed to each widget component's props in `ElementNodeRenderer`
* We updated all of the `WidgetStateManager` setter methods to take an optional
   `fragmentId` parameter so that widgets can pass back their `fragmentId`s to the
   `widgetMgr` instance
* `fragmentId`s are also passed back to the server via `BackMsg` if set in
   `WidgetStateManager. sendUpdateWidgetsMessage()`

Actually having each of our widget types pass an optional `fragmentId` back to the
`WidgetStateManager` is done in #8165. 