### PR TITLE
Add an isFragmentRun field for page profiling

### DIFF
--- a/proto/streamlit/proto/PageProfile.proto
+++ b/proto/streamlit/proto/PageProfile.proto
@@ -30,6 +30,7 @@ message PageProfile {
   string os = 8;
   string timezone = 9;
   bool headless = 10;
+  bool is_fragment_run = 11;
 }
 
 // The field names are used as part of the event json sent


### PR DESCRIPTION
This PR simply adds a new `isFragmentRun` field to our page profiling metrics
so that we can identify which page runs correspond to fragment runs vs full
app runs.