### PR TITLE
Make st.help more resilient with conditional members

### DIFF
--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -538,8 +538,8 @@ def _get_members(obj):
                 else:
                     member_docs = None
                     member_value = human_readable_value
-        except Exception:
-            # If there's any exception, we can just skip it.
+        except AttributeError:
+            # If there's an AttributeError, we can just skip it.
             # This can happen when members are exposed with `dir()`
             # but are conditionally unavailable.
             continue

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -538,7 +538,7 @@ def _get_members(obj):
                 else:
                     member_docs = None
                     member_value = human_readable_value
-        except:
+        except Exception:
             # If there's any exception, we can just skip it.
             # This can happen when members are exposed with `dir()`
             # but are conditionally unavailable.

--- a/lib/streamlit/elements/doc_string.py
+++ b/lib/streamlit/elements/doc_string.py
@@ -514,30 +514,35 @@ def _get_members(obj):
         if attr_name.startswith("_"):
             continue
 
-        is_computed_value = _is_computed_property(obj, attr_name)
+        try:
+            is_computed_value = _is_computed_property(obj, attr_name)
+            if is_computed_value:
+                parent_attr = getattr(obj.__class__, attr_name)
 
-        if is_computed_value:
-            parent_attr = getattr(obj.__class__, attr_name)
+                member_type = "property"
 
-            member_type = "property"
-
-            weight = 0
-            member_docs = _get_docstring(parent_attr)
-            member_value = None
-        else:
-            attr_value = getattr(obj, attr_name)
-            weight = _get_weight(attr_value)
-
-            human_readable_value = _get_human_readable_value(attr_value)
-
-            member_type = _get_type_as_str(attr_value)
-
-            if human_readable_value is None:
-                member_docs = _get_docstring(attr_value)
+                weight = 0
+                member_docs = _get_docstring(parent_attr)
                 member_value = None
             else:
-                member_docs = None
-                member_value = human_readable_value
+                attr_value = getattr(obj, attr_name)
+                weight = _get_weight(attr_value)
+
+                human_readable_value = _get_human_readable_value(attr_value)
+
+                member_type = _get_type_as_str(attr_value)
+
+                if human_readable_value is None:
+                    member_docs = _get_docstring(attr_value)
+                    member_value = None
+                else:
+                    member_docs = None
+                    member_value = human_readable_value
+        except:
+            # If there's any exception, we can just skip it.
+            # This can happen when members are exposed with `dir()`
+            # but are conditionally unavailable.
+            continue
 
         if member_type == "module":
             # Don't pollute the output with all imported modules.

--- a/lib/tests/streamlit/elements/doc_string_test.py
+++ b/lib/tests/streamlit/elements/doc_string_test.py
@@ -45,7 +45,7 @@ class ConditionalHello:
             return object.__getattribute__(self, name)
 
     def say_hello(self):
-        print("Hello")
+        pass
 
 
 class StHelpAPITest(DeltaGeneratorTestCase):
@@ -71,7 +71,7 @@ class StHelpAPITest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element.doc_string
         self.assertEqual("ConditionalHello", el.type)
         member_names = [member.name for member in el.members]
-        self.assertTrue("say_hello" in member_names)
+        self.assertIn("say_hello", member_names)
 
     def test_st_help_with_unavailable_conditional_members(self):
         """Test st.help with conditional members not available
@@ -81,7 +81,7 @@ class StHelpAPITest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element.doc_string
         self.assertEqual("ConditionalHello", el.type)
         member_names = [member.name for member in el.members]
-        self.assertTrue("say_hello" not in member_names)
+        self.assertNotIn("say_hello", member_names)
 
     def test_st_help_with_erroneous_members(self):
         """Test st.help with conditional members not available


### PR DESCRIPTION
## Describe your changes

`st.help` leverages `dir(object)` to determine the members in the object to expose to the docstring. If an object makes a member conditional based on internal state, `st.help` can throw an `AttributeError`. Ideally, in these cases, the developer of the object would implement the `__dir__` method to handle conditional members, but Streamlit can be more resilient in handling this situation.

The example that brought this up was in sklearn, and I created https://github.com/scikit-learn/scikit-learn/issues/28558 with them to better handle this scenario.

## Testing Plan

- Unit Tests should cover the change with the member available and unavailable

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
