### PR TITLE
Add ability to clear cache for specific function arguments by passing args to `<cached_func>.clear()`

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -513,6 +513,9 @@ class CacheDataAPI:
         ...     # Fetch data from _db_connection here, and then clean it up.
         ...     return data
         ...
+        >>> fetch_and_clean_data.clear(_db_connection, 50)
+        >>> # Clear the cached entry for the arguments provided.
+        >>>
         >>> fetch_and_clean_data.clear()
         >>> # Clear all cached entries for this function.
 
@@ -701,8 +704,11 @@ class DataCache(Cache):
 
         self.storage.set(key, pickled_entry)
 
-    def _clear(self) -> None:
-        self.storage.clear()
+    def _clear(self, key: str | None = None) -> None:
+        if not key:
+            self.storage.clear()
+        else:
+            self.storage.delete(key)
 
     def _read_multi_results_from_storage(self, key: str) -> MultiCacheResults:
         """Look up the results from storage and ensure it has the right type.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -384,6 +384,9 @@ class CacheResourceAPI:
         ...     # Create a database connection object that points to the URL.
         ...     return connection
         ...
+        >>> fetch_and_clean_data.clear(_sessionmaker, "https://streamlit.io/")
+        >>> # Clear the cached entry for the arguments provided.
+        >>>
         >>> get_database_session.clear()
         >>> # Clear all cached entries for this function.
 
@@ -549,9 +552,12 @@ class ResourceCache(Cache):
             multi_results.results[widget_key] = result
             self._mem_cache[key] = multi_results
 
-    def _clear(self) -> None:
+    def _clear(self, key: str | None = None) -> None:
         with self._mem_cache_lock:
-            self._mem_cache.clear()
+            if key is None:
+                self._mem_cache.clear()
+            elif key in self._mem_cache:
+                del self._mem_cache[key]
 
     def get_stats(self) -> list[CacheStat]:
         # Shallow clone our cache. Computing item sizes is potentially

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -102,14 +102,19 @@ class Cache:
         with self._value_locks_lock:
             return self._value_locks[value_key]
 
-    def clear(self):
-        """Clear all values from this cache."""
+    def clear(self, key: str | None = None):
+        """Clear values from this cache.
+        If no argument is passed, all items are cleared from the cache.
+        A key can be passed to clear that key from the cache only."""
         with self._value_locks_lock:
-            self._value_locks.clear()
-        self._clear()
+            if not key:
+                self._value_locks.clear()
+            elif key in self._value_locks:
+                del self._value_locks[key]
+        self._clear(key=key)
 
     @abstractmethod
-    def _clear(self) -> None:
+    def _clear(self, key: str | None = None) -> None:
         """Subclasses must implement this to perform cache-clearing logic."""
         raise NotImplementedError
 
@@ -154,7 +159,7 @@ def make_cached_func_wrapper(info: CachedFuncInfo) -> Callable[..., Any]:
     value otherwise.
 
     The wrapper also has a `clear` function that can be called to clear
-    all of the wrapper's cached values.
+    some or all of the wrapper's cached values.
     """
     cached_func = CachedFunc(info)
 
@@ -303,10 +308,22 @@ class CachedFunc:
                     return_value=computed_value, func=self._info.func
                 )
 
-    def clear(self):
-        """Clear the wrapped function's associated cache."""
+    def clear(self, *args, **kwargs):
+        """Clear the wrapped function's associated cache.
+        If no arguments are passed, clear the cache of all values.
+        If args/kwargs are provided, clear the cached value for these arguments only."""
         cache = self._info.get_function_cache(self._function_key)
-        cache.clear()
+        if args or kwargs:
+            key = _make_value_key(
+                cache_type=self._info.cache_type,
+                func=self._info.func,
+                func_args=args,
+                func_kwargs=kwargs,
+                hash_funcs=self._info.hash_funcs,
+            )
+        else:
+            key = None
+        cache.clear(key=key)
 
 
 def _make_value_key(

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -262,6 +262,20 @@ If you think this is actually a Streamlit bug, please
 [file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose)."""
         self.assertEqual(str(ctx.exception), expected_message)
 
+    def test_cached_st_function_clear_args(self):
+        self.x = 0
+
+        @st.cache_data()
+        def foo(y):
+            self.x += y
+            return self.x
+
+        assert foo(1) == 1
+        foo.clear(2)
+        assert foo(1) == 1
+        foo.clear(1)
+        assert foo(1) == 2
+
 
 class CacheDataPersistTest(DeltaGeneratorTestCase):
     """st.cache_data disk persistence tests"""
@@ -457,6 +471,29 @@ class CacheDataPersistTest(DeltaGeneratorTestCase):
             if element.WhichOneof("type") == "text"
         ]
         assert text == ["1"]
+
+    @patch("streamlit.file_util.os.stat", MagicMock())
+    @patch(
+        "streamlit.runtime.caching.storage.local_disk_cache_storage.streamlit_write",
+        MagicMock(),
+    )
+    @patch(
+        "streamlit.file_util.open",
+        wraps=mock_open(read_data=pickle.dumps(1)),
+    )
+    def test_cached_st_function_clear_args_persist(self, _):
+        self.x = 0
+
+        @st.cache_data(persist="disk")
+        def foo(y):
+            self.x += y
+            return self.x
+
+        assert foo(1) == 1
+        foo.clear(2)
+        assert foo(1) == 1
+        foo.clear(1)
+        assert foo(1) == 2
 
     @patch("streamlit.file_util.os.stat", MagicMock())
     @patch(

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -217,6 +217,20 @@ If you think this is actually a Streamlit bug, please
 [file a bug report here](https://github.com/streamlit/streamlit/issues/new/choose)."""
         self.assertEqual(str(ctx.exception), expected_message)
 
+    def test_cached_st_function_clear_args(self):
+        self.x = 0
+
+        @st.cache_resource()
+        def foo(y):
+            self.x += y
+            return self.x
+
+        assert foo(1) == 1
+        foo.clear(2)
+        assert foo(1) == 1
+        foo.clear(1)
+        assert foo(1) == 2
+
 
 class CacheResourceValidateTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Describe your changes

Hi, I really love streamlit and have been having fun developing an LLM app with it. I wanted to cache the LLM responses, unless a user said it was a bad response. So I decided to implement this. Thanks for taking a look!

I know it might not be perfect, if you give me some pointers I am happy to make a lot of changes as needed :) I think the implementation with passing the key though two layers of methods could be better so I'll think how I can improve that.

This keeps the exisiting interface to CachedFunc.clear() where passing no arguments clears all the cache, but also adds the option that if args/kwargs are passed, the value key will be calculated and the cache storage for that key will be invalidated. This only applies to DataCache for now - I know the error raised could be better so please let me know what type of exception you would prefer it to throw.


## GitHub Issue Link

[8153](https://github.com/streamlit/streamlit/issues/8153)

## Testing Plan

- ~~Explanation of why no additional tests are needed~~ **tests are always needed**
- Unit Tests (JS and/or Python) **python unit test only**
- E2E Tests **not sure**
- Any manual testing needed? **since its very explicit I think unit tests are better**

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
