### PR TITLE
Nested Pages Structure Enabled

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -1,0 +1,33 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+st.sidebar.page_link("app.py", label="🏠 Main")
+st.sidebar.page_link("pages/cookbook.py", label="▶️ CookBook")
+st.sidebar.page_link("pages/apps.py", label="▶️ Application", disabled=True)
+
+"""\
+# Welcome To Crimson206's AI 🤖 Hub 👻!
+
+Hi, I am a passionate AI engineer.
+I have just initialized this project, so there are only few contents here.
+
+I will develop streamlit UI and AI functionalities parallelly, and each component will be archived here as a small example
+
+The small component will go to my **CookBook** 📖, and some integrated applications will go to **Applications**.
+
+My hub is still quite empty. I need your attention and support 🥺, and then, I will pay back with plenty of contents! 😤
+
+"""

--- a/application/apps_src/_apps.py
+++ b/application/apps_src/_apps.py
@@ -1,0 +1,19 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def display():
+    st.write("not implemented.")

--- a/application/cookbook_src/_cookbook.py
+++ b/application/cookbook_src/_cookbook.py
@@ -1,0 +1,52 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def display():
+    st.sidebar.page_link("app.py", label="🏠 Main")
+
+    st.sidebar.title("Welcome to the Cookbook page!")
+    st.sidebar.write(
+        "Under this branch, I will showcase uint UI implementation examples and simple Apps requiring endpoints."
+    )
+
+    st.sidebar.page_link("pages/cookbook/multipages.py", label="▶️ Nested Multipages")
+
+    # main page
+    st.markdown(_page)
+
+
+_page = """\
+# Streamlit App Cookbook 📖
+
+I will continuously update new component recipes here.
+Visit from time to time, and look around different UI or AI elements.
+
+## Publish Plan
+
+I won't take much time for docs for a while, but focus on developing.
+Please understand the minial documents.
+
+
+## Multipages
+
+Check the Nested Multipages example.
+
+This structure is not possible with the current version of streamlit.
+I am planning to make a pull request. If this idea is not accepted, I will consider publishing a patch package.
+
+I will write more details in a post exclusively for this component.\
+"""

--- a/application/cookbook_src/multipages_src/_multipages.py
+++ b/application/cookbook_src/multipages_src/_multipages.py
@@ -1,0 +1,41 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def display():
+
+    # Provide links to lower and higher level pages in sidebar
+    # It can be functionized if you don't want to write every time.
+    st.sidebar.page_link("app.py", label="🏠 Main")
+
+    st.sidebar.title("Nested Multipage App")
+    st.sidebar.header("This is a nested multipage example.")
+    st.sidebar.write(
+        "We will make a 2 level nested app. It can be extended as much as you want."
+    )
+
+    st.sidebar.page_link("pages/cookbook.py", label="◀️ Cookbook")
+
+    # main page
+    st.title("Why don't you explain about your sub-pages here?")
+
+    st.header("Applications.")
+    st.write("Describe your app here, and guide your users to the app pages.")
+    st.sidebar.page_link("pages/cookbook/multipages/apps.py", label="▶️ Apps")
+
+    st.header("Blog.")
+    st.write("Describe your blog.")
+    st.sidebar.page_link("pages/cookbook/multipages/blog.py", label="▶️ Blog")

