### PR TITLE
Make Text Input Ids more stable for testing purposes

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -465,4 +465,25 @@ describe("NumberInput widget", () => {
     await user.click(label)
     expect(numberInput).toHaveFocus()
   })
+
+  it("ensures id doesn't change on rerender", () => {
+    const props = getProps()
+    render(<NumberInput {...props} />)
+
+    const numberInputLabel1 = screen.getByTestId("stWidgetLabel")
+    const forId1 = numberInputLabel1.getAttribute("for")
+
+    // Make some change to cause a rerender
+    const numberInput = screen.getByTestId("stNumberInput-Input")
+    // Change the widget value
+    fireEvent.change(numberInput, {
+      target: { value: 15 },
+    })
+    expect(screen.getByTestId("stNumberInput-Input")).toHaveValue(15)
+
+    const numberInputLabel2 = screen.getByTestId("stWidgetLabel")
+    const forId2 = numberInputLabel2.getAttribute("for")
+
+    expect(forId2).toBe(forId1)
+  })
 })

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -50,7 +50,7 @@ import {
   StyledInputControls,
   StyledInstructionsContainer,
 } from "./styled-components"
-import { uniqueId } from "lodash"
+import uniqueId from "lodash/uniqueId"
 
 export interface Props {
   disabled: boolean
@@ -86,6 +86,8 @@ export interface State {
 export class NumberInput extends React.PureComponent<Props, State> {
   private readonly formClearHelper = new FormClearHelper()
 
+  private readonly id: string
+
   private inputRef = React.createRef<HTMLInputElement | HTMLTextAreaElement>()
 
   constructor(props: Props) {
@@ -97,6 +99,8 @@ export class NumberInput extends React.PureComponent<Props, State> {
       formattedValue: this.formatValue(this.initialValue),
       isFocused: false,
     }
+
+    this.id = uniqueId("number_input_")
   }
 
   get initialValue(): number | null {
@@ -364,7 +368,6 @@ export class NumberInput extends React.PureComponent<Props, State> {
   public render(): React.ReactNode {
     const { element, width, disabled, widgetMgr, theme } = this.props
     const { formattedValue, dirty, isFocused } = this.state
-    const id = uniqueId()
 
     const style = { width }
 
@@ -387,7 +390,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
           labelVisibility={labelVisibilityProtoValueToEnum(
             element.labelVisibility?.value
           )}
-          htmlFor={id}
+          htmlFor={this.id}
         >
           {element.help && (
             <StyledWidgetLabelHelp>
@@ -416,7 +419,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
             clearOnEscape={clearable}
             disabled={disabled}
             aria-label={element.label}
-            id={id}
+            id={this.id}
             overrides={{
               ClearIcon: {
                 props: {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -277,4 +277,22 @@ describe("TextArea widget", () => {
       )
     })
   })
+
+  it("ensures id doesn't change on rerender", () => {
+    const props = getProps()
+    render(<TextArea {...props} />)
+
+    const textAreaLabel1 = screen.getByTestId("stWidgetLabel")
+    const forId1 = textAreaLabel1.getAttribute("for")
+
+    // Make some change to cause a rerender
+    const textArea = screen.getByRole("textbox")
+    fireEvent.change(textArea, { target: { value: "testing" } })
+    fireEvent.blur(textArea)
+
+    const textAreaLabel2 = screen.getByTestId("stWidgetLabel")
+    const forId2 = textAreaLabel2.getAttribute("for")
+
+    expect(forId2).toBe(forId1)
+  })
 })

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -36,7 +36,7 @@ import {
 } from "@streamlit/lib/src/util/utils"
 import { breakpoints } from "@streamlit/lib/src/theme/primitives"
 import { StyledTextAreaContainer } from "./styled-components"
-import { uniqueId } from "lodash"
+import uniqueId from "lodash/uniqueId"
 
 export interface Props {
   disabled: boolean
@@ -61,6 +61,8 @@ interface State {
 class TextArea extends React.PureComponent<Props, State> {
   private readonly formClearHelper = new FormClearHelper()
 
+  private readonly id: string
+
   public state: State = {
     dirty: false,
     value: this.initialValue,
@@ -71,6 +73,11 @@ class TextArea extends React.PureComponent<Props, State> {
     // Otherwise, use the default value from the widget protobuf.
     const storedValue = this.props.widgetMgr.getStringValue(this.props.element)
     return storedValue ?? this.props.element.default ?? null
+  }
+
+  constructor(props: Props) {
+    super(props)
+    this.id = uniqueId("text_area_")
   }
 
   public componentDidMount(): void {
@@ -181,7 +188,6 @@ class TextArea extends React.PureComponent<Props, State> {
     const { value, dirty } = this.state
     const style = { width }
     const { height, placeholder } = element
-    const id = uniqueId()
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
@@ -198,7 +204,7 @@ class TextArea extends React.PureComponent<Props, State> {
           labelVisibility={labelVisibilityProtoValueToEnum(
             element.labelVisibility?.value
           )}
-          htmlFor={id}
+          htmlFor={this.id}
         >
           {element.help && (
             <StyledWidgetLabelHelp>
@@ -218,7 +224,7 @@ class TextArea extends React.PureComponent<Props, State> {
             onKeyDown={this.onKeyDown}
             aria-label={element.label}
             disabled={disabled}
-            id={id}
+            id={this.id}
             overrides={{
               Input: {
                 style: {

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -317,4 +317,22 @@ describe("TextInput widget", () => {
     await user.click(label)
     expect(textInput).toHaveFocus()
   })
+
+  it("ensures id doesn't change on rerender", () => {
+    const props = getProps({ maxChars: 10 })
+    render(<TextInput {...props} />)
+
+    const textInputLabel1 = screen.getByTestId("stWidgetLabel")
+    const forId1 = textInputLabel1.getAttribute("for")
+
+    // Make some change to cause a rerender
+    const textInput = screen.getByRole("textbox")
+    fireEvent.change(textInput, { target: { value: "0123456789" } })
+    expect(textInput).toHaveValue("0123456789")
+
+    const textInputLabel2 = screen.getByTestId("stWidgetLabel")
+    const forId2 = textInputLabel2.getAttribute("for")
+
+    expect(forId2).toBe(forId1)
+  })
 })

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -319,7 +319,7 @@ describe("TextInput widget", () => {
   })
 
   it("ensures id doesn't change on rerender", () => {
-    const props = getProps({ maxChars: 10 })
+    const props = getProps()
     render(<TextInput {...props} />)
 
     const textInputLabel1 = screen.getByTestId("stWidgetLabel")

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from "react"
-import { uniqueId } from "lodash"
+import uniqueId from "lodash/uniqueId"
 import { Input as UIInput } from "baseui/input"
 import { TextInput as TextInputProto } from "@streamlit/lib/src/proto"
 import { FormClearHelper } from "@streamlit/lib/src/components/widgets/Form"
@@ -60,9 +60,16 @@ interface State {
 class TextInput extends React.PureComponent<Props, State> {
   private readonly formClearHelper = new FormClearHelper()
 
+  private readonly id: string
+
   public state: State = {
     dirty: false,
     value: this.initialValue,
+  }
+
+  constructor(props: Props) {
+    super(props)
+    this.id = uniqueId("text_input_")
   }
 
   private get initialValue(): string | null {
@@ -194,7 +201,6 @@ class TextInput extends React.PureComponent<Props, State> {
     const { dirty, value } = this.state
     const { element, width, disabled, widgetMgr } = this.props
     const { placeholder } = element
-    const id = uniqueId()
 
     // Manage our form-clear event handler.
     this.formClearHelper.manageFormClearListener(
@@ -215,7 +221,7 @@ class TextInput extends React.PureComponent<Props, State> {
           labelVisibility={labelVisibilityProtoValueToEnum(
             element.labelVisibility?.value
           )}
-          htmlFor={id}
+          htmlFor={this.id}
         >
           {element.help && (
             <StyledWidgetLabelHelp>
@@ -234,7 +240,7 @@ class TextInput extends React.PureComponent<Props, State> {
           onKeyPress={this.onKeyPress}
           aria-label={element.label}
           disabled={disabled}
-          id={id}
+          id={this.id}
           type={this.getTypeString()}
           autoComplete={element.autocomplete}
           overrides={{


### PR DESCRIPTION
## Describe your changes

The id for the widget label changes every rerun. This doesn't have a problem in functionality, but it has a problem with our text where the id changes in a `getByLabelText`

## Testing Plan

- Previous unit test will apply, and I added another such that a change in the value does not change the htmlFor label.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
