### PR TITLE
AppTest `from_function` args

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -510,7 +510,7 @@ class ScriptRunner:
                 #         ...
                 #     ```
                 # in their scripts.
-                module = _new_module("__main__")
+                module = self._new_module("__main__")
 
                 # Install the fake module as the __main__ module. This allows
                 # the pickle module to work inside the user's code, since it now
@@ -624,6 +624,10 @@ class ScriptRunner:
         if config.get_option("runner.postScriptGC"):
             gc.collect(2)
 
+    def _new_module(self, name: str) -> types.ModuleType:
+        """Create a new module with the given name."""
+        return types.ModuleType(name)
+
 
 class ScriptControlException(BaseException):
     """Base exception for ScriptRunner."""
@@ -672,11 +676,6 @@ def _clean_problem_modules() -> None:
         except Exception:
             # We don't want to crash the app if we can't close matplotlib
             pass
-
-
-def _new_module(name: str) -> types.ModuleType:
-    """Create a new module with the given name."""
-    return types.ModuleType(name)
 
 
 # The reason this is not a decorator is because we want to make it clear at the

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -231,6 +231,12 @@ class AppTest:
             Default time in seconds before a script run is timed out. Can be
             overridden for individual ``.run()`` calls.
 
+        args: tuple
+            An optional tuple of args to pass to the script function.
+
+        kwargs: dict
+            An optional dict of kwargs to pass to the script function.
+
         Returns
         -------
         AppTest

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -188,13 +188,7 @@ class AppTest:
             executed via ``.run()``.
 
         """
-        hasher = hashlib.md5(bytes(script, "utf-8"), **HASHLIB_KWARGS)
-        script_name = hasher.hexdigest()
-
-        path = pathlib.Path(TMP_DIR.name, script_name)
-        aligned_script = textwrap.dedent(script)
-        path.write_text(aligned_script)
-        return AppTest(str(path), default_timeout=default_timeout)
+        return cls._from_string(script, default_timeout=default_timeout)
 
     @classmethod
     def _from_string(

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -162,9 +162,7 @@ class AppTest:
         self._tree = tree
 
     @classmethod
-    def from_string(
-        cls, script: str, *, default_timeout: float = 3, args=None, kwargs=None
-    ) -> AppTest:
+    def from_string(cls, script: str, *, default_timeout: float = 3) -> AppTest:
         """
         Create an instance of ``AppTest`` to simulate an app page defined\
         within a string.
@@ -190,6 +188,18 @@ class AppTest:
             executed via ``.run()``.
 
         """
+        hasher = hashlib.md5(bytes(script, "utf-8"), **HASHLIB_KWARGS)
+        script_name = hasher.hexdigest()
+
+        path = pathlib.Path(TMP_DIR.name, script_name)
+        aligned_script = textwrap.dedent(script)
+        path.write_text(aligned_script)
+        return AppTest(str(path), default_timeout=default_timeout)
+
+    @classmethod
+    def _from_string(
+        cls, script: str, *, default_timeout: float = 3, args=None, kwargs=None
+    ) -> AppTest:
         hasher = hashlib.md5(bytes(script, "utf-8"), **HASHLIB_KWARGS)
         script_name = hasher.hexdigest()
 
@@ -237,7 +247,7 @@ class AppTest:
         source_lines, _ = inspect.getsourcelines(script)
         source = textwrap.dedent("".join(source_lines))
         module = source + f"\n{script.__name__}(*__args, **__kwargs)"
-        return cls.from_string(
+        return cls._from_string(
             module, default_timeout=default_timeout, args=args, kwargs=kwargs
         )
 

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -141,7 +141,14 @@ class AppTest:
         dict-like syntax to set ``query_params`` values for the simulated app.
     """
 
-    def __init__(self, script_path: str, *args, default_timeout: float, **kwargs):
+    def __init__(
+        self,
+        script_path: str,
+        *,
+        default_timeout: float,
+        args=None,
+        kwargs=None,
+    ):
         self._script_path = script_path
         self.default_timeout = default_timeout
         self.session_state = SafeSessionState(SessionState(), lambda: None)
@@ -156,7 +163,7 @@ class AppTest:
 
     @classmethod
     def from_string(
-        cls, script: str, *args, default_timeout: float = 3, **kwargs
+        cls, script: str, *, default_timeout: float = 3, args=None, kwargs=None
     ) -> AppTest:
         """
         Create an instance of ``AppTest`` to simulate an app page defined\
@@ -189,11 +196,18 @@ class AppTest:
         path = pathlib.Path(TMP_DIR.name, script_name)
         aligned_script = textwrap.dedent(script)
         path.write_text(aligned_script)
-        return AppTest(str(path), *args, default_timeout=default_timeout, **kwargs)
+        return AppTest(
+            str(path), default_timeout=default_timeout, args=args, kwargs=kwargs
+        )
 
     @classmethod
     def from_function(
-        cls, script: Callable[[], None], *args, default_timeout: float = 3, **kwargs
+        cls,
+        script: Callable[..., Any],
+        *,
+        default_timeout: float = 3,
+        args=None,
+        kwargs=None,
     ) -> AppTest:
         """
         Create an instance of ``AppTest`` to simulate an app page defined\
