### PR TITLE
Pass fragmentIds from widgets -> WidgetStateManager if set

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1283,6 +1283,27 @@ describe("App", () => {
       ).toBe("some_other_page_hash")
     })
 
+    it("sets fragmentId in BackMsg", () => {
+      renderApp(getProps())
+
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const connectionManager = getMockConnectionManager()
+
+      widgetStateManager.sendUpdateWidgetsMessage()
+      widgetStateManager.sendUpdateWidgetsMessage("myFragmentId")
+      expect(connectionManager.sendMessage).toBeCalledTimes(2)
+
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.fragmentId
+      ).toBe(undefined)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[1][0].rerunScript.fragmentId
+      ).toBe("myFragmentId")
+    })
+
     it("extracts the pageName as an empty string if we can't get a pageScriptHash (main page)", () => {
       renderApp(getProps())
       const widgetStateManager =

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -894,6 +894,7 @@ describe("AppRoot.applyDelta", () => {
 
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
+    expect(newRoot.main.fragmentId).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
@@ -914,11 +915,42 @@ describe("AppRoot.applyDelta", () => {
 
     // Check that our new scriptRunId has been set only on the touched nodes
     expect(newRoot.main.scriptRunId).toBe("new_session_id")
+    expect(newRoot.main.fragmentId).toBe(undefined)
     expect(newRoot.main.getIn([0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.main.getIn([1, 0])?.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
     expect(newRoot.main.getIn([1, 1])?.scriptRunId).toBe("new_session_id")
     expect(newRoot.sidebar.scriptRunId).toBe(NO_SCRIPT_RUN_ID)
+  })
+
+  it("can set fragmentId in 'newElement' deltas", () => {
+    const delta = makeProto(DeltaProto, {
+      newElement: { text: { body: "newElement!" } },
+      fragmentId: "myFragmentId",
+    })
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1])
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as ElementNode
+    expect(newNode.fragmentId).toBe("myFragmentId")
+  })
+
+  it("can set fragmentId in 'addBlock' deltas", () => {
+    const delta = makeProto(DeltaProto, {
+      addBlock: {},
+      fragmentId: "myFragmentId",
+    })
+    const newRoot = ROOT.applyDelta(
+      "new_session_id",
+      delta,
+      forwardMsgMetadata([0, 1, 1])
+    )
+
+    const newNode = newRoot.main.getIn([1, 1]) as BlockNode
+    expect(newNode.fragmentId).toBe("myFragmentId")
   })
 })
 

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -98,6 +98,10 @@ describe("Widget State Manager", () => {
       expect(sendBackMsg).not.toHaveBeenCalled()
     } else {
       expect(sendBackMsg).toHaveBeenCalledTimes(1)
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined // fragmentId
+      )
     }
   }
 
@@ -249,6 +253,112 @@ describe("Widget State Manager", () => {
     }
   )
 
+  it("setIntValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
+    widgetMgr.setIntValue(MOCK_WIDGET, Number.MAX_SAFE_INTEGER, {
+      fromUi: true,
+    })
+
+    expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MAX_SAFE_INTEGER)
+
+    widgetMgr.setIntValue(MOCK_WIDGET, Number.MIN_SAFE_INTEGER, {
+      fromUi: true,
+    })
+
+    expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MIN_SAFE_INTEGER)
+  })
+
+  it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
+    const values = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
+    widgetMgr.setIntArrayValue(MOCK_WIDGET, values, {
+      fromUi: true,
+    })
+
+    expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
+  })
+
+  describe("can set fragmentId in setter methods", () => {
+    it.each([
+      {
+        setterMethod: "setStringTriggerValue",
+        value: "Hello world",
+      },
+      {
+        setterMethod: "setBoolValue",
+        value: true,
+      },
+      {
+        setterMethod: "setIntValue",
+        value: 42,
+      },
+      {
+        setterMethod: "setDoubleValue",
+        value: 42.0,
+      },
+      {
+        setterMethod: "setStringValue",
+        value: "Hello world",
+      },
+      {
+        setterMethod: "setStringArrayValue",
+        value: ["Hello", "world"],
+      },
+      {
+        setterMethod: "setDoubleArrayValue",
+        value: [40.0, 2.0],
+      },
+      {
+        setterMethod: "setIntArrayValue",
+        value: [40, 2],
+      },
+      {
+        setterMethod: "setJsonValue",
+        value: MOCK_JSON,
+      },
+      {
+        setterMethod: "setArrowValue",
+        value: MOCK_ARROW_TABLE,
+      },
+      {
+        setterMethod: "setBytesValue",
+        value: MOCK_BYTES,
+      },
+      {
+        setterMethod: "setFileUploaderStateValue",
+        value: MOCK_FILE_UPLOADER_STATE,
+      },
+    ])("%p", ({ setterMethod, value }) => {
+      // @ts-expect-error
+      widgetMgr[setterMethod](
+        MOCK_WIDGET,
+        value,
+        {
+          fromUi: true,
+        },
+        "myFragmentId"
+      )
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        expect.anything(),
+        "myFragmentId"
+      )
+    })
+
+    // This test isn't parameterized like the ones above because setTriggerValue
+    // has a slightly different signature from the other setter methods.
+    it("can set fragmentId in setTriggerValue", () => {
+      widgetMgr.setTriggerValue(
+        MOCK_WIDGET,
+        {
+          fromUi: true,
+        },
+        "myFragmentId"
+      )
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        expect.anything(),
+        "myFragmentId"
+      )
+    })
+  })
+
   describe("Primitive types as JSON values", () => {
     it("sets string value as JSON correctly", () => {
       widgetMgr.setJsonValue(MOCK_WIDGET, "mockStringValue", { fromUi: true })
@@ -288,29 +398,6 @@ describe("Widget State Manager", () => {
       expect(widgetMgr.getJsonValue(MOCK_WIDGET)).toBe(
         JSON.stringify([1.1, 2.2, 3.3])
       )
-    })
-
-    it("setIntValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
-      widgetMgr.setIntValue(MOCK_WIDGET, Number.MAX_SAFE_INTEGER, {
-        fromUi: true,
-      })
-
-      expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MAX_SAFE_INTEGER)
-
-      widgetMgr.setIntValue(MOCK_WIDGET, Number.MIN_SAFE_INTEGER, {
-        fromUi: true,
-      })
-
-      expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MIN_SAFE_INTEGER)
-    })
-
-    it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {
-      const values = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
-      widgetMgr.setIntArrayValue(MOCK_WIDGET, values, {
-        fromUi: true,
-      })
-
-      expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toStrictEqual(values)
     })
   })
 
@@ -375,13 +462,46 @@ describe("Widget State Manager", () => {
 
       // Our backMsg should be populated with our two widget values,
       // plus the submitButton's value.
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [
-          { id: "submitButton", triggerValue: true },
-          { id: "widget1", stringValue: "foo" },
-          { id: "widget2", stringValue: "bar" },
-        ],
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton", triggerValue: true },
+            { id: "widget1", stringValue: "foo" },
+            { id: "widget2", stringValue: "bar" },
+          ],
+        },
+        undefined // fragmentId
+      )
+
+      // We have no more pending form.
+      expect(formsData.formsWithPendingChanges).toEqual(new Set())
+    })
+
+    it("calls sendBackMsg with fragmentId", () => {
+      const formId = "mockFormId"
+      widgetMgr.addSubmitButton(
+        formId,
+        new ButtonProto({ id: "submitButton" })
+      )
+
+      // Populate a form
+      widgetMgr.setStringValue({ id: "widget1", formId }, "foo", {
+        fromUi: true,
       })
+
+      widgetMgr.submitForm(formId, undefined, "myFragmentId")
+
+      // Our backMsg should be populated with our two widget values,
+      // plus the submitButton's value.
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton", triggerValue: true },
+            { id: "widget1", stringValue: "foo" },
+          ],
+        },
+        "myFragmentId"
+      )
 
       // We have no more pending form.
       expect(formsData.formsWithPendingChanges).toEqual(new Set())
