### PR TITLE
Stop pruning empty blocks in clearStaleNodes

### DIFF
--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -938,30 +938,6 @@ describe("AppRoot.clearStaleNodes", () => {
     expect(newRoot.main.getIn([0, 0])).toBeTextNode("newElement!")
     expect(newRoot.getElements().size).toBe(1)
   })
-
-  it("handles `allowEmpty` blocks correctly", () => {
-    // Create a tree with two blocks, one with allowEmpty: true, and the other
-    // with allowEmpty: false
-    const newRoot = AppRoot.empty()
-      .applyDelta(
-        "new_session_id",
-        makeProto(DeltaProto, { addBlock: { allowEmpty: true } }),
-        forwardMsgMetadata([0, 0])
-      )
-      .applyDelta(
-        "new_session_id",
-        makeProto(DeltaProto, { addBlock: { allowEmpty: false } }),
-        forwardMsgMetadata([0, 1])
-      )
-
-    expect(newRoot.main.getIn([0])).toBeInstanceOf(BlockNode)
-    expect(newRoot.main.getIn([1])).toBeInstanceOf(BlockNode)
-
-    // Prune nodes. Only the `allowEmpty` node should remain.
-    const pruned = newRoot.clearStaleNodes("new_session_id")
-    expect(pruned.main.getIn([0])).toBeInstanceOf(BlockNode)
-    expect(pruned.main.getIn([1])).not.toBeDefined()
-  })
 })
 
 describe("AppRoot.getElements", () => {

--- a/frontend/lib/src/AppNode.ts
+++ b/frontend/lib/src/AppNode.ts
@@ -378,12 +378,6 @@ export class BlockNode implements AppNode {
       .map(child => child.clearStaleNodes(currentScriptRunId))
       .filter(notUndefined)
 
-    // If we have no children and our `allowEmpty` flag is not set, prune
-    // ourselves!
-    if (newChildren.length === 0 && !this.deltaBlock.allowEmpty) {
-      return undefined
-    }
-
     return new BlockNode(newChildren, this.deltaBlock, currentScriptRunId)
   }
 


### PR DESCRIPTION
This is another PR that was made to fix a bug on `feature/st.experimental_fragment` but we're merging
straight into `develop` to keep the final diff size down.

One issue that we ran into with using `@st.experimental_fragment` with containers _outside_ of
the fragment is that empty blocks are currently pruned when the `allowEmpty` flag is not set on their
corresponding deltas.

This seems to be just an optimization to prevent us from having too many elements in the DOM
that aren't actually displayed on screen, but it ends up being problematic when interacting with
fragments because it results in the `dg_stack` on the backend and `AppNode` tree on the frontend
sometimes getting out of sync. When this happens, fragments may end up attempting to write to
either an incorrect or nonexistent place in the app.

Since this is just an optimization that likely doesn't impact app frontend app performance in a
particularly notable way, we just get rid of it.

Closes #5592