### PR TITLE
Teach frontend that several fragments can run in one script run

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -240,6 +240,7 @@ const NEW_SESSION_JSON: INewSession = {
   pageScriptHash: "page_script_hash",
   mainScriptPath: "path/to/file.py",
   scriptRunId: "script_run_id",
+  fragmentIdsThisRun: [],
 }
 
 // Prevent "moment-timezone requires moment" exception when mocking "moment".
@@ -1079,7 +1080,7 @@ describe("App", () => {
 
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
-        fragmentId: undefined,
+        fragmentIdsThisRun: [],
       })
 
       expect(document.title).toBe("streamlit_app · Streamlit")
@@ -1092,7 +1093,7 @@ describe("App", () => {
 
       sendForwardMessage("newSession", {
         ...NEW_SESSION_JSON,
-        fragmentId: "myFragmentId",
+        fragmentIdsThisRun: ["myFragmentId"],
       })
 
       expect(document.title).toBe("some title")
@@ -1187,6 +1188,7 @@ describe("App", () => {
         { pageScriptHash: "sub_hash", pageName: "page2" },
       ],
       pageScriptHash: "top_hash",
+      fragmentIdsThisRun: [],
     }
 
     beforeEach(() => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -153,7 +153,7 @@ interface State {
   appPages: IAppPage[]
   currentPageScriptHash: string
   latestRunTime: number
-  currentFragmentId: string
+  fragmentIdsThisRun: Array<string>
   // host communication info
   isOwner: boolean
   hostMenuItems: IMenuItem[]
@@ -269,7 +269,7 @@ export class App extends PureComponent<Props, State> {
       hideSidebarNav: true,
       toolbarMode: Config.ToolbarMode.MINIMAL,
       latestRunTime: performance.now(),
-      currentFragmentId: "",
+      fragmentIdsThisRun: [],
       // Information sent from the host
       isOwner: false,
       hostMenuItems: [],
@@ -861,7 +861,7 @@ export class App extends PureComponent<Props, State> {
       scriptRunId,
       name: scriptName,
       mainScriptPath,
-      fragmentId,
+      fragmentIdsThisRun,
       pageScriptHash: newPageScriptHash,
     } = newSessionProto
 
@@ -877,7 +877,7 @@ export class App extends PureComponent<Props, State> {
     )?.pageName as string
     const viewingMainPage = newPageScriptHash === mainPage.pageScriptHash
 
-    if (!fragmentId) {
+    if (!fragmentIdsThisRun.length) {
       // This is a normal rerun, remove all the auto reruns intervals
       this.state.autoReruns.forEach((value: NodeJS.Timer) => {
         clearInterval(value)
@@ -950,7 +950,7 @@ export class App extends PureComponent<Props, State> {
       )
     } else {
       this.setState({
-        currentFragmentId: fragmentId,
+        fragmentIdsThisRun,
         latestRunTime: performance.now(),
       })
     }
@@ -1106,11 +1106,11 @@ export class App extends PureComponent<Props, State> {
         // (We don't do this if our script had a compilation error and didn't
         // finish successfully.)
         this.setState(
-          ({ scriptRunId, currentFragmentId }) => ({
+          ({ scriptRunId, fragmentIdsThisRun }) => ({
             // Apply any pending elements that haven't been applied.
             elements: this.pendingElementsBuffer.clearStaleNodes(
               scriptRunId,
-              currentFragmentId
+              fragmentIdsThisRun
             ),
           }),
           () => {
@@ -1757,7 +1757,7 @@ export class App extends PureComponent<Props, State> {
             onPageChange: this.onPageChange,
             currentPageScriptHash,
             libConfig,
-            currentFragmentId: this.state.currentFragmentId ?? "",
+            fragmentIdsThisRun: this.state.fragmentIdsThisRun,
           }}
         >
           <HotKeys

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -170,7 +170,7 @@ class StreamlitLibExample extends PureComponent<Props, State> {
   public endScriptRun = (): void => {
     this.setState(prevState => ({
       scriptRunState: ScriptRunState.NOT_RUNNING,
-      elements: prevState.elements.clearStaleNodes(prevState.scriptRunId),
+      elements: prevState.elements.clearStaleNodes(prevState.scriptRunId, []),
     }))
   }
 

--- a/frontend/lib/src/AppNode.test.ts
+++ b/frontend/lib/src/AppNode.test.ts
@@ -964,7 +964,7 @@ describe("AppRoot.clearStaleNodes", () => {
       "new_session_id",
       delta,
       forwardMsgMetadata([0, 1, 1])
-    ).clearStaleNodes("new_session_id")
+    ).clearStaleNodes("new_session_id", [])
 
     // We should now only have a single element, inside a single block
     expect(newRoot.main.getIn([0, 0])).toBeTextNode("newElement!")
@@ -1024,7 +1024,7 @@ describe("AppRoot.clearStaleNodes", () => {
         forwardMsgMetadata([0, 1, 1])
       )
 
-    const pruned = root.clearStaleNodes("new_session_id", "my_fragment_id")
+    const pruned = root.clearStaleNodes("new_session_id", ["my_fragment_id"])
 
     expect(pruned.main.getIn([0])).toBeInstanceOf(BlockNode)
     expect((pruned.main.getIn([0]) as BlockNode).children).toHaveLength(2)

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -66,7 +66,7 @@ interface BlockPropsWithWidth extends BaseBlockProps {
 // Render BlockNodes (i.e. container nodes).
 const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
   const { node } = props
-  const { currentFragmentId } = useContext(LibContext)
+  const { fragmentIdsThisRun } = useContext(LibContext)
 
   if (node.isEmpty && !node.deltaBlock.allowEmpty) {
     return <></>
@@ -78,7 +78,7 @@ const BlockNodeRenderer = (props: BlockPropsWithWidth): ReactElement => {
     node,
     props.scriptRunState,
     props.scriptRunId,
-    currentFragmentId
+    fragmentIdsThisRun
   )
 
   const childProps = { ...props, ...{ node } }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -704,7 +704,7 @@ const RawElementNodeRenderer = (
 const ElementNodeRenderer = (
   props: ElementNodeRendererProps
 ): ReactElement => {
-  const { isFullScreen, currentFragmentId } = React.useContext(LibContext)
+  const { isFullScreen, fragmentIdsThisRun } = React.useContext(LibContext)
   const { node, width } = props
 
   const elementType = node.element.type || ""
@@ -714,7 +714,7 @@ const ElementNodeRenderer = (
     node,
     props.scriptRunState,
     props.scriptRunId,
-    currentFragmentId
+    fragmentIdsThisRun
   )
 
   // TODO: If would be great if we could return an empty fragment if isHidden is true, to keep the

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -25,7 +25,12 @@ describe("isElementStale", () => {
 
   it("returns true if scriptRunState is RERUN_REQUESTED", () => {
     expect(
-      isElementStale(node, ScriptRunState.RERUN_REQUESTED, "someScriptRunId")
+      isElementStale(
+        node,
+        ScriptRunState.RERUN_REQUESTED,
+        "someScriptRunId",
+        []
+      )
     ).toBe(true)
   })
 
@@ -33,21 +38,16 @@ describe("isElementStale", () => {
   // are those belonging to the fragment that's currently running.
   it("if running and currentFragmentId is set, compares with node's fragmentId", () => {
     expect(
-      isElementStale(
-        node,
-        ScriptRunState.RUNNING,
-        "myScriptRunId",
-        "myFragmentId"
-      )
+      isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [
+        "myFragmentId",
+      ])
     ).toBe(true)
 
     expect(
-      isElementStale(
-        node,
-        ScriptRunState.RUNNING,
-        "myScriptRunId",
-        "someOtherFragmentId"
-      )
+      isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [
+        "someFragmentId",
+        "someOtherFragmentId",
+      ])
     ).toBe(false)
   })
 
@@ -55,12 +55,12 @@ describe("isElementStale", () => {
   // the current one should be set to stale.
   it("if running and currentFragmentId is not set, compares with node's scriptRunId", () => {
     expect(
-      isElementStale(node, ScriptRunState.RUNNING, "someOtherScriptRunId")
+      isElementStale(node, ScriptRunState.RUNNING, "someOtherScriptRunId", [])
     ).toBe(true)
 
-    expect(isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId")).toBe(
-      false
-    )
+    expect(
+      isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [])
+    ).toBe(false)
   })
 
   it("returns false for all other script run states", () => {
@@ -70,7 +70,7 @@ describe("isElementStale", () => {
       ScriptRunState.COMPILATION_ERROR,
     ]
     states.forEach(s => {
-      expect(isElementStale(node, s, "someOtherScriptRunId")).toBe(false)
+      expect(isElementStale(node, s, "someOtherScriptRunId", [])).toBe(false)
     })
   })
 })

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -37,7 +37,7 @@ export function isElementStale(
   node: AppNode,
   scriptRunState: ScriptRunState,
   scriptRunId: string,
-  currentFragmentId?: string
+  fragmentIdsThisRun?: Array<string>
 ): boolean {
   if (scriptRunState === ScriptRunState.RERUN_REQUESTED) {
     // If a rerun was just requested, all of our current elements
@@ -46,8 +46,10 @@ export function isElementStale(
   }
 
   if (scriptRunState === ScriptRunState.RUNNING) {
-    if (currentFragmentId) {
-      return node.fragmentId === currentFragmentId
+    if (fragmentIdsThisRun && fragmentIdsThisRun.length) {
+      return Boolean(
+        node.fragmentId && fragmentIdsThisRun.includes(node.fragmentId)
+      )
     }
     return node.scriptRunId !== scriptRunId
   }
@@ -60,11 +62,11 @@ export function isComponentStale(
   node: AppNode,
   scriptRunState: ScriptRunState,
   scriptRunId: string,
-  currentFragmentId?: string
+  fragmentIdsThisRun?: Array<string>
 ): boolean {
   return (
     !enable ||
-    isElementStale(node, scriptRunState, scriptRunId, currentFragmentId)
+    isElementStale(node, scriptRunState, scriptRunId, fragmentIdsThisRun)
   )
 }
 

--- a/frontend/lib/src/components/core/LibContext.tsx
+++ b/frontend/lib/src/components/core/LibContext.tsx
@@ -89,10 +89,10 @@ export interface LibContextProps {
   libConfig: LibConfig
 
   /**
-   * The ID of the fragment that the current script run corresponds to. If the
+   * The IDs of the fragments that the current script run corresponds to. If the
    * current script run isn't due to a fragment, this field is falsy.
    */
-  currentFragmentId: string
+  fragmentIdsThisRun: Array<string>
 }
 
 export const LibContext = React.createContext<LibContextProps>({
@@ -107,5 +107,5 @@ export const LibContext = React.createContext<LibContextProps>({
   onPageChange: () => {},
   currentPageScriptHash: "",
   libConfig: {},
-  currentFragmentId: "",
+  fragmentIdsThisRun: [],
 })

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -41,7 +41,7 @@ export interface TabProps extends BlockPropsWithoutWidth {
 
 function Tabs(props: TabProps): ReactElement {
   const { widgetsDisabled, node, isStale, scriptRunState, scriptRunId } = props
-  const { currentFragmentId } = useContext(LibContext)
+  const { fragmentIdsThisRun } = useContext(LibContext)
 
   let allTabLabels: string[] = []
   const [activeTabKey, setActiveTabKey] = useState<React.Key>(0)
@@ -152,7 +152,7 @@ function Tabs(props: TabProps): ReactElement {
             appNode,
             scriptRunState,
             scriptRunId,
-            currentFragmentId
+            fragmentIdsThisRun
           )
 
           // Ensure stale tab's elements are also marked stale/disabled

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -79,7 +79,7 @@ export const customRenderLibContext = (
     onPageChange: jest.fn(),
     currentPageScriptHash: "",
     libConfig: {},
-    currentFragmentId: "",
+    fragmentIdsThisRun: [],
   }
 
   return reactTestingLibraryRender(component, {

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -461,30 +461,20 @@ class ScriptRunner:
                 else main_page_info["page_script_hash"]
             )
 
+            fragment_ids_this_run = set(rerun_data.fragment_id_queue)
+
             ctx = self._get_script_run_ctx()
             ctx.reset(
                 query_string=rerun_data.query_string,
                 page_script_hash=page_script_hash,
-                fragment_ids_this_run=set(rerun_data.fragment_id_queue),
+                fragment_ids_this_run=fragment_ids_this_run,
             )
 
-            # TODO(vdonato): Changes to take into account multiple fragments running
-            # in a single script run. This will probably either involve:
-            #   * Sending a *set* of fragment_ids to the frontend (probably the easier
-            #     option)
-            #   * Sending events to update the currently running fragment_id to the
-            #     frontend as the script is running (probably the option with nicer UX)
-            # Until one of these changes is implemented, some weirdness with elements
-            # being marked as stale when multiple fragments are being run in a single
-            # script run is expected.
-            fragment_id = (
-                rerun_data.fragment_id_queue[0] if rerun_data.fragment_id_queue else ""
-            )
             self.on_event.send(
                 self,
                 event=ScriptRunnerEvent.SCRIPT_STARTED,
                 page_script_hash=page_script_hash,
-                fragment_id=fragment_id,
+                fragment_ids_this_run=fragment_ids_this_run,
             )
 
             # Compile the script. Any errors thrown here will be surfaced

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -58,7 +58,7 @@ FD = FieldDescriptor
                 ("custom_theme", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
                 ("app_pages", FD.LABEL_REPEATED, FD.TYPE_MESSAGE),
                 ("page_script_hash", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
-                ("fragment_id", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
+                ("fragment_ids_this_run", FD.LABEL_REPEATED, FD.TYPE_STRING),
             },
         ),
         (

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -713,7 +713,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         "streamlit.runtime.app_session._generate_scriptrun_id",
         MagicMock(return_value="mock_scriptrun_id"),
     )
-    async def test_new_session_message_includes_fragment_id(self):
+    async def test_new_session_message_includes_fragment_ids(self):
         session = _create_test_session(asyncio.get_running_loop())
 
         orig_ctx = get_script_run_ctx()
@@ -739,7 +739,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
             sender=mock_scriptrunner,
             event=ScriptRunnerEvent.SCRIPT_STARTED,
             page_script_hash="",
-            fragment_id="my_fragment_id",
+            fragment_ids_this_run={"my_fragment_id"},
         )
 
         # Yield to let the AppSession's callbacks run.
@@ -750,7 +750,7 @@ class AppSessionScriptEventTest(IsolatedAsyncioTestCase):
         session._clear_queue.assert_not_called()
 
         new_session_msg = sent_messages[0].new_session
-        self.assertEqual(new_session_msg.fragment_id, "my_fragment_id")
+        self.assertEqual(new_session_msg.fragment_ids_this_run, ["my_fragment_id"])
 
         add_script_run_ctx(ctx=orig_ctx)
 

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -63,8 +63,9 @@ message NewSession {
   // A hash of the script corresponding to the page currently being viewed.
   string page_script_hash = 9;
 
-  // The fragment ID if the new session corresponds to a fragment script run.
-  string fragment_id = 10;
+  // The fragment IDs being run in this session if it corresponds to a fragment
+  // script run.
+  repeated string fragment_ids_this_run = 10;
 }
 
 // Contains the session status that existed at the time the user connected.


### PR DESCRIPTION
This PR fixes a bug that was mentioned in a TODO comment in #8298: fragments may
be batched so that multiple are run by a single run of a `ScriptRunner`, but the frontend
assumes that at most one is run. The result of this is that, when multiple fragments are
run by one `ScriptRunner`, only one of the corresponding sets of elements rendered to
the app are marked as stale when all of them should be.