### PR TITLE
Fix/timed cleaning cache event loop

### DIFF
--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -22,7 +22,6 @@ import types
 from datetime import timedelta
 from typing import Any, Callable, Final, TypeVar, cast, overload
 
-from cachetools import TTLCache
 from typing_extensions import TypeAlias
 
 import streamlit as st
@@ -48,6 +47,7 @@ from streamlit.runtime.caching.hashing import HashFuncsDict
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
 from streamlit.runtime.stats import CacheStat, CacheStatsProvider, group_stats
+from streamlit.util import TimedCleanupCache
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -472,7 +472,7 @@ class ResourceCache(Cache):
         super().__init__()
         self.key = key
         self.display_name = display_name
-        self._mem_cache: TTLCache[str, MultiCacheResults] = TTLCache(
+        self._mem_cache: TimedCleanupCache[str, MultiCacheResults] = TimedCleanupCache(
             maxsize=max_entries, ttl=ttl_seconds, timer=cache_utils.TTLCACHE_TIMER
         )
         self._mem_cache_lock = threading.Lock()

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 import math
 import threading
 
-from cachetools import TTLCache
-
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
@@ -26,6 +24,7 @@ from streamlit.runtime.caching.storage.cache_storage_protocol import (
     CacheStorageKeyNotFoundError,
 )
 from streamlit.runtime.stats import CacheStat
+from streamlit.util import TimedCleanupCache
 
 _LOGGER = get_logger(__name__)
 
@@ -62,7 +61,7 @@ class InMemoryCacheStorageWrapper(CacheStorage):
         self.function_display_name = context.function_display_name
         self._ttl_seconds = context.ttl_seconds
         self._max_entries = context.max_entries
-        self._mem_cache: TTLCache[str, bytes] = TTLCache(
+        self._mem_cache: TimedCleanupCache[str, bytes] = TimedCleanupCache(
             maxsize=self.max_entries,
             ttl=self.ttl_seconds,
             timer=cache_utils.TTLCACHE_TIMER,

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 from typing import MutableMapping
 
-from cachetools import TTLCache
-
 from streamlit.runtime.session_manager import SessionInfo, SessionStorage
+from streamlit.util import TimedCleanupCache
 
 
 class MemorySessionStorage(SessionStorage):
@@ -57,7 +56,7 @@ class MemorySessionStorage(SessionStorage):
             inaccessible and will be removed eventually.
         """
 
-        self._cache: MutableMapping[str, SessionInfo] = TTLCache(
+        self._cache: MutableMapping[str, SessionInfo] = TimedCleanupCache(
             maxsize=maxsize, ttl=ttl_seconds
         )
 

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -31,6 +31,7 @@ from streamlit.runtime.caching.storage.dummy_cache_storage import (
 )
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
+from streamlit.runtime.runtime import AsyncObjects
 from streamlit.runtime.secrets import Secrets
 from streamlit.runtime.state.common import TESTING_KEY
 from streamlit.runtime.state.safe_session_state import SafeSessionState
@@ -319,6 +320,7 @@ class AppTest:
             MemoryMediaFileStorage("/mock/media")
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
         with source_util._pages_cache_lock:
             saved_cached_pages = source_util._cached_pages

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -16,13 +16,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import functools
 import hashlib
 import os
 import subprocess
 import sys
-from typing import Any, Callable, Final, Iterable, Mapping, TypeVar
+from typing import Any, Callable, Final, Generic, Iterable, Mapping, TypeVar
+
+from cachetools import TTLCache
 
 from streamlit import env_util
 
@@ -199,3 +202,37 @@ def extract_key_query_params(
         ]
         for item in sublist
     }
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class TimedCleanupCache(TTLCache, Generic[K, V]):
+    """A TTLCache that asynchronously expires its entries."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._task: asyncio.Task[Any] | None = None
+
+    def __setitem__(self, key: K, value: V) -> None:
+        # Set an expiration task to run periodically
+        # Can't be created in init because that only runs once and
+        # the event loop might not exist yet.
+        if self._task is None:
+            try:
+                self._task = asyncio.create_task(expire_cache(self))
+            except RuntimeError:
+                # Just continue if the event loop isn't started yet.
+                pass
+        super().__setitem__(key, value)
+
+    def __del__(self):
+        if self._task is not None:
+            self._task.cancel()
+
+
+async def expire_cache(cache: TTLCache) -> None:
+    while True:
+        await asyncio.sleep(30)
+        cache.expire()

--- a/lib/tests/delta_generator_test_case.py
+++ b/lib/tests/delta_generator_test_case.py
@@ -68,6 +68,7 @@ class DeltaGeneratorTestCase(unittest.TestCase):
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
         mock_runtime.media_file_mgr = MediaFileManager(self.media_file_storage)
         mock_runtime.uploaded_file_mgr = self.script_run_ctx.uploaded_file_mgr
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
     def tearDown(self):

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -92,6 +92,7 @@ class CacheDataTest(unittest.TestCase):
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
     def tearDown(self):
@@ -270,6 +271,7 @@ class CacheDataPersistTest(DeltaGeneratorTestCase):
         super().setUp()
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.cache_storage_manager = LocalDiskCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
     def tearDown(self) -> None:
@@ -532,6 +534,7 @@ class CacheDataStatsProviderTest(unittest.TestCase):
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
         # Guard against external tests not properly cache-clearing
@@ -591,6 +594,7 @@ class CacheDataValidateParamsTest(DeltaGeneratorTestCase):
         super().setUp()
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.cache_storage_manager = AlwaysFailingTestCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
     def test_error_logged_and_raised_on_improperly_configured_cache_data(self):

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -694,6 +694,7 @@ class CommonCacheTTLTest(unittest.TestCase):
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
     def tearDown(self):
@@ -830,6 +831,7 @@ class CommonCacheThreadingTest(unittest.TestCase):
     def setUp(self):
         mock_runtime = MagicMock(spec=Runtime)
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime._async_objs = None
         Runtime._instance = mock_runtime
 
     def tearDown(self):

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -17,12 +17,13 @@ import gc
 import random
 import unittest
 from typing import Dict, List, Set
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from parameterized import parameterized
 
 from streamlit import util
+from streamlit.runtime.runtime import AsyncObjects, Runtime
 
 
 class UtilTest(unittest.TestCase):
@@ -192,6 +193,11 @@ class UtilTest(unittest.TestCase):
         """Test that the TimedCleanupCache does not leave behind tasks when
         the cache is not externally reachable"""
         loop = asyncio.new_event_loop()
+        mock_runtime = MagicMock(spec=Runtime)
+        mock_runtime._async_objs = MagicMock(spec=AsyncObjects)
+        mock_runtime._async_objs.eventloop = loop
+        Runtime._instance = mock_runtime
+
         asyncio.set_event_loop(loop)
 
         async def create_cache():


### PR DESCRIPTION

## Describe your changes
Run the cache cleanup coroutine on the runtime's event loop, so that it works when caches are created in script threads, and no longer generates warnings about unawaited tasks.


## Testing Plan

Intend to add a unit test about the warning once I get other test issues sorted out

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
