### PR TITLE
Add metrics tracking for toolbar item clicks

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1740,6 +1740,7 @@ export class App extends PureComponent<Props, State> {
                       sendMessageToHost={
                         this.hostCommunicationMgr.sendMessageToHost
                       }
+                      metricsMgr={this.metricsMgr}
                     />
                   </>
                 )}

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.test.tsx
@@ -16,7 +16,9 @@
 
 import React from "react"
 
-import { render } from "@streamlit/lib"
+import { render, mockSessionInfo } from "@streamlit/lib"
+import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+
 import "@testing-library/jest-dom"
 import { fireEvent, screen } from "@testing-library/react"
 
@@ -66,6 +68,7 @@ describe("ToolbarActions", () => {
       { key: "share", label: "Share" },
     ],
     sendMessageToHost: jest.fn(),
+    metricsMgr: new SegmentMetricsManager(mockSessionInfo()),
     ...extended,
   })
 

--- a/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
+++ b/frontend/app/src/components/ToolbarActions/ToolbarActions.tsx
@@ -22,6 +22,8 @@ import {
   IGuestToHostMessage,
   IToolbarItem,
 } from "@streamlit/lib"
+import { SegmentMetricsManager } from "@streamlit/app/src/SegmentMetricsManager"
+
 import {
   StyledActionButtonContainer,
   StyledActionButtonIcon,
@@ -59,11 +61,13 @@ export function ActionButton({
 export interface ToolbarActionsProps {
   sendMessageToHost: (message: IGuestToHostMessage) => void
   hostToolbarItems: IToolbarItem[]
+  metricsMgr: SegmentMetricsManager
 }
 
 function ToolbarActions({
   sendMessageToHost,
   hostToolbarItems,
+  metricsMgr,
 }: ToolbarActionsProps): ReactElement {
   return (
     <StyledToolbarActions data-testid="stToolbarActions">
@@ -72,12 +76,15 @@ function ToolbarActions({
           key={key}
           label={label}
           icon={icon}
-          onClick={() =>
+          onClick={() => {
+            metricsMgr.enqueue("menuClick", {
+              key,
+            })
             sendMessageToHost({
               type: "TOOLBAR_ITEM_CALLBACK",
               key,
             })
-          }
+          }}
         />
       ))}
     </StyledToolbarActions>


### PR DESCRIPTION
## Describe your changes

This PR adds metrics tracking for clicks on toolbar items via the `menuClick` event. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
