### PR TITLE
Change youtube url regex to match youtube urls more formats

### DIFF
--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -61,6 +61,9 @@ class VideoTest(DeltaGeneratorTestCase):
             "https://www.youtube.com/embed/sSn4e1lLVpA",
             "https://youtube.com/e/0TSXM-BGqHU",
             "https://youtube.com/v/OIQskkX_DK0",
+            # HTTP should also work correctly
+            "http://youtu.be/4sPnOqeUDmk",
+            "http://www.youtube.com/embed/92jUAXBmZyU",
         )
         yt_embeds = (
             "https://www.youtube.com/embed/_T8LGqJtuGc",
@@ -68,6 +71,8 @@ class VideoTest(DeltaGeneratorTestCase):
             "https://www.youtube.com/embed/sSn4e1lLVpA",
             "https://www.youtube.com/embed/0TSXM-BGqHU",
             "https://www.youtube.com/embed/OIQskkX_DK0",
+            "https://www.youtube.com/embed/4sPnOqeUDmk",
+            "https://www.youtube.com/embed/92jUAXBmZyU",
         )
         # url should be transformed into an embed link (or left alone).
         for x in range(0, len(yt_urls)):

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -59,11 +59,15 @@ class VideoTest(DeltaGeneratorTestCase):
             "https://youtu.be/_T8LGqJtuGc",
             "https://www.youtube.com/watch?v=kmfC-i9WgH0",
             "https://www.youtube.com/embed/sSn4e1lLVpA",
+            "https://youtube.com/e/0TSXM-BGqHU",
+            "https://youtube.com/v/OIQskkX_DK0",
         )
         yt_embeds = (
             "https://www.youtube.com/embed/_T8LGqJtuGc",
             "https://www.youtube.com/embed/kmfC-i9WgH0",
             "https://www.youtube.com/embed/sSn4e1lLVpA",
+            "https://www.youtube.com/embed/0TSXM-BGqHU",
+            "https://www.youtube.com/embed/OIQskkX_DK0",
         )
         # url should be transformed into an embed link (or left alone).
         for x in range(0, len(yt_urls)):


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Previously our YouTube regex doesn't match valid YouTube links (e.g. "https://youtube.com/e/0TSXM-BGqHU" or "https://youtube.com/v/OIQskkX_DK0"), which is why we failed to display videos in Streamlit via `st.video`.

Current Regexp covers those cases too.

Also instead of compiling regex on import time we do that lazily on demand (for a first run performance this should affect positively, and for consequent reruns this should not affect negatively, because [Python caches regex patterns](https://docs.python.org/3/howto/regex.html#module-level-functions).



## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python) Added
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
