### PR TITLE
Have fragment rerun requests not interrupt the current script

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner/script_requests.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import cast
 
@@ -46,7 +46,7 @@ class RerunData:
     widget_states: WidgetStates | None = None
     page_script_hash: str = ""
     page_name: str = ""
-    fragment_id: str | None = None
+    fragment_id_queue: list[str] = field(default_factory=list)
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -104,42 +104,46 @@ class ScriptRequests:
                 return False
 
             if self._state == ScriptRequestType.CONTINUE:
-                # If we're running, we can handle a rerun request
-                # unconditionally.
+                # The script is currently running, and we haven't received a request to
+                # rerun it as of yet. We can handle a rerun request unconditionally so
+                # just change self._state and set self._rerun_data.
                 self._state = ScriptRequestType.RERUN
                 self._rerun_data = new_data
                 return True
 
             if self._state == ScriptRequestType.RERUN:
-                # If we have an existing Rerun request, we coalesce this
-                # new request into it.
-                if self._rerun_data.widget_states is None:
-                    # The existing request's widget_states is None, which
-                    # means it wants to rerun with whatever the most
-                    # recent script execution's widget state was.
-                    # We have no meaningful state to merge with, and
-                    # so we simply overwrite the existing request.
-                    self._rerun_data = new_data
-                    return True
+                # We already have an existing Rerun request, so we can coalesce the new
+                # rerun request into the existing one.
 
-                if new_data.widget_states is not None:
-                    # Both the existing and the new request have
-                    # non-null widget_states. Merge them together.
-                    coalesced_states = coalesce_widget_states(
-                        self._rerun_data.widget_states, new_data.widget_states
-                    )
-                    self._rerun_data = RerunData(
-                        query_string=new_data.query_string,
-                        widget_states=coalesced_states,
-                        page_script_hash=new_data.page_script_hash,
-                        page_name=new_data.page_name,
-                        fragment_id=new_data.fragment_id,
-                    )
-                    return True
+                coalesced_states = coalesce_widget_states(
+                    self._rerun_data.widget_states, new_data.widget_states
+                )
 
-                # If old widget_states is NOT None, and new widget_states IS
-                # None, then this new request is entirely redundant. Leave
-                # our existing rerun_data as is.
+                if new_data.fragment_id_queue:
+                    # This RERUN request corresponds to a fragment run. We append the
+                    # new fragment ID to the end of the current fragment_id_queue if it
+                    # isn't already contained in it.
+                    fragment_id_queue = [*self._rerun_data.fragment_id_queue]
+                    if (
+                        # new_data.fragment_id_queue is always a singleton
+                        (new_fragment_id := new_data.fragment_id_queue[0])
+                        not in fragment_id_queue
+                    ):
+                        fragment_id_queue.append(new_fragment_id)
+                else:
+                    # Otherwise, this is a request to rerun the full script, so we want
+                    # to clear out any fragments we have queued to run since they'll all
+                    # be run with the full script anyway.
+                    fragment_id_queue = []
+
+                self._rerun_data = RerunData(
+                    query_string=new_data.query_string,
+                    widget_states=coalesced_states,
+                    page_script_hash=new_data.page_script_hash,
+                    page_name=new_data.page_name,
+                    fragment_id_queue=fragment_id_queue,
+                )
+
                 return True
 
             # We'll never get here
@@ -148,22 +152,32 @@ class ScriptRequests:
     def on_scriptrunner_yield(self) -> ScriptRequest | None:
         """Called by the ScriptRunner when it's at a yield point.
 
-        If we have no request, return None.
+        If we have no request or a RERUN request corresponding to one or more fragments,
+        return None.
 
-        If we have a RERUN request, return the request and set our internal
+        If we have a (full script) RERUN request, return the request and set our internal
         state to CONTINUE.
 
         If we have a STOP request, return the request and remain stopped.
         """