@@ -405,9 +525,12 @@ describe("Widget State Manager", () => {
       )
       widgetMgr.submitForm(formId)
 
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [{ id: "firstSubmitButton", triggerValue: true }],
-      })
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [{ id: "firstSubmitButton", triggerValue: true }],
+        },
+        undefined
+      )
     })
 
     it("does not submit the form if the first submitButton is disabled", () => {
@@ -480,12 +603,15 @@ describe("Widget State Manager", () => {
 
       // Our backMsg should be populated with the first form widget value,
       // plus the first submitButton's triggerValue.
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [
-          { id: "submitButton", triggerValue: true },
-          { id: FORM_1.id, stringValue: "foo" },
-        ],
-      })
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton", triggerValue: true },
+            { id: FORM_1.id, stringValue: "foo" },
+          ],
+        },
+        undefined
+      )
     })
 
     it("checks that only the second form is pending after the first is submitted", () => {
@@ -505,13 +631,16 @@ describe("Widget State Manager", () => {
 
       // Our most recent backMsg should be populated with the both forms' widget values,
       // plus the second submitButton's fromSubmitValue.
-      expect(sendBackMsg).toHaveBeenLastCalledWith({
-        widgets: [
-          { id: FORM_1.id, stringValue: "foo" },
-          { id: "submitButton2", triggerValue: true },
-          { id: FORM_2.id, stringValue: "bar" },
-        ],
-      })
+      expect(sendBackMsg).toHaveBeenLastCalledWith(
+        {
+          widgets: [
+            { id: FORM_1.id, stringValue: "foo" },
+            { id: "submitButton2", triggerValue: true },
+            { id: FORM_2.id, stringValue: "bar" },
+          ],
+        },
+        undefined
+      )
     })
 
     it("checks that no more pending forms exist after both are submitted", () => {
@@ -536,12 +665,15 @@ describe("Widget State Manager", () => {
         new ButtonProto({ id: "submitButton2" })
       )
 
-      expect(sendBackMsg).toHaveBeenCalledWith({
-        widgets: [
-          { id: "submitButton2", triggerValue: true },
-          { id: FORM_2.id, stringValue: "bar" },
-        ],
-      })
+      expect(sendBackMsg).toHaveBeenCalledWith(
+        {
+          widgets: [
+            { id: "submitButton2", triggerValue: true },
+            { id: FORM_2.id, stringValue: "bar" },
+          ],
+        },
+        undefined
+      )
     })
   })
 })

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -154,7 +154,7 @@ class FormState {
 
 interface Props {
   /** Callback to deliver a message to the server */
-  sendRerunBackMsg: (widgetStates: WidgetStates) => void
+  sendRerunBackMsg: (widgetStates: WidgetStates, fragmentId?: string) => void
 
   /**
    * Callback invoked whenever our FormsData changed. (Because FormsData
@@ -206,7 +206,11 @@ export class WidgetStateManager {
    * Commit pending changes for widgets that belong to the given form,
    * and send a rerunBackMsg to the server.
    */
-  public submitForm(formId: string, actualSubmitButton?: WidgetInfo): void {
+  public submitForm(
+    formId: string,
+    actualSubmitButton?: WidgetInfo,
+    fragmentId?: string
+  ): void {
     if (!isValidFormId(formId)) {
       // This should never get thrown - only FormSubmitButton calls this
       // function.
@@ -245,7 +249,7 @@ export class WidgetStateManager {
     this.widgetStates.copyFrom(form.widgetStates)
     form.widgetStates.clear()
 
-    this.sendUpdateWidgetsMessage()
+    this.sendUpdateWidgetsMessage(fragmentId)
     this.syncFormsWithPendingChanges()
 
     if (selectedSubmitButton) {
@@ -270,11 +274,12 @@ export class WidgetStateManager {
   public setStringTriggerValue(
     widget: WidgetInfo,
     value: string,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).stringTriggerValue =
       new StringTriggerValue({ data: value })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
     this.deleteWidgetState(widget.id)
   }
 
@@ -282,9 +287,13 @@ export class WidgetStateManager {
    * Sets the trigger value for the given widget ID to true, sends a rerunScript message
    * to the server, and then immediately unsets the trigger value.
    */
-  public setTriggerValue(widget: WidgetInfo, source: Source): void {
+  public setTriggerValue(
+    widget: WidgetInfo,
+    source: Source,
+    fragmentId?: string
+  ): void {
     this.createWidgetState(widget, source).triggerValue = true
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
     this.deleteWidgetState(widget.id)
   }
 
@@ -300,10 +309,11 @@ export class WidgetStateManager {
   public setBoolValue(
     widget: WidgetInfo,
     value: boolean,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).boolValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getIntValue(widget: WidgetInfo): number | undefined {
@@ -318,10 +328,11 @@ export class WidgetStateManager {
   public setIntValue(
     widget: WidgetInfo,
     value: number | null,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).intValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getDoubleValue(widget: WidgetInfo): number | undefined {
@@ -336,10 +347,11 @@ export class WidgetStateManager {
   public setDoubleValue(
     widget: WidgetInfo,
     value: number | null,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).doubleValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getStringValue(widget: WidgetInfo): string | undefined {
@@ -354,21 +366,23 @@ export class WidgetStateManager {
   public setStringValue(
     widget: WidgetInfo,
     value: string | null,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).stringValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public setStringArrayValue(
     widget: WidgetInfo,
     value: string[],
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).stringArrayValue = new StringArray({
       data: value,
     })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getStringArrayValue(widget: WidgetInfo): string[] | undefined {
@@ -402,12 +416,13 @@ export class WidgetStateManager {
   public setDoubleArrayValue(
     widget: WidgetInfo,
     value: number[],
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({
       data: value,
     })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getIntArrayValue(widget: WidgetInfo): number[] | undefined {
@@ -427,12 +442,13 @@ export class WidgetStateManager {
   public setIntArrayValue(
     widget: WidgetInfo,
     value: number[],
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).intArrayValue = new SInt64Array({
       data: value,
     })
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getJsonValue(widget: WidgetInfo): string | undefined {
@@ -444,18 +460,24 @@ export class WidgetStateManager {
     return undefined
   }
 
-  public setJsonValue(widget: WidgetInfo, value: any, source: Source): void {
+  public setJsonValue(
+    widget: WidgetInfo,
+    value: any,
+    source: Source,
+    fragmentId?: string
+  ): void {
     this.createWidgetState(widget, source).jsonValue = JSON.stringify(value)
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public setArrowValue(
     widget: WidgetInfo,
     value: IArrowTable,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).arrowValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getArrowValue(widget: WidgetInfo): IArrowTable | undefined {
@@ -474,10 +496,11 @@ export class WidgetStateManager {
   public setBytesValue(
     widget: WidgetInfo,
     value: Uint8Array,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).bytesValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getBytesValue(widget: WidgetInfo): Uint8Array | undefined {
@@ -492,10 +515,11 @@ export class WidgetStateManager {
   public setFileUploaderStateValue(
     widget: WidgetInfo,
     value: IFileUploaderState,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     this.createWidgetState(widget, source).fileUploaderStateValue = value
-    this.onWidgetValueChanged(widget.formId, source)
+    this.onWidgetValueChanged(widget.formId, source, fragmentId)
   }
 
   public getFileUploaderStateValue(
@@ -518,14 +542,16 @@ export class WidgetStateManager {
    *
    * Called by every "setValue" function.
    */
+  //
   private onWidgetValueChanged(
     formId: string | undefined,
-    source: Source
+    source: Source,
+    fragmentId?: string
   ): void {
     if (isValidFormId(formId)) {
       this.syncFormsWithPendingChanges()
     } else if (source.fromUi) {
-      this.sendUpdateWidgetsMessage()
+      this.sendUpdateWidgetsMessage(fragmentId)
     }
   }
 
@@ -546,8 +572,11 @@ export class WidgetStateManager {
     })
   }
 
-  public sendUpdateWidgetsMessage(): void {
-    this.props.sendRerunBackMsg(this.widgetStates.createWidgetStatesMsg())
+  public sendUpdateWidgetsMessage(fragmentId?: string): void {
+    this.props.sendRerunBackMsg(
+      this.widgetStates.createWidgetStatesMsg(),
+      fragmentId
+    )
   }
 
   /**

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -62,6 +62,7 @@ interface BlockPropsWithWidth extends BaseBlockProps {
 // Render BlockNodes (i.e. container nodes).
 const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const { node } = props
+  const { currentFragmentId } = useContext(LibContext)
 
   if (node.isEmpty && !node.deltaBlock.allowEmpty) {
     return <></>
@@ -72,7 +73,8 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
     enable,
     node,
     props.scriptRunState,
-    props.scriptRunId
+    props.scriptRunId,
+    currentFragmentId
   )
 
   const childProps = { ...props, ...{ node } }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -246,6 +246,7 @@ const RawElementNodeRenderer = (
     ...elementProps,
     widgetMgr: props.widgetMgr,
     disabled: props.widgetsDisabled,
+    fragmentId: node.fragmentId,
   }
 
   switch (node.element.type) {
@@ -260,6 +261,19 @@ const RawElementNodeRenderer = (
         />
       )
     }
+
+    case "arrowTable":
+      return (
+        <ArrowTable element={node.quiverElement as Quiver} {...elementProps} />
+      )
+
+    case "arrowVegaLiteChart":
+      return (
+        <ArrowVegaLiteChart
+          element={node.vegaLiteChartElement as VegaLiteChartElement}
+          {...elementProps}
+        />
+      )
 
     case "audio":
       return (
@@ -276,19 +290,6 @@ const RawElementNodeRenderer = (
         <Balloons scriptRunId={props.scriptRunId} />
       )
 
-    case "arrowTable":
-      return (
-        <ArrowTable element={node.quiverElement as Quiver} {...elementProps} />
-      )
-
-    case "arrowVegaLiteChart":
-      return (
-        <ArrowVegaLiteChart
-          element={node.vegaLiteChartElement as VegaLiteChartElement}
-          {...elementProps}
-        />
-      )
-
     case "bokehChart":
       return (
         <DebouncedBokehChart
@@ -296,6 +297,18 @@ const RawElementNodeRenderer = (
           {...elementProps}
         />
       )
+
+    case "code": {
+      const codeProto = node.element.code as CodeProto
+      return (
+        <StreamlitSyntaxHighlighter
+          language={codeProto.language}
+          showLineNumbers={codeProto.showLineNumbers}
+        >
+          {codeProto.codeText}
+        </StreamlitSyntaxHighlighter>
+      )
+    }
 
     case "deckGlJsonChart":
       return (
@@ -332,6 +345,14 @@ const RawElementNodeRenderer = (
         />
       )
 
+    case "heading":
+      return (
+        <Heading
+          element={node.element.heading as HeadingProto}
+          {...elementProps}
+        />
+      )
+
     case "iframe":
       return (
         <IFrame
@@ -362,13 +383,8 @@ const RawElementNodeRenderer = (
         />
       )
 
-    case "heading":
-      return (
-        <Heading
-          element={node.element.heading as HeadingProto}
-          {...elementProps}
-        />
-      )
+    case "metric":
+      return <Metric element={node.element.metric as MetricProto} />
 
     case "pageLink": {
       const pageLinkProto = node.element.pageLink as PageLinkProto
@@ -399,6 +415,16 @@ const RawElementNodeRenderer = (
         />
       )
 
+    case "skeleton": {
+      return <AppSkeleton />
+    }
+
+    case "snow":
+      return hideIfStale(
+        props.isStale,
+        <Snow scriptRunId={props.scriptRunId} />
+      )
+
     case "spinner":
       return (
         <Spinner
@@ -415,9 +441,6 @@ const RawElementNodeRenderer = (
         />
       )
 
-    case "metric":
-      return <Metric element={node.element.metric as MetricProto} />
-
     case "video":
       return (
         <Video
@@ -427,7 +450,21 @@ const RawElementNodeRenderer = (
         />
       )
 
-    // Widgets
+    // Events:
+    case "toast": {
+      const toastProto = node.element.toast as ToastProto
+      return (
+        <Toast
+          // React key needed so toasts triggered on re-run
+          key={node.scriptRunId}
+          body={toastProto.body}
+          icon={toastProto.icon}
+          {...elementProps}
+        />
+      )
+    }
+
+    // Widgets:
     case "arrowDataFrame": {
       const arrowProto = node.element.arrowDataFrame as ArrowProto
       widgetProps.disabled = widgetProps.disabled || arrowProto.disabled
@@ -479,11 +516,7 @@ const RawElementNodeRenderer = (
         />
       )
     }
-    case "linkButton": {
-      const linkButtonProto = node.element.linkButton as LinkButtonProto
-      widgetProps.disabled = widgetProps.disabled || linkButtonProto.disabled
-      return <LinkButton element={linkButtonProto} {...widgetProps} />
-    }
+
     case "cameraInput": {
       const cameraInputProto = node.element.cameraInput as CameraInputProto
       widgetProps.disabled = widgetProps.disabled || cameraInputProto.disabled
@@ -567,6 +600,12 @@ const RawElementNodeRenderer = (
       )
     }
 
+    case "linkButton": {
+      const linkButtonProto = node.element.linkButton as LinkButtonProto
+      widgetProps.disabled = widgetProps.disabled || linkButtonProto.disabled
+      return <LinkButton element={linkButtonProto} {...widgetProps} />
+    }
+
     case "multiselect": {
       const multiSelectProto = node.element.multiselect as MultiSelectProto
       widgetProps.disabled = widgetProps.disabled || multiSelectProto.disabled
@@ -611,10 +650,6 @@ const RawElementNodeRenderer = (
       )
     }
 
-    case "skeleton": {
-      return <AppSkeleton />
-    }
-
     case "slider": {
       const sliderProto = node.element.slider as SliderProto
       widgetProps.disabled = widgetProps.disabled || sliderProto.disabled
@@ -622,12 +657,6 @@ const RawElementNodeRenderer = (
         <Slider key={sliderProto.id} element={sliderProto} {...widgetProps} />
       )
     }
-
-    case "snow":
-      return hideIfStale(
-        props.isStale,
-        <Snow scriptRunId={props.scriptRunId} />
-      )
 
     case "textArea": {
       const textAreaProto = node.element.textArea as TextAreaProto
@@ -665,32 +694,6 @@ const RawElementNodeRenderer = (
       )
     }
 
-    case "code": {
-      const codeProto = node.element.code as CodeProto
-      return (
-        <StreamlitSyntaxHighlighter
-          language={codeProto.language}
-          showLineNumbers={codeProto.showLineNumbers}
-        >
-          {codeProto.codeText}
-        </StreamlitSyntaxHighlighter>
-      )
-    }
-
-    // Events:
-    case "toast": {
-      const toastProto = node.element.toast as ToastProto
-      return (
-        <Toast
-          // React key needed so toasts triggered on re-run
-          key={node.scriptRunId}
-          body={toastProto.body}
-          icon={toastProto.icon}
-          {...elementProps}
-        />
-      )
-    }
-
     default:
       throw new Error(`Unrecognized Element type ${node.element.type}`)
   }
@@ -701,7 +704,7 @@ const RawElementNodeRenderer = (
 const ElementNodeRenderer = (
   props: ElementNodeRendererProps
 ): ReactElement => {
-  const { isFullScreen } = React.useContext(LibContext)
+  const { isFullScreen, currentFragmentId } = React.useContext(LibContext)
   const { node, width } = props
 
   const elementType = node.element.type || ""
@@ -710,7 +713,8 @@ const ElementNodeRenderer = (
     enable,
     node,
     props.scriptRunState,
-    props.scriptRunId
+    props.scriptRunId,
+    currentFragmentId
   )
 
   // TODO: If would be great if we could return an empty fragment if isHidden is true, to keep the

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementNode } from "@streamlit/lib/src/AppNode"
+import { ScriptRunState } from "@streamlit/lib/src/ScriptRunState"
+
+import { isElementStale } from "./utils"
+
+describe("isElementStale", () => {
+  // @ts-expect-error
+  const node = new ElementNode(null, null, "myScriptRunId", "myFragmentId")
+
+  it("returns true if scriptRunState is RERUN_REQUESTED", () => {
+    expect(
+      isElementStale(node, ScriptRunState.RERUN_REQUESTED, "someScriptRunId")
+    ).toBe(true)
+  })
+
+  // When running in a fragment, the only elements that should be set to stale
+  // are those belonging to the fragment that's currently running.
+  it("if running and currentFragmentId is set, compares with node's fragmentId", () => {
+    expect(
+      isElementStale(
+        node,
+        ScriptRunState.RUNNING,
+        "myScriptRunId",
+        "myFragmentId"
+      )
+    ).toBe(true)
+
+    expect(
+      isElementStale(
+        node,
+        ScriptRunState.RUNNING,
+        "myScriptRunId",
+        "someOtherFragmentId"
+      )
+    ).toBe(false)
+  })
+
+  // When not running in a fragment, all elements from script runs aside from
+  // the current one should be set to stale.
+  it("if running and currentFragmentId is not set, compares with node's scriptRunId", () => {
+    expect(
+      isElementStale(node, ScriptRunState.RUNNING, "someOtherScriptRunId")
+    ).toBe(true)
+
+    expect(isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId")).toBe(
+      false
+    )
+  })
+
+  it("returns false for all other script run states", () => {
+    const states = [
+      ScriptRunState.NOT_RUNNING,
+      ScriptRunState.STOP_REQUESTED,
+      ScriptRunState.COMPILATION_ERROR,
+    ]
+    states.forEach(s => {
+      expect(isElementStale(node, s, "someOtherScriptRunId")).toBe(false)
+    })
+  })
+})

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -36,16 +36,22 @@ export function shouldComponentBeEnabled(
 export function isElementStale(
   node: AppNode,
   scriptRunState: ScriptRunState,
-  scriptRunId: string
+  scriptRunId: string,
+  currentFragmentId?: string
 ): boolean {
   if (scriptRunState === ScriptRunState.RERUN_REQUESTED) {
     // If a rerun was just requested, all of our current elements
     // are about to become stale.
     return true
   }
+
   if (scriptRunState === ScriptRunState.RUNNING) {
+    if (currentFragmentId) {
+      return node.fragmentId === currentFragmentId
+    }
     return node.scriptRunId !== scriptRunId
   }
+
   return false
 }
 
@@ -53,9 +59,13 @@ export function isComponentStale(
   enable: boolean,
   node: AppNode,
   scriptRunState: ScriptRunState,
-  scriptRunId: string
+  scriptRunId: string,
+  currentFragmentId?: string
 ): boolean {
-  return !enable || isElementStale(node, scriptRunState, scriptRunId)
+  return (
+    !enable ||
+    isElementStale(node, scriptRunState, scriptRunId, currentFragmentId)
+  )
 }
 
 export function assignDividerColor(

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -82,10 +82,17 @@ export interface LibContextProps {
    */
   currentPageScriptHash: string
 
-  /** The lib-specific configuration from the apps host which is requested via the
+  /**
+   * The lib-specific configuration from the apps host which is requested via the
    * _stcore/host-config endpoint.
    */
   libConfig: LibConfig
+
+  /**
+   * The ID of the fragment that the current script run corresponds to. If the
+   * current script run isn't due to a fragment, this field is falsy.
+   */
+  currentFragmentId: string
 }
 
 export const LibContext = React.createContext<LibContextProps>({
@@ -100,4 +107,5 @@ export const LibContext = React.createContext<LibContextProps>({
   onPageChange: () => {},
   currentPageScriptHash: "",
   libConfig: {},
+  currentFragmentId: "",
 })

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, useRef, useState, useEffect } from "react"
+import React, {
+  ReactElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { useTheme } from "@emotion/react"
 import { Tabs as UITabs, Tab as UITab } from "baseui/tabs-motion"
 
 import { BlockNode, AppNode } from "@streamlit/lib/src/AppNode"
 import { BlockPropsWithoutWidth } from "@streamlit/lib/src/components/core/Block"
 import { isElementStale } from "@streamlit/lib/src/components/core/Block/utils"
+import { LibContext } from "@streamlit/lib/src/components/core/LibContext"
 import StreamlitMarkdown from "@streamlit/lib/src/components/shared/StreamlitMarkdown"
 
 import { StyledTabContainer } from "./styled-components"
@@ -34,6 +41,7 @@ export interface TabProps extends BlockPropsWithoutWidth {
 
 function Tabs(props: TabProps): ReactElement {
   const { widgetsDisabled, node, isStale, scriptRunState, scriptRunId } = props
+  const { currentFragmentId } = useContext(LibContext)
 
   let allTabLabels: string[] = []
   const [activeTabKey, setActiveTabKey] = useState<React.Key>(0)
@@ -143,7 +151,8 @@ function Tabs(props: TabProps): ReactElement {
           const isStaleTab = isElementStale(
             appNode,
             scriptRunState,
-            scriptRunId
+            scriptRunId,
+            currentFragmentId
           )
 
           // Ensure stale tab's elements are also marked stale/disabled

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -84,7 +84,24 @@ describe("Button widget", () => {
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,
-        { fromUi: true }
+        { fromUi: true },
+        undefined
+      )
+    })
+
+    it("passes fragmentId to onClick prop", () => {
+      const props = getProps(undefined, {
+        fragmentId: "myFragmentId",
+      })
+      render(<Button {...props} />)
+
+      const buttonWidget = screen.getByRole("button")
+      fireEvent.click(buttonWidget)
+
+      expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
+        props.element,
+        { fromUi: true },
+        "myFragmentId"
       )
     })
 

--- a/frontend/lib/src/components/widgets/Button/Button.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.tsx
@@ -29,10 +29,11 @@ export interface Props {
   element: ButtonProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 function Button(props: Props): ReactElement {
-  const { disabled, element, widgetMgr, width } = props
+  const { disabled, element, widgetMgr, width, fragmentId } = props
   const style = { width }
 
   const kind =
@@ -52,7 +53,9 @@ function Button(props: Props): ReactElement {
           size={BaseButtonSize.SMALL}
           disabled={disabled}
           fluidWidth={element.useContainerWidth ? fluidWidth : false}
-          onClick={() => widgetMgr.setTriggerValue(element, { fromUi: true })}
+          onClick={() =>
+            widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
+          }
         >
           <StreamlitMarkdown
             source={element.label}

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -59,6 +59,7 @@ export interface Props {
   uploadClient: FileUploadClient
   disabled: boolean
   width: number
+  fragmentId?: string
   // Allow for unit testing
   testOverride?: WebcamPermission
 }
@@ -264,20 +265,25 @@ class CameraInput extends React.PureComponent<Props, State> {
     // undefined, and we can early-out of the state update.
     const newWidgetValue = this.createWidgetValue()
 
-    const { element, widgetMgr } = this.props
+    const { element, widgetMgr, fragmentId } = this.props
 
     // Maybe send a widgetValue update to the widgetStateManager.
     const prevWidgetValue = widgetMgr.getFileUploaderStateValue(element)
     if (!isEqual(newWidgetValue, prevWidgetValue)) {
-      widgetMgr.setFileUploaderStateValue(element, newWidgetValue, {
-        fromUi: true,
-      })
+      widgetMgr.setFileUploaderStateValue(
+        element,
+        newWidgetValue,
+        {
+          fromUi: true,
+        },
+        fragmentId
+      )
     }
   }
 
   public componentDidMount(): void {
     const newWidgetValue = this.createWidgetValue()
-    const { element, widgetMgr } = this.props
+    const { element, widgetMgr, fragmentId } = this.props
 
     // Set the state value on mount, to avoid triggering an extra rerun after
     // the first rerun.
@@ -285,9 +291,14 @@ class CameraInput extends React.PureComponent<Props, State> {
     // since simanticly camera_input is just a special case of file uploader.
     const prevWidgetValue = widgetMgr.getFileUploaderStateValue(element)
     if (prevWidgetValue === undefined) {
-      widgetMgr.setFileUploaderStateValue(element, newWidgetValue, {
-        fromUi: false,
-      })
+      widgetMgr.setFileUploaderStateValue(
+        element,
+        newWidgetValue,
+        {
+          fromUi: false,
+        },
+        fragmentId
+      )
     }
   }
 
@@ -322,10 +333,12 @@ class CameraInput extends React.PureComponent<Props, State> {
         imgSrc: null,
       })
 
-      this.props.widgetMgr.setFileUploaderStateValue(
-        this.props.element,
+      const { widgetMgr, element, fragmentId } = this.props
+      widgetMgr.setFileUploaderStateValue(
+        element,
         newWidgetValue,
-        { fromUi: true }
+        { fromUi: true },
+        fragmentId
       )
     })
   }

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -23,7 +23,10 @@ import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 
 import ChatInput, { Props } from "./ChatInput"
 
-const getProps = (elementProps: Partial<ChatInputProto> = {}): Props => ({
+const getProps = (
+  elementProps: Partial<ChatInputProto> = {},
+  widgetProps: Partial<Props> = {}
+): Props => ({
   element: ChatInputProto.create({
     id: "123",
     placeholder: "Enter Text Here",
@@ -37,6 +40,7 @@ const getProps = (elementProps: Partial<ChatInputProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
+  ...widgetProps,
 })
 
 describe("ChatInput widget", () => {
@@ -105,10 +109,33 @@ describe("ChatInput widget", () => {
     fireEvent.change(chatInput, { target: { value: "1234567890" } })
     expect(chatInput).toHaveTextContent("1234567890")
     fireEvent.keyDown(chatInput, { key: "Enter" })
-    expect(spy).toHaveBeenCalledWith(props.element, "1234567890", {
-      fromUi: true,
-    })
+    expect(spy).toHaveBeenCalledWith(
+      props.element,
+      "1234567890",
+      {
+        fromUi: true,
+      },
+      undefined
+    )
     expect(chatInput).toHaveTextContent("")
+  })
+
+  it("can set fragmentId when sending value", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    const spy = jest.spyOn(props.widgetMgr, "setStringTriggerValue")
+    render(<ChatInput {...props} />)
+
+    const chatInput = screen.getByTestId("stChatInputTextArea")
+    fireEvent.change(chatInput, { target: { value: "1234567890" } })
+    fireEvent.keyDown(chatInput, { key: "Enter" })
+    expect(spy).toHaveBeenCalledWith(
+      props.element,
+      "1234567890",
+      {
+        fromUi: true,
+      },
+      "myFragmentId"
+    )
   })
 
   it("will not send an empty value on enter if empty", () => {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -45,6 +45,7 @@ export interface Props {
   element: ChatInputProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 // We want to show easily that there's scrolling so we deliberately choose
@@ -68,7 +69,12 @@ const isEnterKeyPressed = (
   )
 }
 
-function ChatInput({ width, element, widgetMgr }: Props): React.ReactElement {
+function ChatInput({
+  width,
+  element,
+  widgetMgr,
+  fragmentId,
+}: Props): React.ReactElement {
   const theme = useTheme()
   // True if the user-specified state.value has not yet been synced to the WidgetStateManager.
   const [dirty, setDirty] = useState(false)
@@ -99,7 +105,12 @@ function ChatInput({ width, element, widgetMgr }: Props): React.ReactElement {
       return
     }
 
-    widgetMgr.setStringTriggerValue(element, value, { fromUi: true })
+    widgetMgr.setStringTriggerValue(
+      element,
+      value,
+      { fromUi: true },
+      fragmentId
+    )
     setDirty(false)
     setValue("")
     setScrollHeight(0)

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -28,7 +28,10 @@ import {
 
 import Checkbox, { OwnProps } from "./Checkbox"
 
-const getProps = (elementProps: Partial<CheckboxProto> = {}): OwnProps => ({
+const getProps = (
+  elementProps: Partial<CheckboxProto> = {},
+  widgetProps: Partial<OwnProps> = {}
+): OwnProps => ({
   element: CheckboxProto.create({
     id: "1",
     label: "Label",
@@ -42,6 +45,7 @@ const getProps = (elementProps: Partial<CheckboxProto> = {}): OwnProps => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
+  ...widgetProps,
 })
 
 describe("Checkbox widget", () => {
@@ -61,7 +65,8 @@ describe("Checkbox widget", () => {
     expect(props.widgetMgr.setBoolValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
     )
   })
 
@@ -131,9 +136,26 @@ describe("Checkbox widget", () => {
     expect(props.widgetMgr.setBoolValue).toHaveBeenCalledWith(
       props.element,
       true,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
     expect(screen.getByRole("checkbox")).toBeChecked()
+  })
+
+  it("can pass fragmentId to setBoolValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setBoolValue")
+
+    render(<Checkbox {...props} />)
+
+    fireEvent.click(screen.getByRole("checkbox"))
+
+    expect(props.widgetMgr.setBoolValue).toHaveBeenCalledWith(
+      props.element,
+      true,
+      { fromUi: true },
+      "myFragmentId"
+    )
   })
 
   it("resets its value when form is cleared", () => {
@@ -152,7 +174,8 @@ describe("Checkbox widget", () => {
     expect(props.widgetMgr.setBoolValue).toHaveBeenLastCalledWith(
       props.element,
       true,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     // "Submit" the form
@@ -165,7 +188,8 @@ describe("Checkbox widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -45,6 +45,7 @@ export interface OwnProps {
   element: CheckboxProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface ThemeProps {
@@ -108,11 +109,8 @@ class Checkbox extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setBoolValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setBoolValue(element, this.state.value, source, fragmentId)
   }
 
   /**

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -24,7 +24,10 @@ import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 
 import ColorPicker, { Props } from "./ColorPicker"
 
-const getProps = (elementProps: Partial<ColorPickerProto> = {}): Props => ({
+const getProps = (
+  elementProps: Partial<ColorPickerProto> = {},
+  widgetProps: Partial<Props> = {}
+): Props => ({
   element: ColorPickerProto.create({
     id: "1",
     label: "Label",
@@ -37,6 +40,7 @@ const getProps = (elementProps: Partial<ColorPickerProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
+  ...widgetProps,
 })
 
 describe("ColorPicker widget", () => {
@@ -56,7 +60,22 @@ describe("ColorPicker widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setStringValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -92,7 +111,8 @@ describe("ColorPicker widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
       props.element,
       newColor,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
   })
 
@@ -120,7 +140,8 @@ describe("ColorPicker widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
       props.element,
       newColor,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     // "Submit" the form
@@ -133,7 +154,8 @@ describe("ColorPicker widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -29,6 +29,7 @@ export interface Props {
   element: ColorPickerProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -86,11 +87,8 @@ class ColorPicker extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setStringValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setStringValue(element, this.state.value, source, fragmentId)
   }
 
   /**

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -419,9 +419,14 @@ describe("ComponentInstance", () => {
         })
       )
       const widgetMgr = (WidgetStateManager as any).mock.instances[0]
-      expect(widgetMgr.setJsonValue).toHaveBeenCalledWith(element, jsonValue, {
-        fromUi: true,
-      })
+      expect(widgetMgr.setJsonValue).toHaveBeenCalledWith(
+        element,
+        jsonValue,
+        {
+          fromUi: true,
+        },
+        undefined
+      )
     })
 
     it("handles bytes values", () => {
@@ -442,6 +447,8 @@ describe("ComponentInstance", () => {
               formsDataChanged: jest.fn(),
             })
           }
+          // Also verify that we can pass a fragmentID down to setBytesValue.
+          fragmentId="myFragmentId"
         />
       )
 
@@ -480,7 +487,8 @@ describe("ComponentInstance", () => {
       expect(widgetMgr.setBytesValue).toHaveBeenCalledWith(
         element,
         bytesValue,
-        { fromUi: true }
+        { fromUi: true },
+        "myFragmentId"
       )
     })
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -67,6 +67,7 @@ export interface Props {
   element: ComponentInstanceProto
   width: number
   theme: EmotionTheme
+  fragmentId?: string
 }
 
 export interface State {
@@ -243,14 +244,14 @@ export class ComponentInstance extends React.PureComponent<Props, State> {
       return
     }
 
-    const { element } = this.props
+    const { element, fragmentId } = this.props
     const { dataType } = data
     if (dataType === "dataframe") {
-      this.props.widgetMgr.setArrowValue(element, value, source)
+      this.props.widgetMgr.setArrowValue(element, value, source, fragmentId)
     } else if (dataType === "bytes") {
-      this.props.widgetMgr.setBytesValue(element, value, source)
+      this.props.widgetMgr.setBytesValue(element, value, source, fragmentId)
     } else {
-      this.props.widgetMgr.setJsonValue(element, value, source)
+      this.props.widgetMgr.setJsonValue(element, value, source, fragmentId)
     }
   }
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -96,6 +96,7 @@ export interface DataFrameProps {
   expand?: () => void
   collapse?: () => void
   disableFullscreenMode?: boolean
+  fragmentId?: string
 }
 
 /**
@@ -120,6 +121,7 @@ function DataFrame({
   disableFullscreenMode,
   expand,
   collapse,
+  fragmentId,
 }: DataFrameProps): ReactElement {
   const resizableRef = React.useRef<Resizable>(null)
   const dataEditorRef = React.useRef<DataEditorRef>(null)
@@ -297,7 +299,8 @@ function DataFrame({
             currentEditingState,
             {
               fromUi: triggerRerun,
-            }
+            },
+            fragmentId
           )
         }
       })()

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -31,7 +31,10 @@ const originalDate = "1970/1/20"
 const fullOriginalDate = "1970/01/20"
 const newDate = "2020/02/06"
 
-const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
+const getProps = (
+  elementProps: Partial<DateInputProto> = {},
+  widgetProps: Partial<Props> = {}
+): Props => ({
   element: DateInputProto.create({
     id: "1",
     label: "Label",
@@ -47,6 +50,7 @@ const getProps = (elementProps: Partial<DateInputProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
+  ...widgetProps,
 })
 
 describe("DateInput widget", () => {
@@ -103,7 +107,23 @@ describe("DateInput widget", () => {
       [fullOriginalDate],
       {
         fromUi: false,
-      }
+      },
+      undefined
+    )
+  })
+
+  it("can pass a fragmentId to setStringArrayValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    render(<DateInput {...props} />)
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+      props.element,
+      [fullOriginalDate],
+      {
+        fromUi: false,
+      },
+      "myFragmentId"
     )
   })
 
@@ -145,7 +165,8 @@ describe("DateInput widget", () => {
       [newDate],
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -228,7 +249,8 @@ describe("DateInput widget", () => {
       [newDate],
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
 
     // "Submit" the form
@@ -241,7 +263,8 @@ describe("DateInput widget", () => {
       [fullOriginalDate],
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -41,6 +41,7 @@ export interface Props {
   theme: EmotionTheme
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -134,10 +135,12 @@ class DateInput extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setStringArrayValue(
-      this.props.element,
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setStringArrayValue(
+      element,
       datesToStrings(this.state.values),
-      source
+      source,
+      fragmentId
     )
   }
 

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.test.tsx
@@ -89,11 +89,26 @@ describe("DownloadButton widget", () => {
 
       expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
         props.element,
-        { fromUi: true }
+        { fromUi: true },
+        undefined
       )
 
       expect(props.endpoints.buildMediaURL).toHaveBeenCalledWith(
         "/media/mockDownloadURL"
+      )
+    })
+
+    it("can set fragmentId on click", () => {
+      const props = getProps(undefined, { fragmentId: "myFragmentId" })
+      render(<DownloadButton {...props} />)
+
+      const downloadButton = screen.getByRole("button")
+      fireEvent.click(downloadButton)
+
+      expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
+        props.element,
+        { fromUi: true },
+        "myFragmentId"
       )
     })
 

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -31,10 +31,11 @@ export interface Props {
   element: DownloadButtonProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 function DownloadButton(props: Props): ReactElement {
-  const { disabled, element, widgetMgr, width, endpoints } = props
+  const { disabled, element, widgetMgr, width, endpoints, fragmentId } = props
   const style = { width }
 
   const kind =
@@ -45,7 +46,7 @@ function DownloadButton(props: Props): ReactElement {
   const handleDownloadClick: () => void = () => {
     // Downloads are only done on links, so create a hidden one and click it
     // for the user.
-    widgetMgr.setTriggerValue(element, { fromUi: true })
+    widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
     const link = document.createElement("a")
     const uri = endpoints.buildMediaURL(element.url)
     link.setAttribute("href", uri)

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -53,7 +53,10 @@ const buildFileUploaderStateProto = (
     ),
   })
 
-const getProps = (elementProps: Partial<FileUploaderProto> = {}): Props => {
+const getProps = (
+  elementProps: Partial<FileUploaderProto> = {},
+  widgetProps: Partial<Props> = {}
+): Props => {
   return {
     element: FileUploaderProto.create({
       id: "id",
@@ -85,6 +88,7 @@ const getProps = (elementProps: Partial<FileUploaderProto> = {}): Props => {
       }),
       deleteFile: jest.fn(),
     },
+    ...widgetProps,
   }
 }
 
@@ -182,9 +186,40 @@ describe("FileUploader widget tests", () => {
       ]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
+
+  it("can pass fragmentId to setFileUploaderStateValue", async () => {
+    const user = userEvent.setup()
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setFileUploaderStateValue")
+    render(<FileUploader {...props} />)
+
+    const fileDropZoneInput = screen.getByTestId(
+      "stDropzoneInput"
+    ) as HTMLInputElement
+
+    const fileToUpload = createFile()
+    await user.upload(fileDropZoneInput, fileToUpload)
+
+    expect(props.widgetMgr.setFileUploaderStateValue).toHaveBeenCalledWith(
+      props.element,
+      buildFileUploaderStateProto([
+        {
+          fileId: "filename.txt",
+          uploadUrl: "filename.txt",
+          deleteUrl: "filename.txt",
+        },
+      ]),
+      {
+        fromUi: true,
+      },
+      "myFragmentId"
+    )
+  })
+
   it("uploads a single file even if too many files are selected", async () => {
     const props = getProps({ multipleFiles: false })
     jest.spyOn(props.widgetMgr, "setFileUploaderStateValue")
@@ -243,7 +278,8 @@ describe("FileUploader widget tests", () => {
       ]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
   it("replaces file on single file uploader", async () => {
@@ -343,7 +379,8 @@ describe("FileUploader widget tests", () => {
       ]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -385,7 +422,8 @@ describe("FileUploader widget tests", () => {
       ]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
 
     const firstDeleteBtn = screen.getAllByTestId("fileDeleteBtn")[0]
@@ -412,7 +450,8 @@ describe("FileUploader widget tests", () => {
       ]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -452,7 +491,8 @@ describe("FileUploader widget tests", () => {
       buildFileUploaderStateProto([]),
       {
         fromUi: false,
-      }
+      },
+      undefined
     )
   })
 
@@ -612,7 +652,8 @@ describe("FileUploader widget tests", () => {
       ]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
 
     // "Submit" the form
@@ -629,7 +670,8 @@ describe("FileUploader widget tests", () => {
       buildFileUploaderStateProto([]),
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -54,6 +54,7 @@ export interface Props {
   widgetMgr: WidgetStateManager
   uploadClient: FileUploadClient
   width: number
+  fragmentId?: string
 }
 
 type FileUploaderStatus =
@@ -151,28 +152,38 @@ class FileUploader extends React.PureComponent<Props, State> {
     }
 
     const newWidgetValue = this.createWidgetValue()
-    const { element, widgetMgr } = this.props
+    const { element, widgetMgr, fragmentId } = this.props
 
     // Maybe send a widgetValue update to the widgetStateManager.
     const prevWidgetValue = widgetMgr.getFileUploaderStateValue(element)
     if (!isEqual(newWidgetValue, prevWidgetValue)) {
-      widgetMgr.setFileUploaderStateValue(element, newWidgetValue, {
-        fromUi: true,
-      })
+      widgetMgr.setFileUploaderStateValue(
+        element,
+        newWidgetValue,
+        {
+          fromUi: true,
+        },
+        fragmentId
+      )
     }
   }
 
   public componentDidMount(): void {
     const newWidgetValue = this.createWidgetValue()
-    const { element, widgetMgr } = this.props
+    const { element, widgetMgr, fragmentId } = this.props
 
     // Set the state value on mount, to avoid triggering an extra rerun after
     // the first rerun.
     const prevWidgetValue = widgetMgr.getFileUploaderStateValue(element)
     if (prevWidgetValue === undefined) {
-      widgetMgr.setFileUploaderStateValue(element, newWidgetValue, {
-        fromUi: false,
-      })
+      widgetMgr.setFileUploaderStateValue(
+        element,
+        newWidgetValue,
+        {
+          fromUi: false,
+        },
+        fragmentId
+      )
     }
   }
 
@@ -472,10 +483,12 @@ class FileUploader extends React.PureComponent<Props, State> {
         return
       }
 
-      this.props.widgetMgr.setFileUploaderStateValue(
-        this.props.element,
+      const { widgetMgr, element, fragmentId } = this.props
+      widgetMgr.setFileUploaderStateValue(
+        element,
         newWidgetValue,
-        { fromUi: true }
+        { fromUi: true },
+        fragmentId
       )
     })
   }

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.test.tsx
@@ -104,7 +104,23 @@ describe("FormSubmitButton", () => {
     fireEvent.click(formSubmitButton)
     expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(
       props.element.formId,
-      props.element
+      props.element,
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to submitForm", async () => {
+    const props = getProps({ fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "submitForm")
+    render(<FormSubmitButton {...props} />)
+
+    const formSubmitButton = screen.getByRole("button")
+
+    fireEvent.click(formSubmitButton)
+    expect(props.widgetMgr.submitForm).toHaveBeenCalledWith(
+      props.element.formId,
+      props.element,
+      "myFragmentId"
     )
   })
 

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -30,10 +30,18 @@ export interface Props {
   hasInProgressUpload: boolean
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 export function FormSubmitButton(props: Props): ReactElement {
-  const { disabled, element, widgetMgr, hasInProgressUpload, width } = props
+  const {
+    disabled,
+    element,
+    widgetMgr,
+    hasInProgressUpload,
+    width,
+    fragmentId,
+  } = props
   const { formId } = element
   const style = { width }
   const kind =
@@ -63,7 +71,7 @@ export function FormSubmitButton(props: Props): ReactElement {
           fluidWidth={element.useContainerWidth ? fluidWidth : false}
           disabled={disabled || hasInProgressUpload}
           onClick={() => {
-            widgetMgr.submitForm(element.formId, element)
+            widgetMgr.submitForm(element.formId, element, fragmentId)
           }}
         >
           <StreamlitMarkdown

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -68,7 +68,23 @@ describe("Multiselect widget", () => {
       props.element.default,
       {
         fromUi: false,
-      }
+      },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setIntArrayValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setIntArrayValue")
+
+    render(<Multiselect {...props} />)
+    expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      {
+        fromUi: false,
+      },
+      "myFragmentId"
     )
   })
 
@@ -243,7 +259,8 @@ describe("Multiselect widget", () => {
       [0, 1],
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
 
     // "Submit" the form
@@ -263,7 +280,8 @@ describe("Multiselect widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -49,6 +49,7 @@ export interface Props {
   theme: EmotionTheme
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -132,11 +133,8 @@ class Multiselect extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setIntArrayValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setIntArrayValue(element, this.state.value, source, fragmentId)
   }
 
   /**

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -190,7 +190,8 @@ describe("NumberInput widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -223,7 +224,8 @@ describe("NumberInput widget", () => {
         props.element.default,
         {
           fromUi: false,
-        }
+        },
+        undefined
       )
     })
 
@@ -268,7 +270,8 @@ describe("NumberInput widget", () => {
         props.element.default,
         {
           fromUi: false,
-        }
+        },
+        undefined
       )
     })
 
@@ -300,6 +303,27 @@ describe("NumberInput widget", () => {
       })
 
       expect(props.widgetMgr.setIntValue).toHaveBeenCalled()
+    })
+
+    it("can pass fragmentId to setIntValue", () => {
+      const props = {
+        ...getIntProps({ default: 10 }),
+        fragmentId: "myFragmentId",
+      }
+      jest.spyOn(props.widgetMgr, "setIntValue")
+
+      render(<NumberInput {...props} />)
+
+      fireEvent.keyPress(screen.getByTestId("stNumberInput-Input"), {
+        key: "Enter",
+      })
+
+      expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+        expect.anything(),
+        10,
+        { fromUi: false },
+        "myFragmentId"
+      )
     })
 
     it("sets initialValue from widgetMgr", () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -57,6 +57,7 @@ export interface Props {
   widgetMgr: WidgetStateManager
   width: number
   theme: EmotionTheme
+  fragmentId?: string
 }
 
 export interface State {
@@ -191,7 +192,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
     const { value } = this.state
-    const { element, widgetMgr } = this.props
+    const { element, widgetMgr, fragmentId } = this.props
     const data = this.props.element
 
     const min = this.getMin()
@@ -206,9 +207,9 @@ export class NumberInput extends React.PureComponent<Props, State> {
       const valueToBeSaved = value ?? data.default ?? null
 
       if (this.isIntData()) {
-        widgetMgr.setIntValue(element, valueToBeSaved, source)
+        widgetMgr.setIntValue(element, valueToBeSaved, source, fragmentId)
       } else {
-        widgetMgr.setDoubleValue(element, valueToBeSaved, source)
+        widgetMgr.setDoubleValue(element, valueToBeSaved, source, fragmentId)
       }
 
       this.setState({

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -63,7 +63,21 @@ describe("Radio widget", () => {
     expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setIntValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setIntValue")
+    render(<Radio {...props} />)
+
+    expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -163,7 +177,8 @@ describe("Radio widget", () => {
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
       props.element,
       1,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
     expect(secondOption).toBeChecked()
   })
@@ -186,7 +201,8 @@ describe("Radio widget", () => {
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
       props.element,
       1,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     // "Submit" the form
@@ -202,7 +218,8 @@ describe("Radio widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.tsx
@@ -29,6 +29,7 @@ export interface Props {
   element: RadioProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -86,11 +87,8 @@ class Radio extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setIntValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setIntValue(element, this.state.value, source, fragmentId)
   }
 
   /**

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -24,7 +24,10 @@ import { mockTheme } from "@streamlit/lib/src/mocks/mockTheme"
 import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
 
-const getProps = (elementProps: Partial<SelectboxProto> = {}): Props => ({
+const getProps = (
+  elementProps: Partial<SelectboxProto> = {},
+  widgetProps: Partial<Props> = {}
+): Props => ({
   element: SelectboxProto.create({
     id: "1",
     label: "Label",
@@ -39,6 +42,7 @@ const getProps = (elementProps: Partial<SelectboxProto> = {}): Props => ({
     sendRerunBackMsg: jest.fn(),
     formsDataChanged: jest.fn(),
   }),
+  ...widgetProps,
 })
 
 const pickOption = (selectbox: HTMLElement, value: string): void => {
@@ -62,7 +66,21 @@ describe("Selectbox widget", () => {
     expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setIntValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setIntValue")
+
+    render(<Selectbox {...props} />)
+    expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -78,7 +96,8 @@ describe("Selectbox widget", () => {
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
       props.element,
       1,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
     expect(screen.queryByText("a")).not.toBeInTheDocument()
     expect(screen.getByText("b")).toBeInTheDocument()
@@ -99,7 +118,8 @@ describe("Selectbox widget", () => {
     expect(props.widgetMgr.setIntValue).toHaveBeenLastCalledWith(
       props.element,
       1,
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     // "Submit" the form
@@ -113,7 +133,8 @@ describe("Selectbox widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -36,6 +36,7 @@ export interface Props {
   widgetMgr: WidgetStateManager
   width: number
   theme: EmotionTheme
+  fragmentId?: string
 }
 
 interface State {
@@ -93,11 +94,8 @@ export class Selectbox extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setIntValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setIntValue(element, this.state.value, source, fragmentId)
   }
 
   /**

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -101,7 +101,7 @@ describe("Slider widget", () => {
     expect(screen.getByTestId("stWidgetLabel")).toHaveStyle("display: none")
   })
 
-  it("sets widget value on mount", async () => {
+  it("sets widget value on mount", () => {
     const props = getProps()
     jest.spyOn(props.widgetMgr, "setDoubleArrayValue")
 
@@ -113,7 +113,25 @@ describe("Slider widget", () => {
     expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
       props.element,
       [5],
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setDoubleArrayValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setDoubleArrayValue")
+
+    render(<Slider {...props} />)
+
+    // We need to do this as we are using a debounce when the widget value is set
+    jest.runAllTimers()
+
+    expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
+      props.element,
+      [5],
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -170,7 +188,8 @@ describe("Slider widget", () => {
       expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
         props.element,
         [6],
-        { fromUi: true }
+        { fromUi: true },
+        undefined
       )
 
       expect(slider).toHaveAttribute("aria-valuenow", "6")
@@ -193,7 +212,8 @@ describe("Slider widget", () => {
       expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenLastCalledWith(
         props.element,
         [6],
-        { fromUi: true }
+        { fromUi: true },
+        undefined
       )
 
       expect(slider).toHaveAttribute("aria-valuenow", "6")
@@ -207,7 +227,8 @@ describe("Slider widget", () => {
         props.element.default,
         {
           fromUi: true,
-        }
+        },
+        undefined
       )
 
       expect(slider).toHaveAttribute("aria-valuenow", "5")
@@ -336,7 +357,8 @@ describe("Slider widget", () => {
         [1, 10],
         {
           fromUi: true,
-        }
+        },
+        undefined
       )
       expect(sliders[0]).toHaveAttribute("aria-valuenow", "1")
       expect(sliders[1]).toHaveAttribute("aria-valuenow", "10")

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -52,6 +52,7 @@ export interface Props {
   theme: EmotionTheme
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -130,10 +131,12 @@ class Slider extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setDoubleArrayValue(
-      this.props.element,
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setDoubleArrayValue(
+      element,
       this.state.value,
-      source
+      source,
+      fragmentId
     )
   }
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -64,7 +64,21 @@ describe("TextArea widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setStringValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextArea {...props} />)
+
+    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -145,7 +159,8 @@ describe("TextArea widget", () => {
       "testing",
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -164,7 +179,8 @@ describe("TextArea widget", () => {
       "testing",
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -198,7 +214,8 @@ describe("TextArea widget", () => {
       props.element.default,
       {
         fromUi: false,
-      }
+      },
+      undefined
     )
   })
 
@@ -238,7 +255,8 @@ describe("TextArea widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -261,7 +279,8 @@ describe("TextArea widget", () => {
         "testing",
         {
           fromUi: true,
-        }
+        },
+        undefined
       )
     })
   })

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -42,6 +42,7 @@ export interface Props {
   element: TextAreaProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -105,11 +106,8 @@ class TextArea extends React.PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setStringValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setStringValue(element, this.state.value, source, fragmentId)
     this.setState({ dirty: false })
   }
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -143,7 +143,21 @@ describe("TextInput widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setStringValue", () => {
+    const props = getProps(undefined, { fragmentId: "myFragmentId" })
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextInput {...props} />)
+
+    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -178,7 +192,8 @@ describe("TextInput widget", () => {
       "testing",
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -199,7 +214,8 @@ describe("TextInput widget", () => {
       "testing",
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 
@@ -243,9 +259,14 @@ describe("TextInput widget", () => {
       await screen.findByText("Press Enter to submit form")
     ).toBeInTheDocument()
 
-    expect(setStringValueSpy).toHaveBeenCalledWith(props.element, "TEST", {
-      fromUi: true,
-    })
+    expect(setStringValueSpy).toHaveBeenCalledWith(
+      props.element,
+      "TEST",
+      {
+        fromUi: true,
+      },
+      undefined
+    )
   })
 
   it("does not update widget value on text changes when outside of a form", async () => {
@@ -265,7 +286,8 @@ describe("TextInput widget", () => {
       props.element.default,
       {
         fromUi: false,
-      }
+      },
+      undefined
     )
   })
 
@@ -291,7 +313,8 @@ describe("TextInput widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
   })
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -41,6 +41,7 @@ export interface Props {
   element: TextInputProto
   widgetMgr: WidgetStateManager
   width: number
+  fragmentId?: string
 }
 
 interface State {
@@ -111,11 +112,8 @@ class TextInput extends React.PureComponent<Props, State> {
    *                      By default, this is true, meaning the state WILL be updated.
    */
   private commitWidgetValue = (source: Source, updateState = true): void => {
-    this.props.widgetMgr.setStringValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setStringValue(element, this.state.value, source, fragmentId)
     if (updateState) {
       this.setState({ dirty: false })
     }

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -98,7 +98,21 @@ describe("TimeInput widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
       props.element,
       props.element.default,
-      { fromUi: false }
+      { fromUi: false },
+      undefined
+    )
+  })
+
+  it("can pass fragmentId to setStringValue", () => {
+    const props = { ...getProps(), fragmentId: "myFragmentId" }
+    jest.spyOn(props.widgetMgr, "setStringValue")
+    render(<TimeInput {...props} />)
+
+    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+      props.element,
+      props.element.default,
+      { fromUi: false },
+      "myFragmentId"
     )
   })
 
@@ -161,7 +175,8 @@ describe("TimeInput widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
       props.element,
       "12:30",
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     expect(timeDisplay).toHaveAttribute("value", "12:30")
@@ -193,7 +208,8 @@ describe("TimeInput widget", () => {
     expect(props.widgetMgr.setStringValue).toHaveBeenLastCalledWith(
       props.element,
       "13:15",
-      { fromUi: true }
+      { fromUi: true },
+      undefined
     )
 
     expect(timeDisplay).toHaveAttribute("value", "13:15")
@@ -210,7 +226,8 @@ describe("TimeInput widget", () => {
       props.element.default,
       {
         fromUi: true,
-      }
+      },
+      undefined
     )
 
     expect(timeDisplay).toHaveAttribute("value", "12:45")

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -46,6 +46,7 @@ export interface Props {
   widgetMgr: WidgetStateManager
   width: number
   theme: EmotionTheme
+  fragmentId?: string
 }
 
 interface State {
@@ -103,11 +104,8 @@ class TimeInput extends PureComponent<Props, State> {
 
   /** Commit state.value to the WidgetStateManager. */
   private commitWidgetValue = (source: Source): void => {
-    this.props.widgetMgr.setStringValue(
-      this.props.element,
-      this.state.value,
-      source
-    )
+    const { widgetMgr, element, fragmentId } = this.props
+    widgetMgr.setStringValue(element, this.state.value, source, fragmentId)
   }
 
   /**

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -118,6 +118,7 @@ export const customRenderLibContext = (
     onPageChange: jest.fn(),
     currentPageScriptHash: "",
     libConfig: {},
+    currentFragmentId: "",
   }
 
   return reactTestingLibraryRender(component, {


### PR DESCRIPTION
This PR does the now very mechanical work of passing `fragmentId`s from widgets
to the `WidgetStateManager.set*Value()` methods when appropriate.

We added/modified unit tests for all of this plumbing where appropriate but didn't do so
for widgets that don't already include tests for calling appropriate the `WidgetStateManager`
methods as those are likely to have been omitted due to the difficulty of implementing them
for those specific widgets.