### PR TITLE
Remove dangling quote from data_editor docstring

### DIFF
--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -603,7 +603,7 @@ class DataEditorMixin:
             The ``edited_cells`` dictionary is now called ``edited_rows`` and uses a
             different format (``{0: {"column name": "edited value"}}`` instead of
             ``{"0:1": "edited value"}``). You may need to adjust the code if your app uses
-            ``st.experimental_data_editor`` in combination with ``st.session_state``."
+            ``st.experimental_data_editor`` in combination with ``st.session_state``.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Remove dangling quote from data_editor docstring. See below:

![Screenshot 2024-02-16 at 14 07 20](https://github.com/streamlit/streamlit/assets/103002884/775c25ce-63e0-4e69-adf5-fce5a1062d83)

## GitHub Issue Link (if applicable)

n/a

## Testing Plan

- Explanation of why no additional tests are needed
  - Does not touch actual code
- ~~Unit Tests (JS and/or Python)~~
- ~~E2E Tests~~
- ~~Any manual testing needed?~~

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
