### PR TITLE
Allow running on files based on shebang, when extension is missing

### DIFF
--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -207,7 +207,7 @@ def main_run(target: str, args=None, **kwargs):
     if extension[1:] not in ACCEPTED_FILE_EXTENSIONS:
         if extension[1:] == "":
             with open(target) as f:
-                maybe_shebang = f.readline().strip('\n')
+                maybe_shebang = f.readline().strip("\n")
 
             if not maybe_shebang.startswith("#!") or not "python" in maybe_shebang:
                 raise click.BadArgumentUsage(

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -206,9 +206,13 @@ def main_run(target: str, args=None, **kwargs):
     _, extension = os.path.splitext(target)
     if extension[1:] not in ACCEPTED_FILE_EXTENSIONS:
         if extension[1:] == "":
-            raise click.BadArgumentUsage(
-                "Streamlit requires raw Python (.py) files, but the provided file has no extension.\nFor more information, please see https://docs.streamlit.io"
-            )
+            with open(target) as f:
+                maybe_shebang = f.readline().strip('\n')
+
+            if not maybe_shebang.startswith("#!") or not "python" in maybe_shebang:
+                raise click.BadArgumentUsage(
+                    "Streamlit requires raw Python (.py) files, but the provided file has no extension.\nFor more information, please see https://docs.streamlit.io"
+                )
         else:
             raise click.BadArgumentUsage(
                 f"Streamlit requires raw Python (.py) files, not {extension}.\nFor more information, please see https://docs.streamlit.io"


### PR DESCRIPTION
Sometimes python files can have no extension, and the interpreter runs them based on the shebang line, e.g. `#!/usr/bin/env python`. At the moment these files are rejected by streamlit, although they run on identical copies of the file, if it has the correct extension.

This is a simple fix and I'm open to more suggestions, adding tests etc. Just let me know what you need 😄 