### PR TITLE
Increase time until timeout warning is shown for a custom component

### DIFF
--- a/frontend/lib/src/components/elements/Skeleton/Skeleton.test.tsx
+++ b/frontend/lib/src/components/elements/Skeleton/Skeleton.test.tsx
@@ -30,4 +30,12 @@ describe("Skeleton element", () => {
     // writing a very trivial test for it.)
     expect(screen.getByTestId("stSkeleton")).toBeVisible()
   })
+
+  it("renders with height property", () => {
+    const height = "100px"
+    render(<Skeleton height={height} />)
+
+    const style = getComputedStyle(screen.getByTestId("stSkeleton"))
+    expect(style.height).toBe(height)
+  })
 })

--- a/frontend/lib/src/components/elements/Skeleton/Skeleton.tsx
+++ b/frontend/lib/src/components/elements/Skeleton/Skeleton.tsx
@@ -18,8 +18,12 @@ import React, { FC, memo } from "react"
 
 import { SquareSkeleton } from "./styled-components"
 
-const RawSkeleton: FC<React.PropsWithChildren<unknown>> = () => {
-  return <SquareSkeleton data-testid="stSkeleton" />
+interface Props {
+  height?: string
+}
+
+const RawSkeleton: FC<React.PropsWithChildren<Props>> = props => {
+  return <SquareSkeleton data-testid="stSkeleton" {...props} />
 }
 
 export const Skeleton = memo(RawSkeleton)

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -261,6 +261,115 @@ describe("ComponentInstance", () => {
       expect(postMessage).toHaveBeenCalledTimes(2)
     })
 
+    it("send render message whenever the args change and the component is ready", () => {
+      let jsonArgs = { foo: "string", bar: 5 }
+      const componentRegistry = getComponentRegistry()
+      const { rerender } = render(
+        <ComponentInstance
+          element={createElementProp(jsonArgs)}
+          registry={componentRegistry}
+          width={100}
+          disabled={false}
+          theme={mockTheme.emotion}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: jest.fn(),
+              formsDataChanged: jest.fn(),
+            })
+          }
+        />
+      )
+      const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
+      // @ts-expect-error
+      const postMessage = jest.spyOn(iframe.contentWindow, "postMessage")
+      // SET COMPONENT_READY
+      fireEvent(
+        window,
+        new MessageEvent("message", {
+          data: {
+            isStreamlitMessage: true,
+            apiVersion: 1,
+            type: ComponentMessageType.COMPONENT_READY,
+          },
+          // @ts-expect-error
+          source: iframe.contentWindow,
+        })
+      )
+      jsonArgs = { foo: "string", bar: 10 }
+      rerender(
+        <ComponentInstance
+          element={createElementProp(jsonArgs)}
+          registry={componentRegistry}
+          width={100}
+          disabled={false}
+          theme={mockTheme.emotion}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: jest.fn(),
+              formsDataChanged: jest.fn(),
+            })
+          }
+        />
+      )
+
+      expect(postMessage).toHaveBeenCalledTimes(2)
+    })
+
+    it("send render message when viewport changes", () => {
+      const jsonArgs = { foo: "string", bar: 5 }
+      let width = 100
+      const componentRegistry = getComponentRegistry()
+      const { rerender } = render(
+        <ComponentInstance
+          element={createElementProp(jsonArgs)}
+          registry={componentRegistry}
+          width={width}
+          disabled={false}
+          theme={mockTheme.emotion}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: jest.fn(),
+              formsDataChanged: jest.fn(),
+            })
+          }
+        />
+      )
+      const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
+      // @ts-expect-error
+      const postMessage = jest.spyOn(iframe.contentWindow, "postMessage")
+      // SET COMPONENT_READY
+      fireEvent(
+        window,
+        new MessageEvent("message", {
+          data: {
+            isStreamlitMessage: true,
+            apiVersion: 1,
+            type: ComponentMessageType.COMPONENT_READY,
+          },
+          // @ts-expect-error
+          source: iframe.contentWindow,
+        })
+      )
+      width = width + 1
+      rerender(
+        <ComponentInstance
+          element={createElementProp(jsonArgs)}
+          registry={componentRegistry}
+          width={width}
+          disabled={false}
+          theme={mockTheme.emotion}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: jest.fn(),
+              formsDataChanged: jest.fn(),
+            })
+          }
+        />
+      )
+
+      expect(postMessage).toHaveBeenCalledTimes(2)
+    })
+
     it("errors on unrecognized API version", () => {
       const badAPIVersion = CUSTOM_COMPONENT_API_VERSION + 1
       const jsonArgs = { foo: "string", bar: 5 }

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -165,6 +165,7 @@ function ComponentInstance(props: Props): ReactElement {
 
   const { disabled, element, registry, theme, widgetMgr, width } = props
   const { componentName, jsonArgs, specialArgs, url } = element
+
   const [isReady, setIsReady] = useState<boolean>(false)
   const [parsedNewArgs, parsedDataframeArgs] = tryParseArgs(
     jsonArgs,
@@ -192,6 +193,19 @@ function ComponentInstance(props: Props): ReactElement {
     () => setIsReadyTimeout(true),
     COMPONENT_READY_WARNING_TIME_MS
   )
+
+  useEffect(() => {
+    if (!isReady) {
+      return
+    }
+    sendRenderMessage(
+      parsedNewArgs,
+      parsedDataframeArgs,
+      disabled,
+      theme,
+      iframeRef.current ?? undefined
+    )
+  }, [disabled, isReady, parsedDataframeArgs, parsedNewArgs, theme])
 
   useEffect(() => {
     const handleSetFrameHeight = (height: number | undefined): void => {
@@ -226,7 +240,7 @@ function ComponentInstance(props: Props): ReactElement {
         parsedDataframeArgs,
         disabled,
         theme,
-        iframeRef.current || undefined
+        iframeRef.current ?? undefined
       )
       clearTimeoutLog()
       clearTimeoutWarningElement()
@@ -245,10 +259,10 @@ function ComponentInstance(props: Props): ReactElement {
     }
   }, [
     componentName,
-    element,
-    parsedDataframeArgs,
     disabled,
+    element,
     isReady,
+    parsedDataframeArgs,
     parsedNewArgs,
     theme,
     widgetMgr,

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -14,476 +14,333 @@
  * limitations under the License.
  */
 
+import React, { ReactElement, useEffect, useState, useRef } from "react"
+
+import { withTheme } from "@emotion/react"
+import queryString from "query-string"
+
+import AlertElement from "@streamlit/lib/src/components/elements/AlertElement"
+import { Skeleton } from "@streamlit/lib/src/components/elements/Skeleton"
+import ErrorElement from "@streamlit/lib/src/components/shared/ErrorElement"
+import { Kind } from "@streamlit/lib/src/components/shared/AlertContainer"
+import useTimeout from "@streamlit/lib/src/hooks/useTimeout"
 import {
-  ArrowDataframe,
   ComponentInstance as ComponentInstanceProto,
   ISpecialArg,
-  SpecialArg as SpecialArgProto,
 } from "@streamlit/lib/src/proto"
-import AlertElement from "@streamlit/lib/src/components/elements/AlertElement"
-import { Kind } from "@streamlit/lib/src/components/shared/AlertContainer"
-import ErrorElement from "@streamlit/lib/src/components/shared/ErrorElement"
-import { withTheme } from "@emotion/react"
-import { ensureError } from "@streamlit/lib/src/util/ErrorHandling"
+import { EmotionTheme } from "@streamlit/lib/src/theme"
 import {
   DEFAULT_IFRAME_FEATURE_POLICY,
   DEFAULT_IFRAME_SANDBOX_POLICY,
 } from "@streamlit/lib/src/util/IFrameUtil"
-import { logError, logWarning } from "@streamlit/lib/src/util/log"
-import { Timer } from "@streamlit/lib/src/util/Timer"
-import {
-  Source,
-  WidgetStateManager,
-} from "@streamlit/lib/src/WidgetStateManager"
-import queryString from "query-string"
-import React, { createRef, ReactNode } from "react"
-import { EmotionTheme, toExportedTheme } from "@streamlit/lib/src/theme"
+import { logWarning } from "@streamlit/lib/src/util/log"
+import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
 import {
   COMMUNITY_URL,
   COMPONENT_DEVELOPER_URL,
 } from "@streamlit/lib/src/urls"
-import { ComponentRegistry } from "./ComponentRegistry"
-import { ComponentMessageType, StreamlitMessageType } from "./enums"
+import { ensureError } from "@streamlit/lib/src/util/ErrorHandling"
 
-/**
- * The current custom component API version. If our API changes,
- * this value must be incremented. ComponentInstances send their API
- * version in the COMPONENT_READY call.
- */
-export const CUSTOM_COMPONENT_API_VERSION = 1
+import { ComponentRegistry } from "./ComponentRegistry"
+import {
+  Args,
+  DataframeArg,
+  IframeMessageHandlerProps,
+  createIframeMessageHandler,
+  parseArgs,
+  sendRenderMessage,
+} from "./componentUtils"
 
 /**
  * If we haven't received a COMPONENT_READY message this many seconds
  * after the component has been created, explain to the user that there
  * may be a problem with their component, and offer troubleshooting advice.
  */
-export const COMPONENT_READY_WARNING_TIME_MS = 3000
+export const COMPONENT_READY_WARNING_TIME_MS = 60000 // 60 seconds
 
 export interface Props {
   registry: ComponentRegistry
   widgetMgr: WidgetStateManager
-
   disabled: boolean
   element: ComponentInstanceProto
   width: number
   theme: EmotionTheme
 }
 
-export interface State {
+/**
+ * Create the iFrame `src` based on the passed `url` or, if missing, from the ComponentRegistry. Adds a `streamlitUrl` query parameter.
+ * @param componentName name of the component. Only used when `url` is empty
+ * @param componentRegistry component registry to get the `url` for the passed component name if `url` is empty
+ * @param url used as the `src` if passed
+ * @returns the iFrame src including a `streamlitUrl` query parameter
+ */
+function getSrc(
+  componentName: string,
+  componentRegistry: ComponentRegistry,
+  url?: string
+): string {
+  let src: string
+  if (url != null && url !== "") {
+    src = url
+  } else {
+    src = componentRegistry.getComponentURL(componentName, "index.html")
+  }
+
+  // Add streamlitUrl query parameter to src
+  const currentUrl = new URL(window.location.href)
+  src = queryString.stringifyUrl({
+    url: src,
+    query: { streamlitUrl: currentUrl.origin + currentUrl.pathname },
+  })
+  return src
+}
+
+/**
+ * Creates a warn message. The message is different based on whether or not a `url` is provided.
+ * @param componentName
+ * @param url
+ * @returns the created warn message
+ */
+function getWarnMessage(componentName: string, url?: string): string {
+  let message: string
+  if (url && url !== "") {
+    message =
+      `Your app is having trouble loading the **${componentName}** component.` +
+      `\nThe app is attempting to load the component from **${url}**,` +
+      `\nand hasn't received its \`Streamlit.setComponentReady()\` message.` +
+      `\n\nIf this is a development build, have you started the dev server?` +
+      `\n\nFor more troubleshooting help, please see the [Streamlit Component docs](${COMPONENT_DEVELOPER_URL}) or visit our [forums](${COMMUNITY_URL}).`
+  } else {
+    message =
+      `Your app is having trouble loading the **${componentName}** component.` +
+      `\n\nIf this is an installed component that works locally, the app may be having trouble accessing the component frontend assets due to network latency or proxy settings in your app deployment.` +
+      `\n\nFor more troubleshooting help, please see the [Streamlit Component docs](${COMPONENT_DEVELOPER_URL}) or visit our [forums](${COMMUNITY_URL}).`
+  }
+  return message
+}
+
+type HeightUnit = "px"
+/**
+ * Parse the height as a string and add the unit as a suffix, e.g. `(42) => '42px'`
+ *
+ * @param height height number
+ * @returns the height number as a string with suffix or `undefined` if `height` is `undefined`
+ */
+function parseToStringWithUnitSuffix(
+  height?: number,
+  unit: HeightUnit = "px"
+): string | undefined {
+  if (!height) {
+    return undefined
+  }
+
+  return `${height}${unit}`
+}
+
+function tryParseArgs(
+  jsonArgs: string,
+  specialArgs: ISpecialArg[],
+  setComponentError: (e: Error) => void,
   componentError?: Error
+): [newArgs: Args, dataframeArgs: DataframeArg[]] {
+  if (!componentError) {
+    try {
+      return parseArgs(jsonArgs, specialArgs)
+    } catch (e) {
+      const error = ensureError(e)
+      setComponentError(error)
+    }
+  }
 
-  // True if the component hasn't sent the READY message, and
-  // `COMPONENT_READY_WARNING_TIME_MS` has elapsed.
-  readyTimeout: boolean
+  return [{}, []]
 }
 
-interface DataframeArg {
-  key: string
-  value: any
-}
+/**
+ * Render the component element. If an error occurs when parsing the arguments,
+ * an error element is rendered instead. If the component assets take too long to load as specified
+ * by {@link COMPONENT_READY_WARNING_TIME_MS}, a warning element is rendered instead.
+ */
+function ComponentInstance(props: Props): ReactElement {
+  const [componentError, setComponentError] = useState<Error>()
 
-export class ComponentInstance extends React.PureComponent<Props, State> {
-  private readonly iframeRef = createRef<HTMLIFrameElement>()
+  const { disabled, element, registry, theme, widgetMgr, width } = props
+  const { componentName, jsonArgs, specialArgs, url } = element
+  const [isReady, setIsReady] = useState<boolean>(false)
+  const [parsedNewArgs, parsedDataframeArgs] = tryParseArgs(
+    jsonArgs,
+    specialArgs,
+    setComponentError,
+    componentError
+  )
 
-  // True when we've received the COMPONENT_READY message
-  private componentReady = false
+  const [isReadyTimeout, setIsReadyTimeout] = useState<boolean>(false)
+  // by passing the args.height here, we can derive the initial height for
+  //   custom components that define a height property, e.g. in Python
+  //   my_custom_component(height=100)
+  const [frameHeight, setFrameHeight] = useState<number | undefined>(
+    isNaN(parsedNewArgs.height) ? undefined : parsedNewArgs.height
+  )
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const onBackMsgRef = useRef<IframeMessageHandlerProps>()
 
-  // The most recent JSON and bytes args we've received from Python.
-  private curArgs: { [name: string]: any } = {}
+  // show a log in the console as a soft-warning to the developer before showing the more disrupting warning element
+  const clearTimeoutLog = useTimeout(
+    () => logWarning(getWarnMessage(componentName, url)),
+    COMPONENT_READY_WARNING_TIME_MS / 4
+  )
+  const clearTimeoutWarningElement = useTimeout(
+    () => setIsReadyTimeout(true),
+    COMPONENT_READY_WARNING_TIME_MS
+  )
 
-  // The most recent Arrow Dataframe args we've received from Python.
-  private curDataframeArgs: DataframeArg[] = []
-
-  // The most recent frame height we've received from the frontend.
-  private frameHeight = 0
-
-  // The most recent iframe.contentWindow that we've registered to
-  // receive messages from.
-  private contentWindow?: Window
-
-  private readonly componentReadyWarningTimer = new Timer()
-
-  public constructor(props: Props) {
-    super(props)
-    this.state = { componentError: undefined, readyTimeout: false }
-  }
-
-  public componentDidMount = (): void => {
-    this.maybeRegisterIFrameListener()
-
-    // Start a timer. If we haven't gotten the COMPONENT_READY message
-    // after a short time, we'll display a warning to the user.
-    this.componentReadyWarningTimer.setTimeout(
-      () => this.setState({ readyTimeout: true }),
-      COMPONENT_READY_WARNING_TIME_MS
-    )
-  }
-
-  public componentWillUnmount = (): void => {
-    this.deregisterIFrameListener()
-    this.componentReadyWarningTimer.cancel()
-  }
-
-  public componentDidUpdate = (): void => {
-    // It's possible for our iframe to be re-mounted after an update.
-    // When this happens, we need to de-register our previous iframe message
-    // listener, and register a listener for the current iframe.
-    this.maybeRegisterIFrameListener()
-  }
-
-  /**
-   * Return our iframe's contentWindow.
-   * (This is implemented as a function so that we can mock it in a test.)
-   */
-  private getIFrameContentWindow(): Window | null | undefined {
-    return this.iframeRef.current?.contentWindow
-  }
-
-  /**
-   * Register our iframe's contentWindow with our ComponentRegistry, if it's
-   * non-null and not already registered.
-   */
-  private maybeRegisterIFrameListener = (): void => {
-    // Early-out if our contentWindow has not changed since the last
-    // time this function was called.
-    const currContentWindow = this.getIFrameContentWindow()
-    if (this.contentWindow === currContentWindow) {
-      return
-    }
-
-    // De-register our current listener first
-    this.deregisterIFrameListener()
-
-    if (currContentWindow == null) {
-      // This shouldn't be possible.
-      logError(
-        `ComponentInstance iframe does not have a contentWindow, and will not receive messages!`
-      )
-      this.contentWindow = undefined
-      return
-    }
-
-    this.contentWindow = currContentWindow
-    this.props.registry.registerListener(this.contentWindow, this.onBackMsg)
-  }
-
-  /** De-register our contentWindow listener, if we've registered one. */
-  private deregisterIFrameListener = (): void => {
-    if (this.contentWindow == null) {
-      return
-    }
-
-    this.props.registry.deregisterListener(this.contentWindow)
-    this.contentWindow = undefined
-  }
-
-  /**
-   * Receive a ComponentBackMsg from our component iframe.
-   */
-  private onBackMsg = (type: string, data: any): void => {
-    switch (type) {
-      case ComponentMessageType.COMPONENT_READY: {
-        // Our component is ready to begin receiving messages. Send off its
-        // first render message! It is *not* an error to get multiple
-        // COMPONENT_READY messages. This can happen if a component is being
-        // served from the webpack dev server, and gets reloaded. We
-        // always respond to this message with the most recent render
-        // arguments.
-        const { apiVersion } = data
-        if (apiVersion !== CUSTOM_COMPONENT_API_VERSION) {
-          // In the future, we may end up with multiple API versions we
-          // need to support. For now, we just have the one.
-          this.setState({
-            componentError: new Error(
-              `Unrecognized component API version: '${apiVersion}'`
-            ),
-          })
-        } else {
-          this.componentReady = true
-          this.sendRenderMessage()
-        }
-
-        // If our warning timer was running, cancel it. If we were showing
-        // the componentReadyTimeout warning, stop showing it.
-        this.componentReadyWarningTimer.cancel()
-        this.setState({ readyTimeout: false })
-        break
+  useEffect(() => {
+    const handleSetFrameHeight = (height: number | undefined): void => {
+      if (height === undefined) {
+        logWarning(`handleSetFrameHeight: missing 'height' prop`)
+        return
       }
 
-      case ComponentMessageType.SET_COMPONENT_VALUE:
-        if (!this.componentReady) {
-          logWarning(
-            `Got ${type} before ${ComponentMessageType.COMPONENT_READY}!`
-          )
-        } else {
-          this.handleSetComponentValue(data, { fromUi: true })
-        }
-        break
+      if (height === frameHeight) {
+        // Nothing to do!
+        return
+      }
 
-      case ComponentMessageType.SET_FRAME_HEIGHT:
-        if (!this.componentReady) {
-          logWarning(
-            `Got ${type} before ${ComponentMessageType.COMPONENT_READY}!`
-          )
-        } else {
-          this.handleSetFrameHeight(data)
-        }
-        break
+      if (iframeRef.current == null) {
+        // This should not be possible.
+        logWarning(`handleSetFrameHeight: missing our iframeRef!`)
+        return
+      }
 
-      default:
-        logWarning(`Unrecognized ComponentBackMsgType: ${type}`)
+      // We shove our new frameHeight directly into our iframe, to avoid
+      // triggering a re-render. Otherwise, components will receive the RENDER
+      // event several times during startup (because they will generally
+      // immediately change their frameHeight after mounting). This is wasteful,
+      // and it also breaks certain components.
+      iframeRef.current.height = height.toString()
+      setFrameHeight(height)
     }
-  }
 
-  /** The component set a new value. Send it back to Streamlit. */
-  private handleSetComponentValue = (data: any, source: Source): void => {
-    const value = tryGetValue(data, "value")
-    if (value === undefined) {
-      logWarning(`handleSetComponentValue: missing 'value' prop`)
+    const componentReadyCallback = (): void => {
+      sendRenderMessage(
+        parsedNewArgs,
+        parsedDataframeArgs,
+        disabled,
+        theme,
+        iframeRef.current || undefined
+      )
+      clearTimeoutLog()
+      clearTimeoutWarningElement()
+      setIsReady(true)
+    }
+
+    // update the reference fields for the callback that we
+    // passed to the componentRegistry
+    onBackMsgRef.current = {
+      isReady,
+      element,
+      widgetMgr,
+      setComponentError,
+      componentReadyCallback,
+      frameHeightCallback: handleSetFrameHeight,
+    }
+  }, [
+    componentName,
+    element,
+    parsedDataframeArgs,
+    disabled,
+    isReady,
+    parsedNewArgs,
+    theme,
+    widgetMgr,
+    frameHeight,
+    clearTimeoutWarningElement,
+    clearTimeoutLog,
+  ])
+
+  useEffect(() => {
+    const contentWindow: Window | undefined =
+      iframeRef.current?.contentWindow ?? undefined
+    if (!contentWindow) {
       return
     }
 
-    const { element } = this.props
-    const { dataType } = data
-    if (dataType === "dataframe") {
-      this.props.widgetMgr.setArrowValue(element, value, source)
-    } else if (dataType === "bytes") {
-      this.props.widgetMgr.setBytesValue(element, value, source)
-    } else {
-      this.props.widgetMgr.setJsonValue(element, value, source)
-    }
-  }
-
-  /** The component has a new height. Resize its iframe. */
-  private handleSetFrameHeight = (data: any): void => {
-    const height: number | undefined = tryGetValue(data, "height")
-    if (height === undefined) {
-      logWarning(`handleSetFrameHeight: missing 'height' prop`)
-      return
-    }
-
-    if (height === this.frameHeight) {
-      // Nothing to do!
-      return
-    }
-
-    if (this.iframeRef.current == null) {
-      // This should not be possible.
-      logWarning(`handleSetFrameHeight: missing our iframeRef!`)
-      return
-    }
-
-    // We shove our new frameHeight directly into our iframe, to avoid
-    // triggering a re-render. Otherwise, components will receive the RENDER
-    // event several times during startup (because they will generally
-    // immediately change their frameHeight after mounting). This is wasteful,
-    // and it also breaks certain components.
-    this.frameHeight = height
-    this.iframeRef.current.height = this.frameHeight.toString()
-  }
-
-  /** Send a message to the component through its iframe. */
-  private sendForwardMsg = (type: StreamlitMessageType, data: any): void => {
-    if (this.iframeRef.current == null) {
-      // This should never happen!
-      logWarning("Can't send ForwardMsg; missing our iframe!")
-      return
-    }
-
-    if (this.iframeRef.current.contentWindow == null) {
-      // Nor should this!
-      logWarning("Can't send ForwardMsg; iframe has no contentWindow!")
-      return
-    }
-
-    this.iframeRef.current.contentWindow.postMessage(
-      {
-        type,
-        ...data,
-      },
-      "*"
+    // by creating the callback using the reference variable, we
+    // can access up-to-date information from the component when the callback
+    // is called without the need to re-register the callback
+    registry.registerListener(
+      contentWindow,
+      createIframeMessageHandler(onBackMsgRef)
     )
-  }
 
-  /**
-   * Send a RENDER message to the component with the most recent arguments
-   * received from Python.
-   */
-  private sendRenderMessage = (): void => {
-    // NB: if you change or remove any of the arguments here, you'll break
-    // existing components. You can *add* more arguments safely, but any
-    // other modifications require a CUSTOM_COMPONENT_API_VERSION bump.
-    this.sendForwardMsg(StreamlitMessageType.RENDER, {
-      args: this.curArgs,
-      dfs: this.curDataframeArgs,
-      disabled: this.props.disabled,
-      theme: toExportedTheme(this.props.theme),
-    })
-  }
+    // de-register component when unmounting and when effect is re-running
+    return () => {
+      if (!contentWindow) {
+        return
+      }
+      registry.deregisterListener(contentWindow)
+    }
+  }, [registry, componentName])
 
-  private renderError = (error: Error): ReactNode => {
-    return <ErrorElement name={error.name} message={error.message} />
-  }
-
-  private renderComponentReadyTimeoutWarning = (): ReactNode => {
-    const message =
-      `Your app is having trouble loading the **${this.props.element.componentName}** component. ` +
-      `\n\n(The app is attempting to load the component from **${this.props.element.url}**, and hasn't ` +
-      `received its **"${ComponentMessageType.COMPONENT_READY}"** message.)` +
-      "\n- If this is a development build, have you started the dev server?" +
-      "\n- If this is a release build, have you compiled the frontend?" +
-      `\n\nFor more troubleshooting help, please see the [Streamlit Component docs](${COMPONENT_DEVELOPER_URL}) ` +
-      `or visit our [forums](${COMMUNITY_URL}).`
-
+  if (componentError) {
     return (
-      <AlertElement
-        width={this.props.width}
-        body={message}
-        kind={Kind.WARNING}
+      <ErrorElement
+        name={componentError.name}
+        message={componentError.message}
       />
     )
   }
 
-  public render(): ReactNode {
-    // If we have an error, display it and bail.
-    if (this.state.componentError != null) {
-      return this.renderError(this.state.componentError)
-    }
+  // Show the loading Skeleton while we have not received the ready message from the custom component
+  //   but while we also have not waited until the ready timeout
+  const loadingSkeleton = !isReady && !isReadyTimeout && (
+    <Skeleton height={parseToStringWithUnitSuffix(frameHeight)} />
+  )
 
-    // If we've timed out waiting for the READY message from the component,
-    // display a warning.
-    const warns = this.state.readyTimeout
-      ? this.renderComponentReadyTimeoutWarning()
-      : null
+  // If we've timed out waiting for the READY message from the component,
+  // display a warning.
+  const warns =
+    !isReady && isReadyTimeout ? (
+      <AlertElement
+        width={width}
+        body={getWarnMessage(componentName, url)}
+        kind={Kind.WARNING}
+      />
+    ) : null
 
-    // Parse the component's arguments and src URL.
-    // Some of these steps may throw an exception, so we wrap them in a
-    // try-catch. If we catch an error, we show the error message to the user.
-    let newArgs: { [name: string]: any }
-    const newDataframeArgs: DataframeArg[] = []
-    let src: string
-    let componentName: string
-    try {
-      // Determine the component iframe's src. If a URL is specified, we just
-      // use that. Otherwise, we derive the URL from the component's ID.
-      componentName = this.props.element.componentName
-      const { url } = this.props.element
-      if (url != null && url !== "") {
-        src = url
-      } else {
-        src = this.props.registry.getComponentURL(componentName, "index.html")
-      }
-
-      // Create a URL object from window.location
-      const currentUrl = new URL(window.location.href)
-
-      // Add streamlitUrl query parameter to src.
-      src = queryString.stringifyUrl({
-        url: src,
-        query: { streamlitUrl: currentUrl.origin + currentUrl.pathname },
-      })
-
-      // Parse arguments. Our JSON arguments are just stored in a JSON string.
-      newArgs = JSON.parse(this.props.element.jsonArgs)
-
-      // Some notes re: data marshalling:
-      //
-      // Non-JSON arguments are sent from Python in the "specialArgs"
-      // protobuf list. We get DataFrames and Bytes from this list (and
-      // any further non-JSON datatypes we add support for down the road will
-      // also go into it).
-      //
-      // We don't forward raw protobuf objects onto the iframe, however.
-      // Instead, JSON args and Bytes args are shipped to the iframe together
-      // in a plain old JS Object called `args`.
-      //
-      // But! Because dataframes are delivered as instances of our custom
-      // "ArrowTable" class, they can't be sent to the iframe in this same
-      // `args` object. Instead, raw DataFrame data is delivered to the iframe
-      // in a separate Array. The iframe then constructs the required
-      // ArrowTable instances and inserts them into the `args` array itself.
-      this.props.element.specialArgs.forEach((ispecialArg: ISpecialArg) => {
-        const specialArg = ispecialArg as SpecialArgProto
-        const { key } = specialArg
-        switch (specialArg.value) {
-          case "arrowDataframe":
-            newDataframeArgs.push({
-              key,
-              value: ArrowDataframe.toObject(
-                specialArg.arrowDataframe as ArrowDataframe
-              ),
-            })
-            break
-
-          case "bytes":
-            newArgs[key] = specialArg.bytes
-            break
-
-          default:
-            throw new Error(
-              `Unrecognized SpecialArg type: ${specialArg.value}`
-            )
-        }
-      })
-    } catch (e) {
-      const error = ensureError(e)
-      return this.renderError(error)
-    }
-
-    // We always store the most recent render arguments in order to respond
-    // to COMPONENT_READY messages. Components can indicate that they're ready
-    // multiple times (this will happen if a plugin auto-reloads itself -
-    // for example, if it's being served from a webpack dev server). When a
-    // component sends the COMPONENT_READY message, we send it the most
-    // recent arguments.
-    this.curArgs = newArgs
-    this.curDataframeArgs = newDataframeArgs
-
-    if (this.componentReady) {
-      // The component has loaded. Send it a new render message immediately.
-      // This must happen *after* the above "last args" are saved, because
-      // the render message uses them.
-      this.sendRenderMessage()
-    }
-
-    // Render the iframe. We set scrolling="no", because we don't want
-    // scrollbars to appear; instead, we want components to properly auto-size
-    // themselves.
-    //
-    // Without this, there is a potential for a scrollbar to
-    // appear for a brief moment after an iframe's content gets bigger,
-    // and before it sends the "setFrameHeight" message back to Streamlit.
-    //
-    // We may ultimately want to give components control over the "scrolling"
-    // property.
-    //
-    // TODO: make sure horizontal scrolling still works!
-    return (
-      <>
-        {warns}
-        <iframe
-          allow={DEFAULT_IFRAME_FEATURE_POLICY}
-          ref={this.iframeRef}
-          src={src}
-          width={this.props.width}
-          height={this.frameHeight}
-          style={{ colorScheme: "light dark" }}
-          scrolling="no"
-          sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
-          title={componentName}
-        />
-      </>
-    )
-  }
-}
-
-/** Return the property with the given name, if it exists. */
-function tryGetValue(
-  obj: any,
-  name: string,
-  defaultValue: any = undefined
-): any {
-  return obj.hasOwnProperty(name) ? obj[name] : defaultValue
+  // Render the iframe. We set scrolling="no", because we don't want
+  // scrollbars to appear; instead, we want components to properly auto-size
+  // themselves.
+  //
+  // Without this, there is a potential for a scrollbar to
+  // appear for a brief moment after an iframe's content gets bigger,
+  // and before it sends the "setFrameHeight" message back to Streamlit.
+  //
+  // We may ultimately want to give components control over the "scrolling"
+  // property.
+  //
+  // While the custom component is not in ready-state, show the loading Skeletion instead
+  //
+  // TODO: make sure horizontal scrolling still works!
+  return (
+    <>
+      {loadingSkeleton}
+      {warns}
+      <iframe
+        allow={DEFAULT_IFRAME_FEATURE_POLICY}
+        ref={iframeRef}
+        src={getSrc(componentName, registry, url)}
+        width={width}
+        height={frameHeight}
+        style={{
+          colorScheme: "light dark",
+          display: isReady ? "initial" : "none",
+        }}
+        scrolling="no"
+        sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
+        title={componentName}
+      />
+    </>
+  )
 }
 
 export default withTheme(ComponentInstance)

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RefObject } from "react"
+import "@testing-library/jest-dom"
+
+import { mockTheme } from "@streamlit/lib/src/mocks/mockTheme"
+
+import {
+  CUSTOM_COMPONENT_API_VERSION,
+  IframeMessage,
+  IframeMessageHandlerProps,
+  createIframeMessageHandler,
+  parseArgs,
+  sendRenderMessage,
+} from "./componentUtils"
+import { ComponentMessageType, StreamlitMessageType } from "./enums"
+import {
+  ArrowDataframe,
+  ComponentInstance as ComponentInstanceProto,
+} from "@streamlit/lib/src/proto"
+import { WidgetStateManager } from "@streamlit/lib/src/WidgetStateManager"
+
+// Mock our WidgetStateManager
+jest.mock("@streamlit/lib/src/WidgetStateManager")
+
+describe("test componentUtils", () => {
+  describe("createIframeMsgHandler", () => {
+    const element = ComponentInstanceProto.create({})
+    let widgetMgr: WidgetStateManager
+    let setComponentError: jest.Mock
+    let componentReadyCallback: jest.Mock
+    let frameHeightCallback: jest.Mock
+
+    let ref: RefObject<IframeMessageHandlerProps>
+    let iframeMessageHandler: (type: string, data: IframeMessage) => void
+
+    beforeEach(() => {
+      // Clear our class mocks
+      const mockWidgetStateManager = WidgetStateManager as unknown as jest.Mock
+      mockWidgetStateManager.mockClear()
+
+      componentReadyCallback = jest.fn()
+      frameHeightCallback = jest.fn()
+      setComponentError = jest.fn()
+      widgetMgr = new WidgetStateManager({
+        sendRerunBackMsg: jest.fn(),
+        formsDataChanged: jest.fn(),
+      })
+      ref = {
+        current: {
+          isReady: true,
+          element,
+          widgetMgr,
+          setComponentError,
+          componentReadyCallback,
+          frameHeightCallback,
+        },
+      }
+      iframeMessageHandler = createIframeMessageHandler(ref)
+    })
+
+    it("should call readyCallback when iframeMessageHandler receives COMPONENT_READY message", () => {
+      iframeMessageHandler(ComponentMessageType.COMPONENT_READY, {
+        apiVersion: CUSTOM_COMPONENT_API_VERSION,
+      })
+      expect(componentReadyCallback).toBeCalledTimes(1)
+    })
+
+    it("should call componentErrorCallback when iframeMessageHandler receives message with wrong API version", () => {
+      iframeMessageHandler(ComponentMessageType.COMPONENT_READY, {
+        apiVersion: CUSTOM_COMPONENT_API_VERSION + 1,
+      })
+      expect(componentReadyCallback).toBeCalledTimes(0)
+      expect(setComponentError).toBeCalledTimes(1)
+    })
+
+    it("should call frameHeightCallback when iframeMessageHandler receives SET_FRAME_HEIGHT message", () => {
+      const height = 100
+      iframeMessageHandler(ComponentMessageType.SET_FRAME_HEIGHT, {
+        height: height,
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      ref.current!.isReady = false
+      // when isReady = false, the callback should not be called
+      iframeMessageHandler(ComponentMessageType.SET_FRAME_HEIGHT, {
+        height: height,
+      })
+
+      expect(frameHeightCallback).toBeCalledTimes(1)
+      expect(frameHeightCallback).toBeCalledWith(height)
+    })
+
+    it("should call widgetManager when iframeMessageHandler receives SET_COMPONENT_VALUE message", () => {
+      const jsonValue = { someData: "foo" }
+      iframeMessageHandler(ComponentMessageType.SET_COMPONENT_VALUE, {
+        value: jsonValue,
+        dataType: "json",
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      ref.current!.isReady = false
+      // when isReady = false, the callback should not be called
+      iframeMessageHandler(ComponentMessageType.SET_COMPONENT_VALUE, {
+        value: jsonValue,
+        dataType: "json",
+      })
+
+      expect(widgetMgr.setJsonValue).toBeCalledTimes(1)
+      expect(widgetMgr.setJsonValue).toHaveBeenCalledWith(element, jsonValue, {
+        fromUi: true,
+      })
+    })
+  })
+
+  describe("sendRenderMessage", () => {
+    it("should send message to iframe", () => {
+      const handleAction = jest.fn()
+
+      const mockIframe: any = {
+        contentWindow: {
+          postMessage: handleAction,
+        },
+      }
+
+      const args = { foo: "bar" }
+      const dataframeArgs = [{ key: "foo", value: "bar" }]
+      const disabled = true
+
+      sendRenderMessage(
+        args,
+        dataframeArgs,
+        disabled,
+        mockTheme.emotion,
+        mockIframe
+      )
+      expect(handleAction).toBeCalledTimes(1)
+      expect(handleAction).toHaveBeenCalledWith(
+        {
+          type: StreamlitMessageType.RENDER,
+          args,
+          dfs: dataframeArgs,
+          disabled,
+          theme: expect.any(Object),
+        },
+        "*"
+      )
+    })
+
+    it("should not send message when iframe is undefined", () => {
+      const handleAction = jest.fn()
+
+      const mockIframe: any = undefined
+      sendRenderMessage({}, [], false, mockTheme.emotion, mockIframe)
+      expect(handleAction).toBeCalledTimes(0)
+    })
+
+    it("should not send message when iframe's content window is undefined", () => {
+      const handleAction = jest.fn()
+
+      const mockIframe: any = {
+        contentWindow: undefined,
+      }
+      sendRenderMessage({}, [], false, mockTheme.emotion, mockIframe)
+      expect(handleAction).toBeCalledTimes(0)
+    })
+  })
+
+  describe("parseArgs", () => {
+    it("should parse jsonArgs and specialArgs", () => {
+      const args = { foo: "bar", "some-bytes": new Uint8Array(8) }
+      const someBytes = new Uint8Array(8)
+      // set one byte to a different value
+      someBytes[1] = 10
+      const arrowDataframe = new ArrowDataframe()
+      arrowDataframe.height = 100
+      const specialArgs = [
+        {
+          key: "some-dataframe",
+          value: "arrowDataFrame",
+          arrowDataframe: arrowDataframe,
+        },
+        {
+          key: "some-bytes",
+          value: "bytes",
+          bytes: someBytes,
+        },
+      ]
+
+      const [newArgs, dataframeArgs] = parseArgs(
+        JSON.stringify(args),
+        specialArgs
+      )
+      expect(newArgs).toMatchObject({ foo: "bar", "some-bytes": someBytes })
+      expect(dataframeArgs).toMatchObject([
+        {
+          key: "some-dataframe",
+          value: arrowDataframe,
+        },
+      ])
+    })
+
+    it("should throw an error with with unknown specialArgs type", () => {
+      const args = {}
+      const specialArgs = [
+        {
+          key: "some-dataframe",
+          value: "some-unknown-type",
+        },
+      ]
+
+      expect(() => parseArgs(JSON.stringify(args), specialArgs)).toThrowError(
+        Error
+      )
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
@@ -1,0 +1,305 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentMessageType, StreamlitMessageType } from "./enums"
+import { logWarning } from "@streamlit/lib/src/util/log"
+import {
+  ArrowDataframe,
+  ComponentInstance as ComponentInstanceProto,
+  ISpecialArg,
+  SpecialArg as SpecialArgProto,
+} from "@streamlit/lib/src/proto"
+import { EmotionTheme, toExportedTheme } from "@streamlit/lib/src/theme"
+import {
+  Source,
+  WidgetStateManager,
+} from "@streamlit/lib/src/WidgetStateManager"
+
+// The custom component's value posted from the iFrame has one of the three types as defined
+// in component-lib/
+export type ValueType = "bytes" | "dataframe" | "json"
+
+// Define types for messages being sent from the custom component
+// The types are also defined in the component-lib/ module, and we can
+// replace these here when we have a shared module. Until then,
+// the typing is hopefully at least a little bit helpful for devs.
+type ReadyMessage = {
+  apiVersion: number
+}
+type ComponentValueMessage = {
+  /* the value sent from the custom component can be anything */
+  value: any
+  dataType: ValueType
+}
+type FrameHeightMessage = {
+  height: number
+}
+export type IframeMessage =
+  | ReadyMessage
+  | ComponentValueMessage
+  | FrameHeightMessage
+
+export interface IframeMessageHandlerProps {
+  isReady: boolean
+  element: ComponentInstanceProto
+  widgetMgr: WidgetStateManager
+  setComponentError: (error: Error) => void
+  componentReadyCallback: () => void
+  frameHeightCallback: (height: number | undefined) => void
+}
+
+export interface Args {
+  [name: string]: any
+}
+export interface DataframeArg {
+  key: string
+  value: any
+}
+
+/**
+ * The current custom component API version. If our API changes,
+ * this value must be incremented. ComponentInstances send their API
+ * version in the COMPONENT_READY call.
+ */
+export const CUSTOM_COMPONENT_API_VERSION = 1
+
+/**
+ * Create a callback to be passed to  {@link ComponentRegistry#registerListener}.
+ * The passed callbacks RefObject is used in the returned function to access
+ * the current fields of the reference when the callback is executed by the ComponentRegistry.
+ * This ref-approach allows us to register the listener callback in a functional component only once
+ * instead of keeping registering / unregistering multiple times.
+ *
+ * @param callbacks a ref object containing actual callbacks
+ * @returns the callback function to be passed to {@link ComponentRegistry#registerListener}
+ */
+export function createIframeMessageHandler(
+  callbacks: React.RefObject<IframeMessageHandlerProps | undefined>
+): (type: string, data: IframeMessage) => void {
+  return (type: string, data: IframeMessage): void => {
+    if (!callbacks.current) {
+      return undefined
+    }
+
+    // we receive the callbacks as a reference, so that we can use the
+    //  newest version whenever the callback is called without the need
+    //  to register the callback to the outside
+    const {
+      isReady,
+      element,
+      widgetMgr,
+      setComponentError,
+      componentReadyCallback,
+      frameHeightCallback,
+    } = callbacks.current
+
+    switch (type) {
+      case ComponentMessageType.COMPONENT_READY: {
+        // Our component is ready to begin receiving messages. Send off its
+        // first render message! It is *not* an error to get multiple
+        // COMPONENT_READY messages. This can happen if a component is being
+        // served from the webpack dev server, and gets reloaded. We
+        // always respond to this message with the most recent render
+        // arguments.
+        const { apiVersion } = data as ReadyMessage
+        if (apiVersion !== CUSTOM_COMPONENT_API_VERSION) {
+          // In the future, we may end up with multiple API versions we
+          // need to support. For now, we just have the one.
+          setComponentError(
+            new Error(`Unrecognized component API version: '${apiVersion}'`)
+          )
+        } else {
+          componentReadyCallback()
+        }
+        break
+      }
+
+      case ComponentMessageType.SET_COMPONENT_VALUE:
+        if (!isReady) {
+          logWarning(
+            `Got ${type} before ${ComponentMessageType.COMPONENT_READY}!`
+          )
+        } else {
+          handleSetComponentValue(
+            tryGetValue(data, "value"),
+            (data as ComponentValueMessage).dataType,
+            { fromUi: true },
+            element,
+            widgetMgr
+          )
+        }
+        break
+
+      case ComponentMessageType.SET_FRAME_HEIGHT:
+        if (!isReady) {
+          logWarning(
+            `Got ${type} before ${ComponentMessageType.COMPONENT_READY}!`
+          )
+        } else {
+          frameHeightCallback(
+            tryGetValue(data as FrameHeightMessage, "height")
+          )
+        }
+        break
+
+      default:
+        logWarning(`Unrecognized ComponentBackMsgType: ${type}`)
+    }
+  }
+}
+
+/**
+ * Parse incoming arguments and bring them into a new form.
+ *
+ * The `jsonArgs` are parsed to a JSON object.
+ * The `specialArgs` are transformed:
+ * - `specialArgs[{ key, value: 'arrowdataframe', arrowDataFrame }]` to `dataFrameArgs[{ key, value: arrowDataFrame }]`
+ * - `specialArgs[{ key, value: 'bytes', bytes }]` to `newArgs{key: bytes}`
+ *
+ * This means that byte-values from `specialArgs` override entries in `jsonArgs` when having the same key
+ *
+ * @param jsonArgs JSON-string
+ * @param specialArgs array of objects that hold special-typed values
+ * @throws Error when `specialArgs` contains unrecognized type
+ * @returns
+ */
+export function parseArgs(
+  jsonArgs: string,
+  specialArgs: ISpecialArg[]
+): [newArgs: Args, dataframeArgs: DataframeArg[]] {
+  // Parse arguments. Our JSON arguments are just stored in a JSON string.
+  const newArgs: Args = JSON.parse(jsonArgs)
+
+  // Some notes re: data marshalling:
+  //
+  // Non-JSON arguments are sent from Python in the "specialArgs"
+  // protobuf list. We get DataFrames and Bytes from this list (and
+  // any further non-JSON datatypes we add support for down the road will
+  // also go into it).
+  //
+  // We don't forward raw protobuf objects onto the iframe, however.
+  // Instead, JSON args and Bytes args are shipped to the iframe together
+  // in a plain old JS Object called `args`.
+  //
+  // But! Because dataframes are delivered as instances of our custom
+  // "ArrowTable" class, they can't be sent to the iframe in this same
+  // `args` object. Instead, raw DataFrame data is delivered to the iframe
+  // in a separate Array. The iframe then constructs the required
+  // ArrowTable instances and inserts them into the `args` array itself.
+  const dataframeArgs: DataframeArg[] = []
+  for (const specialArg of specialArgs as SpecialArgProto[]) {
+    const { key } = specialArg
+    switch (specialArg.value?.toLowerCase()) {
+      case "arrowdataframe":
+        dataframeArgs.push({
+          key,
+          value: ArrowDataframe.toObject(
+            specialArg.arrowDataframe as ArrowDataframe
+          ),
+        })
+        break
+
+      case "bytes":
+        newArgs[key] = specialArg.bytes
+        break
+
+      default:
+        throw new Error(`Unrecognized SpecialArg type: ${specialArg.value}`)
+    }
+  }
+
+  return [newArgs, dataframeArgs]
+}
+
+/**
+ * Send a RENDER message to the component with the most recent arguments
+ * received from Python.
+ */
+export function sendRenderMessage(
+  currentArgs: Args,
+  currentDataframeArgs: DataframeArg[],
+  disabled: boolean,
+  theme: EmotionTheme,
+  iframe?: HTMLIFrameElement
+): void {
+  if (!iframe) {
+    // This should never happen!
+    logWarning("Can't send ForwardMsg; missing our iframe!")
+    return
+  }
+
+  if (iframe.contentWindow == null) {
+    // Nor should this!
+    logWarning("Can't send ForwardMsg; iframe has no contentWindow!")
+    return
+  }
+
+  // NB: if you change or remove any of the arguments here, you'll break
+  // existing components. You can *add* more arguments safely, but any
+  // other modifications require a CUSTOM_COMPONENT_API_VERSION bump.
+  iframe.contentWindow.postMessage(
+    {
+      type: StreamlitMessageType.RENDER,
+      args: currentArgs,
+      dfs: currentDataframeArgs,
+      disabled: disabled,
+      theme: toExportedTheme(theme),
+    },
+    "*"
+  )
+}
+
+/**
+ * Set the component's value in the widgetManager to be passed to the backend
+ * @param value posted by the custom component. Can be anything
+ * @param dataType of the passed value. Determines the proto field type. See {@link ValueType}
+ * @param source specifies from where the value is coming
+ * @param element the element to which the value belongs
+ * @param widgetMgr the widget manager to report the value to
+ * @returns undefined
+ */
+function handleSetComponentValue(
+  value: any, // we do not know what data the custom component is sending us, so we use 'any' here
+  dataType: ValueType,
+  source: Source,
+  element: ComponentInstanceProto,
+  widgetMgr: WidgetStateManager
+): void {
+  if (value === undefined) {
+    logWarning(`handleSetComponentValue: missing 'value' prop`)
+    return
+  }
+
+  switch (dataType) {
+    case "dataframe":
+      widgetMgr.setArrowValue(element, value, source)
+      break
+    case "bytes":
+      widgetMgr.setBytesValue(element, value, source)
+      break
+    default:
+      widgetMgr.setJsonValue(element, value, source)
+  }
+}
+
+/** Return the property with the given name, if it exists. */
+function tryGetValue(
+  obj: any,
+  name: string,
+  defaultValue: any = undefined
+): any {
+  return obj.hasOwnProperty(name) ? obj[name] : defaultValue
+}

--- a/frontend/lib/src/hooks/useTimeout.test.ts
+++ b/frontend/lib/src/hooks/useTimeout.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { waitFor } from "@testing-library/react"
+import { renderHook } from "@testing-library/react-hooks"
+
+import useTimeout from "./useTimeout"
+
+describe("timeout function", () => {
+  it("should call the callback function after timeout", async () => {
+    const callback = jest.fn()
+    const timeoutDelayMs = 50
+    renderHook(() => useTimeout(callback, timeoutDelayMs))
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+      timeout: 2 * timeoutDelayMs,
+    })
+  })
+
+  it("should not call the callback function when cancel timeout", async () => {
+    const callback = jest.fn()
+    const timeoutDelayMs = 100
+    const { result } = renderHook(() => useTimeout(callback, timeoutDelayMs))
+    const clear = result.current
+    clear()
+    await new Promise(r => setTimeout(r, 2 * timeoutDelayMs))
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
+})

--- a/frontend/lib/src/hooks/useTimeout.tsx
+++ b/frontend/lib/src/hooks/useTimeout.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useRef } from "react"
+
+/**
+ * Call setTimeout with the passed callback and timeout in milliseconds.
+ * The timeout can be cleared by calling the returned clear-function.
+ *
+ * @param callback to be called when the timeout delay is over
+ * @param timeoutMs the delay in milliseconds after which the timeout callback is called
+ * @returns a memoized clear (stable reference across re-runs) function to stop the timeout
+ */
+function useTimeout(callback: () => void, timeoutMs: number): () => void {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const callbackRef = useRef<() => void>(callback)
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    timeoutRef.current = setTimeout(callbackRef.current, timeoutMs)
+
+    return () => {
+      if (!timeoutRef.current) {
+        return
+      }
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [timeoutMs])
+
+  const clear = useCallback(() => {
+    if (!timeoutRef.current) {
+      return
+    }
+    clearTimeout(timeoutRef.current)
+  }, [])
+
+  return clear
+}
+
+export default useTimeout

--- a/frontend/lib/src/hooks/useTimeout.tsx
+++ b/frontend/lib/src/hooks/useTimeout.tsx
@@ -20,6 +20,8 @@ import { useCallback, useEffect, useRef } from "react"
  * Call setTimeout with the passed callback and timeout in milliseconds.
  * The timeout can be cleared by calling the returned clear-function.
  *
+ * A new timeout will be set when the passed timeoutMs changes.
+ *
  * @param callback to be called when the timeout delay is over
  * @param timeoutMs the delay in milliseconds after which the timeout callback is called
  * @returns a memoized clear (stable reference across re-runs) function to stop the timeout


### PR DESCRIPTION
Close #7046

While the custom component is loaded, we show the loading skeleton. Following changes are made in this PR:
1. the warning component will be shown after 60s instead of 3s to make it less disruptive in case of slower loading times
2. after 15s, a console warning is shown in the browser's DevTools as a soft-warning for the developer
3. the warning texts are modified slightly and are now different based on whether a `url` is provided (usually dev mode) or not
4. the existing class component is re-written as a functional component. Since I had to touch the component anyways, I thought it's a good idea to refactor it using the newer React style and make the changes then
5. Add a couple of more tests for some convenient methods that now live in its own file `componentUtils.ts`
6. Add a couple of more types. As a future note: most types are also defined in the `component-lib/` module and we could think about creating a shared module so that we do not duplicate the typing etc. However, I consider this to be out of scope for this PR.
7. The loading skeleton will mimic the same height if we infer from the custom component provides a height value.

<details>
<summary>Screenshot of warning messages</summary>
<img width="1728" alt="Screenshot 2024-02-16 at 14 50 49" src="https://github.com/streamlit/streamlit/assets/3775781/ec2050a2-475c-4dde-ae89-1ca2bcf0199d">
</details>

<details>
<summary>Screenshot of loading skeletons</summary>
<img width="1726" alt="Screenshot 2024-02-19 at 18 43 23" src="https://github.com/streamlit/streamlit/assets/3775781/1545353b-36bd-4ff6-bcfa-3b167c6355b0">
</details>

<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python): 
  - reuse the existing tests before refactoring
  - add some more tests for convenient methods put into it's own `componentUtil.ts` file
  - add test to `Skeleton.test.ts` to check for passed height property
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
