### PR TITLE
Don't reset title and favicon when running fragment

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -450,7 +450,14 @@ describe("App", () => {
       )
     }
 
+    let documentTitle: string
+
+    beforeEach(() => {
+      documentTitle = document.title
+    })
+
     afterEach(() => {
+      document.title = documentTitle
       window.localStorage.clear()
     })
 
@@ -1063,6 +1070,32 @@ describe("App", () => {
         // @ts-expect-error
         window.history.pushState.mockClear()
       })
+    })
+
+    it("resets document title if not fragment", () => {
+      renderApp(getProps())
+
+      document.title = "some title"
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        fragmentId: undefined,
+      })
+
+      expect(document.title).toBe("streamlit_app · Streamlit")
+    })
+
+    it("does *not* reset document title if fragment", () => {
+      renderApp(getProps())
+
+      document.title = "some title"
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        fragmentId: "myFragmentId",
+      })
+
+      expect(document.title).toBe("some title")
     })
   })
 


### PR DESCRIPTION
This PR fixes a bug in the `feature/st.experimental_fragment` branch where fragment runs would
undo things set in an earlier call to `set_page_config`. The reason for this was simply that we were
resetting both the title and favicon in every call to `handleNewSession`, even if the call corresponds
to a fragment run. We fixed this by simply moving parts of `handleNewSession` into an `if` statement
that only runs when we're not running a fragment. Note that no other notable code changes were
made aside from moving blocks of code around.