### PR TITLE
Add simple fix to update container status after llm complete

### DIFF
--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -193,9 +193,9 @@ class LLMThought:
         self.complete(self._labeler.get_final_agent_thought_label())
 
     def on_llm_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
-        self._container.markdown("**LLM encountered an error...**")
         self._container.exception(error)
         self._state = LLMThoughtState.ERROR
+        self._container("LLM encountered an error...")
 
     def on_tool_start(
         self, serialized: dict[str, Any], input_str: str, **kwargs: Any

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -189,6 +189,12 @@ class LLMThought:
         # If we're receiving streaming tokens from `on_llm_new_token`, this response
         # data is redundant
         self._reset_llm_token_stream()
+        # set the container status to complete
+        self._container.update(
+            label="",
+            state="complete",
+            expanded=self.expanded,
+        )
 
     def on_llm_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
         self._container.markdown("**LLM encountered an error...**")

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -258,7 +258,7 @@ class LLMThought:
 
         self._container.update(
             label=final_label,
-            expanded=False if self._collapse_on_complete else True,
+            expanded=False if self._collapse_on_complete else None,
             state="error" if self._state == LLMThoughtState.ERROR else "complete",
         )
 

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -190,11 +190,7 @@ class LLMThought:
         # data is redundant
         self._reset_llm_token_stream()
         # set the container status to complete
-        self._container.update(
-            label="",
-            state="complete",
-            expanded=self.expanded,
-        )
+        self.complete(self._labeler.get_final_agent_thought_label())
 
     def on_llm_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
         self._container.markdown("**LLM encountered an error...**")
@@ -262,7 +258,7 @@ class LLMThought:
 
         self._container.update(
             label=final_label,
-            expanded=False if self._collapse_on_complete else None,
+            expanded=False if self._collapse_on_complete else True,
             state="error" if self._state == LLMThoughtState.ERROR else "complete",
         )
 

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -195,7 +195,7 @@ class LLMThought:
     def on_llm_error(self, error: BaseException, *args: Any, **kwargs: Any) -> None:
         self._container.exception(error)
         self._state = LLMThoughtState.ERROR
-        self._container("LLM encountered an error...")
+        self.complete("LLM encountered an error...")
 
     def on_tool_start(
         self, serialized: dict[str, Any], input_str: str, **kwargs: Any


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

This PR fixes an issue when using Langchain with `StreamlitCallbackHandler`.
Currently, the container status is stuck at "running" after displaying all content.

<img width="741" alt="image" src="https://github.com/streamlit/streamlit/assets/5064852/5af0f447-99c4-44c8-b4b8-8f8c918e6d30">

This PR added one more step to update the container status after displaying all content:

<img width="728" alt="image" src="https://github.com/streamlit/streamlit/assets/5064852/a6667e3a-a653-4c54-b6af-2e0434055c8f">

## GitHub Issue Link (if applicable)

This issue is reported in https://github.com/langchain-ai/langchain/issues/11398

## Testing Plan

- Explanation of why no additional tests are needed: NA
- Unit Tests (JS and/or Python): NA
- E2E Tests: NA
- Any manual testing needed?: Yes, please build a small chat bot with the example code and use Langchain and the callback to ensure that the container status is updated after receiving all tokens from LLM.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