@@ -220,11 +234,12 @@ class AppTest:
             executed via ``.run()``.
 
         """
-        # TODO: Simplify this using `ast.unparse()` once we drop 3.8 support
         source_lines, _ = inspect.getsourcelines(script)
         source = textwrap.dedent("".join(source_lines))
         module = source + f"\n{script.__name__}(*__args, **__kwargs)"
-        return cls.from_string(module, *args, default_timeout=default_timeout, **kwargs)
+        return cls.from_string(
+            module, default_timeout=default_timeout, args=args, kwargs=kwargs
+        )
 
     @classmethod
     def from_file(cls, script_path: str, *, default_timeout: float = 3) -> AppTest:
@@ -300,7 +315,7 @@ class AppTest:
             st.secrets = new_secrets
 
         script_runner = LocalScriptRunner(
-            self._script_path, self.session_state, *self.args, **self.kwargs
+            self._script_path, self.session_state, args=self.args, kwargs=self.kwargs
         )
         self._tree = script_runner.run(widget_state, self.query_params, timeout)
         self._tree._runner = self

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -38,8 +38,8 @@ class LocalScriptRunner(ScriptRunner):
         self,
         script_path: str,
         session_state: SafeSessionState,
-        *args,
-        **kwargs,
+        args=None,
+        kwargs=None,
     ):
         """Initializes the ScriptRunner for the given script_path."""
 
@@ -48,8 +48,8 @@ class LocalScriptRunner(ScriptRunner):
         self.forward_msg_queue = ForwardMsgQueue()
         self.script_path = script_path
         self.session_state = session_state
-        self.args = args
-        self.kwargs = kwargs
+        self.args = args if args is not None else tuple()
+        self.kwargs = kwargs if kwargs is not None else dict()
 
         super().__init__(
             session_id="test session id",

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import time
+import types
 from typing import Any
 from urllib import parse
 
@@ -37,6 +38,8 @@ class LocalScriptRunner(ScriptRunner):
         self,
         script_path: str,
         session_state: SafeSessionState,
+        *args,
+        **kwargs,
     ):
         """Initializes the ScriptRunner for the given script_path."""
 
@@ -45,6 +48,8 @@ class LocalScriptRunner(ScriptRunner):
         self.forward_msg_queue = ForwardMsgQueue()
         self.script_path = script_path
         self.session_state = session_state
+        self.args = args
+        self.kwargs = kwargs
 
         super().__init__(
             session_id="test session id",
@@ -134,6 +139,13 @@ class LocalScriptRunner(ScriptRunner):
         # Remove orphaned files now that the script has run and files in use
         # are marked as active.
         runtime.get_instance().media_file_mgr.remove_orphaned_files()
+
+    def _new_module(self, name: str) -> types.ModuleType:
+        module = types.ModuleType(name)
+        module.__dict__["__args"] = self.args
+        module.__dict__["__kwargs"] = self.kwargs
+        print(f"{module=}, {module.__dict__}")
+        return module
 
 
 def require_widgets_deltas(runner: LocalScriptRunner, timeout: float = 3) -> None:

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -144,7 +144,6 @@ class LocalScriptRunner(ScriptRunner):
         module = types.ModuleType(name)
         module.__dict__["__args"] = self.args
         module.__dict__["__kwargs"] = self.kwargs
-        print(f"{module=}, {module.__dict__}")
         return module
 
 

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -205,3 +205,16 @@ def test_out_of_order_blocks() -> None:
     assert at.markdown.len == 2
     assert at.info[0].value == "Hi!"
     assert at.markdown.values == ["FooBar", "BarFoo"]
+
+
+def test_from_function_kwargs():
+    def script(foo, baz):
+        import streamlit as st
+
+        st.text(foo)
+        st.text(baz)
+        return foo
+
+    at = AppTest.from_function(script, "bar", baz="baz")
+    at.run()
+    assert at.text.values == ["bar", "baz"]

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -215,6 +215,5 @@ def test_from_function_kwargs():
         st.text(baz)
         return foo
 
-    at = AppTest.from_function(script, args=("bar",), kwargs={"baz": "baz"})
-    at.run()
+    at = AppTest.from_function(script, args=("bar",), kwargs={"baz": "baz"}).run()
     assert at.text.values == ["bar", "baz"]

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -215,6 +215,6 @@ def test_from_function_kwargs():
         st.text(baz)
         return foo
 
-    at = AppTest.from_function(script, "bar", baz="baz")
+    at = AppTest.from_function(script, args=("bar",), kwargs={"baz": "baz"})
     at.run()
     assert at.text.values == ["bar", "baz"]


### PR DESCRIPTION


## Describe your changes
Allows `AppTest.from_function` to work with a function that takes arguments, and pass arguments to it.
The new implementation also allows it to work for functions that return values or otherwise do things that are not valid as top level expressions. 

## GitHub Issue Link (if applicable)
#7900 

## Testing Plan

Basic unit test added

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