--- a/application/cookbook_src/multipages_src/apps_src/_apps.py
+++ b/application/cookbook_src/multipages_src/apps_src/_apps.py
@@ -1,0 +1,64 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def display():
+
+    # Provide links to lower and higher level pages in sidebar
+    # It can be functionized if you don't want to write every time.
+    st.sidebar.page_link("app.py", label="🏠 Main")
+
+    st.sidebar.title("Applications")
+    st.sidebar.header("Design your own structure.")
+    st.sidebar.write(
+        "I will use the selectbox to go to an app, and multi-select button for descriptions."
+    )
+
+    st.sidebar.page_link("pages/cookbook/multipages.py", label="◀️ Nested Multipages")
+
+    selected = st.sidebar.selectbox(
+        label="Select an app to use.", options=["idle", "App1", "App2"]
+    )
+    _switch_to_app(selected)
+
+    # main page
+    st.title("If you choose apps, the descriptions of the selected will show up.")
+    selected = st.multiselect(
+        label="Select Apps for descriiptions.", options=["App1", "App2"]
+    )
+    _describe_apps(selected)
+
+
+def _switch_to_app(selected):
+    if selected == "App1":
+        st.switch_page("pages/cookbook/multipages/apps/app1.py")
+    elif selected == "App2":
+        st.switch_page("pages/cookbook/multipages/apps/app2.py")
+    elif selected == "idle":
+        pass
+
+
+def _describe_apps(selected):
+    for key, description in _descriptions.items():
+        if key in selected:
+            st.header(key)
+            st.write(description)
+
+
+_descriptions = {
+    "App1": "Write the description of App1.",
+    "App2": "Write the description of App2.",
+}

--- a/application/cookbook_src/multipages_src/apps_src/app1_src/_app1.py
+++ b/application/cookbook_src/multipages_src/apps_src/app1_src/_app1.py
@@ -1,0 +1,29 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def display():
+
+    # Provide links to lower and higher level pages in sidebar
+    # It can be functionized if you don't want to write every time.
+    st.sidebar.page_link("app.py", label="🏠 Main")
+
+    st.sidebar.title("Not implemented.")
+
+    st.sidebar.page_link("pages/cookbook/multipages/apps.py", label="◀️ Apps")
+
+    # main page
+    st.title("Hi! I am a friendly bot.")

--- a/application/cookbook_src/multipages_src/apps_src/app2_src/_app2.py
+++ b/application/cookbook_src/multipages_src/apps_src/app2_src/_app2.py
@@ -1,0 +1,29 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def display():
+
+    # Provide links to lower and higher level pages in sidebar
+    # It can be functionized if you don't want to write every time.
+    st.sidebar.page_link("app.py", label="🏠 Main")
+
+    st.sidebar.title("Not implemented.")
+
+    st.sidebar.page_link("pages/cookbook/multipages/apps.py", label="◀️ Apps")
+
+    # main page
+    st.title("Hi! I am a helpful bot.")

--- a/application/cookbook_src/multipages_src/blog_src/_blog.py
+++ b/application/cookbook_src/multipages_src/blog_src/_blog.py
@@ -1,0 +1,88 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import streamlit as st
+
+
+def display():
+    st.sidebar.page_link("app.py", label="🏠 Main")
+    st.sidebar.title("This ia a blog page.")
+    st.sidebar.header("Click a post.")
+    st.sidebar.page_link("pages/cookbook/multipages.py", label="◀️ Multipages")
+
+    clicked_once = False
+    for post_name in _titles.keys():
+        title = _titles[post_name]
+        clicked = st.sidebar.button(title)
+        if clicked:
+            clicked_once = True
+            selected = post_name
+    if clicked_once:
+        content = _posts[selected]
+        st.markdown(content)
+    else:
+        content = _posts[selected]
+        st.markdown(content)
+
+
+_titles = {
+    ".main_post": "Main Page",
+    "post1": "Post 1",
+    "post2": "Post 2",
+}
+
+_posts = {
+    ".main_post": """\
+# Post Main
+
+Write your main post for your blog here.
+
+## Sorted Posts
+
+Posts are sorted alphabetically.
+To place the main page on the top, the name of the main page is .main_post.md. It will show the main page on the top regardless of its name.
+
+## Code Optimization
+
+Implementation codes are not optimized.
+Therefore, I recommend you to just refer to the structure rather than to take all the design as they are.\
+""",
+    "post1": """\
+# Title
+
+Instruction
+
+## Session1
+
+Some text
+
+## Session2
+
+Some text\
+""",
+    "post2": """\
+# Title
+
+Another Post
+
+## Session1
+
+Some text
+
+## Session2
+
+Some text\
+""",
+}

