### PR TITLE
Url decode link column display values if regex is used

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
@@ -204,7 +204,9 @@ describe("LinkColumn", () => {
   it("sets displayed value as the applied regex to the href when displayText is a regex with URL encoding", () => {
     const mockColumn = LinkColumn({
       ...MOCK_LINK_COLUMN_PROPS,
-      columnTypeOptions: { display_text: "https://streamlit.app?app=(.*)" },
+      columnTypeOptions: {
+        display_text: "https://streamlit\\.app\\?app=(.*)",
+      },
     })
 
     const cell = mockColumn.getCell(

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
@@ -190,20 +190,6 @@ describe("LinkColumn", () => {
   it("sets displayed value as the applied regex to the href when displayText is a regex", () => {
     const mockColumn = LinkColumn({
       ...MOCK_LINK_COLUMN_PROPS,
-      columnTypeOptions: { display_text: "https://streamlit.app?app=(.*)" },
-    })
-
-    const cell = mockColumn.getCell(
-      "https://streamlit.app?app=foo%20app%20%25",
-      true
-    ) as UriCell
-
-    expect(cell.displayData).toBe("foo app %")
-  })
-
-  it("sets displayed value as the applied regex to the href when displayText is a regex with URL encoding", () => {
-    const mockColumn = LinkColumn({
-      ...MOCK_LINK_COLUMN_PROPS,
       columnTypeOptions: { display_text: "https://(.*?).streamlit.app" },
     })
 
@@ -213,6 +199,20 @@ describe("LinkColumn", () => {
     ) as UriCell
 
     expect(cell.displayData).toBe("roadmap")
+  })
+
+  it("sets displayed value as the applied regex to the href when displayText is a regex with URL encoding", () => {
+    const mockColumn = LinkColumn({
+      ...MOCK_LINK_COLUMN_PROPS,
+      columnTypeOptions: { display_text: "https://streamlit.app?app=(.*)" },
+    })
+
+    const cell = mockColumn.getCell(
+      "https://streamlit.app?app=foo%20app%20%25",
+      true
+    ) as UriCell
+
+    expect(cell.displayData).toBe("foo app %")
   })
 
   it("sets displayed value as the href, when displayText is a regex but there is no match", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
@@ -190,6 +190,20 @@ describe("LinkColumn", () => {
   it("sets displayed value as the applied regex to the href when displayText is a regex", () => {
     const mockColumn = LinkColumn({
       ...MOCK_LINK_COLUMN_PROPS,
+      columnTypeOptions: { display_text: "https://streamlit.app?app=(.*)" },
+    })
+
+    const cell = mockColumn.getCell(
+      "https://streamlit.app?app=foo%20app%20%25",
+      true
+    ) as UriCell
+
+    expect(cell.displayData).toBe("foo app %")
+  })
+
+  it("sets displayed value as the applied regex to the href when displayText is a regex with URL encoding", () => {
+    const mockColumn = LinkColumn({
+      ...MOCK_LINK_COLUMN_PROPS,
       columnTypeOptions: { display_text: "https://(.*?).streamlit.app" },
     })
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -160,7 +160,11 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
         displayData: displayText,
         isMissingValue: isNullOrUndefined(href),
         onClickUri: a => {
-          window.open(href, "_blank", "noopener,noreferrer")
+          window.open(
+            href.startsWith("www.") ? `https://${href}` : href,
+            "_blank",
+            "noopener,noreferrer"
+          )
           a.preventDefault()
         },
         copyData: href,

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
@@ -662,7 +662,8 @@ export function getLinkDisplayValueFromRegex(
     const patternMatch = href.match(displayTextRegex)
     if (patternMatch && patternMatch[1] !== undefined) {
       // return the first matching group
-      return patternMatch[1]
+      // Since this might be a URI encoded value, we decode it.
+      return decodeURI(patternMatch[1])
     }
 
     // if the regex doesn't find a match with the url, just use the url as display value


### PR DESCRIPTION
## Describe your changes

This PR decodes the extracted display values. This is needed since its extracted from an URL, which often requires URL encoding certain chars. 

This also includes a small slightly unrelated one-liner addition to resolve this issue with the link column: https://github.com/streamlit/streamlit/issues/7064 (Closes #7064)

## Testing Plan

- Added unit test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
