### PR TITLE
Fix issue with not correctly waiting for connections

### DIFF
--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -646,7 +646,7 @@ class Runtime:
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break
-                # Wait for new proto messages that needs to be send out:
+                # Wait for new proto messages that need to be sent out:
                 _, pending_tasks = await asyncio.wait(
                     (
                         asyncio.create_task(async_objs.must_stop.wait()),

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -612,6 +612,8 @@ class Runtime:
                 if self._state == RuntimeState.NO_SESSIONS_CONNECTED:  # type: ignore[comparison-overlap]
                     # mypy 1.4 incorrectly thinks this if-clause is unreachable,
                     # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
+
+                    # Wait for new websocket connections (new sessions):
                     _, pending_tasks = await asyncio.wait(  # type: ignore[unreachable]
                         (
                             asyncio.create_task(async_objs.must_stop.wait()),
@@ -644,7 +646,7 @@ class Runtime:
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break
-
+                # Wait for new data that needs to be send out:
                 _, pending_tasks = await asyncio.wait(
                     (
                         asyncio.create_task(async_objs.must_stop.wait()),

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -646,6 +646,7 @@ class Runtime:
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break
+
                 # Wait for new proto messages that need to be sent out:
                 _, pending_tasks = await asyncio.wait(
                     (

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -646,7 +646,7 @@ class Runtime:
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break
-                # Wait for new data that needs to be send out:
+                # Wait for new proto messages that needs to be send out:
                 _, pending_tasks = await asyncio.wait(
                     (
                         asyncio.create_task(async_objs.must_stop.wait()),

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -609,7 +609,20 @@ class Runtime:
             async_objs.started.set_result(None)
 
             while not async_objs.must_stop.is_set():
-                if self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
+                if self._state == RuntimeState.NO_SESSIONS_CONNECTED:  # type: ignore[comparison-overlap]
+                    # mypy 1.4 incorrectly thinks this if-clause is unreachable,
+                    # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
+                    _, pending_tasks = await asyncio.wait(  # type: ignore[unreachable]
+                        (
+                            asyncio.create_task(async_objs.must_stop.wait()),
+                            asyncio.create_task(async_objs.has_connection.wait()),
+                        ),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    # Clean up pending tasks to avoid memory leaks
+                    for task in pending_tasks:
+                        task.cancel()
+                elif self._state == RuntimeState.ONE_OR_MORE_SESSIONS_CONNECTED:
                     async_objs.need_send_data.clear()
 
                     for active_session_info in self._session_mgr.list_active_sessions():
@@ -628,12 +641,6 @@ class Runtime:
                     # Yield for a few milliseconds between session message
                     # flushing.
                     await asyncio.sleep(0.01)
-                elif self._state == RuntimeState.NO_SESSIONS_CONNECTED:  # type: ignore[comparison-overlap]
-                    # mypy 1.4 incorrectly thinks this if-clause is unreachable,
-                    # because it thinks self._state must be INITIAL | ONE_OR_MORE_SESSIONS_CONNECTED.
-
-                    # This will jump to the asyncio.wait below.
-                    pass
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break


### PR DESCRIPTION
## Describe your changes

[In this PR](https://github.com/streamlit/streamlit/pull/8068), we accidentally removed the waiting for `has_connection.` This means that an app without any connection is likely to just do a lot of necessary loops, causing higher CPU usage compared to previous versions. This PR adds the `has_connection` await. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
