### PR TITLE
explicit update() method for query_params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
           # Configure Black to support only syntax supported by the minimum supported Python version in setup.py.
           - --target-version=py37
         files: \.py$|\.pyi$
+        exclude: ^e2e_flaky/.*
   - repo: https://github.com/PyCQA/isort
     rev: 5.11.5
     hooks:
@@ -171,6 +172,7 @@ repos:
           |^vendor/
           |^component-lib/declarations/apache-arrow
           |^lib/tests/isolated_asyncio_test_case\.py$
+          |^e2e_flaky/.*
       - id: insert-license
         name: Add license for all HTML files
         files: \.html$

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -92,6 +92,9 @@ class ForwardMsgQueue:
         self.clear()
         return queue
 
+    def __len__(self) -> int:
+        return len(self._queue)
+
 
 def _is_composable_message(msg: ForwardMsg) -> bool:
     """True if the ForwardMsg is potentially composable with other ForwardMsgs."""

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -15,12 +15,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, Iterator, MutableMapping
+from typing import TYPE_CHECKING, Iterable, Iterator, MutableMapping
 from urllib import parse
 
 from streamlit.constants import EMBED_QUERY_PARAMS_KEYS
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+
+if TYPE_CHECKING:
+    from _typeshed import SupportsKeysAndGetItem
 
 
 @dataclass
@@ -62,6 +65,10 @@ class QueryParams(MutableMapping[str, str]):
             raise KeyError(missing_key_error_message(key))
 
     def __setitem__(self, key: str, value: str | Iterable[str]) -> None:
+        self.__set_item_internal(key, value)
+        self._send_query_param_msg()
+
+    def __set_item_internal(self, key: str, value: str | Iterable[str]) -> None:
         if isinstance(value, dict):
             raise StreamlitAPIException(
                 f"You cannot set a query params key `{key}` to a dictionary."
@@ -77,7 +84,6 @@ class QueryParams(MutableMapping[str, str]):
             self._query_params[key] = [str(item) for item in value]
         else:
             self._query_params[key] = str(value)
-        self._send_query_param_msg()
 
     def __delitem__(self, key: str) -> None:
         try:
@@ -87,6 +93,24 @@ class QueryParams(MutableMapping[str, str]):
             self._send_query_param_msg()
         except KeyError:
             raise KeyError(missing_key_error_message(key))
+
+    def update(
+        self,
+        other: Iterable[tuple[str, str]] | SupportsKeysAndGetItem[str, str] = (),
+        /,
+        **kwds: str,
+    ):
+        # an update function that only sends one ForwardMsg
+        # once all keys have been updated.
+        if hasattr(other, "keys") and hasattr(other, "__getitem__"):
+            for key in other.keys():
+                self.__set_item_internal(key, other[key])
+        else:
+            for (key, value) in other:
+                self.__set_item_internal(key, value)
+        for key, value in kwds.items():
+            self.__set_item_internal(key, value)
+        self._send_query_param_msg()
 
     def get_all(self, key: str) -> list[str]:
         self._ensure_single_query_api_used()

--- a/lib/tests/streamlit/runtime/state/query_params_proxy_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_proxy_test.py
@@ -90,6 +90,11 @@ class TestQueryParamsProxy(unittest.TestCase):
         self.query_params_proxy.key = "value"
         assert self.query_params_proxy["key"] == "value"
 
+    def test_update_sets_entries(self):
+        self.query_params_proxy.update({"key1": "value1", "key2": "value2"})
+        assert self.query_params_proxy["key1"] == "value1"
+        assert self.query_params_proxy["key2"] == "value2"
+
     def test__delattr__deletes_entry(self):
         del self.query_params_proxy.test
         assert "test" not in self.query_params_proxy

--- a/scripts/mypy
+++ b/scripts/mypy
@@ -29,7 +29,11 @@ import click
 import mypy.main as mypy_main
 
 PATHS = ["lib/streamlit/", "scripts/*", "e2e/scripts/*"]
-EXCLUDE_FILES = {"scripts/add_license_headers.py", "e2e/scripts/st_reuse_label.py", "scripts/license-template.txt"}
+EXCLUDE_FILES = {
+    os.path.join("scripts", "add_license_headers.py"),
+    os.path.join("e2e", "scripts", "st_reuse_label.py"),
+    os.path.join("scripts", "license-template.txt"),
+}
 
 
 def shlex_join(split_command: Iterable[str]):


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Adds an explicit .update() method to st.query_params

### Other changes

- Exclude "e2e_flaky" folder from pre-commit formatting checks since the symlinks there cause problems for contributors building on Windows, and on Linux there no point in checking the formatting of a symlinked file that gets covered anyways
- Changes the EXCLUDE list of file paths in "scripts/mypy" to use `os.path.join` instead of hard coded "/" so that, again, path matching works on systems which use "\\" as a path separator.
- Adds a `__len__` method to ForwardMsgQueue because it makes obvious sense and aids with the new testing added on this PR.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8199?notification_referrer_id=NT_kwDOAFahabI5NjEwMDM3NTIxOjU2Nzc0MTc#issuecomment-1964706966
## Testing Plan

Unit tests updated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
