### PR TITLE
Simplify toast message truncation to use character limit directly

### DIFF
--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -89,17 +89,17 @@ function generateToastOverrides(
 }
 
 // Function used to truncate toast messages that are longer than three lines.
-function shortenMessage(fullMessage: string): string {
+export function shortenMessage(fullMessage: string): string {
   const characterLimit = 114
 
   if (fullMessage.length > characterLimit) {
     let message = fullMessage.replace(/^(.{114}[^\s]*).*/, "$1")
 
     if (message.length > characterLimit) {
-      message = message.split(" ").slice(0, -1).join(" ")
+      message = message.substring(0, characterLimit)
     }
 
-    return message
+    return message.trim()
   }
 
   return fullMessage

--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -96,7 +96,11 @@ export function shortenMessage(fullMessage: string): string {
     let message = fullMessage.replace(/^(.{114}[^\s]*).*/, "$1")
 
     if (message.length > characterLimit) {
-      message = message.substring(0, characterLimit)
+      message = message
+        .substring(0, characterLimit)
+        .split(" ")
+        .slice(0, -1)
+        .join(" ")
     }
 
     return message.trim()


### PR DESCRIPTION
## Describe your changes

This PR ensures consistent toast message truncation at the character limit, to avoid overflowing like #8330.

- Modified the `shortenMessage` truncation by preserving whole words while adhering to the character limit
- Also, trimmed the resulting string to ensure no leading or trailing whitespace
- Lastly, exported the function to make it available for testing

## GitHub Issue Link (if applicable)

Closes #8330.

## Testing Plan

- Updated JS unit tests

### Revised

![image](https://github.com/streamlit/streamlit/assets/20672874/bba96ab1-7555-4d4f-a18e-fa63e2e282b3)

### Current

![image](https://github.com/streamlit/streamlit/assets/20672874/df6b5e15-ef57-4c29-81f9-5eb487eb8672)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
