### PR TITLE
Fix bug with elements not always being cleared correctly in fragment runs

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1085,7 +1085,10 @@ export class App extends PureComponent<Props, State> {
         ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
     ) {
       const successful =
-        status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+        status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
+        status ===
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+
       window.setTimeout(() => {
         // Set the theme if url query param ?embed_options=[light,dark]_theme is set
         const [light, dark] = this.props.theme.availableThemes.slice(1, 3)
@@ -1105,9 +1108,12 @@ export class App extends PureComponent<Props, State> {
         // (We don't do this if our script had a compilation error and didn't
         // finish successfully.)
         this.setState(
-          ({ scriptRunId }) => ({
+          ({ scriptRunId, currentFragmentId }) => ({
             // Apply any pending elements that haven't been applied.
-            elements: this.pendingElementsBuffer.clearStaleNodes(scriptRunId),
+            elements: this.pendingElementsBuffer.clearStaleNodes(
+              scriptRunId,
+              currentFragmentId
+            ),
           }),
           () => {
             // We now have no pending elements.

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -81,7 +81,12 @@ class ScriptRunContext:
     _experimental_query_params_used = False
     _production_query_params_used = False
 
-    def reset(self, query_string: str = "", page_script_hash: str = "") -> None:
+    def reset(
+        self,
+        query_string: str = "",
+        page_script_hash: str = "",
+        current_fragment_id: str | None = None,
+    ) -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
         self.widget_user_keys_this_run = set()
@@ -94,7 +99,7 @@ class ScriptRunContext:
         self.command_tracking_deactivated: bool = False
         self.tracked_commands = []
         self.tracked_commands_counter = collections.Counter()
-        self.current_fragment_id = None
+        self.current_fragment_id = current_fragment_id
 
         parsed_query_params = parse.parse_qs(query_string, keep_blank_values=True)
         with self.session_state.query_params() as qp:


### PR DESCRIPTION
This PR fixes three bugs that together resulted in some weird behavior when using
`@st.experimental_fragment`.

* The first is a simple one: we just forgot to also take a snapshot of `ctx.cursors`, which
   also needs to be reset when starting a fragment run to ensure we write to the correct
   position in the app.
* To fix the second bug, we also need to reset both `ctx.cursor` and `dg_stack` when the
   script restarts due to a `RerunException`. Otherwise, we again end up writing to unexpected
   or nonexistent `deltaPath`s. (I'm less sure about whether this fix is the one we want to
   adopt long term, so I left a TODO to revisit it later).
* Finally,  we fix the behavior of the `clearStaleNodes` method to correctly account for the
   different possibilities that come up when clearing stale nodes from a page that contains elements
   both related and unrelated to a given fragment. This bug ended up being a bit more complex, so we
   added comments throughout `clearStaleNodes` to explain what's going on.