### PR TITLE
Use the button width as minimum for `st.popover` container

### DIFF
--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -61,6 +61,22 @@ def test_popover_container_rendering(
     assert_snapshot(popover_container, name="st_popover-container")
 
 
+def test_popover_with_use_container_width(app: Page):
+    """Test that the popover container is correctly stretched to the button width
+    if `use_container_width=True`."""
+    # Get the stretched popover container:
+    popover_element = app.get_by_test_id("stPopover").nth(2)
+    # Click the button to open it:
+    popover_element.locator("button").click()
+
+    # Check that it is open:
+    popover_container = app.get_by_test_id("stPopoverBody")
+    expect(popover_container).to_be_visible()
+    expect(popover_container.get_by_test_id("stMarkdown")).to_have_text("Hello")
+    # Check that the min width is stretched to the full container width:
+    expect(popover_container).to_have_css("min-width", "704px")
+
+
 def test_applying_changes_from_popover_container(app: Page):
     """Test that changes made in the popover container are applied correctly."""
     # Get the widgets popover container:

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -87,9 +87,11 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
               maxHeight: "70vh",
               overflow: "auto",
               maxWidth: `calc(${theme.sizes.contentMaxWidth} - 2rem)`,
-              minWidth: "20rem",
+              minWidth: element.useContainerWidth
+                ? // If use_container_width==True, we use the container width as minimum:
+                  `${Math.max(width, 160)}px` // 10rem ~= 160px
+                : "20rem",
               [`@media (max-width: ${theme.breakpoints.sm})`]: {
-                //  maxWidth: "80vw",
                 maxWidth: `calc(100% - 2rem)`,
               },
               borderTopLeftRadius: theme.radii.xl,


### PR DESCRIPTION
## Describe your changes

If `use_container_width==true` is set for `st.popover`, we use the container width as minimum width for the popover container. 

## GitHub Issue Link (if applicable)

Closes #8261

## Testing Plan

- Added e2e test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
