### PR TITLE
Fully clear App State on page change

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -806,7 +806,7 @@ describe("App", () => {
       )
     })
 
-    it("clears stale app elements if currentPageScriptHash changes with extra stale elements", async () => {
+    it("does not add stale app elements if currentPageScriptHash changes", async () => {
       await makeAppWithElements()
 
       sendForwardMessage("newSession", {
@@ -815,12 +815,12 @@ describe("App", () => {
         scriptRunId: "different_script_run_id",
       })
 
+      // elements are cleared
       expect(
         screen.queryByText("Here is some more text")
       ).not.toBeInTheDocument()
 
-      // Add an element to the screen
-      // Need to set the script to running
+      // Run the script with one new element
       sendForwardMessage("sessionStatusChanged", {
         runOnSave: false,
         scriptIsRunning: true,
@@ -840,10 +840,12 @@ describe("App", () => {
         { deltaPath: [0, 0] }
       )
 
+      // Wait for the new element to appear on the screen
       await waitFor(() => {
         expect(screen.getByText("Here is some other text")).toBeInTheDocument()
       })
 
+      // Continue to expect the original element removed
       expect(
         screen.queryByText("Here is some more text")
       ).not.toBeInTheDocument()

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1127,7 +1127,7 @@ export class App extends PureComponent<Props, State> {
         elements: AppRoot.empty(false, sidebarElements),
       },
       () => {
-        this.pendingElementsBuffer = elements
+        this.pendingElementsBuffer = this.state.elements
         this.widgetMgr.removeInactive(new Set([]))
       }
     )


### PR DESCRIPTION
## Describe your changes

We had a bug where stale elements of the old page remain visible to users on the new page. We want update our `pendingElementBuffer` based on new state and not from the original closure.

## Testing Plan

- Unit Test for this specific scenario
- E2E test is difficult to implement due to the ephemeral nature of this edge case.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
