### PR TITLE
Take fragments into account when clearing stale widgets

### DIFF
--- a/lib/streamlit/runtime/scriptrunner/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner/script_run_context.py
@@ -76,6 +76,7 @@ class ScriptRunContext:
     cursors: dict[int, "streamlit.cursor.RunningCursor"] = field(default_factory=dict)
     script_requests: ScriptRequests | None = None
     current_fragment_id: str | None = None
+    fragment_ids_this_run: set[str] | None = None
 
     # TODO(willhuang1997): Remove this variable when experimental query params are removed
     _experimental_query_params_used = False
@@ -85,6 +86,7 @@ class ScriptRunContext:
         self,
         query_string: str = "",
         page_script_hash: str = "",
+        fragment_ids_this_run: set[str] | None = None,
     ) -> None:
         self.cursors = {}
         self.widget_ids_this_run = set()
@@ -99,6 +101,7 @@ class ScriptRunContext:
         self.tracked_commands = []
         self.tracked_commands_counter = collections.Counter()
         self.current_fragment_id = None
+        self.fragment_ids_this_run = fragment_ids_this_run
 
         parsed_query_params = parse.parse_qs(query_string, keep_blank_values=True)
         with self.session_state.query_params() as qp:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -463,7 +463,9 @@ class ScriptRunner:
 
             ctx = self._get_script_run_ctx()
             ctx.reset(
-                query_string=rerun_data.query_string, page_script_hash=page_script_hash
+                query_string=rerun_data.query_string,
+                page_script_hash=page_script_hash,
+                fragment_ids_this_run=set(rerun_data.fragment_id_queue),
             )
 
             # TODO(vdonato): Changes to take into account multiple fragments running

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -123,6 +123,8 @@ class WidgetMetadata(Generic[T]):
     callback_args: WidgetArgs | None = None
     callback_kwargs: WidgetKwargs | None = None
 
+    fragment_id: str | None = None
+
     def __repr__(self) -> str:
         return util.repr_(self)
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -182,11 +182,21 @@ class WStates(MutableMapping[str, Any]):
         """Set a widget's metadata, overwriting any existing metadata it has."""
         self.widget_metadata[widget_meta.id] = widget_meta
 
-    def remove_stale_widgets(self, active_widget_ids: set[str]) -> None:
-        """Remove widget state for widgets whose ids aren't in `active_widget_ids`."""
-        # TODO(vdonato / kajarenc): Remove files corresponding to an inactive file
-        # uploader.
-        self.states = {k: v for k, v in self.states.items() if k in active_widget_ids}
+    def remove_stale_widgets(
+        self,
+        active_widget_ids: set[str],
+        fragment_ids_this_run: set[str] | None,
+    ) -> None:
+        """Remove widget state for stale widgets."""
+        self.states = {
+            k: v
+            for k, v in self.states.items()
+            if not _is_stale_widget(
+                self.widget_metadata.get(k),
+                active_widget_ids,
+                fragment_ids_this_run,
+            )
+        }
 
     def get_serialized(self, k: str) -> WidgetStateProto | None:
         """Get the serialized value of the widget with the given id.
@@ -561,14 +571,30 @@ class SessionState:
 
     def _remove_stale_widgets(self, active_widget_ids: set[str]) -> None:
         """Remove widget state for widgets whose ids aren't in `active_widget_ids`."""
-        self._new_widget_state.remove_stale_widgets(active_widget_ids)
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            return
+
+        self._new_widget_state.remove_stale_widgets(
+            active_widget_ids,
+            ctx.fragment_ids_this_run,
+        )
 
         # Remove entries from _old_state corresponding to
         # widgets not in widget_ids.
         self._old_state = {
             k: v
             for k, v in self._old_state.items()
-            if (k in active_widget_ids or not is_widget_id(k))
+            if (
+                not is_widget_id(k)
+                or not _is_stale_widget(
+                    self._new_widget_state.widget_metadata.get(k),
+                    active_widget_ids,
+                    ctx.fragment_ids_this_run,
+                )
+            )
         }
 
     def _set_widget_metadata(self, widget_metadata: WidgetMetadata[Any]) -> None:
@@ -669,6 +695,20 @@ class SessionState:
 
 def _is_internal_key(key: str) -> bool:
     return key.startswith(STREAMLIT_INTERNAL_KEY_PREFIX)
+
+
+def _is_stale_widget(
+    metadata: WidgetMetadata[Any] | None,
+    active_widget_ids: set[str],
+    fragment_ids_this_run: set[str] | None,
+) -> bool:
+    if not metadata:
+        return True
+    elif metadata.id in active_widget_ids:
+        return False
+    elif fragment_ids_this_run and metadata.fragment_id not in fragment_ids_this_run:
+        return False
+    return True
 
 
 @dataclass

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -159,6 +159,7 @@ def register_widget(
         callback=on_change_handler,
         callback_args=args,
         callback_kwargs=kwargs,
+        fragment_id=ctx.current_fragment_id if ctx else None,
     )
     return register_widget_from_metadata(metadata, ctx, widget_func_name, element_type)
 


### PR DESCRIPTION
There's currently a bug that occurs when using `st.rerun` within a function decorated with
`@st.experimental_fragment` where widget state is incorrectly reset. See the code below
for an example reproducing the issue.

```python3
import streamlit as st

show_stuff = st.checkbox("Show stuff")
if show_stuff:
    st.write("hello")


@st.experimental_fragment
def fragment():
    if st.button("Rerun everything"):
        st.rerun()
        
fragment()
```

To reproduce the bug:
1. Click on the checkbox so that "hello" is displayed
2. Click the "Rerun everything" button
3. Notice that "hello" is no longer written to the app

The reason this happens is because we incorrectly remove the value of the checkbox because
we think it's a stale widget before rerunning the script due to the call to `st.rerun()`. This happens
because our `remove_stale_widgets` helper methods in session-state related classes currently
incorrectly mark widgets outside of a currently running fragment as stale.