### PR TITLE
LinkColumn & LinkButton target attribute implementation.

### DIFF
--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -107,5 +107,19 @@ describe("LinkButton widget", () => {
       const linkButton = screen.getByRole("link")
       expect(linkButton).toHaveStyle("width: 100%")
     })
+
+    it("default target property is set correctly", () => {
+      render(<LinkButton {...getProps()}>Hello</LinkButton>)
+
+      const linkButton = screen.getByRole("link")
+      expect(linkButton).toHaveAttribute("target", "_blank")
+    })
+
+    it("passes target property correctly", () => {
+      render(<LinkButton {...getProps({ target: "_self" })}>Hello</LinkButton>)
+
+      const linkButton = screen.getByRole("link")
+      expect(linkButton).toHaveAttribute("target", "_self")
+    })
   })
 })

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -44,6 +44,9 @@ function LinkButton(props: Props): ReactElement {
   // we need to pass the container width down to the button
   const fluidWidth = element.help ? width : true
 
+  // Default link target is _blank.
+  const target = "_blank"
+
   const handleClick = (e: MouseEvent<HTMLAnchorElement>): void => {
     // Prevent the link from being followed if the button is disabled.
     if (props.disabled) {
@@ -67,7 +70,7 @@ function LinkButton(props: Props): ReactElement {
           onClick={handleClick}
           fluidWidth={element.useContainerWidth ? fluidWidth : false}
           href={element.url}
-          target="_blank"
+          target={element.target || target}
           rel="noreferrer"
           aria-disabled={disabled}
         >

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
@@ -53,6 +53,7 @@ describe("LinkColumn", () => {
       href: "https://streamlit.io",
       kind: "link-cell",
       displayText: "https://streamlit.io",
+      target: "_blank",
     })
   })
 
@@ -218,5 +219,23 @@ describe("LinkColumn", () => {
     ) as LinkCell
 
     expect(cell.data.displayText).toBe("https://roadmap.streamlit.app")
+  })
+
+  it("asd", () => {
+    const mockColumn = LinkColumn({
+      ...MOCK_LINK_COLUMN_PROPS,
+      // eslint-disable-next-line prettier/prettier
+      columnTypeOptions: {
+        display_text: "https://(.*?)\\.google.com",
+        target: "_self",
+      },
+    })
+
+    const cell = mockColumn.getCell(
+      "https://roadmap.streamlit.app",
+      true
+    ) as LinkCell
+
+    expect(cell.data.target).toBe("_self")
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -35,6 +35,7 @@ export interface LinkColumnParams {
   readonly validate?: string
   // a value to display in the link cell. Can be a regex to parse out a specific substring of the url to be displayed
   readonly display_text?: string
+  readonly target?: string
 }
 
 /**
@@ -81,6 +82,7 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
     style: props.isIndex ? "faded" : "normal",
     data: {
       kind: "link-cell",
+      target: "_blank",
       href: "",
       displayText: "",
     },
@@ -118,12 +120,15 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
     sortMode: "default",
     validateInput,
     getCell(data?: any, validate?: boolean): GridCell {
+      const target: string = parameters.target || "_blank"
+
       if (isNullOrUndefined(data)) {
         return {
           ...cellTemplate,
           data: {
             ...cellTemplate.data,
             href: null,
+            target: target,
           },
           isMissingValue: true,
         } as LinkCell
@@ -164,6 +169,7 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
         ...cellTemplate,
         data: {
           kind: "link-cell",
+          target: target,
           href: href,
           displayText: displayText,
         },

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.test.tsx
@@ -27,6 +27,7 @@ describe("LinkCell", () => {
   function getMockLinkCell(
     href = "",
     display_text = "",
+    target = "",
     props: Partial<LinkCell> = {}
   ): LinkCell {
     return {
@@ -39,6 +40,7 @@ describe("LinkCell", () => {
         kind: "link-cell",
         href: href,
         displayText: display_text,
+        target: target,
       },
     }
   }
@@ -52,7 +54,7 @@ describe("LinkCell", () => {
   })
 
   it("renders into the dom with correct value", async () => {
-    const cell = getMockLinkCell("https://streamlit.io", "", {
+    const cell = getMockLinkCell("https://streamlit.io", "", "_blank", {
       readonly: true,
     })
     const Editor = linkCellRenderer.provideEditor?.(cell)
@@ -68,14 +70,22 @@ describe("LinkCell", () => {
     // check if url value is correct
     expect(linkCell).toHaveAttribute("href", "https://streamlit.io")
 
+    // check if target value is correct
+    expect(linkCell).toHaveAttribute("target", "_blank")
+
     // check that the displayed text is correct
     expect(linkCell).toHaveTextContent("https://streamlit.io")
   })
 
   it("should render the displayText", async () => {
-    const cell = getMockLinkCell("https://streamlit.io", "Click here", {
-      readonly: true,
-    })
+    const cell = getMockLinkCell(
+      "https://streamlit.io",
+      "Click here",
+      "_blank",
+      {
+        readonly: true,
+      }
+    )
     const Editor = linkCellRenderer.provideEditor?.(cell)
 
     render(
@@ -97,5 +107,16 @@ describe("LinkCell", () => {
     ) as LinkCellProps
 
     expect(value.href).toStrictEqual("https://pasted-link.com")
+  })
+
+  it("should allow pasting in a target value", async () => {
+    const cell = getMockLinkCell("https://streamlit.io", "", "_self")
+    // @ts-expect-error
+    const value = linkCellRenderer.onPaste(
+      "https://pasted-link.com",
+      cell.data
+    ) as LinkCellProps
+
+    expect(value.target).toStrictEqual("_self")
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/LinkCell.tsx
@@ -29,6 +29,7 @@ const UNDERLINE_OFFSET = 5
 
 export interface LinkCellProps {
   readonly kind: "link-cell"
+  readonly target: string
   readonly href?: string | null
   readonly displayText?: string | null
 }
@@ -120,9 +121,9 @@ export const linkCellRenderer: CustomRenderer<LinkCell> = {
   needsHoverPosition: true,
   onSelect: e => {
     const redirectLink = onClickSelect(e)
-
+    const cellData = e.cell.data as LinkCellProps
     if (!isNullOrUndefined(redirectLink)) {
-      window.open(redirectLink, "_blank", "noopener,noreferrer")
+      window.open(redirectLink, cellData.target, "noopener,noreferrer")
     }
   },
   onDelete: c => ({

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -22,6 +22,7 @@ from typing_extensions import NotRequired, TypeAlias
 from streamlit.runtime.metrics_util import gather_metrics
 
 ColumnWidth: TypeAlias = Literal["small", "medium", "large"]
+Target: TypeAlias = Literal["_blank", "_self", "_parent", "_top"]
 
 # Type alias that represents all available column types
 # which are configurable by the user.
@@ -68,6 +69,7 @@ class SelectboxColumnConfig(TypedDict):
 
 class LinkColumnConfig(TypedDict):
     type: Literal["link"]
+    target: NotRequired[Target | None]
     max_chars: NotRequired[int | None]
     validate: NotRequired[str | None]
     display_text: NotRequired[str | None]
@@ -476,6 +478,7 @@ def LinkColumn(
     max_chars: int | None = None,
     validate: str | None = None,
     display_text: str | None = None,
+    target: Target | None = None,
 ) -> ColumnConfig:
     """Configure a link column in ``st.dataframe`` or ``st.data_editor``.
 
@@ -531,6 +534,11 @@ def LinkColumn(
         <https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.format.html>`_
         function on the underlying dataframe. Note that this makes the app slow,
         doesn't work with editable columns, and might be removed in the future.
+
+    target: "_blank", "_self", "_parent", "_top"
+        The target attribure specifies where to open the linked document. Can be one of "_blank", "_self", "_parent", "_top".
+        If None (default), the linked document will be opened in a new window or tab.
+        For more details, you may use `HTML documentation <https://www.w3schools.com/tags/att_a_target.asp>`.
 
 
     Examples
@@ -590,6 +598,7 @@ def LinkColumn(
             max_chars=max_chars,
             validate=validate,
             display_text=display_text,
+            target=target,
         ),
     )
 

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -354,6 +354,7 @@ class ButtonMixin:
         type: Literal["primary", "secondary"] = "secondary",
         disabled: bool = False,
         use_container_width: bool = False,
+        target: Literal["_blank", "_self", "_parent", "_top"] = "_blank",
     ) -> DeltaGenerator:
         r"""Display a link button element.
 
@@ -399,6 +400,10 @@ class ButtonMixin:
         use_container_width: bool
             An optional boolean, which makes the button stretch its width to match the
             parent container.
+        target: "_blank", "_self", "_parent", "_top"
+            The target attribure specifies where to open the linked document. Can be one of "_blank", "_self", "_parent", "_top".
+            If None (default), the linked document will be opened in a new window or tab.
+            For more details, you may use `HTML documentation <https://www.w3schools.com/tags/att_a_target.asp>`.
 
         Example
         -------
@@ -425,6 +430,7 @@ class ButtonMixin:
             disabled=disabled,
             type=type,
             use_container_width=use_container_width,
+            target=target,
         )
 
     @gather_metrics("page_link")
@@ -611,13 +617,15 @@ class ButtonMixin:
         type: Literal["primary", "secondary"] = "secondary",
         disabled: bool = False,
         use_container_width: bool = False,
-    ) -> DeltaGenerator:
+        target: Literal["_blank", "_self", "_parent", "_top"] = "_blank",
+    ) -> "DeltaGenerator":
         link_button_proto = LinkButtonProto()
         link_button_proto.label = label
         link_button_proto.url = url
         link_button_proto.type = type
         link_button_proto.use_container_width = use_container_width
         link_button_proto.disabled = disabled
+        link_button_proto.target = target
 
         if help is not None:
             link_button_proto.help = dedent(help)

--- a/lib/tests/streamlit/elements/lib/column_types_test.py
+++ b/lib/tests/streamlit/elements/lib/column_types_test.py
@@ -429,7 +429,7 @@ class ColumnTypesTest(unittest.TestCase):
 
         self.assertEqual(
             remove_none_values(LinkColumn()),
-            {"type_config": {"type": "link"}},
+            {"type_config": {"type": "link", "target": "_blank"}},
             "Should only have the type defined and nothing else.",
         )
 
@@ -445,6 +445,7 @@ class ColumnTypesTest(unittest.TestCase):
                     max_chars=100,
                     validate="^[a-zA-Z]+$",
                     display_text="streamlit",
+                    target="_self",
                 )
             ),
             {
@@ -459,6 +460,7 @@ class ColumnTypesTest(unittest.TestCase):
                     "max_chars": 100,
                     "validate": "^[a-zA-Z]+$",
                     "display_text": "streamlit",
+                    "target": "_self",
                 },
             },
             "Should have all the properties defined.",

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -64,3 +64,17 @@ class LinkButtonTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.link_button
         self.assertEqual(c.use_container_width, False)
+
+    def test_target(self):
+        """Test that it can be called with target param."""
+        st.link_button("the label", url="https://streamlit.io", target="_self")
+
+        c = self.get_delta_from_queue().new_element.link_button
+        self.assertEqual(c.target, "_self")
+
+    def test_target_is_blank_by_default(self):
+        """Test target is "_blank" by default."""
+        st.link_button("the label", url="https://streamlit.io")
+
+        c = self.get_delta_from_queue().new_element.link_button
+        self.assertEqual(c.target, "_blank")

--- a/proto/streamlit/proto/LinkButton.proto
+++ b/proto/streamlit/proto/LinkButton.proto
@@ -26,4 +26,5 @@ message LinkButton {
   bool disabled = 7;
   bool use_container_width = 8;
   string type = 9;
+  string target = 10;
 }


### PR DESCRIPTION
## Describe your changes
Right now all links on Streamlit app (except pages) open in new browser tab/window. In this PR I added a "target" attribute to "st.columnconfig.LinkColumn" and "st.LinkButton" elements. The behaviour of this attribute follows the same principles and [target attribute](https://www.w3schools.com/tags/att_a_target.asp) for HTML <a> tag.
Default behaviour is preserved. When target attribue in not set, "_blank" values is used by default.
Target attribue can be one of these:
1. "_blank":		Opens the linked document in a new window or tab
2. "_self":		Opens the linked document in the same frame as it was clicked (this is default)
3. "_parent":		Opens the linked document in the parent frame
4. "_top":		Opens the linked document in the full body of the window
5. "framename":	Opens the linked document in the named iframe

## GitHub Issue Link 

- [Feature request](https://github.com/streamlit/streamlit/issues/7464)
- [Possible related bug](https://github.com/streamlit/streamlit/issues/8168)

## Testing Plan
- Simple unit tests added both for backend and frontend
- Test custom "framename" values with iframe's or remove this behavior
- In [documentation](https://docs.streamlit.io/library/api-reference/widgets/st.link_button) for "st.link_button" it is said that new session will be started upon navigation within the app. I am not sure how it will behave with different "target" attribute value.