-        if self._state == ScriptRequestType.CONTINUE:
-            # We avoid taking a lock in the common case. If a STOP or RERUN
-            # request is received between the `if` and `return`, it will be
-            # handled at the next `on_scriptrunner_yield`, or when
+        if self._state == ScriptRequestType.CONTINUE or (
+            # Reruns corresponding to fragments should *not* cancel the current script
+            # run as doing so will affect elements outside of the fragment.
+            self._state == ScriptRequestType.RERUN
+            and self._rerun_data.fragment_id_queue
+        ):
+            # We avoid taking the lock in the common cases of having no request and
+            # having a RERUN request corresponding to >=1 fragments. If a STOP or
+            # (full script) RERUN request is received between the `if` and `return`, it
+            # will be handled at the next `on_scriptrunner_yield`, or when
             # `on_scriptrunner_ready` is called.
             return None
 
         with self._lock:
             if self._state == ScriptRequestType.RERUN:
+                if self._rerun_data.fragment_id_queue:
+                    return None
+
                 self._state = ScriptRequestType.CONTINUE
                 return ScriptRequest(ScriptRequestType.RERUN, self._rerun_data)
 

--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -85,7 +85,6 @@ class ScriptRunContext:
         self,
         query_string: str = "",
         page_script_hash: str = "",
-        current_fragment_id: str | None = None,
     ) -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
@@ -99,7 +98,7 @@ class ScriptRunContext:
         self.command_tracking_deactivated: bool = False
         self.tracked_commands = []
         self.tracked_commands_counter = collections.Counter()
-        self.current_fragment_id = current_fragment_id
+        self.current_fragment_id = None
 
         parsed_query_params = parse.parse_qs(query_string, keep_blank_values=True)
         with self.session_state.query_params() as qp:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -217,8 +217,8 @@ def register_widget_from_metadata(
 
 
 def coalesce_widget_states(
-    old_states: WidgetStates, new_states: WidgetStates
-) -> WidgetStates:
+    old_states: WidgetStates | None, new_states: WidgetStates | None
+) -> WidgetStates | None:
     """Coalesce an older WidgetStates into a newer one, and return a new
     WidgetStates containing the result.
 
@@ -228,6 +228,13 @@ def coalesce_widget_states(
     `old_states` will be set to True in the coalesced result, so that button
     presses don't go missing.
     """
+    if not old_states and not new_states:
+        return None
+    elif not old_states:
+        return new_states
+    elif not new_states:
+        return old_states
+
     states_by_id: dict[str, WidgetState] = {
         wstate.id: wstate for wstate in new_states.widgets
     }

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -298,6 +298,17 @@ class WidgetManagerTests(unittest.TestCase):
         # be coalesced
         self.assertEqual(3, session_state["shape_changing_trigger"])
 
+    def coalesce_widget_states_returns_None_if_both_inputs_None(self):
+        assert coalesce_widget_states(None, None) is None
+
+    def coalesce_widget_states_returns_old_states_if_new_states_None(self):
+        old_states = WidgetStates()
+        assert coalesce_widget_states(old_states, None) is old_states
+
+    def coalesce_widget_states_returns_new_states_if_old_states_None(self):
+        new_states = WidgetStates()
+        assert coalesce_widget_states(None, new_states) is new_states
+
 
 class WidgetHelperTests(unittest.TestCase):
     def test_get_widget_with_generated_key(self):


### PR DESCRIPTION
Before the `st.experimental_fragment` feature was implemented, we were previously able to
have a `RERUN` request cancel the currently executing script. This was because the only way
that a script would ever run in the Streamlit execution model was fully from top-to-bottom, so
any portion of the currently executing script that would not get to run due to being cancelled
would still happen later in the rerun.

With fragments, this is no longer true, and a rerun request corresponding to a fragment cancelling
the currently executing script could result in important information from either a full script run or
a different fragment being lost.

To fix this, we change things so that `RERUN` requests corresponding to a fragment don't
immediately cancel the currently executing script. Instead, they are enqueued to run after the
current script run is complete. `RERUN` requests corresponding to full script runs retain their
current behavior of cancelling any currently executing script and running immediately.

---

Note that there's a small known bug in the current implementation that we'll get around to fixing
later: running multiple fragments within a single scriptrunner execution (this can happen if the user
clicks on >=3 slow-running fragments in quick succession) may result in strangeness as the
frontend currently assumes that a scriptrunner execution runs either the full script or only one
fragment.

For now, we just leave a TODO in the code so that we get around to fixing this before the
feature branch is merged.