### PR TITLE
[WIP] File Watcher policy

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -659,7 +659,7 @@ _create_option(
 )
 
 _create_option(
-    "server.fileWatcherPollPolicy",
+    "server.fileWatcherPolicy",
     description="""
        Policy for PollWatcher, should it rely on last modified time, or always
        check all files for changes.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -658,6 +658,22 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "server.fileWatcherPollPolicy",
+    description="""
+       Policy for PollWatcher, should it rely on last modified time, or always
+       check all files for changes.
+
+        Allowed values:
+        * "last-modified" : Streamlit will use the last modified time to determine
+            if a file has changed.
+        * "always" : Streamlit will always check for changed files.
+    """,
+    default_val="last-modified",
+    type_=str,
+    visibility="hidden",
+)
+
 
 @_create_option("server.cookieSecret", type_=str, sensitive=True)
 @util.memoize

--- a/lib/streamlit/watcher/polling_path_watcher.py
+++ b/lib/streamlit/watcher/polling_path_watcher.py
@@ -66,7 +66,7 @@ class PollingPathWatcher:
         self._glob_pattern = glob_pattern
         self._allow_nonexistent = allow_nonexistent
 
-        self.policy = config.get_option("server.fileWatcherPollPolicy")
+        self.policy = config.get_option("server.fileWatcherPolicy")
 
         self._active = True
 
@@ -98,8 +98,9 @@ class PollingPathWatcher:
         modification_time = util.path_modification_time(
             self._path, self._allow_nonexistent
         )
-        # We add modification_time != 0.0 check since on some file systems (s3fs/fuse)
-        # modification_time is always 0.0 because of file system limitations.
+        # We add self.policy == "last-modified" check since on some file systems
+        # (s3fs/fuse) modification_time is always 0.0 or could be cached (nfs)
+        # because of file system limitations.
         if (
             self.policy == "last-modified"
             and modification_time <= self._modification_time

--- a/lib/streamlit/watcher/polling_path_watcher.py
+++ b/lib/streamlit/watcher/polling_path_watcher.py
@@ -66,7 +66,7 @@ class PollingPathWatcher:
         self._glob_pattern = glob_pattern
         self._allow_nonexistent = allow_nonexistent
 
-        self.policy = config.get_option("server.fileWatcherType")
+        self.policy = config.get_option("server.fileWatcherPollPolicy")
 
         self._active = True
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -381,6 +381,7 @@ class ConfigTest(unittest.TestCase):
                 "server.scriptHealthCheckEnabled",
                 "server.enableWebsocketCompression",
                 "server.enableXsrfProtection",
+                "server.fileWatcherPolicy",
                 "server.fileWatcherType",
                 "server.folderWatchBlacklist",
                 "server.headless",


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Add new `"server.fileWatcherPolicy"` config option

If `"last-modified"` we will rely on `os.stat(path).st_mtime`, if `"always"` we will always compute a hash of source file content to identify changes.

Potentially close: https://github.com/streamlit/streamlit/issues/5178

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