--- a/application/pages/apps.py
+++ b/application/pages/apps.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from apps_src._apps import display
+
+display()

--- a/application/pages/cookbook.py
+++ b/application/pages/cookbook.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cookbook_src._cookbook import display
+
+display()

--- a/application/pages/cookbook/multipages.py
+++ b/application/pages/cookbook/multipages.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cookbook_src.multipages_src._multipages import display
+
+display()

--- a/application/pages/cookbook/multipages/apps.py
+++ b/application/pages/cookbook/multipages/apps.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cookbook_src.multipages_src.apps_src._apps import display
+
+display()

--- a/application/pages/cookbook/multipages/apps/app1.py
+++ b/application/pages/cookbook/multipages/apps/app1.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cookbook_src.multipages_src.apps_src.app1_src._app1 import display
+
+display()

--- a/application/pages/cookbook/multipages/apps/app2.py
+++ b/application/pages/cookbook/multipages/apps/app2.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cookbook_src.multipages_src.apps_src.app2_src._app2 import display
+
+display()

--- a/application/pages/cookbook/multipages/blog.py
+++ b/application/pages/cookbook/multipages/blog.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2024)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cookbook_src.multipages_src.blog_src._blog import display
+
+display()

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -65,6 +65,13 @@ def page_sort_key(script_path: Path) -> tuple[float, str]:
     return (float(number), label)
 
 
+def extract_path_after_pages(full_path_str: str) -> str:
+    pre, separator, post = full_path_str.rpartition("/pages/")
+    if post:
+        return post  # .replace('.py', '')
+    return ""
+
+
 def page_icon_and_name(script_path: Path) -> tuple[str, str]:
     """Compute the icon and name of a page from its script path.
 
@@ -74,7 +81,10 @@ def page_icon_and_name(script_path: Path) -> tuple[str, str]:
     URL-encode them. To solve this, we only swap the underscores for spaces
     right before we render page names.
     """
-    extraction = re.search(PAGE_FILENAME_REGEX, script_path.name)
+
+    path_after_pages = extract_path_after_pages(str(script_path))
+
+    extraction = re.search(PAGE_FILENAME_REGEX, path_after_pages)
     if extraction is None:
         return "", ""
 
@@ -139,7 +149,7 @@ def get_pages(main_script_path_str: str) -> dict[str, dict[str, str]]:
         page_scripts = sorted(
             [
                 f
-                for f in pages_dir.glob("*.py")
+                for f in pages_dir.rglob("*.py")
                 if not f.name.startswith(".") and not f.name == "__init__.py"
             ],
             key=page_sort_key,


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes
I have made the "Nested Pages Structure" possible and decided to share this proposed change and discuss it before proceeding further.

It was accomplished by modifying the `get_pages(...)` function. However, this modification causes test failures for all the `page_icon_and_name()` function tests because it doesn't adhere to the [file name to link label](https://docs.streamlit.io/library/advanced-features/multipage-apps) functionality.

Despite this, I still insist on implementing this change because we can compensate for the loss by using the [page_link()](https://docs.streamlit.io/library/api-reference/widgets/st.page_link) function.

I have included an implementation example of a nested pages app in this branch (temporarily). Please see the picture below. To test it, run the following line:
```
streamlit run application/app.py
```

![Screenshot 2024-03-14 124859](https://github.com/streamlit/streamlit/assets/110409356/d65121e6-3186-401c-8952-b03bd89a48e0)

I recommend deprecating the `page_icon_and_name()` function. The flexibility of the nested structure will become increasingly important as the field of Autonomous Agents grows, and this function is limiting the extensibility of the **pages** folder.

I look forward to hearing your opinions, whatever they may be.


## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
